### PR TITLE
Use git describe for version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +331,7 @@ dependencies = [
  "fern",
  "futures-util",
  "fuzzy-matcher",
+ "git2",
  "helix-core",
  "helix-lsp",
  "helix-tui",
@@ -447,6 +461,30 @@ name = "libc"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.21+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -617,6 +655,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"
@@ -995,6 +1039,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "version_check"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -45,3 +45,6 @@ toml = "0.5"
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+
+[build-dependencies]
+git2 = { version = "0.13", default-features = false }

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,0 +1,12 @@
+use git2::{DescribeFormatOptions, DescribeOptions, Repository};
+
+fn main() {
+    let repo = Repository::open_from_env().unwrap();
+    let describe = repo.describe(&DescribeOptions::new()).unwrap();
+    let result = describe
+        .format(Some(&DescribeFormatOptions::new().dirty_suffix("-dirty")))
+        .unwrap();
+    println!("cargo:rustc-env=GIT_DESCRIBE={}", result);
+    // rerun-if-changed=../.git/HEAD not accurate as we check dirty
+    // println!("cargo:rerun-if-changed=../.git/HEAD");
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -141,7 +141,7 @@ FLAGS:
     }
 
     if args.display_version {
-        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("GIT_DESCRIBE"));
         std::process::exit(0);
     }
 


### PR DESCRIPTION
Change -v to display something like helix-term v0.0.9-36-g52d83ae-dirty
rather than according to Cargo.toml version, providing more information.

Run git describe using git bindings in build.rs, using git2 as
build-dependencies, it is faster than using Command, there is vergen
but it seemed to do a lot more.

Before `-v`

    helix-term 0.1.0

After
```
helix-term v0.0.9-36-g52d83ae-dirty
```

New dependency git2 (although we may use this in the future, but this is build dependency, so it will be a separate build from normal builds, +10 compilation units (145 -> 155))

`cargo build` time might increase slightly (not sure how much it increase but it took ~200ms when nothing change) even though nothing changed due to us using `-dirty`, we need to run it if any files change

At least with this we can be very clear when users put `-V` for their version, which they can just copy paste to. Or maybe we ask them to run themselves? It's just `git describe --dirty`.

EDIT: now that I see this I don't think this is very useful, we can just ask users to run that command.