### PR TITLE
align selections

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -90,6 +90,7 @@
 | `s`      | Select all regex matches inside selections                        | `select_regex`                       |
 | `S`      | Split selection into subselections on regex matches               | `split_selection`                    |
 | `Alt-s`  | Split selection on newlines                                       | `split_selection_on_newline`         |
+| `&`      | Align selection in columns                                        | `align_selections`                   |
 | `_`      | Trim whitespace from the selection                                | `trim_selections`                    |
 | `;`      | Collapse selection onto a single cursor                           | `collapse_selection`                 |
 | `Alt-;`  | Flip selection cursor and anchor                                  | `flip_selections`                    |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -629,6 +629,12 @@ fn trim_selections(cx: &mut Context) {
 // align text in selection
 fn align_selections(cx: &mut Context) {
     let align_style = cx.count();
+    if align_style > 3 {
+        cx.editor.set_error(
+            "align only accept 1,2,3 as count to set left/center/right align".to_string(),
+        );
+    }
+
     let (view, doc) = current!(cx.editor);
     let text = doc.text().slice(..);
     let selection = doc.selection(view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -639,7 +639,7 @@ fn align_selections(cx: &mut Context) {
         let (l1, l2) = sel.line_range(text);
         if l1 != l2 {
             cx.editor
-                .set_error(format!("align cannot work with multi line selections"));
+                .set_error("align cannot work with multi line selections".to_string());
             return;
         }
         column = if l1 != last_line { 0 } else { column + 1 };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -633,6 +633,7 @@ fn align_selections(cx: &mut Context) {
         cx.editor.set_error(
             "align only accept 1,2,3 as count to set left/center/right align".to_string(),
         );
+        return;
     }
 
     let (view, doc) = current!(cx.editor);
@@ -686,7 +687,7 @@ fn align_fragment_to_width(fragment: &str, width: usize, align_style: usize) -> 
         2 => s.insert_str(s.len() / 2, trimed), // center align
         3 => s.push_str(trimed),                // right align
         1 => s.insert_str(0, trimed),           // left align
-        n => unimplemented!(n),
+        n => unimplemented!("{}", n),
     }
     s
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3905,7 +3905,6 @@ fn align_lines(cx: &mut Context) {
                     }
                 }
             }
-            log::error!("align contents\n {:?}\n {:?}", &column_widths, &fields);
             let transaction = Transaction::change(
                 doc.text(),
                 fields.iter().flat_map(|line| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -642,6 +642,7 @@ fn align_selections(cx: &mut Context) {
     let mut column_widths = vec![];
     let mut last_line = text.len_lines();
     let mut column = 0;
+    // first of all, we need compute all column's width, let use max width of the selections in a column
     for sel in selection {
         let (l1, l2) = sel.line_range(text);
         if l1 != l2 {
@@ -649,6 +650,7 @@ fn align_selections(cx: &mut Context) {
                 .set_error("align cannot work with multi line selections".to_string());
             return;
         }
+        // if the selection is not in the same line with last selection, we set the column to 0
         column = if l1 != last_line { 0 } else { column + 1 };
         last_line = l1;
 
@@ -657,10 +659,12 @@ fn align_selections(cx: &mut Context) {
                 column_widths[column] = sel.to() - sel.from();
             }
         } else {
+            // a new column, current selection width is the temp width of the column
             column_widths.push(sel.to() - sel.from());
         }
     }
     last_line = text.len_lines();
+    // once we get the with of each column, we transform each selection with to it's column width based on the align style
     let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
         let l = range.cursor_line(text);
         column = if l != last_line { 0 } else { column + 1 };
@@ -684,9 +688,9 @@ fn align_fragment_to_width(fragment: &str, width: usize, align_style: usize) -> 
     let trimed = fragment.trim_matches(|c| c == ' ');
     let mut s = " ".repeat(width - trimed.chars().count());
     match align_style {
+        1 => s.insert_str(0, trimed),           // left align
         2 => s.insert_str(s.len() / 2, trimed), // center align
         3 => s.push_str(trimed),                // right align
-        1 => s.insert_str(0, trimed),           // left align
         n => unimplemented!("{}", n),
     }
     s

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -685,7 +685,8 @@ fn align_fragment_to_width(fragment: &str, width: usize, align_style: usize) -> 
     match align_style {
         2 => s.insert_str(s.len() / 2, trimed), // center align
         3 => s.push_str(trimed),                // right align
-        _ => s.insert_str(0, trimed),           // left align
+        1 => s.insert_str(0, trimed),           // left align
+        n => unimplemented!(n),
     }
     s
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -308,7 +308,7 @@ impl Command {
         join_selections, "Join lines inside selection",
         keep_selections, "Keep selections matching regex",
         remove_selections, "Remove selections matching regex",
-        align_lines, "Align lines by matching regex",
+        align_selections, "Align selections in column",
         keep_primary_selection, "Keep primary selection",
         remove_primary_selection, "Remove primary selection",
         completion, "Invoke completion popup",
@@ -624,6 +624,64 @@ fn trim_selections(cx: &mut Context) {
         collapse_selection(cx);
         keep_primary_selection(cx);
     };
+}
+
+// align text in selection
+fn align_selections(cx: &mut Context) {
+    let align_style = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let selection = doc.selection(view.id);
+    let mut column_widths = vec![];
+    let mut last_line = text.len_lines();
+    let mut column = 0;
+    for sel in selection {
+        let (l1, l2) = sel.line_range(text);
+        if l1 != l2 {
+            cx.editor
+                .set_error(format!("align cannot work with multi line selections"));
+            return;
+        }
+        column = if l1 != last_line { 0 } else { column + 1 };
+        last_line = l1;
+
+        if column < column_widths.len() {
+            if sel.to() - sel.from() > column_widths[column] {
+                column_widths[column] = sel.to() - sel.from();
+            }
+        } else {
+            column_widths.push(sel.to() - sel.from());
+        }
+    }
+    last_line = text.len_lines();
+    let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
+        let l = range.cursor_line(text);
+        column = if l != last_line { 0 } else { column + 1 };
+        last_line = l;
+
+        (
+            range.from(),
+            range.to(),
+            Some(
+                align_fragment_to_width(&range.fragment(text), column_widths[column], align_style)
+                    .into(),
+            ),
+        )
+    });
+
+    doc.apply(&transaction, view.id);
+    doc.append_changes_to_history(view.id);
+}
+
+fn align_fragment_to_width(fragment: &str, width: usize, align_style: usize) -> String {
+    let trimed = fragment.trim_matches(|c| c == ' ');
+    let mut s = " ".repeat(width - trimed.chars().count());
+    match align_style {
+        2 => s.insert_str(s.len() / 2, trimed), // center align
+        3 => s.push_str(trimed),                // right align
+        _ => s.insert_str(0, trimed),           // left align
+    }
+    s
 }
 
 fn goto_window(cx: &mut Context, align: Align) {
@@ -4005,84 +4063,6 @@ fn later(cx: &mut Context) {
             break;
         }
     }
-}
-
-// align text in selection
-fn align_lines(cx: &mut Context) {
-    let align_style = cx.count();
-    let reg = cx.register.unwrap_or('/');
-    let prompt = ui::regex_prompt(
-        cx,
-        "align:".into(),
-        Some(reg),
-        |_input: &str| Vec::new(),
-        move |view, doc, regex, event| {
-            if event != PromptEvent::Update {
-                return;
-            }
-            let text = doc.text().slice(..);
-            let selection = doc.selection(view.id);
-            let start_line = text.char_to_line(selection.ranges()[0].from());
-            let end_line = text.char_to_line(selection.ranges()[selection.len() - 1].to());
-            if start_line == end_line {
-                return;
-            }
-            let mut column_widths = vec![];
-            let mut fields = vec![vec![]; end_line - start_line + 1];
-            for l in start_line..end_line + 1 {
-                let line_text = text.line(l).to_string();
-                let line_start = text.line_to_byte(l);
-                let line_fields = &mut fields[l - start_line];
-                let mut start = line_start;
-                for mat in regex.find_iter(line_text.as_str()) {
-                    line_fields.push((start, line_start + mat.start()));
-                    let w = line_start + mat.start() - start;
-                    start = line_start + mat.end() + 1;
-
-                    if column_widths.len() < line_fields.len() {
-                        column_widths.push(w);
-                    } else if w > column_widths[line_fields.len() - 1] {
-                        column_widths[line_fields.len() - 1] = w;
-                    }
-                }
-            }
-            let transaction = Transaction::change(
-                doc.text(),
-                fields.iter().flat_map(|line| {
-                    line.into_iter().enumerate().map(|(i, &(from, to))| {
-                        (
-                            from,
-                            to,
-                            Some(
-                                align_fragment_to_width(
-                                    text.slice(from..to).to_string().as_str(),
-                                    column_widths[i],
-                                    align_style,
-                                )
-                                .into(),
-                            ),
-                        )
-                    })
-                }),
-            );
-
-            doc.apply(&transaction, view.id);
-            doc.append_changes_to_history(view.id);
-        },
-    );
-
-    cx.push_layer(Box::new(prompt));
-}
-
-fn align_fragment_to_width(fragment: &str, width: usize, align_style: usize) -> String {
-    let trimed = fragment.trim();
-    let mut s = " ".repeat(width - trimed.chars().count());
-    match align_style {
-        2 => s.insert_str(s.len() / 2, trimed), // center align
-        3 => s.push_str(trimed),                // right align
-        _ => s.insert_str(0, trimed),           // left align
-    }
-    s
 }
 
 // Yank / Paste

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -604,8 +604,7 @@ impl Default for Keymaps {
             // "q" => record_macro,
             // "Q" => replay_macro,
 
-            "&" => align_lines,
-            // & align selections
+            "&" => align_selections,
             "_" => trim_selections,
 
             "(" => rotate_selections_backward,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -601,6 +601,7 @@ impl Default for Keymaps {
             // "q" => record_macro,
             // "Q" => replay_macro,
 
+            "&" => align_lines,
             // & align selections
             // _ trim selections
 


### PR DESCRIPTION

<img width="1247" alt="Screen Shot 2021-11-14 at 10 01 06 PM" src="https://user-images.githubusercontent.com/7072/141684472-70467e01-a253-4532-8fa6-b6c6aa616bb7.png">

Select above lines, `&` and input `\|` would turn them to 

<img width="1247" alt="Screen Shot 2021-11-14 at 10 01 25 PM" src="https://user-images.githubusercontent.com/7072/141684485-775bac16-2d0d-4467-81d1-425e789a1338.png">

`2&` and input `\|` would turn them to 
<img width="1247" alt="Screen Shot 2021-11-14 at 10 01 38 PM" src="https://user-images.githubusercontent.com/7072/141684508-f8c50004-ee6d-4fdb-b589-8ffcc81b10dc.png">

`3&` and input `\|` would turn them to 
<img width="1247" alt="Screen Shot 2021-11-14 at 10 01 52 PM" src="https://user-images.githubusercontent.com/7072/141684525-3c0351d8-495d-4265-a85b-7dff784014a9.png">


