### PR TITLE
Remove constraint on the width of the gutter function

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Severity {
     Error,
     Warning,
@@ -6,13 +6,13 @@ pub enum Severity {
     Hint,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Range {
     pub start: usize,
     pub end: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Diagnostic {
     pub range: Range,
     pub line: usize,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -17,7 +17,7 @@ use helix_core::{
 };
 use helix_view::{
     document::Mode,
-    editor::LineNumber,
+    editor::{Config, LineNumber},
     graphics::{CursorKind, Modifier, Rect, Style},
     info::Info,
     input::KeyEvent,
@@ -412,22 +412,6 @@ impl EditorView {
         let text = doc.text().slice(..);
         let last_line = view.last_line(doc);
 
-        let linenr = theme.get("ui.linenr");
-        let linenr_select: Style = theme.try_get("ui.linenr.selected").unwrap_or(linenr);
-
-        let warning = theme.get("warning");
-        let error = theme.get("error");
-        let info = theme.get("info");
-        let hint = theme.get("hint");
-
-        // Whether to draw the line number for the last line of the
-        // document or not.  We only draw it if it's not an empty line.
-        let draw_last = text.line_to_byte(last_line) < text.len_bytes();
-
-        let current_line = doc
-            .text()
-            .char_to_line(doc.selection(view.id).primary().cursor(text));
-
         // it's used inside an iterator so the collect isn't needless:
         // https://github.com/rust-lang/rust-clippy/issues/6164
         #[allow(clippy::needless_collect)]
@@ -437,51 +421,107 @@ impl EditorView {
             .map(|range| range.cursor_line(text))
             .collect();
 
-        for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
-            use helix_core::diagnostic::Severity;
-            if let Some(diagnostic) = doc.diagnostics().iter().find(|d| d.line == line) {
-                surface.set_stringn(
-                    viewport.x,
-                    viewport.y + i as u16,
-                    "●",
-                    1,
-                    match diagnostic.severity {
-                        Some(Severity::Error) => error,
-                        Some(Severity::Warning) | None => warning,
-                        Some(Severity::Info) => info,
-                        Some(Severity::Hint) => hint,
-                    },
-                );
-            }
+        fn diagnostic(
+            doc: &Document,
+            _view: &View,
+            theme: &Theme,
+            _config: &Config,
+            _is_focused: bool,
+            _width: usize,
+        ) -> Box<dyn Fn(usize, bool) -> Option<(String, Style)>> {
+            let warning = theme.get("warning");
+            let error = theme.get("error");
+            let info = theme.get("info");
+            let hint = theme.get("hint");
+            let diagnostics = doc.diagnostics().to_vec(); // TODO
 
-            let selected = cursors.contains(&line);
+            Box::new(move |line: usize, _selected: bool| {
+                use helix_core::diagnostic::Severity;
+                if let Some(diagnostic) = diagnostics.iter().find(|d| d.line == line) {
+                    return Some((
+                        "●".to_string(),
+                        match diagnostic.severity {
+                            Some(Severity::Error) => error,
+                            Some(Severity::Warning) | None => warning,
+                            Some(Severity::Info) => info,
+                            Some(Severity::Hint) => hint,
+                        },
+                    ));
+                }
+                None
+            })
+        }
 
-            let text = if line == last_line && !draw_last {
-                "    ~".into()
-            } else {
-                let line = match config.line_number {
-                    LineNumber::Absolute => line + 1,
-                    LineNumber::Relative => {
-                        if current_line == line {
-                            line + 1
-                        } else {
-                            abs_diff(current_line, line)
-                        }
-                    }
-                };
-                format!("{:>5}", line)
-            };
-            surface.set_stringn(
-                viewport.x + 1,
-                viewport.y + i as u16,
-                text,
-                5,
-                if selected && is_focused {
-                    linenr_select
+        fn line_number(
+            doc: &Document,
+            view: &View,
+            theme: &Theme,
+            config: &Config,
+            is_focused: bool,
+            width: usize,
+        ) -> Box<dyn Fn(usize, bool) -> Option<(String, Style)>> {
+            let text = doc.text().slice(..);
+            let last_line = view.last_line(doc);
+            // Whether to draw the line number for the last line of the
+            // document or not.  We only draw it if it's not an empty line.
+            let draw_last = text.line_to_byte(last_line) < text.len_bytes();
+
+            let linenr = theme.get("ui.linenr");
+            let linenr_select: Style = theme.try_get("ui.linenr.selected").unwrap_or(linenr);
+
+            let current_line = doc
+                .text()
+                .char_to_line(doc.selection(view.id).primary().cursor(text));
+
+            let config = config.line_number;
+
+            Box::new(move |line: usize, selected: bool| {
+                if line == last_line && !draw_last {
+                    Some(("    ~".into(), linenr))
                 } else {
-                    linenr
-                },
-            );
+                    let line = match config {
+                        LineNumber::Absolute => line + 1,
+                        LineNumber::Relative => {
+                            if current_line == line {
+                                line + 1
+                            } else {
+                                abs_diff(current_line, line)
+                            }
+                        }
+                    };
+                    let style = if selected && is_focused {
+                        linenr_select
+                    } else {
+                        linenr
+                    };
+                    Some((format!("{:>1$}", line, width), style))
+                }
+            })
+        }
+
+        let gutters: &[(
+            fn(
+                &Document,
+                &View,
+                &Theme,
+                &Config,
+                bool,
+                usize,
+            ) -> Box<dyn Fn(usize, bool) -> Option<(String, Style)>>,
+            usize,
+        )] = &[(diagnostic, 1), (line_number, 5)];
+
+        let mut offset = 0;
+        for (constructor, width) in gutters {
+            let gutter = constructor(doc, view, theme, config, is_focused, *width);
+            for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
+                let selected = cursors.contains(&line);
+
+                if let Some((text, style)) = gutter(line, selected) {
+                    surface.set_stringn(viewport.x + offset, viewport.y + i as u16, text, 5, style);
+                }
+            }
+            offset += *width as u16;
         }
     }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -87,7 +87,9 @@ impl EditorView {
         };
 
         Self::render_text_highlights(doc, view.offset, inner, surface, theme, highlights);
-        Self::render_gutter(doc, view, view.area, surface, theme, is_focused, config);
+        let gutter_width =
+            Self::render_gutter(doc, view, view.area, surface, theme, is_focused, config);
+        view.gutter_width(gutter_width);
 
         if is_focused {
             Self::render_focused_view_elements(view, doc, inner, theme, surface);
@@ -408,7 +410,7 @@ impl EditorView {
         theme: &Theme,
         is_focused: bool,
         config: &helix_view::editor::Config,
-    ) {
+    ) -> u16 {
         let text = doc.text().slice(..);
         let last_line = view.last_line(doc);
 
@@ -519,6 +521,7 @@ impl EditorView {
             }
             offset += current_offset as u16;
         }
+        offset
     }
 
     pub fn render_diagnostics(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -45,7 +45,7 @@ pub struct Config {
     pub auto_pairs: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LineNumber {
     /// Show absolute line number


### PR DESCRIPTION
Hello @archseer, I was looking at your PR, and I wondered if it would not be possible to remove the need for a fixed size width entirely?

By doing something like that, we could create other gutters more easily; what do you think?
For example, a `git blame` gutter would not need to preload all the names appearing in the file to pre-compute a maximum width for the current view.
Also, for the diagnostic gutter: if there is no diagnostic, the unused column gets automatically removed without any action.