### PR TITLE
Adds single and double quotes to matching pairs

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -1,6 +1,13 @@
 use crate::{Rope, Syntax};
 
-const PAIRS: &[(char, char)] = &[('(', ')'), ('{', '}'), ('[', ']'), ('<', '>')];
+const PAIRS: &[(char, char)] = &[
+    ('(', ')'),
+    ('{', '}'),
+    ('[', ']'),
+    ('<', '>'),
+    ('\'', '\''),
+    ('"', '"'),
+];
 // limit matching pairs to only ( ) { } [ ] < >
 
 #[must_use]


### PR DESCRIPTION
This enables `mm` to work on quote characters as well as highlighting of
matching quote when on it. I'm unsure if there's a reason these weren't
added in the first place, but some brief testing it works for me in some
rust, javascript and php files.
