### PR TITLE
Use doc.path() instead of doc.relative_path() for the buffer picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2240,11 +2240,11 @@ fn buffer_picker(cx: &mut Context) {
         cx.editor
             .documents
             .iter()
-            .map(|(id, doc)| (id, doc.relative_path()))
+            .map(|(id, doc)| (id, doc.path().cloned(), doc.relative_path()))
             .collect(),
-        move |(id, path): &(DocumentId, Option<PathBuf>)| {
+        move |(id, _, relative_path): &(DocumentId, Option<PathBuf>, Option<PathBuf>)| {
             // format_fn
-            match path.as_ref().and_then(|path| path.to_str()) {
+            match relative_path.as_ref().and_then(|path| path.to_str()) {
                 Some(path) => {
                     if *id == current {
                         format!("{} (*)", path).into()
@@ -2255,10 +2255,12 @@ fn buffer_picker(cx: &mut Context) {
                 None => "[scratch buffer]".into(),
             }
         },
-        |editor: &mut Editor, (id, _path): &(DocumentId, Option<PathBuf>), _action| {
+        |editor: &mut Editor,
+         (id, ..): &(DocumentId, Option<PathBuf>, Option<PathBuf>),
+         _action| {
             editor.switch(*id, Action::Replace);
         },
-        |editor, (id, path)| {
+        |editor, (id, path, ..)| {
             let doc = &editor.documents.get(*id)?;
             let &view_id = doc.selections().keys().next()?;
             let line = doc

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -54,7 +54,10 @@ impl<T> FilePicker<T> {
         self.picker
             .selection()
             .and_then(|current| (self.file_fn)(editor, current))
-            .and_then(|(path, line)| canonicalize_path(&path).ok().zip(Some(line)))
+            .and_then(|(path, line)| {
+                debug_assert!(path.exists());
+                canonicalize_path(&path).ok().zip(Some(line))
+            })
     }
 
     fn calculate_preview(&mut self, editor: &Editor) {


### PR DESCRIPTION
Resolves #619

Not sure if `buffers_remaining_impl` also needs to be similarly changed.