### PR TITLE
Fix panic when moving over unicode punctuation

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -188,7 +188,9 @@ pub(crate) enum Category {
     Eol,
     Word,
     Punctuation,
+    Unknown,
 }
+
 pub(crate) fn categorize(ch: char) -> Category {
     if ch == '\n' {
         Category::Eol
@@ -199,7 +201,7 @@ pub(crate) fn categorize(ch: char) -> Category {
     } else if ch.is_ascii_punctuation() {
         Category::Punctuation
     } else {
-        unreachable!("unknown '{}' character category", ch)
+        Category::Unknown
     }
 }
 


### PR DESCRIPTION
`is_ascii_punctuation` will only work for ASCII punctuations, and when
we have unicode punctuation we jump into the `unreachable`.
This patch fallback into categorizing everything in this branch as
punctuation (kakoune approach).

Fixes https://github.com/helix-editor/helix/issues/123

This only prevents panic, but movements by-words are broken (stop at the Unicode punctuation).
I get this selection when pressing `b`
![image](https://user-images.githubusercontent.com/3809077/120898056-4b8c1e00-c5f7-11eb-9635-002b5d06eb4f.png)
