### PR TITLE
prompt add a shortcut `c-s` to pick a word under cursor. command `search` make histories as completions.

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -261,22 +261,22 @@ Keys to use within picker. Remapping currently not supported.
 
 # Prompt
 Keys to use within prompt, Remapping currently not supported.
-| Key                     | Description                     |
-| -----                   | -------------                   |
-| `Escape`, `Ctrl-c`      | Close prompt                    |
-| `Alt-b`, `Alt-Left`     | Backward a word                 |
-| `Ctrl-b`, `Left`        | Backward a char                 |
-| `Alt-f`, `Alt-Right`    | Forward a word                  |
-| `Ctrl-f`, `Right`       | Forward a char                  |
-| `Ctrl-e`, `End`         | move prompt end                 |
-| `Ctrl-a`, `Home`        | move prompt start               |
-| `Ctrl-w`                | delete previous word            |
-| `Ctrl-k`                | delete to end of line           |
-| `backspace`             | delete previous char            |
-| `Ctrl-s`                | insert a word under doc cursor  |
-| `Ctrl-p`, `Up`          | select previous history         |
-| `Ctrl-n`, `Down`        | select next history             |
-| `Tab`                   | slect next completion item      |
-| `BackTab`               | slect previous completion item  |
-| `Enter`                 | Open selected                   |
+| Key                     | Description                                                     |
+| -----                   | -------------                                                   |
+| `Escape`, `Ctrl-c`      | Close prompt                                                    |
+| `Alt-b`, `Alt-Left`     | Backward a word                                                 |
+| `Ctrl-b`, `Left`        | Backward a char                                                 |
+| `Alt-f`, `Alt-Right`    | Forward a word                                                  |
+| `Ctrl-f`, `Right`       | Forward a char                                                  |
+| `Ctrl-e`, `End`         | move prompt end                                                 |
+| `Ctrl-a`, `Home`        | move prompt start                                               |
+| `Ctrl-w`                | delete previous word                                            |
+| `Ctrl-k`                | delete to end of line                                           |
+| `backspace`             | delete previous char                                            |
+| `Ctrl-s`                | insert a word under doc cursor, maybe changed to Ctrl-r Ctrl-w  |
+| `Ctrl-p`, `Up`          | select previous history                                         |
+| `Ctrl-n`, `Down`        | select next history                                             |
+| `Tab`                   | slect next completion item                                      |
+| `BackTab`               | slect previous completion item                                  |
+| `Enter`                 | Open selected                                                   |
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -261,22 +261,22 @@ Keys to use within picker. Remapping currently not supported.
 
 # Prompt
 Keys to use within prompt, Remapping currently not supported.
-| Key                     | Description                                                     |
-| -----                   | -------------                                                   |
-| `Escape`, `Ctrl-c`      | Close prompt                                                    |
-| `Alt-b`, `Alt-Left`     | Backward a word                                                 |
-| `Ctrl-b`, `Left`        | Backward a char                                                 |
-| `Alt-f`, `Alt-Right`    | Forward a word                                                  |
-| `Ctrl-f`, `Right`       | Forward a char                                                  |
-| `Ctrl-e`, `End`         | move prompt end                                                 |
-| `Ctrl-a`, `Home`        | move prompt start                                               |
-| `Ctrl-w`                | delete previous word                                            |
-| `Ctrl-k`                | delete to end of line                                           |
-| `backspace`             | delete previous char                                            |
-| `Ctrl-s`                | insert a word under doc cursor, maybe changed to Ctrl-r Ctrl-w  |
-| `Ctrl-p`, `Up`          | select previous history                                         |
-| `Ctrl-n`, `Down`        | select next history                                             |
-| `Tab`                   | slect next completion item                                      |
-| `BackTab`               | slect previous completion item                                  |
-| `Enter`                 | Open selected                                                   |
+| Key                     | Description                                                             |
+| -----                   | -------------                                                           |
+| `Escape`, `Ctrl-c`      | Close prompt                                                            |
+| `Alt-b`, `Alt-Left`     | Backward a word                                                         |
+| `Ctrl-b`, `Left`        | Backward a char                                                         |
+| `Alt-f`, `Alt-Right`    | Forward a word                                                          |
+| `Ctrl-f`, `Right`       | Forward a char                                                          |
+| `Ctrl-e`, `End`         | move prompt end                                                         |
+| `Ctrl-a`, `Home`        | move prompt start                                                       |
+| `Ctrl-w`                | delete previous word                                                    |
+| `Ctrl-k`                | delete to end of line                                                   |
+| `backspace`             | delete previous char                                                    |
+| `Ctrl-s`                | insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later   |
+| `Ctrl-p`, `Up`          | select previous history                                                 |
+| `Ctrl-n`, `Down`        | select next history                                                     |
+| `Tab`                   | slect next completion item                                              |
+| `BackTab`               | slect previous completion item                                          |
+| `Enter`                 | Open selected                                                           |
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -258,3 +258,25 @@ Keys to use within picker. Remapping currently not supported.
 | `Ctrl-s`                     | Open horizontally |
 | `Ctrl-v`                     | Open vertically   |
 | `Escape`, `Ctrl-c`           | Close picker      |
