### PR TITLE
adjust elixir highlight scopes

### DIFF
--- a/runtime/queries/elixir/highlights.scm
+++ b/runtime/queries/elixir/highlights.scm
@@ -121,9 +121,9 @@
 
 (sigil
   (sigil_name) @__name__
-  quoted_start: _ @string.regex
-  quoted_end: _ @string.regex
-  (#match? @__name__ "^[rR]$")) @string.regex
+  quoted_start: _ @string.regexp
+  quoted_end: _ @string.regexp
+  (#match? @__name__ "^[rR]$")) @string.regexp
 
 (sigil
   (sigil_name) @__name__


### PR DESCRIPTION
per discussion on [the matrix](https://matrix.to/#/!zMuVRxoqjyxyjSEBXc:matrix.org/$BkzHk_cWf9afOoU1SfMDn1WJbh44QKo8Iup61B9pkV0?via=matrix.org)

changes

- string.regex -> string.regexp
- escape -> punctuation.special in interpolations

just gave these a try with some files with interpolations and regexs in them and it looks good!