### PR TITLE
Using pylsp instead of pyls

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -146,7 +146,7 @@ file-types = ["py"]
 roots = []
 comment-token = "#"
 
-language-server = { command = "pyls" }
+language-server = { command = "pylsp" }
 # TODO: pyls needs utf-8 offsets
 indent = { tab-width = 4, unit = "    " }
 


### PR DESCRIPTION
Hi, firstly thanks for your awesome work :-D

I'm starting to try this new editor today, and find out the language server doesn't work for python project.

After investigate python language server, I find out this issue: https://github.com/palantir/python-language-server/issues/935 It seems that the original `pyls` is unmaintained, we need to use new `pylsp`.

I don't know if merely change `languages.toml` to using `pylsp` is enough, but it works fine for me.  Hope it can help.