### PR TITLE
Update configuration.md for Windows

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,6 +1,9 @@
 # Configuration
 
-To override global configuration parameters create a `config.toml` file located in your config directory (i.e `~/.config/helix/config.toml`).
+To override global configuration parameters, create a `config.toml` file located in your config directory:
+
+* Linux and Mac: `~/.config/helix/config.toml`
+* Windows: `%AppData%\helix\config.toml`
 
 ## LSP
 


### PR DESCRIPTION
Added explicit paths for WIndows, Mac, and Linux based on [`choose_base_strategy`](https://docs.rs/etcetera/0.3.2/etcetera/base_strategy/fn.choose_base_strategy.html). If this is obvious, please reject, but I had to trace it down through the etcetera module to be sure I had `config.toml` in the right place.