### PR TITLE
adds build commit hash to --version output

### DIFF
--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!(
+        "cargo:rustc-env=VERSION_WITH_GIT_HASH={}",
+        format!("{} ({})", env!("CARGO_PKG_VERSION"), &git_hash[..8])
+    );
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -81,7 +81,7 @@ FLAGS:
     }
 
     if args.display_version {
-        println!("helix {}", env!("CARGO_PKG_VERSION"));
+        println!("helix {}", env!("VERSION_WITH_GIT_HASH"));
         std::process::exit(0);
     }
 


### PR DESCRIPTION
This commit adds the build commit hash to the `--version` output. This
helps while helix is built regularly from git sources on the master
branch.

This commit works by using a Cargo build script. It shells out to `git
rev-parse HEAD` at compile time. It then sets a Cargo environment
variable with the version plus commit hash. Where the version is
displayed in the `main()` function, at compile time the Cargo env var is
read and the contents compiled into the binary as a static string.

The output looks like:

```console
$ hx --vesrion
helix 0.5.0 (490919df)
```

I find this super useful while building helix from source commonly and knowing where in the history my current binary is at.

If there is no interest in this feature, please feel free to close :smile: 