### PR TITLE
Add commit hash to version info, if present

### DIFF
--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -6,6 +6,6 @@ fn main() {
         .map(|x| String::from_utf8(x.stdout).ok())
         .ok()
         .flatten()
-        .unwrap_or(String::from(env!("CARGO_PKG_VERSION")));
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+        .unwrap_or_else(|| String::from(env!("CARGO_PKG_VERSION")));
+    println!("cargo:rustc-env=VERSION_AND_GIT_HASH={}", git_hash);
 }

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+
 fn main() {
     let git_hash = Command::new("git")
         .args(&["describe", "--dirty"])

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+fn main() {
+    let git_hash = Command::new("git")
+        .args(&["describe", "--dirty"])
+        .output()
+        .map(|x| String::from_utf8(x.stdout).ok())
+        .ok()
+        .flatten()
+        .unwrap_or(String::from(env!("CARGO_PKG_VERSION")));
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -66,7 +66,7 @@ FLAGS:
     -V, --version    Prints version information
 ",
         env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
+        env!("GIT_HASH"),
         env!("CARGO_PKG_AUTHORS"),
         env!("CARGO_PKG_DESCRIPTION"),
         logpath.display(),
@@ -81,7 +81,7 @@ FLAGS:
     }
 
     if args.display_version {
-        println!("helix {}", env!("CARGO_PKG_VERSION"));
+        println!("helix {}", env!("GIT_HASH"));
         std::process::exit(0);
     }
 

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -66,7 +66,7 @@ FLAGS:
     -V, --version    Prints version information
 ",
         env!("CARGO_PKG_NAME"),
-        env!("GIT_HASH"),
+        env!("VERSION_AND_GIT_HASH"),
         env!("CARGO_PKG_AUTHORS"),
         env!("CARGO_PKG_DESCRIPTION"),
         logpath.display(),
@@ -81,7 +81,7 @@ FLAGS:
     }
 
     if args.display_version {
-        println!("helix {}", env!("GIT_HASH"));
+        println!("helix {}", env!("VERSION_AND_GIT_HASH"));
         std::process::exit(0);
     }
 


### PR DESCRIPTION
Fixes #922. Right now it doesn't detect release versions, and just blindly throws on the commit hash in all cases that one exists. Reverts to old (current) behavior if built in an environment with no git repo.