### PR TITLE
Improve Solarzed Dark theme

### DIFF
--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -2,15 +2,9 @@
 "keyword" = { fg = "green" }
 "keyword.directive" = { fg = "orange" }
 "namespace" = { fg = "violet" }
-"punctuation" = { fg = "orange" }
-"punctuation.delimiter" = { fg = "orange" }
 "operator" = { fg = "green" }
 "special" = { fg = "orange" }
-# "property" = { fg = "cyan" }
-"variable" = { fg = "cyan" }
-"variable.parameter" = { fg = "cyan" }
 "variable.builtin" = { fg = "cyan", modifiers = ["bold"] }
-"variable.other.member" = { fg = "cyan" }
 "variable.function" = { fg = "blue" }
 "type" = { fg = "yellow" }
 "type.builtin" = { fg = "yellow", modifiers = ["bold"] }
@@ -19,14 +13,10 @@
 "function.macro" = { fg = "magenta" }
 "function.builtin" = { fg = "blue", modifiers = ["bold"] }
 "function.special" = { fg = "magenta" }
-"comment" = { fg = "base01", modifiers = ["italic"] }
-"string" = { fg= "base1" }
-"constant" = { fg = "base1" }
-"constant.character" = { fg = "base1" }
-"constant.builtin" = { fg = "base1", modifiers = ["bold"] }
-"constant.numeric" = { fg= "base1" }
-"constant.numeric.integer" = { fg= "base1" }
-"constant.numeric.float" = { fg= "base1" }
+"comment" = { fg = "base01" }
+"string" = { fg = "cyan" }
+"constant" = { fg = "cyan" }
+"constant.builtin" = { fg = "cyan", modifiers = ["bold"] }
 "constant.character.escape" = { fg = "red", modifiers = ["bold"] }
 "label" = { fg = "green" }
 "module" = { fg = "violet" }
@@ -79,7 +69,6 @@
 # 当前光标匹配的标点符号
 "ui.cursor.match" = {modifiers = ["reversed"]}
 
-
 "warning" =  { fg = "orange", modifiers= ["bold", "underlined"] }
 "error" = { fg = "red", modifiers= ["bold", "underlined"] }
 "info" = { fg = "blue", modifiers= ["bold", "underlined"] }
@@ -87,23 +76,22 @@
 "diagnostic" = { mdifiers = ["underlined"] }
 
 [palette]
-red     	= '#dc322f'
-green   	= '#859900'
-yellow  	= '#b58900'
-blue    	= '#268bd2'
-magenta 	= '#d33682'
-cyan    	= '#2aa198'
-orange  	= '#cb4b16'
-violet  	= '#6c71c4'
-
 # 深色 越来越深
-base0   	= '#839496'
-base1   	= '#93a1a1'
-base2   	= '#eee8d5'
-base3   	= '#fdf6e3'
+base03  = "#002b36"
+base02  = "#073642"
+base01  = "#586e75"
+base00  = "#657b83"
+base0   = "#839496"
+base1   = "#93a1a1"
+base2   = "#eee8d5"
+base3   = "#fdf6e3"
 
-## 浅色 越來越浅
-base00  	= '#657b63'
-base01  	= '#586e75'
-base02  	= '#073642'
-base03  	= '#002b36'
+# 浅色 越來越浅
+yellow  = "#b58900"
+orange  = "#cb4b16"
+red     = "#dc322f"
+magenta = "#d33682"
+violet  = "#6c71c4"
+blue    = "#268bd2"
+cyan    = "#2aa198"
+green   = "#859900"

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -2,15 +2,9 @@
 "keyword" = { fg = "green" }
 "keyword.directive" = { fg = "orange" }
 "namespace" = { fg = "violet" }
-"punctuation" = { fg = "orange" }
-"punctuation.delimiter" = { fg = "orange" }
 "operator" = { fg = "green" }
 "special" = { fg = "orange" }
