### PR TITLE
Shell commands

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -122,6 +122,16 @@ in reverse, or searching via smartcase.
 | `[D`  | Go to first diagnostic in document | `goto_first_diag` |
 | `]D`  | Go to last diagnostic in document  | `goto_last_diag`  |
 
+### Shell
+
+| Key    | Description                                                              | Command               |
+| ------ | -----------                                                              | -------               |
+| `\|`   | Pipe each selection through shell command, replacing with output         | `shell_pipe`          |
+| `A-\|` | Pipe each selection into shell command, ignoring output                  | `shell_pipe_to`       |
+| `!`    | Run shell command, inserting output before each selection                | `shell_insert_output` |
+| `A-!`  | Run shell command, appending output after each selection                 | `shell_append_output` |
+| `$`    | Pipe each selection into shell command, removing if the command exits >0 | `shell_keep_pipe`     |
+
 ## Select / extend mode
 
 I'm still pondering whether to keep this mode or not. It changes movement

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -133,7 +133,7 @@ pub struct Command {
 }
 
 macro_rules! commands {
-    ( $($name:ident, $doc:literal),* $(,)? ) => {
+    ( $($name:ident, $doc:literal,)* ) => {
         $(
             #[allow(non_upper_case_globals)]
             pub const $name: Self = Self {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4253,31 +4253,35 @@ enum ShellBehavior {
 }
 
 fn shell_pipe(cx: &mut Context) {
-    shell(cx, "pipe:", true, ShellBehavior::Replace);
+    shell(cx, "pipe:", ShellBehavior::Replace);
 }
 
 fn shell_pipe_to(cx: &mut Context) {
-    shell(cx, "pipe-to:", true, ShellBehavior::None);
+    shell(cx, "pipe-to:", ShellBehavior::None);
 }
 
 fn shell_insert_output(cx: &mut Context) {
-    shell(cx, "insert-output:", false, ShellBehavior::Insert);
+    shell(cx, "insert-output:", ShellBehavior::Insert);
 }
 
 fn shell_append_output(cx: &mut Context) {
-    shell(cx, "append-output:", false, ShellBehavior::Append);
+    shell(cx, "append-output:", ShellBehavior::Append);
 }
 
 fn shell_keep_pipe(cx: &mut Context) {
-    shell(cx, "keep-pipe:", true, ShellBehavior::Filter);
+    shell(cx, "keep-pipe:", ShellBehavior::Filter);
 }
 
-fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
+fn shell(cx: &mut Context, prompt: &str, behavior: ShellBehavior) {
     use std::io::Write;
     use std::process::{Command, Stdio};
     if cx.editor.config.shell.is_empty() {
         return;
     }
+    let pipe = match behavior {
+        ShellBehavior::Replace | ShellBehavior::Filter | ShellBehavior::None => true,
+        ShellBehavior::Insert | ShellBehavior::Append => false,
+    };
     let prompt = Prompt::new(
         prompt.to_owned(),
         Some('|'),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4087,17 +4087,10 @@ fn shell_filter(cx: &mut Context) {
 fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
     use std::io::Write;
     use std::process::{Command, Stdio};
-    let shell = Option::<Vec<_>>::None; // this should come from config, but can't currently
-    let shell = match shell {
-        Some(v) if !v.is_empty() => v,
-        _ => {
-            if cfg!(windows) {
-                vec!["cmd".to_owned(), "/C".to_owned()]
-            } else {
-                vec!["sh".to_owned(), "-c".to_owned()]
-            }
-        }
-    };
+    let shell = cx.editor.config.shell.clone();
+    if shell.is_empty() {
+        return;
+    }
     let prompt = Prompt::new(
         prompt.to_owned(),
         Some('|'),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3940,10 +3940,7 @@ fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
             if cfg!(windows) {
                 vec!["cmd".to_owned(), "/C".to_owned()]
             } else {
-                vec![
-                    std::env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()),
-                    "-c".to_owned(),
-                ]
+                vec!["sh".to_owned(), "-c".to_owned()]
             }
         }
     };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -296,10 +296,10 @@ impl Command {
         select_textobject_around, "Select around object",
         select_textobject_inner, "Select inside object",
         shell_pipe, "Pipe selections through shell command",
-        shell_pipe_ignore, "Pipe selections into shell command, ignoring command output",
-        shell_insert, "Insert output of shell command before each selection",
-        shell_append, "Append output of shell command after each selection",
-        shell_filter, "Filter selections with shell predicate",
+        shell_pipe_to, "Pipe selections into shell command, ignoring command output",
+        shell_insert_output, "Insert output of shell command before each selection",
+        shell_append_output, "Append output of shell command after each selection",
+        shell_keep_pipe, "Filter selections with shell predicate",
         suspend, "Suspend",
     );
 }
@@ -4068,19 +4068,19 @@ fn shell_pipe(cx: &mut Context) {
     shell(cx, "pipe:", true, ShellBehavior::Replace);
 }
 
-fn shell_pipe_ignore(cx: &mut Context) {
+fn shell_pipe_to(cx: &mut Context) {
     shell(cx, "pipe-to:", true, ShellBehavior::None);
 }
 
-fn shell_insert(cx: &mut Context) {
+fn shell_insert_output(cx: &mut Context) {
     shell(cx, "insert-output:", false, ShellBehavior::Insert);
 }
 
-fn shell_append(cx: &mut Context) {
+fn shell_append_output(cx: &mut Context) {
     shell(cx, "append-output:", false, ShellBehavior::Append);
 }
 
-fn shell_filter(cx: &mut Context) {
+fn shell_keep_pipe(cx: &mut Context) {
     shell(cx, "keep-pipe:", true, ShellBehavior::Filter);
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4246,10 +4246,10 @@ fn surround_delete(cx: &mut Context) {
 #[derive(Eq, PartialEq)]
 enum ShellBehavior {
     Replace,
+    Ignore,
     Insert,
     Append,
     Filter,
-    None,
 }
 
 fn shell_pipe(cx: &mut Context) {
@@ -4257,7 +4257,7 @@ fn shell_pipe(cx: &mut Context) {
 }
 
 fn shell_pipe_to(cx: &mut Context) {
-    shell(cx, "pipe-to:", ShellBehavior::None);
+    shell(cx, "pipe-to:", ShellBehavior::Ignore);
 }
 
 fn shell_insert_output(cx: &mut Context) {
@@ -4279,7 +4279,7 @@ fn shell(cx: &mut Context, prompt: &str, behavior: ShellBehavior) {
         return;
     }
     let pipe = match behavior {
-        ShellBehavior::Replace | ShellBehavior::Filter | ShellBehavior::None => true,
+        ShellBehavior::Replace | ShellBehavior::Ignore | ShellBehavior::Filter => true,
         ShellBehavior::Insert | ShellBehavior::Append => false,
     };
     let prompt = Prompt::new(
@@ -4358,7 +4358,7 @@ fn shell(cx: &mut Context, prompt: &str, behavior: ShellBehavior) {
 
                 if let Some(error) = error {
                     cx.editor.set_error(error.to_owned());
-                } else if behavior != ShellBehavior::None {
+                } else if behavior != ShellBehavior::Ignore {
                     doc.apply(&transaction, view.id);
                     doc.append_changes_to_history(view.id);
                 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4330,6 +4330,7 @@ fn shell(cx: &mut Context, prompt: &str, behavior: ShellBehavior) {
     use std::io::Write;
     use std::process::{Command, Stdio};
     if cx.editor.config.shell.is_empty() {
+        cx.editor.set_error("No shell set".to_owned());
         return;
     }
     let pipe = match behavior {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4087,8 +4087,7 @@ fn shell_filter(cx: &mut Context) {
 fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
     use std::io::Write;
     use std::process::{Command, Stdio};
-    let shell = cx.editor.config.shell.clone();
-    if shell.is_empty() {
+    if cx.editor.config.shell.is_empty() {
         return;
     }
     let prompt = Prompt::new(
@@ -4096,6 +4095,7 @@ fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
         Some('|'),
         |_input: &str| Vec::new(),
         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
+            let shell = &cx.editor.config.shell;
             if event == PromptEvent::Validate {
                 let (view, doc) = current!(cx.editor);
                 let selection = doc.selection(view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3946,7 +3946,7 @@ fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
     };
     let prompt = Prompt::new(
         prompt.to_owned(),
-        Some('!'),
+        Some('|'),
         |_input: &str| Vec::new(),
         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
             if event == PromptEvent::Validate {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4069,19 +4069,19 @@ fn shell_pipe(cx: &mut Context) {
 }
 
 fn shell_pipe_ignore(cx: &mut Context) {
-    shell(cx, "pipe:", true, ShellBehavior::None);
+    shell(cx, "pipe-to:", true, ShellBehavior::None);
 }
 
 fn shell_insert(cx: &mut Context) {
-    shell(cx, "command:", false, ShellBehavior::Insert);
+    shell(cx, "insert-output:", false, ShellBehavior::Insert);
 }
 
 fn shell_append(cx: &mut Context) {
-    shell(cx, "command:", false, ShellBehavior::Append);
+    shell(cx, "append-output:", false, ShellBehavior::Append);
 }
 
 fn shell_filter(cx: &mut Context) {
-    shell(cx, "filter:", true, ShellBehavior::Filter);
+    shell(cx, "keep-pipe:", true, ShellBehavior::Filter);
 }
 
 fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -5,6 +5,7 @@ use crate::keymap::Keymaps;
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 pub struct Config {
     pub theme: Option<String>,
+    pub shell: Option<Vec<String>>,
     #[serde(default)]
     pub lsp: LspConfig,
     #[serde(default)]

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -5,7 +5,6 @@ use crate::keymap::Keymaps;
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 pub struct Config {
     pub theme: Option<String>,
-    pub shell: Option<Vec<String>>,
     #[serde(default)]
     pub lsp: LspConfig,
     #[serde(default)]

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -509,10 +509,10 @@ impl Default for Keymaps {
 
             "\"" => select_register,
             "|" => shell_pipe,
-            "A-|" => shell_pipe_ignore,
-            "!" => shell_insert,
-            "A-!" => shell_append,
-            "$" => shell_filter,
+            "A-|" => shell_pipe_to,
+            "!" => shell_insert_output,
+            "A-!" => shell_append_output,
+            "$" => shell_keep_pipe,
             "C-z" => suspend,
         });
         let mut select = normal.clone();

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -502,6 +502,11 @@ impl Default for Keymaps {
             },
 
             "\"" => select_register,
+            "|" => shell_pipe,
+            "A-|" => shell_pipe_ignore,
+            "!" => shell_insert,
+            "A-!" => shell_append,
+            "$" => shell_filter,
         });
         // TODO: decide whether we want normal mode to also be select mode (kakoune-like), or whether
         // we keep this separate select mode. More keys can fit into normal mode then, but it's weird

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub scrolloff: usize,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
+    /// Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
+    pub shell: Vec<String>,
 }
 
 impl Default for Config {
@@ -34,6 +36,11 @@ impl Default for Config {
         Self {
             scrolloff: 5,
             mouse: true,
+            shell: if cfg!(windows) {
+                vec!["cmd".to_owned(), "/C".to_owned()]
+            } else {
+                vec!["sh".to_owned(), "-c".to_owned()]
+            },
         }
     }
 }


### PR DESCRIPTION
Addresses #75.

I've added a config option for `shell` which would be set like `shell = ["bash", "-c"]`, ~~but the code does not currently use it because command functions are not able to access config currently. As such, the code is only able to fall back to `cmd /C` on Windows and `sh -c` otherwise.~~ ~~Currently, the command's stderr isn't handled.~~

- [x] Implement commands stated in [this comment](https://github.com/helix-editor/helix/issues/75#issuecomment-854274546), in addition to `$`, which pipes each selection into the command, deleting the selection if the command exits with a nonzero exit status.
- ~~Shell command completions~~
- [x] Allow the user to configure the shell to use in `config.toml`.