### PR TITLE
clean up combined-injections comment

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -527,39 +527,7 @@ impl LanguageLayer {
                     self.tree.as_ref(),
                 )
                 .ok_or(Error::Cancelled)?;
-            // unsafe { syntax.parser.set_cancellation_flag(None) };
-            // let mut cursor = syntax.cursors.pop().unwrap_or_else(QueryCursor::new);
 
-            // Process combined injections. (ERB, EJS, etc https://github.com/tree-sitter/tree-sitter/pull/526)
-            // if let Some(combined_injections_query) = &config.combined_injections_query {
-            //     let mut injections_by_pattern_index =
-            //         vec![(None, Vec::new(), false); combined_injections_query.pattern_count()];
-            //     let matches =
-            //         cursor.matches(combined_injections_query, tree.root_node(), RopeProvider(source));
-            //     for mat in matches {
-            //         let entry = &mut injections_by_pattern_index[mat.pattern_index];
-            //         let (language_name, content_node, include_children) =
-            //             injection_for_match(config, combined_injections_query, &mat, source);
-            //         if language_name.is_some() {
-            //             entry.0 = language_name;
-            //         }
-            //         if let Some(content_node) = content_node {
-            //             entry.1.push(content_node);
-            //         }
-            //         entry.2 = include_children;
-            //     }
-            //     for (lang_name, content_nodes, includes_children) in injections_by_pattern_index {
-            //         if let (Some(lang_name), false) = (lang_name, content_nodes.is_empty()) {
-            //             if let Some(next_config) = (injection_callback)(lang_name) {
-            //                 let ranges =
-            //                     Self::intersect_ranges(&ranges, &content_nodes, includes_children);
-            //                 if !ranges.is_empty() {
-            //                     queue.push((next_config, depth + 1, ranges));
-            //                 }
-            //             }
-            //         }
-            //     }
-            // }
             self.tree = Some(tree)
         }
         Ok(())


### PR DESCRIPTION
from the [matrix](https://matrix.to/#/!zMuVRxoqjyxyjSEBXc:matrix.org/$6JX9RmWoDFXypktBAXPJKG80Adv51WSarfDtKZMJeLk?via=matrix.org):

> What's the story with the combined injections feature (`(#set! injection.combined)` in injections.scm)? I see this commented out block which looks pertinent https://github.com/helix-editor/helix/blob/2ac9d30bf3614a08f2d0216010f5d73845c205fa/helix-core/src/syntax.rs#L533-L562 but in other areas of syntax.rs it looks implemented

Turns out it got implemented a little further down the file https://github.com/helix-editor/helix/blob/cdfa0dfa36ae7b6ae5296d6991ddb7bc7a73f9fc/helix-core/src/syntax.rs#L1078-L1124, so I think it's safe to clean up this comment :broom:  

