### PR TITLE
Keep selection direction from primary selection when `search_next`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1195,14 +1195,18 @@ fn search_impl(doc: &mut Document, view: &mut View, contents: &str, regex: &Rege
             return;
         }
 
-        let selection = if extend {
-            selection.clone().push(Range::new(start, end))
+        let primary = selection.primary();
+        let next_range = if primary.head < primary.anchor {
+            Range::new(end, start)
         } else {
-            selection
-                .clone()
-                .remove(selection.primary_index())
-                .push(Range::new(start, end))
+            Range::new(start, end)
         };
+        let selection = if extend {
+            selection.clone()
+        } else {
+            selection.clone().remove(selection.primary_index())
+        }
+        .push(next_range);
 
         doc.set_selection(view.id, selection);
         align_view(doc, view, Align::Center);


### PR DESCRIPTION
I don't know if it's the habit of a few people that `search_next` expect to keep direction.

![hx_s5](https://user-images.githubusercontent.com/20379044/140453412-9cbfd830-0db0-424c-ad40-5123b89a61e3.gif)

