### PR TITLE
Use current dir for file picker, after change dir.

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -102,7 +102,7 @@ impl Application {
             if first.is_dir() {
                 std::env::set_current_dir(&first)?;
                 editor.new_file(Action::VerticalSplit);
-                compositor.push(Box::new(ui::file_picker(first.clone())));
+                compositor.push(Box::new(ui::file_picker(".".into())));
             } else {
                 let nr_of_files = args.files.len();
                 editor.open(first.to_path_buf(), Action::VerticalSplit)?;


### PR DESCRIPTION
When we run helix with a directory arg like: `hx dir`
the file picker should be opened and populated with files accessible from that directory (files in `dir/*`)

But there an issue with the actual code, since before populating the file picker we do a change directory, this is equivalent to populate the file picker with file in `dir/dir/*`.