### PR TITLE
Cleanup spinners and messages on progress end

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -328,6 +328,9 @@ impl Application {
                                         editor_view.spinners_mut().get_or_create(server_id).stop();
                                     }
                                     self.editor.clear_status();
+
+                                    // we want to render to clear any leftover spinners or messages
+                                    self.render();
                                     return;
                                 }
                             }


### PR DESCRIPTION
As discussed on matrix, this fixes the leftover spinners when workDoneProgress reaches the end without any message.