### PR TITLE
Improve prompt completion

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -253,8 +253,13 @@ impl Component for Prompt {
                 code: KeyCode::Enter,
                 ..
             } => {
-                (self.callback_fn)(cx.editor, &self.line, PromptEvent::Validate);
-                return close_fn;
+                if self.line.ends_with('/') {
+                    self.completion = (self.completion_fn)(&self.line);
+                    self.exit_selection();
+                } else {
+                    (self.callback_fn)(cx.editor, &self.line, PromptEvent::Validate);
+                    return close_fn;
+                }
             }
             KeyEvent {
                 code: KeyCode::Tab, ..

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -91,13 +91,11 @@ impl Prompt {
         }
 
         let index = match direction {
-            CompletionDirection::Forward => {
-                self.selection.map_or(0, |i| i + 1) % self.completion.len()
-            }
+            CompletionDirection::Forward => self.selection.map_or(0, |i| i + 1),
             CompletionDirection::Backward => {
-                (self.selection.unwrap_or(0) + self.completion.len() - 1) % self.completion.len()
+                self.selection.unwrap_or(0) + self.completion.len() - 1
             }
-        };
+        } % self.completion.len();
 
         self.selection = Some(index);
 


### PR DESCRIPTION
This is an attempt to improve prompt completion. More specifically, the following items:

- Completing a directory would not trigger new completion results. Now pressing `Enter` when the selection is over a directory, will trigger new completion results from within that directory.
- While you could use `Tab` to move forward between completion results, you could not use `Shift+Tab` to move backwards. Now pressing `Shift+Tab` will move backwards in the completion results, wrapping to the end as expected.

**Demo**
https://asciinema.org/a/GPWVRd0EhRiO9VmarcWMGtU0x