### PR TITLE
Disable deleting from the end of a buffer which can cause a crash.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -745,6 +745,10 @@ pub fn extend_line(cx: &mut Context) {
 // heuristic: append changes to history after each command, unless we're in insert mode
 
 fn _delete_selection(doc: &mut Document, view_id: ViewId) {
+    if doc.empty() {
+        return;
+    }
+
     // first yank the selection
     let values: Vec<String> = doc
         .selection(view_id)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -759,9 +759,8 @@ fn _delete_selection(doc: &mut Document, view_id: ViewId) {
     // then delete
     let transaction =
         Transaction::change_by_selection(doc.text(), doc.selection(view_id), |range| {
-            use std::cmp::{max, min};
-            let max_to = max(0, doc.text().len_chars() - 1);
-            let to = min(max_to, range.to() + 1);
+            let max_to = doc.text().len_chars().saturating_sub(1);
+            let to = std::cmp::min(max_to, range.to() + 1);
             (range.from(), to, None)
         });
     doc.apply(&transaction, view_id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -762,7 +762,6 @@ fn _delete_selection(doc: &mut Document, view_id: ViewId) {
             use std::cmp::{max, min};
             let max_to = max(0, doc.text().len_chars() - 1);
             let to = min(max_to, range.to() + 1);
-            log::info!("{} {} {}", max_to, to, doc.text().len_chars());
             (range.from(), to, None)
         });
     doc.apply(&transaction, view_id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -745,10 +745,6 @@ pub fn extend_line(cx: &mut Context) {
 // heuristic: append changes to history after each command, unless we're in insert mode
 
 fn _delete_selection(doc: &mut Document, view_id: ViewId) {
-    if doc.empty() {
-        return;
-    }
-
     // first yank the selection
     let values: Vec<String> = doc
         .selection(view_id)
@@ -763,7 +759,11 @@ fn _delete_selection(doc: &mut Document, view_id: ViewId) {
     // then delete
     let transaction =
         Transaction::change_by_selection(doc.text(), doc.selection(view_id), |range| {
-            (range.from(), range.to() + 1, None)
+            use std::cmp::{max, min};
+            let max_to = max(0, doc.text().len_chars() - 1);
+            let to = min(max_to, range.to() + 1);
+            log::info!("{} {} {}", max_to, to, doc.text().len_chars());
+            (range.from(), to, None)
         });
     doc.apply(&transaction, view_id);
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -494,6 +494,10 @@ impl Document {
     pub fn versioned_identifier(&self) -> lsp::VersionedTextDocumentIdentifier {
         lsp::VersionedTextDocumentIdentifier::new(self.url().unwrap(), self.version)
     }
+
+    pub fn empty(&self) -> bool {
+        self.text == "\n"
+    }
 }
 
 #[cfg(test)]

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -494,10 +494,6 @@ impl Document {
     pub fn versioned_identifier(&self) -> lsp::VersionedTextDocumentIdentifier {
         lsp::VersionedTextDocumentIdentifier::new(self.url().unwrap(), self.version)
     }
-
-    pub fn empty(&self) -> bool {
-        self.text == "\n"
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
On the current HEAD one can crash the editor by opening an empty buffer, and inputting d -> i -> enter. This is a possible fix.