### PR TITLE
Only enforce limit outside of .git

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -85,10 +85,15 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
         Err(_err) => None,
     });
 
-    const MAX: usize = 8192;
+    let files = if root.join(".git").is_dir() {
+        files.collect()
+    } else {
+        const MAX: usize = 8192;
+        files.take(MAX).collect()
+    };
 
     Picker::new(
-        files.take(MAX).collect(),
+        files,
         move |path: &PathBuf| {
             // format_fn
             path.strip_prefix(&root)


### PR DESCRIPTION
According to the discussion in #171 I've changed how the limit work. It's now only applied if there's no `.git` folder in the project root.