### PR TITLE
Add filter ability to picker

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -169,3 +169,17 @@ This layer is a kludge of mappings I had under leader key in neovim.
 | s   | Open symbol picker (current document)|
 | w   | Enter window mode |
 | space   | Keep primary selection TODO: it's here because space mode replaced it |
+
+# Picker
+
+Keys to use within picker.
+
+| Key | Description |
+|-----|-------------|
+| up, ctrl-p | Previous entry |
+| down, ctrl-n | Next entry |
+| ctrl-space | Filter options |
+| enter | Open selected |
+| ctrl-h | Open horizontally |
+| ctrl-v | Open vertically |
+| escape, ctrl-c | Close picker |

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -106,6 +106,13 @@ impl Prompt {
         self.exit_selection();
     }
 
+    pub fn clear(&mut self) {
+        self.line.clear();
+        self.cursor = 0;
+        self.completion = (self.completion_fn)(&self.line);
+        self.exit_selection();
+    }
+
     pub fn change_completion_selection(&mut self, direction: CompletionDirection) {
         if self.completion.is_empty() {
             return;


### PR DESCRIPTION
Inspired by doom emacs. Able to filter picker options multiple times using ctrl-space.

[![asciicast](https://asciinema.org/a/hiZcV8V6jnSrGZeWp6ECK56Ha.svg)](https://asciinema.org/a/hiZcV8V6jnSrGZeWp6ECK56Ha)