### PR TITLE
fix: change primary cursor color in bogster theme

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -42,6 +42,7 @@
 
 "ui.selection" = { bg = "#313f4e" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
+"ui.cursor.primary" = { fg = "#ABB2BF", modifiers = ["reversed"] }
 "ui.menu.selected" = { fg = "#e5ded6", bg = "#313f4e" }
 
 "warning" = "#dc7759"


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/34353640/127002491-59247188-5a12-4f9c-968a-d629c529e5e1.png)



After:
![image](https://user-images.githubusercontent.com/34353640/127002387-53e80134-2da9-4bbc-93fc-f24a0079c7e5.png)
