### PR TITLE
Embed the runtime folder into the binary instead of using HELIX_RUNTIME env variable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "once_cell",
  "regex",
  "ropey",
+ "rust-embed",
  "serde",
  "smallvec",
  "tendril",
@@ -690,6 +691,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f3ef16589fdbb3e8fbce3dca944c08e61f39c7f16064b21a257d68ea911a83"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe1fe6aac5d6bb9e1ffd81002340363272a7648234ec7bdfac5ee202cb65523"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed91c41c42ef7bf687384439c312e75e0da9c149b0390889b94de3c7d9d9e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d"
+dependencies = [
+ "walkdir",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ the `HELIX_RUNTIME` environment variable.
 > NOTE: You should set this to <path to repository>/runtime in development (if
 > running via cargo).
 
+If you want to bake the `runtime/` directory into the Helix binary you can build
+it with:
+
+```
+cargo install --path helix-term --features "embed_runtime"
+```
+
 ## Arch Linux
 There are two packages available from AUR:
  - `helix-bin`: contains prebuilt binary from GitHub releases

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the `HELIX_RUNTIME` environment variable.
 > NOTE: You should set this to <path to repository>/runtime in development (if
 > running via cargo).
 
-If you want to bake the `runtime/` directory into the Helix binary you can build
+If you want to embed the `runtime/` directory into the Helix binary you can build
 it with:
 
 ```
@@ -82,4 +82,3 @@ All shortcuts/keymaps can be found in the documentation on the website:
 # Getting help
 
 Discuss the project on the community [Matrix Space](https://matrix.to/#/#helix-community:matrix.org) (make sure to join `#helix-editor:matrix.org` if you're on a client that doesn't support Matrix Spaces yet).
-

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -36,7 +36,7 @@ Now copy the `runtime/` directory somewhere. Helix will by default look for the
 runtime inside the same folder as the executable, but that can be overriden via
 the `HELIX_RUNTIME` environment variable.
 
-If you want to bake the `runtime/` directory into the Helix binary you can build
+If you want to embed the `runtime/` directory into the Helix binary you can build
 it with:
 
 ```

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -35,3 +35,10 @@ This will install the `hx` binary to `$HOME/.cargo/bin`.
 Now copy the `runtime/` directory somewhere. Helix will by default look for the
 runtime inside the same folder as the executable, but that can be overriden via
 the `HELIX_RUNTIME` environment variable.
+
+If you want to bake the `runtime/` directory into the Helix binary you can build
+it with:
+
+```
+cargo install --path helix-term --features "embed_runtime"
+```

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -7,6 +7,10 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+
+[features]
+embed_runtime = []
+
 [dependencies]
 helix-syntax = { path = "../helix-syntax" }
 
@@ -24,3 +28,4 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 
 etcetera = "0.3"
+rust-embed="5.9.0" 

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 
 
 [features]
-embed_runtime = []
+embed_runtime = ["rust-embed"]
 
 [dependencies]
 helix-syntax = { path = "../helix-syntax" }
@@ -28,4 +28,4 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 
 etcetera = "0.3"
-rust-embed="5.9.0" 
+rust-embed = { version = "5.9.0", optional = true }

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) fn find_first_non_whitespace_char(text: RopeSlice, line_num: usize) -
     None
 }
 
+#[cfg(not(embed_runtime))]
 pub fn runtime_dir() -> std::path::PathBuf {
     // runtime env var || dir where binary is located
     std::env::var("HELIX_RUNTIME")

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -87,8 +87,7 @@ struct Runtime;
 
 #[cfg(feature = "embed_runtime")]
 fn load_runtime_file(language: &str, filename: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let root = PathBuf::new();
-    let path = root.join("queries").join(language).join(filename);
+    let path = PathBuf::from("queries").join(language).join(filename);
 
     let query_bytes = Runtime::get(&path.display().to_string()).unwrap_or_default();
     std::str::from_utf8(query_bytes.as_ref())

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -81,10 +81,7 @@ fn load_runtime_file(language: &str, filename: &str) -> Result<String, std::io::
 }
 
 #[cfg(feature = "embed_runtime")]
-use rust_embed::RustEmbed;
-
-#[cfg(feature = "embed_runtime")]
-#[derive(RustEmbed)]
+#[derive(rust_embed::RustEmbed)]
 #[folder = "../runtime/"]
 struct Runtime;
 
@@ -93,7 +90,7 @@ fn load_runtime_file(language: &str, filename: &str) -> Result<String, Box<dyn s
     let root = PathBuf::new();
     let path = root.join("queries").join(language).join(filename);
 
-    let query_bytes = Runtime::get(&path.as_path().display().to_string()).unwrap_or_default();
+    let query_bytes = Runtime::get(&path.display().to_string()).unwrap_or_default();
     std::str::from_utf8(query_bytes.as_ref())
         .map(|s| s.to_string())
         .map_err(|err| err.into())

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -81,18 +81,15 @@ fn load_runtime_file(language: &str, filename: &str) -> Result<String, std::io::
 }
 
 #[cfg(feature = "embed_runtime")]
-#[derive(rust_embed::RustEmbed)]
-#[folder = "../runtime/"]
-struct Runtime;
-
-#[cfg(feature = "embed_runtime")]
 fn load_runtime_file(language: &str, filename: &str) -> Result<String, Box<dyn std::error::Error>> {
+    #[derive(rust_embed::RustEmbed)]
+    #[folder = "../runtime/"]
+    struct Runtime;
+
     let path = PathBuf::from("queries").join(language).join(filename);
 
     let query_bytes = Runtime::get(&path.display().to_string()).unwrap_or_default();
-    std::str::from_utf8(query_bytes.as_ref())
-        .map(|s| s.to_string())
-        .map_err(|err| err.into())
+    String::from_utf8(query_bytes.to_vec()).map_err(|err| err.into())
 }
 
 fn read_query(language: &str, filename: &str) -> String {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1717,3 +1717,10 @@ fn test_input_edits() {
         }]
     );
 }
+
+#[test]
+fn test_load_runtime_file() {
+    // Test to make sure we can load some data from the runtime directory.
+    let contents = load_runtime_file("rust", "indents.toml").unwrap();
+    assert!(!contents.is_empty())
+}

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+embed_runtime = ["helix-core/embed_runtime"]
+
 [[bin]]
 name = "hx"
 path = "src/main.rs"


### PR DESCRIPTION
Hello, love the project! I don't know if this feature is desirable or not it wasn't clear to me whether the user is supposed to be able to easily edit things inside the runtime folder. If that's the case feel free to close this :)

I did consider making it so that if the HELIX_RUNTIME env variable is not specified we will use the baked in queries which I can do if desired.