### PR TITLE
Theme key to change highlight of selected line numbers

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -70,6 +70,7 @@ Possible keys:
 | `module`                |                                     |
 | `ui.background`         |                                     |
 | `ui.linenr`             |                                     |
+| `ui.linenr.selected`    | For lines with cursors              |
 | `ui.statusline`         |                                     |
 | `ui.popup`              |                                     |
 | `ui.window`             |                                     |

--- a/contrib/themes/bogster.toml
+++ b/contrib/themes/bogster.toml
@@ -30,6 +30,7 @@
 
 "ui.background" = { bg = "#161c23" }
 "ui.linenr" = { fg = "#415367" }
+"ui.linenr.selected" = { fg = "#e5ded6" }  # TODO
 "ui.statusline" = { bg = "#232d38" }
 "ui.popup" = { bg = "#232d38" }
 "ui.window" = { bg = "#232d38" }

--- a/contrib/themes/ingrid.toml
+++ b/contrib/themes/ingrid.toml
@@ -30,6 +30,7 @@
 
 "ui.background" = { bg = "#FFFCFD" }
 "ui.linenr" = { fg = "#bbbbbb" }
+"ui.linenr.selected" = { fg = "#F3EAE9" }  # TODO
 "ui.statusline" = { bg = "#F3EAE9" }
 "ui.popup" = { bg = "#F3EAE9" }
 "ui.window" = { bg = "#D8B8B3" }

--- a/contrib/themes/onedark.toml
+++ b/contrib/themes/onedark.toml
@@ -33,6 +33,7 @@
 "ui.background" = { fg = "#ABB2BF", bg = "#282C34" }
 "ui.help" = { bg = "#3E4452" }
 "ui.linenr" = { fg = "#4B5263", modifiers = ['dim'] }
+"ui.linenr.selected" = { fg = "#ABB2BF" }
 "ui.popup" = { bg = "#3E4452" }
 "ui.statusline" = { fg = "#ABB2BF", bg = "#2C323C" }
 "ui.selection" = { bg = "#3E4452" }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -200,10 +200,12 @@ fn parse_modifier(value: &Value) -> Option<Modifier> {
 
 impl Theme {
     pub fn get(&self, scope: &str) -> Style {
-        self.styles
-            .get(scope)
-            .copied()
+        self.try_get(scope)
             .unwrap_or_else(|| Style::default().fg(Color::Rgb(0, 0, 255)))
+    }
+
+    pub fn try_get(&self, scope: &str) -> Option<Style> {
+        self.styles.get(scope).copied()
     }
 
     #[inline]

--- a/theme.toml
+++ b/theme.toml
@@ -40,6 +40,7 @@
 
 "ui.background" = { bg = "#3b224c" } # midnight
 "ui.linenr" = { fg = "#5a5977" } # comet
+"ui.linenr.selected" = { fg = "#dbbfef" } # lilac
 "ui.statusline" = { bg = "#281733" } # revolver
 "ui.popup" = { bg = "#281733" } # revolver
 "ui.window" = { bg = "#452859" } # bossa nova


### PR DESCRIPTION
Adds `ui.linenr.selected` which controls highlight of line numbers which have cursors on them. Selections are now rendered before the gutter to accommodate this change (is this important ?).

![Screenshot_2021-06-14_20-01-14](https://user-images.githubusercontent.com/23398472/121909214-565b5700-cd4b-11eb-9882-333746f2df20.png)

TODO:
- [x] Update documentation
- [x] Change `contrib/` theme files to include new key