### PR TITLE
movement: fix panic for w or e on line's last char

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -64,8 +64,14 @@ pub fn move_next_word_start(slice: RopeSlice, mut begin: usize, count: usize) ->
     let mut end = begin;
 
     for _ in 0..count {
+        // if beyond end of line, do nothing
         if begin + 1 == slice.len_chars() {
             return None;
+        }
+        // if on last char, only select that char
+        if begin + 2 == slice.len_chars() {
+            end += 1;
+            break;
         }
 
         let mut ch = slice.char(begin);
@@ -134,8 +140,14 @@ pub fn move_next_word_end(slice: RopeSlice, mut begin: usize, count: usize) -> O
     let mut end = begin;
 
     for _ in 0..count {
+        // if beyond end of line, do nothing
         if begin + 1 == slice.len_chars() {
             return None;
+        }
+        // if on last char, only select that char
+        if begin + 2 == slice.len_chars() {
+            end += 1;
+            break;
         }
 
         let ch = slice.char(begin);


### PR DESCRIPTION
Currently if the cursor is on the last character of a line, and you press w or e, it panics. With this fix it simply selects the character under the cursor instead, which I believe is the intended behaviour.

This error checking should maybe be split out into another function, since it's repeated twice here. I'm not sure where to put such a function though, so I haven't done that.