### PR TITLE
flake: add darwin devshell dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,22 +30,7 @@
           };
           # link languages and theme toml files since helix-view expects them
           helix-view = _: { preConfigure = "ln -s ${common.root}/{languages.toml,theme.toml} .."; };
-          helix-syntax = prev: {
-            src =
-              let
-                pkgs = common.pkgs;
-                helix = pkgs.fetchgit {
-                  url = "https://github.com/helix-editor/helix.git";
-                  rev = "987d8e6dd66d65c2503cc81a3b9ea8787435839a";
-                  fetchSubmodules = true;
-                  sha256 = "sha256-GRJ0zMJva9upUatc89AeKYuLq73nxcxDPKDSgEcPASE=";
-                };
-              in
-              pkgs.runCommand prev.src.name { } ''
-                mkdir -p $out
-                ln -s ${prev.src}/* $out
-                ln -sf ${helix}/helix-syntax/languages $out
-              '';
+          helix-syntax = _prev: {
             preConfigure = "mkdir -p ../runtime/grammars";
             postInstall = "cp -r ../runtime $out/runtime";
           };


### PR DESCRIPTION
This adds a dependency needed for local builds for darwin. This is pretty straightforward

(from here this is just a description of a weird behavior related to flakes, not related to this PR).

@yusdacra the weirdest thing happened today. Trying to build helix from the flake, I couldn't get some changes that actually work with local compilation.
If you look at the following [PR](https://github.com/helix-editor/helix/pull/733), trying to build it from the flake did not enable syntax highlighting on svelte files (which is what the pr is about). However a local `cargo build --release` actually works.
I can't explain it. (there is a svelte example on the PR in case you are interested in testing).
(I verified that I was on the right commit)
(this is what the flake.lock contained)
```
 "helix": {
      "inputs": {
        "flakeCompat": "flakeCompat",
        "nixCargoIntegration": "nixCargoIntegration",
        "nixpkgs": "nixpkgs"
      },
      "locked": {
        "lastModified": 1631837505,
        "narHash": "sha256-DLYYl7K2WTcmCJKxVERZKcVCm+Ayph+hiNgl0VXvdDM=",
        "owner": "happysalada",
        "repo": "helix",
        "rev": "392f0bf13bd5f572a9d5eac406d2d48918ac5e32",
        "type": "github"
      },
      "original": {
        "owner": "happysalada",
        "ref": "add_svelte",
        "repo": "helix",
        "type": "github"
      }
    },
```

and the flake
```
    # tools
    helix.url = "github:happysalada/helix/add_svelte";
```

You can try on the latest master as well. Svelte file syntax highlighting doesn't work, even though on local compilation it does.
Maybe that's just a darwin problem.
I'm not sure how to debug this further. Happy to provide more informations.

(if you think it's not that important, feel free to ignore, happy to let this go, just thought you might be interested)