### PR TITLE
Update settings at runtime

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -41,3 +41,4 @@
 | `:hsplit`, `:hs`, `:sp` | Open the file in a horizontal split. |
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
+| `:set-option`, `:set` | Set a config option at runtime |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2647,22 +2647,24 @@ pub mod cmd {
     ) -> anyhow::Result<()> {
         let runtime_config = &mut cx.editor.config;
 
-        if args.len() != 3 || args.get(1).map(|s| s.as_ref()) != Some("=") {
-            anyhow::bail!("Bad arguments. Usage: `:set key = field`");
+        if args.len() != 2 {
+            anyhow::bail!("Bad arguments. Usage: `:set key field`");
         }
 
-        match args[0].to_lowercase().as_ref() {
-            "scrolloff" => runtime_config.scrolloff = args[2].parse()?,
-            "scroll-lines" => runtime_config.scroll_lines = args[2].parse()?,
-            "mouse" => runtime_config.mouse = args[2].parse()?,
-            "line-number" => runtime_config.line_number = args[2].parse()?,
-            "middle-click_paste" => runtime_config.middle_click_paste = args[2].parse()?,
-            "smart-case" => runtime_config.smart_case = args[2].parse()?,
-            "auto-pairs" => runtime_config.auto_pairs = args[2].parse()?,
-            "auto-completion" => runtime_config.auto_completion = args[2].parse()?,
-            "completion-trigger-len" => runtime_config.completion_trigger_len = args[2].parse()?,
-            "auto-info" => runtime_config.auto_info = args[2].parse()?,
-            "true-color" => runtime_config.true_color = args[2].parse()?,
+        let (key, arg) = (&args[0].to_lowercase(), &args[1]);
+
+        match key.as_ref() {
+            "scrolloff" => runtime_config.scrolloff = arg.parse()?,
+            "scroll-lines" => runtime_config.scroll_lines = arg.parse()?,
+            "mouse" => runtime_config.mouse = arg.parse()?,
+            "line-number" => runtime_config.line_number = arg.parse()?,
+            "middle-click_paste" => runtime_config.middle_click_paste = arg.parse()?,
+            "smart-case" => runtime_config.smart_case = arg.parse()?,
+            "auto-pairs" => runtime_config.auto_pairs = arg.parse()?,
+            "auto-completion" => runtime_config.auto_completion = arg.parse()?,
+            "completion-trigger-len" => runtime_config.completion_trigger_len = arg.parse()?,
+            "auto-info" => runtime_config.auto_info = arg.parse()?,
+            "true-color" => runtime_config.true_color = arg.parse()?,
             _ => anyhow::bail!("Unknown key `{}`.", args[0]),
         }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2637,6 +2637,34 @@ pub mod cmd {
         let (view, doc) = current!(cx.editor);
 
         view.ensure_cursor_in_view(doc, line);
+        Ok(())
+    }
+
+    fn setting(
+        cx: &mut compositor::Context,
+        args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let runtime_config = &mut cx.editor.config;
+
+        if args.len() != 3 || args.get(1).map(|s| s.as_ref()) != Some("=") {
+            anyhow::bail!("Bad arguments. Usage: `:set key = field`");
+        }
+
+        match args[0].to_lowercase().as_ref() {
+            "scrolloff" => runtime_config.scrolloff = args[2].parse()?,
+            "scroll-lines" => runtime_config.scroll_lines = args[2].parse()?,
+            "mouse" => runtime_config.mouse = args[2].parse()?,
+            "line-number" => runtime_config.line_number = args[2].parse()?,
+            "middle-click_paste" => runtime_config.middle_click_paste = args[2].parse()?,
+            "smart-case" => runtime_config.smart_case = args[2].parse()?,
+            "auto-pairs" => runtime_config.auto_pairs = args[2].parse()?,
+            "auto-completion" => runtime_config.auto_completion = args[2].parse()?,
+            "completion-trigger-len" => runtime_config.completion_trigger_len = args[2].parse()?,
+            "auto-info" => runtime_config.auto_info = args[2].parse()?,
+            "true-color" => runtime_config.true_color = args[2].parse()?,
+            _ => anyhow::bail!("Unknown key `{}`.", args[0]),
+        }
 
         Ok(())
     }
@@ -2928,6 +2956,13 @@ pub mod cmd {
             doc: "Go to line number.",
             fun: goto_line_number,
             completer: None,
+        },
+        TypableCommand {
+            name: "set-option",
+            aliases: &["set"],
+            doc: "Set a config option at runtime",
+            fun: setting,
+            completer: Some(completers::setting),
         }
     ];
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -174,7 +174,9 @@ pub mod completers {
     use crate::ui::prompt::Completion;
     use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
     use fuzzy_matcher::FuzzyMatcher;
+    use helix_view::editor::Config;
     use helix_view::theme;
+    use once_cell::sync::Lazy;
     use std::borrow::Cow;
     use std::cmp::Reverse;
 
@@ -206,6 +208,34 @@ pub mod completers {
         names = matches.into_iter().map(|(name, _)| ((0..), name)).collect();
 
         names
+    }
+
+    pub fn setting(input: &str) -> Vec<Completion> {
+        static KEYS: Lazy<Vec<Completion>> = Lazy::new(|| {
+            use serde_json::{Map, Value};
+            serde_json::de::from_slice::<Map<String, Value>>(
+                &serde_json::ser::to_vec(&Config::default()).unwrap(),
+            )
+            .unwrap()
+            .keys()
+            .map(|key| ((0..), Cow::from(key.to_string())))
+            .collect()
+        });
+
+        let matcher = Matcher::default();
+
+        let mut matches: Vec<_> = KEYS
+            .iter()
+            .filter_map(|(_range, name)| {
+                matcher.fuzzy_match(name, input).map(|score| (name, score))
+            })
+            .collect();
+
+        matches.sort_unstable_by_key(|(_file, score)| Reverse(*score));
+        matches
+            .into_iter()
+            .map(|(name, _)| ((0..), name.clone()))
+            .collect()
     }
 
     pub fn filename(input: &str) -> Vec<Completion> {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -212,14 +212,13 @@ pub mod completers {
 
     pub fn setting(input: &str) -> Vec<Completion> {
         static KEYS: Lazy<Vec<Completion>> = Lazy::new(|| {
-            use serde_json::{Map, Value};
-            serde_json::de::from_slice::<Map<String, Value>>(
-                &serde_json::ser::to_vec(&Config::default()).unwrap(),
-            )
-            .unwrap()
-            .keys()
-            .map(|key| ((0..), Cow::from(key.to_string())))
-            .collect()
+            serde_json::to_value(Config::default())
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(|key| ((0..), Cow::from(key.to_string())))
+                .collect()
         });
 
         let matcher = Matcher::default();

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -211,13 +211,13 @@ pub mod completers {
     }
 
     pub fn setting(input: &str) -> Vec<Completion> {
-        static KEYS: Lazy<Vec<Completion>> = Lazy::new(|| {
+        static KEYS: Lazy<Vec<String>> = Lazy::new(|| {
             serde_json::to_value(Config::default())
                 .unwrap()
                 .as_object()
                 .unwrap()
                 .keys()
-                .map(|key| ((0..), Cow::from(key.to_string())))
+                .cloned()
                 .collect()
         });
 
@@ -225,15 +225,13 @@ pub mod completers {
 
         let mut matches: Vec<_> = KEYS
             .iter()
-            .filter_map(|(_range, name)| {
-                matcher.fuzzy_match(name, input).map(|score| (name, score))
-            })
+            .filter_map(|name| matcher.fuzzy_match(name, input).map(|score| (name, score)))
             .collect();
 
         matches.sort_unstable_by_key(|(_file, score)| Reverse(*score));
         matches
             .into_iter()
-            .map(|(name, _)| ((0..), name.clone()))
+            .map(|(name, _)| ((0..), name.into()))
             .collect()
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -27,7 +27,7 @@ pub use helix_core::register::Registers;
 use helix_core::syntax;
 use helix_core::{Position, Selection};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 fn deserialize_duration_millis<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
@@ -37,7 +37,7 @@ where
     Ok(Duration::from_millis(millis))
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
     /// IgnoreOptions
@@ -77,7 +77,8 @@ impl Default for FilePickerConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+// #[serde(rename_all = "kebab-case", default)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
@@ -109,7 +110,7 @@ pub struct Config {
     pub true_color: bool,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LineNumber {
     /// Show absolute line number
@@ -117,6 +118,18 @@ pub enum LineNumber {
 
     /// Show relative line number to the primary cursor
     Relative,
+}
+
+impl std::str::FromStr for LineNumber {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "absolute" | "abs" => Ok(Self::Absolute),
+            "relative" | "rel" => Ok(Self::Relative),
+            _ => anyhow::bail!("Line number can only be `absolute` or `relative`."),
+        }
+    }
 }
 
 impl Default for Config {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -78,7 +78,6 @@ impl Default for FilePickerConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-// #[serde(rename_all = "kebab-case", default)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.


### PR DESCRIPTION
Hello,

I would love to add this feature to helix, but there are multiple issues that I don't know how to solve currently.
1. I'm currently deserializing and re-serializing the same struct [over](https://github.com/helix-editor/helix/compare/master...irevoire:settings_at_runtime?expand=1#diff-d782c07f22492bcae17333aba5dc5b840fb30317727e71267ebf4863f84787fdR2093-R2103) and [over](https://github.com/helix-editor/helix/compare/master...irevoire:settings_at_runtime?expand=1#diff-a2f72be0dae9186774ac716ae568f5216a5223dbf91e6ac8a25f62617c4fa55cR187-R192) again.
    I can see multiples solutions here, but I'm not a fan of either of them:
    * We could do a `match` on the `keys` of the deserialized conf and updates the `current_conf` accordingly:
    ```
        let conf = toml::from_str::<Map<String, Value>>(&args.join(" "))?;
        for (key, value) in conf {
            match key {
                "scrolloff" => cx.editor.config.line_number = value.as_usize()?;
                ... => ...,
            }
    ```
    The problem with this solution is that every time the `Configuration` struct is going to evolve, we'll need to remember to update this match.
    * We could create a new struct exactly like the `Configuration` one but with every field as `Optional`, and then implements a merge between this new struct and the current one. Same problem as the previous solution.
    * We could keep the code as-is, maybe put one or two things in `lazy_static` and consider that this code is really not called often and don't need to be fast.
2. For the autocompletion, if I understood correctly, my function is called for every word. Now we would need way more information about what part of the query we are auto-completing. For example, if we are autocompleting `line-numbers` I would like the autocomplete to propose "relative" or "absolute" instead of nothing or bad things 


Here is a little demo of how it works currently: https://asciinema.org/a/0KjjI5CsWPFwXGuxqN7ERTh4x
Let me know if you are interested and have any idea on how to improve these things.

I would really love to see this feature implemented because when I'm sharing my screen with a colleague, it's easier for them to have absolute line numbers. While when I'm alone, I'm usually deactivating `line-numbers` entirely and having to update my global configuration is really boring :unamused: