### PR TITLE
The Great Line Ending & Cursor Range Cleanup

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -46,8 +46,7 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
     let comment = Tendril::from(format!("{} ", token));
 
     for selection in selection {
-        let start = text.char_to_line(selection.from());
-        let end = text.char_to_line(selection.to());
+        let (start, end) = selection.line_range(text);
         let lines = start..end + 1;
         let (commented, skipped, min) = find_line_comment(&token, text, lines.clone());
 

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -71,6 +71,8 @@ pub fn nth_prev_grapheme_boundary(slice: RopeSlice, char_idx: usize, n: usize) -
 }
 
 /// Finds the previous grapheme boundary before the given char position.
+#[must_use]
+#[inline(always)]
 pub fn prev_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> usize {
     nth_prev_grapheme_boundary(slice, char_idx, 1)
 }
@@ -117,12 +119,16 @@ pub fn nth_next_grapheme_boundary(slice: RopeSlice, char_idx: usize, n: usize) -
 }
 
 /// Finds the next grapheme boundary after the given char position.
+#[must_use]
+#[inline(always)]
 pub fn next_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> usize {
     nth_next_grapheme_boundary(slice, char_idx, 1)
 }
 
 /// Returns the passed char index if it's already a grapheme boundary,
 /// or the next grapheme boundary char index if not.
