### PR TITLE
First attempt at sync formatting.

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -182,6 +182,22 @@ pub mod util {
             }),
         )
     }
+
+    /// The result of asking the language server to format the document. This can be turned into a
+    /// `Transaction`, but the advantage of not doing that straight away is that this one is
+    /// `Send` and `Sync`.
+    #[derive(Clone, Debug)]
+    pub struct LspFormatting {
+        pub doc: Rope,
+        pub edits: Vec<lsp::TextEdit>,
+        pub offset_encoding: OffsetEncoding,
+    }
+
+    impl From<LspFormatting> for Transaction {
+        fn from(fmt: LspFormatting) -> Transaction {
+            generate_transaction_from_edits(&fmt.doc, fmt.edits, fmt.offset_encoding)
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -167,7 +167,7 @@ impl Application {
                     }
                     self.render();
                 }
-                Some(callback) = self.jobs.next() => {
+                Some(callback) = self.jobs.next_job() => {
                     self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
                     self.render();
                 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -6,6 +6,7 @@ use crate::{
     args::Args,
     compositor::Compositor,
     config::Config,
+    job::Jobs,
     keymap::Keymaps,
     ui::{self, Spinner},
 };
@@ -31,13 +32,6 @@ use crossterm::{
 
 use futures_util::{future, stream::FuturesUnordered};
 
-type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-pub type LspCallback =
-    BoxFuture<Result<Box<dyn FnOnce(&mut Editor, &mut Compositor) + Send>, anyhow::Error>>;
-
-pub type LspCallbacks = FuturesUnordered<LspCallback>;
-pub type LspCallbackWrapper = Box<dyn FnOnce(&mut Editor, &mut Compositor) + Send>;
-
 pub struct Application {
     compositor: Compositor,
     editor: Editor,
@@ -48,7 +42,7 @@ pub struct Application {
     theme_loader: Arc<theme::Loader>,
     syn_loader: Arc<syntax::Loader>,
 
-    callbacks: LspCallbacks,
+    jobs: Jobs,
     lsp_progress: LspProgressMap,
 }
 
@@ -120,7 +114,7 @@ impl Application {
             theme_loader,
             syn_loader,
 
-            callbacks: FuturesUnordered::new(),
+            jobs: Jobs::new(),
             lsp_progress: LspProgressMap::new(),
         };
 
@@ -130,11 +124,11 @@ impl Application {
     fn render(&mut self) {
         let editor = &mut self.editor;
         let compositor = &mut self.compositor;
-        let callbacks = &mut self.callbacks;
+        let jobs = &mut self.jobs;
 
         let mut cx = crate::compositor::Context {
             editor,
-            callbacks,
+            jobs,
             scroll: None,
         };
 
@@ -148,6 +142,7 @@ impl Application {
 
         loop {
             if self.editor.should_close() {
+                self.jobs.finish();
                 break;
             }
 
@@ -172,27 +167,18 @@ impl Application {
                     }
                     self.render();
                 }
-                Some(callback) = &mut self.callbacks.next() => {
-                    self.handle_language_server_callback(callback)
+                Some(callback) = self.jobs.next() => {
+                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
+                    self.render();
                 }
             }
-        }
-    }
-    pub fn handle_language_server_callback(
-        &mut self,
-        callback: Result<LspCallbackWrapper, anyhow::Error>,
-    ) {
-        if let Ok(callback) = callback {
-            // TODO: handle Err()
-            callback(&mut self.editor, &mut self.compositor);
-            self.render();
         }
     }
 
     pub fn handle_terminal_events(&mut self, event: Option<Result<Event, crossterm::ErrorKind>>) {
         let mut cx = crate::compositor::Context {
             editor: &mut self.editor,
-            callbacks: &mut self.callbacks,
+            jobs: &mut self.jobs,
             scroll: None,
         };
         // Handle key events

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -35,8 +35,8 @@ use crate::{
     ui::{self, Completion, Picker, Popup, Prompt, PromptEvent},
 };
 
-use crate::application::{LspCallback, LspCallbackWrapper, LspCallbacks};
-use futures_util::FutureExt;
+use crate::job::{self, Job, JobFuture, Jobs};
+use futures_util::{FutureExt, TryFutureExt};
 use std::{fmt, future::Future, path::Display, str::FromStr};
 
 use std::{
@@ -54,7 +54,7 @@ pub struct Context<'a> {
 
     pub callback: Option<crate::compositor::Callback>,
     pub on_next_key_callback: Option<Box<dyn FnOnce(&mut Context, KeyEvent)>>,
-    pub callbacks: &'a mut LspCallbacks,
+    pub jobs: &'a mut Jobs,
 }
 
 impl<'a> Context<'a> {
@@ -85,13 +85,13 @@ impl<'a> Context<'a> {
         let callback = Box::pin(async move {
             let json = call.await?;
             let response = serde_json::from_value(json)?;
-            let call: LspCallbackWrapper =
+            let call: job::Callback =
                 Box::new(move |editor: &mut Editor, compositor: &mut Compositor| {
                     callback(editor, compositor, response)
                 });
             Ok(call)
         });
-        self.callbacks.push(callback);
+        self.jobs.callback(callback);
     }
 
     /// Returns 1 if no explicit count was provided
@@ -1110,7 +1110,7 @@ mod cmd {
         path: Option<P>,
     ) -> Result<tokio::task::JoinHandle<Result<(), anyhow::Error>>, anyhow::Error> {
         use anyhow::anyhow;
-        let callbacks = &mut cx.callbacks;
+        let jobs = &mut cx.jobs;
         let (view, doc) = current!(cx.editor);
 
         if let Some(path) = path {
@@ -1129,7 +1129,7 @@ mod cmd {
             doc.format().map(|fmt| {
                 let shared = fmt.shared();
                 let callback = make_format_callback(doc.id(), doc.version(), true, shared.clone());
-                callbacks.push(callback);
+                jobs.callback(callback);
                 shared
             })
         } else {
@@ -1139,8 +1139,12 @@ mod cmd {
     }
 
     fn write(cx: &mut compositor::Context, args: &[&str], event: PromptEvent) {
-        if let Err(e) = write_impl(cx, args.first()) {
-            cx.editor.set_error(e.to_string());
+        match write_impl(cx, args.first()) {
+            Err(e) => cx.editor.set_error(e.to_string()),
+            Ok(handle) => {
+                cx.jobs
+                    .add(Job::new(handle.unwrap_or_else(|e| Err(e.into()))).wait_before_exiting());
+            }
         };
     }
 
@@ -1153,7 +1157,7 @@ mod cmd {
 
         if let Some(format) = doc.format() {
             let callback = make_format_callback(doc.id(), doc.version(), false, format);
-            cx.callbacks.push(callback);
+            cx.jobs.callback(callback);
         }
     }
 
@@ -1879,10 +1883,10 @@ fn make_format_callback(
     doc_version: i32,
     set_unmodified: bool,
     format: impl Future<Output = helix_lsp::util::LspFormatting> + Send + 'static,
-) -> LspCallback {
-    Box::pin(async move {
+) -> impl Future<Output = anyhow::Result<job::Callback>> {
+    async move {
         let format = format.await;
-        let call: LspCallbackWrapper =
+        let call: job::Callback =
             Box::new(move |editor: &mut Editor, compositor: &mut Compositor| {
                 let view_id = view!(editor).id;
                 if let Some(doc) = editor.document_mut(doc_id) {
@@ -1898,7 +1902,7 @@ fn make_format_callback(
                 }
             });
         Ok(call)
-    })
+    }
 }
 
 enum Open {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1123,7 +1123,12 @@ mod cmd {
         }
         let fmt = doc.auto_format().map(|fmt| {
             let shared = fmt.shared();
-            let callback = make_format_callback(doc.id(), doc.version(), true, shared.clone());
+            let callback = make_format_callback(
+                doc.id(),
+                doc.version(),
+                Modified::SetUnmodified,
+                shared.clone(),
+            );
             jobs.callback(callback);
             shared
         });
@@ -1148,7 +1153,8 @@ mod cmd {
         let (_, doc) = current!(cx.editor);
 
         if let Some(format) = doc.format() {
-            let callback = make_format_callback(doc.id(), doc.version(), false, format);
+            let callback =
+                make_format_callback(doc.id(), doc.version(), Modified::LeaveModified, format);
             cx.jobs.callback(callback);
         }
     }
@@ -1868,6 +1874,13 @@ fn append_to_line(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
+/// Sometimes when applying formatting changes we want to mark the buffer as unmodified, for
+/// example because we just applied the same changes while saving.
+enum Modified {
+    SetUnmodified,
+    LeaveModified,
+}
+
 // Creates an LspCallback that waits for formatting changes to be computed. When they're done,
 // it applies them, but only if the doc hasn't changed.
 //
@@ -1876,7 +1889,7 @@ fn append_to_line(cx: &mut Context) {
 async fn make_format_callback(
     doc_id: DocumentId,
     doc_version: i32,
-    set_unmodified: bool,
+    modified: Modified,
     format: impl Future<Output = helix_lsp::util::LspFormatting> + Send + 'static,
 ) -> anyhow::Result<job::Callback> {
     let format = format.await;
@@ -1886,7 +1899,7 @@ async fn make_format_callback(
             if doc.version() == doc_version {
                 doc.apply(&Transaction::from(format), view_id);
                 doc.append_changes_to_history(view_id);
-                if set_unmodified {
+                if let Modified::SetUnmodified = modified {
                     doc.reset_modified();
                 }
             } else {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1121,20 +1121,12 @@ mod cmd {
         if doc.path().is_none() {
             return Err(anyhow!("cannot write a buffer without a filename"));
         }
-        let autofmt = doc
-            .language_config()
-            .map(|config| config.auto_format)
-            .unwrap_or_default();
-        let fmt = if autofmt {
-            doc.format().map(|fmt| {
-                let shared = fmt.shared();
-                let callback = make_format_callback(doc.id(), doc.version(), true, shared.clone());
-                jobs.callback(callback);
-                shared
-            })
-        } else {
-            None
-        };
+        let fmt = doc.auto_format().map(|fmt| {
+            let shared = fmt.shared();
+            let callback = make_format_callback(doc.id(), doc.version(), true, shared.clone());
+            jobs.callback(callback);
+            shared
+        });
         Ok(tokio::spawn(doc.format_and_save(fmt)))
     }
 
@@ -1878,6 +1870,9 @@ fn append_to_line(cx: &mut Context) {
 
 // Creates an LspCallback that waits for formatting changes to be computed. When they're done,
 // it applies them, but only if the doc hasn't changed.
+//
+// TODO: provide some way to cancel this, probably as part of a more general job cancellation
+// scheme
 async fn make_format_callback(
     doc_id: DocumentId,
     doc_version: i32,

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -26,12 +26,12 @@ pub enum EventResult {
 
 use helix_view::Editor;
 
-use crate::application::LspCallbacks;
+use crate::job::Jobs;
 
 pub struct Context<'a> {
     pub editor: &'a mut Editor,
     pub scroll: Option<usize>,
-    pub callbacks: &'a mut LspCallbacks,
+    pub jobs: &'a mut Jobs,
 }
 
 pub trait Component: Any + AnyComponent {

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -1,0 +1,100 @@
+use helix_view::Editor;
+
+use crate::compositor::Compositor;
+
+use futures_util::future::{self, BoxFuture, Future, FutureExt};
+use futures_util::stream::{self, FuturesUnordered, Select, StreamExt};
+
+pub type Callback = Box<dyn FnOnce(&mut Editor, &mut Compositor) + Send>;
+pub type JobFuture = BoxFuture<'static, anyhow::Result<Option<Callback>>>;
+
+pub struct Job {
+    pub future: BoxFuture<'static, anyhow::Result<Option<Callback>>>,
+    /// Do we need to wait for this job to finish before exiting?
+    pub wait: bool,
+}
+
+#[derive(Default)]
+pub struct Jobs {
+    futures: FuturesUnordered<JobFuture>,
+    /// These are the ones that need to complete before we exit.
+    wait_futures: FuturesUnordered<JobFuture>,
+}
+
+impl Job {
+    pub fn new<F: Future<Output = anyhow::Result<()>> + Send + 'static>(f: F) -> Job {
+        Job {
+            future: f.map(|r| r.map(|()| None)).boxed(),
+            wait: false,
+        }
+    }
+
+    pub fn with_callback<F: Future<Output = anyhow::Result<Callback>> + Send + 'static>(
+        f: F,
+    ) -> Job {
+        Job {
+            future: f.map(|r| r.map(|x| Some(x))).boxed(),
+            wait: false,
+        }
+    }
+
+    pub fn wait_before_exiting(mut self) -> Job {
+        self.wait = true;
+        self
+    }
+}
+
+impl Jobs {
+    pub fn new() -> Jobs {
+        Jobs::default()
+    }
+
+    pub fn spawn<F: Future<Output = anyhow::Result<()>> + Send + 'static>(&mut self, f: F) {
+        self.add(Job::new(f));
+    }
+
+    pub fn callback<F: Future<Output = anyhow::Result<Callback>> + Send + 'static>(
+        &mut self,
+        f: F,
+    ) {
+        self.add(Job::with_callback(f));
+    }
+
+    pub fn handle_callback(
+        &mut self,
+        editor: &mut Editor,
+        compositor: &mut Compositor,
+        call: anyhow::Result<Option<Callback>>,
+    ) {
+        match call {
+            Ok(None) => {}
+            Ok(Some(call)) => {
+                call(editor, compositor);
+            }
+            Err(e) => {
+                editor.set_error(format!("Async job failed: {}", e));
+            }
+        }
+    }
+
+    pub fn next<'a>(
+        &'a mut self,
+    ) -> impl Future<Output = Option<anyhow::Result<Option<Callback>>>> + 'a {
+        future::select(self.futures.next(), self.wait_futures.next())
+            .map(|either| either.factor_first().0)
+    }
+
+    pub fn add(&mut self, j: Job) {
+        if j.wait {
+            self.wait_futures.push(j.future);
+        } else {
+            self.futures.push(j.future);
+        }
+    }
+
+    /// Blocks until all the jobs that need to be waited on are done.
+    pub fn finish(&mut self) {
+        let wait_futures = std::mem::take(&mut self.wait_futures);
+        helix_lsp::block_on(wait_futures.for_each(|_| future::ready(())));
+    }
+}

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -33,7 +33,7 @@ impl Job {
         f: F,
     ) -> Job {
         Job {
-            future: f.map(|r| r.map(|x| Some(x))).boxed(),
+            future: f.map(|r| r.map(Some)).boxed(),
             wait: false,
         }
     }
@@ -77,9 +77,9 @@ impl Jobs {
         }
     }
 
-    pub fn next<'a>(
-        &'a mut self,
-    ) -> impl Future<Output = Option<anyhow::Result<Option<Callback>>>> + 'a {
+    pub fn next_job(
+        &mut self,
+    ) -> impl Future<Output = Option<anyhow::Result<Option<Callback>>>> + '_ {
         future::select(self.futures.next(), self.wait_futures.next())
             .map(|either| either.factor_first().0)
     }

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -8,5 +8,6 @@ pub mod args;
 pub mod commands;
 pub mod compositor;
 pub mod config;
+pub mod job;
 pub mod keymap;
 pub mod ui;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -621,7 +621,7 @@ impl Component for EditorView {
                     count: None,
                     callback: None,
                     on_next_key_callback: None,
-                    callbacks: cx.callbacks,
+                    jobs: cx.jobs,
                 };
 
                 if let Some(on_next_key) = self.on_next_key.take() {
@@ -639,7 +639,7 @@ impl Component for EditorView {
                                 // use a fake context here
                                 let mut cx = Context {
                                     editor: cxt.editor,
-                                    callbacks: cxt.callbacks,
+                                    jobs: cxt.jobs,
                                     scroll: None,
                                 };
                                 let res = completion.handle_event(event, &mut cx);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -473,6 +473,18 @@ impl Document {
         Ok(doc)
     }
 
+    /// The same as [`format`], but only returns formatting changes if auto-formatting
+    /// is configured.
+    pub fn auto_format(&self) -> Option<impl Future<Output = LspFormatting> + 'static> {
+        if self.language_config().map(|c| c.auto_format) == Some(true) {
+            self.format()
+        } else {
+            None
+        }
+    }
+
+    /// If supported, returns the changes that should be applied to this document in order
+    /// to format it nicely.
     pub fn format(&self) -> Option<impl Future<Output = LspFormatting> + 'static> {
         if let Some(language_server) = self.language_server.clone() {
             let text = self.text.clone();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -270,6 +270,10 @@ impl Editor {
         self.documents.get(id)
     }
 
+    pub fn document_mut(&mut self, id: DocumentId) -> Option<&mut Document> {
+        self.documents.get_mut(id)
+    }
+
     pub fn documents(&self) -> impl Iterator<Item = &Document> {
         self.documents.iter().map(|(_id, doc)| doc)
     }


### PR DESCRIPTION
This is a first stab at #53. 

There are definitely some rough edges still:
- I wanted commands to be able to provide `LspCallback`s, so I made them take a `compositor::Context` instead of an `Editor`. I don't know whether that's reasonable.
- I'm not sure if I'm keeping the language-server's changes in sync correctly
- `Transaction` isn't `Sync`, so lots of `Arc<Mutex<>>`...