### PR TITLE
Launch with defaults upon invalid config/theme

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use crate::keymap::Keymaps;
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub theme: Option<String>,
     #[serde(default)]
@@ -14,7 +15,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
     pub display_messages: bool,
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -91,7 +91,16 @@ FLAGS:
     }
 
     let config = match std::fs::read_to_string(conf_dir.join("config.toml")) {
-        Ok(config) => merge_keys(toml::from_str(&config)?),
+        Ok(config) => toml::from_str(&config)
+            .map(merge_keys)
+            .unwrap_or_else(|err| {
+                eprintln!("Bad config: {}", err);
+                eprintln!("Press <ENTER> to continue with default config");
+                use std::io::Read;
+                // This waits for an enter press.
+                let _ = std::io::stdin().read(&mut []);
+                Config::default()
+            }),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Config::default(),
         Err(err) => return Err(Error::new(err)),
     };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -34,7 +34,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -192,6 +192,12 @@ impl Editor {
     }
 
     pub fn set_theme(&mut self, theme: Theme) {
+        // `ui.selection` is the only scope required to be able to render a theme.
+        if theme.find_scope_index("ui.selection").is_none() {
+            self.set_error("Invalid theme: `ui.selection` required".to_owned());
+            return;
+        }
+
         let scopes = theme.scopes();
         for config in self
             .syn_loader


### PR DESCRIPTION
Resolves #670.

* Startup message if there is a problematic config, then launch with default config.
* Statusline error if trying to switch to an invalid theme, and reject the switch. This results in using the default theme if an invalid theme is set in `config.toml`.