+#[must_use]
+#[inline]
 pub fn ensure_grapheme_boundary_next(slice: RopeSlice, char_idx: usize) -> usize {
     if char_idx == 0 {
         char_idx
@@ -133,6 +139,8 @@ pub fn ensure_grapheme_boundary_next(slice: RopeSlice, char_idx: usize) -> usize
 
 /// Returns the passed char index if it's already a grapheme boundary,
 /// or the prev grapheme boundary char index if not.
+#[must_use]
+#[inline]
 pub fn ensure_grapheme_boundary_prev(slice: RopeSlice, char_idx: usize) -> usize {
     if char_idx == slice.len_chars() {
         char_idx
@@ -142,6 +150,7 @@ pub fn ensure_grapheme_boundary_prev(slice: RopeSlice, char_idx: usize) -> usize
 }
 
 /// Returns whether the given char position is a grapheme boundary.
+#[must_use]
 pub fn is_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> bool {
     // Bounds check
     debug_assert!(char_idx <= slice.len_chars());

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -123,11 +123,21 @@ pub fn next_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> usize {
 
 /// Returns the passed char index if it's already a grapheme boundary,
 /// or the next grapheme boundary char index if not.
-pub fn ensure_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> usize {
+pub fn ensure_grapheme_boundary_next(slice: RopeSlice, char_idx: usize) -> usize {
     if char_idx == 0 {
-        0
+        char_idx
     } else {
         next_grapheme_boundary(slice, char_idx - 1)
+    }
+}
+
+/// Returns the passed char index if it's already a grapheme boundary,
+/// or the prev grapheme boundary char index if not.
+pub fn ensure_grapheme_boundary_prev(slice: RopeSlice, char_idx: usize) -> usize {
+    if char_idx == slice.len_chars() {
+        char_idx
+    } else {
+        prev_grapheme_boundary(slice, char_idx + 1)
     }
 }
 

--- a/helix-core/src/line_ending.rs
+++ b/helix-core/src/line_ending.rs
@@ -159,6 +159,13 @@ pub fn line_end_char_index(slice: &RopeSlice, line: usize) -> usize {
             .unwrap_or(0)
 }
 
+/// Fetches line `line_idx` from the passed rope slice, sans any line ending.
+pub fn line_without_line_ending<'a>(slice: &'a RopeSlice, line_idx: usize) -> RopeSlice<'a> {
+    let start = slice.line_to_char(line_idx);
+    let end = line_end_char_index(slice, line_idx);
+    slice.slice(start..end)
+}
+
 /// Returns the char index of the end of the given RopeSlice, not including
 /// any final line ending.
 pub fn rope_end_without_line_ending(slice: &RopeSlice) -> usize {

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -24,12 +24,13 @@ pub fn find(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
         return None;
     }
 
-    let start_byte = node.start_byte();
     let len = doc.len_bytes();
-    if start_byte >= len {
+    let start_byte = node.start_byte();
+    let end_byte = node.end_byte() - 1; // it's end exclusive
+    if start_byte >= len || end_byte >= len {
         return None;
     }
-    let end_byte = node.end_byte() - 1; // it's end exclusive
+
     let start_char = doc.byte_to_char(start_byte);
     let end_char = doc.byte_to_char(end_byte);
 

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -285,7 +285,7 @@ impl CharHelpers for Chars<'_> {
         // Find our target position(s).
         let head_start = head;
         while let Some(next_ch) = self.next() {
-            if reached_target(target, prev_ch.unwrap_or(next_ch), next_ch) {
+            if prev_ch.is_none() || reached_target(target, prev_ch.unwrap(), next_ch) {
                 if head == head_start {
                     anchor = head;
                 } else {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -56,7 +56,7 @@ pub fn move_horizontally(
     };
 
     // Compute the final new range.
-    range.put(slice, behaviour == Extend, new_pos)
+    range.put(slice, new_pos, behaviour == Extend)
 }
 
 pub fn move_vertically(
@@ -106,7 +106,7 @@ pub fn move_vertically(
                 new_pos
             };
 
-            let mut new_range = range.put(slice, true, new_head);
+            let mut new_range = range.put(slice, new_head, true);
             new_range.horiz = Some(horiz);
             new_range
         }
@@ -427,7 +427,7 @@ mod test {
     #[test]
     fn vertical_moves_in_single_column() {
         let text = Rope::from(MULTILINE_SAMPLE);
-        let slice = dbg!(&text).slice(..);
+        let slice = text.slice(..);
         let position = pos_at_coords(slice, (0, 0).into());
         let mut range = Range::point(position);
         let moves_and_expected_coordinates = IntoIter::new([

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -521,16 +521,14 @@ mod test {
             V,
         }
         let moves_and_expected_coordinates = IntoIter::new([
-            // Places cursor at the fourth kana (each of which are double-wide,
-            // so the visual column is 8).
-            ((Axis::H, Direction::Forward, 4), (0, 8)),
-            // Descent places cursor at the 8th character.
-            ((Axis::V, Direction::Forward, 1usize), (1, 8)),
-            // Moving back a single-width character.
-            ((Axis::H, Direction::Backward, 1usize), (1, 7)),
-            // Jumping back up into the middle of a double-width character shifts
-            // the column to the start of that character.
-            ((Axis::V, Direction::Backward, 1usize), (0, 6)),
+            // Places cursor at the fourth kana.
+            ((Axis::H, Direction::Forward, 4), (0, 4)),
+            // Descent places cursor at the 4th character.
+            ((Axis::V, Direction::Forward, 1usize), (1, 4)),
+            // Moving back 1 character.
+            ((Axis::H, Direction::Backward, 1usize), (1, 3)),
+            // Jumping back up 1 line.
+            ((Axis::V, Direction::Backward, 1usize), (0, 3)),
         ]);
 
         for ((axis, direction, amount), coordinates) in moves_and_expected_coordinates {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -65,7 +65,7 @@ pub fn move_vertically(
         Direction::Backward => row.saturating_sub(count),
         Direction::Forward => std::cmp::min(
             row.saturating_add(count),
-            slice.len_lines().saturating_sub(2),
+            slice.len_lines().saturating_sub(1),
         ),
     };
 
@@ -402,12 +402,13 @@ mod test {
         let moves_and_expected_coordinates = IntoIter::new([
             ((Direction::Forward, 1usize), (1, 0)),
             ((Direction::Forward, 2usize), (3, 0)),
+            ((Direction::Forward, 1usize), (4, 0)),
             ((Direction::Backward, 999usize), (0, 0)),
-            ((Direction::Forward, 3usize), (3, 0)),
-            ((Direction::Forward, 0usize), (3, 0)),
-            ((Direction::Backward, 0usize), (3, 0)),
-            ((Direction::Forward, 5), (4, 0)),
-            ((Direction::Forward, 999usize), (4, 0)),
+            ((Direction::Forward, 4usize), (4, 0)),
+            ((Direction::Forward, 0usize), (4, 0)),
+            ((Direction::Backward, 0usize), (4, 0)),
+            ((Direction::Forward, 5), (5, 0)),
+            ((Direction::Forward, 999usize), (5, 0)),
         ]);
 
         for ((direction, amount), coordinates) in moves_and_expected_coordinates {
@@ -439,7 +440,8 @@ mod test {
             ((Axis::V, Direction::Forward, 1usize), (3, 8)),
             // Behaviour is preserved even through long jumps
             ((Axis::V, Direction::Backward, 999usize), (0, 8)),
-            ((Axis::V, Direction::Forward, 999usize), (4, 8)),
+            ((Axis::V, Direction::Forward, 4usize), (4, 8)),
+            ((Axis::V, Direction::Forward, 999usize), (5, 0)),
         ]);
 
         for ((axis, direction, amount), coordinates) in moves_and_expected_coordinates {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -34,10 +34,9 @@ pub fn move_horizontally(
     let pos = range.cursor(slice);
 
     // Compute the new position.
-    let new_pos = if dir == Direction::Backward {
-        nth_prev_grapheme_boundary(slice, pos, count)
-    } else {
-        nth_next_grapheme_boundary(slice, pos, count)
+    let new_pos = match dir {
+        Direction::Forward => nth_next_grapheme_boundary(slice, pos, count),
+        Direction::Backward => nth_prev_grapheme_boundary(slice, pos, count),
     };
 
     // Compute the final new range.
@@ -59,10 +58,9 @@ pub fn move_vertically(
 
     // Compute the new position.
     let (new_pos, new_row) = {
-        let new_row = if dir == Direction::Backward {
-            row.saturating_sub(count)
-        } else {
-            (row + count).min(slice.len_lines().saturating_sub(1))
+        let new_row = match dir {
+            Direction::Forward => (row + count).min(slice.len_lines().saturating_sub(1)),
+            Direction::Backward => row.saturating_sub(count),
         };
         let new_col = col.max(horiz as usize);
         (

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -57,17 +57,12 @@ pub fn move_vertically(
     let horiz = range.horiz.unwrap_or(col as u32);
 
     // Compute the new position.
-    let (new_pos, new_row) = {
-        let new_row = match dir {
-            Direction::Forward => (row + count).min(slice.len_lines().saturating_sub(1)),
-            Direction::Backward => row.saturating_sub(count),
-        };
-        let new_col = col.max(horiz as usize);
-        (
-            pos_at_coords(slice, Position::new(new_row, new_col), true),
-            new_row,
-        )
+    let new_row = match dir {
+        Direction::Forward => (row + count).min(slice.len_lines().saturating_sub(1)),
+        Direction::Backward => row.saturating_sub(count),
     };
+    let new_col = col.max(horiz as usize);
+    let new_pos = pos_at_coords(slice, Position::new(new_row, new_col), true);
 
     // Special-case to avoid moving to the end of the last non-empty line.
     if behaviour == Movement::Extend && slice.line(new_row).len_chars() == 0 {

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -6,7 +6,7 @@ use smallvec::smallvec;
 pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
     let tree = syntax.tree();
 
-    selection.transform(|range| {
+    selection.clone().transformed(|range| {
         let from = text.char_to_byte(range.from());
         let to = text.char_to_byte(range.to());
 

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -6,7 +6,7 @@ use smallvec::smallvec;
 pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
     let tree = syntax.tree();
 
-    selection.clone().transformed(|range| {
+    selection.clone().transform(|range| {
         let from = text.char_to_byte(range.from());
         let to = text.char_to_byte(range.to());
 

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -53,6 +53,8 @@ impl From<Position> for tree_sitter::Point {
 }
 /// Convert a character index to (line, column) coordinates.
 pub fn coords_at_pos(text: RopeSlice, pos: usize) -> Position {
+    // TODO: this isn't correct.  This needs to work in terms of
+    // visual horizontal position, not graphemes.
     let line = text.char_to_line(pos);
     let line_start = text.line_to_char(line);
     let col = RopeGraphemes::new(text.slice(line_start..pos)).count();
@@ -61,6 +63,8 @@ pub fn coords_at_pos(text: RopeSlice, pos: usize) -> Position {
 
 /// Convert (line, column) coordinates to a character index.
 pub fn pos_at_coords(text: RopeSlice, coords: Position) -> usize {
+    // TODO: this isn't correct.  This needs to work in terms of
+    // visual horizontal position, not graphemes.
     let Position { row, col } = coords;
     let line_start = text.line_to_char(row);
     // line_start + col

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
+
 use crate::{
     chars::char_is_line_ending,
-    graphemes::{nth_next_grapheme_boundary, RopeGraphemes},
+    graphemes::{ensure_grapheme_boundary_prev, grapheme_width, RopeGraphemes},
+    line_ending::line_end_char_index,
     RopeSlice,
 };
 
@@ -52,23 +55,58 @@ impl From<Position> for tree_sitter::Point {
     }
 }
 /// Convert a character index to (line, column) coordinates.
+///
+/// TODO: this should be split into two methods: one for visual
+/// row/column, and one for "objective" row/column (possibly with
+/// the column specified in `char`s).  The former would be used
+/// for cursor movement, and the latter would be used for e.g. the
+/// row:column display in the status line.
 pub fn coords_at_pos(text: RopeSlice, pos: usize) -> Position {
-    // TODO: this isn't correct.  This needs to work in terms of
-    // visual horizontal position, not graphemes.
     let line = text.char_to_line(pos);
+
     let line_start = text.line_to_char(line);
-    let col = RopeGraphemes::new(text.slice(line_start..pos)).count();
+    let pos = ensure_grapheme_boundary_prev(text, pos);
+    let col = RopeGraphemes::new(text.slice(line_start..pos))
+        .map(|g| {
+            let g: Cow<str> = g.into();
+            grapheme_width(&g)
+        })
+        .sum();
+
     Position::new(line, col)
 }
 
 /// Convert (line, column) coordinates to a character index.
-pub fn pos_at_coords(text: RopeSlice, coords: Position) -> usize {
-    // TODO: this isn't correct.  This needs to work in terms of
-    // visual horizontal position, not graphemes.
+///
+/// `is_1_width` specifies whether the position should be treated
+/// as a block cursor or not.  This effects how line-ends are handled.
+/// `false` corresponds to properly round-tripping with `coords_at_pos()`,
+/// whereas `true` will ensure that block cursors don't jump off the
+/// end of the line.
+pub fn pos_at_coords(text: RopeSlice, coords: Position, is_1_width: bool) -> usize {
     let Position { row, col } = coords;
     let line_start = text.line_to_char(row);
-    // line_start + col
-    nth_next_grapheme_boundary(text, line_start, col)
+    let line_end = if is_1_width {
+        line_end_char_index(&text, row)
+    } else {
+        text.line_to_char((row + 1).min(text.len_lines()))
+    };
+
+    let mut prev_col = 0;
+    let mut col_char_offset = 0;
+    for g in RopeGraphemes::new(text.slice(line_start..line_end)) {
+        let g: Cow<str> = g.into();
+        let next_col = prev_col + grapheme_width(&g);
+
+        if next_col > col {
+            break;
+        }
+
+        prev_col = next_col;
+        col_char_offset += g.chars().count();
+    }
+
+    line_start + col_char_offset
 }
 
 #[cfg(test)]
@@ -84,13 +122,24 @@ mod test {
 
     #[test]
     fn test_coords_at_pos() {
-        // let text = Rope::from("ḧëḷḷö\nẅöṛḷḋ");
-        // let slice = text.slice(..);
-        // assert_eq!(coords_at_pos(slice, 0), (0, 0).into());
-        // assert_eq!(coords_at_pos(slice, 5), (0, 5).into()); // position on \n
-        // assert_eq!(coords_at_pos(slice, 6), (1, 0).into()); // position on w
-        // assert_eq!(coords_at_pos(slice, 7), (1, 1).into()); // position on o
-        // assert_eq!(coords_at_pos(slice, 10), (1, 4).into()); // position on d
+        let text = Rope::from("ḧëḷḷö\nẅöṛḷḋ");
+        let slice = text.slice(..);
+        assert_eq!(coords_at_pos(slice, 0), (0, 0).into());
+        assert_eq!(coords_at_pos(slice, 5), (0, 5).into()); // position on \n
+        assert_eq!(coords_at_pos(slice, 6), (1, 0).into()); // position on w
+        assert_eq!(coords_at_pos(slice, 7), (1, 1).into()); // position on o
+        assert_eq!(coords_at_pos(slice, 10), (1, 4).into()); // position on d
+
+        // Test with wide characters.
+        let text = Rope::from("今日はいい\n");
+        let slice = text.slice(..);
+        assert_eq!(coords_at_pos(slice, 0), (0, 0).into());
+        assert_eq!(coords_at_pos(slice, 1), (0, 2).into());
+        assert_eq!(coords_at_pos(slice, 2), (0, 4).into());
+        assert_eq!(coords_at_pos(slice, 3), (0, 6).into());
+        assert_eq!(coords_at_pos(slice, 4), (0, 8).into());
+        assert_eq!(coords_at_pos(slice, 5), (0, 10).into());
+        assert_eq!(coords_at_pos(slice, 6), (1, 0).into());
 
         // test with grapheme clusters
         let text = Rope::from("a̐éö̲\r\n");
@@ -99,40 +148,64 @@ mod test {
         assert_eq!(coords_at_pos(slice, 2), (0, 1).into());
         assert_eq!(coords_at_pos(slice, 4), (0, 2).into());
         assert_eq!(coords_at_pos(slice, 7), (0, 3).into());
+        assert_eq!(coords_at_pos(slice, 9), (1, 0).into());
 
-        let text = Rope::from("किमपि");
+        let text = Rope::from("किमपि\n");
         let slice = text.slice(..);
         assert_eq!(coords_at_pos(slice, 0), (0, 0).into());
-        assert_eq!(coords_at_pos(slice, 2), (0, 1).into());
-        assert_eq!(coords_at_pos(slice, 3), (0, 2).into());
-        assert_eq!(coords_at_pos(slice, 5), (0, 3).into());
+        assert_eq!(coords_at_pos(slice, 2), (0, 2).into());
+        assert_eq!(coords_at_pos(slice, 3), (0, 3).into());
+        assert_eq!(coords_at_pos(slice, 5), (0, 5).into());
+        assert_eq!(coords_at_pos(slice, 6), (1, 0).into());
     }
 
     #[test]
     fn test_pos_at_coords() {
         let text = Rope::from("ḧëḷḷö\nẅöṛḷḋ");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into()), 0);
-        assert_eq!(pos_at_coords(slice, (0, 5).into()), 5); // position on \n
-        assert_eq!(pos_at_coords(slice, (1, 0).into()), 6); // position on w
-        assert_eq!(pos_at_coords(slice, (1, 1).into()), 7); // position on o
-        assert_eq!(pos_at_coords(slice, (1, 4).into()), 10); // position on d
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 5).into(), false), 5); // position on \n
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), false), 6); // position after \n
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), true), 5); // position after \n
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 6); // position on w
+        assert_eq!(pos_at_coords(slice, (1, 1).into(), false), 7); // position on o
+        assert_eq!(pos_at_coords(slice, (1, 4).into(), false), 10); // position on d
+
+        // Test with wide characters.
+        let text = Rope::from("今日はいい\n");
+        let slice = text.slice(..);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 1);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 1);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 8).into(), false), 4);
+        assert_eq!(pos_at_coords(slice, (0, 10).into(), false), 5);
+        assert_eq!(pos_at_coords(slice, (0, 11).into(), false), 6);
+        assert_eq!(pos_at_coords(slice, (0, 11).into(), true), 5);
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 6);
 
         // test with grapheme clusters
         let text = Rope::from("a̐éö̲\r\n");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into()), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into()), 2);
-        assert_eq!(pos_at_coords(slice, (0, 2).into()), 4);
-        assert_eq!(pos_at_coords(slice, (0, 3).into()), 7); // \r\n is one char here
-        assert_eq!(pos_at_coords(slice, (0, 4).into()), 9);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 4);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 7); // \r\n is one char here
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), false), 9);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), true), 7);
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 9);
+
         let text = Rope::from("किमपि");
         // 2 - 1 - 2 codepoints
         // TODO: delete handling as per https://news.ycombinator.com/item?id=20058454
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into()), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into()), 2);
-        assert_eq!(pos_at_coords(slice, (0, 2).into()), 3);
-        assert_eq!(pos_at_coords(slice, (0, 3).into()), 5); // eol
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 5).into(), false), 5); // eol
     }
 }

--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -7,12 +7,11 @@ pub fn find_nth_next(
     n: usize,
     inclusive: bool,
 ) -> Option<usize> {
-    if pos >= text.len_chars() {
+    if pos >= text.len_chars() || n == 0 {
         return None;
     }
 
-    // start searching right after pos
-    let mut chars = text.chars_at(pos + 1);
+    let mut chars = text.chars_at(pos);
 
     for _ in 0..n {
         loop {
@@ -40,14 +39,17 @@ pub fn find_nth_prev(
     n: usize,
     inclusive: bool,
 ) -> Option<usize> {
-    // start searching right before pos
+    if pos == 0 || n == 0 {
+        return None;
+    }
+
     let mut chars = text.chars_at(pos);
 
     for _ in 0..n {
         loop {
             let c = chars.prev()?;
 
-            pos = pos.saturating_sub(1);
+            pos -= 1;
 
             if c == ch {
                 break;

--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -1,12 +1,6 @@
 use crate::RopeSlice;
 
-pub fn find_nth_next(
-    text: RopeSlice,
-    ch: char,
-    mut pos: usize,
-    n: usize,
-    inclusive: bool,
-) -> Option<usize> {
+pub fn find_nth_next(text: RopeSlice, ch: char, mut pos: usize, n: usize) -> Option<usize> {
     if pos >= text.len_chars() || n == 0 {
         return None;
     }
@@ -25,20 +19,10 @@ pub fn find_nth_next(
         }
     }
 
-    if !inclusive {
-        pos -= 1;
-    }
-
-    Some(pos)
+    Some(pos - 1)
 }
 
-pub fn find_nth_prev(
-    text: RopeSlice,
-    ch: char,
-    mut pos: usize,
-    n: usize,
-    inclusive: bool,
-) -> Option<usize> {
+pub fn find_nth_prev(text: RopeSlice, ch: char, mut pos: usize, n: usize) -> Option<usize> {
     if pos == 0 || n == 0 {
         return None;
     }
@@ -55,10 +39,6 @@ pub fn find_nth_prev(
                 break;
             }
         }
-    }
-
-    if !inclusive {
-        pos += 1;
     }
 
     Some(pos)

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -804,6 +804,86 @@ mod test {
     }
 
     #[test]
+    fn test_line_range() {
+        let r = Rope::from_str("\r\nHi\r\nthere!");
+        let s = r.slice(..);
+
+        // Zero-width ranges.
+        assert_eq!(Range::new(0, 0).line_range(s), (0, 0));
+        assert_eq!(Range::new(1, 1).line_range(s), (0, 0));
+        assert_eq!(Range::new(2, 2).line_range(s), (1, 1));
+        assert_eq!(Range::new(3, 3).line_range(s), (1, 1));
+
+        // Forward ranges.
+        assert_eq!(Range::new(0, 1).line_range(s), (0, 0));
+        assert_eq!(Range::new(0, 2).line_range(s), (0, 0));
+        assert_eq!(Range::new(0, 3).line_range(s), (0, 1));
+        assert_eq!(Range::new(1, 2).line_range(s), (0, 0));
+        assert_eq!(Range::new(2, 3).line_range(s), (1, 1));
+        assert_eq!(Range::new(3, 8).line_range(s), (1, 2));
+        assert_eq!(Range::new(0, 12).line_range(s), (0, 2));
+
+        // Reverse ranges.
+        assert_eq!(Range::new(1, 0).line_range(s), (0, 0));
+        assert_eq!(Range::new(2, 0).line_range(s), (0, 0));
+        assert_eq!(Range::new(3, 0).line_range(s), (0, 1));
+        assert_eq!(Range::new(2, 1).line_range(s), (0, 0));
+        assert_eq!(Range::new(3, 2).line_range(s), (1, 1));
+        assert_eq!(Range::new(8, 3).line_range(s), (1, 2));
+        assert_eq!(Range::new(12, 0).line_range(s), (0, 2));
+    }
+
+    #[test]
+    fn test_cursor() {
+        let r = Rope::from_str("\r\nHi\r\nthere!");
+        let s = r.slice(..);
+
+        // Zero-width ranges.
+        assert_eq!(Range::new(0, 0).cursor(s), 0);
+        assert_eq!(Range::new(2, 2).cursor(s), 2);
+        assert_eq!(Range::new(3, 3).cursor(s), 3);
+
+        // Forward ranges.
+        assert_eq!(Range::new(0, 2).cursor(s), 0);
+        assert_eq!(Range::new(0, 3).cursor(s), 2);
+        assert_eq!(Range::new(3, 6).cursor(s), 4);
+
+        // Reverse ranges.
+        assert_eq!(Range::new(2, 0).cursor(s), 0);
+        assert_eq!(Range::new(6, 2).cursor(s), 2);
+        assert_eq!(Range::new(6, 3).cursor(s), 3);
+    }
+
+    #[test]
+    fn test_put_cursor() {
+        let r = Rope::from_str("\r\nHi\r\nthere!");
+        let s = r.slice(..);
+
+        // Zero-width ranges.
+        assert_eq!(Range::new(0, 0).put_cursor(s, 0, true), Range::new(0, 2));
+        assert_eq!(Range::new(0, 0).put_cursor(s, 2, true), Range::new(0, 3));
+        assert_eq!(Range::new(2, 3).put_cursor(s, 4, true), Range::new(2, 6));
+        assert_eq!(Range::new(2, 8).put_cursor(s, 4, true), Range::new(2, 6));
+        assert_eq!(Range::new(8, 8).put_cursor(s, 4, true), Range::new(9, 4));
+
+        // Forward ranges.
+        assert_eq!(Range::new(3, 6).put_cursor(s, 0, true), Range::new(4, 0));
+        assert_eq!(Range::new(3, 6).put_cursor(s, 2, true), Range::new(4, 2));
+        assert_eq!(Range::new(3, 6).put_cursor(s, 3, true), Range::new(3, 4));
+        assert_eq!(Range::new(3, 6).put_cursor(s, 4, true), Range::new(3, 6));
+        assert_eq!(Range::new(3, 6).put_cursor(s, 6, true), Range::new(3, 7));
+        assert_eq!(Range::new(3, 6).put_cursor(s, 8, true), Range::new(3, 9));
+
+        // Reverse ranges.
+        assert_eq!(Range::new(6, 3).put_cursor(s, 0, true), Range::new(6, 0));
+        assert_eq!(Range::new(6, 3).put_cursor(s, 2, true), Range::new(6, 2));
+        assert_eq!(Range::new(6, 3).put_cursor(s, 3, true), Range::new(6, 3));
+        assert_eq!(Range::new(6, 3).put_cursor(s, 4, true), Range::new(6, 4));
+        assert_eq!(Range::new(6, 3).put_cursor(s, 6, true), Range::new(4, 7));
+        assert_eq!(Range::new(6, 3).put_cursor(s, 8, true), Range::new(4, 9));
+    }
+
+    #[test]
     fn test_split_on_matches() {
         use crate::regex::Regex;
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -11,15 +11,6 @@ use crate::{
 use smallvec::{smallvec, SmallVec};
 use std::borrow::Cow;
 
-#[inline]
-fn abs_difference(x: usize, y: usize) -> usize {
-    if x < y {
-        y - x
-    } else {
-        x - y
-    }
-}
-
 /// A single selection range.
 ///
 /// The range consists of an "anchor" and "head" position in
@@ -367,7 +358,7 @@ impl Selection {
     }
 
     /// A convenience short-cut for `transform(|r| r.min_width_1(text))`.
-    pub fn min_width_1(mut self, text: RopeSlice) -> Self {
+    pub fn min_width_1(self, text: RopeSlice) -> Self {
         self.transform(|r| r.min_width_1(text))
     }
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -455,13 +455,18 @@ impl Selection {
         for range in self.ranges.iter_mut() {
             *range = f(*range)
         }
-
         self.normalize()
     }
 
-    /// A convenience short-cut for `transform(|r| r.min_width_1(text))`.
-    pub fn min_width_1(self, text: RopeSlice) -> Self {
-        self.transform(|r| r.min_width_1(text))
+    // Ensures the selection adheres to the following invariants:
+    // 1. All ranges are grapheme aligned.
+    // 2. All ranges are at least 1 character wide, unless at the
+    //    very end of the document.
+    // 3. Ranges are non-overlapping.
+    // 4. Ranges are sorted by their position in the text.
+    pub fn ensure_invariants(self, text: RopeSlice) -> Self {
+        self.transform(|r| r.min_width_1(text).grapheme_aligned(text))
+            .normalize()
     }
 
     /// Transforms the selection into all of the left-side head positions,

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -290,11 +290,12 @@ impl Selection {
         }
     }
 
+    /// Adds a new range to the selection and makes it the primary range.
     pub fn push(mut self, range: Range) -> Self {
         self.ranges.push(range);
+        self.set_primary_index(self.ranges().len() - 1);
         self.normalize()
     }
-    // replace_range
 
     /// Map selections over a set of changes. Useful for adjusting the selection position after
     /// applying changes to a document.
@@ -318,6 +319,11 @@ impl Selection {
 
     pub fn primary_index(&self) -> usize {
         self.primary_index
+    }
+
+    pub fn set_primary_index(&mut self, idx: usize) {
+        assert!(idx < self.ranges.len());
+        self.primary_index = idx;
     }
 
     #[must_use]

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -357,13 +357,13 @@ impl Selection {
         let mut prev_i = 0;
         for i in 1..self.ranges.len() {
             if self.ranges[prev_i].overlaps(&self.ranges[i]) {
-                if i == self.primary_index {
-                    self.primary_index = prev_i;
-                }
                 self.ranges[prev_i] = self.ranges[prev_i].merge(self.ranges[i]);
             } else {
                 prev_i += 1;
                 self.ranges[prev_i] = self.ranges[i];
+            }
+            if i == self.primary_index {
+                self.primary_index = prev_i;
             }
         }
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -73,6 +73,20 @@ impl Range {
         std::cmp::max(self.anchor, self.head)
     }
 
+    /// The (inclusive) range of lines that the range overlaps.
+    #[inline]
+    #[must_use]
+    pub fn line_range(&self, text: RopeSlice) -> (usize, usize) {
+        let from = self.from();
+        let to = if self.is_empty() {
+            self.to()
+        } else {
+            prev_grapheme_boundary(text, self.to()).max(from)
+        };
+
+        (text.char_to_line(from), text.char_to_line(to))
+    }
+
     /// `true` when head and anchor are at the same position.
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -267,8 +267,15 @@ impl Selection {
     }
 
     #[must_use]
-    pub fn cursor(&self) -> usize {
-        self.primary().head
+    pub fn cursor(&self, text: RopeSlice) -> usize {
+        let range = self.primary();
+
+        // For 1-width cursor semantics.
+        if range.anchor < range.head {
+            prev_grapheme_boundary(text, range.head)
+        } else {
+            range.head
+        }
     }
 
     /// Ensure selection containing only the primary selection.

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -308,7 +308,7 @@ impl Selection {
     }
 
     /// Normalizes a `Selection`.
-    pub fn normalize(mut self) -> Self {
+    fn normalize(mut self) -> Self {
         let primary = self.ranges[self.primary_index];
         self.ranges.sort_unstable_by_key(Range::from);
         self.primary_index = self
@@ -363,7 +363,12 @@ impl Selection {
             *range = f(*range)
         }
 
-        self
+        self.normalize()
+    }
+
+    /// A convenience short-cut for `transform(|r| r.min_width_1(text))`.
+    pub fn min_width_1(mut self, text: RopeSlice) -> Self {
+        self.transform(|r| r.min_width_1(text))
     }
 
     pub fn fragments<'a>(&'a self, text: RopeSlice<'a>) -> impl Iterator<Item = Cow<str>> + 'a {

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -73,6 +73,18 @@ impl Range {
         std::cmp::max(self.anchor, self.head)
     }
 
+    /// The line number that the head is on (using 1-width semantics).
+    #[inline]
+    #[must_use]
+    pub fn head_line(&self, text: RopeSlice) -> usize {
+        let head = if self.anchor < self.head {
+            prev_grapheme_boundary(text, self.head)
+        } else {
+            self.head
+        };
+        text.char_to_line(head)
+    }
+
     /// The (inclusive) range of lines that the range overlaps.
     #[inline]
     #[must_use]

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -217,7 +217,7 @@ impl Range {
     /// grapheme-aligned.
     #[must_use]
     #[inline]
-    pub fn put(self, text: RopeSlice, extend: bool, char_idx: usize) -> Range {
+    pub fn put(self, text: RopeSlice, char_idx: usize, extend: bool) -> Range {
         let anchor = if !extend {
             char_idx
         } else if self.head >= self.anchor && char_idx < self.anchor {

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -109,8 +109,21 @@ impl Range {
     /// Map a range through a set of changes. Returns a new range representing the same position
     /// after the changes are applied.
     pub fn map(self, changes: &ChangeSet) -> Self {
-        let anchor = changes.map_pos(self.anchor, Assoc::After);
-        let head = changes.map_pos(self.head, Assoc::After);
+        use std::cmp::Ordering;
+        let (anchor, head) = match self.anchor.cmp(&self.head) {
+            Ordering::Equal => (
+                changes.map_pos(self.anchor, Assoc::After),
+                changes.map_pos(self.head, Assoc::After),
+            ),
+            Ordering::Less => (
+                changes.map_pos(self.anchor, Assoc::After),
+                changes.map_pos(self.head, Assoc::Before),
+            ),
+            Ordering::Greater => (
+                changes.map_pos(self.anchor, Assoc::Before),
+                changes.map_pos(self.head, Assoc::After),
+            ),
+        };
 
         // We want to return a new `Range` with `horiz == None` every time,
         // even if the anchor and head haven't changed, because we don't

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -286,7 +286,7 @@ impl Selection {
 
         // For 1-width cursor semantics.
         if range.anchor < range.head {
-            prev_grapheme_boundary(text, range.head)
+            prev_grapheme_boundary(text, range.head).max(range.anchor)
         } else {
             range.head
         }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -447,6 +447,20 @@ impl Selection {
         self.transform(|r| r.min_width_1(text))
     }
 
+    /// Transforms the selection into all of the left-side head positions,
+    /// using 1-width semantics.
+    pub fn cursors(self, text: RopeSlice) -> Self {
+        self.transform(|range| {
+            // For 1-width cursor semantics.
+            let pos = if range.anchor < range.head {
+                prev_grapheme_boundary(text, range.head).max(range.anchor)
+            } else {
+                range.head
+            };
+            Range::new(pos, pos)
+        })
+    }
+
     pub fn fragments<'a>(&'a self, text: RopeSlice<'a>) -> impl Iterator<Item = Cow<str>> + 'a {
         self.ranges.iter().map(move |range| range.fragment(text))
     }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -261,7 +261,7 @@ impl Selection {
 
     pub fn push(mut self, range: Range) -> Self {
         self.ranges.push(range);
-        self.normalized()
+        self.normalize()
     }
     // replace_range
 
@@ -308,7 +308,7 @@ impl Selection {
     }
 
     /// Normalizes a `Selection`.
-    pub fn normalize(&mut self) -> &mut Self {
+    pub fn normalize(mut self) -> Self {
         let primary = self.ranges[self.primary_index];
         self.ranges.sort_unstable_by_key(Range::from);
         self.primary_index = self
@@ -335,13 +335,6 @@ impl Selection {
         self
     }
 
-    /// Normalizes a `Selection`.
-    #[must_use]
-    pub fn normalized(mut self) -> Self {
-        self.normalize();
-        self
-    }
-
     // TODO: consume an iterator or a vec to reduce allocations?
     #[must_use]
     pub fn new(ranges: SmallVec<[Range; 1]>, primary_index: usize) -> Self {
@@ -355,14 +348,14 @@ impl Selection {
 
         if selection.ranges.len() > 1 {
             // TODO: only normalize if needed (any ranges out of order)
-            selection.normalize();
+            selection = selection.normalize();
         }
 
         selection
     }
 
     /// Takes a closure and maps each `Range` over the closure.
-    pub fn transform<F>(&mut self, f: F) -> &mut Self
+    pub fn transform<F>(mut self, f: F) -> Self
     where
         F: Fn(Range) -> Range,
     {
@@ -370,16 +363,6 @@ impl Selection {
             *range = f(*range)
         }
 
-        self
-    }
-
-    /// Takes a closure and maps each `Range` over the closure.
-    #[must_use]
-    pub fn transformed<F>(mut self, f: F) -> Self
-    where
-        F: Fn(Range) -> Range,
-    {
-        self.transform(f);
         self
     }
 

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -1,3 +1,4 @@
+use crate::graphemes::next_grapheme_boundary;
 use crate::{search, Selection};
 use ropey::RopeSlice;
 
@@ -40,23 +41,35 @@ pub fn find_nth_pairs_pos(
 ) -> Option<(usize, usize)> {
     let (open, close) = get_pair(ch);
 
-    let (open_pos, close_pos) = if open == close {
-        let prev = search::find_nth_prev(text, open, pos, n, true);
-        let next = search::find_nth_next(text, close, pos, n, true);
-        if text.char(pos) == open {
-            // cursor is *on* a pair
-            next.map(|n| (pos, n)).or_else(|| prev.map(|p| (p, pos)))?
+    if text.len_chars() < 2 || pos >= text.len_chars() {
+        return None;
+    }
+
+    if open == close {
+        if Some(open) == text.get_char(pos) {
+            // Special case: cursor is directly on a matching char.
+            match pos {
+                0 => Some((pos, search::find_nth_next(text, close, pos + 1, n, true)?)),
+                _ if (pos + 1) == text.len_chars() => Some((
+                    search::find_nth_prev(text, open, pos, n, true)?,
+                    text.len_chars(),
+                )),
+                // We return no match because there's no way to know which
+                // side of the char we should be searching on.
+                _ => None,
+            }
         } else {
-            (prev?, next?)
+            Some((
+                search::find_nth_prev(text, open, pos, n, true)?,
+                search::find_nth_next(text, close, pos, n, true)?,
+            ))
         }
     } else {
-        (
+        Some((
             find_nth_open_pair(text, open, close, pos, n)?,
-            find_nth_close_pair(text, open, close, pos, n)?,
-        )
-    };
-
-    Some((open_pos, close_pos))
+            next_grapheme_boundary(text, find_nth_close_pair(text, open, close, pos, n)?),
+        ))
+    }
 }
 
 fn find_nth_open_pair(
@@ -173,12 +186,13 @@ mod test {
         let slice = doc.slice(..);
 
         // cursor on [t]ext
-        assert_eq!(find_nth_pairs_pos(slice, '(', 6, 1), Some((5, 10)));
-        assert_eq!(find_nth_pairs_pos(slice, ')', 6, 1), Some((5, 10)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 6, 1), Some((5, 11)));
+        assert_eq!(find_nth_pairs_pos(slice, ')', 6, 1), Some((5, 11)));
         // cursor on so[m]e
         assert_eq!(find_nth_pairs_pos(slice, '(', 2, 1), None);
         // cursor on bracket itself
-        assert_eq!(find_nth_pairs_pos(slice, '(', 5, 1), Some((5, 10)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 5, 1), Some((5, 11)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 10, 1), Some((5, 11)));
     }
 
     #[test]
@@ -187,9 +201,9 @@ mod test {
         let slice = doc.slice(..);
 
         // cursor on go[o]d
-        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 1), Some((10, 15)));
-        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 2), Some((4, 21)));
-        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 3), Some((0, 27)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 1), Some((10, 16)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 2), Some((4, 22)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 3), Some((0, 28)));
     }
 
     #[test]
@@ -198,14 +212,14 @@ mod test {
         let slice = doc.slice(..);
 
         // cursor on go[o]d
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 1), Some((10, 15)));
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 2), Some((4, 21)));
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 3), Some((0, 27)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 1), Some((10, 16)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 2), Some((4, 22)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 13, 3), Some((0, 28)));
         // cursor on the quotes
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 10, 1), Some((10, 15)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 10, 1), None);
         // this is the best we can do since opening and closing pairs are same
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 0, 1), Some((0, 4)));
-        assert_eq!(find_nth_pairs_pos(slice, '\'', 27, 1), Some((21, 27)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 0, 1), Some((0, 5)));
+        assert_eq!(find_nth_pairs_pos(slice, '\'', 27, 1), Some((21, 28)));
     }
 
     #[test]
@@ -214,8 +228,8 @@ mod test {
         let slice = doc.slice(..);
 
         // cursor on go[o]d
-        assert_eq!(find_nth_pairs_pos(slice, '(', 15, 1), Some((5, 24)));
-        assert_eq!(find_nth_pairs_pos(slice, '(', 15, 2), Some((0, 31)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 15, 1), Some((5, 25)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 15, 2), Some((0, 32)));
     }
 
     #[test]
@@ -224,9 +238,9 @@ mod test {
         let slice = doc.slice(..);
 
         // cursor on go[o]d
-        assert_eq!(find_nth_pairs_pos(slice, '{', 13, 1), Some((10, 15)));
-        assert_eq!(find_nth_pairs_pos(slice, '[', 13, 1), Some((4, 21)));
-        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 1), Some((0, 27)));
+        assert_eq!(find_nth_pairs_pos(slice, '{', 13, 1), Some((10, 16)));
+        assert_eq!(find_nth_pairs_pos(slice, '[', 13, 1), Some((4, 22)));
+        assert_eq!(find_nth_pairs_pos(slice, '(', 13, 1), Some((0, 28)));
     }
 
     #[test]
@@ -243,7 +257,7 @@ mod test {
             get_surround_pos(slice, &selection, '(', 1)
                 .unwrap()
                 .as_slice(),
-            &[0, 5, 7, 13, 15, 23]
+            &[0, 6, 7, 14, 15, 24]
         );
     }
 

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -49,19 +49,18 @@ pub fn find_nth_pairs_pos(
         if Some(open) == text.get_char(pos) {
             // Special case: cursor is directly on a matching char.
             match pos {
-                0 => Some((pos, search::find_nth_next(text, close, pos + 1, n, true)?)),
-                _ if (pos + 1) == text.len_chars() => Some((
-                    search::find_nth_prev(text, open, pos, n, true)?,
-                    text.len_chars(),
-                )),
+                0 => Some((pos, search::find_nth_next(text, close, pos + 1, n)? + 1)),
+                _ if (pos + 1) == text.len_chars() => {
+                    Some((search::find_nth_prev(text, open, pos, n)?, text.len_chars()))
+                }
                 // We return no match because there's no way to know which
                 // side of the char we should be searching on.
                 _ => None,
             }
         } else {
             Some((
-                search::find_nth_prev(text, open, pos, n, true)?,
-                search::find_nth_next(text, close, pos, n, true)?,
+                search::find_nth_prev(text, open, pos, n)?,
+                search::find_nth_next(text, close, pos, n)? + 1,
             ))
         }
     } else {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1758,10 +1758,20 @@ impl<I: Iterator<Item = HighlightEvent>> Iterator for Merge<I> {
                 self.next_event = self.iter.next();
                 Some(event)
             }
-            // can happen if deleting and cursor at EOF, and diagnostic reaches past the end
-            (None, Some((_, _))) => {
-                self.next_span = None;
-                None
+            // Can happen if cursor at EOF and/or diagnostic reaches past the end.
+            // We need to actually emit events for the cursor-at-EOF situation,
+            // even though the range is past the end of the text.  This needs to be
+            // handled appropriately by the drawing code by not assuming that
+            // all `Source` events point to valid indices in the rope.
+            (None, Some((span, range))) => {
+                let event = HighlightStart(Highlight(*span));
+                self.queue.push(HighlightEnd);
+                self.queue.push(Source {
+                    start: range.start,
+                    end: range.end,
+                });
+                self.next_span = self.spans.next();
+                Some(event)
             }
             (None, None) => None,
             e => unreachable!("{:?}", e),

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -1,21 +1,16 @@
 use ropey::RopeSlice;
 
-use crate::chars::{categorize_char, char_is_line_ending, char_is_whitespace, CharCategory};
-use crate::movement::{self, Direction};
+use crate::chars::{categorize_char, CharCategory};
+use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
+use crate::movement::Direction;
 use crate::surround;
 use crate::Range;
 
-fn this_word_end_pos(slice: RopeSlice, pos: usize) -> usize {
-    this_word_bound_pos(slice, pos, Direction::Forward)
-}
+fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction) -> usize {
+    use CharCategory::{Eol, Whitespace};
 
-fn this_word_start_pos(slice: RopeSlice, pos: usize) -> usize {
-    this_word_bound_pos(slice, pos, Direction::Backward)
-}
-
-fn this_word_bound_pos(slice: RopeSlice, mut pos: usize, direction: Direction) -> usize {
     let iter = match direction {
-        Direction::Forward => slice.chars_at(pos + 1),
+        Direction::Forward => slice.chars_at(pos),
         Direction::Backward => {
             let mut iter = slice.chars_at(pos);
             iter.reverse();
@@ -23,25 +18,32 @@ fn this_word_bound_pos(slice: RopeSlice, mut pos: usize, direction: Direction) -
         }
     };
 
-    match categorize_char(slice.char(pos)) {
-        CharCategory::Eol | CharCategory::Whitespace => pos,
-        category => {
-            for peek in iter {
-                let curr_category = categorize_char(peek);
-                if curr_category != category
-                    || curr_category == CharCategory::Eol
-                    || curr_category == CharCategory::Whitespace
-                {
+    let mut prev_category = match direction {
+        Direction::Forward if pos == 0 => Whitespace,
+        Direction::Forward => categorize_char(slice.char(pos - 1)),
+        Direction::Backward if pos == slice.len_chars() => Whitespace,
+        Direction::Backward => categorize_char(slice.char(pos)),
+    };
+
+    for ch in iter {
+        match categorize_char(ch) {
+            Eol | Whitespace => return pos,
+            category => {
+                if category != prev_category && pos != 0 && pos != slice.len_chars() {
                     return pos;
-                }
-                pos = match direction {
-                    Direction::Forward => pos + 1,
-                    Direction::Backward => pos.saturating_sub(1),
+                } else {
+                    if direction == Direction::Forward {
+                        pos += 1;
+                    } else {
+                        pos = pos.saturating_sub(1);
+                    }
+                    prev_category = category;
                 }
             }
-            pos
         }
     }
+
+    pos
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -55,46 +57,42 @@ pub fn textobject_word(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
-    count: usize,
+    _count: usize,
 ) -> Range {
-    let this_word_start = this_word_start_pos(slice, range.head);
-    let this_word_end = this_word_end_pos(slice, range.head);
-
-    let (anchor, head);
-    match textobject {
-        TextObject::Inside => {
-            anchor = this_word_start;
-            head = this_word_end;
-        }
-        TextObject::Around => {
-            if slice
-                .get_char(this_word_end + 1)
-                .map_or(true, char_is_line_ending)
-            {
-                head = this_word_end;
-                if slice
-                    .get_char(this_word_start.saturating_sub(1))
-                    .map_or(true, char_is_line_ending)
-                {
-                    // single word on a line
-                    anchor = this_word_start;
-                } else {
-                    // last word on a line, select the whitespace before it too
-                    anchor = movement::move_prev_word_end(slice, range, count).head;
-                }
-            } else if char_is_whitespace(slice.char(range.head)) {
-                // select whole whitespace and next word
-                head = movement::move_next_word_end(slice, range, count).head;
-                anchor = movement::backwards_skip_while(slice, range.head, |c| c.is_whitespace())
-                    .map(|p| p + 1) // p is first *non* whitespace char, so +1 to get whitespace pos
-                    .unwrap_or(0);
-            } else {
-                head = movement::move_next_word_start(slice, range, count).head;
-                anchor = this_word_start;
-            }
-        }
+    // For 1-width cursor semantics.
+    let head = if range.head > range.anchor {
+        prev_grapheme_boundary(slice, range.head)
+    } else {
+        range.head
     };
-    Range::new(anchor, head)
+
+    let word_start = find_word_boundary(slice, head, Direction::Backward);
+    let word_end = match slice.get_char(head).map(categorize_char) {
+        None | Some(CharCategory::Whitespace | CharCategory::Eol) => head,
+        _ => find_word_boundary(slice, head + 1, Direction::Forward),
+    };
+
+    // Special case.
+    if word_start == word_end {
+        return Range::new(word_start, word_end);
+    }
+
+    match textobject {
+        TextObject::Inside => Range::new(word_start, word_end),
+        TextObject::Around => Range::new(
+            match slice
+                .get_char(word_start.saturating_sub(1))
+                .map(categorize_char)
+            {
+                None | Some(CharCategory::Eol) => word_start,
+                _ => prev_grapheme_boundary(slice, word_start),
+            },
+            match slice.get_char(word_end).map(categorize_char) {
+                None | Some(CharCategory::Eol) => word_end,
+                _ => next_grapheme_boundary(slice, word_end),
+            },
+        ),
+    }
 }
 
 pub fn textobject_surround(
@@ -106,7 +104,10 @@ pub fn textobject_surround(
 ) -> Range {
     surround::find_nth_pairs_pos(slice, ch, range.head, count)
         .map(|(anchor, head)| match textobject {
-            TextObject::Inside => Range::new(anchor + 1, head.saturating_sub(1)),
+            TextObject::Inside => Range::new(
+                next_grapheme_boundary(slice, anchor),
+                prev_grapheme_boundary(slice, head),
+            ),
             TextObject::Around => Range::new(anchor, head),
         })
         .unwrap_or(range)
@@ -126,70 +127,70 @@ mod test {
         let tests = &[
             (
                 "cursor at beginning of doc",
-                vec![(0, Inside, (0, 5)), (0, Around, (0, 6))],
+                vec![(0, Inside, (0, 6)), (0, Around, (0, 7))],
             ),
             (
                 "cursor at middle of word",
                 vec![
-                    (13, Inside, (10, 15)),
-                    (10, Inside, (10, 15)),
-                    (15, Inside, (10, 15)),
-                    (13, Around, (10, 16)),
-                    (10, Around, (10, 16)),
-                    (15, Around, (10, 16)),
+                    (13, Inside, (10, 16)),
+                    (10, Inside, (10, 16)),
+                    (15, Inside, (10, 16)),
+                    (13, Around, (9, 17)),
+                    (10, Around, (9, 17)),
+                    (15, Around, (9, 17)),
                 ],
             ),
             (
                 "cursor between word whitespace",
-                vec![(6, Inside, (6, 6)), (6, Around, (6, 13))],
+                vec![(6, Inside, (6, 6)), (6, Around, (6, 6))],
             ),
             (
                 "cursor on word before newline\n",
                 vec![
-                    (22, Inside, (22, 28)),
-                    (28, Inside, (22, 28)),
-                    (25, Inside, (22, 28)),
-                    (22, Around, (21, 28)),
-                    (28, Around, (21, 28)),
-                    (25, Around, (21, 28)),
+                    (22, Inside, (22, 29)),
+                    (28, Inside, (22, 29)),
+                    (25, Inside, (22, 29)),
+                    (22, Around, (21, 29)),
+                    (28, Around, (21, 29)),
+                    (25, Around, (21, 29)),
                 ],
             ),
             (
                 "cursor on newline\nnext line",
-                vec![(17, Inside, (17, 17)), (17, Around, (17, 22))],
+                vec![(17, Inside, (17, 17)), (17, Around, (17, 17))],
             ),
             (
                 "cursor on word after newline\nnext line",
                 vec![
-                    (29, Inside, (29, 32)),
-                    (30, Inside, (29, 32)),
-                    (32, Inside, (29, 32)),
-                    (29, Around, (29, 33)),
-                    (30, Around, (29, 33)),
-                    (32, Around, (29, 33)),
+                    (29, Inside, (29, 33)),
+                    (30, Inside, (29, 33)),
+                    (32, Inside, (29, 33)),
+                    (29, Around, (29, 34)),
+                    (30, Around, (29, 34)),
+                    (32, Around, (29, 34)),
                 ],
             ),
             (
                 "cursor on #$%:;* punctuation",
                 vec![
-                    (13, Inside, (10, 15)),
-                    (10, Inside, (10, 15)),
-                    (15, Inside, (10, 15)),
-                    (13, Around, (10, 16)),
-                    (10, Around, (10, 16)),
-                    (15, Around, (10, 16)),
+                    (13, Inside, (10, 16)),
+                    (10, Inside, (10, 16)),
+                    (15, Inside, (10, 16)),
+                    (13, Around, (9, 17)),
+                    (10, Around, (9, 17)),
+                    (15, Around, (9, 17)),
                 ],
             ),
             (
                 "cursor on punc%^#$:;.tuation",
                 vec![
-                    (14, Inside, (14, 20)),
-                    (20, Inside, (14, 20)),
-                    (17, Inside, (14, 20)),
-                    (14, Around, (14, 20)),
+                    (14, Inside, (14, 21)),
+                    (20, Inside, (14, 21)),
+                    (17, Inside, (14, 21)),
+                    (14, Around, (13, 22)),
                     // FIXME: edge case
                     // (20, Around, (14, 20)),
-                    (17, Around, (14, 20)),
+                    (17, Around, (13, 22)),
                 ],
             ),
             (
@@ -198,14 +199,14 @@ mod test {
                     (9, Inside, (9, 9)),
                     (10, Inside, (10, 10)),
                     (11, Inside, (11, 11)),
-                    (9, Around, (9, 16)),
-                    (10, Around, (9, 16)),
-                    (11, Around, (9, 16)),
+                    (9, Around, (9, 9)),
+                    (10, Around, (10, 10)),
+                    (11, Around, (11, 11)),
                 ],
             ),
             (
                 "cursor at end of doc",
-                vec![(19, Inside, (17, 19)), (19, Around, (16, 19))],
+                vec![(19, Inside, (17, 20)), (19, Around, (16, 20))],
             ),
         ];
 
@@ -234,67 +235,67 @@ mod test {
                 "simple (single) surround pairs",
                 vec![
                     (3, Inside, (3, 3), '(', 1),
-                    (7, Inside, (8, 13), ')', 1),
-                    (10, Inside, (8, 13), '(', 1),
-                    (14, Inside, (8, 13), ')', 1),
+                    (7, Inside, (8, 14), ')', 1),
+                    (10, Inside, (8, 14), '(', 1),
+                    (14, Inside, (8, 14), ')', 1),
                     (3, Around, (3, 3), '(', 1),
-                    (7, Around, (7, 14), ')', 1),
-                    (10, Around, (7, 14), '(', 1),
-                    (14, Around, (7, 14), ')', 1),
+                    (7, Around, (7, 15), ')', 1),
+                    (10, Around, (7, 15), '(', 1),
+                    (14, Around, (7, 15), ')', 1),
                 ],
             ),
             (
                 "samexx 'single' surround pairs",
                 vec![
                     (3, Inside, (3, 3), '\'', 1),
-                    (7, Inside, (8, 13), '\'', 1),
-                    (10, Inside, (8, 13), '\'', 1),
-                    (14, Inside, (8, 13), '\'', 1),
+                    (7, Inside, (7, 7), '\'', 1),
+                    (10, Inside, (8, 14), '\'', 1),
+                    (14, Inside, (14, 14), '\'', 1),
                     (3, Around, (3, 3), '\'', 1),
-                    (7, Around, (7, 14), '\'', 1),
-                    (10, Around, (7, 14), '\'', 1),
-                    (14, Around, (7, 14), '\'', 1),
+                    (7, Around, (7, 7), '\'', 1),
+                    (10, Around, (7, 15), '\'', 1),
+                    (14, Around, (14, 14), '\'', 1),
                 ],
             ),
             (
                 "(nested (surround (pairs)) 3 levels)",
                 vec![
-                    (0, Inside, (1, 34), '(', 1),
-                    (6, Inside, (1, 34), ')', 1),
-                    (8, Inside, (9, 24), '(', 1),
-                    (8, Inside, (9, 34), ')', 2),
-                    (20, Inside, (9, 24), '(', 2),
-                    (20, Inside, (1, 34), ')', 3),
-                    (0, Around, (0, 35), '(', 1),
-                    (6, Around, (0, 35), ')', 1),
-                    (8, Around, (8, 25), '(', 1),
-                    (8, Around, (8, 35), ')', 2),
-                    (20, Around, (8, 25), '(', 2),
-                    (20, Around, (0, 35), ')', 3),
+                    (0, Inside, (1, 35), '(', 1),
+                    (6, Inside, (1, 35), ')', 1),
+                    (8, Inside, (9, 25), '(', 1),
+                    (8, Inside, (9, 35), ')', 2),
+                    (20, Inside, (9, 25), '(', 2),
+                    (20, Inside, (1, 35), ')', 3),
+                    (0, Around, (0, 36), '(', 1),
+                    (6, Around, (0, 36), ')', 1),
+                    (8, Around, (8, 26), '(', 1),
+                    (8, Around, (8, 36), ')', 2),
+                    (20, Around, (8, 26), '(', 2),
+                    (20, Around, (0, 36), ')', 3),
                 ],
             ),
             (
                 "(mixed {surround [pair] same} line)",
                 vec![
-                    (2, Inside, (1, 33), '(', 1),
-                    (9, Inside, (8, 27), '{', 1),
-                    (18, Inside, (18, 21), '[', 1),
-                    (2, Around, (0, 34), '(', 1),
-                    (9, Around, (7, 28), '{', 1),
-                    (18, Around, (17, 22), '[', 1),
+                    (2, Inside, (1, 34), '(', 1),
+                    (9, Inside, (8, 28), '{', 1),
+                    (18, Inside, (18, 22), '[', 1),
+                    (2, Around, (0, 35), '(', 1),
+                    (9, Around, (7, 29), '{', 1),
+                    (18, Around, (17, 23), '[', 1),
                 ],
             ),
             (
                 "(stepped (surround) pairs (should) skip)",
-                vec![(22, Inside, (1, 38), '(', 1), (22, Around, (0, 39), '(', 1)],
+                vec![(22, Inside, (1, 39), '(', 1), (22, Around, (0, 40), '(', 1)],
             ),
             (
                 "[surround pairs{\non different]\nlines}",
                 vec![
-                    (7, Inside, (1, 28), '[', 1),
-                    (15, Inside, (16, 35), '{', 1),
-                    (7, Around, (0, 29), '[', 1),
-                    (15, Around, (15, 36), '{', 1),
+                    (7, Inside, (1, 29), '[', 1),
+                    (15, Inside, (16, 36), '{', 1),
+                    (7, Around, (0, 30), '[', 1),
+                    (15, Around, (15, 37), '{', 1),
                 ],
             ),
         ];

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -59,17 +59,12 @@ pub fn textobject_word(
     textobject: TextObject,
     _count: usize,
 ) -> Range {
-    // For 1-width cursor semantics.
-    let head = if range.head > range.anchor {
-        prev_grapheme_boundary(slice, range.head)
-    } else {
-        range.head
-    };
+    let pos = range.cursor(slice);
 
-    let word_start = find_word_boundary(slice, head, Direction::Backward);
-    let word_end = match slice.get_char(head).map(categorize_char) {
-        None | Some(CharCategory::Whitespace | CharCategory::Eol) => head,
-        _ => find_word_boundary(slice, head + 1, Direction::Forward),
+    let word_start = find_word_boundary(slice, pos, Direction::Backward);
+    let word_end = match slice.get_char(pos).map(categorize_char) {
+        None | Some(CharCategory::Whitespace | CharCategory::Eol) => pos,
+        _ => find_word_boundary(slice, pos + 1, Direction::Forward),
     };
 
     // Special case.

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -32,10 +32,9 @@ fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction) ->
                 if category != prev_category && pos != 0 && pos != slice.len_chars() {
                     return pos;
                 } else {
-                    if direction == Direction::Forward {
-                        pos += 1;
-                    } else {
-                        pos = pos.saturating_sub(1);
+                    match direction {
+                        Direction::Forward => pos += 1,
+                        Direction::Backward => pos = pos.saturating_sub(1),
                     }
                     prev_category = category;
                 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -652,8 +652,13 @@ where
         let text = doc.text().slice(..);
 
         let selection = doc.selection(view.id).clone().transform(|range| {
-            search_fn(text, ch, range.head, count, inclusive)
-                .map_or(range, |pos| range.put(text, pos, extend))
+            search_fn(text, ch, range.head, count, inclusive).map_or(range, |pos| {
+                if extend {
+                    range.put(text, pos, true)
+                } else {
+                    range.put(text, pos.saturating_sub(1), false)
+                }
+            })
         });
         doc.set_selection(view.id, selection);
     })

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -917,7 +917,7 @@ fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
         .min(last_line.saturating_sub(scrolloff));
 
     let text = doc.text().slice(..);
-    let pos = pos_at_coords(text, Position::new(line, cursor.col)); // this func will properly truncate to line end
+    let pos = pos_at_coords(text, Position::new(line, cursor.col), true); // this func will properly truncate to line end
 
     // TODO: only manipulate main selection
     doc.set_selection(view.id, Selection::point(pos));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -646,7 +646,7 @@ where
 
         let selection = doc.selection(view.id).clone().transform(|range| {
             // TODO: use `Range::cursor()` here instead.  However, that works in terms of
-            // graphemes, wheras this function does yet.  So we're doing the same logic
+            // graphemes, whereas this function doesn't yet.  So we're doing the same logic
             // here, but just in terms of chars instead.
             let search_start_pos = if range.anchor < range.head {
                 range.head - 1

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1017,7 +1017,10 @@ fn search_impl(doc: &mut Document, view: &mut View, contents: &str, regex: &Rege
     let selection = doc.selection(view.id);
 
     // Get the right side of the primary block cursor.
-    let start = graphemes::next_grapheme_boundary(text, selection.primary().cursor(text));
+    let start = text.char_to_byte(graphemes::next_grapheme_boundary(
+        text,
+        selection.primary().cursor(text),
+    ));
 
     // use find_at to find the next match after the cursor, loop around the end
     // Careful, `Regex` uses `bytes` as offsets, not character indices!

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -325,140 +325,111 @@ impl PartialEq for Command {
 fn move_char_left(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_horizontally(
-                doc.text().slice(..),
-                range,
-                Direction::Backward,
-                count,
-                Movement::Move,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_horizontally(text, range, Direction::Backward, count, Movement::Move)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn move_char_right(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_horizontally(
-                doc.text().slice(..),
-                range,
-                Direction::Forward,
-                count,
-                Movement::Move,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_horizontally(text, range, Direction::Forward, count, Movement::Move)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn move_line_up(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_vertically(
-                doc.text().slice(..),
-                range,
-                Direction::Backward,
-                count,
-                Movement::Move,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_vertically(text, range, Direction::Backward, count, Movement::Move)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn move_line_down(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_vertically(
-                doc.text().slice(..),
-                range,
-                Direction::Forward,
-                count,
-                Movement::Move,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_vertically(text, range, Direction::Forward, count, Movement::Move)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_line_end(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let line = range.head_line(text);
+    let text = doc.text().slice(..);
 
-            let mut pos = line_end_char_index(&text, line);
-            if doc.mode != Mode::Select {
-                pos = graphemes::prev_grapheme_boundary(text, pos);
-            }
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let line = range.head_line(text);
 
-            pos = range.head.max(pos).max(text.line_to_char(line));
+        let mut pos = line_end_char_index(&text, line);
+        if doc.mode != Mode::Select {
+            pos = graphemes::prev_grapheme_boundary(text, pos);
+        }
 
-            range.put(text, pos, doc.mode == Mode::Select)
-        }),
-    );
+        pos = range.head.max(pos).max(text.line_to_char(line));
+
+        range.put(text, pos, doc.mode == Mode::Select)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_line_end_newline(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let line = range.head_line(text);
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let line = range.head_line(text);
 
-            let mut pos = text.line_to_char((line + 1).min(text.len_lines()));
-            if doc.mode != Mode::Select {
-                pos = graphemes::prev_grapheme_boundary(text, pos);
-            }
-            range.put(text, pos, doc.mode == Mode::Select)
-        }),
-    );
+        let mut pos = text.line_to_char((line + 1).min(text.len_lines()));
+        if doc.mode != Mode::Select {
+            pos = graphemes::prev_grapheme_boundary(text, pos);
+        }
+        range.put(text, pos, doc.mode == Mode::Select)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_line_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let line = range.head_line(text);
+    let text = doc.text().slice(..);
 
-            // adjust to start of the line
-            let pos = text.line_to_char(line);
-            range.put(text, pos, doc.mode == Mode::Select)
-        }),
-    );
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let line = range.head_line(text);
+
+        // adjust to start of the line
+        let pos = text.line_to_char(line);
+        range.put(text, pos, doc.mode == Mode::Select)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_first_nonwhitespace(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let line = range.head_line(text);
+    let text = doc.text().slice(..);
 
-            if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
-                let pos = pos + text.line_to_char(line);
-                range.put(text, pos, doc.mode == Mode::Select)
-            } else {
-                range
-            }
-        }),
-    );
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let line = range.head_line(text);
+
+        if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
+            let pos = pos + text.line_to_char(line);
+            range.put(text, pos, doc.mode == Mode::Select)
+        } else {
+            range
+        }
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_window(cx: &mut Context, align: Align) {
@@ -499,80 +470,79 @@ fn goto_window_bottom(cx: &mut Context) {
 fn move_next_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| movement::move_next_word_start(doc.text().slice(..), range, count)),
-    );
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_next_word_start(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn move_prev_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| movement::move_prev_word_start(doc.text().slice(..), range, count)),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_prev_word_start(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn move_next_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| movement::move_next_word_end(doc.text().slice(..), range, count)),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_next_word_end(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn move_next_long_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                movement::move_next_long_word_start(doc.text().slice(..), range, count)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_next_long_word_start(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn move_prev_long_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                movement::move_prev_long_word_start(doc.text().slice(..), range, count)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_prev_long_word_start(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn move_next_long_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                movement::move_next_long_word_end(doc.text().slice(..), range, count)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| movement::move_next_long_word_end(text, range, count));
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_file_start(cx: &mut Context) {
@@ -590,52 +560,52 @@ fn goto_file_end(cx: &mut Context) {
 fn extend_next_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                let text = doc.text().slice(..);
-                let word = movement::move_next_word_start(text, range, count);
-                let pos = word.head;
-                range.put(text, pos, true)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| {
+            let word = movement::move_next_word_start(text, range, count);
+            let pos = word.head;
+            range.put(text, pos, true)
+        });
+    doc.set_selection(view.id, selection);
 }
 
 fn extend_prev_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                let text = doc.text().slice(..);
-                let word = movement::move_prev_word_start(text, range, count);
-                let pos = word.head;
-                range.put(text, pos, true)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| {
+            let word = movement::move_prev_word_start(text, range, count);
+            let pos = word.head;
+            range.put(text, pos, true)
+        });
+    doc.set_selection(view.id, selection);
 }
 
 fn extend_next_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .min_width_1(doc.text().slice(..))
-            .transform(|range| {
-                let text = doc.text().slice(..);
-                let word = movement::move_next_word_end(text, range, count);
-                let pos = word.head;
-                range.put(text, pos, true)
-            }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(text)
+        .transform(|range| {
+            let word = movement::move_next_word_end(text, range, count);
+            let pos = word.head;
+            range.put(text, pos, true)
+        });
+    doc.set_selection(view.id, selection);
 }
 
 #[inline]
@@ -678,15 +648,13 @@ where
         };
 
         let (view, doc) = current!(cx.editor);
+        let text = doc.text().slice(..);
 
-        doc.set_selection(
-            view.id,
-            doc.selection(view.id).clone().transform(|range| {
-                let text = doc.text().slice(..);
-                search_fn(text, ch, range.head, count, inclusive)
-                    .map_or(range, |pos| range.put(text, pos, extend))
-            }),
-        );
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            search_fn(text, ch, range.head, count, inclusive)
+                .map_or(range, |pos| range.put(text, pos, extend))
+        });
+        doc.set_selection(view.id, selection);
     })
 }
 
@@ -939,69 +907,45 @@ fn half_page_down(cx: &mut Context) {
 fn extend_char_left(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_horizontally(
-                doc.text().slice(..),
-                range,
-                Direction::Backward,
-                count,
-                Movement::Extend,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_horizontally(text, range, Direction::Backward, count, Movement::Extend)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn extend_char_right(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_horizontally(
-                doc.text().slice(..),
-                range,
-                Direction::Forward,
-                count,
-                Movement::Extend,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_horizontally(text, range, Direction::Forward, count, Movement::Extend)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_up(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_vertically(
-                doc.text().slice(..),
-                range,
-                Direction::Backward,
-                count,
-                Movement::Extend,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_vertically(text, range, Direction::Backward, count, Movement::Extend)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_down(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_vertically(
-                doc.text().slice(..),
-                range,
-                Direction::Forward,
-                count,
-                Movement::Extend,
-            )
-        }),
-    );
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        movement::move_vertically(text, range, Direction::Forward, count, Movement::Extend)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn select_all(cx: &mut Context) {
@@ -1222,30 +1166,28 @@ fn change_selection(cx: &mut Context) {
 
 fn collapse_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let pos = if range.head > range.anchor {
-                // For 1-width cursor semantics.
-                graphemes::prev_grapheme_boundary(doc.text().slice(..), range.head)
-            } else {
-                range.head
-            };
-            Range::new(pos, pos)
-        }),
-    );
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let pos = if range.head > range.anchor {
+            // For 1-width cursor semantics.
+            graphemes::prev_grapheme_boundary(text, range.head)
+        } else {
+            range.head
+        };
+        Range::new(pos, pos)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn flip_selections(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .transform(|range| Range::new(range.head, range.anchor)),
-    );
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|range| Range::new(range.head, range.anchor));
+    doc.set_selection(view.id, selection);
 }
 
 fn enter_insert_mode(doc: &mut Document) {
@@ -1257,12 +1199,11 @@ fn insert_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     enter_insert_mode(doc);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id)
-            .clone()
-            .transform(|range| Range::new(range.to(), range.from())),
-    );
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|range| Range::new(range.to(), range.from()));
+    doc.set_selection(view.id, selection);
 }
 
 // inserts at the end of each selection
@@ -1286,15 +1227,13 @@ fn append_mode(cx: &mut Context) {
         doc.apply(&transaction, view.id);
     }
 
-    doc.set_selection(
-        view.id,
-        selection.clone().transform(|range| {
-            Range::new(
-                range.from(),
-                graphemes::next_grapheme_boundary(doc.text().slice(..), range.to()),
-            )
-        }),
-    );
+    let selection = selection.transform(|range| {
+        Range::new(
+            range.from(),
+            graphemes::next_grapheme_boundary(doc.text().slice(..), range.to()),
+        )
+    });
+    doc.set_selection(view.id, selection);
 }
 
 mod cmd {
@@ -2200,15 +2139,13 @@ fn append_to_line(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     enter_insert_mode(doc);
 
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let line = range.head_line(text);
-            let pos = line_end_char_index(&text, line);
-            Range::new(pos, pos)
-        }),
-    );
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let text = doc.text().slice(..);
+        let line = range.head_line(text);
+        let pos = line_end_char_index(&text, line);
+        Range::new(pos, pos)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 /// Sometimes when applying formatting changes we want to mark the buffer as unmodified, for
@@ -2338,15 +2275,14 @@ fn normal_mode(cx: &mut Context) {
 
     // if leaving append mode, move cursor back by 1
     if doc.restore_cursor {
-        doc.set_selection(
-            view.id,
-            doc.selection(view.id).clone().transform(|range| {
-                Range::new(
-                    range.from(),
-                    graphemes::prev_grapheme_boundary(doc.text().slice(..), range.to()),
-                )
-            }),
-        );
+        let text = doc.text().slice(..);
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            Range::new(
+                range.from(),
+                graphemes::prev_grapheme_boundary(text, range.to()),
+            )
+        });
+        doc.set_selection(view.id, selection);
 
         doc.restore_cursor = false;
     }
@@ -2370,22 +2306,21 @@ fn goto_last_accessed_file(cx: &mut Context) {
 
 fn select_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
 
     // Make sure all selections are at least 1-wide.
     // (With the exception of being in an empty document, of course.)
-    doc.set_selection(
-        view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            if range.is_empty() && range.head == doc.text().len_chars() {
-                Range::new(
-                    graphemes::prev_grapheme_boundary(doc.text().slice(..), range.anchor),
-                    range.head,
-                )
-            } else {
-                range.min_width_1(doc.text().slice(..))
-            }
-        }),
-    );
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        if range.is_empty() && range.head == text.len_chars() {
+            Range::new(
+                graphemes::prev_grapheme_boundary(text, range.anchor),
+                range.head,
+            )
+        } else {
+            range.min_width_1(text)
+        }
+    });
+    doc.set_selection(view.id, selection);
 
     doc_mut!(cx.editor).mode = Mode::Select;
 }
@@ -2964,13 +2899,13 @@ pub mod insert {
     pub fn delete_word_backward(cx: &mut Context) {
         let count = cx.count();
         let (view, doc) = current!(cx.editor);
+        let text = doc.text().slice(..);
 
-        doc.set_selection(
-            view.id,
-            doc.selection(view.id).clone().transform(|range| {
-                movement::move_prev_word_start(doc.text().slice(..), range, count)
-            }),
-        );
+        let selection = doc
+            .selection(view.id)
+            .clone()
+            .transform(|range| movement::move_prev_word_start(text, range, count));
+        doc.set_selection(view.id, selection);
         delete_selection(cx)
     }
 }
@@ -3721,21 +3656,19 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         } = event
         {
             let (view, doc) = current!(cx.editor);
+            let text = doc.text().slice(..);
 
-            doc.set_selection(
-                view.id,
-                doc.selection(view.id).clone().transform(|range| {
-                    let text = doc.text().slice(..);
-                    match ch {
-                        'w' => textobject::textobject_word(text, range, objtype, count),
-                        // TODO: cancel new ranges if inconsistent surround matches across lines
-                        ch if !ch.is_ascii_alphanumeric() => {
-                            textobject::textobject_surround(text, range, objtype, ch, count)
-                        }
-                        _ => range,
+            let selection = doc.selection(view.id).clone().transform(|range| {
+                match ch {
+                    'w' => textobject::textobject_word(text, range, objtype, count),
+                    // TODO: cancel new ranges if inconsistent surround matches across lines
+                    ch if !ch.is_ascii_alphanumeric() => {
+                        textobject::textobject_surround(text, range, objtype, ch, count)
                     }
-                }),
-            );
+                    _ => range,
+                }
+            });
+            doc.set_selection(view.id, selection);
         }
     })
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -498,6 +498,7 @@ fn move_next_word_start(cx: &mut Context) {
         view.id,
         doc.selection(view.id)
             .clone()
+            .min_width_1(doc.text().slice(..))
             .transform(|range| movement::move_next_word_start(doc.text().slice(..), range, count)),
     );
 }
@@ -509,6 +510,7 @@ fn move_prev_word_start(cx: &mut Context) {
         view.id,
         doc.selection(view.id)
             .clone()
+            .min_width_1(doc.text().slice(..))
             .transform(|range| movement::move_prev_word_start(doc.text().slice(..), range, count)),
     );
 }
@@ -520,6 +522,7 @@ fn move_next_word_end(cx: &mut Context) {
         view.id,
         doc.selection(view.id)
             .clone()
+            .min_width_1(doc.text().slice(..))
             .transform(|range| movement::move_next_word_end(doc.text().slice(..), range, count)),
     );
 }
@@ -529,9 +532,12 @@ fn move_next_long_word_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_next_long_word_start(doc.text().slice(..), range, count)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                movement::move_next_long_word_start(doc.text().slice(..), range, count)
+            }),
     );
 }
 
@@ -540,9 +546,12 @@ fn move_prev_long_word_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_prev_long_word_start(doc.text().slice(..), range, count)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                movement::move_prev_long_word_start(doc.text().slice(..), range, count)
+            }),
     );
 }
 
