### PR TITLE
Changed startup behaviour regarding multiple files.

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -83,15 +83,18 @@ impl Application {
                 editor.new_file(Action::VerticalSplit);
                 compositor.push(Box::new(ui::file_picker(first.clone())));
             } else {
+                let nr_of_files = args.files.len();
+                editor.open(first.to_path_buf(), Action::VerticalSplit)?;
                 for file in args.files {
                     if file.is_dir() {
                         return Err(anyhow::anyhow!(
                             "expected a path to file, found a directory. (to open a directory pass it as first argument)"
                         ));
                     } else {
-                        editor.open(file, Action::VerticalSplit)?;
+                        editor.open(file.to_path_buf(), Action::Load)?;
                     }
                 }
+                editor.set_status(format!("Loaded {} files.", nr_of_files));
             }
         } else {
             editor.new_file(Action::VerticalSplit);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -39,6 +39,7 @@ pub struct Editor {
 
 #[derive(Debug, Copy, Clone)]
 pub enum Action {
+    Load,
     Replace,
     HorizontalSplit,
     VerticalSplit,
@@ -149,6 +150,9 @@ impl Editor {
                 let line = doc.text().char_to_line(pos);
                 view.first_line = line.saturating_sub(view.area.height as usize / 2);
 
+                return;
+            }
+            Action::Load => {
                 return;
             }
             Action::HorizontalSplit => {


### PR DESCRIPTION
See discussion #444.

This changes the startup behaviour of helix; When multiple files were specified from the command-line, it used to be that helix would open a view per file (potentially causing a crash). Now it will open only one view with the first file specified, regardless how many files are given on the command-line.

 This commit does not allow for any configuration; I can add that if desired.