### PR TITLE
Check for unsaved changes with `C-w q`, add `C-w x` as force close

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -469,6 +469,7 @@ impl Default for Keymaps {
                 "C-h" | "h" => hsplit,
                 "C-v" | "v" => vsplit,
                 "C-q" | "q" => wclose,
+                "C-x" | "x" => wclose_force,
             },
 
             // move under <space>c


### PR DESCRIPTION
This PR adds a check for document modification when closing a view with `C-w C-q` or `C-w q` . A new keybinding `C-w C-x` `C-w x` is added to forcefully close a view discarding unsaved changes.  

Closes: #674