### PR TITLE
Make command implementation return a Result<()>

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -94,16 +94,17 @@ impl Editor {
         self._refresh();
     }
 
-    pub fn set_theme_from_name(&mut self, theme: &str) {
+    pub fn set_theme_from_name(&mut self, theme: &str) -> anyhow::Result<()> {
         let theme = match self.theme_loader.load(theme.as_ref()) {
             Ok(theme) => theme,
             Err(e) => {
                 log::warn!("failed setting theme `{}` - {}", theme, e);
-                return;
+                anyhow::bail!("failed setting theme `{}` - {}", theme, e);
             }
         };
 
         self.set_theme(theme);
+        Ok(())
     }
 
     fn _refresh(&mut self) {


### PR DESCRIPTION
This is the change we discussed briefly in #335 

I did it "my way", let me know what you think and if it fits in the codebase.

Basically I `anyhow` everything, and I use `bail!` whenever convenient.

There are several locations where `log` calls were made when an error was detected, and then the error wouldn't bubble up (the clipboard errors for instance). I left the log calls but I changed the code to actually bubble the error to display a message for the user.

As such I wonder if it wouldn't be better to remove those log calls and just add one `error` log in `command_mode` any time a command fails.