### PR TITLE
Fix lsp config deserialization case

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
 }
 
 #[derive(Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct LspConfig {
     pub display_messages: bool,
 }


### PR DESCRIPTION
It should have been in kebab-case, but it was the default snake_case.