### PR TITLE
Fix Doc Comment Typo

### DIFF
--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -75,7 +75,7 @@ pub enum KeyCode {
     End,
     /// Page up key.
     PageUp,
-    /// Page dow key.
+    /// Page down key.
     PageDown,
     /// Tab key.
     Tab,


### PR DESCRIPTION
While I was reading through this file, I found a doc-comment typo. This fixes it. 