### PR TITLE
Add julia support (LSP not working)

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -165,6 +165,31 @@ roots = []
 
 indent = { tab-width = 4, unit = "\t" }
 
+[[language]]
+name = "julia"
+scope = "source.julia"
+injection-regex = "julia"
+file-types = ["jl"]
+roots = []
+
+args = [
+        "--startup-file=no",
+        "--history-file=no",
+        "-e",
+        """
+                using LanguageServer;
+                using Pkg;
+                import StaticLint;
+                import SymbolServer;
+                env_path = dirname(Pkg.Types.Context().env.project_file);
+
+                server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, "");
+                server.runlinter = true;
+                run(server);
+        """,
+        ]
+indent = { tab-width = 2, unit = "  " }
+
 # [[language]]
 # name = "haskell"
 # scope = "source.haskell"

--- a/languages.toml
+++ b/languages.toml
@@ -171,23 +171,7 @@ scope = "source.julia"
 injection-regex = "julia"
 file-types = ["jl"]
 roots = []
-
-args = [
-        "--startup-file=no",
-        "--history-file=no",
-        "-e",
-        """
-                using LanguageServer;
-                using Pkg;
-                import StaticLint;
-                import SymbolServer;
-                env_path = dirname(Pkg.Types.Context().env.project_file);
-
-                server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, "");
-                server.runlinter = true;
-                run(server);
-        """,
-        ]
+language-server = { command = "julia", args = [ "--startup-file=no", "--history-file=no", "-e", "using LanguageServer;using Pkg;import StaticLint;import SymbolServer;env_path = dirname(Pkg.Types.Context().env.project_file);server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, \"\");server.runlinter = true;run(server);" ] }
 indent = { tab-width = 2, unit = "  " }
 
 # [[language]]

