### PR TITLE
Fix panic opening rust file

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -51,7 +51,8 @@ pub struct Args {
     files: Vec<PathBuf>,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let help = format!(
         "\
 {} {}
@@ -113,13 +114,9 @@ FLAGS:
     let config = toml::from_slice(toml).context("Could not parse languages.toml")?;
     LOADER.get_or_init(|| Loader::new(config));
 
-    let runtime = tokio::runtime::Runtime::new().context("unable to start tokio runtime")?;
-
     // TODO: use the thread local executor to spawn the application task separately from the work pool
     let mut app = Application::new(args).context("unable to create new appliction")?;
-    runtime.block_on(async move {
-        app.run().await;
-    });
+    app.run().await;
 
     Ok(())
 }


### PR DESCRIPTION
Application::new will use stuff that requires tokio runtime.

```
thread 'main' panicked at 'there is no reactor running, must be called from the context of a Tokio 1.x runtime', /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/context.rs:18:26
```

I see that there seemed to be quite a lot of panic as well.