### PR TITLE
Add a check to prevent decrementing primary selection index OOB

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -363,7 +363,9 @@ impl Selection {
     /// Adds a new range to the selection and makes it the primary range.
     pub fn remove(mut self, index: usize) -> Self {
         self.ranges.remove(index);
-        if index < self.primary_index || self.primary_index == self.ranges.len() {
+        if index < self.primary_index
+            || self.primary_index == self.ranges.len() && self.primary_index > 0
+        {
             self.primary_index -= 1;
         }
         self


### PR DESCRIPTION
I'm not sure why, but on master locally (via `cargo run`), when I try to search within the document with `/`, it panics at this part in code on the very first character typed after the prompt appears. The panic was due to subtracting 1 from the primary index when it was at 0, causing an out of bounds error for the usize. Ultimately this comes from the search imple trying to remove the primary selection from the selections, when there is only one selection. This can be confirmed by running through the steps to reproduce, but making more than one selection with `C` before starting the search.

This is a quick and dirty change I made that preveted the error from showing up any more, but I must confess I don't fully understand why the search_impl is trying to remove the primary cursor in the first place.

Steps to reproduce:

* Run with `cargo run`
* Open any nonempty file
* Immediately type `/` to begin a search
* type any character

Here's the full backtrace of the panic for reference:

```
thread 'main' panicked at 'attempt to subtract with overflow', helix-core/src/selection.rs:367:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/panicking.rs:101:14
   2: core::panicking::panic
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/panicking.rs:50:5
   3: helix_core::selection::Selection::remove
             at ./helix-core/src/selection.rs:367:13
   4: helix_term::commands::search_impl
             at ./helix-term/src/commands.rs:1201:13
   5: helix_term::commands::search::{{closure}}
             at ./helix-term/src/commands.rs:1248:13
   6: helix_term::ui::regex_prompt::{{closure}}
             at ./helix-term/src/ui/mod.rs:82:29
   7: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/alloc/src/boxed.rs:1643:9
   8: <helix_term::ui::prompt::Prompt as helix_term::compositor::Component>::handle_event
             at ./helix-term/src/ui/prompt.rs:569:17
   9: helix_term::compositor::Compositor::handle_event
             at ./helix-term/src/compositor.rs:132:19
  10: helix_term::application::Application::handle_terminal_events
             at ./helix-term/src/application.rs:288:32
  11: helix_term::application::Application::event_loop::{{closure}}
             at ./helix-term/src/application.rs:186:21
  12: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/future/mod.rs:80:19
  13: helix_term::application::Application::run::{{closure}}
             at ./helix-term/src/application.rs:595:9
  14: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/future/mod.rs:80:19
  15: hx::main::{{closure}}
             at ./helix-term/src/main.rs:103:5
  16: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/future/mod.rs:80:19
  17: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/park/thread.rs:263:54
  18: tokio::coop::with_budget::{{closure}}
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/coop.rs:106:9
  19: std::thread::local::LocalKey<T>::try_with
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/thread/local.rs:399:16
  20: std::thread::local::LocalKey<T>::with
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/thread/local.rs:375:9
  21: tokio::coop::with_budget
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/coop.rs:99:5
  22: tokio::coop::budget
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/coop.rs:76:5
  23: tokio::park::thread::CachedParkThread::block_on
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/park/thread.rs:263:31
  24: tokio::runtime::enter::Enter::block_on
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/runtime/enter.rs:151:13
  25: tokio::runtime::thread_pool::ThreadPool::block_on
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/runtime/thread_pool/mod.rs:77:9
  26: tokio::runtime::Runtime::block_on
             at /home/epocsquadron/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.13.0/src/runtime/mod.rs:463:43
  27: hx::main
             at ./helix-term/src/main.rs:105:5
  28: core::ops::function::FnOnce::call_once
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/ops/function.rs:227:5
```