### PR TITLE
Add `Command` column to keymap documentation

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -6,121 +6,121 @@
 
 > NOTE: `f`, `F`, `t` and `T` are not confined to the current line.
 
-| Key          | Description                                                                |
-| -----        | -----------                                                                |
-| `h`, `Left`  | Move left                                                                  |
-| `j`, `Down`  | Move down                                                                  |
-| `k`, `Up`    | Move up                                                                    |
-| `l`, `Right` | Move right                                                                 |
-| `w`          | Move next word start                                                       |
-| `b`          | Move previous word start                                                   |
-| `e`          | Move next word end                                                         |
-| `W`          | Move next WORD start                                                       |
-| `B`          | Move previous WORD start                                                   |
-| `E`          | Move next WORD end                                                         |
-| `t`          | Find 'till next char                                                       |
-| `f`          | Find next char                                                             |
-| `T`          | Find 'till previous char                                                   |
-| `F`          | Find previous char                                                         |
-| `Home`       | Move to the start of the line                                              |
-| `End`        | Move to the end of the line                                                |
-| `PageUp`     | Move page up                                                               |
-| `PageDown`   | Move page down                                                             |
-| `Ctrl-u`     | Move half page up                                                          |
-| `Ctrl-d`     | Move half page down                                                        |
-| `Ctrl-i`     | Jump forward on the jumplist TODO: conflicts tab                           |
-| `Ctrl-o`     | Jump backward on the jumplist                                              |
-| `v`          | Enter [select (extend) mode](#select--extend-mode)                         |
-| `g`          | Enter [goto mode](#goto-mode)                                              |
-| `m`          | Enter [match mode](#match-mode)                                            |
-| `:`          | Enter command mode                                                         |
-| `z`          | Enter [view mode](#view-mode)                                              |
-| `Ctrl-w`     | Enter [window mode](#window-mode) (maybe will be remove for spc w w later) |
-| `Space`      | Enter [space mode](#space-mode)                                            |
-| `K`          | Show documentation for the item under the cursor                           |
+| Key          | Description                                                                | Command                     |
+| -----        | -----------                                                                | -------                     |
+| `h`, `Left`  | Move left                                                                  | `move_char_left`            |
+| `j`, `Down`  | Move down                                                                  | `move_char_right`           |
+| `k`, `Up`    | Move up                                                                    | `move_line_up`              |
+| `l`, `Right` | Move right                                                                 | `move_line_down`            |
+| `w`          | Move next word start                                                       | `move_next_word_start`      |
+| `b`          | Move previous word start                                                   | `move_prev_word_start`      |
+| `e`          | Move next word end                                                         | `move_next_word_end`        |
+| `W`          | Move next WORD start                                                       | `move_next_long_word_start` |
+| `B`          | Move previous WORD start                                                   | `move_prev_long_word_start` |
+| `E`          | Move next WORD end                                                         | `move_next_long_word_end`   |
+| `t`          | Find 'till next char                                                       | `find_till_char`            |
+| `f`          | Find next char                                                             | `find_next_char`            |
+| `T`          | Find 'till previous char                                                   | `till_prev_char`            |
+| `F`          | Find previous char                                                         | `find_prev_char`            |
+| `Home`       | Move to the start of the line                                              | `goto_line_start`           |
+| `End`        | Move to the end of the line                                                | `goto_line_end`             |
+| `PageUp`     | Move page up                                                               | `page_up`                   |
+| `PageDown`   | Move page down                                                             | `page_down`                 |
+| `Ctrl-u`     | Move half page up                                                          | `half_page_up`              |
+| `Ctrl-d`     | Move half page down                                                        | `half_page_down`            |
+| `Ctrl-i`     | Jump forward on the jumplist TODO: conflicts tab                           | `jump_forward`              |
+| `Ctrl-o`     | Jump backward on the jumplist                                              | `jump_backward`             |
+| `v`          | Enter [select (extend) mode](#select--extend-mode)                         | `select_mode`               |
+| `g`          | Enter [goto mode](#goto-mode)                                              | N/A                         |
+| `m`          | Enter [match mode](#match-mode)                                            | N/A                         |
+| `:`          | Enter command mode                                                         | `command_mode`              |
+| `z`          | Enter [view mode](#view-mode)                                              | N/A                         |
+| `Ctrl-w`     | Enter [window mode](#window-mode) (maybe will be remove for spc w w later) | N/A                         |
+| `Space`      | Enter [space mode](#space-mode)                                            | N/A                         |
+| `K`          | Show documentation for the item under the cursor                           | `hover`                     |
 
 ### Changes
 
-| Key         | Description                                     |
-| -----       | -----------                                     |
-| `r`         | Replace with a character                        |
-| `R`         | Replace with yanked text                        |
-| `~`         | Switch case of the selected text                |
-| `` ` ``     | Set the selected text to lower case             |
-| `` Alt-` `` | Set the selected text to upper case             |
-| `i`         | Insert before selection                         |
-| `a`         | Insert after selection (append)                 |
-| `I`         | Insert at the start of the line                 |
-| `A`         | Insert at the end of the line                   |
-| `o`         | Open new line below selection                   |
-| `O`         | Open new line above selection                   |
-| `u`         | Undo change                                     |
-| `U`         | Redo change                                     |
-| `y`         | Yank selection                                  |
-| `p`         | Paste after selection                           |
-| `P`         | Paste before selection                          |
-| `"` `<reg>` | Select a register to yank to or paste from      |
-| `>`         | Indent selection                                |
-| `<`         | Unindent selection                              |
-| `=`         | Format selection                                |
-| `d`         | Delete selection                                |
-| `c`         | Change selection (delete and enter insert mode) |
+| Key         | Description                                     | Command               |
+| -----       | -----------                                     | -------               |
+| `r`         | Replace with a character                        | `replace`             |
+| `R`         | Replace with yanked text                        | `replace_with_yanked` |
+| `~`         | Switch case of the selected text                | `switch_case`         |
+| `` ` ``     | Set the selected text to lower case             | `switch_to_lowercase` |
+| `` Alt-` `` | Set the selected text to upper case             | `switch_to_uppercase` |
+| `i`         | Insert before selection                         | `insert_mode`         |
+| `a`         | Insert after selection (append)                 | `append_mode`         |
+| `I`         | Insert at the start of the line                 | `prepend_to_line`     |
+| `A`         | Insert at the end of the line                   | `append_to_line`      |
+| `o`         | Open new line below selection                   | `open_below`          |
+| `O`         | Open new line above selection                   | `open_above`          |
+| `u`         | Undo change                                     | `undo`                |
+| `U`         | Redo change                                     | `redo`                |
+| `y`         | Yank selection                                  | `yank`                |
+| `p`         | Paste after selection                           | `paste_after`         |
+| `P`         | Paste before selection                          | `paste_before`        |
+| `"` `<reg>` | Select a register to yank to or paste from      | `select_register`     |
+| `>`         | Indent selection                                | `indent`              |
+| `<`         | Unindent selection                              | `unindent`            |
+| `=`         | Format selection                                | `format_selections`   |
+| `d`         | Delete selection                                | `delete_selection`    |
+| `c`         | Change selection (delete and enter insert mode) | `change_selection`    |
 
 ### Selection manipulation
 
-| Key      | Description                                                       |
-| -----    | -----------                                                       |
-| `s`      | Select all regex matches inside selections                        |
-| `S`      | Split selection into subselections on regex matches               |
-| `Alt-s`  | Split selection on newlines                                       |
-| `;`      | Collapse selection onto a single cursor                           |
-| `Alt-;`  | Flip selection cursor and anchor                                  |
-| `C`      | Copy selection onto the next line                                 |
-| `Alt-C`  | Copy selection onto the previous line                             |
-| `(`      | Rotate main selection forward                                     |
-| `)`      | Rotate main selection backward                                    |
-| `Alt-(`  | Rotate selection contents forward                                 |
-| `Alt-)`  | Rotate selection contents backward                                |
-| `%`      | Select entire file                                                |
-| `x`      | Select current line, if already selected, extend to next line     |
-| `X`      | Extend selection to line bounds (line-wise selection)             |
-|          | Expand selection to parent syntax node TODO: pick a key           |
-| `J`      | Join lines inside selection                                       |
-| `K`      | Keep selections matching the regex TODO: overlapped by hover help |
-| `Space`  | Keep only the primary selection TODO: overlapped by space mode    |
-| `Ctrl-c` | Comment/uncomment the selections                                  |
+| Key      | Description                                                       | Command                              |
+| -----    | -----------                                                       | -------                              |
+| `s`      | Select all regex matches inside selections                        | `select_regex`                       |
+| `S`      | Split selection into subselections on regex matches               | `split_selection`                    |
+| `Alt-s`  | Split selection on newlines                                       | `split_selection_on_newline`         |
+| `;`      | Collapse selection onto a single cursor                           | `collapse_selection`                 |
+| `Alt-;`  | Flip selection cursor and anchor                                  | `flip_selections`                    |
+| `C`      | Copy selection onto the next line                                 | `copy_selection_on_next_line`        |
+| `Alt-C`  | Copy selection onto the previous line                             | `copy_selection_on_prev_line`        |
+| `(`      | Rotate main selection forward                                     | `rotate_selections_backward`         |
+| `)`      | Rotate main selection backward                                    | `rotate_selections_forward`          |
+| `Alt-(`  | Rotate selection contents forward                                 | `rotate_selection_contents_backward` |
+| `Alt-)`  | Rotate selection contents backward                                | `rotate_selection_contents_forward`  |
+| `%`      | Select entire file                                                | `select_all`                         |
+| `x`      | Select current line, if already selected, extend to next line     | `extend_line`                        |
+| `X`      | Extend selection to line bounds (line-wise selection)             | `extend_to_line_bounds`              |
+|          | Expand selection to parent syntax node TODO: pick a key           | `expand_selection`                   |
+| `J`      | Join lines inside selection                                       | `join_selections`                    |
+| `K`      | Keep selections matching the regex TODO: overlapped by hover help | `keep_selections`                    |
+| `Space`  | Keep only the primary selection TODO: overlapped by space mode    | `keep_primary_selection`             |
+| `Ctrl-c` | Comment/uncomment the selections                                  | `toggle_comments`                    |
 
 ### Insert Mode
 
-| Key      | Description           |
-| -----    | -----------           |
-| `Escape` | Switch to normal mode |
-| `Ctrl-x` | Autocomplete          |
-| `Ctrl-w` | Delete previous word  |
+| Key      | Description           | Command                |
+| -----    | -----------           | -------                |
+| `Escape` | Switch to normal mode | `normal_mode`          |
+| `Ctrl-x` | Autocomplete          | `completion`           |
+| `Ctrl-w` | Delete previous word  | `delete_word_backward` |
 
 ### Search
 
 > TODO: The search implementation isn't ideal yet -- we don't support searching
 in reverse, or searching via smartcase.
 
-| Key   | Description                                 |
-| ----- | -----------                                 |
-| `/`   | Search for regex pattern                    |
-| `n`   | Select next search match                    |
-| `N`   | Add next search match to selection          |
-| `*`   | Use current selection as the search pattern |
+| Key   | Description                                 | Command              |
+| ----- | -----------                                 | -------              |
+| `/`   | Search for regex pattern                    | `search`             |
+| `n`   | Select next search match                    | `search_next`        |
+| `N`   | Add next search match to selection          | `extend_search_next` |
+| `*`   | Use current selection as the search pattern | `search_selection`   |
 
 ### Diagnostics
 
 > NOTE: `[` and `]` will likely contain more pair mappings in the style of
 > [vim-unimpaired](https://github.com/tpope/vim-unimpaired)
 
-| Key   | Description                        |
-| ----- | -----------                        |
-| `[d`  | Go to previous diagnostic          |
-| `]d`  | Go to next diagnostic              |
-| `[D`  | Go to first diagnostic in document |
-| `]D`  | Go to last diagnostic in document  |
+| Key   | Description                        | Command           |
+| ----- | -----------                        | -------           |
+| `[d`  | Go to previous diagnostic          | `goto_prev_diag`  |
+| `]d`  | Go to next diagnostic              | `goto_next_diag`  |
+| `[D`  | Go to first diagnostic in document | `goto_first_diag` |
+| `]D`  | Go to last diagnostic in document  | `goto_last_diag`  |
 
 ## Select / extend mode
 
@@ -135,14 +135,14 @@ commands to extend the existing selection instead of replacing it.
 View mode is intended for scrolling and manipulating the view without changing
 the selection.
 
-| Key       | Description                                               |
-| -----     | -----------                                               |
-| `z` , `c` | Vertically center the line                                |
-| `t`       | Align the line to the top of the screen                   |
-| `b`       | Align the line to the bottom of the screen                |
-| `m`       | Align the line to the middle of the screen (horizontally) |
-| `j`       | Scroll the view downwards                                 |
-| `k`       | Scroll the view upwards                                   |
+| Key       | Description                                               | Command             |
+| -----     | -----------                                               | -------             |
+| `z` , `c` | Vertically center the line                                | `align_view_center` |
+| `t`       | Align the line to the top of the screen                   | `align_view_top`    |
+| `b`       | Align the line to the bottom of the screen                | `align_view_bottom` |
+| `m`       | Align the line to the middle of the screen (horizontally) | `align_view_middle` |
+| `j`       | Scroll the view downwards                                 | `scroll_down`       |
+| `k`       | Scroll the view upwards                                   | `scroll_up`         |
 
 ## Goto mode
 
@@ -150,21 +150,21 @@ Jumps to various locations.
 
 > NOTE: Some of these features are only available with the LSP present.
 
-| Key   | Description                                      |
-| ----- | -----------                                      |
-| `g`   | Go to the start of the file                      |
-| `e`   | Go to the end of the file                        |
-| `h`   | Go to the start of the line                      |
-| `l`   | Go to the end of the line                        |
-| `s`   | Go to first non-whitespace character of the line |
-| `t`   | Go to the top of the screen                      |
-| `m`   | Go to the middle of the screen                   |
-| `b`   | Go to the bottom of the screen                   |
-| `d`   | Go to definition                                 |
-| `y`   | Go to type definition                            |
-| `r`   | Go to references                                 |
-| `i`   | Go to implementation                             |
-| `a`   | Go to the last accessed/alternate file           |
+| Key   | Description                                      | Command                    |
+| ----- | -----------                                      | -------                    |
+| `g`   | Go to the start of the file                      | `goto_file_start`          |
+| `e`   | Go to the end of the file                        | `goto_last_line`           |
+| `h`   | Go to the start of the line                      | `goto_line_start`          |
+| `l`   | Go to the end of the line                        | `goto_line_end`            |
+| `s`   | Go to first non-whitespace character of the line | `goto_first_nonwhitespace` |
+| `t`   | Go to the top of the screen                      | `goto_window_top`          |
+| `m`   | Go to the middle of the screen                   | `goto_window_middle`       |
+| `b`   | Go to the bottom of the screen                   | `goto_window_bottom`       |
+| `d`   | Go to definition                                 | `goto_definition`          |
+| `y`   | Go to type definition                            | `goto_type_definition`     |
+| `r`   | Go to references                                 | `goto_reference`           |
+| `i`   | Go to implementation                             | `goto_implementation`      |
+| `a`   | Go to the last accessed/alternate file           | `goto_last_accessed_file`  |
 
 ## Match mode
 
@@ -172,14 +172,14 @@ Enter this mode using `m` from normal mode. See the relavant section
 in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
 and [textobject](./usage.md#textobject) usage.
 
-| Key              | Description                                     |
-| -----            | -----------                                     |
-| `m`              | Goto matching bracket                           |
-| `s` `<char>`     | Surround current selection with `<char>`        |
-| `r` `<from><to>` | Replace surround character `<from>` with `<to>` |
-| `d` `<char>`     | Delete surround character `<char>`              |
-| `a` `<object>`   | Select around textobject                        |
-| `i` `<object>`   | Select inside textobject                        |
+| Key              | Description                                     | Command                    |
+| -----            | -----------                                     | -------                    |
+| `m`              | Goto matching bracket                           | `match_brackets`           |
+| `s` `<char>`     | Surround current selection with `<char>`        | `surround_add`             |
+| `r` `<from><to>` | Replace surround character `<from>` with `<to>` | `surround_replace`         |
+| `d` `<char>`     | Delete surround character `<char>`              | `surround_delete`          |
+| `a` `<object>`   | Select around textobject                        | `select_textobject_around` |
+| `i` `<object>`   | Select inside textobject                        | `select_textobject_inner`  |
 
 ## Object mode
 
@@ -189,35 +189,35 @@ TODO: Mappings for selecting syntax nodes (a superset of `[`).
 
 This layer is similar to vim keybindings as kakoune does not support window.
 
-| Key           | Description             |
-| -----         | -------------           |
-| `w`, `Ctrl-w` | Switch to next window   |
-| `v`, `Ctrl-v` | Vertical right split    |
-| `h`, `Ctrl-h` | Horizontal bottom split |
-| `q`, `Ctrl-q` | Close current window    |
+| Key           | Description             | Command       |
+| -----         | -------------           | -------       |
+| `w`, `Ctrl-w` | Switch to next window   | `rotate_view` |
+| `v`, `Ctrl-v` | Vertical right split    | `vsplit`      |
+| `h`, `Ctrl-h` | Horizontal bottom split | `hsplit       |
+| `q`, `Ctrl-q` | Close current window    | `wclose`      |
 
 ## Space mode
 
 This layer is a kludge of mappings I had under leader key in neovim.
 
-| Key     | Description                                                           |
-| -----   | -----------                                                           |
-| `f`     | Open file picker                                                      |
-| `b`     | Open buffer picker                                                    |
-| `s`     | Open symbol picker (current document)                                 |
-| `a`     | Apply code action                                                     |
-| `'`     | Open last fuzzy picker                                                |
-| `w`     | Enter [window mode](#window-mode)                                     |
-| `space` | Keep primary selection TODO: it's here because space mode replaced it |
-| `p`     | Paste system clipboard after selections                               |
-| `P`     | Paste system clipboard before selections                              |
-| `y`     | Join and yank selections to clipboard                                 |
-| `Y`     | Yank main selection to clipboard                                      |
-| `R`     | Replace selections by clipboard contents                              |
+| Key     | Description                                                           | Command                             |
+| -----   | -----------                                                           | -------                             |
+| `f`     | Open file picker                                                      | `file_picker`                       |
+| `b`     | Open buffer picker                                                    | `buffer_picker`                     |
+| `s`     | Open symbol picker (current document)                                 | `symbol_picker`                     |
+| `a`     | Apply code action                                                     | `code_action`                       |
+| `'`     | Open last fuzzy picker                                                | `last_picker`                       |
+| `w`     | Enter [window mode](#window-mode)                                     | N/A                                 |
+| `space` | Keep primary selection TODO: it's here because space mode replaced it | `keep_primary_selection`            |
+| `p`     | Paste system clipboard after selections                               | `paste_clipboard_after`             |
+| `P`     | Paste system clipboard before selections                              | `paste_clipboard_before`            |
+| `y`     | Join and yank selections to clipboard                                 | `yank_joined_to_clipboard`          |
+| `Y`     | Yank main selection to clipboard                                      | `yank_main_selection_to_clipboard`  |
+| `R`     | Replace selections by clipboard contents                              | `replace_selections_with_clipboard` |
 
 # Picker
 
-Keys to use within picker.
+Keys to use within picker. Remapping currently not supported.
 
 | Key                | Description       |
 | -----              | -------------     |


### PR DESCRIPTION
So that users don't have to look into the source code when they want to remap keys.