### PR TITLE
WIP: Fix picker panicking at out-of bounds lines

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -122,8 +122,13 @@ impl<T: 'static> Component for FilePicker<T> {
                 .or_else(|| self.preview_cache.get(&path))
                 .zip(Some(range))
         }) {
+            let bounded_line = line.map(|(start, end)| match start >= doc.text().len_lines() {
+                true => (0, 0),
+                false => (start, end),
+            });
+
             // align to middle
-            let first_line = line
+            let first_line = bounded_line
                 .map(|(start, end)| {
                     let height = end.saturating_sub(start) + 1;
                     let middle = start + (height.saturating_sub(1) / 2);


### PR DESCRIPTION
Fixes #934
However, it is probably a very ugly non-rusty way to do it.
What would be a better helix-idiomatic way (and end can be out of bounds too!)?

Some strangeness encountered:
Nonexistence of the file does not stop rendering, but document is attempted to be fetched from cache.
What is the point of this?

And something probably needs to be added to tests before the merge.