### PR TITLE
Fix/lsp crash content length

### DIFF
--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -84,7 +84,7 @@ impl Transport {
         loop {
             buffer.truncate(0);
             reader.read_line(buffer).await?;
-            if let None = semaphore_guard {
+            if semaphore_guard.is_none() {
                 semaphore_guard = Some(
                     semaphore
                         .acquire()

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -140,7 +140,7 @@ impl Transport {
         let output: serde_json::Result<ServerMessage> = serde_json::from_str(&msg);
         log::trace!("parsed JSON, output: {:?}", output);
 
-        semaphore_guard.unwrap().forget();
+        drop(semaphore_guard.unwrap());
 
         Ok(output?)
     }


### PR DESCRIPTION
closes #504

I have not tested it yet, if anyone else could confirm if it still crashes, that'd be really great.

I am also working on implementing unit-tests, however I'm not yet sure how I can make a structure that implements `AsyncRead` , there is a `Cursor` type, but the difference is that when it's empty it returns nothing, while types `ChildStdin`/`ChildStdout`/`ChildStderr` or `TcpStream` instead of returning nothing, they just return a waiting future for a new data to come.