### PR TITLE
fix: use head instead of anchor for relative line

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -427,7 +427,7 @@ impl EditorView {
 
         let current_line = doc
             .text()
-            .char_to_line(doc.selection(view.id).primary().head);
+            .char_to_line(doc.selection(view.id).primary().cursor(text));
 
         // it's used inside an iterator so the collect isn't needless:
         // https://github.com/rust-lang/rust-clippy/issues/6164

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -427,7 +427,7 @@ impl EditorView {
 
         let current_line = doc
             .text()
-            .char_to_line(doc.selection(view.id).primary().anchor);
+            .char_to_line(doc.selection(view.id).primary().head);
 
         // it's used inside an iterator so the collect isn't needless:
         // https://github.com/rust-lang/rust-clippy/issues/6164


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/34353640/131387355-390eaf47-a4ae-49c0-9e6c-525b39f8bfb3.png)


After: 
![image](https://user-images.githubusercontent.com/34353640/131387269-aa427acf-4dea-41c4-a23f-585cd0a3ad7d.png)
