### PR TITLE
improve nord theme status bar line

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -10,11 +10,11 @@
 # Polar Night
 # nord0 - background color
 "ui.background" = { bg = "nord0" }
-"ui.statusline.inactive" = { fg = "nord4", bg = "nord0" }
+"ui.statusline.inactive" = { fg = "nord8", bg = "nord1" }
 
 
 # nord1 - status bars, panels, modals, autocompletion
-"ui.statusline" = { fg = "nord8", bg = "nord1" }
+"ui.statusline" = { fg = "nord4", bg = "#4c566a" }
 "ui.popup" = { bg = "#232d38" }
 "ui.window" = { bg = "#232d38" }
 "ui.help" = { bg = "#232d38", fg = "nord4" }
@@ -25,7 +25,7 @@
 
 # nord3 - comments, nord3 based lighter color
 # relative: https://github.com/arcticicestudio/nord/issues/94
-"comment" = "gray"
+"comment" = { fg = "gray", modifiers = ["italic"] }
 "ui.linenr" = { fg = "gray" }
 
 # Snow Storm


### PR DESCRIPTION
Before:
![nord before](https://user-images.githubusercontent.com/22256154/141952654-4ccc951d-0f09-4ea8-bd36-5735e009debc.png)

After
![nord after](https://user-images.githubusercontent.com/22256154/141952659-5954db32-8478-4208-acca-c6de30446890.png)

New color borrow from:
https://github.com/arcticicestudio/nord-jetbrains/blob/430eed72fa2d94e60a609a0a9d396aa4b3e9d0d1/src/nord.theme.json#L314

Also using italic font for comment, Err... just based on my personal habit....