### PR TITLE
Adding mjs to JavaScript file type

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -88,7 +88,7 @@ indent = { tab-width = 4, unit = "\t" }
 name = "javascript"
 scope = "source.js"
 injection-regex = "^(js|javascript)$"
-file-types = ["js"]
+file-types = ["js", "mjs"]
 roots = []
 comment-token = "//"
 # TODO: highlights-jsx, highlights-params


### PR DESCRIPTION
MJS is a file extension for JavaScript modules using standard ES2015+