### PR TITLE
Fix #442

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -461,7 +461,8 @@ impl Document {
                 std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
             from_reader(&mut file, encoding)?
         } else {
-            (Rope::from(DEFAULT_LINE_ENDING.as_str()), encoding_rs::UTF_8)
+            let encoding = encoding.unwrap_or(encoding_rs::UTF_8);
+            (Rope::from(DEFAULT_LINE_ENDING.as_str()), encoding)
         };
 
         let line_ending = with_line_ending(&mut rope);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -461,7 +461,7 @@ impl Document {
                 std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
             from_reader(&mut file, encoding)?
         } else {
-            (Rope::default(), encoding_rs::UTF_8)
+            (Rope::from(DEFAULT_LINE_ENDING.as_str()), encoding_rs::UTF_8)
         };
 
         let line_ending = with_line_ending(&mut rope);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -456,14 +456,15 @@ impl Document {
         theme: Option<&Theme>,
         config_loader: Option<&syntax::Loader>,
     ) -> Result<Self, Error> {
-        if !path.exists() {
-            return Ok(Self::default());
-        }
+        let (mut rope, encoding) = if path.exists() {
+            let mut file =
+                std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
+            from_reader(&mut file, encoding)?
+        } else {
+            (Rope::default(), encoding_rs::UTF_8)
+        };
 
-        let mut file = std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
-        let (mut rope, encoding) = from_reader(&mut file, encoding)?;
         let line_ending = with_line_ending(&mut rope);
-
         let mut doc = Self::from(rope, Some(encoding));
 
         // set the path and try detecting the language


### PR DESCRIPTION
Before, the function incorrectly returned `Document::default()` if the path did not exist instead of simply creating an empty `Rope` and proceeding with the rest of the function.

Closes #442