### PR TITLE
build(nix): use nix-cargo-integration, make shell.nix use flake devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,5 @@
 watch_file shell.nix
-use flake
+watch_file flake.lock
+
+# try to use flakes, if it fails use normal nix (ie. shell.nix)
+use flake || use nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,91 +1,83 @@
 {
   "nodes": {
-    "flake-utils": {
+    "devshell": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1622711433,
+        "narHash": "sha256-rGjXz7FA7HImAT3TtoqwecByLO5yhVPSwPdaYPBFRQw=",
         "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "repo": "devshell",
+        "rev": "1f4fb67b662b65fa7cfe696fc003fcc1e8f7cc36",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "repo": "flake-utils",
+        "repo": "devshell",
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flakeCompat": {
+      "flake": false,
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
     "helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1623200791,
-        "narHash": "sha256-kZKThNh1dBSCnISk9vwbqctk1+U0s8Lzasz/CVytJps=",
+        "lastModified": 1623545930,
+        "narHash": "sha256-14ASoYbxXHU/qPGctiUymb4fMRCoih9c7YujjxqEkdU=",
         "ref": "master",
-        "rev": "b20e4a108cd890afa6cdf83656856fc2157a8e84",
-        "revCount": 789,
+        "rev": "9640ed1425f2db904fb42cd0c54dc6fbc05ca292",
+        "revCount": 821,
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/helix-editor/helix"
+        "url": "https://github.com/helix-editor/helix.git"
       },
       "original": {
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/helix-editor/helix"
+        "url": "https://github.com/helix-editor/helix.git"
       }
     },
-    "naersk": {
+    "nixCargoIntegration": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "devshell": "devshell",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rustOverlay": "rustOverlay"
       },
       "locked": {
-        "lastModified": 1620316130,
-        "narHash": "sha256-sU0VS5oJS1FsHsZsLELAXc7G2eIelVuucRw+q5B1x9k=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "a3f40fe42cc6d267ff7518fa3199e99ff1444ac4",
+        "lastModified": 1623560601,
+        "narHash": "sha256-H1Dq461b2m8v/FxmPphd8pOAx4pPja0UE/xvcMUYwwY=",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "rev": "1238fd751e5d6eb030aee244da9fee6c3ad8b316",
         "type": "github"
       },
       "original": {
-        "owner": "nmattia",
-        "repo": "naersk",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1622059058,
-        "narHash": "sha256-t1/ZMtyxClVSfcV4Pt5C1YpkeJ/UwFF3oitLD7Ch/UA=",
-        "path": "/nix/store/2gam4i1fa1v19k3n5rc9vgvqac1c2xj5-source",
-        "rev": "84aa23742f6c72501f9cc209f29c438766f5352d",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1622194753,
-        "narHash": "sha256-76qtvFp/vFEz46lz5iZMJ0mnsWQYmuGYlb0fHgKqqMg=",
+        "lastModified": 1623324058,
+        "narHash": "sha256-Jm9GUTXdjXz56gWDKy++EpFfjrBaxqXlLvTLfgEi8lo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "540dccb2aeaffa9dc69bfdc41c55abd7ccc6baa3",
+        "rev": "432fc2d9a67f92e05438dff5fdc2b39d33f77997",
         "type": "github"
       },
       "original": {
@@ -95,41 +87,22 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1617325113,
-        "narHash": "sha256-GksR0nvGxfZ79T91UUtWjjccxazv6Yh/MvEJ82v1Xmw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "54c1e44240d8a527a8f4892608c4bce5440c3ecb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flakeCompat": "flakeCompat",
         "helix": "helix",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
+        "nixCargoIntegration": "nixCargoIntegration",
+        "nixpkgs": "nixpkgs"
       }
     },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
