### PR TITLE
fix: 9999x panic! because of index out of bounds

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -718,7 +718,9 @@ pub fn select_line(cx: &mut Context) {
 
     let line = text.char_to_line(pos.head);
     let start = text.line_to_char(line);
-    let end = text.line_to_char(line + count).saturating_sub(1);
+    let end = text
+        .line_to_char(std::cmp::min(text.len_lines(), line + count))
+        .saturating_sub(1);
 
     doc.set_selection(view.id, Selection::single(start, end));
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -718,6 +718,7 @@ pub fn select_line(cx: &mut Context) {
 
     let line = text.char_to_line(pos.head);
     let start = text.line_to_char(line);
+    // This subtract 1 is for end of file.
     let end = text
         .line_to_char(std::cmp::min(text.len_lines(), line + count))
         .saturating_sub(1);


### PR DESCRIPTION
use std::cmp::min(text.len_lines(), ...) to not go out of bounds