### PR TITLE
Match keybindings of menu

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -151,7 +151,11 @@ impl<T: 'static> Component for Picker<T> {
                 code: KeyCode::Up, ..
             }
             | KeyEvent {
-                code: KeyCode::Char('k'),
+                code: KeyCode::BackTab,
+                ..
+            }
+            | KeyEvent {
+                code: KeyCode::Char('p'),
                 modifiers: KeyModifiers::CONTROL,
             } => self.move_up(),
             KeyEvent {
@@ -159,11 +163,18 @@ impl<T: 'static> Component for Picker<T> {
                 ..
             }
             | KeyEvent {
-                code: KeyCode::Char('j'),
+                code: KeyCode::Tab, ..
+            }
+            | KeyEvent {
+                code: KeyCode::Char('n'),
                 modifiers: KeyModifiers::CONTROL,
             } => self.move_down(),
             KeyEvent {
                 code: KeyCode::Esc, ..
+            }
+            | KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::CONTROL,
             } => {
                 return close_fn;
             }


### PR DESCRIPTION
In preparation of consolidating the picker and menu, I've adjusted the key bindings to match those of menu.

Move down: `Tab`, `Ctrl-n` or `Down`
Move up: `Shift-Tab`, `ctrl-p` or `Up`