### PR TITLE
File picker config

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -23,11 +23,8 @@ To override global configuration parameters, create a `config.toml` file located
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
-| `file-picker` | Sets options for file picker and global search. Supports multiple pairs within an inline table. Details below.  | `{hidden = true, parents = true, ignore = true, git-ignore = true, git-global = true, git-exclude = true }` |
 
-#### file-picker 
-
-All the pairs listed in the default file-picker configuration above are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default. 
+`[editor.filepicker]` section of the config. Sets options for file picker and global search. All but the last key listed in the default file-picker configuration below are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default.
 
 | Key | Description | Default |
 |--|--|---------|

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -23,6 +23,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
+| `git_ignore` | Whether to hide files listed in .gitignore in filepicker. | `false` |
 
 ## LSP
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -28,13 +28,13 @@ To override global configuration parameters, create a `config.toml` file located
 
 | Key | Description | Default |
 |--|--|---------|
-|`hidden` | Directly enables ignoring hidden files. | true
+|`hidden` | Enables ignoring hidden files. | true
 |`parents` | Enables reading ignore files from parent directories. | true
 |`ignore` | Enables reading `.ignore` files. | true
 |`git-ignore` | Enables reading `.gitignore` files. | true
 |`git-global` | Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option. | true
 |`git-exclude` | Enables reading `.git/info/exclude` files. | true
