### PR TITLE
fix: show current line number even if relative line is on

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -462,7 +462,13 @@ impl EditorView {
             } else {
                 let line = match config.line_number {
                     LineNumber::Absolute => line + 1,
-                    LineNumber::Relative => abs_diff(current_line, line),
+                    LineNumber::Relative => {
+                        if current_line == line {
+                            line + 1
+                        } else {
+                            abs_diff(current_line, line)
+                        }
+                    }
                 };
                 format!("{:>5}", line)
             };


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/34353640/131002300-f8bb55dc-c4b1-47ac-8ef1-8cd66a4179d7.png)

After:
![image](https://user-images.githubusercontent.com/34353640/131002323-62db5893-ec31-40a2-b488-716091389602.png)
