### PR TITLE
Add ctrl-w for prompt

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -94,6 +94,8 @@ pub use ropey::{Rope, RopeSlice};
 
 pub use tendril::StrTendril as Tendril;
 
+pub use unicode_general_category::get_general_category;
+
 #[doc(inline)]
 pub use {regex, tree_sitter};
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -85,6 +85,27 @@ impl Prompt {
         self.exit_selection();
     }
 
+    pub fn delete_word_backwards(&mut self) {
+        use helix_core::get_general_category;
+        let mut chars = self.line.char_indices().rev();
+        // TODO add skipping whitespace logic here
+        let (mut i, cat) = match chars.next() {
+            Some((i, c)) => (i, get_general_category(c)),
+            None => return,
+        };
+        self.cursor -= 1;
+        for (nn, nc) in chars {
+            if get_general_category(nc) != cat {
+                break;
+            }
+            i = nn;
+            self.cursor -= 1;
+        }
+        self.line.drain(i..);
+        self.completion = (self.completion_fn)(&self.line);
+        self.exit_selection();
+    }
+
     pub fn change_completion_selection(&mut self, direction: CompletionDirection) {
         if self.completion.is_empty() {
             return;
@@ -257,6 +278,10 @@ impl Component for Prompt {
                 code: KeyCode::Char('a'),
                 modifiers: KeyModifiers::CONTROL,
             } => self.move_start(),
+            KeyEvent {
+                code: KeyCode::Char('w'),
+                modifiers: KeyModifiers::CONTROL,
+            } => self.delete_word_backwards(),
             KeyEvent {
                 code: KeyCode::Backspace,
                 modifiers: KeyModifiers::NONE,


### PR DESCRIPTION
Maybe need to update docs but there is none for prompt yet I believe, we also didn't differentiate between prompt and picker so we need to have docs to explain those. I am so used to ctrl-w to delete word in rather than backspace so many times.