### PR TITLE
Cargo manifests cleanup

### DIFF
--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.2.0"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+description = "Helix editor core editing primitives"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 
 [features]
 embed_runtime = ["rust-embed"]

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+include = ["src/**/*", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 embed_runtime = ["rust-embed"]
 
 [dependencies]
-helix-syntax = { path = "../helix-syntax" }
+helix-syntax = { version = "0.2", path = "../helix-syntax" }
 
 ropey = "1.2"
 smallvec = "1.4"

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-helix-core = { path = "../helix-core" }
+helix-core = { version = "0.2", path = "../helix-core" }
 
 anyhow = "1.0"
 futures-executor = "0.3"

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.2.0"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+description = "LSP client implementation for Helix project"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/helix-syntax/Cargo.toml
+++ b/helix-syntax/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.2.0"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Tree-sitter grammars support"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
+include = ["src/**/*", "languages/**/*", "build.rs", "!**/docs/**/*", "!**/test/**/*", "!**/examples/**/*", "!**/build/**/*"]
 
 [dependencies]
 tree-sitter = "0.19"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -5,6 +5,9 @@ description = "A post-modern text editor."
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+categories = ["editor", "command-line-utilities"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 
 [package.metadata.nix]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -18,9 +18,9 @@ name = "hx"
 path = "src/main.rs"
 
 [dependencies]
-helix-core = { path = "../helix-core" }
-helix-view = { path = "../helix-view", features = ["term"]}
-helix-lsp = { path = "../helix-lsp"}
+helix-core = { version = "0.2", path = "../helix-core" }
+helix-view = { version = "0.2", path = "../helix-view", features = ["term"]}
+helix-lsp = { version = "0.2", path = "../helix-lsp"}
 
 anyhow = "1"
 once_cell = "1.8"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -5,6 +5,7 @@ description = "A post-modern text editor."
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+include = ["src/**/*", "README.md"]
 
 [package.metadata.nix]
 build = true

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -7,6 +7,9 @@ A library to build rich terminal user interfaces or dashboards
 """
 edition = "2018"
 license = "MPL-2.0"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 
 [features]

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -7,6 +7,7 @@ A library to build rich terminal user interfaces or dashboards
 """
 edition = "2018"
 license = "MPL-2.0"
+include = ["src/**/*", "README.md"]
 
 [features]
 default = ["crossterm"]

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -13,8 +13,8 @@ default = ["term"]
 
 [dependencies]
 anyhow = "1"
-helix-core = { path = "../helix-core" }
-helix-lsp = { path = "../helix-lsp"}
+helix-core = { version = "0.2", path = "../helix-core" }
+helix-lsp = { version = "0.2", path = "../helix-lsp"}
 
 # Conversion traits
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"], optional = true }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.2.0"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 edition = "2018"
 license = "MPL-2.0"
+description = "UI abstractions for use in backends"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
~~This enables us to publish on crates.io~~
This is a first step towards enabling us to publish on crates.io.

I also ran [cargo-diet](https://github.com/the-lean-crate/cargo-diet), a helper for computing the optimal `include` directives for Cargo.toml manifests.

See #42