@@ -551,9 +560,12 @@ fn move_next_long_word_end(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            movement::move_next_long_word_end(doc.text().slice(..), range, count)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                movement::move_next_long_word_end(doc.text().slice(..), range, count)
+            }),
     );
 }
 
@@ -574,12 +586,15 @@ fn extend_next_word_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let word = movement::move_next_word_start(text, range, count);
-            let pos = word.head;
-            range.put(text, pos, true)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                let text = doc.text().slice(..);
+                let word = movement::move_next_word_start(text, range, count);
+                let pos = word.head;
+                range.put(text, pos, true)
+            }),
     );
 }
 
@@ -588,12 +603,15 @@ fn extend_prev_word_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let word = movement::move_prev_word_start(text, range, count);
-            let pos = word.head;
-            range.put(text, pos, true)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                let text = doc.text().slice(..);
+                let word = movement::move_prev_word_start(text, range, count);
+                let pos = word.head;
+                range.put(text, pos, true)
+            }),
     );
 }
 
@@ -602,12 +620,15 @@ fn extend_next_word_end(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     doc.set_selection(
         view.id,
-        doc.selection(view.id).clone().transform(|range| {
-            let text = doc.text().slice(..);
-            let word = movement::move_next_word_end(text, range, count);
-            let pos = word.head;
-            range.put(text, pos, true)
-        }),
+        doc.selection(view.id)
+            .clone()
+            .min_width_1(doc.text().slice(..))
+            .transform(|range| {
+                let text = doc.text().slice(..);
+                let word = movement::move_next_word_end(text, range, count);
+                let pos = word.head;
+                range.put(text, pos, true)
+            }),
     );
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1100,16 +1100,18 @@ fn extend_line(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
 
-    let pos = doc.selection(view.id).primary();
     let text = doc.text();
+    let pos = doc.selection(view.id).primary().min_width_1(text.slice(..));
 
-    let line_start = text.char_to_line(pos.anchor);
-    let start = text.line_to_char(line_start);
-    let line_end = text.char_to_line(pos.head);
-    let mut end = line_end_char_index(&text.slice(..), line_end + count.saturating_sub(1));
+    let line_max = text.len_lines();
+    let start_line = text.char_to_line(pos.from()).min(line_max);
+    let end_line = (text.char_to_line(pos.to()) + count).min(line_max);
 
-    if pos.anchor == start && pos.head == end && line_end < (text.len_lines() - 2) {
-        end = line_end_char_index(&text.slice(..), line_end + 1);
+    let start = text.line_to_char(start_line);
+    let mut end = text.line_to_char(end_line);
+
+    if pos.from() == start && pos.to() == end {
+        end = text.line_to_char((end_line + 1).min(line_max));
     }
 
     doc.set_selection(view.id, Selection::single(start, end));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3000,9 +3000,13 @@ fn redo(cx: &mut Context) {
 
 fn yank(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
     let values: Vec<String> = doc
         .selection(view.id)
-        .fragments(doc.text().slice(..))
+        .clone()
+        .min_width_1(text)
+        .fragments(text)
         .map(Cow::into_owned)
         .collect();
 
@@ -3021,10 +3025,13 @@ fn yank(cx: &mut Context) {
 
 fn yank_joined_to_clipboard_impl(editor: &mut Editor, separator: &str) -> anyhow::Result<()> {
     let (view, doc) = current!(editor);
+    let text = doc.text().slice(..);
 
     let values: Vec<String> = doc
         .selection(view.id)
-        .fragments(doc.text().slice(..))
+        .clone()
+        .min_width_1(text)
+        .fragments(text)
         .map(Cow::into_owned)
         .collect();
 
@@ -3052,11 +3059,13 @@ fn yank_joined_to_clipboard(cx: &mut Context) {
 
 fn yank_main_selection_to_clipboard_impl(editor: &mut Editor) -> anyhow::Result<()> {
     let (view, doc) = current!(editor);
+    let text = doc.text().slice(..);
 
     let value = doc
         .selection(view.id)
         .primary()
-        .fragment(doc.text().slice(..));
+        .min_width_1(text)
+        .fragment(text);
 
     if let Err(e) = editor.clipboard_provider.set_contents(value.into_owned()) {
         bail!("Couldn't set system clipboard content: {:?}", e);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3238,8 +3238,7 @@ fn get_lines(doc: &Document, view_id: ViewId) -> Vec<usize> {
 
     // Get all line numbers
     for range in doc.selection(view_id) {
-        let start = doc.text().char_to_line(range.from());
-        let end = doc.text().char_to_line(range.to());
+        let (start, end) = range.line_range(doc.text().slice(..));
 
         for line in start..=end {
             lines.push(line)
@@ -3367,10 +3366,9 @@ fn join_selections(cx: &mut Context) {
     let fragment = Tendril::from(" ");
 
     for selection in doc.selection(view.id) {
-        let start = text.char_to_line(selection.from());
-        let mut end = text.char_to_line(selection.to());
+        let (start, mut end) = selection.line_range(slice);
         if start == end {
-            end += 1
+            end = (end + 1).min(text.len_lines() - 1);
         }
         let lines = start..end;
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3738,8 +3738,11 @@ fn surround_replace(cx: &mut Context) {
                     let transaction = Transaction::change(
                         doc.text(),
                         change_pos.iter().enumerate().map(|(i, &pos)| {
-                            let ch = if i % 2 == 0 { open } else { close };
-                            (pos, pos + 1, Some(Tendril::from_char(ch)))
+                            if i % 2 == 0 {
+                                (pos, pos + 1, Some(Tendril::from_char(open)))
+                            } else {
+                                (pos.saturating_sub(1), pos, Some(Tendril::from_char(close)))
+                            }
                         }),
                     );
                     doc.apply(&transaction, view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1024,25 +1024,15 @@ fn split_selection_on_newline(cx: &mut Context) {
 }
 
 fn search_impl(doc: &mut Document, view: &mut View, contents: &str, regex: &Regex, extend: bool) {
-    let text = doc.text();
+    let text = doc.text().slice(..);
     let selection = doc.selection(view.id);
     let start = {
+        // Get the right side of the block cursor.
         let range = selection.primary();
-
-        // This is a little bit weird.  Due to 1-width cursor semantics, we
-        // would typically want the search to always begin at the visual left-side
-        // of the head.  However, when there's already a selection from e.g. a
-        // previous search result, we don't want to include any of that selection
-        // in the subsequent search.  The code below makes a compromise between the
-        // two behaviors that hopefully behaves the way most people expect most of
-        // the time.
-        if range.anchor <= range.head {
-            text.char_to_byte(range.head)
+        if range.anchor < range.head {
+            range.head
         } else {
-            text.char_to_byte(graphemes::next_grapheme_boundary(
-                text.slice(..),
-                range.head,
-            ))
+            graphemes::next_grapheme_boundary(text, range.head)
         }
     };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3093,7 +3093,10 @@ fn paste_impl(
             // paste linewise before
             (Paste::Before, true) => text.line_to_char(text.char_to_line(range.from())),
             // paste linewise after
-            (Paste::After, true) => text.line_to_char(text.char_to_line(range.to())),
+            (Paste::After, true) => {
+                let idx = range.to().saturating_sub(1).max(range.from());
+                text.line_to_char((text.char_to_line(idx) + 1).min(text.len_lines()))
+            }
             // paste insert
             (Paste::Before, false) => range.from(),
             // paste append

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -310,48 +310,44 @@ impl PartialEq for Command {
 fn move_char_left(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_horizontally(text, range, Direction::Backward, count, Movement::Move)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn move_char_right(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_horizontally(text, range, Direction::Forward, count, Movement::Move)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn move_line_up(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_vertically(text, range, Direction::Backward, count, Movement::Move)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn move_line_down(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_vertically(text, range, Direction::Forward, count, Movement::Move)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn move_line_end(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line = text.char_to_line(range.head);
 
         let pos = line_end_char_index(&text.slice(..), line);
@@ -360,30 +356,26 @@ fn move_line_end(cx: &mut Context) {
 
         Range::new(pos, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn move_line_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line = text.char_to_line(range.head);
 
         // adjust to start of the line
         let pos = text.line_to_char(line);
         Range::new(pos, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn move_first_nonwhitespace(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line_idx = text.char_to_line(range.head);
 
         if let Some(pos) = find_first_non_whitespace_char(text.line(line_idx)) {
@@ -393,8 +385,6 @@ fn move_first_nonwhitespace(cx: &mut Context) {
             range
         }
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 // TODO: move vs extend could take an extra type Extend/Move that would
@@ -404,73 +394,49 @@ fn move_first_nonwhitespace(cx: &mut Context) {
 fn move_next_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_next_word_start(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_next_word_start(text, range, count));
 }
 
 fn move_prev_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_prev_word_start(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_prev_word_start(text, range, count));
 }
 
 fn move_next_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_next_word_end(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_next_word_end(text, range, count));
 }
 
 fn move_next_long_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_next_long_word_start(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_next_long_word_start(text, range, count));
 }
 
 fn move_prev_long_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_prev_long_word_start(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_prev_long_word_start(text, range, count));
 }
 
 fn move_next_long_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| movement::move_next_long_word_end(text, range, count));
-
-    doc.set_selection(view.id, selection);
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| movement::move_next_long_word_end(text, range, count));
 }
 
 fn move_file_start(cx: &mut Context) {
@@ -490,42 +456,37 @@ fn move_file_end(cx: &mut Context) {
 fn extend_next_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc.selection(view.id).transform(|mut range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|mut range| {
         let word = movement::move_next_word_start(text, range, count);
         let pos = word.head;
         Range::new(range.anchor, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_prev_word_start(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc.selection(view.id).transform(|mut range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|mut range| {
         let word = movement::move_prev_word_start(text, range, count);
         let pos = word.head;
         Range::new(range.anchor, pos)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_next_word_end(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
 
-    let selection = doc.selection(view.id).transform(|mut range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|mut range| {
         let word = movement::move_next_word_end(text, range, count);
         let pos = word.head;
         Range::new(range.anchor, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 #[inline]
@@ -568,9 +529,9 @@ where
         };
 
         let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
 
-        let selection = doc.selection(view.id).transform(|mut range| {
+        let (text, selection) = doc.text_and_mut_selection(view.id);
+        selection.transform(|mut range| {
             search_fn(text, ch, range.head, count, inclusive).map_or(range, |pos| {
                 if extend {
                     Range::new(range.anchor, pos)
@@ -581,8 +542,6 @@ where
                 // or (pos, pos) to move to found val
             })
         });
-
-        doc.set_selection(view.id, selection);
     })
 }
 
@@ -661,8 +620,8 @@ fn extend_prev_char(cx: &mut Context) {
 fn extend_first_nonwhitespace(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line_idx = text.char_to_line(range.head);
 
         if let Some(pos) = find_first_non_whitespace_char(text.line(line_idx)) {
@@ -672,8 +631,6 @@ fn extend_first_nonwhitespace(cx: &mut Context) {
             range
         }
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn replace(cx: &mut Context) {
@@ -784,48 +741,44 @@ fn half_page_down(cx: &mut Context) {
 fn extend_char_left(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_horizontally(text, range, Direction::Backward, count, Movement::Extend)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_char_right(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_horizontally(text, range, Direction::Forward, count, Movement::Extend)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_up(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_vertically(text, range, Direction::Backward, count, Movement::Extend)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_down(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         movement::move_vertically(text, range, Direction::Forward, count, Movement::Extend)
     });
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_end(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line = text.char_to_line(range.head);
 
         let pos = line_end_char_index(&text.slice(..), line);
@@ -834,23 +787,19 @@ fn extend_line_end(cx: &mut Context) {
 
         Range::new(range.anchor, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_line_start(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line = text.char_to_line(range.head);
 
         // adjust to start of the line
         let pos = text.line_to_char(line);
         Range::new(range.anchor, pos)
     });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn select_all(cx: &mut Context) {
@@ -1043,20 +992,16 @@ fn change_selection(cx: &mut Context) {
 
 fn collapse_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| Range::new(range.head, range.head));
 
-    doc.set_selection(view.id, selection);
+    doc.selection_mut(view.id)
+        .transform(|range| Range::new(range.head, range.head));
 }
 
 fn flip_selections(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let selection = doc
-        .selection(view.id)
-        .transform(|range| Range::new(range.head, range.anchor));
 
-    doc.set_selection(view.id, selection);
+    doc.selection_mut(view.id)
+        .transform(|range| Range::new(range.head, range.anchor));
 }
 
 fn enter_insert_mode(doc: &mut Document) {
@@ -1068,10 +1013,8 @@ fn insert_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     enter_insert_mode(doc);
 
-    let selection = doc
-        .selection(view.id)
+    doc.selection_mut(view.id)
         .transform(|range| Range::new(range.to(), range.from()));
-    doc.set_selection(view.id, selection);
 }
 
 // inserts at the end of each selection
@@ -1080,8 +1023,8 @@ fn append_mode(cx: &mut Context) {
     enter_insert_mode(doc);
     doc.restore_cursor = true;
 
-    let text = doc.text().slice(..);
-    let selection = doc.selection(view.id).transform(|range| {
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         Range::new(
             range.from(),
             graphemes::next_grapheme_boundary(text, range.to()), // to() + next char
@@ -1097,8 +1040,6 @@ fn append_mode(cx: &mut Context) {
         );
         doc.apply(&transaction, view.id);
     }
-
-    doc.set_selection(view.id, selection);
 }
 
 mod cmd {
@@ -1904,13 +1845,12 @@ fn append_to_line(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     enter_insert_mode(doc);
 
-    let selection = doc.selection(view.id).transform(|range| {
-        let text = doc.text();
+    let (text, selection) = doc.text_and_mut_selection(view.id);
+    selection.transform(|range| {
         let line = text.char_to_line(range.head);
         let pos = line_end_char_index(&text.slice(..), line);
         Range::new(pos, pos)
     });
-    doc.set_selection(view.id, selection);
 }
 
 /// Sometimes when applying formatting changes we want to mark the buffer as unmodified, for
@@ -2040,14 +1980,13 @@ fn normal_mode(cx: &mut Context) {
 
     // if leaving append mode, move cursor back by 1
     if doc.restore_cursor {
-        let text = doc.text().slice(..);
-        let selection = doc.selection(view.id).transform(|range| {
+        let (text, selection) = doc.text_and_mut_selection(view.id);
+        selection.transform(|range| {
             Range::new(
                 range.from(),
                 graphemes::prev_grapheme_boundary(text, range.to()),
             )
         });
-        doc.set_selection(view.id, selection);
 
         doc.restore_cursor = false;
     }
@@ -2679,11 +2618,9 @@ pub mod insert {
     pub fn delete_word_backward(cx: &mut Context) {
         let count = cx.count();
         let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-        let selection = doc
-            .selection(view.id)
-            .transform(|range| movement::move_prev_word_start(text, range, count));
-        doc.set_selection(view.id, selection);
+
+        let (text, selection) = doc.text_and_mut_selection(view.id);
+        selection.transform(|range| movement::move_prev_word_start(text, range, count));
         delete_selection(cx)
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -786,24 +786,27 @@ fn replace(cx: &mut Context) {
 
 fn switch_case(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let transaction =
-        Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
-            let text: Tendril = range
-                .fragment(doc.text().slice(..))
-                .chars()
-                .flat_map(|ch| {
-                    if ch.is_lowercase() {
-                        ch.to_uppercase().collect()
-                    } else if ch.is_uppercase() {
-                        ch.to_lowercase().collect()
-                    } else {
-                        vec![ch]
-                    }
-                })
-                .collect();
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(doc.text().slice(..));
+    let transaction = Transaction::change_by_selection(doc.text(), &selection, |range| {
+        let text: Tendril = range
+            .fragment(doc.text().slice(..))
+            .chars()
+            .flat_map(|ch| {
+                if ch.is_lowercase() {
+                    ch.to_uppercase().collect()
+                } else if ch.is_uppercase() {
+                    ch.to_lowercase().collect()
+                } else {
+                    vec![ch]
+                }
+            })
+            .collect();
 
-            (range.from(), range.to() + 1, Some(text))
-        });
+        (range.from(), range.to(), Some(text))
+    });
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view.id);
@@ -811,12 +814,15 @@ fn switch_case(cx: &mut Context) {
 
 fn switch_to_uppercase(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let transaction =
-        Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
-            let text: Tendril = range.fragment(doc.text().slice(..)).to_uppercase().into();
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(doc.text().slice(..));
+    let transaction = Transaction::change_by_selection(doc.text(), &selection, |range| {
+        let text: Tendril = range.fragment(doc.text().slice(..)).to_uppercase().into();
 
-            (range.from(), range.to() + 1, Some(text))
-        });
+        (range.from(), range.to(), Some(text))
+    });
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view.id);
@@ -824,12 +830,15 @@ fn switch_to_uppercase(cx: &mut Context) {
 
 fn switch_to_lowercase(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let transaction =
-        Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
-            let text: Tendril = range.fragment(doc.text().slice(..)).to_lowercase().into();
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .min_width_1(doc.text().slice(..));
+    let transaction = Transaction::change_by_selection(doc.text(), &selection, |range| {
+        let text: Tendril = range.fragment(doc.text().slice(..)).to_lowercase().into();
 
-            (range.from(), range.to() + 1, Some(text))
-        });
+        (range.from(), range.to(), Some(text))
+    });
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view.id);

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -86,7 +86,7 @@ impl Completion {
                     let item = item.unwrap();
 
                     // if more text was entered, remove it
-                    let cursor = doc.selection(view.id).cursor();
+                    let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
                     if trigger_offset < cursor {
                         let remove = Transaction::change(
                             doc.text(),
@@ -109,7 +109,7 @@ impl Completion {
                         )
                     } else {
                         let text = item.insert_text.as_ref().unwrap_or(&item.label);
-                        let cursor = doc.selection(view.id).cursor();
+                        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
                         Transaction::change(
                             doc.text(),
                             vec![(cursor, cursor, Some(text.as_str().into()))].into_iter(),
@@ -155,7 +155,7 @@ impl Completion {
         // TODO: hooks should get processed immediately so maybe do it after select!(), before
         // looping?
 
-        let cursor = doc.selection(view.id).cursor();
+        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
         if self.trigger_offset <= cursor {
             let fragment = doc.text().slice(self.trigger_offset..cursor);
             let text = Cow::from(fragment);
@@ -212,7 +212,7 @@ impl Component for Completion {
                 .language()
                 .and_then(|scope| scope.strip_prefix("source."))
                 .unwrap_or("");
-            let cursor_pos = doc.selection(view.id).cursor();
+            let cursor_pos = doc.selection(view.id).cursor(doc.text().slice(..));
             let cursor_pos = (helix_core::coords_at_pos(doc.text().slice(..), cursor_pos).row
                 - view.first_line) as u16;
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -86,7 +86,10 @@ impl Completion {
                     let item = item.unwrap();
 
                     // if more text was entered, remove it
-                    let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
+                    let cursor = doc
+                        .selection(view.id)
+                        .primary()
+                        .cursor(doc.text().slice(..));
                     if trigger_offset < cursor {
                         let remove = Transaction::change(
                             doc.text(),
@@ -109,7 +112,10 @@ impl Completion {
                         )
                     } else {
                         let text = item.insert_text.as_ref().unwrap_or(&item.label);
-                        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
+                        let cursor = doc
+                            .selection(view.id)
+                            .primary()
+                            .cursor(doc.text().slice(..));
                         Transaction::change(
                             doc.text(),
                             vec![(cursor, cursor, Some(text.as_str().into()))].into_iter(),
@@ -155,7 +161,10 @@ impl Completion {
         // TODO: hooks should get processed immediately so maybe do it after select!(), before
         // looping?
 
-        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
+        let cursor = doc
+            .selection(view.id)
+            .primary()
+            .cursor(doc.text().slice(..));
         if self.trigger_offset <= cursor {
             let fragment = doc.text().slice(self.trigger_offset..cursor);
             let text = Cow::from(fragment);
@@ -212,7 +221,10 @@ impl Component for Completion {
                 .language()
                 .and_then(|scope| scope.strip_prefix("source."))
                 .unwrap_or("");
-            let cursor_pos = doc.selection(view.id).cursor(doc.text().slice(..));
+            let cursor_pos = doc
+                .selection(view.id)
+                .primary()
+                .cursor(doc.text().slice(..));
             let cursor_pos = (helix_core::coords_at_pos(doc.text().slice(..), cursor_pos).row
                 - view.first_line) as u16;
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -378,7 +378,15 @@ impl EditorView {
             let selection = doc.selection(view.id);
 
             for selection in selection.iter().filter(|range| range.overlaps(&screen)) {
-                let head = view.screen_coords_at_pos(doc, text, selection.head);
+                let head = view.screen_coords_at_pos(
+                    doc,
+                    text,
+                    if selection.head > selection.anchor {
+                        selection.head - 1
+                    } else {
+                        selection.head
+                    },
+                );
                 if let Some(head) = head {
                     // Draw line number for selected lines.
                     let line_number = view.first_line + head.row;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -406,7 +406,10 @@ impl EditorView {
                     // TODO: set cursor position for IME
                     if let Some(syntax) = doc.syntax() {
                         use helix_core::match_brackets;
-                        let pos = doc.selection(view.id).cursor(doc.text().slice(..));
+                        let pos = doc
+                            .selection(view.id)
+                            .primary()
+                            .cursor(doc.text().slice(..));
                         let pos = match_brackets::find(syntax, doc.text(), pos)
                             .and_then(|pos| view.screen_coords_at_pos(doc, text, pos));
 
@@ -451,7 +454,10 @@ impl EditorView {
             widgets::{Paragraph, Widget},
         };
 
-        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
+        let cursor = doc
+            .selection(view.id)
+            .primary()
+            .cursor(doc.text().slice(..));
 
         let diagnostics = doc.diagnostics().iter().filter(|diagnostic| {
             diagnostic.range.start <= cursor && diagnostic.range.end >= cursor
@@ -565,7 +571,9 @@ impl EditorView {
         let position_info = {
             let pos = coords_at_pos(
                 doc.text().slice(..),
-                doc.selection(view.id).cursor(doc.text().slice(..)),
+                doc.selection(view.id)
+                    .primary()
+                    .cursor(doc.text().slice(..)),
             );
             format!("{}:{}", pos.row + 1, pos.col + 1) // convert to 1-indexing
         };

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use helix_core::{
     coords_at_pos,
-    graphemes::ensure_grapheme_boundary_next,
+    graphemes::{ensure_grapheme_boundary_next, next_grapheme_boundary, prev_grapheme_boundary},
     syntax::{self, HighlightEvent},
     LineEnding, Position, Range,
 };
@@ -165,21 +165,18 @@ impl EditorView {
         }
         .unwrap_or(base_cursor_scope);
 
-        let primary_selection_scope = theme
-            .find_scope_index("ui.selection.primary")
-            .unwrap_or(selection_scope);
-
         let highlights: Box<dyn Iterator<Item = HighlightEvent>> = if is_focused {
-            // inject selections as highlight scopes
-            let mut spans: Vec<(usize, std::ops::Range<usize>)> = Vec::new();
-
             // TODO: primary + insert mode patching:
             // (ui.cursor.primary).patch(mode).unwrap_or(cursor)
-
             let primary_cursor_scope = theme
                 .find_scope_index("ui.cursor.primary")
                 .unwrap_or(cursor_scope);
+            let primary_selection_scope = theme
+                .find_scope_index("ui.selection.primary")
+                .unwrap_or(selection_scope);
 
+            // inject selections as highlight scopes
+            let mut spans: Vec<(usize, std::ops::Range<usize>)> = Vec::new();
             for (i, range) in selections.iter().enumerate() {
                 let (cursor_scope, selection_scope) = if i == primary_idx {
                     (primary_cursor_scope, primary_selection_scope)
@@ -187,19 +184,23 @@ impl EditorView {
                     (cursor_scope, selection_scope)
                 };
 
-                if range.head == range.anchor {
+                // Special-case: cursor at end of the rope.
+                if range.head == range.anchor && range.head == text.len_chars() {
                     spans.push((cursor_scope, range.head..range.head + 1));
                     continue;
                 }
 
-                let reverse = range.head < range.anchor;
-
-                if reverse {
-                    spans.push((cursor_scope, range.head..range.head + 1));
-                    spans.push((selection_scope, range.head + 1..range.anchor + 1));
+                let range = range.min_width_1(text);
+                if range.head > range.anchor {
+                    // Standard case.
+                    let cursor_start = prev_grapheme_boundary(text, range.head);
+                    spans.push((selection_scope, range.anchor..cursor_start));
+                    spans.push((cursor_scope, cursor_start..range.head));
                 } else {
-                    spans.push((selection_scope, range.anchor..range.head));
-                    spans.push((cursor_scope, range.head..range.head + 1));
+                    // Reverse case.
+                    let cursor_end = next_grapheme_boundary(text, range.head);
+                    spans.push((cursor_scope, range.head..cursor_end));
+                    spans.push((selection_scope, cursor_end..range.anchor));
                 }
             }
 
@@ -232,7 +233,10 @@ impl EditorView {
                     spans.pop();
                 }
                 HighlightEvent::Source { start, end } => {
-                    let text = text.slice(start..end);
+                    // `unwrap_or_else` part is for off-the-end indices of
+                    // the rope, to allow cursor highlighting at the end
+                    // of the rope.
+                    let text = text.get_slice(start..end).unwrap_or_else(|| " ".into());
 
                     use helix_core::graphemes::{grapheme_width, RopeGraphemes};
 
@@ -301,7 +305,11 @@ impl EditorView {
         let info: Style = theme.get("info");
         let hint: Style = theme.get("hint");
 
-        for (i, line) in (view.first_line..last_line).enumerate() {
+        // Whether to draw the line number for the last line of the
+        // document or not.  We only draw it if it's not an empty line.
+        let draw_last = text.line_to_byte(last_line) < text.len_bytes();
+
+        for (i, line) in (view.first_line..=last_line).enumerate() {
             use helix_core::diagnostic::Severity;
             if let Some(diagnostic) = doc.diagnostics().iter().find(|d| d.line == line) {
                 surface.set_stringn(
@@ -318,11 +326,17 @@ impl EditorView {
                 );
             }
 
-            // line numbers having selections are rendered differently
+            // Line numbers having selections are rendered
+            // differently, further below.
+            let line_number_text = if line == last_line && !draw_last {
+                "    ~".into()
+            } else {
+                format!("{:>5}", line + 1)
+            };
             surface.set_stringn(
                 viewport.x + 1 - OFFSET,
                 viewport.y + i as u16,
-                format!("{:>5}", line + 1),
+                line_number_text,
                 5,
                 linenr,
             );
@@ -336,7 +350,7 @@ impl EditorView {
         if is_focused {
             let screen = {
                 let start = text.line_to_char(view.first_line);
-                let end = text.line_to_char(last_line + 1);
+                let end = text.line_to_char(last_line + 1) + 1; // +1 for cursor at end of text.
                 Range::new(start, end)
             };
 
@@ -345,10 +359,17 @@ impl EditorView {
             for selection in selection.iter().filter(|range| range.overlaps(&screen)) {
                 let head = view.screen_coords_at_pos(doc, text, selection.head);
                 if let Some(head) = head {
+                    // Draw line number for selected lines.
+                    let line_number = view.first_line + head.row;
+                    let line_number_text = if line_number == last_line && !draw_last {
+                        "    ~".into()
+                    } else {
+                        format!("{:>5}", line_number + 1)
+                    };
                     surface.set_stringn(
                         viewport.x + 1 - OFFSET,
                         viewport.y + head.row as u16,
-                        format!("{:>5}", view.first_line + head.row + 1),
+                        line_number_text,
                         5,
                         linenr_select,
                     );

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -330,16 +330,7 @@ impl EditorView {
         // document or not.  We only draw it if it's not an empty line.
         let draw_last = text.line_to_byte(last_line) < text.len_bytes();
 
-        // This is a little confuding: We can't use the `last_line` variable for
-        // our iteration below, because there's a mismatch between the
-        // inclusive/exclusiveness of the screen-based last line and the
-        // text-based last line.  So we compute what we actually need specially here.
-        let last_line_number = std::cmp::min(
-            view.first_line + view.area.height.saturating_sub(1) as usize,
-            doc.text().len_lines(),
-        );
-
-        for (i, line) in (view.first_line..last_line_number).enumerate() {
+        for (i, line) in (view.first_line..(last_line + 1)).enumerate() {
             use helix_core::diagnostic::Severity;
             if let Some(diagnostic) = doc.diagnostics().iter().find(|d| d.line == line) {
                 surface.set_stringn(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use helix_core::{
     coords_at_pos,
-    graphemes::ensure_grapheme_boundary,
+    graphemes::ensure_grapheme_boundary_next,
     syntax::{self, Highlight, HighlightEvent},
     LineEnding, Position, Range,
 };
@@ -144,8 +144,8 @@ impl EditorView {
         let highlights = highlights.into_iter().map(|event| match event.unwrap() {
             // convert byte offsets to char offset
             HighlightEvent::Source { start, end } => {
-                let start = ensure_grapheme_boundary(text, text.byte_to_char(start));
-                let end = ensure_grapheme_boundary(text, text.byte_to_char(end));
+                let start = ensure_grapheme_boundary_next(text, text.byte_to_char(start));
+                let end = ensure_grapheme_boundary_next(text, text.byte_to_char(end));
                 HighlightEvent::Source { start, end }
             }
             event => event,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -330,7 +330,16 @@ impl EditorView {
         // document or not.  We only draw it if it's not an empty line.
         let draw_last = text.line_to_byte(last_line) < text.len_bytes();
 
-        for (i, line) in (view.first_line..=last_line).enumerate() {
+        // This is a little confuding: We can't use the `last_line` variable for
+        // our iteration below, because there's a mismatch between the
+        // inclusive/exclusiveness of the screen-based last line and the
+        // text-based last line.  So we compute what we actually need specially here.
+        let last_line_number = std::cmp::min(
+            view.first_line + view.area.height.saturating_sub(1) as usize,
+            doc.text().len_lines(),
+        );
+
+        for (i, line) in (view.first_line..last_line_number).enumerate() {
             use helix_core::diagnostic::Severity;
             if let Some(diagnostic) = doc.diagnostics().iter().find(|d| d.line == line) {
                 surface.set_stringn(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -398,7 +398,7 @@ impl EditorView {
                     // TODO: set cursor position for IME
                     if let Some(syntax) = doc.syntax() {
                         use helix_core::match_brackets;
-                        let pos = doc.selection(view.id).cursor();
+                        let pos = doc.selection(view.id).cursor(doc.text().slice(..));
                         let pos = match_brackets::find(syntax, doc.text(), pos)
                             .and_then(|pos| view.screen_coords_at_pos(doc, text, pos));
 
@@ -443,7 +443,7 @@ impl EditorView {
             widgets::{Paragraph, Widget},
         };
 
-        let cursor = doc.selection(view.id).cursor();
+        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
 
         let diagnostics = doc.diagnostics().iter().filter(|diagnostic| {
             diagnostic.range.start <= cursor && diagnostic.range.end >= cursor
@@ -555,7 +555,10 @@ impl EditorView {
         //     _ => "indent:ERROR",
         // };
         let position_info = {
-            let pos = coords_at_pos(doc.text().slice(..), doc.selection(view.id).cursor());
+            let pos = coords_at_pos(
+                doc.text().slice(..),
+                doc.selection(view.id).cursor(doc.text().slice(..)),
+            );
             format!("{}:{}", pos.row + 1, pos.col + 1) // convert to 1-indexing
         };
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -448,15 +448,7 @@ impl Document {
         }
 
         let mut file = std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
-        let (mut rope, encoding) = from_reader(&mut file, encoding)?;
-
-        // search for line endings
-        let line_ending = auto_detect_line_ending(&rope).unwrap_or(DEFAULT_LINE_ENDING);
-
-        // add missing newline at the end of file
-        if rope.len_bytes() == 0 || !char_is_line_ending(rope.char(rope.len_chars() - 1)) {
-            rope.insert(rope.len_chars(), line_ending.as_str());
-        }
+        let (rope, encoding) = from_reader(&mut file, encoding)?;
 
         let mut doc = Self::from(rope, Some(encoding));
 
@@ -466,9 +458,9 @@ impl Document {
             doc.detect_language(theme, loader);
         }
 
-        // Detect indentation style and set line ending.
+        // Detect indentation style and line ending.
         doc.detect_indent_style();
-        doc.line_ending = line_ending;
+        doc.line_ending = auto_detect_line_ending(&doc.text).unwrap_or(DEFAULT_LINE_ENDING);
 
         Ok(doc)
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1161,11 +1161,7 @@ mod test {
 
     #[test]
     fn test_line_ending() {
-        if cfg!(windows) {
-            assert_eq!(Document::default().text().to_string(), "\r\n");
-        } else {
-            assert_eq!(Document::default().text().to_string(), "\n");
-        }
+        assert_eq!(Document::default().text().to_string(), "");
     }
 
     macro_rules! test_decode {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -13,8 +13,8 @@ use helix_core::{
     history::History,
     line_ending::auto_detect_line_ending,
     syntax::{self, LanguageConfiguration},
-    ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, RopeSlice, Selection, State, Syntax,
-    Transaction, DEFAULT_LINE_ENDING,
+    ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, Selection, State, Syntax, Transaction,
+    DEFAULT_LINE_ENDING,
 };
 use helix_lsp::util::LspFormatting;
 
@@ -998,22 +998,6 @@ impl Document {
     #[inline]
     pub fn selection(&self, view_id: ViewId) -> &Selection {
         &self.selections[&view_id]
-    }
-
-    #[inline]
-    pub fn selection_mut(&mut self, view_id: ViewId) -> &mut Selection {
-        self.selections
-            .get_mut(&view_id)
-            .expect("No selection set with the given ViewId")
-    }
-
-    pub fn text_and_mut_selection(&mut self, view_id: ViewId) -> (RopeSlice, &mut Selection) {
-        (
-            self.text.slice(..),
-            self.selections
-                .get_mut(&view_id)
-                .expect("No selection set with the given ViewId"),
-        )
     }
 
     pub fn relative_path(&self) -> Option<PathBuf> {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -13,8 +13,8 @@ use helix_core::{
     history::History,
     line_ending::auto_detect_line_ending,
     syntax::{self, LanguageConfiguration},
-    ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, Selection, State, Syntax, Transaction,
-    DEFAULT_LINE_ENDING,
+    ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, RopeSlice, Selection, State, Syntax,
+    Transaction, DEFAULT_LINE_ENDING,
 };
 use helix_lsp::util::LspFormatting;
 
@@ -998,6 +998,22 @@ impl Document {
     #[inline]
     pub fn selection(&self, view_id: ViewId) -> &Selection {
         &self.selections[&view_id]
+    }
+
+    #[inline]
+    pub fn selection_mut(&mut self, view_id: ViewId) -> &mut Selection {
+        self.selections
+            .get_mut(&view_id)
+            .expect("No selection set with the given ViewId")
+    }
+
+    pub fn text_and_mut_selection(&mut self, view_id: ViewId) -> (RopeSlice, &mut Selection) {
+        (
+            self.text.slice(..),
+            self.selections
+                .get_mut(&view_id)
+                .expect("No selection set with the given ViewId"),
+        )
     }
 
     pub fn relative_path(&self) -> Option<PathBuf> {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1036,7 +1036,7 @@ impl Document {
 
 impl Default for Document {
     fn default() -> Self {
-        let text = Rope::from(DEFAULT_LINE_ENDING.as_str());
+        let text = Rope::from("");
         Self::from(text, None)
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -145,7 +145,10 @@ impl Editor {
                     .entry(view.id)
                     .or_insert_with(|| Selection::point(0));
                 // TODO: reuse align_view
-                let pos = doc.selection(view.id).cursor(doc.text().slice(..));
+                let pos = doc
+                    .selection(view.id)
+                    .primary()
+                    .cursor(doc.text().slice(..));
                 let line = doc.text().char_to_line(pos);
                 view.first_line = line.saturating_sub(view.area.height as usize / 2);
 
@@ -295,7 +298,10 @@ impl Editor {
         const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
         let view = view!(self);
         let doc = &self.documents[view.doc];
-        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
+        let cursor = doc
+            .selection(view.id)
+            .primary()
+            .cursor(doc.text().slice(..));
         if let Some(mut pos) = view.screen_coords_at_pos(doc, doc.text().slice(..), cursor) {
             pos.col += view.area.x as usize + OFFSET as usize;
             pos.row += view.area.y as usize;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -141,12 +141,11 @@ impl Editor {
                 let (view, doc) = current!(self);
 
                 // initialize selection for view
-                let selection = doc
-                    .selections
+                doc.selections
                     .entry(view.id)
                     .or_insert_with(|| Selection::point(0));
                 // TODO: reuse align_view
-                let pos = selection.cursor();
+                let pos = doc.selection(view.id).cursor(doc.text().slice(..));
                 let line = doc.text().char_to_line(pos);
                 view.first_line = line.saturating_sub(view.area.height as usize / 2);
 
@@ -296,7 +295,7 @@ impl Editor {
         const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
         let view = view!(self);
         let doc = &self.documents[view.doc];
-        let cursor = doc.selection(view.id).cursor();
+        let cursor = doc.selection(view.id).cursor(doc.text().slice(..));
         if let Some(mut pos) = view.screen_coords_at_pos(doc, doc.text().slice(..), cursor) {
             pos.col += view.area.x as usize + OFFSET as usize;
             pos.row += view.area.y as usize;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -97,9 +97,9 @@ impl View {
         const OFFSET: usize = 7; // 1 diagnostic + 5 linenr + 1 gutter
         let last_col = self.first_col + (self.area.width as usize - OFFSET);
 
-        if line > last_line.saturating_sub(scrolloff) {
+        if line > last_line.saturating_sub(scrolloff + 1) {
             // scroll down
-            self.first_line += line - (last_line.saturating_sub(scrolloff));
+            self.first_line += line - (last_line.saturating_sub(scrolloff + 1));
         } else if line < self.first_line + scrolloff {
             // scroll up
             self.first_line = line.saturating_sub(scrolloff);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -84,7 +84,10 @@ impl View {
     }
 
     pub fn ensure_cursor_in_view(&mut self, doc: &Document) {
-        let cursor = doc.selection(self.id).cursor(doc.text().slice(..));
+        let cursor = doc
+            .selection(self.id)
+            .primary()
+            .cursor(doc.text().slice(..));
         let pos = coords_at_pos(doc.text().slice(..), cursor);
         let line = pos.row;
         let col = pos.col;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -84,7 +84,7 @@ impl View {
     }
 
     pub fn ensure_cursor_in_view(&mut self, doc: &Document) {
-        let cursor = doc.selection(self.id).cursor();
+        let cursor = doc.selection(self.id).cursor(doc.text().slice(..));
         let pos = coords_at_pos(doc.text().slice(..), cursor);
         let line = pos.row;
         let col = pos.col;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -119,8 +119,9 @@ impl View {
     pub fn last_line(&self, doc: &Document) -> usize {
         let height = self.area.height.saturating_sub(1); // - 1 for statusline
         std::cmp::min(
-            self.first_line + height as usize,
-            doc.text().len_lines() - 1,
+            // Saturating subs to make it inclusive zero indexing.
+            (self.first_line + height as usize).saturating_sub(1),
+            doc.text().len_lines().saturating_sub(1),
         )
     }
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -92,17 +92,17 @@ impl View {
         let line = pos.row;
         let col = pos.col;
         let height = self.area.height.saturating_sub(1); // - 1 for statusline
-        let last_line = self.first_line + height as usize;
+        let last_line = (self.first_line + height as usize).saturating_sub(1);
 
         let scrolloff = PADDING.min(self.area.height as usize / 2); // TODO: user pref
 
         // TODO: not ideal
         const OFFSET: usize = 7; // 1 diagnostic + 5 linenr + 1 gutter
-        let last_col = self.first_col + (self.area.width as usize - OFFSET);
+        let last_col = (self.first_col + self.area.width as usize).saturating_sub(OFFSET + 1);
 
-        if line > last_line.saturating_sub(scrolloff + 1) {
+        if line > last_line.saturating_sub(scrolloff) {
             // scroll down
-            self.first_line += line - (last_line.saturating_sub(scrolloff + 1));
+            self.first_line += line - (last_line.saturating_sub(scrolloff));
         } else if line < self.first_line + scrolloff {
             // scroll up
             self.first_line = line.saturating_sub(scrolloff);


### PR DESCRIPTION
Addresses #362.

Switch all code over to:
1. Use gap indexing.
2. Not assume a file-final line-ending.

All code has been adjusted so that it still presents an on-char indexing model to the user, but internally everything works in terms of gap indexing.