### PR TITLE
helix-term/commands: implement buffer-close (bc, bclose)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1659,8 +1659,7 @@ mod cmd {
             buffers_remaining_impl(cx.editor)?
         }
 
-        cx.editor
-            .close(view!(cx.editor).id, /* close_buffer */ false);
+        cx.editor.close(view!(cx.editor).id);
 
         Ok(())
     }
@@ -1670,8 +1669,7 @@ mod cmd {
         _args: &[&str],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        cx.editor
-            .close(view!(cx.editor).id, /* close_buffer */ false);
+        cx.editor.close(view!(cx.editor).id);
 
         Ok(())
     }
@@ -1941,7 +1939,7 @@ mod cmd {
             // close all views
             let views: Vec<_> = cx.editor.tree.views().map(|(view, _)| view.id).collect();
             for view_id in views {
-                cx.editor.close(view_id, false);
+                cx.editor.close(view_id);
             }
         }
 
@@ -1985,7 +1983,7 @@ mod cmd {
         // close all views
         let views: Vec<_> = editor.tree.views().map(|(view, _)| view.id).collect();
         for view_id in views {
-            editor.close(view_id, false);
+            editor.close(view_id);
         }
 
         Ok(())
@@ -4740,7 +4738,7 @@ fn wclose(cx: &mut Context) {
     }
     let view_id = view!(cx.editor).id;
     // close current split
-    cx.editor.close(view_id, /* close_buffer */ false);
+    cx.editor.close(view_id);
 }
 
 fn wonly(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1698,6 +1698,17 @@ mod cmd {
         Ok(())
     }
 
+    fn force_buffer_close(
+        cx: &mut compositor::Context,
+        _args: &[&str],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let view = view!(cx.editor);
+        let doc_id = view.doc;
+        cx.editor.close_document(doc_id, true)?;
+        Ok(())
+    }
+
     fn write_impl<P: AsRef<Path>>(
         cx: &mut compositor::Context,
         path: Option<P>,
@@ -2292,6 +2303,13 @@ mod cmd {
           aliases: &["bc", "bclose"],
           doc: "Close the current buffer.",
           fun: buffer_close,
+          completer: None, // FIXME: buffer completer
+        },
+        TypableCommand {
+          name: "buffer-close!",
+          aliases: &["bc!", "bclose!"],
+          doc: "Close the current buffer forcefully (ignoring unsaved changes).",
+          fun: force_buffer_close,
           completer: None, // FIXME: buffer completer
         },
         TypableCommand {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1687,6 +1687,17 @@ mod cmd {
         Ok(())
     }
 
+    fn buffer_close(
+        cx: &mut compositor::Context,
+        _args: &[&str],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let view = view!(cx.editor);
+        let doc_id = view.doc;
+        cx.editor.close_document(doc_id, false)?;
+        Ok(())
+    }
+
     fn write_impl<P: AsRef<Path>>(
         cx: &mut compositor::Context,
         path: Option<P>,
@@ -2275,6 +2286,13 @@ mod cmd {
             doc: "Open a file from disk into the current view.",
             fun: open,
             completer: Some(completers::filename),
+        },
+        TypableCommand {
+          name: "buffer-close",
+          aliases: &["bc", "bclose"],
+          doc: "Close the current buffer.",
+          fun: buffer_close,
+          completer: None, // FIXME: buffer completer
         },
         TypableCommand {
             name: "write",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4786,7 +4786,7 @@ fn wonly(cx: &mut Context) {
         .collect::<Vec<_>>();
     for (view_id, focus) in views {
         if !focus {
-            cx.editor.close(view_id, /* close_buffer */ false);
+            cx.editor.close(view_id);
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -475,11 +475,9 @@ impl Editor {
         }
 
         for (view_id, doc_id, doc_is_focused) in v {
-            if doc_is_focused {
-                if self.tree.views().count() > 1 {
-                    self.close(view_id);
-                    continue;
-                }
+            if doc_is_focused && self.tree.views().count() > 1 {
+                self.close(view_id);
+                continue;
             }
 
             let doc_id = if let Some(doc_id) = doc_id {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -484,9 +484,9 @@ impl Editor {
             self.replace_document_in_view(view_id, doc_id);
         }
 
-        if !self.tree.views().any(|(view, _)| view.doc == doc_id) {
-            self.documents.remove(&doc_id);
-        }
+        debug_assert!(!self.tree.views().any(|(view, _)| view.doc == doc_id));
+        self.documents.remove(&doc_id);
+        self._refresh();
 
         Ok(())
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -482,7 +482,6 @@ impl Editor {
             let doc_id = doc_id.unwrap_or_else(|| self.new_document(Document::default()));
 
             self.replace_document_in_view(view_id, doc_id);
-            self._refresh();
         }
 
         if !self.tree.views().any(|(view, _)| view.doc == doc_id) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -389,7 +389,7 @@ impl Editor {
         Ok(id)
     }
 
-    pub fn close(&mut self, id: ViewId, close_buffer: bool) {
+    pub fn close(&mut self, id: ViewId) {
         let view = self.tree.get(self.tree.focus);
         // remove selection
         self.documents
@@ -397,16 +397,6 @@ impl Editor {
             .unwrap()
             .selections
             .remove(&id);
-
-        if close_buffer {
-            // get around borrowck issues
-            let doc = &self.documents[&view.doc];
-
-            if let Some(language_server) = doc.language_server() {
-                tokio::spawn(language_server.text_document_did_close(doc.identifier()));
-            }
-            self.documents.remove(&view.doc);
-        }
 
         self.tree.remove(id);
         self._refresh();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -479,11 +479,7 @@ impl Editor {
                 continue;
             }
 
-            let doc_id = if let Some(doc_id) = doc_id {
-                doc_id
-            } else {
-                self.new_document(Document::default())
-            };
+            let doc_id = doc_id.unwrap_or_else(|| self.new_document(Document::default()));
 
             self.replace_document_in_view(view_id, doc_id);
             self._refresh();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -485,6 +485,7 @@ impl Editor {
             } else {
                 self.new_document(Document::default())
             };
+
             self.replace_document_in_view(view_id, doc_id);
             self._refresh();
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -417,11 +417,10 @@ impl Editor {
     }
 
     pub fn close_document(&mut self, doc_id: DocumentId, force: bool) -> anyhow::Result<()> {
-        if !self.documents.contains_key(&doc_id) {
-            anyhow::bail!("document does not exist");
-        }
-
-        let doc = &self.documents[&doc_id];
+        let doc = match self.documents.get(&doc_id) {
+            Some(doc) => doc,
+            None => anyhow::bail!("document does not exist"),
+        };
 
         if !force && doc.is_modified() {
             anyhow::bail!(

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -314,6 +314,9 @@ impl Tree {
 
     pub fn recalculate(&mut self) {
         if self.is_empty() {
+            // There are no more views, so the tree should focus itself again.
+            self.focus = self.root;
+
             return;
         }
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -54,6 +54,10 @@ impl JumpList {
             None
         }
     }
+
+    pub fn remove(&mut self, doc_id: &DocumentId) {
+        self.jumps.retain(|(other_id, _)| other_id != doc_id);
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This behaves the same as Kakoune's `delete-buffer` / `db` command:

* With 3 files opened by the user with `:o ab`, `:o cd`, and `:o ef`:
  * `buffer-close` once closes `ef` and switches to `cd`
  * `buffer-close` again closes `cd` and switches to `ab`
  * `buffer-close` again closes `ab` and switches to a scratch buffer
* With 3 files opened from the command line with `hx -- ab cd ef`:
  * `buffer-close` once closes `ab` and switches to `cd`
  * `buffer-close` again closes `cd` and switches to `ef`
  * `buffer-close` again closes `ef` and switches to a scratch buffer
* With 1 file opened (`ab`):
  * `buffer-close` once closes `ab` and switches to a scratch buffer
  * `buffer-close` again closes the scratch buffer and switches to a new
    scratch buffer

---

Closes https://github.com/helix-editor/helix/issues/851.

I'm new to the codebase (as you can see by this being my first contribution...), so I may have done some things "wrong". Please correct me on everything, no matter how small.

Note that I publicized the `jumps` field of the `JumpList` struct in `helix-view/src/view.rs` in order to ensure that no references to the now-removed buffer exist anywhere. I took a naive approach at validating this: I simply used the debug formatter to print the `compositor::Context` struct and looked for any references to the now-removed document's ID.

If you'd prefer, I could instead make a method that would give access (mutable and not) to this field.

Also note that I named the command `buffer-close` instead of only `bclose` (but I did add this and `bc` as an alias) or `close` in order to pave the way for potentially more buffer-specific actions. Namespacing is easier at implementation time than at some point in the future where we wished we had done this.