### PR TITLE
Change `exit_select_mode` to check that select mode is active before switching to normal mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2468,7 +2468,10 @@ fn select_mode(cx: &mut Context) {
 }
 
 fn exit_select_mode(cx: &mut Context) {
-    doc_mut!(cx.editor).mode = Mode::Normal;
+    let doc = doc_mut!(cx.editor);
+    if doc.mode == Mode::Select {
+        doc.mode = Mode::Normal;
+    }
 }
 
 fn goto_impl(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -133,7 +133,7 @@ pub struct Command {
 }
 
 macro_rules! commands {
-    ( $($name:ident, $doc:literal),* $(,)? ) => {
+    ( $($name:ident, $doc:literal,)* ) => {
         $(
             #[allow(non_upper_case_globals)]
             pub const $name: Self = Self {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3940,10 +3940,7 @@ fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
             if cfg!(windows) {
                 vec!["cmd".to_owned(), "/C".to_owned()]
             } else {
-                vec![
-                    std::env::var("SHELL").unwrap_or_else(|_| "sh".to_owned()),
-                    "-c".to_owned(),
-                ]
+                vec!["sh".to_owned(), "-c".to_owned()]
             }
         }
     };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3946,7 +3946,7 @@ fn shell(cx: &mut Context, prompt: &str, pipe: bool, behavior: ShellBehavior) {
     };
     let prompt = Prompt::new(
         prompt.to_owned(),
-        Some('!'),
+        Some('|'),
         |_input: &str| Vec::new(),
         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
             if event == PromptEvent::Validate {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -5,6 +5,7 @@ use crate::keymap::Keymaps;
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 pub struct Config {
     pub theme: Option<String>,
+    pub shell: Option<Vec<String>>,
     #[serde(default)]
     pub lsp: LspConfig,
     #[serde(default)]

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -502,6 +502,11 @@ impl Default for Keymaps {
             },
 
             "\"" => select_register,
+            "|" => shell_pipe,
+            "A-|" => shell_pipe_ignore,
+            "!" => shell_insert,
+            "A-!" => shell_append,
+            "$" => shell_filter,
         });
         // TODO: decide whether we want normal mode to also be select mode (kakoune-like), or whether
         // we keep this separate select mode. More keys can fit into normal mode then, but it's weird


### PR DESCRIPTION
I realized this issue after noticing that `C-w` in insert mode correctly deleted a word backward, but wrongly exited insert mode in the process.