### PR TITLE
WIP for LSP "rename symbol"

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -241,6 +241,12 @@ impl Client {
                         context_support: None, // additional context information Some(true)
                         ..Default::default()
                     }),
+                    rename: Some(lsp::RenameClientCapabilities {
+                        dynamic_registration: Some(false),
+                        prepare_support: Some(false),
+                        prepare_support_default_behavior: None,
+                        honors_change_annotations: Some(false),
+                    }),
                     hover: Some(lsp::HoverClientCapabilities {
                         // if not specified, rust-analyzer returns plaintext marked as markdown but
                         // badly formatted.
@@ -759,5 +765,26 @@ impl Client {
         };
 
         self.call::<lsp::request::CodeActionRequest>(params)
+    }
+
+    pub async fn rename_symbol(
+        &self,
+        text_document: lsp::TextDocumentIdentifier,
+        position: lsp::Position,
+        new_name: String
+    ) -> anyhow::Result<lsp::WorkspaceEdit> {
+        let params = lsp::RenameParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document,
+                position,
+            },
+            new_name,
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        };
+
+        let response = self.request::<lsp::request::Rename>(params).await?;
+        Ok(response.unwrap_or_default())
     }
 }

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -484,6 +484,7 @@ impl Default for Keymaps {
                 "b" => buffer_picker,
                 "s" => symbol_picker,
                 "a" => code_action,
+                "r" => rename,
                 "'" => last_picker,
                 "w" => { "Window"
                     "C-w" | "w" => rotate_view,


### PR DESCRIPTION
Like the title says.

The server is currently giving and error of `Invalid params: No references found at position` which I don't understand why...
I also notice a off-by-one mismatch between the line/col reported by Helix and the ones mention on the LSP server response...?

Still missing:
- Apply the `WorkspaceEdit` result from the server into the workspace.
- Probably coding cleanups since my knowledge of Rust is primitive...