### PR TITLE
Use pep 8 indentation for python

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -116,7 +116,7 @@ roots = []
 
 language-server = { command = "pyls" }
 # TODO: pyls needs utf-8 offsets
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 4, unit = "    " }
 
 [[language]]
 name = "nix"


### PR DESCRIPTION
Change the default spaces of python indentation to follow pep8 which is the standard.

Kakoune does not support language defaults as far as I know https://github.com/mawww/kakoune/pull/3510 but I think we should follow standards for respective language rather than follow editor defaults.