### PR TITLE
Remove double entry of extend_line in keymap.rs

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -120,7 +120,6 @@ impl Default for Keymaps {
             alt!(';') => Command::flip_selections,
             key!('%') => Command::select_all,
             key!('x') => Command::extend_line,
-            key!('x') => Command::extend_line,
             key!('X') => Command::extend_to_line_bounds,
             // crop_to_whole_line
 


### PR DESCRIPTION
Extend_line has two identical entries in keymap.rs; this removes one of them.