### PR TITLE
remove unsafe code

### DIFF
--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -125,7 +125,7 @@ impl ChangeSet {
     /// In other words,  If `this` goes `docA` → `docB` and `other` represents `docB` → `docC`, the
     /// returned value will represent the change `docA` → `docC`.
     pub fn compose(self, other: Self) -> Self {
-        debug_assert!(self.len_after == other.len);
+        assert!(self.len_after == other.len);
 
         // composing fails in weird ways if one of the sets is empty
         // a: [] len: 0 len_after: 1 | b: [Insert(Tendril<UTF8>(inline: "\n")), Retain(1)] len 1


### PR DESCRIPTION
Since `ChangeSet` has a `Default` impl, I think it doesn't make sense to use unsafe and we can just use `mem::take`. Additionally, aborting the process is a very extreme measure, especially when the `compose` can panic multiple times.