### PR TITLE
Make matching bracket dimmed, prevent out of bounds rendering

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -334,11 +334,13 @@ impl EditorView {
                         if let Some(pos) = pos {
                             let pos = view.screen_coords_at_pos(doc, text, pos);
                             if let Some(pos) = pos {
-                                // this only prevents panic due to painting selection too far
-                                // TODO: prevent painting when scroll past x or in gutter
-                                // TODO: use a more correct width check
-                                if (pos.col as u16) < viewport.width {
-                                    let style = Style::default().add_modifier(Modifier::REVERSED);
+                                if (pos.col as u16) < viewport.width + view.first_col as u16
+                                    && pos.col >= view.first_col
+                                {
+                                    let style = Style::default()
+                                        .add_modifier(Modifier::REVERSED)
+                                        .add_modifier(Modifier::DIM);
+
                                     surface
                                         .get_mut(
                                             viewport.x + pos.col as u16,


### PR DESCRIPTION
Closes: #156 

![out](https://user-images.githubusercontent.com/46892771/121122448-c20c6400-c821-11eb-9f1c-dd39b1829c6c.gif)
