### PR TITLE
Add commands that extends to long words

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -180,6 +180,9 @@ impl Command {
         move_next_long_word_end, "Move to end of next long word",
         extend_next_word_start, "Extend to beginning of next word",
         extend_prev_word_start, "Extend to beginning of previous word",
+        extend_next_long_word_start, "Extend to beginning of next long word",
+        extend_prev_long_word_start, "Extend to beginning of previous long word",
+        extend_next_long_word_end, "Extend to end of next long word",
         extend_next_word_end, "Extend to end of next word",
         find_till_char, "Move till next occurance of char",
         find_next_char, "Move to next occurance of char",
@@ -616,6 +619,45 @@ fn extend_next_word_end(cx: &mut Context) {
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         let word = movement::move_next_word_end(text, range, count);
+        let pos = word.cursor(text);
+        range.put_cursor(text, pos, true)
+    });
+    doc.set_selection(view.id, selection);
+}
+
+fn extend_next_long_word_start(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let word = movement::move_next_long_word_start(text, range, count);
+        let pos = word.cursor(text);
+        range.put_cursor(text, pos, true)
+    });
+    doc.set_selection(view.id, selection);
+}
+
+fn extend_prev_long_word_start(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let word = movement::move_prev_long_word_start(text, range, count);
+        let pos = word.cursor(text);
+        range.put_cursor(text, pos, true)
+    });
+    doc.set_selection(view.id, selection);
+}
+
+fn extend_next_long_word_end(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let word = movement::move_next_long_word_end(text, range, count);
         let pos = word.cursor(text);
         range.put_cursor(text, pos, true)
     });

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -527,6 +527,9 @@ impl Default for Keymaps {
             "w" => extend_next_word_start,
             "b" => extend_prev_word_start,
             "e" => extend_next_word_end,
+            "W" => extend_next_long_word_start,
+            "B" => extend_prev_long_word_start,
+            "E" => extend_next_long_word_end,
 
             "t" => extend_till_char,
             "f" => extend_next_char,


### PR DESCRIPTION
I want to use kakoune's keybindings in helix. But commands extending to long words are missing in helix. This PR adds those commands.