### PR TITLE
fix digit escapes in java & php highlights

### DIFF
--- a/runtime/queries/java/highlights.scm
+++ b/runtime/queries/java/highlights.scm
@@ -47,7 +47,7 @@
 ; Variables
 
 ((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\d_]+"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
 
 (identifier) @variable
 

--- a/runtime/queries/php/highlights.scm
+++ b/runtime/queries/php/highlights.scm
@@ -42,7 +42,7 @@
 (relative_scope) @variable.builtin
 
 ((name) @constant
- (#match? @constant "^_?[A-Z][A-Z\d_]+$"))
+ (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
 
 ((name) @constructor
  (#match? @constructor "^[A-Z]"))


### PR DESCRIPTION
A bit confusingly, the `\d` escape actually needs to be `\\d` to get picked up as the digit escape. As far as I can tell the `\d` just gets ignored. The java regex correctly matches constants but only because it doesn't end the regex with `$`. The PHP highlight currently mistreats the `PI_314` in the following:

```php
<?php
define("PI_314", 3.14);
echo PI_314;
?>
```

as a `@constructor` instead of a `@constant`.

connects #845 