### PR TITLE
Add .DS_Store to ignored directories

### DIFF
--- a/helix-syntax/build.rs
+++ b/helix-syntax/build.rs
@@ -107,7 +107,7 @@ fn build_dir(dir: &str, language: &str) {
 }
 
 fn main() {
-    let ignore = vec!["tree-sitter-typescript".to_string()];
+    let ignore = vec!["tree-sitter-typescript".to_string(), ".DS_Store".to_string()];
     let dirs = collect_tree_sitter_dirs(&ignore);
 
     let mut n_jobs = 0;


### PR DESCRIPTION
When building helix, I was gettting the following error:

```
--- stderr
  thread '<unnamed>' panicked at 'byte index 12 is out of bounds of `.DS_Store`', helix-syntax/build.rs:122:29
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  Collect files for tree-sitter-go
  Collect files for tree-sitter-rust
  Collect files for tree-sitter-java
  Collect files for tree-sitter-html
  Collect files for tree-sitter-python
  Collect files for tree-sitter-cpp
  Collect files for tree-sitter-bash
  Collect files for tree-sitter-toml
  Collect files for tree-sitter-c
  Collect files for tree-sitter-php
  Collect files for tree-sitter-ruby
  Collect files for tree-sitter-swift
  Collect files for tree-sitter-scala
  Collect files for tree-sitter-javascript
  Collect files for tree-sitter-agda
  Collect files for tree-sitter-css
  Collect files for tree-sitter-json
  Collect files for tree-sitter-c-sharp
  Collect files for tree-sitter-julia
  thread 'main' panicked at 'assertion failed: `(left == right)`
    left: `19`,
   right: `20`', helix-syntax/build.rs:131:5
```

This was caused by an annoying file that macOS adds named `.DS_Store`, so I added it to the ignored directories Vec.