### PR TITLE
only remove primary index when search next without extend

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1161,7 +1161,10 @@ fn search_impl(doc: &mut Document, view: &mut View, contents: &str, regex: &Rege
         let selection = if extend {
             selection.clone().push(Range::new(start, end))
         } else {
-            Selection::single(start, end)
+            selection
+                .clone()
+                .remove(selection.primary_index())
+                .push(Range::new(start, end))
         };
 
         doc.set_selection(view.id, selection);


### PR DESCRIPTION
Only remove primary selection with `search_next` without extend.
![hx_s2](https://user-images.githubusercontent.com/20379044/139692180-25252d81-08aa-4248-a86f-1e5c88717f61.gif)


