### PR TITLE
adding markdown support (WIP)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,7 @@
 	path = helix-syntax/languages/tree-sitter-latex
 	url = https://github.com/latex-lsp/tree-sitter-latex
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-markdown"]
+	path = helix-syntax/languages/tree-sitter-markdown
+	url = https://github.com/ikatyang/tree-sitter-markdown
+    shallow = true

--- a/helix-syntax/src/lib.rs
+++ b/helix-syntax/src/lib.rs
@@ -81,6 +81,7 @@ mk_langs!(
     (Json, tree_sitter_json),
     (Julia, tree_sitter_julia),
     (Latex, tree_sitter_latex),
+    (Markdown, tree_sitter_markdown),
     (Nix, tree_sitter_nix),
     (Php, tree_sitter_php),
     (Python, tree_sitter_python),

--- a/languages.toml
+++ b/languages.toml
@@ -173,3 +173,13 @@ indent = { tab-width = 4, unit = "\t" }
 # roots = []
 #
 # indent = { tab-width = 2, unit = "  " }
+#
+
+[[language]]
+name = "markdown"
+scope = "source.md"
+injection-regex = "md"
+file-types = ["md"]
+roots = []
+
+indent = { tab-width = 4, unit = "\t" }

--- a/runtime/queries/markdown/folds.scm
+++ b/runtime/queries/markdown/folds.scm
@@ -1,0 +1,8 @@
+[
+    (header1)
+    (header2)
+    (header3)
+    (header4)
+    (header5)
+    (header6)
+] @fold

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -1,0 +1,25 @@
+
+(atx_heading) @text.title
+
+[
+  (code_span)
+  (fenced_code_block)
+]@text.literal
+
+(code_block
+"```" @escape
+(_)
+"```" @escape) 
+
+[
+  (link_text)
+  (image_description)
+] @text.strong
+
+[
+  (emphasis)
+  (strong_emphasis)
+] @text.emphasis
+(link_destination) @text.uri
+
+(html_comment) @comment

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,0 +1,5 @@
+(code_block
+  (info_string) @language
+  (code_fence_content) @content)
+
+((html_block) @html)


### PR DESCRIPTION
trying to add markdown support to helix.

will solve [#215](https://github.com/helix-editor/helix/issues/215)

I might be going about this the wrong way as I wasn't sure what changes were needed to add markdown support so I'm repeating the changes commited to [add latex support](https://github.com/helix-editor/helix/pull/276)