### PR TITLE
Add object selection (textobjects)

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -147,7 +147,8 @@ Jumps to various locations.
 ## Match mode
 
 Enter this mode using `m` from normal mode. See the relavant section
-in [Usage](./usage.md#surround) for an explanation about surround usage.
+in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
+and [textobject](./usage.md#textobject) usage.
 
 | Key              | Description                                     |
 | -----            | -----------                                     |
@@ -155,6 +156,8 @@ in [Usage](./usage.md#surround) for an explanation about surround usage.
 | `s` `<char>`     | Surround current selection with `<char>`        |
 | `r` `<from><to>` | Replace surround character `<from>` with `<to>` |
 | `d` `<char>`     | Delete surround character `<char>`              |
+| `a` `<object>`   | Select around textobject                        |
+| `i` `<object>`   | Select inside textobject                        |
 
 ## Object mode
 

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -24,3 +24,19 @@ It can also act on multiple seletions (yay!). For example, to change every occur
 - `mr([` to replace the parens with square brackets
 
 Multiple characters are currently not supported, but planned.
+
+## Textobjects
+
+Currently supported: `word`, `surround`.
+
+![textobject-demo](https://user-images.githubusercontent.com/23398472/124231131-81a4bb00-db2d-11eb-9d10-8e577ca7b177.gif)
+
+- `ma` - Select around the object (`va` in vim, `<alt-a>` in kakoune)
+- `mi` - Select inside the object (`vi` in vim, `<alt-i>` in kakoune)
+
+| Key after `mi` or `ma` | Textobject selected      |
+| ---                    | ---                      |
+| `w`                    | Word                     |
+| `(`, `[`, `'`, etc     | Specified surround pairs |
+
+Textobjects based on treesitter, like `function`, `class`, etc are planned.

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod selection;
 mod state;
 pub mod surround;
 pub mod syntax;
+pub mod textobject;
 mod transaction;
 
 pub mod unicode {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -120,7 +120,6 @@ pub fn move_this_word_prev_bound(slice: RopeSlice, range: Range, count: usize) -
     word_move(slice, range, count, WordMotionTarget::ThisWordPrevBound)
 }
 
-
 fn word_move(slice: RopeSlice, mut range: Range, count: usize, target: WordMotionTarget) -> Range {
     (0..count).fold(range, |range, _| {
         slice.chars_at(range.head).range_to_target(target, range)

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -186,7 +186,9 @@ impl CharHelpers for Chars<'_> {
     fn range_to_target(&mut self, target: WordMotionTarget, origin: Range) -> Range {
         // Characters are iterated forward or backwards depending on the motion direction.
         let characters: Box<dyn Iterator<Item = char>> = match target {
-            WordMotionTarget::PrevWordStart | WordMotionTarget::PrevLongWordStart | WordMotionTarget::PrevWordEnd => {
+            WordMotionTarget::PrevWordStart
+            | WordMotionTarget::PrevLongWordStart
+            | WordMotionTarget::PrevWordEnd => {
                 self.next();
                 Box::new(from_fn(|| self.prev()))
             }
@@ -195,9 +197,9 @@ impl CharHelpers for Chars<'_> {
 
         // Index advancement also depends on the direction.
         let advance: &dyn Fn(&mut usize) = match target {
-            WordMotionTarget::PrevWordStart | WordMotionTarget::PrevLongWordStart | WordMotionTarget::PrevWordEnd => {
-                &|u| *u = u.saturating_sub(1)
-            }
+            WordMotionTarget::PrevWordStart
+            | WordMotionTarget::PrevLongWordStart
+            | WordMotionTarget::PrevWordEnd => &|u| *u = u.saturating_sub(1),
             _ => &|u| *u += 1,
         };
 

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -761,4 +761,86 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_behaviour_when_moving_to_end_of_previous_words() {
+        let tests = array::IntoIter::new([
+            ("Basic backward motion from the middle of a word",
+                vec![(1, Range::new(9, 9), Range::new(9, 5))]),
+            ("Starting from after boundary retreats the anchor",
+                vec![(1, Range::new(0, 13), Range::new(12, 8))]),
+            ("Jump     to end of a word succeeded by whitespace",
+                vec![(1, Range::new(10, 10), Range::new(10, 4))]),
+            ("    Jump to start of line from end of word preceded by whitespace",
+                vec![(1, Range::new(7, 7), Range::new(7, 0))]),
+            ("Previous anchor is irrelevant for backward motions",
+                vec![(1, Range::new(26, 12), Range::new(12, 8))]),
+            ("    Starting from whitespace moves to first space in sequence",
+                vec![(1, Range::new(0, 3), Range::new(3, 0))]),
+            ("Test identifiers_with_underscores are considered a single word",
+                vec![(1, Range::new(0, 25), Range::new(25, 4))]),
+            ("Jumping\n    \nback through a newline selects whitespace",
+                vec![(1, Range::new(0, 13), Range::new(11, 8))]),
+            ("Jumping to start of word from the end selects the whole word",
+                vec![(1, Range::new(15, 15), Range::new(15, 10))]),
+            ("alphanumeric.!,and.?=punctuation are considered 'words' for the purposes of word motion",
+                vec![
+                    (1, Range::new(30, 30), Range::new(30, 21)),
+                    (1, Range::new(30, 21), Range::new(20, 18)),
+                    (1, Range::new(20, 18), Range::new(17, 15))
+                ]),
+
+            ("...   ... punctuation and spaces behave as expected",
+                vec![
+                    (1, Range::new(0, 10), Range::new(9, 9)),
+                    (1, Range::new(9, 6), Range::new(5, 3)),
+                ]),
+            (".._.._ punctuation is not joined by underscores into a single block",
+                vec![(1, Range::new(0, 5), Range::new(4, 3))]),
+            ("Newlines\n\nare bridged seamlessly.",
+                vec![
+                    (1, Range::new(0, 10), Range::new(7, 0)),
+                ]),
+            ("Jumping    \n\n\n\n\nback from within a newline group selects previous block",
+                vec![
+                    (1, Range::new(0, 13), Range::new(10, 7)),
+                ]),
+            ("Failed motions do not modify the range",
+                vec![
+                    (0, Range::new(3, 0), Range::new(3, 0)),
+                ]),
+            ("Multiple motions at once resolve correctly",
+                vec![
+                    (3, Range::new(23, 23), Range::new(15, 8)),
+                ]),
+            ("Excessive motions are performed partially",
+                vec![
+                    (999, Range::new(40, 40), Range::new(8, 0)),
+                ]),
+            ("", // Edge case of moving backwards in empty string
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 0)),
+                ]),
+            ("\n\n\n\n\n", // Edge case of moving backwards in all newlines
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 0)),
+                ]),
+            ("   \n   \nJumping back through alternated space blocks and newlines selects the space blocks",
+                vec![
+                    (1, Range::new(0, 7), Range::new(6, 4)),
+                    (1, Range::new(6, 4), Range::new(2, 0)),
+                ]),
+            ("Test ヒーリクス multibyte characters behave as normal characters",
+                vec![
+                    (1, Range::new(0, 9), Range::new(9, 4)),
+                ]),
+        ]);
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_prev_word_end(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
 }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -130,6 +130,16 @@ impl Range {
     }
 }
 
+impl From<(usize, usize)> for Range {
+    fn from(tuple: (usize, usize)) -> Self {
+        Self {
+            anchor: tuple.0,
+            head: tuple.1,
+            horiz: None,
+        }
+    }
+}
+
 /// A selection consists of one or more selection ranges.
 /// invariant: A selection can never be empty (always contains at least primary range).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -1,43 +1,43 @@
 use ropey::{Rope, RopeSlice};
 
 use crate::chars::{categorize_char, char_is_line_ending, char_is_whitespace, CharCategory};
-use crate::movement;
+use crate::movement::{self, Direction};
 use crate::surround;
 use crate::Range;
 
 fn this_word_end_pos(slice: RopeSlice, mut pos: usize) -> usize {
-    match categorize_char(slice.char(pos)) {
-        CharCategory::Eol | CharCategory::Whitespace => pos,
-        category => {
-            for c in slice.chars_at(pos) {
-                let curr_category = categorize_char(c);
-                if curr_category != category
-                    || curr_category == CharCategory::Eol
-                    || curr_category == CharCategory::Whitespace
-                {
-                    return pos.saturating_sub(1);
-                }
-                pos += 1;
-            }
-            pos.saturating_sub(1)
-        }
-    }
+    this_word_bound_pos(slice, pos, Direction::Forward)
 }
 
 fn this_word_start_pos(slice: RopeSlice, mut pos: usize) -> usize {
+    this_word_bound_pos(slice, pos, Direction::Backward)
+}
+
+fn this_word_bound_pos(slice: RopeSlice, mut pos: usize, direction: Direction) -> usize {
+    let iter = match direction {
+        Direction::Forward => slice.chars_at(pos + 1),
+        Direction::Backward => {
+            let mut iter = slice.chars_at(pos);
+            iter.reverse();
+            iter
+        }
+    };
+
     match categorize_char(slice.char(pos)) {
         CharCategory::Eol | CharCategory::Whitespace => pos,
         category => {
-            let mut iter = slice.chars_at(pos + 1);
-            for c in std::iter::from_fn(|| iter.prev()) {
-                let curr_category = categorize_char(c);
+            for peek in iter {
+                let curr_category = categorize_char(peek);
                 if curr_category != category
                     || curr_category == CharCategory::Eol
                     || curr_category == CharCategory::Whitespace
                 {
-                    return pos + 1;
+                    return pos;
                 }
-                pos = pos.saturating_sub(1);
+                pos = match direction {
+                    Direction::Forward => pos + 1,
+                    Direction::Backward => pos.saturating_sub(1),
+                }
             }
             pos
         }
@@ -47,7 +47,7 @@ fn this_word_start_pos(slice: RopeSlice, mut pos: usize) -> usize {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum TextObject {
     Around,
-    Inner,
+    Inside,
 }
 
 // count doesn't do anything yet
@@ -62,7 +62,7 @@ pub fn textobject_word(
 
     let (anchor, head);
     match textobject {
-        TextObject::Inner => {
+        TextObject::Inside => {
             anchor = this_word_start;
             head = this_word_end;
         }
@@ -115,7 +115,7 @@ pub fn textobject_surround(
 ) -> Range {
     surround::find_nth_pairs_pos(slice, ch, range.head, count)
         .map(|(anchor, head)| match textobject {
-            TextObject::Inner => Range::new(anchor + 1, head - 1),
+            TextObject::Inside => Range::new(anchor + 1, head - 1),
             TextObject::Around => Range::new(anchor, head),
         })
         .unwrap_or(range)
@@ -135,14 +135,14 @@ mod test {
         let tests = &[
             (
                 "cursor at beginning of doc",
-                vec![(0, Inner, (0, 5)), (0, Around, (0, 6))],
+                vec![(0, Inside, (0, 5)), (0, Around, (0, 6))],
             ),
             (
                 "cursor at middle of word",
                 vec![
-                    (13, Inner, (10, 15)),
-                    (10, Inner, (10, 15)),
-                    (15, Inner, (10, 15)),
+                    (13, Inside, (10, 15)),
+                    (10, Inside, (10, 15)),
+                    (15, Inside, (10, 15)),
                     (13, Around, (10, 16)),
                     (10, Around, (10, 16)),
                     (15, Around, (10, 16)),
@@ -150,14 +150,14 @@ mod test {
             ),
             (
                 "cursor between word whitespace",
-                vec![(6, Inner, (6, 6)), (6, Around, (6, 13))],
+                vec![(6, Inside, (6, 6)), (6, Around, (6, 13))],
             ),
             (
                 "cursor on word before newline\n",
                 vec![
-                    (22, Inner, (22, 28)),
-                    (28, Inner, (22, 28)),
-                    (25, Inner, (22, 28)),
+                    (22, Inside, (22, 28)),
+                    (28, Inside, (22, 28)),
+                    (25, Inside, (22, 28)),
                     (22, Around, (21, 28)),
                     (28, Around, (21, 28)),
                     (25, Around, (21, 28)),
@@ -165,14 +165,14 @@ mod test {
             ),
             (
                 "cursor on newline\nnext line",
-                vec![(17, Inner, (17, 17)), (17, Around, (17, 22))],
+                vec![(17, Inside, (17, 17)), (17, Around, (17, 22))],
             ),
             (
                 "cursor on word after newline\nnext line",
                 vec![
-                    (29, Inner, (29, 32)),
-                    (30, Inner, (29, 32)),
-                    (32, Inner, (29, 32)),
+                    (29, Inside, (29, 32)),
+                    (30, Inside, (29, 32)),
+                    (32, Inside, (29, 32)),
                     (29, Around, (29, 33)),
                     (30, Around, (29, 33)),
                     (32, Around, (29, 33)),
@@ -181,9 +181,9 @@ mod test {
             (
                 "cursor on #$%:;* punctuation",
                 vec![
-                    (13, Inner, (10, 15)),
-                    (10, Inner, (10, 15)),
-                    (15, Inner, (10, 15)),
+                    (13, Inside, (10, 15)),
+                    (10, Inside, (10, 15)),
+                    (15, Inside, (10, 15)),
                     (13, Around, (10, 16)),
                     (10, Around, (10, 16)),
                     (15, Around, (10, 16)),
@@ -192,9 +192,9 @@ mod test {
             (
                 "cursor on punc%^#$:;.tuation",
                 vec![
-                    (14, Inner, (14, 20)),
-                    (20, Inner, (14, 20)),
-                    (17, Inner, (14, 20)),
+                    (14, Inside, (14, 20)),
+                    (20, Inside, (14, 20)),
+                    (17, Inside, (14, 20)),
                     (14, Around, (14, 20)),
                     // FIXME: edge case
                     // (20, Around, (14, 20)),
@@ -204,9 +204,9 @@ mod test {
             (
                 "cursor in   extra whitespace",
                 vec![
-                    (9, Inner, (9, 9)),
-                    (10, Inner, (10, 10)),
-                    (11, Inner, (11, 11)),
+                    (9, Inside, (9, 9)),
+                    (10, Inside, (10, 10)),
+                    (11, Inside, (11, 11)),
                     (9, Around, (9, 16)),
                     (10, Around, (9, 16)),
                     (11, Around, (9, 16)),
@@ -214,7 +214,7 @@ mod test {
             ),
             (
                 "cursor at end of doc",
-                vec![(19, Inner, (17, 19)), (19, Around, (16, 19))],
+                vec![(19, Inside, (17, 19)), (19, Around, (16, 19))],
             ),
         ];
 
@@ -242,10 +242,10 @@ mod test {
             (
                 "simple (single) surround pairs",
                 vec![
-                    (3, Inner, (3, 3), '(', 1),
-                    (7, Inner, (8, 13), ')', 1),
-                    (10, Inner, (8, 13), '(', 1),
-                    (14, Inner, (8, 13), ')', 1),
+                    (3, Inside, (3, 3), '(', 1),
+                    (7, Inside, (8, 13), ')', 1),
+                    (10, Inside, (8, 13), '(', 1),
+                    (14, Inside, (8, 13), ')', 1),
                     (3, Around, (3, 3), '(', 1),
                     (7, Around, (7, 14), ')', 1),
                     (10, Around, (7, 14), '(', 1),
@@ -255,10 +255,10 @@ mod test {
             (
                 "samexx 'single' surround pairs",
                 vec![
-                    (3, Inner, (3, 3), '\'', 1),
+                    (3, Inside, (3, 3), '\'', 1),
                     // FIXME: surround doesn't work when *on* same chars pair
                     // (7, Inner, (8, 13), '\'', 1),
-                    (10, Inner, (8, 13), '\'', 1),
+                    (10, Inside, (8, 13), '\'', 1),
                     // (14, Inner, (8, 13), '\'', 1),
                     (3, Around, (3, 3), '\'', 1),
                     // (7, Around, (7, 14), '\'', 1),
@@ -269,12 +269,12 @@ mod test {
             (
                 "(nested (surround (pairs)) 3 levels)",
                 vec![
-                    (0, Inner, (1, 34), '(', 1),
-                    (6, Inner, (1, 34), ')', 1),
-                    (8, Inner, (9, 24), '(', 1),
-                    (8, Inner, (9, 34), ')', 2),
-                    (20, Inner, (9, 24), '(', 2),
-                    (20, Inner, (1, 34), ')', 3),
+                    (0, Inside, (1, 34), '(', 1),
+                    (6, Inside, (1, 34), ')', 1),
+                    (8, Inside, (9, 24), '(', 1),
+                    (8, Inside, (9, 34), ')', 2),
+                    (20, Inside, (9, 24), '(', 2),
+                    (20, Inside, (1, 34), ')', 3),
                     (0, Around, (0, 35), '(', 1),
                     (6, Around, (0, 35), ')', 1),
                     (8, Around, (8, 25), '(', 1),
@@ -286,9 +286,9 @@ mod test {
             (
                 "(mixed {surround [pair] same} line)",
                 vec![
-                    (2, Inner, (1, 33), '(', 1),
-                    (9, Inner, (8, 27), '{', 1),
-                    (18, Inner, (18, 21), '[', 1),
+                    (2, Inside, (1, 33), '(', 1),
+                    (9, Inside, (8, 27), '{', 1),
+                    (18, Inside, (18, 21), '[', 1),
                     (2, Around, (0, 34), '(', 1),
                     (9, Around, (7, 28), '{', 1),
                     (18, Around, (17, 22), '[', 1),
@@ -296,13 +296,13 @@ mod test {
             ),
             (
                 "(stepped (surround) pairs (should) skip)",
-                vec![(22, Inner, (1, 38), '(', 1), (22, Around, (0, 39), '(', 1)],
+                vec![(22, Inside, (1, 38), '(', 1), (22, Around, (0, 39), '(', 1)],
             ),
             (
                 "[surround pairs{\non different]\nlines}",
                 vec![
-                    (7, Inner, (1, 28), '[', 1),
-                    (15, Inner, (16, 35), '{', 1),
+                    (7, Inside, (1, 28), '[', 1),
+                    (15, Inside, (16, 35), '{', 1),
                     (7, Around, (0, 29), '[', 1),
                     (15, Around, (15, 36), '{', 1),
                 ],

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -30,12 +30,12 @@ pub fn textobject_word(
         TextObject::Around => {
             if slice
                 .get_char(this_word_end + 1)
-                .map_or(true, |c| char_is_line_ending(c))
+                .map_or(true, char_is_line_ending)
             {
                 head = this_word_end;
                 if slice
                     .get_char(this_word_start - 1)
-                    .map_or(true, |c| char_is_line_ending(c))
+                    .map_or(true, char_is_line_ending)
                 {
                     // single word on a line
                     anchor = this_word_start;

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -46,7 +46,7 @@ pub fn textobject_word(
             } else if char_is_whitespace(slice.char(range.head)) {
                 // select whole whitespace and next word
                 head = movement::move_next_word_end(slice, range, count).head;
-                anchor = movement::move_this_word_prev_bound(slice, range, count).head;
+                anchor = movement::move_prev_word_end_sticky(slice, range, count).head;
             } else {
                 head = movement::move_next_word_start(slice, range, count).head;
                 anchor = movement::move_this_word_start(slice, range, count).head;

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -1,15 +1,15 @@
-use ropey::{Rope, RopeSlice};
+use ropey::RopeSlice;
 
 use crate::chars::{categorize_char, char_is_line_ending, char_is_whitespace, CharCategory};
 use crate::movement::{self, Direction};
 use crate::surround;
 use crate::Range;
 
-fn this_word_end_pos(slice: RopeSlice, mut pos: usize) -> usize {
+fn this_word_end_pos(slice: RopeSlice, pos: usize) -> usize {
     this_word_bound_pos(slice, pos, Direction::Forward)
 }
 
-fn this_word_start_pos(slice: RopeSlice, mut pos: usize) -> usize {
+fn this_word_start_pos(slice: RopeSlice, pos: usize) -> usize {
     this_word_bound_pos(slice, pos, Direction::Backward)
 }
 
@@ -95,15 +95,6 @@ pub fn textobject_word(
         }
     };
     Range::new(anchor, head)
-}
-
-pub fn textobject_paragraph(
-    slice: RopeSlice,
-    range: Range,
-    textobject: TextObject,
-    count: usize,
-) -> Range {
-    Range::point(0)
 }
 
 pub fn textobject_surround(

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -1,0 +1,126 @@
+use ropey::{Rope, RopeSlice};
+
+use crate::chars::{char_is_line_ending, char_is_whitespace};
+use crate::movement;
+use crate::Range;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum TextObject {
+    Around,
+    Inner,
+}
+
+// count doesn't do anything yet
+pub fn textobject_word(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    count: usize,
+) -> Range {
+    let this_word_start = movement::move_this_word_start(slice, range, count).head;
+    let this_word_end = movement::move_this_word_end(slice, range, count).head;
+
+    let (anchor, head);
+    match textobject {
+        TextObject::Inner => {
+            anchor = this_word_start;
+            head = this_word_end;
+        }
+        TextObject::Around => {
+            if slice
+                .get_char(this_word_end + 1)
+                .map_or(true, |c| char_is_line_ending(c))
+            {
+                head = this_word_end;
+                if slice
+                    .get_char(this_word_start - 1)
+                    .map_or(true, |c| char_is_line_ending(c))
+                {
+                    // single word on a line
+                    anchor = this_word_start;
+                } else {
+                    // last word on a line, select the whitespace before it too
+                    anchor = movement::move_prev_word_end(slice, range, count).head;
+                }
+            } else if char_is_whitespace(slice.char(range.head)) {
+                // select whole whitespace and next word
+                head = movement::move_next_word_end(slice, range, count).head;
+                anchor = movement::move_this_word_prev_bound(slice, range, count).head;
+            } else {
+                head = movement::move_next_word_start(slice, range, count).head;
+                anchor = movement::move_this_word_start(slice, range, count).head;
+            }
+        }
+    };
+    Range::new(anchor, head)
+}
+
+pub fn textobject_paragraph(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    count: usize,
+) -> Range {
+    Range::point(0)
+}
+
+pub fn textobject_surround(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    ch: char,
+    count: usize,
+) -> Range {
+    Range::point(0)
+}
+
+#[cfg(test)]
+mod test {
+    use super::TextObject::*;
+    use super::*;
+
+    use crate::Range;
+    use ropey::Rope;
+
+    #[test]
+    fn test_textobject_word() {
+        let doc = Rope::from("text with chars\nmore lines\n$!@%word   next ");
+        let slice = doc.slice(..);
+
+        // initial, textobject, final
+        let cases = &[
+            // cursor at w[i]th
+            ((6, 6), Inner, (5, 8)), // [with]
+            ((6, 6), Around, (5, 9)), // [with ]
+            // cursor at text[ ]with
+            ((4, 4), Inner, (4, 4)), // no change
+            ((4, 4), Around, (4, 8)), // [ with]
+            // cursor at [c]hars
+            ((10, 10), Inner, (10, 14)), // [chars]
+            ((10, 10), Around, (9, 14)), // [ chars]
+            // cursor at char[s]
+            ((14, 14), Inner, (10, 14)), // [chars]
+            ((14, 14), Around, (9, 14)), // [ chars]
+            // cursor at chars[\n]more
+            ((15, 15), Inner, (15, 15)), // no change
+            ((15, 15), Around, (15, 20)), // [\nmore ]
+            // cursor at [m]ore
+            ((16, 16), Inner, (16, 19)), // [more]
+            ((16, 16), Around, (16, 20)), // [more ]
+            // cursor at $!@[%]
+            ((30, 30), Inner, (27, 30)), // [$!@%]
+            // ((30, 30), Around, (27, 30)), // [$!@%]
+            // cursor at word [ ] next
+            ((36, 36), Inner, (36, 36)), // no change
+            ((36, 36), Around, (35, 41)), // word[   next]
+        ];
+
+        for &case in cases {
+            let (before, textobject, after) = case;
+            let before = Range::new(before.0, before.1);
+            let expected = Range::new(after.0, after.1);
+            let result = textobject_word(slice, before, textobject, 1);
+            assert_eq!(expected, result, "\n{:?}", case);
+        }
+    }
+}

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -73,7 +73,7 @@ pub fn textobject_word(
             {
                 head = this_word_end;
                 if slice
-                    .get_char(this_word_start - 1)
+                    .get_char(this_word_start.saturating_sub(1))
                     .map_or(true, char_is_line_ending)
                 {
                     // single word on a line
@@ -106,7 +106,7 @@ pub fn textobject_surround(
 ) -> Range {
     surround::find_nth_pairs_pos(slice, ch, range.head, count)
         .map(|(anchor, head)| match textobject {
-            TextObject::Inside => Range::new(anchor + 1, head - 1),
+            TextObject::Inside => Range::new(anchor + 1, head.saturating_sub(1)),
             TextObject::Around => Range::new(anchor, head),
         })
         .unwrap_or(range)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3426,6 +3426,10 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             let selection = doc.selection(view.id).transform(|mut range| {
                 match ch {
                     'w' => textobject::textobject_word(text, range, objtype, count),
+                    // TODO: cancel new ranges if inconsistent surround matches across lines
+                    ch if !ch.is_ascii_alphanumeric() => {
+                        textobject::textobject_surround(text, range, objtype, ch, count)
+                    }
                     _ => range,
                 }
             });
@@ -3433,7 +3437,6 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             doc.set_selection(view.id, selection);
         }
     })
-
 }
 
 fn surround_add(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3507,7 +3507,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             let (view, doc) = current!(cx.editor);
             let text = doc.text().slice(..);
 
-            let selection = doc.selection(view.id).transform(|mut range| {
+            let selection = doc.selection(view.id).transform(|range| {
                 match ch {
                     'w' => textobject::textobject_word(text, range, objtype, count),
                     // TODO: cancel new ranges if inconsistent surround matches across lines

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3405,7 +3405,7 @@ fn match_mode(cx: &mut Context) {
                 'r' => surround_replace(cx),
                 'd' => surround_delete(cx),
                 'a' => select_textobject(cx, textobject::TextObject::Around),
-                'i' => select_textobject(cx, textobject::TextObject::Inner),
+                'i' => select_textobject(cx, textobject::TextObject::Inside),
                 _ => (),
             }
         }


### PR DESCRIPTION
Closes #213.

![helix-textobject-1](https://user-images.githubusercontent.com/23398472/124231131-81a4bb00-db2d-11eb-9d10-8e577ca7b177.gif)

Uses `ma` (match around) and `mi` (match inside).

#### TODO

- [x] Objects
    - [x] Word - `maw`, `miw`
    - [x] Brackets (surround) - `ma(`, `mi"`, `2ma[`, etc
- [x] Docs
    - [x] Usage
    - [x] Keymaps

#### Future Work

- Treesitter based objects (function, class, parameter, etc)
- Paragraph object
- WORD object
