### PR TITLE
More C++ extensions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -64,7 +64,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "cpp"
 scope = "source.cpp"
 injection-regex = "cpp"
-file-types = ["cc", "cpp", "hpp", "h", "ino"]
+file-types = ["cc", "hh", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino"]
 roots = []
 comment-token = "//"
 


### PR DESCRIPTION
``.hh`` is often used alongside ``.cc`` files. However, it is not part of Google's C++ style guide.

``.ipp`` and ``.tpp`` are template implementation files, which are kind of like ``.cpp`` files in what they do, except that they have to be ``#include``'ed in a different way due to how the linker works.

``.*xx`` files are common alternatives to ``.*pp`` files. They are discouraged by the CPP Core Guidelines, but legacy code often still uses them, and even some modern coders favor them to ``.*pp`` files.
