### PR TITLE
Prevent preview binary or large file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +424,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "content_inspector",
  "crossterm",
  "fern",
  "futures-util",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -46,6 +46,8 @@ fuzzy-matcher = "0.3"
 ignore = "0.4"
 # markdown doc rendering
 pulldown-cmark = { version = "0.8", default-features = false }
+# file type detection
+content_inspector = "0.2.4"
 
 # config
 toml = "0.5"

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -108,7 +108,7 @@ impl<T> FilePicker<T> {
             )
             .unwrap_or(Preview::NotFound);
         self.preview_cache.insert(path.to_owned(), preview);
-        self.preview_cache[path]
+        &self.preview_cache[path]
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -108,7 +108,7 @@ impl<T> FilePicker<T> {
             )
             .unwrap_or(Preview::NotFound);
         self.preview_cache.insert(path.to_owned(), preview);
-        self.preview_cache.get(path).unwrap()
+        self.preview_cache[path]
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -70,9 +70,9 @@ impl<T> FilePicker<T> {
                 let content_type = {
                     let mut buffer = Vec::new();
                     let file = std::fs::File::open(&path).unwrap();
-                    file.take(MAX_PREVIEW_SIZE)
-                        .read_to_end(&mut buffer)
-                        .unwrap();
+                    // read first 1024 bytes is enough size to guess the content type by
+                    // [content_inspector]
+                    file.take(1024).read_to_end(&mut buffer).unwrap();
                     content_inspector::inspect(&buffer)
                 };
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -77,7 +77,7 @@ impl<T> FilePicker<T> {
                 };
 
                 // TODO: enable syntax highlighting; blocked by async rendering
-                let doc = match (metadata.size(), content_type) {
+                let doc = match (metadata.len(), content_type) {
                     (size, _) if size > MAX_BYTE_PREVIEW => Document::from(
                         helix_core::Rope::from_str(&format!(
                             "<<TOO LARGE TO PREVIEW>>.\n\n File : {} MB\n Limit: {} MB",

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -36,13 +36,13 @@ pub struct FilePicker<T> {
     file_fn: Box<dyn Fn(&Editor, &T) -> Option<FileLocation>>,
 }
 
-pub enum Preview<'c, 'e> {
-    OwenedPreview(&'c CaluculatedPreview),
-    EditorDocument(&'e Document),
+pub enum Preview<'picker, 'editor> {
+    Cached(&'picker CachedPreview),
+    EditorDocument(&'editor Document),
 }
-/// Caluculated file preview
-pub enum CaluculatedPreview {
-    OwenedDocument(Document),
+
+pub enum CachedPreview {
+    Document(Document),
     Binary,
     LargeFile,
     NotFound,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -62,7 +62,7 @@ impl<T> FilePicker<T> {
 
     fn calculate_preview(&mut self, editor: &Editor) {
         /// Biggest file size to preview in bytes
-        const MAX_BYTE_PREVIEW: u64 = 10 * 1024 * 1024;
+        const MAX_PREVIEW_SIZE: u64 = 10 * 1024 * 1024;
 
         if let Some((path, _line)) = self.current_file(editor) {
             if !self.preview_cache.contains_key(&path) && editor.document_by_path(&path).is_none() {
@@ -70,7 +70,7 @@ impl<T> FilePicker<T> {
                 let content_type = {
                     let mut buffer = Vec::new();
                     let file = std::fs::File::open(&path).unwrap();
-                    file.take(MAX_BYTE_PREVIEW)
+                    file.take(MAX_PREVIEW_SIZE)
                         .read_to_end(&mut buffer)
                         .unwrap();
                     content_inspector::inspect(&buffer)
@@ -78,11 +78,11 @@ impl<T> FilePicker<T> {
 
                 // TODO: enable syntax highlighting; blocked by async rendering
                 let doc = match (metadata.len(), content_type) {
-                    (size, _) if size > MAX_BYTE_PREVIEW => Document::from(
+                    (size, _) if size > MAX_PREVIEW_SIZE => Document::from(
                         helix_core::Rope::from_str(&format!(
                             "<<TOO LARGE TO PREVIEW>>.\n\n File : {} MB\n Limit: {} MB",
                             size / 1024 / 1024,
-                            MAX_BYTE_PREVIEW / 1024 / 1024
+                            MAX_PREVIEW_SIZE / 1024 / 1024
                         )),
                         None,
                     ),

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -12,7 +12,7 @@ use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
 use fuzzy_matcher::FuzzyMatcher;
 use tui::widgets::Widget;
 
-use std::{borrow::Cow, collections::HashMap, path::PathBuf};
+use std::{borrow::Cow, collections::HashMap, io::Read, path::PathBuf};
 
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::Position;


### PR DESCRIPTION
This PR adds detect binary file and large file on file picker. (#847)

Use [content_inspector](https://github.com/sharkdp/content_inspector) to detect binary file (I'm new to this project, let me know any already exist way on this project to detect binary file).