### PR TITLE
Fix panicked missing field `shebangs`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -405,6 +405,7 @@ language-server = { command = "cmake-language-server" }
 name = "glsl"
 scope = "source.glsl"
 file-types = ["glsl", "vert", "tesc", "tese", "geom", "frag", "comp" ]
+shebangs = []
 roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }


### PR DESCRIPTION
Fix the error:
```
thread 'main' panicked at 'Could not parse merged (built-in + user) languages.toml: Error { inner: ErrorInner { kind: Custom, line: None, col: 0, at: None, message: "missing field `shebangs`", key: ["language"] } }', helix-term/src/application.rs:87:14
```