### PR TITLE
Make auto-completion a config

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -19,6 +19,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `line-number` | Line number display (`absolute`, `relative`) | `absolute` |
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
 | `auto-pairs` | Enable automatic insertion of pairs to parenthese, brackets, etc. | `true` |
+| `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 
 ## LSP

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -238,7 +238,7 @@ impl Application {
         use crate::commands::{completion, Context};
         use helix_view::document::Mode;
 
-        if doc_mut!(self.editor).mode != Mode::Insert {
+        if doc_mut!(self.editor).mode != Mode::Insert || !self.config.editor.auto_completion {
             return;
         }
         let editor_view = self

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -47,12 +47,14 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
-    /// Middle click paste support. Defaults to true
+    /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
     /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
     pub smart_case: bool,
     /// Automatic insertion of pairs to parentheses, brackets, etc. Defaults to true.
     pub auto_pairs: bool,
+    /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
+    pub auto_completion: bool,
     /// Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. Defaults to 400ms.
     #[serde(skip_serializing, deserialize_with = "deserialize_duration_millis")]
     pub idle_timeout: Duration,
@@ -83,6 +85,7 @@ impl Default for Config {
             middle_click_paste: true,
             smart_case: true,
             auto_pairs: true,
+            auto_completion: true,
             idle_timeout: Duration::from_millis(400),
         }
     }


### PR DESCRIPTION
I prefer manual completion. Usually I am fine with auto-completion but there are a few issues, like tab failed to indent and instead select next completion candidate, most cases I prefer to manually complete.

Not sure if it would be clearer to rename it to `manual-completion` because people might think if auto-completion is set to false, any sort of completion will not work, including manual auto-completion.