### PR TITLE
Add system clipboard yank and paste commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "etcetera"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +366,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -1062,6 +1069,16 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -171,6 +171,11 @@ This layer is a kludge of mappings I had under leader key in neovim.
 | `s`     | Open symbol picker (current document)                                 |
 | `w`     | Enter [window mode](#window-mode)                                     |
 | `space` | Keep primary selection TODO: it's here because space mode replaced it |
+| `p`     | paste system clipboard after selections                               |
+| `P`     | paste system clipboard before selections                              |
+| `y`     | join and yank selections to clipboard                                 |
+| `Y`     | yank main selection to clipboard                                      |
+| `R`     | replace selections by clipboard contents                              |
 
 # Picker
 

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -34,3 +34,6 @@ slotmap = "1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 log = "~0.4"
+
+which = "4.1"
+

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -1,0 +1,193 @@
+// Implementation reference: https://github.com/neovim/neovim/blob/f2906a4669a2eef6d7bf86a29648793d63c98949/runtime/autoload/provider/clipboard.vim#L68-L152
+
+use anyhow::Result;
+use std::borrow::Cow;
+
+pub trait ClipboardProvider: std::fmt::Debug {
+    fn name(&self) -> Cow<str>;
+    fn get_contents(&self) -> Result<String>;
+    fn set_contents(&self, contents: String) -> Result<()>;
+}
+
+macro_rules! command_provider {
+    (paste => $get_prg:literal $( , $get_arg:literal )* ; copy => $set_prg:literal $( , $set_arg:literal )* ; ) => {{
+        Box::new(provider::CommandProvider {
+            get_cmd: provider::CommandConfig {
+                prg: $get_prg,
+                args: &[ $( $get_arg ),* ],
+            },
+            set_cmd: provider::CommandConfig {
+                prg: $set_prg,
+                args: &[ $( $set_arg ),* ],
+            },
+        })
+    }};
+}
+
+pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
+    // TODO: support for user-defined provider, probably when we have plugin support by setting a
+    // variable?
+
+    if exists("pbcopy") && exists("pbpaste") {
+        command_provider! {
+            paste => "pbpaste";
+            copy => "pbcopy";
+        }
+    } else if env_var_is_set("WAYLAND_DISPLAY") && exists("wl-copy") && exists("wl-paste") {
+        command_provider! {
+            paste => "wl-paste", "--no-newline";
+            copy => "wl-copy", "--foreground", "--type", "text/plain";
+        }
+    } else if env_var_is_set("DISPLAY") && exists("xclip") {
+        command_provider! {
+            paste => "xclip", "-o", "-selection", "clipboard";
+            copy => "xclip", "-i", "-selection", "clipboard";
+        }
+    } else if env_var_is_set("DISPLAY") && exists("xsel") && is_exit_success("xsel", &["-o", "-b"])
+    {
+        // FIXME: check performance of is_exit_success
+        command_provider! {
+            paste => "xsel", "-o", "-b";
+            copy => "xsel", "--nodetach", "-i", "-b";
+        }
+    } else if exists("lemonade") {
+        command_provider! {
+            paste => "lemonade", "paste";
+            copy => "lemonade", "copy";
+        }
+    } else if exists("doitclient") {
+        command_provider! {
+            paste => "doitclient", "wclip", "-r";
+            copy => "doitclient", "wclip";
+        }
+    } else if exists("win32yank.exe") {
+        // FIXME: does it work within WSL?
+        command_provider! {
+            paste => "win32yank.exe", "-o", "--lf";
+            copy => "win32yank.exe", "-i", "--crlf";
+        }
+    } else if exists("termux-clipboard-set") && exists("termux-clipboard-get") {
+        command_provider! {
+            paste => "termux-clipboard-get";
+            copy => "termux-clipboard-set";
+        }
+    } else if env_var_is_set("TMUX") && exists("tmux") {
+        command_provider! {
+            paste => "tmux", "save-buffer", "-";
+            copy => "tmux", "load-buffer", "-";
+        }
+    } else {
+        Box::new(provider::NopProvider)
+    }
+}
+
+fn exists(executable_name: &str) -> bool {
+    which::which(executable_name).is_ok()
+}
+
+fn env_var_is_set(env_var_name: &str) -> bool {
+    std::env::var_os(env_var_name).is_some()
+}
+
+fn is_exit_success(program: &str, args: &[&str]) -> bool {
+    std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|out| out.status.success().then(|| ())) // TODO: use then_some when stabilized
+        .is_some()
+}
+
+mod provider {
+    use super::ClipboardProvider;
+    use anyhow::{bail, Context as _, Result};
+    use std::borrow::Cow;
+
+    #[derive(Debug)]
+    pub struct NopProvider;
+
+    impl ClipboardProvider for NopProvider {
+        fn name(&self) -> Cow<str> {
+            Cow::Borrowed("none")
+        }
+
+        fn get_contents(&self) -> Result<String> {
+            Ok(String::new())
+        }
+
+        fn set_contents(&self, _: String) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct CommandConfig {
+        pub prg: &'static str,
+        pub args: &'static [&'static str],
+    }
+
+    impl CommandConfig {
+        fn execute(&self, input: Option<&str>, pipe_output: bool) -> Result<Option<String>> {
+            use std::io::Write;
+            use std::process::{Command, Stdio};
+
+            let stdin = input.map(|_| Stdio::piped()).unwrap_or_else(Stdio::null);
+            let stdout = pipe_output.then(Stdio::piped).unwrap_or_else(Stdio::null);
+
+            let mut child = Command::new(self.prg)
+                .args(self.args)
+                .stdin(stdin)
+                .stdout(stdout)
+                .stderr(Stdio::null())
+                .spawn()?;
+
+            if let Some(input) = input {
+                let mut stdin = child.stdin.take().context("stdin is missing")?;
+                stdin
+                    .write_all(input.as_bytes())
+                    .context("couldn't write in stdin")?;
+            }
+
+            // TODO: add timer?
+            let output = child.wait_with_output()?;
+
+            if !output.status.success() {
+                bail!("clipboard provider {} failed", self.prg);
+            }
+
+            if pipe_output {
+                Ok(Some(String::from_utf8(output.stdout)?))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct CommandProvider {
+        pub get_cmd: CommandConfig,
+        pub set_cmd: CommandConfig,
+    }
+
+    impl ClipboardProvider for CommandProvider {
+        fn name(&self) -> Cow<str> {
+            if self.get_cmd.prg != self.set_cmd.prg {
+                Cow::Owned(format!("{}+{}", self.get_cmd.prg, self.set_cmd.prg))
+            } else {
+                Cow::Borrowed(self.get_cmd.prg)
+            }
+        }
+
+        fn get_contents(&self) -> Result<String> {
+            let output = self
+                .get_cmd
+                .execute(None, true)?
+                .context("output is missing")?;
+            Ok(output)
+        }
+
+        fn set_contents(&self, value: String) -> Result<()> {
+            self.set_cmd.execute(Some(&value), false).map(|_| ())
+        }
+    }
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,3 +1,4 @@
+use crate::clipboard::{get_clipboard_provider, ClipboardProvider};
 use crate::{
     theme::{self, Theme},
     tree::Tree,
@@ -14,9 +15,10 @@ use slotmap::SlotMap;
 
 use anyhow::Error;
 
+use helix_core::Position;
+
 pub use helix_core::diagnostic::Severity;
 pub use helix_core::register::Registers;
-use helix_core::Position;
 
 #[derive(Debug)]
 pub struct Editor {
@@ -27,6 +29,7 @@ pub struct Editor {
     pub registers: Registers,
     pub theme: Theme,
     pub language_servers: helix_lsp::Registry,
+    pub clipboard_provider: Box<dyn ClipboardProvider>,
 
     pub syn_loader: Arc<syntax::Loader>,
     pub theme_loader: Arc<theme::Loader>,
@@ -62,6 +65,7 @@ impl Editor {
             syn_loader: config_loader,
             theme_loader: themes,
             registers: Registers::default(),
+            clipboard_provider: get_clipboard_provider(),
             status_msg: None,
         }
     }

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod macros;
 
+pub mod clipboard;
 pub mod document;
 pub mod editor;
 pub mod register_selection;


### PR DESCRIPTION
This commit adds six new commands to interact with system clipboard:
- clipboard-yank
- clipboard-yank-join
- clipboard-paste-after
- clipboard-paste-before
- clipboard-paste-replace
- show-clipboard-provider

System clipboard provider is detected by checking a few environment
variables and executables. Currently only built-in detection is
supported.

`clipboard-yank` will only yank the "main" selection, which is currently the first
one. This will need to be revisited later.

Closes https://github.com/helix-editor/helix/issues/76