### PR TITLE
Inform when reaching undo/redo bounds

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3679,13 +3679,19 @@ pub mod insert {
 fn undo(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let view_id = view.id;
-    doc.undo(view_id);
+    let success = doc.undo(view_id);
+    if !success {
+        cx.editor.set_status("Already at oldest change".to_owned());
+    }
 }
 
 fn redo(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let view_id = view.id;
-    doc.redo(view_id);
+    let success = doc.redo(view_id);
+    if !success {
+        cx.editor.set_status("Already at newest change".to_owned());
+    }
 }
 
 // Yank / Paste

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -704,7 +704,7 @@ impl Document {
         success
     }
 
-    /// Undo the last modification to the [`Document`]. Returns whether undo was successful.
+    /// Undo the last modification to the [`Document`]. Returns whether the undo was successful.
     pub fn undo(&mut self, view_id: ViewId) -> bool {
         let mut history = self.history.take();
         let success = if let Some(transaction) = history.undo() {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -704,8 +704,8 @@ impl Document {
         success
     }
 
-    /// Undo the last modification to the [`Document`].
-    pub fn undo(&mut self, view_id: ViewId) {
+    /// Undo the last modification to the [`Document`]. Returns whether undo was successful.
+    pub fn undo(&mut self, view_id: ViewId) -> bool {
         let mut history = self.history.take();
         let success = if let Some(transaction) = history.undo() {
             self.apply_impl(transaction, view_id)
@@ -718,10 +718,11 @@ impl Document {
             // reset changeset to fix len
             self.changes = ChangeSet::new(self.text());
         }
+        success
     }
 
-    /// Redo the last modification to the [`Document`].
-    pub fn redo(&mut self, view_id: ViewId) {
+    /// Redo the last modification to the [`Document`]. Returns whether the redo was sucessful.
+    pub fn redo(&mut self, view_id: ViewId) -> bool {
         let mut history = self.history.take();
         let success = if let Some(transaction) = history.redo() {
             self.apply_impl(transaction, view_id)
@@ -734,6 +735,7 @@ impl Document {
             // reset changeset to fix len
             self.changes = ChangeSet::new(self.text());
         }
+        success
     }
 
     pub fn savepoint(&mut self) {


### PR DESCRIPTION
* `Already at oldest change` when undo fails
* `Already at newest change` when redo fails