### PR TITLE
Sort files in file picker by access, modification and creation date

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -112,7 +112,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
         files.take(MAX).collect()
     };
 
-    files.sort_by(|(_, time1), (_, time2)| time1.cmp(time2));
+    files.sort_by_key(|file| file.1);
 
     let files = files.into_iter().map(|(path, _)| path).collect();
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -84,15 +84,11 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
             // filter dirs, but we might need special handling for symlinks!
             if !entry.file_type().map_or(false, |entry| entry.is_dir()) {
                 let time = if let Ok(metadata) = entry.metadata() {
-                    if let Ok(atime) = metadata.accessed() {
-                        atime
-                    } else if let Ok(mtime) = metadata.modified() {
-                        mtime
-                    } else if let Ok(ctime) = metadata.created() {
-                        ctime
-                    } else {
-                        time::UNIX_EPOCH
-                    }
+                    metadata
+                        .accessed()
+                        .or_else(|_| metadata.modified())
+                        .or_else(|_| metadata.created())
+                        .unwrap_or(time::UNIX_EPOCH)
                 } else {
                     time::UNIX_EPOCH
                 };


### PR DESCRIPTION
So this might not be very optimized but it's a big quality of life improvement. I use file picker a lot and sometimes I just want to see what I edited last without having to remember the exact filename. I tested this change on a quiet big repository - https://fuchsia.googlesource.com/fuchsia/  and the additional time to sort the entries was negligible even in debug mode.

I'm ok not to push it either if that will be the general consensus.

EDIT:
Actually meant access time not modification time