### PR TITLE
Reuse status buffer

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Severity {
     Error,
     Warning,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -613,7 +613,7 @@ impl Component for EditorView {
             Event::Key(mut key) => {
                 canonicalize_key(&mut key);
                 // clear status
-                cx.editor.status_msg = None;
+                cx.editor.clear_status();
 
                 let (view, doc) = current!(cx.editor);
                 let mode = doc.mode();
@@ -726,7 +726,7 @@ impl Component for EditorView {
         }
 
         // render status msg
-        if let Some((status_msg, severity)) = &cx.editor.status_msg {
+        if let Some((message, severity)) = &cx.editor.status() {
             use helix_view::editor::Severity;
             let style = if *severity == Severity::Error {
                 cx.editor.theme.get("error")
@@ -737,7 +737,7 @@ impl Component for EditorView {
             surface.set_string(
                 area.x,
                 area.y + area.height.saturating_sub(1),
-                status_msg,
+                message,
                 style,
             );
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -22,7 +22,12 @@ pub struct Editor {
     pub theme: Theme,
     pub language_servers: helix_lsp::Registry,
 
-    pub status_msg: Option<(String, Severity)>,
+    // TODO we might want to limit severity to only info and error
+    // since we only use those two
+    /// Status message, always have to check severity even if it is empty.
+    status: String,
+    /// If Some means status should be shown, with severity level.
+    severity: Option<Severity>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -67,20 +72,34 @@ impl Editor {
             theme,
             language_servers,
             registers: Registers::default(),
-            status_msg: None,
+            status: String::new(),
+            severity: None,
         }
     }
 
+    /// Get status message and severity.
+    pub fn status(&self) -> Option<(&str, Severity)> {
+        self.severity.map(|level| (self.status.as_str(), level))
+    }
+
+    /// Clear status.
     pub fn clear_status(&mut self) {
-        self.status_msg = None;
+        self.status.clear();
+        self.severity = None;
     }
 
-    pub fn set_status(&mut self, status: String) {
-        self.status_msg = Some((status, Severity::Info));
+    /// Get mutable status with severity info.
+    pub fn status_mut(&mut self) -> &mut String {
+        self.status.clear();
+        self.severity = Some(Severity::Info);
+        &mut self.status
     }
 
-    pub fn set_error(&mut self, error: String) {
-        self.status_msg = Some((error, Severity::Error));
+    /// Get mutable status with severity error.
+    pub fn error_mut(&mut self) -> &mut String {
+        self.status.clear();
+        self.severity = Some(Severity::Error);
+        &mut self.status
     }
 
     fn _refresh(&mut self) {


### PR DESCRIPTION
Seemed painful for the editor to keep allocating and disallocating the
status when rust-analyzer is spamming at a speed of ~100/s maybe.

Note that some parts especially the error parts still allocates rather than writing directly to the status string buffer but those are less frequently shown compared to rust-analyzer progress spam, so I guess it's fine for now.

cc @wojciechkepka 