### PR TITLE
[WIP] adding `picker` mode

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -632,10 +632,21 @@ impl Default for Keymaps {
 
             "C-x" => completion,
         });
+        let picker = keymap!({ "Picker mode"
+             "esc" | "C-c" => normal_mode,
+
+             "C-p" | "up" | "backtab" => move_line_up,
+             "C-n" | "down" | "tab"  => move_line_down,
+
+             // "ret" => open,
+             "C-h" => hsplit,
+             "C-v" => vsplit,
+        });
         Keymaps(hashmap!(
             Mode::Normal => Keymap::new(normal),
             Mode::Select => Keymap::new(select),
             Mode::Insert => Keymap::new(insert),
+            Mode::Picker => Keymap::new(picker),
         ))
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -229,7 +229,7 @@ impl EditorView {
         let cursor_scope = match doc.mode() {
             Mode::Insert => theme.find_scope_index("ui.cursor.insert"),
             Mode::Select => theme.find_scope_index("ui.cursor.select"),
-            Mode::Normal => Some(base_cursor_scope),
+            Mode::Normal | Mode::Picker => Some(base_cursor_scope),
         }
         .unwrap_or(base_cursor_scope);
 
@@ -556,6 +556,7 @@ impl EditorView {
             Mode::Insert => "INS",
             Mode::Select => "SEL",
             Mode::Normal => "NOR",
+            Mode::Picker => "PIC",
         };
         let progress = doc
             .language_server()

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -28,6 +28,7 @@ pub enum Mode {
     Normal,
     Select,
     Insert,
+    Picker,
 }
 
 impl Display for Mode {
@@ -36,6 +37,7 @@ impl Display for Mode {
             Mode::Normal => f.write_str("normal"),
             Mode::Select => f.write_str("select"),
             Mode::Insert => f.write_str("insert"),
+            Mode::Picker => f.write_str("picker"),
         }
     }
 }
@@ -48,6 +50,7 @@ impl FromStr for Mode {
             "normal" => Ok(Mode::Normal),
             "select" => Ok(Mode::Select),
             "insert" => Ok(Mode::Insert),
+            "picker" => Ok(Mode::Picker),
             _ => Err(anyhow!("Invalid mode '{}'", s)),
         }
     }


### PR DESCRIPTION
Attmept to fix #615
(also helpful for #851)

I am trying to add an actual `picker` mode.

As I am new to this code base (and a project of this scale as well), may I ask for some guidance if I am on the right track?

Some notes on the progress so far:
```rust
// "ret" => open,
"C-h" => hsplit,
"C-v" => vsplit,
```
there obviously needs to be added an actual `open` command to the 'open as split' binds as well and add the 'filter options'.

Any pointers on how to replace the `match key_event {}` in `impl<T: 'static> Component for Picker<T> {}` best?