### PR TITLE
Fix append newline indent

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -47,7 +47,7 @@ fn calculate_indentation(query: &IndentQuery, node: Option<Node>, newline: bool)
     // NOTE: can't use contains() on query because of comparing Vec<String> and &str
     // https://doc.rust-lang.org/std/vec/struct.Vec.html#method.contains
 
-    let mut increment: i32 = 0;
+    let mut increment: isize = 0;
 
     let mut node = match node {
         Some(node) => node,
@@ -93,9 +93,7 @@ fn calculate_indentation(query: &IndentQuery, node: Option<Node>, newline: bool)
         node = parent;
     }
 
-    assert!(increment >= 0);
-
-    increment as usize
+    increment.max(0) as usize
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Fix #492

cc @luctius thanks for reporting the issue

I noticed an issue when I try reproduce it and spammed `}}}}}}}}}}}}}}}}}}}}}}}}}}<newline>`, and it crashed like yours.

Seemed like the function is also a source of slowness in debug mode, whenever I typed `}` or `{`, it feels very slow. Maybe I will fix that next time.