### PR TITLE
Separate helix-term as a library

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,6 +1,6 @@
 use helix_view::{document::Mode, Document, Editor, Theme, View};
 
-use crate::{compositor::Compositor, ui, Args};
+use crate::{args::Args, compositor::Compositor, ui};
 
 use log::{error, info};
 

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -1,0 +1,53 @@
+use anyhow::{Error, Result};
+use std::path::PathBuf;
+
+#[derive(Default)]
+pub struct Args {
+    pub display_help: bool,
+    pub display_version: bool,
+    pub verbosity: u64,
+    pub files: Vec<PathBuf>,
+}
+
+impl Args {
+    pub fn parse_args() -> Result<Args> {
+        let mut args = Args::default();
+        let argv: Vec<String> = std::env::args().collect();
+        let mut iter = argv.iter();
+
+        iter.next(); // skip the program, we don't care about that
+
+        while let Some(arg) = iter.next() {
+            match arg.as_str() {
+                "--" => break, // stop parsing at this point treat the remaining as files
+                "--version" => args.display_version = true,
+                "--help" => args.display_help = true,
+                arg if arg.starts_with("--") => {
+                    return Err(Error::msg(format!(
+                        "unexpected double dash argument: {}",
+                        arg
+                    )))
+                }
+                arg if arg.starts_with('-') => {
+                    let arg = arg.get(1..).unwrap().chars();
+                    for chr in arg {
+                        match chr {
+                            'v' => args.verbosity += 1,
+                            'V' => args.display_version = true,
+                            'h' => args.display_help = true,
+                            _ => return Err(Error::msg(format!("unexpected short arg {}", chr))),
+                        }
+                    }
+                }
+                arg => args.files.push(PathBuf::from(arg)),
+            }
+        }
+
+        // push the remaining args, if any to the files
+        for filename in iter {
+            args.files.push(PathBuf::from(filename));
+        }
+
+        Ok(args)
+    }
+}

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -1,0 +1,8 @@
+#![allow(unused)]
+
+pub mod application;
+pub mod args;
+pub mod commands;
+pub mod compositor;
+pub mod keymap;
+pub mod ui;


### PR DESCRIPTION
helix-term stuff will now be documented in rustdoc.

It will be useful for us to generate docs directly in keymap to keep the docs beside code.

![image](https://user-images.githubusercontent.com/4687791/120960093-b96a4e00-c78d-11eb-969b-43b241a83f12.png)
