### PR TITLE
Use unicode_width to correctly truncate picker chars

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -309,7 +309,7 @@ impl Buffer {
             index += width;
             x_offset += width;
         }
-        if ellipsis && x_offset - (x as usize) < string.as_ref().chars().count() {
+        if ellipsis && x_offset - (x as usize) < UnicodeWidthStr::width(string.as_ref()) {
             self.content[index].set_symbol("…");
         }
         (x_offset as u16, y)


### PR DESCRIPTION
(please do not merge before testing with CJK characters)

cc @pickfire 