### PR TITLE
languages: nix: enable auto-format

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -164,6 +164,7 @@ scope = "source.nix"
 injection-regex = "nix"
 file-types = ["nix"]
 roots = []
+auto-format = true
 comment-token = "#"
 
 language-server = { command = "rnix-lsp" }


### PR DESCRIPTION
This just enable autoformat for nix.
I think the decision could be deemed controversial dependending on who you talk about it.
I've tested locally and I love it.


On a completely different note. The PR about fetching submodules by default in flakes is being reverted. This might break a few things for people doing development with nix @yusdacra perhaps.
I'm happy to be tagged on people having questions or issue with nix.
[ref](https://github.com/NixOS/nix/pull/5284)