### PR TITLE
Implement change_directory/show_directory commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1335,6 +1335,15 @@ mod cmd {
         }
     }
 
+    fn show_current_directory(editor: &mut Editor, args: &[&str], _: PromptEvent) {
+        match std::env::current_dir() {
+            Ok(cwd) => editor.set_status(format!("Current working directory is {}", cwd.display())),
+            Err(e) => {
+                editor.set_error(format!("Couldn't get the current working directory: {}", e))
+            }
+        }
+    }
+
     pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -1503,6 +1512,13 @@ mod cmd {
             doc: "Change the current working directory (:cd <dir>).",
             fun: change_current_directory,
             completer: Some(completers::directory),
+        },
+        TypableCommand {
+            name: "show-directory",
+            alias: Some("pwd"),
+            doc: "Show the current working directory.",
+            fun: show_current_directory,
+            completer: None,
         },
     ];
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1309,6 +1309,32 @@ mod cmd {
         editor.set_status(editor.clipboard_provider.name().into());
     }
 
+    fn change_current_directory(editor: &mut Editor, args: &[&str], _: PromptEvent) {
+        let dir = match args.first() {
+            Some(dir) => dir,
+            None => {
+                editor.set_error("target directory not provided".into());
+                return;
+            }
+        };
+
+        if let Err(e) = std::env::set_current_dir(dir) {
+            editor.set_error(format!(
+                "Couldn't change the current working directory: {:?}",
+                e
+            ));
+            return;
+        }
+
+        match std::env::current_dir() {
+            Ok(cwd) => editor.set_status(format!(
+                "Current working directory is now {}",
+                cwd.display()
+            )),
+            Err(e) => editor.set_error(format!("Couldn't get the new working directory: {}", e)),
+        }
+    }
+
     pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -1470,6 +1496,13 @@ mod cmd {
             doc: "Show clipboard provider name in status bar.",
             fun: show_clipboard_provider,
             completer: None,
+        },
+        TypableCommand {
+            name: "change-current-directory",
+            alias: Some("cd"),
+            doc: "Change the current working directory (:cd <dir>).",
+            fun: change_current_directory,
+            completer: Some(completers::directory),
         },
     ];
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -154,8 +154,46 @@ pub mod completers {
         names
     }
 
-    // TODO: we could return an iter/lazy thing so it can fetch as many as it needs.
     pub fn filename(input: &str) -> Vec<Completion> {
+        filename_impl(input, |entry| {
+            let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
+
+            if is_dir {
+                FileMatch::AcceptIncomplete
+            } else {
+                FileMatch::Accept
+            }
+        })
+    }
+
+    pub fn directory(input: &str) -> Vec<Completion> {
+        filename_impl(input, |entry| {
+            let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
+
+            if is_dir {
+                FileMatch::Accept
+            } else {
+                FileMatch::Reject
+            }
+        })
+    }
+
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    enum FileMatch {
+        /// Entry should be ignored
+        Reject,
+        /// Entry is usable but can't be the end (for instance if the entry is a directory and we
+        /// try to match a file)
+        AcceptIncomplete,
+        /// Entry is usable and can be the end of the match
+        Accept,
+    }
+
+    // TODO: we could return an iter/lazy thing so it can fetch as many as it needs.
+    fn filename_impl<F>(input: &str, filter_fn: F) -> Vec<Completion>
+    where
+        F: Fn(&ignore::DirEntry) -> FileMatch,
+    {
         // Rust's filename handling is really annoying.
 
         use ignore::WalkBuilder;
@@ -186,7 +224,13 @@ pub mod completers {
             .max_depth(Some(1))
             .build()
             .filter_map(|file| {
-                file.ok().map(|entry| {
+                file.ok().and_then(|entry| {
+                    let fmatch = filter_fn(&entry);
+
+                    if fmatch == FileMatch::Reject {
+                        return None;
+                    }
+
                     let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
 
                     let path = entry.path();
@@ -201,11 +245,12 @@ pub mod completers {
                         path.strip_prefix(&dir).unwrap_or(path).to_path_buf()
                     };
 
-                    if is_dir {
+                    if fmatch == FileMatch::AcceptIncomplete {
                         path.push("");
                     }
+
                     let path = path.to_str().unwrap().to_owned();
-                    (end.clone(), Cow::from(path))
+                    Some((end.clone(), Cow::from(path)))
                 })
             }) // TODO: unwrap or skip
             .filter(|(_, path)| !path.is_empty()) // TODO


### PR DESCRIPTION
These commands let the user check and change the current working directory for the running helix session.

I mostly implemented those to play with the codebase but I thought they might be useful (they would be useful to me at least, I regularly change the working directory in vim).

As an aside, I think it would be nice if TypableCommands returned a Result<()> and any error was automatically logged using `editor.set_error(_)`, that would let one `bail!` out of a command implementation without having to manually call `editor.set_error(format!(...)); return;`. I could submit such a change if it was deemed acceptable.