### PR TITLE
global search: show file names as relative paths

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1291,6 +1291,7 @@ fn global_search(cx: &mut Context) {
 
     cx.push_layer(Box::new(prompt));
 
+    let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
     let show_picker = async move {
         let all_matches: Vec<(usize, PathBuf)> =
             UnboundedReceiverStream::new(all_matches_rx).collect().await;
@@ -1302,7 +1303,13 @@ fn global_search(cx: &mut Context) {
                 }
                 let picker = FilePicker::new(
                     all_matches,
-                    move |(_line_num, path)| path.to_str().unwrap().into(),
+                    move |(_line_num, path)| {
+                        path.strip_prefix(&root)
+                            .unwrap_or(path)
+                            .to_str()
+                            .unwrap()
+                            .into()
+                    },
                     move |editor: &mut Editor, (line_num, path), action| {
                         match editor.open(path.into(), action) {
                             Ok(_) => {}


### PR DESCRIPTION
This commit fixes #786

I basically copied the code from `ui/mod.rs :: file_picker` for this, nothing special.