### PR TITLE
Add indents for PHP

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -200,7 +200,7 @@ injection-regex = "php"
 file-types = ["php"]
 roots = []
 
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 4, unit = "    " }
 
 [[language]]
 name = "latex"

--- a/runtime/queries/php/indents.toml
+++ b/runtime/queries/php/indents.toml
@@ -1,0 +1,17 @@
+indent = [
+  "array_creation_expression",
+  "arguments",
+  "formal_parameters",
+  "compound_statement",
+  "declaration_list",
+  "binary_expression",
+  "return_statement",
+  "expression_statement",
+  "switch_block",
+  "anonymous_function_use_clause",
+]
+
+oudent = [
+  "}",
+  ")",
+]


### PR DESCRIPTION
This adds an indents.toml for PHP, based on the one from nvim-treesitter. I added a few more indents to the list nvim had. I also adjusted the default indent unit to 4 spaces based on the PSR2/PSR12 standards that are popular in modern PHP application development.