### PR TITLE
Limit goto count

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1250,7 +1250,8 @@ pub fn goto_mode(cx: &mut Context) {
         // TODO: can't go to line 1 since we can't distinguish between g and 1g, g gets converted
         // to 1g
         let (view, doc) = cx.current();
-        let pos = doc.text().line_to_char(count - 1);
+        let line_idx = std::cmp::min(count - 1, doc.text().len_lines().saturating_sub(2));
+        let pos = doc.text().line_to_char(line_idx);
         doc.set_selection(view.id, Selection::point(pos));
         return;
     }


### PR DESCRIPTION
Giving a goto count greater than the number of lines in the buffer
would cause Helix to panic.

```console
thread 'main' panicked at 'Attempt to index past end of Rope: line index 299, Rope line length 11', /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec8
23/ropey-1.2.0/src/rope.rs:946:9
```

Fixes #94
