### PR TITLE
Add option for automatic insertion of closing-parens/brackets/etc

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -18,6 +18,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display (`absolute`, `relative`) | `absolute` |
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
+| `auto-pair` | Enable automatic insertion of pairs to parenthese, brackets, etc. | `true` |
 
 ## LSP
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -18,7 +18,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display (`absolute`, `relative`) | `absolute` |
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
-| `auto-pair` | Enable automatic insertion of pairs to parenthese, brackets, etc. | `true` |
+| `auto-pairs` | Enable automatic insertion of pairs to parenthese, brackets, etc. | `true` |
 
 ## LSP
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3366,16 +3366,13 @@ pub mod insert {
     }
 
     use helix_core::auto_pairs;
-    const HOOKS_PAIR: &[Hook] = &[auto_pairs::hook, insert];
-    const HOOKS_NOPAIR: &[Hook] = &[insert];
-    const POST_HOOKS: &[PostHook] = &[completion, signature_help];
 
     pub fn insert_char(cx: &mut Context, c: char) {
         let (view, doc) = current!(cx.editor);
 
-        let hooks = match cx.editor.config.auto_pair {
-            true => HOOKS_PAIR,
-            false => HOOKS_NOPAIR,
+        let hooks: &[Hook] = match cx.editor.config.auto_pairs {
+            true => &[auto_pairs::hook, insert],
+            false => &[insert],
         };
 
         let text = doc.text();
@@ -3392,7 +3389,7 @@ pub mod insert {
         // TODO: need a post insert hook too for certain triggers (autocomplete, signature help, etc)
         // this could also generically look at Transaction, but it's a bit annoying to look at
         // Operation instead of Change.
-        for hook in POST_HOOKS {
+        for hook in &[completion, signature_help] {
             hook(cx, c);
         }
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3375,7 +3375,7 @@ pub mod insert {
 
         let hooks = match cx.editor.config.auto_pair {
             true => HOOKS_PAIR,
-            false => HOOKS_NOPAIR
+            false => HOOKS_NOPAIR,
         };
 
         let text = doc.text();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3374,7 +3374,7 @@ pub mod insert {
         let (view, doc) = current!(cx.editor);
 
         let hooks = match cx.editor.config.auto_pair {
-            true  => HOOKS_PAIR,
+            true => HOOKS_PAIR,
             false => HOOKS_NOPAIR
         };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3366,17 +3366,23 @@ pub mod insert {
     }
 
     use helix_core::auto_pairs;
-    const HOOKS: &[Hook] = &[auto_pairs::hook, insert];
+    const HOOKS_PAIR: &[Hook] = &[auto_pairs::hook, insert];
+    const HOOKS_NOPAIR: &[Hook] = &[insert];
     const POST_HOOKS: &[PostHook] = &[completion, signature_help];
 
     pub fn insert_char(cx: &mut Context, c: char) {
         let (view, doc) = current!(cx.editor);
 
+        let hooks = match cx.editor.config.auto_pair {
+            true  => HOOKS_PAIR,
+            false => HOOKS_NOPAIR
+        };
+
         let text = doc.text();
         let selection = doc.selection(view.id).clone().cursors(text.slice(..));
 
         // run through insert hooks, stopping on the first one that returns Some(t)
-        for hook in HOOKS {
+        for hook in hooks {
             if let Some(transaction) = hook(text, &selection, c) {
                 doc.apply(&transaction, view.id);
                 break;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -42,7 +42,7 @@ pub struct Config {
     /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
     pub smart_case: bool,
     /// Automatic insertion of pairs to parentheses, brackets, etc. Defaults to true.
-    pub auto_pair: bool,
+    pub auto_pairs: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -69,7 +69,7 @@ impl Default for Config {
             line_number: LineNumber::Absolute,
             middle_click_paste: true,
             smart_case: true,
-            auto_pair: true,
+            auto_pairs: true,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -41,6 +41,8 @@ pub struct Config {
     pub middle_click_paste: bool,
     /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
     pub smart_case: bool,
+    /// Automatic insertion of pairs to parentheses, brackets, etc. Defaults to true.
+    pub auto_pair: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -67,6 +69,7 @@ impl Default for Config {
             line_number: LineNumber::Absolute,
             middle_click_paste: true,
             smart_case: true,
+            auto_pair: true,
         }
     }
 }


### PR DESCRIPTION
This just makes it possible to turn off the automatic insertion of parentheses.

I assume `HOOKS` was `const` for a reason (maybe generating it is computationally expensive, so you wouldn't want it running on every key press?). So, instead of moving the definition of `HOOKS` to within the function it's used in, I added an alternative `HOOKS` without the auto-pair hook, and had the function determine which to use on the fly.