### PR TITLE
fix: 2 panics while setting style + off by 1 in find_nth_prev

### DIFF
--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -41,7 +41,6 @@ pub fn find_nth_prev(
     inclusive: bool,
 ) -> Option<usize> {
     // start searching right before pos
-    pos = pos.saturating_sub(1);
     let mut chars = text.chars_at(pos);
 
     for _ in 0..n {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -261,7 +261,16 @@ impl EditorView {
                         Rect::new(
                             viewport.x + start.col as u16,
                             viewport.y + start.row as u16,
-                            ((end.col - start.col) as u16 + 1).min(viewport.width),
+                            // .min is important, because set_style does a
+                            // for i in area.left()..area.right() and
+                            // area.right = x + width !!! which shouldn't be > then surface.area.right()
+                            // This is checked by a debug_assert! in Buffer::index_of
+                            ((end.col - start.col) as u16 + 1).min(
+                                surface
+                                    .area
+                                    .width
+                                    .saturating_sub(viewport.x + start.col as u16),
+                            ),
                             1,
                         ),
                         selection_style,
@@ -290,7 +299,12 @@ impl EditorView {
                         );
                     }
                     surface.set_style(
-                        Rect::new(viewport.x, viewport.y + end.row as u16, end.col as u16, 1),
+                        Rect::new(
+                            viewport.x,
+                            viewport.y + end.row as u16,
+                            (end.col as u16).min(viewport.width),
+                            1,
+                        ),
                         selection_style,
                     );
                 }


### PR DESCRIPTION
The panics will only appear while using a `debug build` of helix, because of `debug_assertions` in helix-tui/src/buffer.rs +217 in `Buffer::index_of`
The panics would occur because `set_style` would draw outside the `surface`. 
Both occurred using `find_prev` or `till_prev`. In my case the first `panic!` would appear
in a terminal with around 80 columns in helix/README.md going to the end of the file
with `geglF(` 
the second with `geglFX`
The off by one fix ensures that `find_nth_prev` starts at the first character to the left. 
Before it started at the second to the left.