### PR TITLE
Add aliases to command doc tooltip and fix height with multiline strings

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2263,14 +2263,14 @@ mod cmd {
         TypableCommand {
             name: "write-quit",
             aliases: &["wq", "x"],
-            doc: "Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt)",
+            doc: "Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt).",
             fun: write_quit,
             completer: Some(completers::filename),
         },
         TypableCommand {
             name: "write-quit!",
             aliases: &["wq!", "x!"],
-            doc: "Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt)",
+            doc: "Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt).",
             fun: force_write_quit,
             completer: Some(completers::filename),
         },

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -32,7 +32,7 @@ use movement::Movement;
 
 use crate::{
     compositor::{self, Component, Compositor},
-    ui::{self, FilePicker, Picker, Popup, Prompt, PromptEvent},
+    ui::{self, FilePicker, Picker, Popup, Prompt, PromptDoc, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -2525,7 +2525,7 @@ fn command_mode(cx: &mut Context) {
         let part = input.split(' ').next().unwrap_or_default();
 
         if let Some(cmd::TypableCommand { doc, aliases, .. }) = cmd::COMMANDS.get(part) {
-            return Some((doc, aliases));
+            return Some(PromptDoc { doc, aliases });
         }
 
         None

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2524,8 +2524,8 @@ fn command_mode(cx: &mut Context) {
     prompt.doc_fn = Box::new(|input: &str| {
         let part = input.split(' ').next().unwrap_or_default();
 
-        if let Some(cmd::TypableCommand { doc, .. }) = cmd::COMMANDS.get(part) {
-            return Some(doc);
+        if let Some(cmd::TypableCommand { doc, aliases, .. }) = cmd::COMMANDS.get(part) {
+            return Some((doc, aliases));
         }
 
         None

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -15,7 +15,7 @@ pub use markdown::Markdown;
 pub use menu::Menu;
 pub use picker::{FilePicker, Picker};
 pub use popup::Popup;
-pub use prompt::{Prompt, PromptEvent};
+pub use prompt::{Prompt, PromptDoc, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
 pub use text::Text;
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -355,8 +355,24 @@ impl Prompt {
             }
         }
 
-        if let Some(doc) = (self.doc_fn)(&self.line) {
-            let mut text = ui::Text::new(doc.to_string());
+        if let Some((doc, aliases)) = (self.doc_fn)(&self.line) {
+            let mut string = String::with_capacity(
+                doc.len() + aliases.iter().fold(0, |acc, alias| acc + alias.len() + 2) + 12,
+            );
+            string.push_str(doc);
+
+            if aliases.len() > 0 {
+                string.push_str("\n");
+                string.push_str("Aliases: ");
+                for alias in aliases {
+                    string.push_str(alias);
+                    string.push_str(", ");
+                }
+                string.pop();
+                string.pop();
+            }
+
+            let mut text = ui::Text::new(string);
 
             let viewport = area;
             let area = viewport.intersection(Rect::new(

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -24,7 +24,7 @@ pub struct Prompt {
     history_pos: Option<usize>,
     completion_fn: Box<dyn FnMut(&str) -> Vec<Completion>>,
     callback_fn: Box<dyn FnMut(&mut Context, &str, PromptEvent)>,
-    pub doc_fn: Box<dyn Fn(&str) -> Option<&'static str>>,
+    pub doc_fn: Box<dyn Fn(&str) -> Option<(&'static str, &'static [&'static str])>>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -372,14 +372,19 @@ impl Prompt {
                 string.pop();
             }
 
+            let width = BASE_WIDTH * 3;
+            let height = 2 + string
+                .lines()
+                .fold(0, |acc, s| acc + (s.len() as u16 / width) + 1);
+
             let mut text = ui::Text::new(string);
 
             let viewport = area;
             let area = viewport.intersection(Rect::new(
                 completion_area.x,
-                completion_area.y.saturating_sub(3),
-                BASE_WIDTH * 3,
-                3,
+                completion_area.y.saturating_sub(height),
+                width,
+                height,
             ));
 
             let background = theme.get("ui.help");

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -24,7 +24,12 @@ pub struct Prompt {
     history_pos: Option<usize>,
     completion_fn: Box<dyn FnMut(&str) -> Vec<Completion>>,
     callback_fn: Box<dyn FnMut(&mut Context, &str, PromptEvent)>,
-    pub doc_fn: Box<dyn Fn(&str) -> Option<(&'static str, &'static [&'static str])>>,
+    pub doc_fn: Box<dyn Fn(&str) -> Option<PromptDoc>>,
+}
+
+pub struct PromptDoc {
+    pub doc: &'static str,
+    pub aliases: &'static [&'static str],
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -355,14 +360,14 @@ impl Prompt {
             }
         }
 
-        if let Some((doc, aliases)) = (self.doc_fn)(&self.line) {
+        if let Some(PromptDoc { doc, aliases }) = (self.doc_fn)(&self.line) {
             let mut string = String::with_capacity(
                 doc.len() + aliases.iter().fold(0, |acc, alias| acc + alias.len() + 2) + 12,
             );
             string.push_str(doc);
 
-            if aliases.len() > 0 {
-                string.push_str("\n");
+            if !aliases.is_empty() {
+                string.push('\n');
                 string.push_str("Aliases: ");
                 for alias in aliases {
                     string.push_str(alias);


### PR DESCRIPTION
This PR adds a list of aliases below the command's doc:
![image](https://user-images.githubusercontent.com/29989290/140516801-93af2e4f-7e11-465e-9d1b-254d5e03a013.png)

I also fixed the prompt height, which originally looked like this:
![image](https://user-images.githubusercontent.com/29989290/140517013-76fb8e96-934e-4495-a965-dde3ceda5696.png)
