### PR TITLE
fix: add missing optional keyword to protobuf syntax

### DIFF
--- a/runtime/queries/protobuf/highlights.scm
+++ b/runtime/queries/protobuf/highlights.scm
@@ -14,6 +14,7 @@
   "to"
   "stream"
   "extend"
+  "optional"
 ] @keyword
 
 [
@@ -23,7 +24,6 @@
 
 [
   (mapName)
-  (oneofName)
   (enumName)
   (messageName)
   (extendName)


### PR DESCRIPTION
It appears I forgot about the "optional" keyword while doing the other PR. This adds it.