### PR TITLE
Detect file language before file indent style.

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -461,12 +461,13 @@ impl Document {
 
         // set the path and try detecting the language
         doc.set_path(&path)?;
-        doc.detect_indent_style();
-        doc.line_ending = line_ending;
-
         if let Some(loader) = config_loader {
             doc.detect_language(theme, loader);
         }
+
+        // Detect indentation style and set line ending.
+        doc.detect_indent_style();
+        doc.line_ending = line_ending;
 
         Ok(doc)
     }


### PR DESCRIPTION
Fixes #378.  The issue was that because indent style detection
ran before language detection, there was no language indent
style to fall back on if indent style detection failed, so it
would just default to 2 spaces.