-|`max-depth` | May be used as a key, bound to an integer value for maximum depth to recurse. Defaults within helix logic to `None`. | N/A: not present by default.
+|`max-depth` | Set with an integer value for maximum depth to recurse. | Defaults to `None`.
 
 ## LSP
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -23,15 +23,21 @@ To override global configuration parameters, create a `config.toml` file located
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
-| `file-picker` | Sets options for file picker and global search. Multiple pairs in an inline table. Details below.  | `{hidden = true, parents = true, ignore = false, git-ignore = true, git-global = true, git-exclude = true } |
-All the pairs listed in the default configuration above are IgnoreOptions: which types of files are ignored in the file picker and global search. 
-`hidden` Directly enables ignoring hidden files.
-`parents` Enables reading ignore files from parent directories. 
-`ignore` Enables reading `.ignore` files.
-`git-ignore` Enables reading `.gitignore` files.
-`git-global` Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-`git-exclude` Enables reading `.git/info/exclude` files.
-`max-depth` can also be used as a key, and can be bound to an integer value for maximum depth to recurse. Defaults to `None`.
+| `file-picker` | Sets options for file picker and global search. Supports multiple pairs within an inline table. Details below.  | `{hidden = true, parents = true, ignore = true, git-ignore = true, git-global = true, git-exclude = true }` |
+
+#### file-picker 
+
+All the pairs listed in the default file-picker configuration above are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default. 
+
+| Key | Description | Default |
+|--|--|---------|
+|`hidden` | Directly enables ignoring hidden files. | true
+|`parents` | Enables reading ignore files from parent directories. | true
+|`ignore` | Enables reading `.ignore` files. | true
+|`git-ignore` | Enables reading `.gitignore` files. | true
+|`git-global` | Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option. | true
+|`git-exclude` | Enables reading `.git/info/exclude` files. | true
+|`max-depth` | May be used as a key, bound to an integer value for maximum depth to recurse. Defaults within helix logic to `None`. | N/A: not present by default.
 
 ## LSP
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -23,7 +23,15 @@ To override global configuration parameters, create a `config.toml` file located
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
-| `git_ignore` | Whether to hide files listed in .gitignore in filepicker. | `false` |
+| `file-picker` | Sets options for file picker and global search. Multiple pairs in an inline table. Details below.  | `{hidden = true, parents = true, ignore = false, git-ignore = true, git-global = true, git-exclude = true } |
+All the pairs listed in the default configuration above are IgnoreOptions: which types of files are ignored in the file picker and global search. 
+`hidden` Directly enables ignoring hidden files.
+`parents` Enables reading ignore files from parent directories. 
+`ignore` Enables reading `.ignore` files.
+`git-ignore` Enables reading `.gitignore` files.
+`git-global` Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
+`git-exclude` Enables reading `.git/info/exclude` files.
+`max-depth` can also be used as a key, and can be bound to an integer value for maximum depth to recurse. Defaults to `None`.
 
 ## LSP
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -120,7 +120,7 @@ impl Application {
             if first.is_dir() {
                 std::env::set_current_dir(&first)?;
                 editor.new_file(Action::VerticalSplit);
-                compositor.push(Box::new(ui::file_picker(".".into(), config.editor.clone())));
+                compositor.push(Box::new(ui::file_picker(".".into(), &config.editor)));
             } else {
                 let nr_of_files = args.files.len();
                 editor.open(first.to_path_buf(), Action::VerticalSplit)?;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -120,7 +120,7 @@ impl Application {
             if first.is_dir() {
                 std::env::set_current_dir(&first)?;
                 editor.new_file(Action::VerticalSplit);
-                compositor.push(Box::new(ui::file_picker(".".into())));
+                compositor.push(Box::new(ui::file_picker(".".into(), config.editor.clone())));
             } else {
                 let nr_of_files = args.files.len();
                 editor.open(first.to_path_buf(), Action::VerticalSplit)?;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1395,7 +1395,6 @@ fn global_search(cx: &mut Context) {
                     .git_ignore(file_picker_config.git_ignore)
                     .git_global(file_picker_config.git_global)
                     .git_exclude(file_picker_config.git_exclude)
-                    .follow_links(file_picker_config.follow_links)
                     .max_depth(file_picker_config.max_depth)
                     .build_parallel()
                     .run(|| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1359,7 +1359,7 @@ fn global_search(cx: &mut Context) {
     let (all_matches_sx, all_matches_rx) =
         tokio::sync::mpsc::unbounded_channel::<(usize, PathBuf)>();
     let smart_case = cx.editor.config.smart_case;
-    let git_ignore = cx.editor.config.git_ignore;
+    let file_picker_config = cx.editor.config.file_picker.clone();
 
     let completions = search_completions(cx, None);
     let prompt = ui::regex_prompt(
@@ -1389,7 +1389,8 @@ fn global_search(cx: &mut Context) {
                 let search_root = std::env::current_dir()
                     .expect("Global search error: Failed to get current dir");
                 WalkBuilder::new(search_root)
-                    .git_ignore(git_ignore)
+                    .git_ignore(file_picker_config.git_ignore)
+                    // etc
                     .build_parallel()
                     .run(|| {
                         let mut searcher_cl = searcher.clone();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1389,8 +1389,12 @@ fn global_search(cx: &mut Context) {
                 let search_root = std::env::current_dir()
                     .expect("Global search error: Failed to get current dir");
                 WalkBuilder::new(search_root)
+                    .hidden(file_picker_config.hidden)
+                    .parents(file_picker_config.parents)
+                    .ignore(file_picker_config.ignore)
                     .git_ignore(file_picker_config.git_ignore)
-                    // etc
+                    .git_global(file_picker_config.git_global)
+                    .git_exclude(file_picker_config.git_exclude)
                     .build_parallel()
                     .run(|| {
                         let mut searcher_cl = searcher.clone();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1389,13 +1389,14 @@ fn global_search(cx: &mut Context) {
                 let search_root = std::env::current_dir()
                     .expect("Global search error: Failed to get current dir");
                 WalkBuilder::new(search_root)
-                    // opinionated to look for everything, this is a search?
-                    //.hidden(file_picker_config.hidden)
-                    //.parents(file_picker_config.parents)
-                    //.ignore(file_picker_config.ignore)
-                    //.git_ignore(file_picker_config.git_ignore)
-                    //.git_global(file_picker_config.git_global)
-                    //.git_exclude(file_picker_config.git_exclude)
+                    .hidden(file_picker_config.hidden)
+                    .parents(file_picker_config.parents)
+                    .ignore(file_picker_config.ignore)
+                    .git_ignore(file_picker_config.git_ignore)
+                    .git_global(file_picker_config.git_global)
+                    .git_exclude(file_picker_config.git_exclude)
+                    .follow_links(file_picker_config.follow_links)
+                    .max_depth(file_picker_config.max_depth)
                     .build_parallel()
                     .run(|| {
                         let mut searcher_cl = searcher.clone();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2593,7 +2593,7 @@ fn command_mode(cx: &mut Context) {
 
 fn file_picker(cx: &mut Context) {
     let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
-    let picker = ui::file_picker(root, cx.editor.config.clone());
+    let picker = ui::file_picker(root, &cx.editor.config);
     cx.push_layer(Box::new(picker));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1389,12 +1389,13 @@ fn global_search(cx: &mut Context) {
                 let search_root = std::env::current_dir()
                     .expect("Global search error: Failed to get current dir");
                 WalkBuilder::new(search_root)
-                    .hidden(file_picker_config.hidden)
-                    .parents(file_picker_config.parents)
-                    .ignore(file_picker_config.ignore)
-                    .git_ignore(file_picker_config.git_ignore)
-                    .git_global(file_picker_config.git_global)
-                    .git_exclude(file_picker_config.git_exclude)
+                    // opinionated to look for everything, this is a search?
+                    //.hidden(file_picker_config.hidden)
+                    //.parents(file_picker_config.parents)
+                    //.ignore(file_picker_config.ignore)
+                    //.git_ignore(file_picker_config.git_ignore)
+                    //.git_global(file_picker_config.git_global)
+                    //.git_exclude(file_picker_config.git_exclude)
                     .build_parallel()
                     .run(|| {
                         let mut searcher_cl = searcher.clone();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2594,7 +2594,6 @@ fn command_mode(cx: &mut Context) {
 fn file_picker(cx: &mut Context) {
     let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
     let picker = ui::file_picker(root, cx.editor.config.clone());
-    //let picker = ui::file_picker(root, None);
     cx.push_layer(Box::new(picker));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2593,7 +2593,8 @@ fn command_mode(cx: &mut Context) {
 
 fn file_picker(cx: &mut Context) {
     let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
-    let picker = ui::file_picker(root);
+    let picker = ui::file_picker(root, cx.editor.config.clone());
+    //let picker = ui::file_picker(root, None);
     cx.push_layer(Box::new(picker));
 }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -93,7 +93,7 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf, config: helix_view::editor::Config) -> FilePicker<PathBuf> {
+pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePicker<PathBuf> {
     use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time;
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -100,7 +100,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
-    walk_builder.git_ignore(config.hide_gitignore);
+    walk_builder.git_ignore(config.git_ignore);
     let walk_builder = match type_builder.add(
         "compressed",
         "*.{zip,gz,bz2,zst,lzo,sz,tgz,tbz2,lz,lz4,lzma,lzo,z,Z,xz,7z,rar,cab}",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -107,8 +107,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
-        .follow_links(config.file_picker.git_exclude)
-        .max_depth(Some(1));
+        .max_depth(config.file_picker.max_depth);
 
     let walk_builder = match type_builder.add(
         "compressed",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -100,14 +100,15 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
-    // from 'standard filters'
     walk_builder
         .hidden(config.file_picker.hidden)
         .parents(config.file_picker.parents)
         .ignore(config.file_picker.ignore)
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
-        .git_exclude(config.file_picker.git_exclude);
+        .git_exclude(config.file_picker.git_exclude)
+        .follow_links(config.file_picker.git_exclude)
+        .max_depth(Some(1));
 
     let walk_builder = match type_builder.add(
         "compressed",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -93,13 +93,14 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf) -> FilePicker<PathBuf> {
+pub fn file_picker(root: PathBuf, config: helix_view::editor::Config) -> FilePicker<PathBuf> {
     use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time;
 
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
+    walk_builder.git_ignore(config.show_hidden_files);
     let walk_builder = match type_builder.add(
         "compressed",
         "*.{zip,gz,bz2,zst,lzo,sz,tgz,tbz2,lz,lz4,lzma,lzo,z,Z,xz,7z,rar,cab}",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -100,14 +100,14 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
-    //from 'standard filters'
-    // reduce with fluent notation?
-    walk_builder.hidden(config.file_picker.hidden);
-    walk_builder.parents(config.file_picker.parents);
-    walk_builder.ignore(config.file_picker.ignore);
-    walk_builder.git_ignore(config.file_picker.git_ignore);
-    walk_builder.git_global(config.file_picker.git_global);
-    walk_builder.git_exclude(config.file_picker.git_exclude);
+    // from 'standard filters'
+    walk_builder
+        .hidden(config.file_picker.hidden)
+        .parents(config.file_picker.parents)
+        .ignore(config.file_picker.ignore)
+        .git_ignore(config.file_picker.git_ignore)
+        .git_global(config.file_picker.git_global)
+        .git_exclude(config.file_picker.git_exclude);
 
     let walk_builder = match type_builder.add(
         "compressed",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -100,7 +100,15 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
-    walk_builder.git_ignore(config.git_ignore);
+    //from 'standard filters'
+    // reduce with fluent notation?
+    walk_builder.hidden(config.file_picker.hidden);
+    walk_builder.parents(config.file_picker.parents);
+    walk_builder.ignore(config.file_picker.ignore);
+    walk_builder.git_ignore(config.file_picker.git_ignore);
+    walk_builder.git_global(config.file_picker.git_global);
+    walk_builder.git_exclude(config.file_picker.git_exclude);
+
     let walk_builder = match type_builder.add(
         "compressed",
         "*.{zip,gz,bz2,zst,lzo,sz,tgz,tbz2,lz,lz4,lzma,lzo,z,Z,xz,7z,rar,cab}",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -100,7 +100,7 @@ pub fn file_picker(root: PathBuf, config: helix_view::editor::Config) -> FilePic
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     let mut walk_builder = WalkBuilder::new(&root);
-    walk_builder.git_ignore(config.show_hidden_files);
+    walk_builder.git_ignore(config.hide_gitignore);
     let walk_builder = match type_builder.add(
         "compressed",
         "*.{zip,gz,bz2,zst,lzo,sz,tgz,tbz2,lz,lz4,lzma,lzo,z,Z,xz,7z,rar,cab}",

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -39,24 +39,24 @@ where
 pub struct FilePickerConfig {
     /// IgnoreOptions
     /// Enables ignoring hidden files.
-    /// Whether to hide, that is, to stop hidden files from displaying in file picker. Defaults to false.
+    /// Whether to hide hidden files in file picker and global search results. Defaults to true.
     pub hidden: bool,
-    /// Enables reading ignore files from parent directories.
+    /// Enables reading ignore files from parent directories. Defaults to true.
     pub parents: bool,
     /// Enables reading `.ignore` files.
-    /// Whether to hide files listed in .ignore from displaying in file picker. Defaults to false.
+    /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to true.
     pub ignore: bool,
     /// Enables reading `.gitignore` files.
-    /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
+    /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to true.
     pub git_ignore: bool,
     /// Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-    /// Whether to hide files in global .gitignore from displaying in file picker. Defaults to false.
+    /// Whether to hide files listed in global .gitignore in file picker and global search results. Defaults to true.
     pub git_global: bool,
     /// Enables reading `.git/info/exclude` files.
-    /// Whether to hide files in .git/info/exclude from displaying in file picker. Defaults to false.
+    /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to true.
     pub git_exclude: bool,
     /// WalkBuilder options
-    /// Maximum Depth to recurse.
+    /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -61,6 +61,7 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
+    pub show_hidden_files: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -92,6 +93,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,
+            show_hidden_files: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -61,7 +61,7 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
-    pub hide_gitignore: bool,
+    pub git_ignore: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -93,7 +93,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,
-            hide_gitignore: false,
+            git_ignore: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -61,7 +61,7 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
-    pub show_hidden_files: bool,
+    pub hide_gitignore: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -93,7 +93,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,
-            show_hidden_files: false,
+            hide_gitignore: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -43,7 +43,6 @@ pub struct FilePickerConfig {
     pub git_ignore: bool,
     pub git_global: bool,
     pub git_exclude: bool,
-    pub follow_links: bool,
     pub max_depth: Option<usize>,
 }
 
@@ -65,8 +64,6 @@ impl Default for FilePickerConfig {
             // Enables reading `.git/info/exclude` files.
             git_exclude: true,
             // WalkBuilder options
-            // Whether to follow symbolic links.
-            follow_links: false,
             // Maximum Depth to recurse.
             max_depth: None,
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -37,34 +37,38 @@ where
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
+    /// IgnoreOptions
+    /// Enables ignoring hidden files.
+    /// Whether to hide, that is, to stop hidden files from displaying in file picker. Defaults to false.
     pub hidden: bool,
+    /// Enables reading ignore files from parent directories.
     pub parents: bool,
+    /// Enables reading `.ignore` files.
+    /// Whether to hide files listed in .ignore from displaying in file picker. Defaults to false.
     pub ignore: bool,
+    /// Enables reading `.gitignore` files.
+    /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
     pub git_ignore: bool,
+    /// Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
+    /// Whether to hide files in global .gitignore from displaying in file picker. Defaults to false.
     pub git_global: bool,
+    /// Enables reading `.git/info/exclude` files.
+    /// Whether to hide files in .git/info/exclude from displaying in file picker. Defaults to false.
     pub git_exclude: bool,
+    /// WalkBuilder options
+    /// Maximum Depth to recurse.
     pub max_depth: Option<usize>,
 }
 
 impl Default for FilePickerConfig {
     fn default() -> Self {
         Self {
-            // IgnoreOptions
-            // Enables ignoring hidden files.
             hidden: true,
-            // Enables reading ignore files from parent directories.
             parents: true,
-            // Enables reading `.ignore` files.
             ignore: true,
-            // Enables reading `.gitignore` files.
-            /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
             git_ignore: true,
-            // Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
             git_global: true,
-            // Enables reading `.git/info/exclude` files.
             git_exclude: true,
-            // WalkBuilder options
-            // Maximum Depth to recurse.
             max_depth: None,
         }
     }
@@ -97,8 +101,6 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
-    /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
-    //pub git_ignore: bool,
     pub file_picker: FilePickerConfig,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -61,6 +61,7 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
+    /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
     pub git_ignore: bool,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -45,28 +45,30 @@ pub struct FilePickerConfig {
     pub git_exclude: bool,
     pub follow_links: bool,
     pub max_depth: Option<usize>,
-    // filter_entry - maybe use for a handle to block descent into .git ?
 }
 
 impl Default for FilePickerConfig {
     fn default() -> Self {
         Self {
-            // could simply use .standard_filters if these are uniform.
+            // IgnoreOptions
             // Enables ignoring hidden files.
-            hidden: false,
+            hidden: true,
             // Enables reading ignore files from parent directories.
-            parents: false,
+            parents: true,
             // Enables reading `.ignore` files.
-            ignore: false,
+            ignore: true,
             // Enables reading `.gitignore` files.
             /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
-            git_ignore: false,
+            git_ignore: true,
             // Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-            git_global: false,
+            git_global: true,
             // Enables reading `.git/info/exclude` files.
-            git_exclude: false,
-            follow_links: true,
-            max_depth: Some(1),
+            git_exclude: true,
+            // WalkBuilder options
+            // Whether to follow symbolic links.
+            follow_links: false,
+            // Maximum Depth to recurse.
+            max_depth: None,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -43,11 +43,15 @@ pub struct FilePickerConfig {
     pub git_ignore: bool,
     pub git_global: bool,
     pub git_exclude: bool,
+    pub follow_links: bool,
+    pub max_depth: Option<usize>,
+    // filter_entry - maybe use for a handle to block descent into .git ?
 }
 
 impl Default for FilePickerConfig {
     fn default() -> Self {
         Self {
+            // could simply use .standard_filters if these are uniform.
             // Enables ignoring hidden files.
             hidden: false,
             // Enables reading ignore files from parent directories.
@@ -57,10 +61,12 @@ impl Default for FilePickerConfig {
             // Enables reading `.gitignore` files.
             /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
             git_ignore: false,
-            // Enables reading global .gitignore, whose path is specified in git's `core.excludesFile` option.
+            // Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
             git_global: false,
             // Enables reading `.git/info/exclude` files.
             git_exclude: false,
+            follow_links: true,
+            max_depth: Some(1),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -36,6 +36,37 @@ where
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct FilePickerConfig {
+    pub hidden: bool,
+    pub parents: bool,
+    pub ignore: bool,
+    pub git_ignore: bool,
+    pub git_global: bool,
+    pub git_exclude: bool,
+}
+
+impl Default for FilePickerConfig {
+    fn default() -> Self {
+        Self {
+            // Enables ignoring hidden files.
+            hidden: false,
+            // Enables reading ignore files from parent directories.
+            parents: false,
+            // Enables reading `.ignore` files.
+            ignore: false,
+            // Enables reading `.gitignore` files.
+            /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
+            git_ignore: false,
+            // Enables reading global .gitignore, whose path is specified in git's `core.excludesFile` option.
+            git_global: false,
+            // Enables reading `.git/info/exclude` files.
+            git_exclude: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
@@ -62,7 +93,8 @@ pub struct Config {
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     /// Whether to hide files in .gitignore from displaying in file picker. Defaults to false.
-    pub git_ignore: bool,
+    //pub git_ignore: bool,
+    pub file_picker: FilePickerConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -94,7 +126,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,
-            git_ignore: false,
+            file_picker: FilePickerConfig::default(),
         }
     }
 }


### PR DESCRIPTION
Fixes #280

Connects settings from user defined config in `cargo.toml` to file picker by adding a second parameter to `file_picker()`.

This is an extensible pattern for more user defined file picker configuration options, including the option to see or ignore dotfiles, etc.

Currently sets config for file picker to hide or display files listed in `.gitignore`. 

Sets default preference to see files listed in `.gitignore`.