### PR TITLE
allow async commands and async in handle_event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
+name = "async-trait"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +367,7 @@ name = "helix-term"
 version = "0.4.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "crossterm",
  "fern",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -35,6 +35,7 @@ crossterm = { version = "0.20", features = ["event-stream"] }
 signal-hook = "0.3"
 
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
+async-trait = "0.1.51"
 
 # Logging
 fern = "0.6"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -170,7 +170,7 @@ impl Application {
                 biased;
 
                 event = reader.next() => {
-                    self.handle_terminal_events(event)
+                    self.handle_terminal_events(event).await;
                 }
                 Some(signal) = self.signals.next() => {
                     self.handle_signals(signal).await;
@@ -221,7 +221,7 @@ impl Application {
         }
     }
 
-    pub fn handle_terminal_events(&mut self, event: Option<Result<Event, crossterm::ErrorKind>>) {
+    pub async fn handle_terminal_events(&mut self, event: Option<Result<Event, crossterm::ErrorKind>>) {
         let mut cx = crate::compositor::Context {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
@@ -233,9 +233,9 @@ impl Application {
                 self.compositor.resize(width, height);
 
                 self.compositor
-                    .handle_event(Event::Resize(width, height), &mut cx)
+                    .handle_event(Event::Resize(width, height), &mut cx).await
             }
-            Some(Ok(event)) => self.compositor.handle_event(event, &mut cx),
+            Some(Ok(event)) => self.compositor.handle_event(event, &mut cx).await,
             Some(Err(x)) => panic!("{}", x),
             None => panic!(),
         };

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -3,6 +3,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent};
 use tui::buffer::Buffer as Surface;
 
 use std::borrow::Cow;
+use async_trait::async_trait;
 
 use helix_core::Transaction;
 use helix_view::{graphics::Rect, Document, Editor, View};
@@ -225,8 +226,9 @@ impl Completion {
 // - components register for hooks, then unregister when terminated
 // ... since completion is a special case, maybe just build it into doc/render?
 
+#[async_trait(?Send)]
 impl Component for Completion {
-    fn handle_event(&mut self, event: Event, cx: &mut Context) -> EventResult {
+    async fn handle_event(&mut self, event: Event, cx: &mut Context<'_>) -> EventResult {
         // let the Editor handle Esc instead
         if let Event::Key(KeyEvent {
             code: KeyCode::Esc, ..
@@ -234,7 +236,7 @@ impl Component for Completion {
         {
             return EventResult::Ignored;
         }
-        self.popup.handle_event(event, cx)
+        self.popup.handle_event(event, cx).await
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -30,7 +30,7 @@ pub struct Menu<T: Item> {
 
     widths: Vec<Constraint>,
 
-    callback_fn: Box<dyn Fn(&mut Editor, Option<&T>, MenuEvent)>,
+    callback_fn: Box<dyn Fn(&mut Editor, Option<&T>, MenuEvent) + Send>,
 
     scroll: usize,
     size: (u16, u16),
@@ -41,7 +41,7 @@ impl<T: Item> Menu<T> {
     // rendering)
     pub fn new(
         options: Vec<T>,
-        callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
+        callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static + Send,
     ) -> Self {
         let mut menu = Self {
             options,

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,6 +1,7 @@
 use crate::compositor::{Component, Compositor, Context, EventResult};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use tui::{buffer::Buffer as Surface, widgets::Table};
+use async_trait::async_trait;
 
 pub use tui::widgets::{Cell, Row};
 
@@ -133,8 +134,9 @@ impl<T: Item> Menu<T> {
 
 use super::PromptEvent as MenuEvent;
 
+#[async_trait(?Send)]
 impl<T: Item + 'static> Component for Menu<T> {
-    fn handle_event(&mut self, event: Event, cx: &mut Context) -> EventResult {
+    async fn handle_event(&mut self, event: Event, cx: &mut Context<'_>) -> EventResult {
         let event = match event {
             Event::Key(event) => event,
             _ => return EventResult::Ignored,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -57,7 +57,7 @@ impl<T> FilePicker<T> {
             .and_then(|(path, line)| canonicalize_path(&path).ok().zip(Some(line)))
     }
 
-    fn calculate_preview(&mut self, editor: &Editor) {
+    pub fn calculate_preview(&mut self, editor: &Editor) {
         if let Some((path, _line)) = self.current_file(editor) {
             if !self.preview_cache.contains_key(&path) && editor.document_by_path(&path).is_none() {
                 // TODO: enable syntax highlighting; blocked by async rendering

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -3,6 +3,7 @@ use crate::ui;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use std::{borrow::Cow, ops::RangeFrom};
 use tui::buffer::Buffer as Surface;
+use async_trait::async_trait;
 
 use helix_core::{
     unicode::segmentation::GraphemeCursor, unicode::width::UnicodeWidthStr, Position,
@@ -387,8 +388,9 @@ impl Prompt {
     }
 }
 
+#[async_trait(?Send)]
 impl Component for Prompt {
-    fn handle_event(&mut self, event: Event, cx: &mut Context) -> EventResult {
+    async fn handle_event(&mut self, event: Event, cx: &mut Context<'_>) -> EventResult {
         let event = match event {
             Event::Key(event) => event,
             Event::Resize(..) => return EventResult::Consumed(None),

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -8,7 +8,7 @@ pub enum ClipboardType {
     Selection,
 }
 
-pub trait ClipboardProvider: std::fmt::Debug {
+pub trait ClipboardProvider: std::fmt::Debug + Send {
     fn name(&self) -> Cow<str>;
     fn get_contents(&self, clipboard_type: ClipboardType) -> Result<String>;
     fn set_contents(&mut self, contents: String, clipboard_type: ClipboardType) -> Result<()>;


### PR DESCRIPTION
Currently there is not way to make a command async and then await it. You can add it to the jobs and this is useful for things like `write` but some commands should be awaited and not run in the background. For example currently `open` uses synchronous io which can be converted to an async command easily with this. Another command that blocks is `write_all` which we can make it async. Awaiting a command will 'block' the event loop but it still uses asynchronous io which is better. Since commands are async `handle_event` becomes async through `async_trait`. @archseer let me know if I am on the right track or not, this might be a bad idea.