-# "property" = { fg = "cyan" }
-"variable" = { fg = "cyan" }
-"variable.parameter" = { fg = "cyan" }
 "variable.builtin" = { fg = "cyan", modifiers = ["bold"] }
-"variable.other.member" = { fg = "cyan" }
 "variable.function" = { fg = "blue" }
 "type" = { fg = "yellow" }
 "type.builtin" = { fg = "yellow", modifiers = ["bold"] }
@@ -19,14 +13,10 @@
 "function.macro" = { fg = "magenta" }
 "function.builtin" = { fg = "blue", modifiers = ["bold"] }
 "function.special" = { fg = "magenta" }
-"comment" = { fg = "base01", modifiers = ["italic"] }
-"string" = { fg= "base1" }
-"constant" = { fg = "base1" }
-"constant.character" = { fg = "base1" }
-"constant.builtin" = { fg = "base1", modifiers = ["bold"] }
-"constant.numeric" = { fg= "base1" }
-"constant.numeric.integer" = { fg= "base1" }
-"constant.numeric.float" = { fg= "base1" }
+"comment" = { fg = "base01" }
+"string" = { fg = "cyan" }
+"constant" = { fg = "cyan" }
+"constant.builtin" = { fg = "cyan", modifiers = ["bold"] }
 "constant.character.escape" = { fg = "red", modifiers = ["bold"] }
 "label" = { fg = "green" }
 "module" = { fg = "violet" }
@@ -78,7 +68,6 @@
 "ui.cursor.insert" = {fg = "base03", bg = "base3"}
 # 当前光标匹配的标点符号
 "ui.cursor.match" = {modifiers = ["reversed"]}
-
 
 "warning" =  { fg = "orange", modifiers= ["bold", "underlined"] }
 "error" = { fg = "red", modifiers= ["bold", "underlined"] }


### PR DESCRIPTION
Hi, I began work on a Solarized Dark theme based on the existing Solarized Light theme, and then found out that one had already been merged (this repo is moving very fast!). However, I think the current theme highlights a bit too much. It also did some weird stuff like colors string literals white. After studying the vim solarized theme that was developed by the original author of the theme, I made some adjustments to more closely match the vim theme. Here are some screenshots for comparison:

### current 

![current-01](https://user-images.githubusercontent.com/846275/141825594-007f45f9-6873-43c7-a299-cf14f0673d97.png)

### with changes

![with-pr-01](https://user-images.githubusercontent.com/846275/141829024-20035aaf-032d-47c2-be18-d2e5bc0a75c4.png)

### vim

![vim-01](https://user-images.githubusercontent.com/846275/141829044-b9e675d8-5740-4cb8-acce-6965c70331ca.png)

### current

![current-02](https://user-images.githubusercontent.com/846275/141829109-caee7781-91c2-405d-8f08-f7963e606c05.png)

### with changes

![with-pr-02](https://user-images.githubusercontent.com/846275/141829150-e1e45c41-659d-4182-b709-a936fff30f82.png)

### vim

![vim-02](https://user-images.githubusercontent.com/846275/141829183-e7328925-5cbe-49f6-9c73-74dbf553aad0.png)

### current

![current-03](https://user-images.githubusercontent.com/846275/141829201-ac326d0e-ec9a-4397-8bb9-32300b3aea93.png)

### with changes

![with-pr-03](https://user-images.githubusercontent.com/846275/141829230-1fc719c3-6ea3-4c0c-94a5-a9f5eeb50e9f.png)

### vim

![vim-03](https://user-images.githubusercontent.com/846275/141829264-7c36b4c2-0492-461c-bf4c-9b229d86a1ee.png)

And here are the light theme changes:

![light-01](https://user-images.githubusercontent.com/846275/141829716-03af05e8-29f7-4d40-8bb3-7a471532a8ac.png)

![light-02](https://user-images.githubusercontent.com/846275/141829721-c2c534ca-eca0-490f-9ec8-38193f6853f2.png)

![light-03](https://user-images.githubusercontent.com/846275/141829725-eb15d0ae-b12e-404b-bbc9-71406dcd1fb6.png)

