### PR TITLE
Picker: Don't panick at move_up/move_down when matches is empty

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -270,12 +270,18 @@ impl<T> Picker<T> {
     }
 
     pub fn move_up(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
         let len = self.matches.len();
         let pos = ((self.cursor + len.saturating_sub(1)) % len) % len;
         self.cursor = pos;
     }
 
     pub fn move_down(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
         let len = self.matches.len();
         let pos = (self.cursor + 1) % len;
         self.cursor = pos;


### PR DESCRIPTION
This should resolve #817 