### PR TITLE
add language server for elixir and nix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -48,6 +48,7 @@ file-types = ["ex", "exs"]
 roots = []
 comment-token = "#"
 
+language-server = { command = "elixir-ls" }
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]
@@ -165,6 +166,7 @@ file-types = ["nix"]
 roots = []
 comment-token = "#"
 
+language-server = { command = "rnix-lsp" }
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]


### PR DESCRIPTION
this adds language servers for elixir and nix.

I tried testing, but upon `nix build . -L`, I hit a compilation error on darwin

```
 Building build.rs (helix-syntax)
       > Running rustc --crate-name build_script_build build.rs --crate-type bin -C debuginfo=2 -C codegen-units=4 --edition 2018 --cfg feature="default" --out-dir target/build/helix-syntax --emit=dep-info,link -L dependency=target/buildDeps --extern anyhow=/nix/store/4qppk39q3ailrlx1h3756q76dwd5d3f9-rust_anyhow-1.0.43-lib/lib/libanyhow-70434c982d.rlib --extern cc=/nix/store/6z4n0z64yb56idhxmjq1jjvirdg2zrvp-rust_cc-1.0.70-lib/lib/libcc-a04023643d.rlib --extern threadpool=/nix/store/rw61d1dy16gizzarhh88328my0wg6x3p-rust_threadpool-1.8.1-lib/lib/libthreadpool-56ad10a5c6.rlib --cap-lints allow --color always
       > thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', build.rs:156:10
       > stack backtrace:
```