### PR TITLE
Make match work with extend and multi cursors

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4361,14 +4361,15 @@ fn match_brackets(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     if let Some(syntax) = doc.syntax() {
-        let pos = doc
-            .selection(view.id)
-            .primary()
-            .cursor(doc.text().slice(..));
-        if let Some(pos) = match_brackets::find(syntax, doc.text(), pos) {
-            let selection = Selection::point(pos);
-            doc.set_selection(view.id, selection);
-        };
+        let text = doc.text().slice(..);
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            if let Some(pos) = match_brackets::find(syntax, doc.text(), range.anchor) {
+                range.put_cursor(text, pos, doc.mode == Mode::Select)
+            } else {
+                range
+            }
+        });
+        doc.set_selection(view.id, selection);
     }
 }
 


### PR DESCRIPTION
Similar to #909 (that only makes it work with extend since no point for multi cursors) except that this is for match. I hit this issue quite a few times when I want to extend or multi cursors up till now.

https://asciinema.org/a/wWrA4WbcLneruY5hnFYOY0kyJ