### PR TITLE
Update dark_plus.toml

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -55,6 +55,7 @@
 "ui.linenr.selected" = { fg = "#c6c6c6" }
 
 "ui.statusline" = { fg = "#ffffff", bg = "#007acc" }
+"ui.statusline.inactive" = { fg = "#ffffff", bg = "#007acc" }
 
 "ui.text" = { fg = "text", bg = "background" }
 "ui.text.focus" = { fg = "#ffffff" }


### PR DESCRIPTION
Didn't realize what `ui.statusline.active` was for. It's needed for view splits.