### PR TITLE
Fix Shift-Tab for moving upwards in menu

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -166,8 +166,8 @@ impl<T: Item + 'static> Component for Menu<T> {
             }
             // arrow up/ctrl-p/shift-tab prev completion choice (including updating the doc)
             KeyEvent {
-                code: KeyCode::Tab,
-                modifiers: KeyModifiers::SHIFT,
+                code: KeyCode::BackTab,
+                ..
             }
             | KeyEvent {
                 code: KeyCode::Up, ..


### PR DESCRIPTION
`Shift-Tab` wasn't working for moving upwards in the menu.