### PR TITLE
helix-term/commands: implement cquit

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -599,7 +599,7 @@ impl Application {
         Ok(())
     }
 
-    pub async fn run(&mut self) -> Result<(), Error> {
+    pub async fn run(&mut self) -> Result<i32, Error> {
         self.claim_term().await?;
 
         // Exit the alternate screen and disable raw mode before panicking
@@ -622,6 +622,6 @@ impl Application {
 
         self.restore_term()?;
 
-        Ok(())
+        Ok(self.editor.exit_code)
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2005,6 +2005,25 @@ mod cmd {
         quit_all_impl(&mut cx.editor, args, event, true)
     }
 
+    fn cquit(
+        cx: &mut compositor::Context,
+        args: &[&str],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let exit_code = args
+            .first()
+            .and_then(|code| code.parse::<i32>().ok())
+            .unwrap_or(1);
+        cx.editor.exit_code = exit_code;
+
+        let views: Vec<_> = cx.editor.tree.views().map(|(view, _)| view.id).collect();
+        for view_id in views {
+            cx.editor.close(view_id, false);
+        }
+
+        Ok(())
+    }
+
     fn theme(
         cx: &mut compositor::Context,
         args: &[&str],
@@ -2372,6 +2391,13 @@ mod cmd {
             aliases: &["qa!"],
             doc: "Close all views forcefully (ignoring unsaved changes).",
             fun: force_quit_all,
+            completer: None,
+        },
+        TypableCommand {
+            name: "cquit",
+            aliases: &["cq"],
+            doc: "Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).",
+            fun: cquit,
             completer: None,
         },
         TypableCommand {

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -38,8 +38,13 @@ fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
     Ok(())
 }
 
+fn main() -> Result<()> {
+    let exit_code = main_impl()?;
+    std::process::exit(exit_code);
+}
+
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main_impl() -> Result<i32> {
     let cache_dir = helix_core::cache_dir();
     if !cache_dir.exists() {
         std::fs::create_dir_all(&cache_dir).ok();
@@ -109,7 +114,8 @@ FLAGS:
 
     // TODO: use the thread local executor to spawn the application task separately from the work pool
     let mut app = Application::new(args, config).context("unable to create new application")?;
-    app.run().await.unwrap();
 
-    Ok(())
+    let exit_code = app.run().await?;
+
+    Ok(exit_code)
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -129,6 +129,8 @@ pub struct Editor {
 
     pub idle_timer: Pin<Box<Sleep>>,
     pub last_motion: Option<Motion>,
+
+    pub exit_code: i32,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -167,6 +169,7 @@ impl Editor {
             idle_timer: Box::pin(sleep(config.idle_timeout)),
             last_motion: None,
             config,
+            exit_code: 0,
         }
     }
 


### PR DESCRIPTION
This allows you to exit helix with an exit code, e.g. `:cq 2`.

---

Closes https://github.com/helix-editor/helix/issues/1082.