### PR TITLE
Use `CARGO_BIN_NAME` instead of `CARGO_PKG_NAME` in `hx --help` output

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -65,7 +65,7 @@ FLAGS:
                      (default file: {})
     -V, --version    Prints version information
 ",
-        env!("CARGO_PKG_NAME"),
+        env!("CARGO_BIN_NAME"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_PKG_AUTHORS"),
         env!("CARGO_PKG_DESCRIPTION"),


### PR DESCRIPTION
So that it displays `hx <VERSION>` instead of `helix-term <VERSION>`.