### PR TITLE
changed flag in build_cpp '/std:c++14' to '/std:c++17' due to tree_si…

### DIFF
--- a/helix-syntax/build.rs
+++ b/helix-syntax/build.rs
@@ -59,7 +59,7 @@ fn build_cpp(files: Vec<String>, language: &str) {
     let mut build = cc::Build::new();
 
     let flag = if build.get_compiler().is_like_msvc() {
-        "/std:c++14"
+        "/std:c++17"
     } else {
         "-std=c++14"
     };


### PR DESCRIPTION
…tter_haskell not compiling on msvc without it