### PR TITLE
Show file preview in split pane in fuzzy finder

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -46,7 +46,7 @@ use std::borrow::Cow;
 /// single grapheme inward from the range's edge.  There are a
 /// variety of helper methods on `Range` for working in terms of
 /// that block cursor, all of which have `cursor` in their name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Range {
     /// The anchor of the range: the side that doesn't move when extending.
     pub anchor: usize,

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -46,7 +46,7 @@ use std::borrow::Cow;
 /// single grapheme inward from the range's edge.  There are a
 /// variety of helper methods on `Range` for working in terms of
 /// that block cursor, all of which have `cursor` in their name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Range {
     /// The anchor of the range: the side that doesn't move when extending.
     pub anchor: usize,
@@ -494,6 +494,12 @@ impl Selection {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.ranges.len()
+    }
+}
+
+impl From<Range> for Selection {
+    fn from(range: Range) -> Self {
+        Self::single(range.anchor, range.head)
     }
 }
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -497,12 +497,6 @@ impl Selection {
     }
 }
 
-impl From<Range> for Selection {
-    fn from(range: Range) -> Self {
-        Self::single(range.anchor, range.head)
-    }
-}
-
 impl<'a> IntoIterator for &'a Selection {
     type Item = &'a Range;
     type IntoIter = std::slice::Iter<'a, Range>;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2132,9 +2132,14 @@ fn symbol_picker(cx: &mut Context) {
                     move |editor, symbol| {
                         let view = editor.tree.get(editor.tree.focus);
                         let doc = &editor.documents[view.doc];
-                        let range =
-                            lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding);
-                        doc.path().cloned().zip(range)
+                        // let range =
+                        //     lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding);
+                        // Calculating the exact range is expensive, so use line number only
+                        let pos = doc
+                            .text()
+                            .line_to_char(symbol.location.range.start.line as usize);
+                        let range = Range::point(pos);
+                        doc.path().cloned().zip(Some(range))
                     },
                 );
                 compositor.push(Box::new(picker))
@@ -2186,7 +2191,7 @@ pub fn code_action(cx: &mut Context) {
                             }
                         }
                     },
-                    |editor, symbol| None,
+                    |_editor, _action| None,
                 );
                 compositor.push(Box::new(picker))
             }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2068,7 +2068,7 @@ fn buffer_picker(cx: &mut Context) {
                 .selection(view_id)
                 .primary()
                 .cursor_line(doc.text().slice(..));
-            Some((path.clone()?, line))
+            Some((path.clone()?, Some(line)))
         },
     );
     cx.push_layer(Box::new(picker));
@@ -2140,9 +2140,8 @@ fn symbol_picker(cx: &mut Context) {
                     move |editor, symbol| {
                         let view = editor.tree.get(editor.tree.focus);
                         let doc = &editor.documents[view.doc];
-                        doc.path()
-                            .cloned()
-                            .zip(Some(symbol.location.range.start.line as usize))
+                        let line = Some(symbol.location.range.start.line as usize);
+                        doc.path().cloned().zip(Some(line))
                     },
                 );
                 compositor.push(Box::new(picker))
@@ -2534,7 +2533,8 @@ fn goto_impl(
                 },
                 |_editor, location| {
                     let path = location.uri.to_file_path().unwrap();
-                    Some((path, location.range.start.line as usize))
+                    let line = Some(location.range.start.line as usize);
+                    Some((path, line))
                 },
             );
             compositor.push(Box::new(picker));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -101,13 +101,13 @@ impl<'a> Context<'a> {
     }
 }
 
-enum Align {
+pub enum Align {
     Top,
     Center,
     Bottom,
 }
 
-fn align_view(doc: &Document, view: &mut View, align: Align) {
+pub fn align_view(doc: &Document, view: &mut View, align: Align) {
     let pos = doc
         .selection(view.id)
         .primary()
@@ -2061,6 +2061,7 @@ fn buffer_picker(cx: &mut Context) {
         |editor: &mut Editor, (id, _path): &(DocumentId, Option<PathBuf>), _action| {
             editor.switch(*id, Action::Replace);
         },
+        |symbol| None,
     );
     cx.push_layer(Box::new(picker));
 }
@@ -2128,6 +2129,7 @@ fn symbol_picker(cx: &mut Context) {
                             align_view(doc, view, Align::Center);
                         }
                     },
+                    |symbol| None,
                 );
                 compositor.push(Box::new(picker))
             }
