### PR TITLE
log syntax highlighting init errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "arc-swap",
  "etcetera",
  "helix-syntax",
+ "log",
  "once_cell",
  "quickcheck",
  "regex",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.8"
 arc-swap = "1"
 regex = "1"
 
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -159,7 +159,9 @@ impl LanguageConfiguration {
         if highlights_query.is_empty() {
             None
         } else {
-            let language = get_language(&crate::RUNTIME_DIR, &self.language_id).ok()?;
+            let language = get_language(&crate::RUNTIME_DIR, &self.language_id)
+                .map_err(|e| log::info!("{}", e))
+                .ok()?;
             let config = HighlightConfiguration::new(
                 language,
                 &highlights_query,

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -16,6 +16,11 @@ fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
     };
 
     // Separate file config so we can include year, month and day in file logs
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(logpath)?;
     let file_config = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(
@@ -26,7 +31,7 @@ fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
                 message
             ))
         })
-        .chain(fern::log_file(logpath)?);
+        .chain(file);
 
     base_config.chain(file_config).apply()?;
 

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -116,7 +116,7 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
         }
     } else {
         #[cfg(target_os = "windows")]
-        return Box::new(provider::WindowsProvider::new());
+        return Box::new(provider::WindowsProvider::default());
 
         #[cfg(not(target_os = "windows"))]
         return Box::new(provider::NopProvider::new());
@@ -145,15 +145,15 @@ mod provider {
     use anyhow::{bail, Context as _, Result};
     use std::borrow::Cow;
 
+    #[cfg(not(target_os = "windows"))]
     #[derive(Debug)]
     pub struct NopProvider {
         buf: String,
         primary_buf: String,
     }
 
+    #[cfg(not(target_os = "windows"))]
     impl NopProvider {
-        #[allow(dead_code)]
-        // Only dead_code on Windows.
         pub fn new() -> Self {
             Self {
                 buf: String::new(),
@@ -162,6 +162,7 @@ mod provider {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     impl ClipboardProvider for NopProvider {
         fn name(&self) -> Cow<str> {
             Cow::Borrowed("none")
@@ -186,19 +187,8 @@ mod provider {
     }
 
     #[cfg(target_os = "windows")]
-    #[derive(Debug)]
-    pub struct WindowsProvider {
-        selection_buf: String,
-    }
-
-    #[cfg(target_os = "windows")]
-    impl WindowsProvider {
-        pub fn new() -> Self {
-            Self {
-                selection_buf: String::new(),
-            }
-        }
-    }
+    #[derive(Default, Debug)]
+    pub struct WindowsProvider;
 
     #[cfg(target_os = "windows")]
     impl ClipboardProvider for WindowsProvider {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -294,7 +294,11 @@ impl Editor {
                 self.language_servers
                     .get(language)
                     .map_err(|e| {
-                        log::error!("Failed to get LSP, {}, for `{}`", e, language.scope())
+                        log::error!(
+                            "Failed to initialize the LSP for `{}` {{ {} }}",
+                            language.scope(),
+                            e
+                        )
                     })
                     .ok()
             });


### PR DESCRIPTION
Resolves #820 and #735

```
2021-10-22T23:00:20.968 helix_core::syntax [INFO] Error opening dynamic library "C:\\dev\\helix\\runtime\\grammars\\rust.dll"
2021-10-22T23:00:21.020 helix_view::editor [ERROR] Failed to initialize the LSP for `source.rust` { IO Error: The system cannot find the file specified. (os error 2) }
```