### PR TITLE
Fix empty command cause panic

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1031,6 +1031,9 @@ pub fn command_mode(cx: &mut Context) {
             }
 
             let parts = input.split_ascii_whitespace().collect::<Vec<&str>>();
+            if parts.is_empty() {
+                return;
+            }
 
             if let Some(cmd) = cmd::COMMANDS.get(parts[0]) {
                 (cmd.fun)(editor, &parts[1..], event);


### PR DESCRIPTION
Fixed panic when enter command mode and press enter key.

``` shell
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', helix-term/src/commands.rs:1035:50
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```