### PR TITLE
Ignore uneditable files in the file picker

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -73,9 +73,25 @@ pub fn regex_prompt(
 }
 
 pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
-    use ignore::Walk;
+    use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time;
-    let files = Walk::new(&root).filter_map(|entry| {
+
+    // We want to exclude files that the editor can't handle yet
+    let mut type_builder = TypesBuilder::new();
+    let mut walk_builder = WalkBuilder::new(&root);
+    let walk_builder = match type_builder.add(
+        "compressed",
+        "*.{zip,gz,bz2,zst,lzo,sz,tgz,tbz2,lz,lz4,lzma,lzo,z,Z,xz,7z,rar,cab}",
+    ) {
+        Err(_) => &walk_builder,
+        _ => {
+            type_builder.negate("all");
+            let excluded_types = type_builder.build().unwrap();
+            walk_builder.types(excluded_types)
+        }
+    };
+
+    let files = walk_builder.build().filter_map(|entry| {
         let entry = entry.ok()?;
         // Path::is_dir() traverses symlinks, so we use it over DirEntry::is_dir
         if entry.path().is_dir() {


### PR DESCRIPTION
This is probably incomplete, in that it only touches the file picker and not the suggestions in the `open` command, and it also only lists out common compressed file extensions. It should probably include a lot more things that are not editable, like iso, dmg, and more. I'm also unsure if this approach is preferred as file extension isn't 100% reliable, but I feel the blacklist approach is better than whitelist as we don't want to inadvertently prevent people from editing files that are perfectly editable.

This is probably my first contributed rust code ever. I'm unsure if I did things the best way or not, so style critique is appreciated as well.