### PR TITLE
Don't derive `Default` for `GlobalConfig`

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -5,9 +5,14 @@ use serde::{de::Error as SerdeError, Deserialize, Serialize};
 
 use crate::keymap::{parse_keymaps, Keymaps};
 
-#[derive(Default)]
 pub struct GlobalConfig {
     pub lsp_progress: bool,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self { lsp_progress: true }
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
As @pickfire noticed, we shouldn't derive `Default` because `lsp_progress` by default should be turned on (opt out).