### PR TITLE
Fix surround bug when cursor on same pair

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -44,7 +44,7 @@ pub fn find_nth_pairs_pos(
         let prev = search::find_nth_prev(text, open, pos, n, true);
         let next = search::find_nth_next(text, close, pos, n, true);
         if text.char(pos) == open {
-            // curosr is *on* a pair
+            // cursor is *on* a pair
             next.map(|n| (pos, n)).or_else(|| prev.map(|p| (p, pos)))?
         } else {
             (prev?, next?)

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -247,14 +247,13 @@ mod test {
                 "samexx 'single' surround pairs",
                 vec![
                     (3, Inside, (3, 3), '\'', 1),
-                    // FIXME: surround doesn't work when *on* same chars pair
-                    // (7, Inner, (8, 13), '\'', 1),
+                    (7, Inside, (8, 13), '\'', 1),
                     (10, Inside, (8, 13), '\'', 1),
-                    // (14, Inner, (8, 13), '\'', 1),
+                    (14, Inside, (8, 13), '\'', 1),
                     (3, Around, (3, 3), '\'', 1),
-                    // (7, Around, (7, 14), '\'', 1),
+                    (7, Around, (7, 14), '\'', 1),
                     (10, Around, (7, 14), '\'', 1),
-                    // (14, Around, (7, 14), '\'', 1),
+                    (14, Around, (7, 14), '\'', 1),
                 ],
             ),
             (


### PR DESCRIPTION
For example when the cursor is on the `'` in `'word'`, the cursor wouldn't move because the search for a matching pair started _from_ the position of the cursor and simply found itself.