### PR TITLE
helix-term: handle scrolling when mouse is enabled

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -87,7 +87,10 @@ impl Application {
             config.editor.clone(),
         );
 
-        let editor_view = Box::new(ui::EditorView::new(std::mem::take(&mut config.keys)));
+        let editor_view = Box::new(ui::EditorView::new(
+            std::mem::take(&mut config.keys),
+            config.clone(),
+        ));
         compositor.push(editor_view);
 
         if !args.files.is_empty() {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -87,10 +87,7 @@ impl Application {
             config.editor.clone(),
         );
 
-        let editor_view = Box::new(ui::EditorView::new(
-            std::mem::take(&mut config.keys),
-            config.clone(),
-        ));
+        let editor_view = Box::new(ui::EditorView::new(std::mem::take(&mut config.keys)));
         compositor.push(editor_view);
 
         if !args.files.is_empty() {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -871,7 +871,7 @@ fn switch_to_lowercase(cx: &mut Context) {
     doc.append_changes_to_history(view.id);
 }
 
-fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
+pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
     use Direction::*;
     let (view, doc) = current!(cx.editor);
     let cursor = coords_at_pos(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,7 +1,6 @@
 use crate::{
     commands,
     compositor::{Component, Context, EventResult},
-    config::Config,
     key,
     keymap::{KeymapResult, Keymaps},
     ui::{Completion, ProgressSpinners},
@@ -30,7 +29,6 @@ use tui::buffer::Buffer as Surface;
 
 pub struct EditorView {
     keymaps: Keymaps,
-    config: Config,
     on_next_key: Option<Box<dyn FnOnce(&mut commands::Context, KeyEvent)>>,
     last_insert: (commands::Command, Vec<KeyEvent>),
     completion: Option<Completion>,
@@ -42,15 +40,14 @@ pub const GUTTER_OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
 
 impl Default for EditorView {
     fn default() -> Self {
-        Self::new(Keymaps::default(), Config::default())
+        Self::new(Keymaps::default())
     }
 }
 
 impl EditorView {
-    pub fn new(keymaps: Keymaps, config: Config) -> Self {
+    pub fn new(keymaps: Keymaps) -> Self {
         Self {
             keymaps,
-            config,
             on_next_key: None,
             last_insert: (commands::Command::normal_mode, Vec::new()),
             completion: None,
@@ -781,7 +778,7 @@ impl Component for EditorView {
                 }
 
                 let (view, doc) = current!(cxt.editor);
-                view.ensure_cursor_in_view(doc, cx.editor.config.scrolloff);
+                view.ensure_cursor_in_view(doc, cxt.editor.config.scrolloff);
 
                 // mode transitions
                 match (mode, doc.mode()) {
@@ -864,7 +861,7 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollUp,
                 ..
             }) => {
-                for _ in 0..self.config.terminal.scroll_lines {
+                for _ in 0..cxt.editor.config.scrolloff {
                     commands::Command::scroll_up.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)
@@ -874,7 +871,7 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollDown,
                 ..
             }) => {
-                for _ in 0..self.config.terminal.scroll_lines {
+                for _ in 0..cxt.editor.config.scrolloff {
                     commands::Command::scroll_down.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -864,6 +864,7 @@ impl Component for EditorView {
                 ..
             }) => {
                 let editor = &mut cxt.editor;
+                let current_view = editor.tree.focus;
 
                 let direction = match event {
                     Event::Mouse(MouseEvent {
@@ -895,6 +896,9 @@ impl Component for EditorView {
                 for _ in 0..editor.config.scroll_lines.abs() {
                     cmd.execute(&mut cxt);
                 }
+
+                cxt.editor.tree.focus = current_view;
+
                 EventResult::Consumed(None)
             }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,6 +1,7 @@
 use crate::{
     commands,
     compositor::{Component, Context, EventResult},
+    config::Config,
     key,
     keymap::{KeymapResult, Keymaps},
     ui::{Completion, ProgressSpinners},
@@ -29,6 +30,7 @@ use tui::buffer::Buffer as Surface;
 
 pub struct EditorView {
     keymaps: Keymaps,
+    config: Config,
     on_next_key: Option<Box<dyn FnOnce(&mut commands::Context, KeyEvent)>>,
     last_insert: (commands::Command, Vec<KeyEvent>),
     completion: Option<Completion>,
@@ -40,14 +42,15 @@ pub const GUTTER_OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
 
 impl Default for EditorView {
     fn default() -> Self {
-        Self::new(Keymaps::default())
+        Self::new(Keymaps::default(), Config::default())
     }
 }
 
 impl EditorView {
-    pub fn new(keymaps: Keymaps) -> Self {
+    pub fn new(keymaps: Keymaps, config: Config) -> Self {
         Self {
             keymaps,
+            config,
             on_next_key: None,
             last_insert: (commands::Command::normal_mode, Vec::new()),
             completion: None,
@@ -861,7 +864,9 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollUp,
                 ..
             }) => {
-                commands::Command::scroll_up.execute(&mut cxt);
+                for _ in 0..self.config.terminal.scroll_lines {
+                    commands::Command::scroll_up.execute(&mut cxt);
+                }
                 EventResult::Consumed(None)
             }
 
@@ -869,7 +874,9 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollDown,
                 ..
             }) => {
-                commands::Command::scroll_down.execute(&mut cxt);
+                for _ in 0..self.config.terminal.scroll_lines {
+                    commands::Command::scroll_down.execute(&mut cxt);
+                }
                 EventResult::Consumed(None)
             }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -861,7 +861,7 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollUp,
                 ..
             }) => {
-                for _ in 0..cxt.editor.config.scrolloff {
+                for _ in 0..cxt.editor.config.scroll_lines {
                     commands::Command::scroll_up.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)
@@ -871,7 +871,7 @@ impl Component for EditorView {
                 kind: MouseEventKind::ScrollDown,
                 ..
             }) => {
-                for _ in 0..cxt.editor.config.scrolloff {
+                for _ in 0..cxt.editor.config.scroll_lines {
                     commands::Command::scroll_down.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -859,9 +859,23 @@ impl Component for EditorView {
 
             Event::Mouse(MouseEvent {
                 kind: MouseEventKind::ScrollUp,
+                row,
+                column,
                 ..
             }) => {
-                for _ in 0..cxt.editor.config.scroll_lines {
+                let editor = &mut cxt.editor;
+
+                let result = editor.tree.views().find_map(|(view, _focus)| {
+                    view.pos_at_screen_coords(&editor.documents[view.doc], row, column)
+                        .map(|_| view.id)
+                });
+
+                match result {
+                    Some(view_id) => editor.tree.focus = view_id,
+                    None => return EventResult::Ignored,
+                }
+
+                for _ in 0..editor.config.scroll_lines {
                     commands::Command::scroll_up.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)
@@ -869,8 +883,22 @@ impl Component for EditorView {
 
             Event::Mouse(MouseEvent {
                 kind: MouseEventKind::ScrollDown,
+                row,
+                column,
                 ..
             }) => {
+                let editor = &mut cxt.editor;
+
+                let result = editor.tree.views().find_map(|(view, _focus)| {
+                    view.pos_at_screen_coords(&editor.documents[view.doc], row, column)
+                        .map(|_| view.id)
+                });
+
+                match result {
+                    Some(view_id) => editor.tree.focus = view_id,
+                    None => return EventResult::Ignored,
+                }
+
                 for _ in 0..cxt.editor.config.scroll_lines {
                     commands::Command::scroll_down.execute(&mut cxt);
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -865,6 +865,12 @@ impl Component for EditorView {
             }) => {
                 let editor = &mut cxt.editor;
 
+                let cmd = match editor.config.scroll_lines.signum() {
+                    1 => commands::Command::scroll_up,
+                    -1 => commands::Command::scroll_down,
+                    _ => return EventResult::Ignored,
+                };
+
                 let result = editor.tree.views().find_map(|(view, _focus)| {
                     view.pos_at_screen_coords(&editor.documents[view.doc], row, column)
                         .map(|_| view.id)
@@ -875,8 +881,8 @@ impl Component for EditorView {
                     None => return EventResult::Ignored,
                 }
 
-                for _ in 0..editor.config.scroll_lines {
-                    commands::Command::scroll_up.execute(&mut cxt);
+                for _ in 0..editor.config.scroll_lines.abs() {
+                    cmd.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)
             }
@@ -889,6 +895,12 @@ impl Component for EditorView {
             }) => {
                 let editor = &mut cxt.editor;
 
+                let cmd = match editor.config.scroll_lines.signum() {
+                    1 => commands::Command::scroll_down,
+                    -1 => commands::Command::scroll_up,
+                    _ => return EventResult::Ignored,
+                };
+
                 let result = editor.tree.views().find_map(|(view, _focus)| {
                     view.pos_at_screen_coords(&editor.documents[view.doc], row, column)
                         .map(|_| view.id)
@@ -899,8 +911,8 @@ impl Component for EditorView {
                     None => return EventResult::Ignored,
                 }
 
-                for _ in 0..cxt.editor.config.scroll_lines {
-                    commands::Command::scroll_down.execute(&mut cxt);
+                for _ in 0..editor.config.scroll_lines.abs() {
+                    cmd.execute(&mut cxt);
                 }
                 EventResult::Consumed(None)
             }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -21,7 +21,7 @@ use helix_core::Position;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", default)]
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -26,7 +26,7 @@ pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
     /// Number of lines to scroll at once. Defaults to 3
-    pub scroll_lines: usize,
+    pub scroll_lines: isize,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -25,6 +25,8 @@ use serde::Deserialize;
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
+    /// Number of lines to scroll at once. Defaults to 3
+    pub scroll_lines: usize,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
 }
@@ -33,6 +35,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             scrolloff: 5,
+            scroll_lines: 3,
             mouse: true,
         }
     }


### PR DESCRIPTION
Fix #552
- [x] Switch view when scrolling happens on another view (and maybe go back to previously active view? needs design)
- ~~Possibly add scrolling inside pickers, that also worked when terminal emulated up/down keypresses~~ out of scope

Both tasks can be done separately if that would be better.