### PR TITLE
Per-document indentation style, and indent-style auto-detection.

### DIFF
--- a/helix-core/src/chars.rs
+++ b/helix-core/src/chars.rs
@@ -1,0 +1,41 @@
+/// Determine whether a character is a line break.
+pub fn char_is_linebreak(c: char) -> bool {
+    matches!(
+        c,
+        '\u{000A}' | // LineFeed
+        '\u{000B}' | // VerticalTab
+        '\u{000C}' | // FormFeed
+        '\u{000D}' | // CarriageReturn
+        '\u{0085}' | // NextLine
+        '\u{2028}' | // Line Separator
+        '\u{2029}' // ParagraphSeparator
+    )
+}
+
+/// Determine whether a character qualifies as (non-line-break)
+/// whitespace.
+pub fn char_is_whitespace(c: char) -> bool {
+    // TODO: this is a naive binary categorization of whitespace
+    // characters.  For display, word wrapping, etc. we'll need a better
+    // categorization based on e.g. breaking vs non-breaking spaces
+    // and whether they're zero-width or not.
+    match c {
+        //'\u{1680}' | // Ogham Space Mark (here for completeness, but usually displayed as a dash, not as whitespace)
+        '\u{0009}' | // Character Tabulation
+        '\u{0020}' | // Space
+        '\u{00A0}' | // No-break Space
+        '\u{180E}' | // Mongolian Vowel Separator
+        '\u{202F}' | // Narrow No-break Space
+        '\u{205F}' | // Medium Mathematical Space
+        '\u{3000}' | // Ideographic Space
+        '\u{FEFF}'   // Zero Width No-break Space
+        => true,
+
+        // En Quad, Em Quad, En Space, Em Space, Three-per-em Space,
+        // Four-per-em Space, Six-per-em Space, Figure Space,
+        // Punctuation Space, Thin Space, Hair Space, Zero Width Space.
+        c if ('\u{2000}' ..= '\u{200B}').contains(&c) => true,
+
+        _ => false,
+    }
+}

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 pub mod auto_pairs;
+pub mod chars;
 pub mod comment;
 pub mod diagnostic;
 pub mod graphemes;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -984,14 +984,12 @@ mod cmd {
 
         let style = match args.get(0) {
             Some(arg) if "tabs".starts_with(&arg.to_lowercase()) => Some(Tabs),
-            Some(arg) if arg.len() == 1 => {
-                let ch = arg.chars().next().unwrap();
-                if ('1'..='8').contains(&ch) {
-                    Some(Spaces(ch.to_digit(10).unwrap() as u8))
-                } else {
-                    None
-                }
-            }
+            Some(&"0") => Some(Tabs),
+            Some(arg) => arg
+                .parse::<u8>()
+                .ok()
+                .filter(|n| (1..=8).contains(n))
+                .map(Spaces),
             _ => None,
         };
 
@@ -1166,7 +1164,7 @@ mod cmd {
             completer: None,
         },
         Command {
-            name: "indent_style",
+            name: "indent-style",
             alias: None,
             doc: "Set the indentation style for editing. ('t' for tabs or 1-8 for number of spaces.)",
             fun: set_indent_style,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -9,7 +9,7 @@ use helix_core::{
 };
 
 use helix_view::{
-    document::Mode,
+    document::{IndentStyle, Mode},
     view::{View, PADDING},
     Document, DocumentId, Editor, ViewId,
 };
@@ -979,6 +979,28 @@ mod cmd {
         doc.format(view.id)
     }
 
+    fn set_indent_style(editor: &mut Editor, args: &[&str], event: PromptEvent) {
+        use IndentStyle::*;
+
+        let style = match args.get(0) {
+            Some(arg) if "tabs".starts_with(&arg.to_lowercase()) => Some(Tabs),
+            Some(arg) if arg.len() == 1 => {
+                let ch = arg.chars().next().unwrap();
+                if ('1'..='8').contains(&ch) {
+                    Some(Spaces(ch.to_digit(10).unwrap() as u8))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        if let Some(s) = style {
+            let (_, doc) = editor.current();
+            doc.indent_style = s;
+        }
+    }
+
     fn earlier(editor: &mut Editor, args: &[&str], event: PromptEvent) {
         let uk = match args.join(" ").parse::<helix_core::history::UndoKind>() {
             Ok(uk) => uk,
@@ -1141,6 +1163,13 @@ mod cmd {
             alias: Some("fmt"),
             doc: "Format the file using a formatter.",
             fun: format,
+            completer: None,
+        },
+        Command {
+            name: "indent_style",
+            alias: None,
+            doc: "Set the indentation style for editing. ('t' for tabs or 1-8 for number of spaces.)",
+            fun: set_indent_style,
             completer: None,
         },
         Command {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -500,18 +500,18 @@ impl EditorView {
 
         // Compute the individual info strings.
         let diag_count = format!("{}", doc.diagnostics().len());
-        let indent_info = match doc.indent_style {
-            IndentStyle::Tabs => "tabs",
-            IndentStyle::Spaces(1) => "spaces:1",
-            IndentStyle::Spaces(2) => "spaces:2",
-            IndentStyle::Spaces(3) => "spaces:3",
-            IndentStyle::Spaces(4) => "spaces:4",
-            IndentStyle::Spaces(5) => "spaces:5",
-            IndentStyle::Spaces(6) => "spaces:6",
-            IndentStyle::Spaces(7) => "spaces:7",
-            IndentStyle::Spaces(8) => "spaces:8",
-            _ => "indent:ERROR",
-        };
+        // let indent_info = match doc.indent_style {
+        //     IndentStyle::Tabs => "tabs",
+        //     IndentStyle::Spaces(1) => "spaces:1",
+        //     IndentStyle::Spaces(2) => "spaces:2",
+        //     IndentStyle::Spaces(3) => "spaces:3",
+        //     IndentStyle::Spaces(4) => "spaces:4",
+        //     IndentStyle::Spaces(5) => "spaces:5",
+        //     IndentStyle::Spaces(6) => "spaces:6",
+        //     IndentStyle::Spaces(7) => "spaces:7",
+        //     IndentStyle::Spaces(8) => "spaces:8",
+        //     _ => "indent:ERROR",
+        // };
         let position_info = {
             let pos = coords_at_pos(doc.text().slice(..), doc.selection(view.id).cursor());
             format!("{}:{}", pos.row + 1, pos.col + 1) // convert to 1-indexing
@@ -519,9 +519,9 @@ impl EditorView {
 
         // Render them to the status line together.
         let right_side_text = format!(
-            "{}  {}  {} ",
+            "{}    {} ",
             &diag_count[..diag_count.len().min(4)],
-            indent_info,
+            // indent_info,
             position_info
         );
         let text_len = right_side_text.len() as u16;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -501,7 +501,7 @@ impl EditorView {
         // Compute the individual info strings.
         let diag_count = format!("{}", doc.diagnostics().len());
         let indent_info = match doc.indent_style {
-            IndentStyle::Tabs => "tab",
+            IndentStyle::Tabs => "tabs",
             IndentStyle::Spaces(1) => "spaces:1",
             IndentStyle::Spaces(2) => "spaces:2",
             IndentStyle::Spaces(3) => "spaces:3",

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -11,7 +11,10 @@ use helix_core::{
     syntax::{self, HighlightEvent},
     Position, Range,
 };
-use helix_view::{document::Mode, Document, Editor, Theme, View};
+use helix_view::{
+    document::{IndentStyle, Mode},
+    Document, Editor, Theme, View,
+};
 use std::borrow::Cow;
 
 use crossterm::{
@@ -455,6 +458,10 @@ impl EditorView {
         theme: &Theme,
         is_focused: bool,
     ) {
+        //-------------------------------
+        // Left side of the status line.
+        //-------------------------------
+
         let mode = match doc.mode() {
             Mode::Insert => "INS",
             Mode::Select => "SEL",
@@ -487,24 +494,41 @@ impl EditorView {
             );
         }
 
-        surface.set_stringn(
-            viewport.x + viewport.width.saturating_sub(15),
-            viewport.y,
-            format!("{}", doc.diagnostics().len()),
-            4,
-            text_color,
+        //-------------------------------
+        // Right side of the status line.
+        //-------------------------------
+
+        // Compute the individual info strings.
+        let diag_count = format!("{}", doc.diagnostics().len());
+        let indent_info = match doc.indent_style {
+            IndentStyle::Tabs => "tab",
+            IndentStyle::Spaces(1) => "spaces:1",
+            IndentStyle::Spaces(2) => "spaces:2",
+            IndentStyle::Spaces(3) => "spaces:3",
+            IndentStyle::Spaces(4) => "spaces:4",
+            IndentStyle::Spaces(5) => "spaces:5",
+            IndentStyle::Spaces(6) => "spaces:6",
+            IndentStyle::Spaces(7) => "spaces:7",
+            IndentStyle::Spaces(8) => "spaces:8",
+            _ => "indent:ERROR",
+        };
+        let position_info = {
+            let pos = coords_at_pos(doc.text().slice(..), doc.selection(view.id).cursor());
+            format!("{}:{}", pos.row + 1, pos.col + 1) // convert to 1-indexing
+        };
+
+        // Render them to the status line together.
+        let right_side_text = format!(
+            "{}  {}  {} ",
+            &diag_count[..diag_count.len().min(4)],
+            indent_info,
+            position_info
         );
-
-        // render line:col
-        let pos = coords_at_pos(doc.text().slice(..), doc.selection(view.id).cursor());
-
-        let text = format!("{}:{}", pos.row + 1, pos.col + 1); // convert to 1-indexing
-        let len = text.len();
-
+        let text_len = right_side_text.len() as u16;
         surface.set_string(
-            viewport.x + viewport.width.saturating_sub(len as u16 + 1),
+            viewport.x + viewport.width.saturating_sub(text_len),
             viewport.y,
-            text,
+            right_side_text,
             text_color,
         );
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -32,13 +32,15 @@ pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
     pub(crate) selections: HashMap<ViewId, Selection>,
-    pub(crate) indent_style: IndentStyle,
 
     path: Option<PathBuf>,
 
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+
+    /// Current indent style.
+    pub indent_style: IndentStyle,
 
     syntax: Option<Syntax>,
     // /// Corresponding language scope name. Usually `source.<lang>`.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -280,18 +280,16 @@ impl Document {
         // TODO: this is probably a generally useful utility function.  Where
         // should we put it?
         fn char_is_linebreak(c: char) -> bool {
-            match c {
-                '\u{000A}' | // LineFeed
-                '\u{000B}' | // VerticalTab
-                '\u{000C}' | // FormFeed
-                '\u{000D}' | // CarriageReturn
-                '\u{0085}' | // NextLine
-                '\u{2028}' | // Line Separator
-                '\u{2029}'   // ParagraphSeparator
-                => true,
-
-                _ => false,
-            }
+            [
+                '\u{000A}', // LineFeed
+                '\u{000B}', // VerticalTab
+                '\u{000C}', // FormFeed
+                '\u{000D}', // CarriageReturn
+                '\u{0085}', // NextLine
+                '\u{2028}', // Line Separator
+                '\u{2029}', // ParagraphSeparator
+            ]
+            .contains(&c)
         }
 
         // Determine whether a character qualifies as (non-line-break)
@@ -320,7 +318,7 @@ impl Document {
                 // En Quad, Em Quad, En Space, Em Space, Three-per-em Space,
                 // Four-per-em Space, Six-per-em Space, Figure Space,
                 // Punctuation Space, Thin Space, Hair Space, Zero Width Space.
-                c if c >= '\u{2000}' && c <= '\u{200B}' => true,
+                c if ('\u{2000}' ..= '\u{200B}').contains(&c) => true,
 
                 _ => false,
             }
@@ -436,7 +434,7 @@ impl Document {
                 .and_then(|config| config.indent.as_ref())
                 .map_or("  ", |config| config.unit.as_str()); // fallback to 2 spaces
 
-            self.indent_style = if indent.starts_with(" ") {
+            self.indent_style = if indent.starts_with(' ') {
                 IndentStyle::Spaces(indent.len() as u8)
             } else {
                 IndentStyle::Tabs


### PR DESCRIPTION
- Move the primary indentation-style setting into `Document`.
- Attempt to auto-detect the indentation style of a document when first loading it, but fall back to a language-based default when confidence is too low.
- Add a command to manually set a document's indentation style.