### PR TITLE
Move path util functions from `helix-term` to `helix-core`

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod macros;
 pub mod match_brackets;
 pub mod movement;
 pub mod object;
+pub mod path;
 mod position;
 pub mod register;
 pub mod search;

--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -1,0 +1,92 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Replaces users home directory from `path` with tilde `~` if the directory
+/// is available, otherwise returns the path unchanged.
+pub fn fold_home_dir(path: &Path) -> PathBuf {
+    if let Ok(home) = super::home_dir() {
+        if path.starts_with(&home) {
+            // it's ok to unwrap, the path starts with home dir
+            return PathBuf::from("~").join(path.strip_prefix(&home).unwrap());
+        }
+    }
+
+    path.to_path_buf()
+}
+
+/// Expands tilde `~` into users home directory if avilable, otherwise returns the path
+/// unchanged. The tilde will only be expanded when present as the first component of the path
+/// and only slash follows it.
+pub fn expand_tilde(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    if let Some(Component::Normal(c)) = components.peek() {
+        if c == &"~" {
+            if let Ok(home) = super::home_dir() {
+                // it's ok to unwrap, the path starts with `~`
+                return home.join(path.strip_prefix("~").unwrap());
+            }
+        }
+    }
+
+    path.to_path_buf()
+}
+
+/// Normalize a path, removing things like `.` and `..`.
+///
+/// CAUTION: This does not resolve symlinks (unlike
+/// [`std::fs::canonicalize`]). This may cause incorrect or surprising
+/// behavior at times. This should be used carefully. Unfortunately,
+/// [`std::fs::canonicalize`] can be hard to use correctly, since it can often
+/// fail, or on Windows returns annoying device paths. This is a problem Cargo
+/// needs to improve on.
+/// Copied from cargo: <https://github.com/rust-lang/cargo/blob/070e459c2d8b79c5b2ac5218064e7603329c92ae/crates/cargo-util/src/paths.rs#L81>
+pub fn get_normalized_path(path: &Path) -> PathBuf {
+    let path = expand_tilde(path);
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
+
+/// Returns the canonical, absolute form of a path with all intermediate components normalized.
+///
+/// This function is used instead of `std::fs::canonicalize` because we don't want to verify
+/// here if the path exists, just normalize it's components.
+pub fn get_canonicalized_path(path: &Path) -> std::io::Result<PathBuf> {
+    let path = if path.is_relative() {
+        std::env::current_dir().map(|current_dir| current_dir.join(path))?
+    } else {
+        path.to_path_buf()
+    };
+
+    Ok(get_normalized_path(path.as_path()))
+}
+
+pub fn get_relative_path(path: &Path) -> PathBuf {
+    let path = if path.is_absolute() {
+        let cwdir = std::env::current_dir().expect("couldn't determine current directory");
+        path.strip_prefix(cwdir).unwrap_or(path)
+    } else {
+        path
+    };
+    fold_home_dir(path)
+}

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2291,8 +2291,7 @@ fn buffer_picker(cx: &mut Context) {
             .map(|(id, doc)| (id, doc.path().cloned()))
             .collect(),
         move |(id, path): &(DocumentId, Option<PathBuf>)| {
-            use helix_view::document::relative_path;
-            let path = path.as_deref().map(relative_path);
+            let path = path.as_deref().map(helix_core::path::get_relative_path);
             match path.as_ref().and_then(|path| path.to_str()) {
                 Some(path) => {
                     if *id == current {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -208,7 +208,7 @@ pub mod completers {
         use std::path::Path;
 
         let is_tilde = input.starts_with('~') && input.len() == 1;
-        let path = helix_view::document::expand_tilde(Path::new(input));
+        let path = helix_core::path::expand_tilde(Path::new(input));
 
         let (dir, file_name) = if input.ends_with('/') {
             (path, None)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -17,7 +17,6 @@ use std::{borrow::Cow, collections::HashMap, path::PathBuf};
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::Position;
 use helix_view::{
-    document::canonicalize_path,
     editor::Action,
     graphics::{Color, CursorKind, Margin, Rect, Style},
     Document, Editor,
@@ -54,7 +53,11 @@ impl<T> FilePicker<T> {
         self.picker
             .selection()
             .and_then(|current| (self.file_fn)(editor, current))
-            .and_then(|(path, line)| canonicalize_path(&path).ok().zip(Some(line)))
+            .and_then(|(path, line)| {
+                helix_core::path::get_canonicalized_path(&path)
+                    .ok()
+                    .zip(Some(line))
+            })
     }
 
     fn calculate_preview(&mut self, editor: &Editor) {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -317,95 +317,6 @@ where
     }
 }
 
-/// Expands tilde `~` into users home directory if avilable, otherwise returns the path
-/// unchanged. The tilde will only be expanded when present as the first component of the path
-/// and only slash follows it.
-pub fn expand_tilde(path: &Path) -> PathBuf {
-    let mut components = path.components().peekable();
-    if let Some(Component::Normal(c)) = components.peek() {
-        if c == &"~" {
-            if let Ok(home) = helix_core::home_dir() {
-                // it's ok to unwrap, the path starts with `~`
-                return home.join(path.strip_prefix("~").unwrap());
-            }
-        }
-    }
-
-    path.to_path_buf()
-}
-
-/// Replaces users home directory from `path` with tilde `~` if the directory
-/// is available, otherwise returns the path unchanged.
-pub fn fold_home_dir(path: &Path) -> PathBuf {
-    if let Ok(home) = helix_core::home_dir() {
-        if path.starts_with(&home) {
-            // it's ok to unwrap, the path starts with home dir
-            return PathBuf::from("~").join(path.strip_prefix(&home).unwrap());
-        }
-    }
-
-    path.to_path_buf()
-}
-
-/// Normalize a path, removing things like `.` and `..`.
-///
-/// CAUTION: This does not resolve symlinks (unlike
-/// [`std::fs::canonicalize`]). This may cause incorrect or surprising
-/// behavior at times. This should be used carefully. Unfortunately,
-/// [`std::fs::canonicalize`] can be hard to use correctly, since it can often
-/// fail, or on Windows returns annoying device paths. This is a problem Cargo
-/// needs to improve on.
-/// Copied from cargo: <https://github.com/rust-lang/cargo/blob/070e459c2d8b79c5b2ac5218064e7603329c92ae/crates/cargo-util/src/paths.rs#L81>
-pub fn normalize_path(path: &Path) -> PathBuf {
-    let path = expand_tilde(path);
-    let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-        components.next();
-        PathBuf::from(c.as_os_str())
-    } else {
-        PathBuf::new()
-    };
-
-    for component in components {
-        match component {
-            Component::Prefix(..) => unreachable!(),
-            Component::RootDir => {
-                ret.push(component.as_os_str());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-        }
-    }
-    ret
-}
-
-/// Returns the canonical, absolute form of a path with all intermediate components normalized.
-///
-/// This function is used instead of `std::fs::canonicalize` because we don't want to verify
-/// here if the path exists, just normalize it's components.
-pub fn canonicalize_path(path: &Path) -> std::io::Result<PathBuf> {
-    let path = if path.is_relative() {
-        std::env::current_dir().map(|current_dir| current_dir.join(path))?
-    } else {
-        path.to_path_buf()
-    };
-
-    Ok(normalize_path(&path))
-}
-
-pub fn relative_path(mut path: &Path) -> PathBuf {
-    let cwdir = std::env::current_dir().expect("couldn't determine current directory");
-    if path.is_absolute() {
-        path = path.strip_prefix(cwdir).unwrap_or(path)
-    };
-    fold_home_dir(path)
-}
-
 use helix_lsp::lsp;
 use url::Url;
 
@@ -639,7 +550,7 @@ impl Document {
     }
 
     pub fn set_path(&mut self, path: &Path) -> Result<(), std::io::Error> {
-        let path = canonicalize_path(path)?;
+        let path = helix_core::path::get_canonicalized_path(path)?;
 
         // if parent doesn't exist we still want to open the document
         // and error out when document is saved
@@ -944,7 +855,9 @@ impl Document {
     }
 
     pub fn relative_path(&self) -> Option<PathBuf> {
-        self.path.as_deref().map(relative_path)
+        self.path
+            .as_deref()
+            .map(helix_core::path::get_relative_path)
     }
 
     // pub fn slice<R>(&self, range: R) -> RopeSlice where R: RangeBounds {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -229,7 +229,7 @@ impl Editor {
     }
 
     pub fn open(&mut self, path: PathBuf, action: Action) -> Result<DocumentId, Error> {
-        let path = crate::document::canonicalize_path(&path)?;
+        let path = helix_core::path::get_canonicalized_path(&path)?;
 
         let id = self
             .documents()


### PR DESCRIPTION
I had already done this work for #634.