### PR TITLE
Add a conf option to show no line number

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -53,6 +53,9 @@ pub enum LineNumber {
 
     /// Show relative line number to the primary cursor
     Relative,
+
+    /// Do not show the line number
+    None,
 }
 
 impl Default for Config {
@@ -215,14 +218,14 @@ impl Editor {
                 return;
             }
             Action::HorizontalSplit => {
-                let view = View::new(id);
+                let view = View::new(id, self.config.clone());
                 let view_id = self.tree.split(view, Layout::Horizontal);
                 // initialize selection for view
                 let doc = &mut self.documents[id];
                 doc.selections.insert(view_id, Selection::point(0));
             }
             Action::VerticalSplit => {
-                let view = View::new(id);
+                let view = View::new(id, self.config.clone());
                 let view_id = self.tree.split(view, Layout::Vertical);
                 // initialize selection for view
                 let doc = &mut self.documents[id];


### PR DESCRIPTION
This PR adds the possibility to **not** print any line number:
On the left is a file opened with this patch vs the default settings on the right:
![image](https://user-images.githubusercontent.com/7032172/133947607-12ae8d3b-2939-49ab-a2aa-29892ee5327c.png)

This is not ideal because if we don't print any line number we could save 5 unused spaces on the left but I don't know how to do it for now :unamused: 
A little help would be appreciated if you have the time :+1: 