### PR TITLE
smartcase regex search

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,8 +22,6 @@ as you type completion!
 
 - [ ] lsp: signature help
 
-- [ ] search: smart case by default: insensitive unless upper detected
-
 2
 - [ ] macro recording
 - [ ] extend selection (treesitter select parent node) (replaces viw, vi(, va( etc )

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -17,6 +17,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display (`absolute`, `relative`) | `absolute` |
+| `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
 
 ## LSP
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -104,8 +104,7 @@
 
 ### Search
 
-> TODO: The search implementation isn't ideal yet -- we don't support searching
-in reverse, or searching via smartcase.
+> TODO: The search implementation isn't ideal yet -- we don't support searching in reverse.
 
 | Key   | Description                                 | Command              |
 | ----- | -----------                                 | -------              |

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -20,6 +20,7 @@ pub use spinner::{ProgressSpinners, Spinner};
 pub use text::Text;
 
 use helix_core::regex::Regex;
+use helix_core::regex::RegexBuilder;
 use helix_view::{Document, Editor, View};
 
 use std::path::PathBuf;
@@ -53,7 +54,16 @@ pub fn regex_prompt(
                         return;
                     }
 
-                    match Regex::new(input) {
+                    let case_insensitive = if cx.editor.config.smart_case {
+                        !input.chars().any(char::is_uppercase)
+                    } else {
+                        false
+                    };
+
+                    match RegexBuilder::new(input)
+                        .case_insensitive(case_insensitive)
+                        .build()
+                    {
                         Ok(regex) => {
                             let (view, doc) = current!(cx.editor);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub line_number: LineNumber,
     /// Middle click paste support. Defaults to true
     pub middle_click_paste: bool,
+    /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
+    pub smart_case: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -64,6 +66,7 @@ impl Default for Config {
             },
             line_number: LineNumber::Absolute,
             middle_click_paste: true,
+            smart_case: true,
         }
     }
 }


### PR DESCRIPTION
First stab at smartcase search.

Some thoughts:
- What's the desired behaviour for `select_regex`? Never enabled? Configured with a separate option?
- Where would the regex builder live in `helix-core`? (so it can be used for other ui:s than term and #651) 

(edit: i didn't look at 651:s implementation before. guess the pr's not a reason for moving it to `helix-core`..) 