### PR TITLE
Compile the grammar libraries with full RELRO

### DIFF
--- a/helix-syntax/build.rs
+++ b/helix-syntax/build.rs
@@ -105,7 +105,9 @@ fn build_library(src_path: &Path, language: &str) -> Result<()> {
             }
         }
         command.arg("-xc").arg(parser_path);
-        command.arg("-Wl,-z,relro,-z,now");
+        if cfg!(all(unix, not(target_os = "macos"))) {
+            command.arg("-Wl,-z,relro,-z,now");
+        }
     }
 
     let output = command

--- a/helix-syntax/build.rs
+++ b/helix-syntax/build.rs
@@ -105,6 +105,7 @@ fn build_library(src_path: &Path, language: &str) -> Result<()> {
             }
         }
         command.arg("-xc").arg(parser_path);
+        command.arg("-Wl,-z,relro,-z,now");
     }
 
     let output = command


### PR DESCRIPTION
Hey, Arch Linux maintainer of [`helix`](https://archlinux.org/packages/community/x86_64/helix/) is here.

While updating `helix` from `0.3.0` to `0.4.1` I realized the grammar libraries are loaded dynamically at runtime (dd2903ff10387c04e933aa37846663131297b8b3) which is fine but they all lack [full RELRO](https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro) when they are built. [namcap](https://gitlab.archlinux.org/pacman/namcap) shows the following warning:

```
helix W: ELF file ('usr/lib/helix/runtime/grammars/agda.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/bash.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/c-sharp.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/c.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/cpp.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/css.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/elixir.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/go.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/html.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/java.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/javascript.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/json.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/julia.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/latex.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/nix.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/php.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/python.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/ruby.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/rust.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/scala.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/swift.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/toml.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/tsx.so') lacks FULL RELRO, check LDFLAGS.
helix W: ELF file ('usr/lib/helix/runtime/grammars/typescript.so') lacks FULL RELRO, check LDFLAGS.
```

From a security standpoint I thought it would be very good to implement this by adding the full RELRO options to the compiler arguments in [build.rs](https://github.com/helix-editor/helix/blob/v0.4.1/helix-syntax/build.rs)