@@ -2178,6 +2180,7 @@ pub fn code_action(cx: &mut Context) {
                             }
                         }
                     },
+                    |symbol| None,
                 );
                 compositor.push(Box::new(picker))
             }
@@ -2515,6 +2518,7 @@ fn goto_impl(
                 move |editor: &mut Editor, location, action| {
                     jump_to(editor, location, offset_encoding, action)
                 },
+                |symbol| None,
             );
             compositor.push(Box::new(picker));
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2135,11 +2135,9 @@ fn symbol_picker(cx: &mut Context) {
                         // let range =
                         //     lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding);
                         // Calculating the exact range is expensive, so use line number only
-                        let pos = doc
-                            .text()
-                            .line_to_char(symbol.location.range.start.line as usize);
-                        let range = Range::point(pos);
-                        doc.path().cloned().zip(Some(range))
+                        doc.path()
+                            .cloned()
+                            .zip(Some(symbol.location.range.start.line as usize))
                     },
                 );
                 compositor.push(Box::new(picker))
@@ -2529,7 +2527,10 @@ fn goto_impl(
                 move |editor: &mut Editor, location, action| {
                     jump_to(editor, location, offset_encoding, action)
                 },
-                |editor, symbol| None,
+                |_editor, location| {
+                    let path = location.uri.to_file_path().unwrap();
+                    Some((path, location.range.start.line as usize))
+                },
             );
             compositor.push(Box::new(picker));
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -31,7 +31,7 @@ use movement::Movement;
 
 use crate::{
     compositor::{self, Component, Compositor},
-    ui::{self, Picker, Popup, Prompt, PromptEvent},
+    ui::{self, FilePicker, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -2039,7 +2039,7 @@ fn file_picker(cx: &mut Context) {
 fn buffer_picker(cx: &mut Context) {
     let current = view!(cx.editor).doc;
 
-    let picker = Picker::new(
+    let picker = FilePicker::new(
         cx.editor
             .documents
             .iter()
@@ -2123,7 +2123,7 @@ fn symbol_picker(cx: &mut Context) {
                     }
                 };
 
-                let picker = Picker::new(
+                let picker = FilePicker::new(
                     symbols,
                     |symbol| (&symbol.name).into(),
                     move |editor: &mut Editor, symbol, _action| {
@@ -2177,7 +2177,7 @@ pub fn code_action(cx: &mut Context) {
               compositor: &mut Compositor,
               response: Option<lsp::CodeActionResponse>| {
             if let Some(actions) = response {
-                let picker = Picker::new(
+                let picker = FilePicker::new(
                     actions,
                     |action| match action {
                         lsp::CodeActionOrCommand::CodeAction(action) => {
@@ -2525,7 +2525,7 @@ fn goto_impl(
             editor.set_error("No definition found.".to_string());
         }
         _locations => {
-            let picker = ui::Picker::new(
+            let picker = FilePicker::new(
                 locations,
                 |location| {
                     let file = location.uri.as_str();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -31,7 +31,7 @@ use movement::Movement;
 
 use crate::{
     compositor::{self, Component, Compositor},
-    ui::{self, FilePicker, Popup, Prompt, PromptEvent},
+    ui::{self, Popup, PreviewedPicker, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -2039,7 +2039,7 @@ fn file_picker(cx: &mut Context) {
 fn buffer_picker(cx: &mut Context) {
     let current = view!(cx.editor).doc;
 
-    let picker = FilePicker::new(
+    let picker = PreviewedPicker::new(
         cx.editor
             .documents
             .iter()
@@ -2123,7 +2123,7 @@ fn symbol_picker(cx: &mut Context) {
                     }
                 };
 
-                let picker = FilePicker::new(
+                let picker = PreviewedPicker::new(
                     symbols,
                     |symbol| (&symbol.name).into(),
                     move |editor: &mut Editor, symbol, _action| {
@@ -2177,7 +2177,7 @@ pub fn code_action(cx: &mut Context) {
               compositor: &mut Compositor,
               response: Option<lsp::CodeActionResponse>| {
             if let Some(actions) = response {
-                let picker = FilePicker::new(
+                let picker = PreviewedPicker::new(
                     actions,
                     |action| match action {
                         lsp::CodeActionOrCommand::CodeAction(action) => {
@@ -2525,7 +2525,7 @@ fn goto_impl(
             editor.set_error("No definition found.".to_string());
         }
         _locations => {
-            let picker = FilePicker::new(
+            let picker = PreviewedPicker::new(
                 locations,
                 |location| {
                     let file = location.uri.as_str();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -101,13 +101,13 @@ impl<'a> Context<'a> {
     }
 }
 
-pub enum Align {
+enum Align {
     Top,
     Center,
     Bottom,
 }
 
-pub fn align_view(doc: &Document, view: &mut View, align: Align) {
+fn align_view(doc: &Document, view: &mut View, align: Align) {
     let pos = doc
         .selection(view.id)
         .primary()
@@ -2140,9 +2140,6 @@ fn symbol_picker(cx: &mut Context) {
                     move |editor, symbol| {
                         let view = editor.tree.get(editor.tree.focus);
                         let doc = &editor.documents[view.doc];
-                        // let range =
-                        //     lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding);
-                        // Calculating the exact range is expensive, so use line number only
                         doc.path()
                             .cloned()
                             .zip(Some(symbol.location.range.start.line as usize))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2061,7 +2061,15 @@ fn buffer_picker(cx: &mut Context) {
         |editor: &mut Editor, (id, _path): &(DocumentId, Option<PathBuf>), _action| {
             editor.switch(*id, Action::Replace);
         },
-        |editor, symbol| None,
+        |editor, (id, path)| {
+            let doc = &editor.documents.get(*id)?;
+            let &view_id = doc.selections().keys().next()?;
+            let line = doc
+                .selection(view_id)
+                .primary()
+                .cursor_line(doc.text().slice(..));
+            Some((path.clone()?, line))
+        },
     );
     cx.push_layer(Box::new(picker));
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -27,7 +27,7 @@ use movement::Movement;
 
 use crate::{
     compositor::{self, Component, Compositor},
-    ui::{self, FilePicker, Popup, Prompt, PromptEvent},
+    ui::{self, FilePicker, Picker, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -2251,7 +2251,8 @@ pub fn code_action(cx: &mut Context) {
               compositor: &mut Compositor,
               response: Option<lsp::CodeActionResponse>| {
             if let Some(actions) = response {
-                let picker = FilePicker::new(
+                let picker = Picker::new(
+                    true,
                     actions,
                     |action| match action {
                         lsp::CodeActionOrCommand::CodeAction(action) => {
@@ -2271,7 +2272,6 @@ pub fn code_action(cx: &mut Context) {
                             }
                         }
                     },
-                    |_editor, _action| None,
                 );
                 compositor.push(Box::new(picker))
             }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2211,15 +2211,14 @@ fn symbol_picker(cx: &mut Context) {
                         if let Some(range) =
                             lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding)
                         {
-                            doc.set_selection(view.id, Selection::from(range));
+                            doc.set_selection(view.id, Selection::single(range.anchor, range.head));
                             align_view(doc, view, Align::Center);
                         }
                     },
-                    move |editor, symbol| {
-                        let view = editor.tree.get(editor.tree.focus);
-                        let doc = &editor.documents[view.doc];
+                    move |_editor, symbol| {
+                        let path = symbol.location.uri.to_file_path().unwrap();
                         let line = Some(symbol.location.range.start.line as usize);
-                        doc.path().cloned().zip(Some(line))
+                        Some((path, line))
                     },
                 );
                 compositor.push(Box::new(picker))
@@ -3606,7 +3605,7 @@ fn keep_primary_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     let range = doc.selection(view.id).primary();
-    doc.set_selection(view.id, Selection::from(range));
+    doc.set_selection(view.id, Selection::single(range.anchor, range.head));
 }
 
 fn completion(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -31,7 +31,7 @@ use movement::Movement;
 
 use crate::{
     compositor::{self, Component, Compositor},
-    ui::{self, Popup, PreviewedPicker, Prompt, PromptEvent},
+    ui::{self, FilePicker, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -2039,7 +2039,7 @@ fn file_picker(cx: &mut Context) {
 fn buffer_picker(cx: &mut Context) {
     let current = view!(cx.editor).doc;
 
-    let picker = PreviewedPicker::new(
+    let picker = FilePicker::new(
         cx.editor
             .documents
             .iter()
@@ -2123,7 +2123,7 @@ fn symbol_picker(cx: &mut Context) {
                     }
                 };
 
-                let picker = PreviewedPicker::new(
+                let picker = FilePicker::new(
                     symbols,
                     |symbol| (&symbol.name).into(),
                     move |editor: &mut Editor, symbol, _action| {
@@ -2177,7 +2177,7 @@ pub fn code_action(cx: &mut Context) {
               compositor: &mut Compositor,
               response: Option<lsp::CodeActionResponse>| {
             if let Some(actions) = response {
-                let picker = PreviewedPicker::new(
+                let picker = FilePicker::new(
                     actions,
                     |action| match action {
                         lsp::CodeActionOrCommand::CodeAction(action) => {
@@ -2525,7 +2525,7 @@ fn goto_impl(
             editor.set_error("No definition found.".to_string());
         }
         _locations => {
-            let picker = PreviewedPicker::new(
+            let picker = FilePicker::new(
                 locations,
                 |location| {
                     let file = location.uri.as_str();

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -46,14 +46,12 @@ pub trait Component: Any + AnyComponent {
     }
 
     /// Render the component onto the provided surface.
-    fn render(&self, area: Rect, frame: &mut Surface, ctx: &mut Context);
+    fn render(&mut self, area: Rect, frame: &mut Surface, ctx: &mut Context);
 
     /// Get cursor position and cursor kind.
     fn cursor(&self, _area: Rect, _ctx: &Editor) -> (Option<Position>, CursorKind) {
         (None, CursorKind::Hidden)
     }
-
-    fn prepare_for_render(&mut self, _ctx: &Context) {}
 
     /// May be used by the parent component to compute the child area.
     /// viewport is the maximum allowed area, and the child should stay within those bounds.
@@ -155,7 +153,6 @@ impl Compositor {
         let area = *surface.area();
 
         for layer in &mut self.layers {
-            layer.prepare_for_render(cx);
             layer.render(area, surface, cx);
         }
 

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -53,6 +53,8 @@ pub trait Component: Any + AnyComponent {
         (None, CursorKind::Hidden)
     }
 
+    fn prepare_for_render(&mut self, _ctx: &Context) {}
+
     /// May be used by the parent component to compute the child area.
     /// viewport is the maximum allowed area, and the child should stay within those bounds.
     fn required_size(&mut self, _viewport: (u16, u16)) -> Option<(u16, u16)> {
@@ -137,8 +139,9 @@ impl Compositor {
 
         let area = *surface.area();
 
-        for layer in &self.layers {
-            layer.render(area, surface, cx)
+        for layer in &mut self.layers {
+            layer.prepare_for_render(cx);
+            layer.render(area, surface, cx);
         }
 
         let (pos, kind) = self.cursor(area, cx.editor);

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -206,7 +206,7 @@ impl Component for Completion {
         self.popup.required_size(viewport)
     }
 
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         self.popup.render(area, surface, cx);
 
         // if we have a selection, render a markdown popup on top/below with info
@@ -228,7 +228,7 @@ impl Component for Completion {
             let cursor_pos = (helix_core::coords_at_pos(doc.text().slice(..), cursor_pos).row
                 - view.first_line) as u16;
 
-            let doc = match &option.documentation {
+            let mut doc = match &option.documentation {
                 Some(lsp::Documentation::String(contents))
                 | Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
                     kind: lsp::MarkupKind::PlainText,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -33,7 +33,7 @@ pub struct EditorView {
     last_insert: (commands::Command, Vec<KeyEvent>),
     completion: Option<Completion>,
     spinners: ProgressSpinners,
-    pub autoinfo: Option<Info>,
+    autoinfo: Option<Info>,
 }
 
 const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -5,7 +5,7 @@ use tui::buffer::Buffer as Surface;
 use tui::widgets::{Block, Borders, Widget};
 
 impl Component for Info {
-    fn render(&self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
         let style = cx.editor.theme.get("ui.popup");
 
         // Calculate the area of the terminal to modify. Because we want to

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -198,7 +198,7 @@ fn parse<'a>(
     Text::from(lines)
 }
 impl Component for Markdown {
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         use tui::widgets::{Paragraph, Widget, Wrap};
 
         let text = parse(&self.contents, Some(&cx.editor.theme), &self.config_loader);

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -263,7 +263,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
     // TODO: required size should re-trigger when we filter items so we can draw a smaller menu
 
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let style = cx.editor.theme.get("ui.text");
         let selected = cx.editor.theme.get("ui.menu.selected");
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -123,7 +123,7 @@ pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
         },
         |_editor, path| {
             // FIXME: directories are creeping up in filepicker
-            Some((path.clone(), 0))
+            Some((path.clone(), None))
         },
     )
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -13,7 +13,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::FilePicker;
+pub use picker::PreviewedPicker;
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
@@ -73,7 +73,7 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
+pub fn file_picker(root: PathBuf) -> PreviewedPicker<PathBuf> {
     use ignore::Walk;
     use std::time;
     let files = Walk::new(root.clone()).filter_map(|entry| match entry {
@@ -109,7 +109,7 @@ pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
 
     let files = files.into_iter().map(|(path, _)| path).collect();
 
-    FilePicker::new(
+    PreviewedPicker::new(
         files,
         move |path: &PathBuf| {
             // format_fn

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -121,10 +121,7 @@ pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
                 .open(path.into(), action)
                 .expect("editor.open failed");
         },
-        |_editor, path| {
-            // FIXME: directories are creeping up in filepicker
-            Some((path.clone(), None))
-        },
+        |_editor, path| Some((path.clone(), None)),
     )
 }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -125,7 +125,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
                 .open(path.into(), action)
                 .expect("editor.open failed");
         },
-        |path| {
+        |_editor, path| {
             // FIXME: directories are creeping up in filepicker
             Some((path.clone(), Range::point(0)))
         },

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -11,7 +11,6 @@ mod text;
 
 pub use completion::Completion;
 pub use editor::EditorView;
-use helix_core::Range;
 pub use markdown::Markdown;
 pub use menu::Menu;
 pub use picker::Picker;
@@ -127,7 +126,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
         },
         |_editor, path| {
             // FIXME: directories are creeping up in filepicker
-            Some((path.clone(), Range::point(0)))
+            Some((path.clone(), 0))
         },
     )
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -13,7 +13,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::PreviewedPicker;
+pub use picker::FilePicker;
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
@@ -73,7 +73,7 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf) -> PreviewedPicker<PathBuf> {
+pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
     use ignore::Walk;
     use std::time;
     let files = Walk::new(root.clone()).filter_map(|entry| match entry {
@@ -109,7 +109,7 @@ pub fn file_picker(root: PathBuf) -> PreviewedPicker<PathBuf> {
 
     let files = files.into_iter().map(|(path, _)| path).collect();
 
-    PreviewedPicker::new(
+    FilePicker::new(
         files,
         move |path: &PathBuf| {
             // format_fn

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -11,7 +11,7 @@ mod text;
 
 pub use completion::Completion;
 pub use editor::EditorView;
-use helix_core::Selection;
+use helix_core::Range;
 pub use markdown::Markdown;
 pub use menu::Menu;
 pub use picker::Picker;
@@ -127,7 +127,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
         },
         |path| {
             // FIXME: directories are creeping up in filepicker
-            Some((path.clone(), Selection::point(0)))
+            Some((path.clone(), Range::point(0)))
         },
     )
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -13,7 +13,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::Picker;
+pub use picker::FilePicker;
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
@@ -73,7 +73,7 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
+pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
     use ignore::Walk;
     use std::time;
     let files = Walk::new(root.clone()).filter_map(|entry| match entry {
@@ -109,7 +109,7 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
 
     let files = files.into_iter().map(|(path, _)| path).collect();
 
-    Picker::new(
+    FilePicker::new(
         files,
         move |path: &PathBuf| {
             // format_fn

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -11,6 +11,7 @@ mod text;
 
 pub use completion::Completion;
 pub use editor::EditorView;
+use helix_core::Selection;
 pub use markdown::Markdown;
 pub use menu::Menu;
 pub use picker::Picker;
@@ -123,6 +124,10 @@ pub fn file_picker(root: PathBuf) -> Picker<PathBuf> {
             editor
                 .open(path.into(), action)
                 .expect("editor.open failed");
+        },
+        |path| {
+            // FIXME: directories are creeping up in filepicker
+            Some((path.clone(), Selection::point(0)))
         },
     )
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -13,7 +13,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::FilePicker;
+pub use picker::{FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -62,9 +62,8 @@ impl<T> FilePicker<T> {
     fn calculate_preview(&mut self, editor: &Editor) {
         if let Some((path, _line)) = self.current_file(editor) {
             if !self.preview_cache.contains_key(&path) && editor.document_by_path(&path).is_none() {
-                let mut doc =
-                    Document::open(&path, None, Some(&editor.theme), Some(&editor.syn_loader))
-                        .unwrap();
+                // TODO: enable syntax highlighting; blocked by async rendering
+                let mut doc = Document::open(&path, None, Some(&editor.theme), None).unwrap();
                 // HACK: a doc needs atleast one selection
                 doc.set_selection(self._preview_view_id, Selection::point(0));
                 self.preview_cache.insert(path, doc);
@@ -75,12 +74,12 @@ impl<T> FilePicker<T> {
 
 impl<T: 'static> Component for FilePicker<T> {
     fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        // |---------|  |---------|
-        // |prompt   |  |preview  |
-        // |---------|  |         |
-        // |picker   |  |         |
-        // |         |  |         |
-        // |---------|  |---------|
+        // +---------+ +---------+
+        // |prompt   | |preview  |
+        // +---------+ |         |
+        // |picker   | |         |
+        // |         | |         |
+        // +---------+ +---------+
         let area = inner_rect(area);
         // -- Render the frame:
         // clear area

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -67,13 +67,14 @@ impl<T> FilePicker<T> {
 }
 
 impl<T: 'static> Component for FilePicker<T> {
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         // +---------+ +---------+
         // |prompt   | |preview  |
         // +---------+ |         |
         // |picker   | |         |
         // |         | |         |
         // +---------+ +---------+
+        self.calculate_preview(cx.editor);
         let area = inner_rect(area);
         // -- Render the frame:
         // clear area
@@ -105,17 +106,12 @@ impl<T: 'static> Component for FilePicker<T> {
         }) {
             // align to middle
             let first_line = line.unwrap_or(0).saturating_sub(inner.height as usize / 2);
-            let last_line = std::cmp::min(
-                // Saturating subs to make it inclusive zero indexing.
-                (first_line + area.height as usize).saturating_sub(1),
-                doc.text().len_lines().saturating_sub(1),
-            );
             let offset = Position::new(first_line, 0);
 
             let highlights = EditorView::doc_syntax_highlights(
                 doc,
                 offset,
-                last_line,
+                area.height,
                 &cx.editor.theme,
                 &cx.editor.syn_loader,
             );
@@ -137,10 +133,6 @@ impl<T: 'static> Component for FilePicker<T> {
                 }
             }
         }
-    }
-
-    fn prepare_for_render(&mut self, cx: &Context) {
-        self.calculate_preview(cx.editor);
     }
 
     fn handle_event(&mut self, event: Event, ctx: &mut Context) -> EventResult {
@@ -382,7 +374,7 @@ impl<T: 'static> Component for Picker<T> {
         EventResult::Consumed(None)
     }
 
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let area = if self.render_centered {
             inner_rect(area)
         } else {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -42,7 +42,7 @@ impl<T> FilePicker<T> {
         preview_fn: impl Fn(&Editor, &T) -> Option<FileLocation> + 'static,
     ) -> Self {
         Self {
-            picker: Picker::new(options, format_fn, callback_fn),
+            picker: Picker::new(false, options, format_fn, callback_fn),
             preview_cache: HashMap::new(),
             file_fn: Box::new(preview_fn),
         }
@@ -165,6 +165,8 @@ pub struct Picker<T> {
     cursor: usize,
     // pattern: String,
     prompt: Prompt,
+    /// Whether to render in the middle of the area
+    render_centered: bool,
 
     format_fn: Box<dyn Fn(&T) -> Cow<str>>,
     callback_fn: Box<dyn Fn(&mut Editor, &T, Action)>,
@@ -172,6 +174,7 @@ pub struct Picker<T> {
 
 impl<T> Picker<T> {
     pub fn new(
+        render_centered: bool,
         options: Vec<T>,
         format_fn: impl Fn(&T) -> Cow<str> + 'static,
         callback_fn: impl Fn(&mut Editor, &T, Action) + 'static,
@@ -192,6 +195,7 @@ impl<T> Picker<T> {
             filters: Vec::new(),
             cursor: 0,
             prompt,
+            render_centered,
             format_fn: Box::new(format_fn),
             callback_fn: Box::new(callback_fn),
         };
@@ -379,6 +383,12 @@ impl<T: 'static> Component for Picker<T> {
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        let area = if self.render_centered {
+            inner_rect(area)
+        } else {
+            area
+        };
+
         // -- Render the frame:
         // clear area
         let background = cx.editor.theme.get("ui.background");

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -39,6 +39,7 @@ pub struct Picker<T> {
 
     format_fn: Box<dyn Fn(&T) -> Cow<str>>,
     callback_fn: Box<dyn Fn(&mut Editor, &T, Action)>,
+    #[allow(clippy::type_complexity)]
     preview_fn: Box<dyn Fn(&Editor, &T) -> Option<(PathBuf, usize)>>,
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -367,7 +367,6 @@ impl<T: 'static> Component for Picker<T> {
                 modifiers: KeyModifiers::CONTROL,
             } => {
                 self.move_up();
-                self.calculate_preview(cx.editor);
             }
             KeyEvent {
                 code: KeyCode::Down,
@@ -381,7 +380,6 @@ impl<T: 'static> Component for Picker<T> {
                 modifiers: KeyModifiers::CONTROL,
             } => {
                 self.move_down();
-                self.calculate_preview(cx.editor);
             }
             KeyEvent {
                 code: KeyCode::Esc, ..
@@ -427,18 +425,20 @@ impl<T: 'static> Component for Picker<T> {
                 modifiers: KeyModifiers::CONTROL,
             } => {
                 self.save_filter();
-                self.calculate_preview(cx.editor);
             }
             _ => {
                 if let EventResult::Consumed(_) = self.prompt.handle_event(event, cx) {
                     // TODO: recalculate only if pattern changed
                     self.score();
-                    self.calculate_preview(cx.editor);
                 }
             }
         }
 
         EventResult::Consumed(None)
+    }
+
+    fn prepare_for_render(&mut self, cx: &Context) {
+        self.calculate_preview(cx.editor)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -105,7 +105,7 @@ impl<T: Component> Component for Popup<T> {
         Some(self.size)
     }
 
-    fn render(&self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
         cx.scroll = Some(self.scroll);
 
         let position = self

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -352,7 +352,7 @@ impl Prompt {
         }
 
         if let Some(doc) = (self.doc_fn)(&self.line) {
-            let text = ui::Text::new(doc.to_string());
+            let mut text = ui::Text::new(doc.to_string());
 
             let viewport = area;
             let area = viewport.intersection(Rect::new(
@@ -546,7 +546,7 @@ impl Component for Prompt {
         EventResult::Consumed(None)
     }
 
-    fn render(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         self.render_prompt(area, surface, cx)
     }
 

--- a/helix-term/src/ui/text.rs
+++ b/helix-term/src/ui/text.rs
@@ -13,7 +13,7 @@ impl Text {
     }
 }
 impl Component for Text {
-    fn render(&self, area: Rect, surface: &mut Surface, _cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, _cx: &mut Context) {
         use tui::widgets::{Paragraph, Widget, Wrap};
         let contents = tui::text::Text::from(self.contents.clone());
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -431,13 +431,12 @@ impl Document {
     // TODO: async fn?
     /// Create a new document from `path`. Encoding is auto-detected, but it can be manually
     /// overwritten with the `encoding` parameter.
-    pub fn open<P: AsRef<Path>>(
-        path: P,
+    pub fn open(
+        path: &Path,
         encoding: Option<&'static encoding_rs::Encoding>,
         theme: Option<&Theme>,
         config_loader: Option<&syntax::Loader>,
     ) -> Result<Self, Error> {
-        let path = path.as_ref();
         let (rope, encoding) = if path.exists() {
             let mut file =
                 std::fs::File::open(path).context(format!("unable to open {:?}", path))?;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -431,15 +431,16 @@ impl Document {
     // TODO: async fn?
     /// Create a new document from `path`. Encoding is auto-detected, but it can be manually
     /// overwritten with the `encoding` parameter.
-    pub fn open(
-        path: PathBuf,
+    pub fn open<P: AsRef<Path>>(
+        path: P,
         encoding: Option<&'static encoding_rs::Encoding>,
         theme: Option<&Theme>,
         config_loader: Option<&syntax::Loader>,
     ) -> Result<Self, Error> {
+        let path = path.as_ref();
         let (rope, encoding) = if path.exists() {
             let mut file =
-                std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
+                std::fs::File::open(path).context(format!("unable to open {:?}", path))?;
             from_reader(&mut file, encoding)?
         } else {
             let encoding = encoding.unwrap_or(encoding_rs::UTF_8);
@@ -449,7 +450,7 @@ impl Document {
         let mut doc = Self::from(rope, Some(encoding));
 
         // set the path and try detecting the language
-        doc.set_path(&path)?;
+        doc.set_path(path)?;
         if let Some(loader) = config_loader {
             doc.detect_language(theme, loader);
         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -901,6 +901,10 @@ impl Document {
         &self.selections[&view_id]
     }
 
+    pub fn selections(&self) -> &HashMap<ViewId, Selection> {
+        &self.selections
+    }
+
     pub fn relative_path(&self) -> Option<PathBuf> {
         let cwdir = std::env::current_dir().expect("couldn't determine current directory");
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -7,7 +7,11 @@ use crate::{
 };
 
 use futures_util::future;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use slotmap::SlotMap;
 
@@ -284,6 +288,11 @@ impl Editor {
 
     pub fn documents_mut(&mut self) -> impl Iterator<Item = &mut Document> {
         self.documents.iter_mut().map(|(_id, doc)| doc)
+    }
+
+    pub fn document_by_path<P: AsRef<Path>>(&self, path: P) -> Option<&Document> {
+        self.documents()
+            .find(|doc| doc.path().map(|p| p == path.as_ref()).unwrap_or(false))
     }
 
     // pub fn current_document(&self) -> Document {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -220,7 +220,7 @@ impl Editor {
         let id = if let Some(id) = id {
             id
         } else {
-            let mut doc = Document::open(path, None, Some(&self.theme), Some(&self.syn_loader))?;
+            let mut doc = Document::open(&path, None, Some(&self.theme), Some(&self.syn_loader))?;
 
             // try to find a language server based on the language name
             let language_server = doc

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -12,7 +12,7 @@ pub const PADDING: usize = 5;
 
 type Jump = (DocumentId, Selection);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct JumpList {
     jumps: Vec<Jump>,
     current: usize,
@@ -59,7 +59,7 @@ impl JumpList {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct View {
     pub id: ViewId,
     pub doc: DocumentId,

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -59,7 +59,7 @@ impl JumpList {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct View {
     pub id: ViewId,
     pub doc: DocumentId,


### PR DESCRIPTION
![Screenshot_2021-08-03_15-23-49](https://user-images.githubusercontent.com/23398472/127996766-3d7836bf-1b69-41ad-be96-50a535b20062.png)


### TODO

- [x] Add preview for:
    - [x] File picker
    - [x] Buffer picker
    - [x] Symbol picker
    - [x] Goto {reference, implementation}
- [x] Fix lagging caused by tree sitter (cache ?)
- [x] Fix preview not being shown for the first item when opened 
- [x] Reuse `EditorView::render_buffer()`
- [x] Code action should use normal picker

### Bugs

- [x] File picker has directories in the list and panics (caused by symlinks)
- [x] Last line of preview not highlighted: https://github.com/helix-editor/helix/blob/ab41e4519c8ce20f5e4f7fbe9d689f2848279828/helix-view/src/view.rs#L124