### PR TITLE
Made toggle_comments language dependent

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -38,18 +38,22 @@ fn find_line_comment(
 }
 
 #[must_use]
-pub fn toggle_line_comments(doc: &Rope, selection: &Selection) -> Transaction {
+pub fn toggle_line_comments(
+    doc: &Rope,
+    selection: &Selection,
+    token: Option<String>,
+) -> Transaction {
     let text = doc.slice(..);
     let mut changes: Vec<Change> = Vec::new();
 
-    let token = "//";
+    let token = token.unwrap_or("//".to_owned());
     let comment = Tendril::from(format!("{} ", token));
 
     for selection in selection {
         let start = text.char_to_line(selection.from());
         let end = text.char_to_line(selection.to());
         let lines = start..end + 1;
-        let (commented, skipped, min) = find_line_comment(token, text, lines.clone());
+        let (commented, skipped, min) = find_line_comment(&token, text, lines.clone());
 
         changes.reserve((end - start).saturating_sub(skipped.len()));
 

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -46,7 +46,7 @@ pub fn toggle_line_comments(
     let text = doc.slice(..);
     let mut changes: Vec<Change> = Vec::new();
 
-    let token = token.unwrap_or("//".to_owned());
+    let token = token.unwrap_or_else(|| "//".to_owned());
     let comment = Tendril::from(format!("{} ", token));
 
     for selection in selection {

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -38,15 +38,11 @@ fn find_line_comment(
 }
 
 #[must_use]
-pub fn toggle_line_comments(
-    doc: &Rope,
-    selection: &Selection,
-    token: Option<String>,
-) -> Transaction {
+pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&str>) -> Transaction {
     let text = doc.slice(..);
     let mut changes: Vec<Change> = Vec::new();
 
-    let token = token.unwrap_or_else(|| "//".to_owned());
+    let token = token.unwrap_or("//");
     let comment = Tendril::from(format!("{} ", token));
 
     for selection in selection {

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -99,14 +99,14 @@ mod test {
         assert_eq!(res, (false, vec![1], 2));
 
         // comment
-        let transaction = toggle_line_comments(&state.doc, &state.selection);
+        let transaction = toggle_line_comments(&state.doc, &state.selection, None);
         transaction.apply(&mut state.doc);
         state.selection = state.selection.clone().map(transaction.changes());
 
         assert_eq!(state.doc, "  // 1\n\n  // 2\n  // 3");
 
         // uncomment
-        let transaction = toggle_line_comments(&state.doc, &state.selection);
+        let transaction = toggle_line_comments(&state.doc, &state.selection, None);
         transaction.apply(&mut state.doc);
         state.selection = state.selection.clone().map(transaction.changes());
         assert_eq!(state.doc, "  1\n\n  2\n  3");

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -264,6 +264,7 @@ where
                 highlight_config: OnceCell::new(),
                 //
                 roots: vec![],
+                comment_token: None,
                 auto_format: false,
                 language_server: None,
                 indent: Some(IndentationConfiguration {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -35,6 +35,7 @@ pub struct LanguageConfiguration {
     pub scope: String,           // source.rust
     pub file_types: Vec<String>, // filename ends_with? <Gemfile, rb, etc>
     pub roots: Vec<String>,      // these indicate project roots <.git, Cargo.toml>
+    pub comment_token: Option<String>,
 
     #[serde(default)]
     pub auto_format: bool,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3399,7 +3399,10 @@ fn hover(cx: &mut Context) {
 // comments
 fn toggle_comments(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let token = doc.language.as_ref().and_then(|l| l.comment_token.clone());
+    let token = doc
+        .language_config()
+        .and_then(|lc| lc.comment_token.as_ref())
+        .and_then(|tc| Some(tc.as_ref()));
     let transaction = comment::toggle_line_comments(doc.text(), doc.selection(view.id), token);
 
     doc.apply(&transaction, view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3399,7 +3399,8 @@ fn hover(cx: &mut Context) {
 // comments
 fn toggle_comments(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let transaction = comment::toggle_line_comments(doc.text(), doc.selection(view.id));
+    let token = doc.language.as_ref().and_then(|l| l.comment_token.clone());
+    let transaction = comment::toggle_line_comments(doc.text(), doc.selection(view.id), token);
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3402,7 +3402,7 @@ fn toggle_comments(cx: &mut Context) {
     let token = doc
         .language_config()
         .and_then(|lc| lc.comment_token.as_ref())
-        .and_then(|tc| Some(tc.as_ref()));
+        .map(|tc| tc.as_ref());
     let transaction = comment::toggle_line_comments(doc.text(), doc.selection(view.id), token);
 
     doc.apply(&transaction, view.id);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -89,7 +89,7 @@ pub struct Document {
 
     syntax: Option<Syntax>,
     // /// Corresponding language scope name. Usually `source.<lang>`.
-    pub(crate) language: Option<Arc<LanguageConfiguration>>,
+    pub language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -89,7 +89,7 @@ pub struct Document {
 
     syntax: Option<Syntax>,
     // /// Corresponding language scope name. Usually `source.<lang>`.
-    pub language: Option<Arc<LanguageConfiguration>>,
+    pub(crate) language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,

--- a/languages.toml
+++ b/languages.toml
@@ -5,6 +5,7 @@ injection-regex = "rust"
 file-types = ["rs"]
 roots = []
 auto-format = true
+comment_token = "//"
 
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
@@ -15,6 +16,7 @@ scope = "source.toml"
 injection-regex = "toml"
 file-types = ["toml"]
 roots = []
+comment_token = "#"
 
 indent = { tab-width = 2, unit = "  " }
 
@@ -42,6 +44,7 @@ scope = "source.c"
 injection-regex = "c"
 file-types = ["c"] # TODO: ["h"]
 roots = []
+comment_token = "//"
 
 language-server = { command = "clangd" }
 indent = { tab-width = 2, unit = "  " }
@@ -52,6 +55,7 @@ scope = "source.cpp"
 injection-regex = "cpp"
 file-types = ["cc", "cpp", "hpp", "h"]
 roots = []
+comment_token = "//"
 
 language-server = { command = "clangd" }
 indent = { tab-width = 2, unit = "  " }
@@ -63,6 +67,7 @@ injection-regex = "go"
 file-types = ["go"]
 roots = ["Gopkg.toml", "go.mod"]
 auto-format = true
+comment_token = "//"
 
 language-server = { command = "gopls" }
 # TODO: gopls needs utf-8 offsets?
@@ -74,6 +79,7 @@ scope = "source.js"
 injection-regex = "^(js|javascript)$"
 file-types = ["js"]
 roots = []
+comment_token = "//"
 # TODO: highlights-jsx, highlights-params
 
 indent = { tab-width = 2, unit = "  " }
@@ -113,6 +119,7 @@ scope = "source.python"
 injection-regex = "python"
 file-types = ["py"]
 roots = []
+comment_token = "#"
 
 language-server = { command = "pyls" }
 # TODO: pyls needs utf-8 offsets
@@ -133,6 +140,7 @@ scope = "source.ruby"
 injection-regex = "ruby"
 file-types = ["rb"]
 roots = []
+comment_token = "#"
 
 language-server = { command = "solargraph", args = ["stdio"] }
 indent = { tab-width = 2, unit = "  " }
@@ -143,6 +151,7 @@ scope = "source.bash"
 injection-regex = "bash"
 file-types = ["sh", "bash"]
 roots = []
+comment_token = "#"
 
 language-server = { command = "bash-language-server", args = ["start"] }
 indent = { tab-width = 2, unit = "  " }
@@ -162,6 +171,7 @@ scope = "source.tex"
 injection-regex = "tex"
 file-types = ["tex"]
 roots = []
+comment_token = "%"
 
 indent = { tab-width = 4, unit = "\t" }
 
@@ -171,6 +181,7 @@ scope = "source.julia"
 injection-regex = "julia"
 file-types = ["jl"]
 roots = []
+comment_token = "#"
 language-server = { command = "julia", args = [ "--startup-file=no", "--history-file=no", "-e", "using LanguageServer;using Pkg;import StaticLint;import SymbolServer;env_path = dirname(Pkg.Types.Context().env.project_file);server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, \"\");server.runlinter = true;run(server);" ] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -180,5 +191,6 @@ indent = { tab-width = 2, unit = "  " }
 # injection-regex = "haskell"
 # file-types = ["hs"]
 # roots = []
+# comment_token = "--"
 #
 # indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
This adds a line in the language.toml file declaring the type of single line comment to use for the specified language. This still does not support <start> <end> comment types like xml, nor multiline comments.