### PR TITLE
Fix flake package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .direnv
 helix-term/rustfmt.toml
 helix-syntax/languages/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -30,6 +30,24 @@
         "type": "github"
       }
     },
+    "helix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1623200791,
+        "narHash": "sha256-kZKThNh1dBSCnISk9vwbqctk1+U0s8Lzasz/CVytJps=",
+        "ref": "master",
+        "rev": "b20e4a108cd890afa6cdf83656856fc2157a8e84",
+        "revCount": 789,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/helix-editor/helix"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/helix-editor/helix"
+      }
+    },
     "naersk": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -95,6 +113,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "helix": "helix",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         naerskLib.buildPackage {
           pname = "helix";
           root = inputs.helix;
+          cargoBuildOptions = self: self ++ [ ''--features "embed_runtime"'' ];
         };
 
     in flake-utils.lib.eachDefaultSystem (system:

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,12 @@
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
     naersk.url = "github:nmattia/naersk";
+    helix = {
+      flake = false;
+      url = "https://github.com/helix-editor/helix";
+      type = "git";
+      submodules = true;
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, naersk, rust-overlay, flake-utils, ... }:
@@ -25,7 +31,7 @@
       in rec {
         packages.helix = naerskLib.buildPackage {
           pname = "helix";
-          root = ./.;
+          root = inputs.helix;
         };
         defaultPackage = packages.helix;
         devShell = pkgs.callPackage ./shell.nix {};


### PR DESCRIPTION
This isn't ideal for development, since it pulls Helix from GitHub instead of from the underlying filesystem, but it does get the package working for nix users. As an additional convenience, I also embedded the runtime by default.

Opening as a draft as I'm not sure if this is the direction we want to take here, but unless NixOS/nix#3978 get's a proper solution, this may be the best way to do it for now.

Potentially resolves #27