### PR TITLE
Determine whether to use a margin of 0 or 1 when uncommenting

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -102,8 +102,8 @@ mod test {
         let text = state.doc.slice(..);
 
         let res = find_line_comment("//", text, 0..3);
-        // (commented = true, skipped = [line 1], min = col 2)
-        assert_eq!(res, (false, vec![1], 2));
+        // (commented = true, skipped = [line 1], min = col 2, margin = 1)
+        assert_eq!(res, (false, vec![1], 2, 1));
 
         // comment
         let transaction = toggle_line_comments(&state.doc, &state.selection, None);

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -49,6 +49,10 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
     let text = doc.slice(..);
     let mut changes: Vec<Change> = Vec::new();
 
+    // keep track of which lines have been affected, so that multiple
+    // selections on one line don't each try to change it.
+    let mut affected_lines: Vec<usize> = Vec::new();
+
     let token = token.unwrap_or("//");
     let comment = Tendril::from(format!("{} ", token));
 
@@ -61,9 +65,10 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
         changes.reserve((end - start).saturating_sub(skipped.len()));
 
         for line in lines {
-            if skipped.contains(&line) {
+            if skipped.contains(&line) || affected_lines.contains(&line) {
                 continue;
             }
+            affected_lines.push(line);
 
             let pos = text.line_to_char(line) + min;
 

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -3,6 +3,15 @@ use crate::{
 };
 use std::borrow::Cow;
 
+/// Given text, a comment token, and a set of line indices, returns the following:
+/// - Whether the given lines should be considered commented
+///     - If any of the lines are uncommented, all lines are considered as such.
+/// - The lines to change for toggling comments
+///     - This is all provided lines excluding blanks lines.
+/// - The column of the comment tokens
+///     - Column of existing tokens, if the lines are commented; column to place tokens at otherwise.
+/// - The margin to the right of the comment tokens
+///     - Defaults to `1`. If any existing comment token is not followed by a space, changes to `0`.
 fn find_line_comment(
     token: &str,
     text: RopeSlice,

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -12,6 +12,7 @@ fn find_line_comment(
     let mut to_change = Vec::new();
     let mut min = usize::MAX; // minimum col for find_first_non_whitespace_char
     let mut margin = 1;
+    let token_len = token.chars().count();
     for line in lines {
         let line_slice = text.line(line);
         if let Some(pos) = find_first_non_whitespace_char(line_slice) {
@@ -32,7 +33,7 @@ fn find_line_comment(
 
             // determine margin of 0 or 1 for uncommenting; if any comment token is not followed by a space,
             // a margin of 0 is used for all lines.
-            if matches!(line_slice.get_char(pos + token.len()), Some(c) if c != ' ') {
+            if matches!(line_slice.get_char(pos + token_len), Some(c) if c != ' ') {
                 margin = 0;
             }
 

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -47,7 +47,6 @@ fn find_line_comment(
 #[must_use]
 pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&str>) -> Transaction {
     let text = doc.slice(..);
-    let mut changes: Vec<Change> = Vec::new();
 
     let token = token.unwrap_or("//");
     let comment = Tendril::from(format!("{} ", token));
@@ -64,7 +63,7 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
 
     let (commented, to_change, min, margin) = find_line_comment(&token, text, lines);
 
-    changes.reserve(to_change.len());
+    let mut changes: Vec<Change> = Vec::with_capacity(to_change.len());
 
     for line in to_change {
         let pos = text.line_to_char(line) + min;

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -61,9 +61,9 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
         min_next_line = end + 1;
     }
 
-    changes.reserve(lines.len());
-
     let (commented, to_change, min, margin) = find_line_comment(&token, text, lines);
+
+    changes.reserve(to_change.len());
 
     for line in to_change {
         let pos = text.line_to_char(line) + min;

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -114,7 +114,16 @@ mod test {
         state.selection = state.selection.map(transaction.changes());
         assert_eq!(state.doc, "  1\n\n  2\n  3");
 
-        // TODO: account for no margin after comment
+        // 0 margin comments
+        state.doc = Rope::from("  //1\n\n  //2\n  //3");
+        // reset the selection.
+        state.selection = Selection::single(0, state.doc.len_chars() - 1);
+
+        let transaction = toggle_line_comments(&state.doc, &state.selection, None);
+        transaction.apply(&mut state.doc);
+        state.selection = state.selection.map(transaction.changes());
+        assert_eq!(state.doc, "  1\n\n  2\n  3");
+
         // TODO: account for uncommenting with uneven comment indentation
     }
 }

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -104,14 +104,14 @@ mod test {
         // comment
         let transaction = toggle_line_comments(&state.doc, &state.selection, None);
         transaction.apply(&mut state.doc);
-        state.selection = state.selection.clone().map(transaction.changes());
+        state.selection = state.selection.map(transaction.changes());
 
         assert_eq!(state.doc, "  // 1\n\n  // 2\n  // 3");
 
         // uncomment
         let transaction = toggle_line_comments(&state.doc, &state.selection, None);
         transaction.apply(&mut state.doc);
-        state.selection = state.selection.clone().map(transaction.changes());
+        state.selection = state.selection.map(transaction.changes());
         assert_eq!(state.doc, "  1\n\n  2\n  3");
 
         // TODO: account for no margin after comment

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -53,6 +53,26 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
 
         changes.reserve((end - start).saturating_sub(skipped.len()));
 
+        // determine margin of 0 or 1 for uncommenting; if any comment token is not followed by a space,
+        // a margin of 0 is used for all lines.
+        let mut margin = 1;
+        if commented {
+            for line in lines.clone() {
+                if skipped.contains(&line) {
+                    continue;
+                }
+
+                let pos = text.line_to_char(line) + min;
+
+                if let Some(c) = text.get_char(pos + token.len()) {
+                    if c != ' ' {
+                        margin = 0;
+                        break;
+                    }
+                }
+            }
+        }
+
         for line in lines {
             if skipped.contains(&line) {
                 continue;
@@ -65,7 +85,6 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
                 changes.push((pos, pos, Some(comment.clone())))
             } else {
                 // uncomment line
-                let margin = 1; // TODO: margin is hardcoded 1 but could easily be 0
                 changes.push((pos, pos + token.len() + margin, None))
             }
         }

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -98,8 +98,8 @@ mod test {
         let text = state.doc.slice(..);
 
         let res = find_line_comment("//", text, 0..3);
-        // (commented = true, skipped = [line 1], min = col 2, margin = 1)
-        assert_eq!(res, (false, vec![1], 2, 1));
+        // (commented = true, to_change = [line 0, line 2], min = col 2, margin = 1)
+        assert_eq!(res, (false, vec![0, 2], 2, 1));
 
         // comment
         let transaction = toggle_line_comments(&state.doc, &state.selection, None);


### PR DESCRIPTION
Fix #474. This change will cause uncommenting to use a margin of `0` when any of the uncommented lines does not have a space after the comment token, rather than unconditionally using a margin of `1`. I apologise if I might have overlooked something, I've never actually contributed to an open source project before.