### PR TITLE
Change `exit_select_mode` to check that select mode is active before switching to normal mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2560,7 +2560,10 @@ fn select_mode(cx: &mut Context) {
 }
 
 fn exit_select_mode(cx: &mut Context) {
-    doc_mut!(cx.editor).mode = Mode::Normal;
+    let doc = doc_mut!(cx.editor);
+    if doc.mode == Mode::Select {
+        doc.mode = Mode::Normal;
+    }
 }
 
 fn goto_impl(


### PR DESCRIPTION
I realized this issue after noticing that `C-w` in insert mode correctly deleted a word backward, but wrongly exited insert mode in the process.