### PR TITLE
improve contract on nord comment color

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -24,8 +24,8 @@
 "ui.cursor.match" = { bg = "434c5e" }
 
 # nord3 - comments
-"comment" = "#4c566a"
-"ui.linenr" = { fg = "#4c566a" }
+"comment" = "#616E88"
+"ui.linenr" = { fg = "#616E88" }
 
 # Snow Storm
 # nord4 - cursor, variables, constants, attributes, fields


### PR DESCRIPTION
Before:
![图片](https://user-images.githubusercontent.com/22256154/137276692-ced0e093-a6e1-433a-9b86-55930529f873.png)

After:
![图片](https://user-images.githubusercontent.com/22256154/137276724-8b33b1e0-65f7-4076-ab03-65958b305341.png)

The color comes from official nord theme in vscode: https://github.com/arcticicestudio/nord-visual-studio-code/blob/develop/themes/nord-color-theme.json#L337