### PR TITLE
Optimize space for DocumentId with NonZeroUsize

### DIFF
--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -12,8 +12,18 @@ pub mod theme;
 pub mod tree;
 pub mod view;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
-pub struct DocumentId(usize);
+use std::num::NonZeroUsize;
+
+// uses NonZeroUsize so Option<DocumentId> use a byte rather than two
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct DocumentId(NonZeroUsize);
+
+impl Default for DocumentId {
+    fn default() -> DocumentId {
+        // Safety: 1 is non-zero
+        DocumentId(unsafe { NonZeroUsize::new_unchecked(1) })
+    }
+}
 
 slotmap::new_key_type! {
     pub struct ViewId;


### PR DESCRIPTION
Now `Option<DocumentId>` uses one byte rather than two