### PR TITLE
Ensure coords in screen depends on char width

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -193,7 +193,7 @@ pub use tendril::StrTendril as Tendril;
 pub use {regex, tree_sitter};
 
 pub use graphemes::RopeGraphemes;
-pub use position::{coords_at_pos, pos_at_coords, Position};
+pub use position::{coords_at_pos, pos_at_coords, visual_coords_at_pos, Position};
 pub use selection::{Range, Selection};
 pub use smallvec::SmallVec;
 pub use syntax::Syntax;

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -53,6 +53,10 @@ pub fn move_vertically(
     let pos = range.cursor(slice);
 
     // Compute the current position's 2d coordinates.
+    // TODO: switch this to use `visual_coords_at_pos` rather than
+    // `coords_at_pos` as this will cause a jerky movement when the visual
+    // position does not match, like moving from a line with tabs/CJK to
+    // a line without
     let Position { row, col } = coords_at_pos(slice, pos);
     let horiz = range.horiz.unwrap_or(col as u32);
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -274,12 +274,10 @@ impl Component for Completion {
                 .language()
                 .and_then(|scope| scope.strip_prefix("source."))
                 .unwrap_or("");
-            let cursor_pos = doc
-                .selection(view.id)
-                .primary()
-                .cursor(doc.text().slice(..));
-            let cursor_pos = (helix_core::coords_at_pos(doc.text().slice(..), cursor_pos).row
-                - view.offset.row) as u16;
+            let text = doc.text().slice(..);
+            let cursor_pos = doc.selection(view.id).primary().cursor(text);
+            let coords = helix_core::visual_coords_at_pos(text, cursor_pos, doc.tab_width());
+            let cursor_pos = (coords.row - view.offset.row) as u16;
             let mut markdown_doc = match &option.documentation {
                 Some(lsp::Documentation::String(contents))
                 | Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use crate::{graphics::Rect, Document, DocumentId, ViewId};
 use helix_core::{
-    coords_at_pos,
     graphemes::{grapheme_width, RopeGraphemes},
     line_ending::line_end_char_index,
-    Position, RopeSlice, Selection,
+    visual_coords_at_pos, Position, RopeSlice, Selection,
 };
 
 type Jump = (DocumentId, Selection);
@@ -91,7 +90,10 @@ impl View {
             .selection(self.id)
             .primary()
             .cursor(doc.text().slice(..));
-        let Position { col, row: line } = coords_at_pos(doc.text().slice(..), cursor);
+
+        let Position { col, row: line } =
+            visual_coords_at_pos(doc.text().slice(..), cursor, doc.tab_width());
+
         let inner_area = self.inner_area();
         let last_line = (self.offset.row + inner_area.height as usize).saturating_sub(1);
 


### PR DESCRIPTION
The issue affected files with lots of tabs at the start as well.

Fix #840

Before

![Screenshot_20211020_223530](https://user-images.githubusercontent.com/4687791/138114159-d00ff53b-fae9-4ddb-b59a-1513b8326ac0.png)

After

![Screenshot_20211020_223548](https://user-images.githubusercontent.com/4687791/138114222-6beeceb3-9d9b-4e4e-be8e-c59c71e99e14.png)