+
+# Prompt
+Keys to use within prompt, Remapping currently not supported.
+| Key                     | Description                     |
+| -----                   | -------------                   |
+| `Escape`, `Ctrl-c`      | Close prompt                    |
+| `Alt-b`, `Alt-Left`     | Backward a word                 |
+| `Ctrl-b`, `Left`        | Backward a char                 |
+| `Alt-f`, `Alt-Right`    | Forward a word                  |
+| `Ctrl-f`, `Right`       | Forward a char                  |
+| `Ctrl-e`, `End`         | move prompt end                 |
+| `Ctrl-a`, `Home`        | move prompt start               |
+| `Ctrl-w`                | delete previous word            |
+| `Ctrl-k`                | delete to end of line           |
+| `backspace`             | delete previous char            |
+| `Ctrl-s`                | insert a word under doc cursor  |
+| `Ctrl-p`, `Up`          | select previous history         |
+| `Ctrl-n`, `Down`        | select next history             |
+| `Tab`                   | slect next completion item      |
+| `BackTab`               | slect previous completion item  |
+| `Enter`                 | Open selected                   |
+

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1177,6 +1177,7 @@ fn search_completions(cx: &mut Context, reg: Option<char>) -> Vec<String> {
         .map_or(Vec::new(), |reg| {
             reg.read()
                 .iter()
+                .rev()
                 .filter(|&item| {
                     if exist_elems.contains(item) {
                         false
@@ -1185,7 +1186,7 @@ fn search_completions(cx: &mut Context, reg: Option<char>) -> Vec<String> {
                         true
                     }
                 })
-                .take(10)
+                .take(20)
                 .cloned()
                 .collect()
         })

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1172,24 +1172,12 @@ fn search_impl(doc: &mut Document, view: &mut View, contents: &str, regex: &Rege
 }
 
 fn search_completions(cx: &mut Context, reg: Option<char>) -> Vec<String> {
-    let mut exist_elems = std::collections::BTreeSet::new();
-    reg.and_then(|reg| cx.editor.registers.get(reg))
-        .map_or(Vec::new(), |reg| {
-            reg.read()
-                .iter()
-                .rev()
-                .filter(|&item| {
-                    if exist_elems.contains(item) {
-                        false
-                    } else {
-                        exist_elems.insert(item);
-                        true
-                    }
-                })
-                .take(20)
-                .cloned()
-                .collect()
-        })
+    let mut items = reg
+        .and_then(|reg| cx.editor.registers.get(reg))
+        .map_or(Vec::new(), |reg| reg.read().iter().take(200).collect());
+    items.sort_unstable();
+    items.dedup();
+    items.into_iter().cloned().collect()
 }
 
 // TODO: use one function for search vs extend

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -29,6 +29,7 @@ pub fn regex_prompt(
     cx: &mut crate::commands::Context,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
+    completion_fn: impl FnMut(&str) -> Vec<prompt::Completion> + 'static,
     fun: impl Fn(&mut View, &mut Document, Regex, PromptEvent) + 'static,
 ) -> Prompt {
     let (view, doc) = current!(cx.editor);
@@ -38,7 +39,7 @@ pub fn regex_prompt(
     Prompt::new(
         prompt,
         history_register,
-        |_input: &str| Vec::new(), // this is fine because Vec::new() doesn't allocate
+        completion_fn,
         move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
             match event {
                 PromptEvent::Abort => {

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -185,6 +185,11 @@ impl Prompt {
         self.exit_selection();
     }
 
+    pub fn insert_str(&mut self, s: &str) {
+        self.line.insert_str(self.cursor, s);
+        self.cursor += s.len();
+    }
+
     pub fn move_cursor(&mut self, movement: Movement) {
         let pos = self.eval_movement(movement);
         self.cursor = pos
@@ -474,6 +479,26 @@ impl Component for Prompt {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }
             KeyEvent {
+                code: KeyCode::Char('s'),
+                modifiers: KeyModifiers::CONTROL,
+            } => {
+                let (view, doc) = current!(cx.editor);
+                let text = doc.text().slice(..);
+
+                use helix_core::textobject;
+                let range = textobject::textobject_word(
+                    text,
+                    doc.selection(view.id).primary(),
+                    textobject::TextObject::Inside,
+                    1,
+                );
+                let line = text.slice(range.from()..range.to()).to_string();
+                if !line.is_empty() {
+                    self.insert_str(line.as_str());
+                    (self.callback_fn)(cx, &self.line, PromptEvent::Update);
+                }
+            }
+            KeyEvent {
                 code: KeyCode::Enter,
                 ..
             } => {
@@ -520,11 +545,17 @@ impl Component for Prompt {
             }
             KeyEvent {
                 code: KeyCode::Tab, ..
-            } => self.change_completion_selection(CompletionDirection::Forward),
+            } => {
+                self.change_completion_selection(CompletionDirection::Forward);
+                (self.callback_fn)(cx, &self.line, PromptEvent::Update)
+            }
             KeyEvent {
                 code: KeyCode::BackTab,
                 ..
-            } => self.change_completion_selection(CompletionDirection::Backward),
+            } => {
+                self.change_completion_selection(CompletionDirection::Backward);
+                (self.callback_fn)(cx, &self.line, PromptEvent::Update)
+            }
             KeyEvent {
                 code: KeyCode::Char('q'),
                 modifiers: KeyModifiers::CONTROL,


### PR DESCRIPTION
Like title
ui prompt add a shortcut to pick a word.
Command `search` make histories as completions
The `global search` currently has no completions because it does't have histories register.