### PR TITLE
Fix regression in 821565e4efe84f97e08327138cbe8f09aba934e0

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -489,7 +489,6 @@ impl Application {
         terminal::enable_raw_mode()?;
         let mut stdout = stdout();
         execute!(stdout, terminal::EnterAlternateScreen)?;
-        self.editor.close_language_servers(None).await?;
         if self.config.terminal.mouse {
             execute!(stdout, EnableMouseCapture)?;
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -314,6 +314,7 @@ impl Editor {
         &self,
         timeout: Option<u64>,
     ) -> Result<(), tokio::time::error::Elapsed> {
+        info!("closing language server");
         tokio::time::timeout(
             Duration::from_millis(timeout.unwrap_or(500)),
             future::join_all(


### PR DESCRIPTION
I broke something during rebase, close_language_servers is called
when the application starts so lsp stop working.

821565e4efe84f97e08327138cbe8f09aba934e0