### PR TITLE
Hide keys bound to `no_op` from infobox

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -140,7 +140,12 @@ impl KeyTrieNode {
         let mut body: Vec<(&str, BTreeSet<KeyEvent>)> = Vec::with_capacity(self.len());
         for (&key, trie) in self.iter() {
             let desc = match trie {
-                KeyTrie::Leaf(cmd) => cmd.doc(),
+                KeyTrie::Leaf(cmd) => {
+                    if cmd.name() == "no_op" {
+                        continue;
+                    }
+                    cmd.doc()
+                }
                 KeyTrie::Node(n) => n.name(),
             };
             match body.iter().position(|(d, _)| d == &desc) {


### PR DESCRIPTION
If a user wants to disable a key by binding it to `no_op`, they probably don't want it showing as `Do nothing` in infoboxes.