### PR TITLE
Implement key ordering for info box

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -147,11 +147,7 @@ impl KeyTrieNode {
                 Some(pos) => {
                     body[pos].1.insert(key);
                 }
-                None => {
-                    let mut keys = BTreeSet::new();
-                    keys.insert(key);
-                    body.push((desc, keys));
-                }
+                None => body.push((desc, BTreeSet::from([key]))),
             }
         }
         body.sort_unstable_by_key(|(_, keys)| {

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -1,6 +1,6 @@
 use crate::input::KeyEvent;
 use helix_core::unicode::width::UnicodeWidthStr;
-use std::fmt::Write;
+use std::{collections::BTreeSet, fmt::Write};
 
 #[derive(Debug)]
 /// Info box used in editor. Rendering logic will be in other crate.
@@ -16,7 +16,7 @@ pub struct Info {
 }
 
 impl Info {
-    pub fn new(title: &str, body: Vec<(&str, Vec<KeyEvent>)>) -> Info {
+    pub fn new(title: &str, body: Vec<(&str, BTreeSet<KeyEvent>)>) -> Info {
         let body = body
             .into_iter()
             .map(|(desc, events)| {

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -8,7 +8,7 @@ use crate::keyboard::{KeyCode, KeyModifiers};
 
 /// Represents a key event.
 // We use a newtype here because we want to customize Deserialize and Display.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct KeyEvent {
     pub code: KeyCode,
     pub modifiers: KeyModifiers,

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -54,7 +54,7 @@ impl From<crossterm::event::KeyModifiers> for KeyModifiers {
 }
 
 /// Represents a key.
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyCode {
     /// Backspace key.


### PR DESCRIPTION
This sorts the keys in the infobox, when multiple keys are associated to a command (or command group).
What previously looked like this:
![current-master](https://user-images.githubusercontent.com/16193831/139749660-4a1a142a-211e-41f8-8486-562944c1b496.png)
now looks like this:
![sorting](https://user-images.githubusercontent.com/16193831/139749751-d60d2cca-bb72-4361-9aa6-bf6e20c6a5ea.png)

I also tried adding a padding to make everything align but I'm not sure if that's an improvement. If that is desired, I can add it to this PR:
![sorting-and-padding](https://user-images.githubusercontent.com/16193831/139749902-025bbda1-1e3c-4437-8328-1720ea10bc46.png)

