### PR TITLE
Global search now indicates currently open document

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1291,6 +1291,8 @@ fn global_search(cx: &mut Context) {
 
     cx.push_layer(Box::new(prompt));
 
+    let current_path = doc_mut!(cx.editor).path().cloned();
+
     let show_picker = async move {
         let all_matches: Vec<(usize, PathBuf)> =
             UnboundedReceiverStream::new(all_matches_rx).collect().await;
@@ -1300,9 +1302,20 @@ fn global_search(cx: &mut Context) {
                     editor.set_status("No matches found".to_string());
                     return;
                 }
+
                 let picker = FilePicker::new(
                     all_matches,
-                    move |(_line_num, path)| path.to_str().unwrap().into(),
+                    move |(_line_num, path)| {
+                        let relative_path = helix_core::path::get_relative_path(path)
+                            .to_str()
+                            .unwrap()
+                            .to_owned();
+                        if current_path.as_ref().map(|p| p == path).unwrap_or(false) {
+                            format!("{} (*)", relative_path).into()
+                        } else {
+                            relative_path.into()
+                        }
+                    },
                     move |editor: &mut Editor, (line_num, path), action| {
                         match editor.open(path.into(), action) {
                             Ok(_) => {}


### PR DESCRIPTION
So I guess I also implemented the global search relative file paths slightly after someone else. I decided to add the `(*)` like the buffer picker indicates the currently open document.

![image](https://user-images.githubusercontent.com/613651/135737876-45f47bcd-bbad-469b-98eb-d514172d1e7b.png)
