### PR TITLE
Default log file to cache

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -58,12 +58,21 @@ pub fn runtime_dir() -> std::path::PathBuf {
 
 pub fn config_dir() -> std::path::PathBuf {
     // TODO: allow env var override
-    use etcetera::base_strategy::{choose_base_strategy, BaseStrategy};
     let strategy = choose_base_strategy().expect("Unable to find the config directory!");
     let mut path = strategy.config_dir();
     path.push("helix");
     path
 }
+
+pub fn cache_dir() -> std::path::PathBuf {
+    // TODO: allow env var override
+    let strategy = choose_base_strategy().expect("Unable to find the config directory!");
+    let mut path = strategy.cache_dir();
+    path.push("helix");
+    path
+}
+
+use etcetera::base_strategy::{choose_base_strategy, BaseStrategy};
 
 pub use ropey::{Rope, RopeSlice};
 


### PR DESCRIPTION
```
helix-term 0.1.0
Blaž Hrastnik <blaz@mxxn.io>
A post-modern text editor.

USAGE:
    hx [FLAGS] [files]...

ARGS:
    <files>...    Sets the input file to use

FLAGS:
    -h, --help       Prints help information
    -v               Increases logging verbosity each use for up to 3 times
                     (default file: /home/xxx/.cache/helix/helix.log)
    -V, --version    Prints version information
```