### PR TITLE
Make the prompt callback take a Context.

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -39,10 +39,10 @@ pub fn regex_prompt(
     Prompt::new(
         prompt,
         |input: &str| Vec::new(), // this is fine because Vec::new() doesn't allocate
-        move |editor: &mut Editor, input: &str, event: PromptEvent| {
+        move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
             match event {
                 PromptEvent::Abort => {
-                    let (view, doc) = current!(editor);
+                    let (view, doc) = current!(cx.editor);
                     doc.set_selection(view.id, snapshot.clone());
                 }
                 PromptEvent::Validate => {
@@ -56,8 +56,8 @@ pub fn regex_prompt(
 
                     match Regex::new(input) {
                         Ok(regex) => {
-                            let (view, doc) = current!(editor);
-                            let registers = &mut editor.registers;
+                            let (view, doc) = current!(cx.editor);
+                            let registers = &mut cx.editor.registers;
 
                             // revert state to what it was before the last update
                             doc.set_selection(view.id, snapshot.clone());

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -44,7 +44,7 @@ impl<T> Picker<T> {
         let prompt = Prompt::new(
             "".to_string(),
             |pattern: &str| Vec::new(),
-            |editor: &mut Editor, pattern: &str, event: PromptEvent| {
+            |editor: &mut Context, pattern: &str, event: PromptEvent| {
                 //
             },
         );

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -20,7 +20,7 @@ pub struct Prompt {
     completion: Vec<Completion>,
     selection: Option<usize>,
     completion_fn: Box<dyn FnMut(&str) -> Vec<Completion>>,
-    callback_fn: Box<dyn FnMut(&mut Editor, &str, PromptEvent)>,
+    callback_fn: Box<dyn FnMut(&mut Context, &str, PromptEvent)>,
     pub doc_fn: Box<dyn Fn(&str) -> Option<&'static str>>,
 }
 
@@ -54,7 +54,7 @@ impl Prompt {
     pub fn new(
         prompt: String,
         mut completion_fn: impl FnMut(&str) -> Vec<Completion> + 'static,
-        callback_fn: impl FnMut(&mut Editor, &str, PromptEvent) + 'static,
+        callback_fn: impl FnMut(&mut Context, &str, PromptEvent) + 'static,
     ) -> Self {
         Self {
             prompt,
@@ -386,7 +386,7 @@ impl Component for Prompt {
                 modifiers: KeyModifiers::SHIFT,
             } => {
                 self.insert_char(c);
-                (self.callback_fn)(cx.editor, &self.line, PromptEvent::Update);
+                (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }
             KeyEvent {
                 code: KeyCode::Char('c'),
@@ -395,7 +395,7 @@ impl Component for Prompt {
             | KeyEvent {
                 code: KeyCode::Esc, ..
             } => {
-                (self.callback_fn)(cx.editor, &self.line, PromptEvent::Abort);
+                (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
                 return close_fn;
             }
             KeyEvent {
@@ -459,7 +459,7 @@ impl Component for Prompt {
                 modifiers: KeyModifiers::NONE,
             } => {
                 self.delete_char_backwards();
-                (self.callback_fn)(cx.editor, &self.line, PromptEvent::Update);
+                (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }
             KeyEvent {
                 code: KeyCode::Enter,
@@ -469,7 +469,7 @@ impl Component for Prompt {
                     self.completion = (self.completion_fn)(&self.line);
                     self.exit_selection();
                 } else {
-                    (self.callback_fn)(cx.editor, &self.line, PromptEvent::Validate);
+                    (self.callback_fn)(cx, &self.line, PromptEvent::Validate);
                     return close_fn;
                 }
             }


### PR DESCRIPTION
This is the part of #285 that changes the callbacks' argument from an `Editor` to a `compositor::Context`. It's the source of lots of merge conflicts, so I'm hoping I can get this in quickly while I work on the other parts of #285.