### PR TITLE
Do not move past number of matches in file picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -100,8 +100,11 @@ impl<T> Picker<T> {
     }
 
     pub fn move_down(&mut self) {
-        // TODO: len - 1
-        if self.cursor < self.options.len() {
+        if self.matches.is_empty() {
+            return;
+        }
+
+        if self.cursor < self.matches.len() - 1 {
             self.cursor += 1;
         }
     }


### PR DESCRIPTION
When moving down in the picker, we should not allow moving past the number of matches.

Fixes #141 