### PR TITLE
helix-term/commands: move SCRATCH_BUFFER_NAME to helix-view/document

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -13,7 +13,7 @@ use helix_core::{
 
 use helix_view::{
     clipboard::ClipboardType,
-    document::Mode,
+    document::{Mode, SCRATCH_BUFFER_NAME},
     editor::{Action, Motion},
     input::KeyEvent,
     keyboard::KeyCode,
@@ -52,8 +52,6 @@ use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
 use ignore::{DirEntry, WalkBuilder, WalkState};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-
-pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
 
 pub struct Context<'a> {
     pub register: Option<char>,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -25,6 +25,8 @@ const BUF_SIZE: usize = 8192;
 
 const DEFAULT_INDENT: IndentStyle = IndentStyle::Spaces(4);
 
+pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Mode {
     Normal,


### PR DESCRIPTION
This way, the name is accessible everywhere Document and related types
are.

----

While working on https://github.com/helix-editor/helix/pull/1035, I needed the name of the scratch buffer. However, since the const is defined in `helix-term` and not `helix-view`, I have no way to access it. This PR moves the const to `helix-view/src/document.rs` so that the const is accessible everywhere `Document` and related types are.

(I didn't think the original placement through, sorry. I swear, I'm not trying to pad my PR stats :P)