### PR TITLE
adds: base16 default dark theme for Helix editor

### DIFF
--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -1,0 +1,50 @@
+# Author: RayGervais<raygervais@hotmail.ca>
+
+"ui.background" = { bg = "base00" }
+"ui.menu"  = "base01"
+"ui.menu.selected" = { fg = "base04", bg = "base01" }
+"ui.linenr" = {fg = "base01" }
+"ui.popup" = { bg = "base01" }
+"ui.window" = { bg = "base01" }
+"ui.liner.selected" = "base02"
+"ui.selection" = "base02"
+"comment" = "base03"
+"ui.statusline" = {fg = "base04", bg = "base01" }
+"ui.help" = { fg = "base04", bg = "base01" }
+"ui.cursor" = { fg = "base05", modifiers = ["reversed"] }
+"ui.text"   = { fg = "base05" }
+"operator"  = "base05"
+"ui.text.focus" = { fg = "base05" }
+"variable" = "base08"
+"number"     = "base09"
+"constant"   = "base09"
+"attributes" = "base09" 
+"type" = "base0A"
+"ui.cursor.match" = { fg = "base0A", modifiers = ["underlined"] }
+"strings"  = "base0B"
+"property" = "base0B"
+"escape" = "base0C"
+"function"    = "base0D"
+"constructor" = "base0D"
+"special"     = "base0D"
+"keyword" = "base0E"
+"label"   = "base0E"
+"namespace" = "base0E"
+
+[palette]
+base00 = "#181818" # Default Background
+base01 = "#282828" # Lighter Background (Used for status bars, line number and folding marks)
+base02 = "#383838" # Selection Background
+base03 = "#585858" # Comments, Invisibles, Line Highlighting
+base04 = "#b8b8b8" # Dark Foreground (Used for status bars)
+base05 = "#d8d8d8" # Default Foreground, Caret, Delimiters, Operators
+base06 = "#e8e8e8" # Light Foreground (Not often used)
+base07 = "#f8f8f8" # Light Background (Not often used)
+base08 = "#ab4642" # Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+base09 = "#dc9656" # Integers, Boolean, Constants, XML Attributes, Markup Link Url
+base0A = "#f7ca88" # Classes, Markup Bold, Search Text Background
+base0B = "#a1b56c" # Strings, Inherited Class, Markup Code, Diff Inserted
+base0C = "#86c1b9" # Support, Regular Expressions, Escape Characters, Markup Quotes
+base0D = "#7cafc2" # Functions, Methods, Attribute IDs, Headings
+base0E = "#ba8baf" # Keywords, Storage, Selector, Markup Italic, Diff Changed
+base0F = "#a16946" # Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>


### PR DESCRIPTION
Theme sample: 

_Go_
<img width="907" alt="Screen Shot 2021-10-12 at 9 11 29 PM" src="https://user-images.githubusercontent.com/14265337/137049753-d5cdf437-3315-4d33-a14f-36c94dd85c60.png">

_Rust_
<img width="845" alt="Screen Shot 2021-10-12 at 9 12 01 PM" src="https://user-images.githubusercontent.com/14265337/137049797-a9b91703-ce3e-4c08-ba48-5975c0fdd807.png">