--- a/runtime/queries/julia/folds.scm
+++ b/runtime/queries/julia/folds.scm
@@ -1,0 +1,11 @@
+[
+ (module_definition)
+ (struct_definition)
+ (macro_definition)
+ (function_definition)
+ (compound_expression) ; begin blocks
+ (let_statement)
+ (if_statement)
+ (for_statement)
+ (while_statement)
+] @fold

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -1,0 +1,180 @@
+(identifier) @variable
+;; In case you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
+;((identifier) @type ; exception: mark `A_foo` sort of identifiers as variables
+  ;(match? @type "^[A-Z][^_]"))
+((identifier) @constant
+  (match? @constant "^[A-Z][A-Z_]{2}[A-Z_]*$"))
+
+[
+  (triple_string)
+  (string)
+] @string
+
+(string
+  prefix: (identifier) @constant.builtin)
+
+(macro_identifier) @function.macro
+(macro_identifier (identifier) @function.macro) ; for any one using the variable highlight
+(macro_definition
+  name: (identifier) @function.macro
+  ["macro" "end" @keyword])
+
+(field_expression
+  (identifier)
+  (identifier) @field .)
+
+(function_definition
+  name: (identifier) @function)
+(call_expression
+  (identifier) @function)
+(call_expression
+  (field_expression (identifier) @method .))
+(broadcast_call_expression
+  (identifier) @function)
+(broadcast_call_expression
+  (field_expression (identifier) @method .))
+(parameter_list
+  (identifier) @parameter)
+(parameter_list
+  (optional_parameter .
+    (identifier) @parameter))
+(typed_parameter
+  (identifier) @parameter
+  (identifier) @type)
+(type_parameter_list
+  (identifier) @type)
+(typed_parameter
+  (identifier) @parameter
+  (parameterized_identifier) @type)
+(function_expression
+  . (identifier) @parameter)
+(spread_parameter) @parameter
+(spread_parameter
+  (identifier) @parameter)
+(named_argument
+    . (identifier) @parameter)
+(argument_list
+  (typed_expression
+    (identifier) @parameter
+    (identifier) @type))
+(argument_list
+  (typed_expression
+    (identifier) @parameter
+    (parameterized_identifier) @type))
+
+;; Symbol expressions (:my-wanna-be-lisp-keyword)
+(quote_expression
+ (identifier)) @symbol
+
+;; Parsing error! foo (::Type) get's parsed as two quote expressions
+(argument_list 
+  (quote_expression
+    (quote_expression
+      (identifier) @type)))
+
+(type_argument_list
+  (identifier) @type)
+(parameterized_identifier (_)) @type
+(argument_list
+  (typed_expression . (identifier) @parameter))
+
+(typed_expression
+  (identifier) @type .)
+(typed_expression
+  (parameterized_identifier) @type .)
+
+(struct_definition
+  name: (identifier) @type)
+
+(number) @number
+(range_expression
+    (identifier) @number
+      (eq? @number "end"))
+(range_expression
+  (_
+    (identifier) @number
+      (eq? @number "end")))
+(coefficient_expression
+  (number)
+  (identifier) @constant.builtin)
+
+;; TODO: operators.
+;; Those are a bit difficult to implement since the respective nodes are hidden right now (_power_operator)
+;; and heavily use Unicode chars (support for those are bad in vim/lua regexes)
+;[;
+    ;(power_operator);
+    ;(times_operator);
+    ;(plus_operator);
+    ;(arrow_operator);
+    ;(comparison_operator);
+    ;(assign_operator);
+;] @operator ;
+
+"end" @keyword
+
+(if_statement
+  ["if" "end"] @conditional)
+(elseif_clause
+  ["elseif"] @conditional)
+(else_clause
+  ["else"] @conditional)
+(ternary_expression
+  ["?" ":"] @conditional)
+
+(function_definition ["function" "end"] @keyword.function)
+
+(comment) @comment
+
+[
+  "const"
+  "return"
+  "macro"
+  "struct"
+  "primitive"
+  "type"
+] @keyword
+
+((identifier) @keyword (#any-of? @keyword "global" "local"))
+
+(compound_expression
+  ["begin" "end"] @keyword)
+(try_statement
+  ["try" "end" ] @exception)
+(finally_clause
+  "finally" @exception)
+(catch_clause
+  "catch" @exception)
+(quote_statement
+  ["quote" "end"] @keyword)
+(let_statement
+  ["let" "end"] @keyword)
+(for_statement
+  ["for" "end"] @repeat)
+(while_statement
+  ["while" "end"] @repeat)
+(break_statement) @repeat
+(continue_statement) @repeat
+(for_binding
+  "in" @repeat)
+(for_clause
+  "for" @repeat)
+(do_clause
+  ["do" "end"] @keyword)
+
+(export_statement
+  ["export"] @include)
+
+[
+  "using"
+  "module"
+  "import"
+] @include
+
+((identifier) @include (#eq? @include "baremodule"))
+
+(((identifier) @constant.builtin) (match? @constant.builtin "^(nothing|Inf|NaN)$"))
+(((identifier) @boolean) (eq? @boolean "true"))
+(((identifier) @boolean) (eq? @boolean "false"))
+
+["::" ":" "." "," "..." "!"] @punctuation.delimiter
+["[" "]" "(" ")" "{" "}"] @punctuation.bracket

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,0 +1,5 @@
+; TODO: re-add when markdown is added.
+; ((triple_string) @markdown
+;   (#offset! @markdown 0 3 0 -3))
+
+(comment) @comment

--- a/runtime/queries/julia/locals.scm
+++ b/runtime/queries/julia/locals.scm
@@ -1,0 +1,59 @@
+
+(import_statement
+ (identifier) @definition.import)
+(variable_declaration
+ (identifier) @definition.var)
+(variable_declaration
+ (tuple_expression
+  (identifier) @definition.var))
+(for_binding
+ (identifier) @definition.var)
+(for_binding
+ (tuple_expression
+  (identifier) @definition.var))
+
+(assignment_expression
+ (tuple_expression
+  (identifier) @definition.var))
+(assignment_expression
+ (bare_tuple_expression
+  (identifier) @definition.var))
+(assignment_expression
+ (identifier) @definition.var)
+
+(type_parameter_list
+  (identifier) @definition.type)
+(type_argument_list
+  (identifier) @definition.type)
+(struct_definition
+  name: (identifier) @definition.type)
+
+(parameter_list
+ (identifier) @definition.parameter)
+(typed_parameter
+ (identifier) @definition.parameter
+ (identifier))
+(function_expression
+ . (identifier) @definition.parameter)
+(argument_list
+ (typed_expression
+  (identifier) @definition.parameter
+  (identifier)))
+(spread_parameter
+ (identifier) @definition.parameter)
+
+(function_definition
+ name: (identifier) @definition.function) @scope
+(macro_definition 
+ name: (identifier) @definition.macro) @scope
+
+(identifier) @reference
+
+[
+  (try_statement)
+  (finally_clause)
+  (quote_statement)
+  (let_statement)
+  (compound_expression)
+  (for_statement)
+] @scope


### PR DESCRIPTION
I took the treesitter recipes from here: https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries/julia
and the command for the LSP is from: https://github.com/julia-vscode/LanguageServer.jl/wiki/Kakoune

I can't make the languageserver work, but this is maybe because I can't make it work in general.

***

Got the following log:
```
2021-07-05T10:55:54.618 mio::poll [TRACE] registering event source with poller: token=Token(1), interests=READABLE | WRITABLE
2021-07-05T10:55:54.618 mio::poll [TRACE] registering event source with poller: token=Token(2), interests=READABLE | WRITABLE
2021-07-05T10:55:54.618 mio::poll [TRACE] registering event source with poller: token=Token(3), interests=READABLE | WRITABLE
2021-07-05T10:55:54.618 helix_lsp::transport [INFO] -> {"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{"textDocument":{"completion":{"completionItem":{"snippetSupport":false},"completionItemKind":{}},"hover":{"contentFormat":["markdown"]}},"window":{"workDoneProgress":true}},"processId":48451,"rootUri":"file:///path/to/Folder"},"id":0}
2021-07-05T10:55:56.620 mio::poll [TRACE] deregistering event source from poller
2021-07-05T10:55:56.620 mio::poll [TRACE] deregistering event source from poller
2021-07-05T10:55:56.620 mio::poll [TRACE] deregistering event source from poller
2021-07-05T10:55:56.620 mio::poll [TRACE] registering event source with poller: token=Token(0), interests=READABLE
2021-07-05T10:55:56.620 mio::poll [TRACE] registering event source with poller: token=Token(1), interests=READABLE

```