### PR TITLE
The item `fmt` was imported redundantly

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -95,7 +95,6 @@ fn load_runtime_file(language: &str, filename: &str) -> Result<String, std::io::
 
 #[cfg(feature = "embed_runtime")]
 fn load_runtime_file(language: &str, filename: &str) -> Result<String, Box<dyn std::error::Error>> {
-    use std::fmt;
     use std::path::PathBuf;
 
     #[derive(rust_embed::RustEmbed)]


### PR DESCRIPTION
Fixed warning:

```
warning: the item `fmt` is imported redundantly
  --> helix-core/src/syntax.rs:98:9
   |
16 |     fmt,
   |     --- the item `fmt` is already imported here
...
98 |     use std::fmt;
   |         ^^^^^^^^
   |
```