### PR TITLE
adds: rose_pine.toml colorscheme

### DIFF
--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -1,0 +1,61 @@
+# Author: RayGervais<raygervais@hotmail.ca>
+
+"ui.background" = { bg = "base" }
+"ui.menu" = "surface"
+"ui.menu.selected" = { fg = "iris", bg = "surface" }
+"ui.linenr" = {fg = "subtle" }
+"ui.popup" = { bg = "overlay" }
+"ui.window" = { bg = "overlay" }
+"ui.liner.selected" = "highlightOverlay"
+"ui.selection" = "highlight"
+"comment" = "subtle"
+"ui.statusline" = {fg = "foam", bg = "surface" }
+"ui.help" = { fg = "foam", bg = "surface" }
+"ui.cursor" = { fg = "rose", modifiers = ["reversed"] }
+"ui.text" = { fg = "text" }
+"operator" = "rose"
+"ui.text.focus" = { fg = "base05" }
+"variable" = "text"
+"number" = "iris"
+"constant" = "gold"
+"attributes" = "gold" 
+"type" = "foam"
+"ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
+"string"  = "gold"
+"property" = "foam"
+"escape" = "subtle"
+"function" = "rose"
+"function.builtin" = "rose"
+"function.method"  = "foam"
+"constructor" = "gold"
+"special" = "gold"
+"keyword" = "pine"
+"label" = "iris"
+"namespace" = "pine"
+"ui.popup" = { bg = "overlay" }
+"ui.window" = { bg = "base" }
+"ui.help" = { bg = "overlay", fg = "foam" }
+"text" = "text"
+
+"info" = "gold"
+"hint" = "gold"
+"debug" = "rose"
+"diagnostic" = "rose"
+"error" = "love"
+
+[palette]
+base     = "#191724" 
+surface  = "#1f1d2e" 
+overlay  = "#26233a"
+inactive = "#555169"
+subtle   = "#6e6a86"
+text     = "#e0def4"
+love     = "#eb6f92"
+gold     = "#f6c177"
+rose     = "#ebbcba"
+pine     = "#31748f"
+foam     = "#9ccfd8"
+iris     = "#c4a7e7"
+highlight = "#2a2837"
+highlightInactive = "#211f2d"
+highlightOverlay = "#3a384a"


### PR DESCRIPTION
Adds the recently growing in popularity colorscheme, [Rose Pine](https://rosepinetheme.com)! And this time, I remembered the info, diagnostics UI elements :D. Though there is not an official spec, I based the highlighting around how the VS Code extension handles certain elements, and then used deductive reasoning from there. 

_Rust_
<img width="948" alt="Screen Shot 2021-10-23 at 5 09 32 PM" src="https://user-images.githubusercontent.com/14265337/138571680-a8758098-6ca1-472b-afeb-bc51f8d0c574.png">

_Go_
<img width="949" alt="Screen Shot 2021-10-23 at 5 10 09 PM" src="https://user-images.githubusercontent.com/14265337/138571700-bdbdec01-6154-464e-ae68-759ef8ee0631.png">


