### PR TITLE
surround as selection

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -128,6 +128,11 @@ impl Range {
     pub fn fragment<'a, 'b: 'a>(&'a self, text: RopeSlice<'b>) -> Cow<'b, str> {
         Cow::from(text.slice(self.from()..self.to() + 1))
     }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.from() + 1 - self.to()
+    }
 }
 
 /// A selection consists of one or more selection ranges.

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -61,13 +61,13 @@ pub fn find_balanced_pairs_pos(text: RopeSlice, ch: char, pos: usize) -> Option<
     }?;
     let mut count = 1;
     for (i, c) in text.slice(open_pos + 1..).chars().enumerate() {
-        if c == open {
-            count += 1;
-        } else if c == close {
+        if c == close {
             count -= 1;
             if count == 0 {
                 return Some((open_pos, open_pos + 1 + i));
             }
+        } else if c == open {
+            count += 1;
         }
     }
     None

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -619,7 +619,7 @@ fn replace(cx: &mut Context) {
                 [open_range, close_range] => {
                     let open_char = text.char(open_range.from());
                     let close_char = text.char(close_range.from());
-                    let ch = ch.chars().nth(0).unwrap();
+                    let ch = ch.chars().next().unwrap();
                     let (open, close) = get_pair(open_char);
                     if open_char == open
                         && close_char == close


### PR DESCRIPTION
I am proposing an alternative to at least part of match-mode.

Current implementation has one big drawback:
It doesn't visually show what text will be affected(VIM way).

My implementation fixes this, but has a very different design. 

Solution:
`m` followed by match-char will make a selection of nearest enclosing pair by counting open/close.

example with brackets being cursor position: `Some (text (here)[ ) ]`
Pressing `m(` will result in  `Some [ ( ]text (here)[ ) ]`

Now we have two normal cursors, so all commands like `d` or `c` works as expected.
But we have one important modification to the `replace` command:

When exactly two selections of length 1 are present and they match according to `get_pair`, we will do replacement as a pair.
`Some [ ( ]text (here)[ ) ]`
press `r{`
`Some [ { ]text (here)[ } ]`
Note that this `replace` will happen whenever the selection matches the conditions, it could have been created without `m`.

What I intend to fix:
`replace` should enforce that pairs will be balanced after. (this is mostly handled already if selection was made by `m`)
Condition for matching replace should be extended to selection pairs of `count_selections % 2 == 0`

I know that there are a few more special cases to handle, but I want feedback on this idea before I move forward with it.
My WIP is working quite nicely I think, please give it a try