### PR TITLE
Add default color for cursor match

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -41,6 +41,7 @@
 "ui.text.focus" = { fg = "#e5ded6", modifiers= ["bold"] }
 
 "ui.selection" = { bg = "#313f4e" }
+# "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
 "ui.menu.selected" = { fg = "#e5ded6", bg = "#313f4e" }
 
 "warning" = "#dc7759"

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -41,6 +41,7 @@
 "ui.text.focus" = { fg = "#250E07", modifiers= ["bold"] }
 
 "ui.selection" = { bg = "#540099" }
+# "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
 "ui.menu.selected" = { fg = "#D74E50", bg = "#F3EAE9" }
 
 "warning" = "#D4A520"

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -41,3 +41,4 @@
 "ui.text" = { fg = "#ABB2BF", bg = "#282C34" }
 "ui.text.focus" = { fg = "#ABB2BF", bg = "#2C323C", modifiers = ['bold'] }
 "ui.window" = { bg = "#3E4452" }
+# "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported

--- a/theme.toml
+++ b/theme.toml
@@ -54,6 +54,7 @@
 "ui.selection.primary" = { bg = "#540099" }
 "ui.cursor.select" = { bg = "#6F44F0" }
 "ui.cursor.insert" = { bg = "#802F00" }
+"ui.cursor.match" = { fg = "#212121", bg = "#757575" }
 "ui.menu.selected" = { fg = "#281733", bg = "#ffffff" } # revolver
 
 "warning" = "#ffcd1c"

--- a/theme.toml
+++ b/theme.toml
@@ -54,7 +54,7 @@
 "ui.selection.primary" = { bg = "#540099" }
 "ui.cursor.select" = { bg = "#6F44F0" }
 "ui.cursor.insert" = { bg = "#802F00" }
-"ui.cursor.match" = { fg = "#212121", bg = "#757575" }
+"ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
 "ui.menu.selected" = { fg = "#281733", bg = "#ffffff" } # revolver
 
 "warning" = "#ffcd1c"


### PR DESCRIPTION
Not all terminals support dim, for those terminal that does not support
this (konsole, item2, wezterm), users cannot differentiate between match
and primary cursor. So set a color for this.

Before

![Screenshot_20210624_233613](https://user-images.githubusercontent.com/4687791/123300243-f9328300-d54c-11eb-9703-d2d51254cdd9.png)


After

![Screenshot_20210625_003157](https://user-images.githubusercontent.com/4687791/123300068-c092a980-d54c-11eb-8676-5cf3d943f084.png)

cc @wojciechkepka 