### PR TITLE
Initial implementation of global search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,8 +41,16 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "bytes"
@@ -175,6 +183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "error-code"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +318,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-matcher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d27563c33062cd33003b166ade2bb4fd82db1fd6a86db764dfdad132d46c1cc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121553c9768c363839b92fc2d7cdbbad44a3b70e8d6e7b1b72b05c977527bd06"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdbde90ba52adc240d2deef7b6ad1f99f53142d074b771fe9b7bede6c4c23d"
+dependencies = [
+ "bstr",
+ "bytecount",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memmap2",
+]
+
+[[package]]
 name = "helix-core"
 version = "0.4.1"
 dependencies = [
@@ -361,6 +417,8 @@ dependencies = [
  "fern",
  "futures-util",
  "fuzzy-matcher",
+ "grep-regex",
+ "grep-searcher",
  "helix-core",
  "helix-lsp",
  "helix-tui",
@@ -551,6 +609,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mio"
@@ -752,6 +819,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-tokio",
  "tokio",
+ "tokio-stream",
  "toml",
 ]
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -207,8 +207,10 @@ This layer is a kludge of mappings, mostly pickers.
 | `y`     | Join and yank selections to clipboard                                 | `yank_joined_to_clipboard`          |
 | `Y`     | Yank main selection to clipboard                                      | `yank_main_selection_to_clipboard`  |
 | `R`     | Replace selections by clipboard contents                              | `replace_selections_with_clipboard` |
+| `/`     | Global search in workspace folder                                     | `global_search`                     |
 
-
+> NOTE: Global search display results in a fuzzy picker, use `space + '` to bring it back up after opening a file.
+ 
 #### Unimpaired
 
 Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaired).

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -56,9 +56,9 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 # ripgrep for global search
-# grep = "0.2.8"
 grep-regex = "0.1.9"
 grep-searcher = "0.1.8"
+tokio-stream = "0.1.7"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -55,5 +55,10 @@ toml = "0.5"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
+# ripgrep for global search
+# grep = "0.2.8"
+grep-regex = "0.1.9"
+grep-searcher = "0.1.8"
+
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -555,6 +555,7 @@ impl Default for Keymaps {
                 "P" => paste_clipboard_before,
                 "R" => replace_selections_with_clipboard,
                 "space" => keep_primary_selection,
+                "/" => global_search,
             },
             "z" => { "View"
                 "z" | "c" => align_view_center,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -28,7 +28,7 @@ pub fn regex_prompt(
     cx: &mut crate::commands::Context,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
-    fun: impl Fn(&mut View, &mut Document, Regex) + 'static,
+    fun: impl Fn(&mut View, &mut Document, Regex, PromptEvent) + 'static,
 ) -> Prompt {
     let (view, doc) = current!(cx.editor);
     let view_id = view.id;
@@ -49,7 +49,8 @@ pub fn regex_prompt(
 
                     match Regex::new(input) {
                         Ok(regex) => {
-                            let (view, _doc) = current!(cx.editor);
+                            let (view, doc) = current!(cx.editor);
+                            fun(view, doc, regex, event);
                         }
                         Err(_err) => (), // TODO: mark command line as error
                     }
@@ -67,7 +68,7 @@ pub fn regex_prompt(
                             // revert state to what it was before the last update
                             doc.set_selection(view.id, snapshot.clone());
 
-                            fun(view, doc, regex);
+                            fun(view, doc, regex, event);
 
                             view.ensure_cursor_in_view(doc, cx.editor.config.scrolloff);
                         }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -46,6 +46,13 @@ pub fn regex_prompt(
                 }
                 PromptEvent::Validate => {
                     // TODO: push_jump to store selection just before jump
+
+                    match Regex::new(input) {
+                        Ok(regex) => {
+                            let (view, _doc) = current!(cx.editor);
+                        }
+                        Err(_err) => (), // TODO: mark command line as error
+                    }
                 }
                 PromptEvent::Update => {
                     // skip empty input, TODO: trigger default


### PR DESCRIPTION
Since we haven't figure out how to properly implement a global search feature yet #196 , I hope this could at least be an inspiration of an potential better design:)
This implementation bind ```space + /``` to display a prompt (like the search prompt), and on ```Enter```, start the search, gathers the result and pop up a ```FilePicker```. A few necessary changes are made, such as ```regex_prompt```, which now accepts an extra callback that would be invoked once ```Enter``` is pressed.
Feel free to close this if we figure out something better later.