### PR TITLE
Do not shutdown lsp during claim_term

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -489,7 +489,6 @@ impl Application {
         terminal::enable_raw_mode()?;
         let mut stdout = stdout();
         execute!(stdout, terminal::EnterAlternateScreen)?;
-        self.editor.close_language_servers(None).await?;
         if self.config.terminal.mouse {
             execute!(stdout, EnableMouseCapture)?;
         }


### PR DESCRIPTION
Fixes a bug where the language server is told to shutdown directly after application start.

I'm not sure _why_ the call of close_language_servers is here, to opinions are welcome.