### PR TITLE
Bump file picker limit

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -85,7 +85,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
         Err(_err) => None,
     });
 
-    const MAX: usize = 2048;
+    const MAX: usize = 8192;
 
     Picker::new(
         files.take(MAX).collect(),


### PR DESCRIPTION
As a quick fix before we decide what to do next in #52, I've bumped the limit.