-      },
+    "rustOverlay": {
+      "flake": false,
       "locked": {
-        "lastModified": 1622257069,
-        "narHash": "sha256-+QVnS/es9JCRZXphoHL0fOIUhpGqB4/wreBsXWArVck=",
+        "lastModified": 1623550815,
+        "narHash": "sha256-RumRrkE6OTJDndHV4qZNZv8kUGnzwRHZQSyzx29r6/g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8aa5f93c0b665e5357af19c5631a3450bff4aba5",
+        "rev": "9824f142cbd7bc3e2a92eefbb79addfff8704cd3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,54 +3,54 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    naersk.url = "github:nmattia/naersk";
-    helix = {
+    nixCargoIntegration = {
+      url = "github:yusdacra/nix-cargo-integration";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flakeCompat = {
+      url = "github:edolstra/flake-compat";
       flake = false;
-      url = "https://github.com/helix-editor/helix";
+    };
+    helix = {
+      url = "https://github.com/helix-editor/helix.git";
       type = "git";
+      flake = false;
       submodules = true;
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, naersk, rust-overlay, flake-utils, ... }:
-    let
-      rust = pkgs:
-        (pkgs.rustChannelOf {
-          date = "2021-05-01";
-          channel = "nightly";
-        }).minimal; # cargo, rustc and rust-std
-
-      mkNaerskLib = system: pkgs:
-        naersk.lib."${system}".override {
-          # naersk can't build with stable?!
-          # inherit (pkgs.rust-bin.stable.latest) rustc cargo;
-          rustc = rust pkgs;
-          cargo = rust pkgs;
+  outputs = inputs@{ nixCargoIntegration, helix, ... }:
+    nixCargoIntegration.lib.makeOutputs {
+      root = ./.;
+      buildPlatform = "crate2nix";
+      renameOutputs = { "helix-term" = "helix"; };
+      # Set default app to hx (binary is from helix-term release build)
+      # Set default package to helix-term release build
+      defaultOutputs = { app = "hx"; package = "helix"; };
+      overrides = {
+        crateOverrides = common: _: {
+          helix-term = prev: { buildInputs = (prev.buildInputs or [ ]) ++ [ common.cCompiler.cc.lib ]; };
+          # link runtime since helix-core expects it because of embed_runtime feature
+          helix-core = _: { preConfigure = "ln -s ${common.root + "/runtime"} ../runtime"; };
+          # link languages and theme toml files since helix-view expects them
+          helix-view = _: { preConfigure = "ln -s ${common.root}/{languages.toml,theme.toml} .."; };
+          helix-syntax = prev: {
+            src = common.pkgs.runCommand prev.src.name { } ''
+              mkdir -p $out
+              ln -s ${prev.src}/* $out
+              ln -sf ${helix}/helix-syntax/languages $out
+            '';
+          };
         };
-
-      pkg = naerskLib:
-        naerskLib.buildPackage {
-          pname = "helix";
-          root = inputs.helix;
-          cargoBuildOptions = self: self ++ [ ''--features "embed_runtime"'' ];
+        shell = common: prev: {
+          packages = prev.packages ++ (with common.pkgs; [ lld_10 lldb ]);
+          env = prev.env ++ [
+            { name = "HELIX_RUNTIME"; eval = "$PWD/runtime"; }
+            { name = "RUST_BACKTRACE"; value = "1"; }
+            { name = "RUSTFLAGS"; value = "-C link-arg=-fuse-ld=lld -C target-cpu=native"; }
+          ];
         };
-
-    in flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlay ];
-        };
-        naerskLib = mkNaerskLib system pkgs;
-      in rec {
-        packages.helix = pkg naerskLib;
-        defaultPackage = packages.helix;
-        devShell = pkgs.callPackage ./shell.nix { };
-      }) // {
-        overlay = final: prev:
-          let naerskLib = mkNaerskLib prev.system final;
-          in (rust-overlay.overlay final prev) // { helix = pkg naerskLib; };
+        build = _: prev: { rootFeatures = prev.rootFeatures ++ [ "embed_runtime" ]; };
       };
+    };
 }

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.nix]
+build = true
+app = true
 
 [features]
 embed_runtime = ["helix-core/embed_runtime"]

--- a/shell.nix
+++ b/shell.nix
@@ -1,22 +1,6 @@
-{ lib, stdenv, pkgs }:
-
-pkgs.mkShell {
-  nativeBuildInputs = with pkgs; [
-    (rust-bin.stable.latest.default.override { extensions = ["rust-src"]; })
-    lld_10
-    lldb
-    # pythonPackages.six
-    stdenv.cc.cc.lib
-    # pkg-config
-  ];
-  RUSTFLAGS = "-C link-arg=-fuse-ld=lld -C target-cpu=native";
-  RUST_BACKTRACE = "1";
-  # https://github.com/rust-lang/rust/issues/55979
-  LD_LIBRARY_PATH = lib.makeLibraryPath (with pkgs; [
-    stdenv.cc.cc.lib
-  ]);
-
-  shellHook = ''
-    export HELIX_RUNTIME=$PWD/runtime
-  '';
-}
+# Flake's devShell for non-flake-enabled nix instances
+let
+  src = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flakeCompat.locked;
+  compat = fetchTarball { url = "https://github.com/edolstra/flake-compat/archive/${src.rev}.tar.gz"; sha256 = src.narHash; };
+in
+(import compat { src = ./.; }).shellNix.default


### PR DESCRIPTION
This does a few changes:
- use nix-cargo-integration to integrate with cargo instead of own rust expressions
- use crate2nix to build the package instead of naersk (much more cache friendly)
- make the shell.nix file use the flake devshell (thanks to flake-compat)
- use local code, submodules will still be taken from git master branch