### PR TITLE
Add :vsplit and :hsplit commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1908,11 +1908,12 @@ mod cmd {
         let (_, doc) = current!(cx.editor);
         let id = doc.id();
 
-        cx.editor.switch(id, Action::VerticalSplit);
+        if let Some(path) = args.get(0) {
+            cx.editor.open(path.into(), Action::VerticalSplit)?;
+        } else {
+            cx.editor.switch(id, Action::VerticalSplit);
+        }
 
-        let path = args.get(0).context("wrong argument count")?;
-
-        let _ = cx.editor.open(path.into(), Action::Replace)?;
         Ok(())
     }
 
@@ -1924,11 +1925,12 @@ mod cmd {
         let (_, doc) = current!(cx.editor);
         let id = doc.id();
 
-        cx.editor.switch(id, Action::HorizontalSplit);
+        if let Some(path) = args.get(0) {
+            cx.editor.open(path.into(), Action::HorizontalSplit)?;
+        } else {
+            cx.editor.switch(id, Action::HorizontalSplit);
+        }
 
-        let path = args.get(0).context("wrong argument count")?;
-
-        let _ = cx.editor.open(path.into(), Action::Replace)?;
         Ok(())
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1900,6 +1900,38 @@ mod cmd {
         Ok(())
     }
 
+    fn vsplit(
+        cx: &mut compositor::Context,
+        args: &[&str],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let (_, doc) = current!(cx.editor);
+        let id = doc.id();
+
+        cx.editor.switch(id, Action::VerticalSplit);
+
+        let path = args.get(0).context("wrong argument count")?;
+
+        let _ = cx.editor.open(path.into(), Action::Replace)?;
+        Ok(())
+    }
+
+    fn hsplit(
+        cx: &mut compositor::Context,
+        args: &[&str],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let (_, doc) = current!(cx.editor);
+        let id = doc.id();
+
+        cx.editor.switch(id, Action::HorizontalSplit);
+
+        let path = args.get(0).context("wrong argument count")?;
+
+        let _ = cx.editor.open(path.into(), Action::Replace)?;
+        Ok(())
+    }
+
     pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -2138,6 +2170,20 @@ mod cmd {
             doc: "Display tree sitter scopes, primarily for theming and development.",
             fun: tree_sitter_scopes,
             completer: None,
+        },
+        TypableCommand {
+            name: "vsplit",
+            alias: Some("vsp"),
+            doc: "Open the file in a vertical split.",
+            fun: vsplit,
+            completer: Some(completers::filename),
+        },
+        TypableCommand {
+            name: "hsplit",
+            alias: Some("sp"),
+            doc: "Open the file in a horizontal split.",
+            fun: hsplit,
+            completer: Some(completers::filename),
         }
     ];
 


### PR DESCRIPTION
Mostly copied this from `helix-term::src::commands::split`, but it works similar to how vim handles splits.