### PR TITLE
Adding INO to C++ file type

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -64,7 +64,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "cpp"
 scope = "source.cpp"
 injection-regex = "cpp"
-file-types = ["cc", "cpp", "hpp", "h"]
+file-types = ["cc", "cpp", "hpp", "h", "ino"]
 roots = []
 comment-token = "//"
 


### PR DESCRIPTION
INO is file extension for C++ files used in Arduino sketches.
Reference: https://www.arduino.cc/en/Guide/Environment