### PR TITLE
removed shift matching

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -103,15 +103,6 @@ macro_rules! key {
     };
 }
 
-macro_rules! shift {
-    ($($ch:tt)*) => {
-        KeyEvent {
-            code: KeyCode::Char($($ch)*),
-            modifiers: KeyModifiers::SHIFT,
-        }
-    };
-}
-
 macro_rules! ctrl {
     ($($ch:tt)*) => {
         KeyEvent {
@@ -139,8 +130,8 @@ pub fn default() -> Keymaps {
 
         key!('t') => commands::find_till_char,
         key!('f') => commands::find_next_char,
-        shift!('T') => commands::till_prev_char,
-        shift!('F') => commands::find_prev_char,
+        key!('T') => commands::till_prev_char,
+        key!('F') => commands::find_prev_char,
         // and matching set for select mode (extend)
         //
         key!('r') => commands::replace,
@@ -157,11 +148,11 @@ pub fn default() -> Keymaps {
         key!(':') => commands::command_mode,
 
         key!('i') => commands::insert_mode,
-        shift!('I') => commands::prepend_to_line,
+        key!('I') => commands::prepend_to_line,
         key!('a') => commands::append_mode,
-        shift!('A') => commands::append_to_line,
+        key!('A') => commands::append_to_line,
         key!('o') => commands::open_below,
-        shift!('O') => commands::open_above,
+        key!('O') => commands::open_above,
         // [<space>  ]<space> equivalents too (add blank new line, no edit)
 
 
@@ -174,12 +165,12 @@ pub fn default() -> Keymaps {
 
         key!('s') => commands::select_regex,
         alt!('s') => commands::split_selection_on_newline,
-        shift!('S') => commands::split_selection,
+        key!('S') => commands::split_selection,
         key!(';') => commands::collapse_selection,
         alt!(';') => commands::flip_selections,
         key!('%') => commands::select_all,
         key!('x') => commands::select_line,
-        shift!('X') => commands::extend_line,
+        key!('X') => commands::extend_line,
         // or select mode X?
         // extend_to_whole_line, crop_to_whole_line
 
@@ -199,25 +190,25 @@ pub fn default() -> Keymaps {
         key!('/') => commands::search,
         // ? for search_reverse
         key!('n') => commands::search_next,
-        shift!('N') => commands::extend_search_next,
+        key!('N') => commands::extend_search_next,
         // N for search_prev
         key!('*') => commands::search_selection,
 
         key!('u') => commands::undo,
-        shift!('U') => commands::redo,
+        key!('U') => commands::redo,
 
         key!('y') => commands::yank,
         // yank_all
         key!('p') => commands::paste_after,
         // paste_all
-        shift!('P') => commands::paste_before,
+        key!('P') => commands::paste_before,
 
         key!('>') => commands::indent,
         key!('<') => commands::unindent,
         key!('=') => commands::format_selections,
-        shift!('J') => commands::join_selections,
+        key!('J') => commands::join_selections,
         // TODO: conflicts hover/doc
-        shift!('K') => commands::keep_selections,
+        key!('K') => commands::keep_selections,
         // TODO: and another method for inverse
 
         // TODO: clashes with space mode
@@ -256,7 +247,7 @@ pub fn default() -> Keymaps {
 
         // move under <space>c
         ctrl!('c') => commands::toggle_comments,
-        shift!('K') => commands::hover,
+        key!('K') => commands::hover,
 
         // z family for save/restore/combine from/to sels from register
 
@@ -284,8 +275,8 @@ pub fn default() -> Keymaps {
 
             key!('t') => commands::extend_till_char,
             key!('f') => commands::extend_next_char,
-            shift!('T') => commands::extend_till_prev_char,
-            shift!('F') => commands::extend_prev_char,
+            key!('T') => commands::extend_till_prev_char,
+            key!('F') => commands::extend_prev_char,
 
             KeyEvent {
                 code: KeyCode::Esc,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -530,6 +530,7 @@ impl Component for EditorView {
                 EventResult::Consumed(None)
             }
             Event::Key(mut key) => {
+                canonicalize_key(&mut key);
                 // clear status
                 cx.editor.status_msg = None;
 
@@ -551,7 +552,7 @@ impl Component for EditorView {
                     match mode {
                         Mode::Insert => {
                             // record last_insert key
-                            self.last_insert.1.push(canonicalize_key(&mut key));
+                            self.last_insert.1.push(key);
 
                             // let completion swallow the event if necessary
                             let mut consumed = false;
@@ -576,7 +577,7 @@ impl Component for EditorView {
 
                             // if completion didn't take the event, we pass it onto commands
                             if !consumed {
-                                self.insert_mode(&mut cxt, canonicalize_key(&mut key));
+                                self.insert_mode(&mut cxt, key);
 
                                 // lastly we recalculate completion
                                 if let Some(completion) = &mut self.completion {
@@ -587,7 +588,7 @@ impl Component for EditorView {
                                 }
                             }
                         }
-                        mode => self.command_mode(mode, &mut cxt, canonicalize_key(&mut key)),
+                        mode => self.command_mode(mode, &mut cxt, key),
                     }
                 }
 
@@ -673,7 +674,7 @@ impl Component for EditorView {
     }
 }
 
-fn canonicalize_key(key: &mut KeyEvent) -> KeyEvent {
+fn canonicalize_key(key: &mut KeyEvent) {
     if let KeyEvent {
         code: KeyCode::Char(_),
         modifiers: _,
@@ -681,5 +682,4 @@ fn canonicalize_key(key: &mut KeyEvent) -> KeyEvent {
     {
         key.modifiers.remove(KeyModifiers::SHIFT)
     }
-    *key
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -674,8 +674,12 @@ impl Component for EditorView {
 }
 
 fn canonicalize_key(key: &mut KeyEvent) -> KeyEvent {
-    if let KeyEvent { code: KeyCode::Char(_), modifiers: KeyModifiers::SHIFT } = key {
-            key.modifiers = KeyModifiers::NONE;
+    if let KeyEvent {
+        code: KeyCode::Char(_),
+        modifiers: _,
+    } = key
+    {
+        key.modifiers.remove(KeyModifiers::SHIFT)
     }
     *key
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -529,9 +529,14 @@ impl Component for EditorView {
                 cx.editor.resize(Rect::new(0, 0, width, height - 1));
                 EventResult::Consumed(None)
             }
-            Event::Key(key) => {
+            Event::Key(mut key) => {
                 // clear status
                 cx.editor.status_msg = None;
+
+                 //canonicalize the key
+                if key.modifiers == KeyModifiers::SHIFT {
+                    key.modifiers = KeyModifiers::NONE;
+                }
 
                 let (view, doc) = cx.editor.current();
                 let mode = doc.mode();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -533,11 +533,6 @@ impl Component for EditorView {
                 // clear status
                 cx.editor.status_msg = None;
 
-                 //canonicalize the key
-                if key.modifiers == KeyModifiers::SHIFT {
-                    key.modifiers = KeyModifiers::NONE;
-                }
-
                 let (view, doc) = cx.editor.current();
                 let mode = doc.mode();
 
@@ -556,7 +551,7 @@ impl Component for EditorView {
                     match mode {
                         Mode::Insert => {
                             // record last_insert key
-                            self.last_insert.1.push(key);
+                            self.last_insert.1.push(canonicalize_key(&mut key));
 
                             // let completion swallow the event if necessary
                             let mut consumed = false;
@@ -581,7 +576,7 @@ impl Component for EditorView {
 
                             // if completion didn't take the event, we pass it onto commands
                             if !consumed {
-                                self.insert_mode(&mut cxt, key);
+                                self.insert_mode(&mut cxt, canonicalize_key(&mut key));
 
                                 // lastly we recalculate completion
                                 if let Some(completion) = &mut self.completion {
@@ -592,7 +587,7 @@ impl Component for EditorView {
                                 }
                             }
                         }
-                        mode => self.command_mode(mode, &mut cxt, key),
+                        mode => self.command_mode(mode, &mut cxt, canonicalize_key(&mut key)),
                     }
                 }
 
@@ -676,4 +671,11 @@ impl Component for EditorView {
         // It's easier to just not render the cursor and use selection rendering instead.
         None
     }
+}
+
+fn canonicalize_key(key: &mut KeyEvent) -> KeyEvent {
+    if let KeyEvent { code: KeyCode::Char(_), modifiers: KeyModifiers::SHIFT } = key {
+            key.modifiers = KeyModifiers::NONE;
+    }
+    *key
 }


### PR DESCRIPTION
I would like to remove the shift modifier from ascii keys, as the current key matching is running into some problems on windows 10 for me.