### PR TITLE
Improve sorting for the file picker

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -120,7 +120,11 @@ impl Application {
             if first.is_dir() {
                 std::env::set_current_dir(&first)?;
                 editor.new_file(Action::VerticalSplit);
-                compositor.push(Box::new(ui::file_picker(".".into(), &config.editor)));
+                compositor.push(Box::new(ui::file_picker(
+                    ".".into(),
+                    Some(".".into()),
+                    &config.editor,
+                )));
             } else {
                 let nr_of_files = args.files.len();
                 editor.open(first.to_path_buf(), Action::VerticalSplit)?;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1575,6 +1575,7 @@ fn global_search(cx: &mut Context) {
                         align_view(doc, view, Align::Center);
                     },
                     |_editor, (line_num, path)| Some((path.clone(), Some((*line_num, *line_num)))),
+                    |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
                 );
                 compositor.push(Box::new(picker));
             });
@@ -2757,7 +2758,8 @@ fn command_mode(cx: &mut Context) {
 
 fn file_picker(cx: &mut Context) {
     let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
-    let picker = ui::file_picker(root, &cx.editor.config);
+    let current_dir = std::env::current_dir().ok();
+    let picker = ui::file_picker(root, current_dir, &cx.editor.config);
     cx.push_layer(Box::new(picker));
 }
 
@@ -2825,6 +2827,7 @@ fn buffer_picker(cx: &mut Context) {
                 .cursor_line(doc.text().slice(..));
             Some((meta.path.clone()?, Some((line, line))))
         },
+        |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
     );
     cx.push_layer(Box::new(picker));
 }
@@ -2902,6 +2905,7 @@ fn symbol_picker(cx: &mut Context) {
                         ));
                         Some((path, line))
                     },
+                    |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
                 );
                 picker.truncate_start = false;
                 compositor.push(Box::new(picker))
@@ -2964,6 +2968,7 @@ fn workspace_symbol_picker(cx: &mut Context) {
                         ));
                         Some((path, line))
                     },
+                    |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
                 );
                 picker.truncate_start = false;
                 compositor.push(Box::new(picker))
@@ -3016,6 +3021,7 @@ pub fn code_action(cx: &mut Context) {
                             }
                         }
                     },
+                    |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
                 );
                 compositor.push(Box::new(picker))
             }
@@ -3530,6 +3536,7 @@ fn goto_impl(
                     ));
                     Some((path, line))
                 },
+                |_, l_score, _, r_score| l_score.cmp(&r_score).reverse(),
             );
             compositor.push(Box::new(picker));
         }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -176,6 +176,9 @@ pub fn file_picker(
         },
         |_editor, (path, _, _)| Some((path.clone(), None)),
         |(_, l_time, l_in_current_dir), mut l_score, (_, r_time, r_in_current_dir), mut r_score| {
+            // Sort the matches of the picker by:
+            // * The closeness of the file name to the search with a small boost being given to files in the current directory
+            // * As a tie-breaker, use the timestamp of the file
             if *l_in_current_dir {
                 l_score += FILE_CURRENT_DIR_BONUS;
             }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -287,7 +287,8 @@ pub struct Picker<T> {
 
     format_fn: Box<dyn Fn(&T) -> Cow<str>>,
     callback_fn: Box<dyn Fn(&mut Editor, &T, Action)>,
-    /// The ordering of the matches of the picker
+    /// This function specifies the ordering of any 2 matches given as (l_element, l_matching_score, r_element, r_matching_score).
+    /// The matches are sorted in ascending order, so the highest priority match should be the smallest element in terms of this ordering.
     sort_fn: Box<dyn Fn(&T, i64, &T, i64) -> Ordering>,
 }
 


### PR DESCRIPTION
The main motivation for this change is that files under the current working directory should be prioritized over files that are somewhere else in the same workspace.

Matches of the file picker are now sorted by:
* The closeness of the file name to the search with a small boost being given to files in the current directory
* As a tie-breaker, the timestamp of the file is used as before
 
This sort of sorting could now similiarly be implemented for other pickers (for example for buffer access recency).

EDIT: I've previously used a strictly hierarchical sorting method which didn't work as well, I've updated this text to avoid any confusion.
