### PR TITLE
Add surround keybinds

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -21,7 +21,6 @@
 | `F`          | Find previous char                                                         |
 | `Home`       | Move to the start of the line                                              |
 | `End`        | Move to the end of the line                                                |
-| `m`          | Jump to matching bracket                                                   |
 | `PageUp`     | Move page up                                                               |
 | `PageDown`   | Move page down                                                             |
 | `Ctrl-u`     | Move half page up                                                          |
@@ -30,6 +29,7 @@
 | `Ctrl-o`     | Jump backward on the jumplist                                              |
 | `v`          | Enter [select (extend) mode](#select--extend-mode)                         |
 | `g`          | Enter [goto mode](#goto-mode)                                              |
+| `m`          | Enter [match mode](#match-mode)
 | `:`          | Enter command mode                                                         |
 | `z`          | Enter [view mode](#view-mode)                                              |
 | `Ctrl-w`     | Enter [window mode](#window-mode) (maybe will be remove for spc w w later) |
@@ -70,7 +70,7 @@
 | `Alt-;`  | Flip selection cursor and anchor                                  |
 | `%`      | Select entire file                                                |
 | `x`      | Select current line, if already selected, extend to next line     |
-| ``       | Expand selection to parent syntax node TODO: pick a key           |
+|          | Expand selection to parent syntax node TODO: pick a key           |
 | `J`      | join lines inside selection                                       |
 | `K`      | keep selections matching the regex TODO: overlapped by hover help |
 | `Space`  | keep only the primary selection TODO: overlapped by space mode    |
@@ -143,6 +143,18 @@ Jumps to various locations.
 | `r`   | Go to references                                 |
 | `i`   | Go to implementation                             |
 | `a`   | Go to the last accessed/alternate file           |
+
+## Match mode
+
+Enter this mode using `m` from normal mode. See the relavant section
+in [Usage](./usage.md#surround) for an explanation about surround usage.
+
+| Key              | Description                                     |
+| -----            | -----------                                     |
+| `m`              | Goto matching bracket                           |
+| `s` `<char>`     | Surround current selection with `<char>`        |
+| `r` `<from><to>` | Replace surround character `<from>` with `<to>` |
+| `d` `<char>`     | Delete surround character `<char>`              |
 
 ## Object mode
 

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -1,1 +1,26 @@
 # Usage
+
+(Currently not fully documented, see the [keymappings](./keymap.md) list for more.)
+
+## Surround
+
+Functionality similar to [vim-surround](https://github.com/tpope/vim-surround) is built into
+helix. The keymappings have been inspired from [vim-sandwich](https://github.com/machakann/vim-sandwich):
+
+![surround demo](https://user-images.githubusercontent.com/23398472/122865801-97073180-d344-11eb-8142-8f43809982c6.gif)
+
+- `ms` - Add surround characters
+- `mr` - Replace surround characters
+- `md` - Delete surround characters
+
+`ms` acts on a selection, so select the text first and use `ms<char>`. `mr` and `md` work
+on the closest pairs found and selections are not required; use counts to act in outer pairs.
+
+It can also act on multiple seletions (yay!). For example, to change every occurance of `(use)` to `[use]`:
+
+- `%` to select the whole file
+- `s` to split the selections on a search term
+- Input `use` and hit Enter
+- `mr([` to replace the parens with square brackets
+
+Multiple characters are currently not supported, but planned.

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod register;
 pub mod search;
 pub mod selection;
 mod state;
+pub mod surround;
 pub mod syntax;
 mod transaction;
 

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -39,8 +39,9 @@ pub fn find_nth_pairs_pos(
     n: usize,
 ) -> Option<(usize, usize)> {
     let (open, close) = get_pair(ch);
-    let open_pos = search::find_nth_prev(text, open, pos, n, true)?;
-    let close_pos = search::find_nth_next(text, close, pos, n, true)?;
+    // find_nth* do not consider current character; +1/-1 to include them
+    let open_pos = search::find_nth_prev(text, open, pos + 1, n, true)?;
+    let close_pos = search::find_nth_next(text, close, pos - 1, n, true)?;
 
     Some((open_pos, close_pos))
 }
@@ -86,7 +87,7 @@ mod test {
         // cursor on so[m]e
         assert_eq!(find_nth_pairs_pos(slice, '(', 2, 1), None);
         // cursor on bracket itself
-        // assert_eq!(find_nth_pairs_pos(slice, '(', 5, 1), Some((5, 10)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 5, 1), Some((5, 10)));
     }
 
     #[test]
@@ -134,10 +135,8 @@ mod test {
         let doc = Rope::from("[some]\n(chars)xx\n(newline)");
         let slice = doc.slice(..);
 
-        let selection = Selection::new(
-            SmallVec::from_slice(&[Range::point(2), Range::point(9)]),
-            0,
-        );
+        let selection =
+            Selection::new(SmallVec::from_slice(&[Range::point(2), Range::point(9)]), 0);
 
         // cursor on s[o]me, c[h]ars
         assert_eq!(
@@ -152,7 +151,7 @@ mod test {
         // cursor on [x]x, newli[n]e
         assert_eq!(
             get_surround_pos(slice, &selection, '(', 1),
-            None  // overlapping surround chars
+            None // overlapping surround chars
         );
     }
 }

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -1,0 +1,58 @@
+use crate::{search, Selection};
+use ropey::RopeSlice;
+
+pub const PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+
+/// Given any char in [PAIRS], return the open and closing chars. If not found in
+/// [PAIRS] return (ch, ch).
+pub fn get_pair(ch: char) -> (char, char) {
+    PAIRS
+        .iter()
+        .find(|(open, close)| *open == ch || *close == ch)
+        .copied()
+        .unwrap_or((ch, ch))
+}
+
+/// Find the position of surround pairs of `ch` which can be either a closing
+/// or opening pair. `n` will skip n - 1 pairs (eg. n=2 will discard (only)
+/// the first pair found and keep looking)
+pub fn find_nth_pairs_pos(
+    text: RopeSlice,
+    ch: char,
+    pos: usize,
+    n: usize,
+) -> Option<(usize, usize)> {
+    let (open, close) = get_pair(ch);
+    let open_pos = search::find_nth_prev(text, open, pos, n, true)?;
+    let close_pos = search::find_nth_next(text, close, pos, n, true)?;
+
+    Some((open_pos, close_pos))
+}
+
+/// Find position of surround characters around every cursor. Returns None
+/// if any positions overlap. Note that the positions are in a flat Vec.
+/// Use get_surround_pos().chunks(2) to get matching pairs of surround positions.
+/// `ch` can be either closing or opening pair.
+pub fn get_surround_pos(
+    text: RopeSlice,
+    selection: &Selection,
+    ch: char,
+    skip: usize,
+) -> Option<Vec<usize>> {
+    let mut change_pos = Vec::new();
+
+    for range in selection {
+        let head = range.head;
+
+        match find_nth_pairs_pos(text, ch, head, skip) {
+            Some((open_pos, close_pos)) => {
+                if change_pos.contains(&open_pos) || change_pos.contains(&close_pos) {
+                    return None;
+                }
+                change_pos.extend_from_slice(&[open_pos, close_pos]);
+            }
+            None => return None,
+        }
+    }
+    Some(change_pos)
+}

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -1,7 +1,15 @@
 use crate::{search, Selection};
 use ropey::RopeSlice;
 
-pub const PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+pub const PAIRS: &[(char, char)] = &[
+    ('(', ')'),
+    ('[', ']'),
+    ('{', '}'),
+    ('<', '>'),
+    ('«', '»'),
+    ('「', '」'),
+    ('（', '）'),
+];
 
 /// Given any char in [PAIRS], return the open and closing chars. If not found in
 /// [PAIRS] return (ch, ch).

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -256,7 +256,7 @@ impl Command {
         view_mode,
         left_bracket_mode,
         right_bracket_mode,
-        surround
+        match_mode
     );
 }
 
@@ -3312,7 +3312,7 @@ fn right_bracket_mode(cx: &mut Context) {
     })
 }
 
-fn surround(cx: &mut Context) {
+fn match_mode(cx: &mut Context) {
     let count = cx.count;
     cx.on_next_key(move |cx, event| {
         if let KeyEvent {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3352,7 +3352,15 @@ fn surround_add(cx: &mut Context) {
 
             let mut changes = Vec::new();
             for (i, range) in selection.iter().enumerate() {
-                let (from, to) = (range.from(), range.to() + 1);
+                let from = range.from();
+                let line = text.char_to_line(range.to());
+                let max_to = doc.text().len_chars().saturating_sub(
+                    get_line_ending(&text.line(line))
+                        .map(|le| le.len_chars())
+                        .unwrap_or(0),
+                );
+                let to = std::cmp::min(range.to() + 1, max_to);
+
                 changes.push((from, from, Some(Tendril::from_char(open))));
                 changes.push((to, to, Some(Tendril::from_char(close))));
             }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3324,7 +3324,7 @@ fn surround(cx: &mut Context) {
             cx.count = count;
             match ch {
                 'm' => match_brackets(cx),
-                'a' => surround_add(cx),
+                's' => surround_add(cx),
                 'r' => surround_replace(cx),
                 'd' => {
                     surround_delete(cx);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1907,7 +1907,6 @@ fn goto_mode(cx: &mut Context) {
             match (doc.mode, ch) {
                 (_, 'g') => move_file_start(cx),
                 (_, 'e') => move_file_end(cx),
-                (_, 'm') => match_brackets(cx),
                 (_, 'a') => switch_to_last_accessed_file(cx),
                 (Mode::Normal, 'h') => move_line_start(cx),
                 (Mode::Normal, 'l') => move_line_end(cx),
@@ -3324,6 +3323,7 @@ fn surround(cx: &mut Context) {
             // FIXME: count gets reset because of cx.on_next_key()
             cx.count = count;
             match ch {
+                'm' => match_brackets(cx),
                 'a' => surround_add(cx),
                 'r' => surround_replace(cx),
                 'd' => {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -200,7 +200,7 @@ impl Default for Keymaps {
             // extend_to_whole_line, crop_to_whole_line
 
 
-            key!('m') => Command::surround,
+            key!('m') => Command::match_mode,
             key!('[') => Command::left_bracket_mode,
             key!(']') => Command::right_bracket_mode,
 

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -200,7 +200,7 @@ impl Default for Keymaps {
             // extend_to_whole_line, crop_to_whole_line
 
 
-            key!('m') => Command::match_brackets,
+            key!('m') => Command::surround,
             // TODO: refactor into
             // key!('m') => commands::select_to_matching,
             // key!('M') => commands::back_select_to_matching,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -201,16 +201,6 @@ impl Default for Keymaps {
 
 
             key!('m') => Command::surround,
-            // TODO: refactor into
-            // key!('m') => commands::select_to_matching,
-            // key!('M') => commands::back_select_to_matching,
-            // select mode extend equivalents
-
-            // key!('.') => commands::repeat_insert,
-            // repeat_select
-
-            // TODO: figure out what key to use
-            // key!('[') => Command::expand_selection, ??
             key!('[') => Command::left_bracket_mode,
             key!(']') => Command::right_bracket_mode,
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -649,6 +649,7 @@ impl Document {
         }
     }
 
+    /// Commit pending changes to history
     pub fn append_changes_to_history(&mut self, view_id: ViewId) {
         if self.changes.is_empty() {
             return;


### PR DESCRIPTION
Adds [vim-surround](https://github.com/tpope/vim-surround) functionality, with keybinds inspired from [vim-sandwich](https://github.com/machakann/vim-sandwich):

- ~`ma<char>`~ `ms<char>` - Add `char` around selection
- `md<char>` - Delete `char` pair
- `mr<from><to>` - Replace `from` with `to`

![helix-surround-2](https://user-images.githubusercontent.com/23398472/122865801-97073180-d344-11eb-8142-8f43809982c6.gif)

Goto matching bracket (previously `m`) has been moved to `mm`.

### TODO:

- [x] Add documentation
    - [x] Usage section
    - [x] Keymaps
    - [x] `mm` change
- [x] Add tests
- [x] [bug] Correctly identify pairs when cursor is _on_ a pair character

### Future work:

- `vim-sandwich` like visual feedback
- `b` as a generic surround char finder (like `b` in vim-sandwich)
- Show error when replace or delete cannot be done
- Treesitter based implementation ?

### Bugs

There are some subtle bugs right now with finding the correct surround pairs when they are spread across multiline lines, which can be solved by either using indent heuristics (works for most files) or directly querying treesitter, which is easier and accurate for languages with defined grammars (see `match_bracket` implementation).