### PR TITLE
Use content_inspector create to remove binaries from file picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +424,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "content_inspector",
  "crossterm",
  "fern",
  "futures-util",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -33,6 +33,7 @@ num_cpus = "1"
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.22", features = ["event-stream"] }
 signal-hook = "0.3"
+content_inspector = "0.2.4"
 
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 


### PR DESCRIPTION
This expands on #767 in the suggested way -- by pulling in some logic that sniffs the first kilobyte of a file for the type of file. I'm unsure what the impact of this is going to be on large codebases like say the linux kernel, but the hope is that filtering out much of the uneditable/binary file types by extension first (as in the previous pull request) will mitigate that.

If the approach is acceptable, I'll build on this pull request with commits adding further file extensions to exclude prior to the binary sniffing, as in the previous pull request.