### PR TITLE
Create file if it doesn't exist on save

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -198,6 +198,7 @@ impl Document {
         async move {
             use tokio::{fs::File, io::AsyncWriteExt};
             if let Some(parent) = path.parent() {
+                // TODO: display a prompt asking the user if the directories should be created
                 if !parent.exists() {
                     return Err(Error::msg(
                         "can't save file, parent directory does not exist",

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -104,6 +104,10 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     ret
 }
 
+// Returns the canonical, absolute form of a path with all intermediate components normalized.
+//
+// This function is used instead of `std::fs::canonicalize` because we don't want to verify
+// here if the path exists, just normalize it's components.
 pub fn canonicalize_path(path: &Path) -> std::io::Result<PathBuf> {
     std::env::current_dir().map(|current_dir| normalize_path(&current_dir.join(path)))
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -137,7 +137,7 @@ impl Editor {
     }
 
     pub fn open(&mut self, path: PathBuf, action: Action) -> Result<DocumentId, Error> {
-        let path = std::fs::canonicalize(path)?;
+        let path = crate::document::canonicalize_path(&path)?;
 
         let id = self
             .documents()


### PR DESCRIPTION
This PR fixes a crash on startup when the document that should be opened doesn't exist. For now the file will be created at launch, and will exist even if the user doesn't save it.

Closes: #25