### PR TITLE
Add (SWI-)Prolog LSP support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -315,3 +315,15 @@ comment-token = "//"
 
 language-server = { command = "zls" }
 indent = { tab-width = 4, unit = "    " }
+
+[[language]]
+name = "prolog"
+scope = "source.prolog"
+roots = []
+file-types = ["pl", "prolog"]
+comment-token = "%"
+
+language-server = { command = "swipl", args = [
+    "-g", "use_module(library(lsp_server))",
+    "-g", "lsp_server:main",
+    "-t", "halt", "--", "stdio"] }


### PR DESCRIPTION
As discussed in #809 ; I also have a [tree-sitter implementation](https://github.com/jamesnvc/tree-sitter-prolog), but for reasons discussed in the linked post, I kind of gave up on that sort of static approach for making a general-purpose Prolog grammar (since it has a very flexible syntax and allows defining new operators with new precedences dynamically).

That being said, the LSP implementation here at least shows documentation and does support the semantic token API, so when Helix supports that, this should also provide highlighting.