### PR TITLE
fix: make find_prev_char and till_prev_char work + fix one panic

### DIFF
--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -41,7 +41,8 @@ pub fn find_nth_prev(
     inclusive: bool,
 ) -> Option<usize> {
     // start searching right before pos
-    let mut chars = text.chars_at(pos.saturating_sub(1));
+    pos = pos.saturating_sub(1);
+    let mut chars = text.chars_at(pos);
 
     for _ in 0..n {
         loop {
@@ -56,7 +57,7 @@ pub fn find_nth_prev(
     }
 
     if !inclusive {
-        pos -= 1;
+        pos += 1;
     }
 
     Some(pos)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -315,7 +315,7 @@ fn _find_char<F>(cx: &mut Context, search_fn: F, inclusive: bool, extend: bool)
 where
     // TODO: make an options struct for and abstract this Fn into a searcher type
     // use the definition for w/b/e too
-    F: Fn(RopeSlice, char, usize, usize, bool) -> Option<usize>,
+    F: Fn(RopeSlice, char, usize, usize, bool) -> Option<usize> + 'static,
 {
     // TODO: count is reset to 1 before next key so we move it into the closure here.
     // Would be nice to carry over.
@@ -332,7 +332,7 @@ where
             let text = doc.text().slice(..);
 
             let selection = doc.selection(view.id).transform(|mut range| {
-                search::find_nth_next(text, ch, range.head, count, inclusive).map_or(range, |pos| {
+                search_fn(text, ch, range.head, count, inclusive).map_or(range, |pos| {
                     if extend {
                         Range::new(range.anchor, pos)
                     } else {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -272,7 +272,7 @@ impl EditorView {
                             viewport.x + start.col as u16,
                             viewport.y + start.row as u16,
                             // text.line(view.first_line).len_chars() as u16 - start.col as u16,
-                            viewport.width - start.col as u16,
+                            viewport.width.saturating_sub(start.col as u16),
                             1,
                         ),
                         selection_style,


### PR DESCRIPTION
Bevore this PR `commands::find_prev_char` and `commands::till_prev_char` were triggerable through keys but `seach::find_nth_next()` was hardcoded in `_find_char`.
The passed `fn` was nerver used. With this PR the passed `fn` is used.
The change in `search.rs` resolves an off by one error in the behivor of `find_nth_prev`

fix: panicked at 'attempt to subtract with overflow' helix-term/src/ui/editor.rs:275:29
This would happen when the window-size was to small to display the entire `width` and one would start jumping forwards with `f<some_char>` and the beginning of the highlighted area would end up outside of the window and was greater than the end-postion. 
For me this happend when I opened helix/README.md in a terminal that is to small to display the entire width and start jumping forward with `f(` 4times.

