### PR TITLE
lsp: Gracefully shutdown language servers, fix unwraps in transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "futures-util",
  "helix-core",
  "helix-lsp",
  "helix-tui",

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -272,6 +272,21 @@ impl Client {
         self.notify::<lsp::notification::Exit>(())
     }
 
+    /// Tries to shut down the language server but returns
+    /// early if server responds with an error.
+    pub async fn shutdown_and_exit(&self) -> Result<()> {
+        self.shutdown().await?;
+        self.exit().await
+    }
+
+    /// Forcefully shuts down the language server ignoring any errors.
+    pub async fn force_shutdown(&self) -> Result<()> {
+        if let Err(e) = self.shutdown().await {
+            log::warn!("language server failed to terminate gracefully - {}", e);
+        }
+        self.exit().await
+    }
+
     // -------------------------------------------------------------------------------------------
     // Text document
     // -------------------------------------------------------------------------------------------

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -310,6 +310,10 @@ impl Registry {
             Err(Error::LspNotDefined)
         }
     }
+
+    pub fn iter_clients(&self) -> impl Iterator<Item = &Arc<Client>> {
+        self.inner.values().map(|(_, client)| client)
+    }
 }
 
 #[derive(Debug)]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -406,16 +406,7 @@ impl Application {
 
         self.event_loop().await;
 
-        tokio::time::timeout(
-            Duration::from_millis(500),
-            future::join_all(
-                self.editor
-                    .language_servers
-                    .iter_clients()
-                    .map(|client| client.force_shutdown()),
-            ),
-        )
-        .await;
+        self.editor.close_language_servers(None).await;
 
         // reset cursor shape
         write!(stdout, "\x1B[2 q");

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.8"
 url = "2"
 
 tokio = { version = "1", features = ["full"] }
+futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 
 slotmap = "1"
 


### PR DESCRIPTION
Closes: #266 
Closes: #33 
Maybe closes?: #278

Tested with clangd and it correctly removes the `preamble...` file from `/tmp` on close.