### PR TITLE
Adds mint language server (WIP)

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -44,6 +44,17 @@ language-server = { command = "elixir-ls" }
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]
+name = "mint"
+scope = "source.mint"
+injection-regex = "mint"
+file-types = ["mint"]
+roots = []
+comment-token = "//"
+
+language-server = { command = "mint", args = ["ls"] }
+indent = { tab-width = 2, unit = "  " }
+
+[[language]]
 name = "json"
 scope = "source.json"
 injection-regex = "json"


### PR DESCRIPTION
#968 

https://www.mint-lang.com/

mint ls was merged into nvim-lspconfig recently.

There is an open pull request for mint in emacs here.

Mint's language server is built into the cli interface of mint itself.

Here are the features that are currently supported by the mint language server:

https://github.com/mint-lang/mint/blob/master/src/ls/README.md