### PR TITLE
Jump to end char of surrounding pair from any cursor pos

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -1,3 +1,5 @@
+use tree_sitter::Node;
+
 use crate::{Rope, Syntax};
 
 const PAIRS: &[(char, char)] = &[
@@ -10,54 +12,83 @@ const PAIRS: &[(char, char)] = &[
 ];
 // limit matching pairs to only ( ) { } [ ] < >
 
+// Returns the position of the matching bracket under cursor.
+//
+// If the cursor is one the opening bracket, the position of
+// the closing bracket is returned. If the cursor in the closing
+// bracket, the position of the opening bracket is returned.
+//
+// If the cursor is not on a bracket, `None` is returned.
 #[must_use]
-pub fn find(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
+pub fn find_matching_bracket(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
     let tree = syntax.tree();
-
     let byte_pos = doc.char_to_byte(pos);
 
-    // a little less naive implementation: find the innermost syntax node at
-    // the given byte position. Traverse up the syntax tree until we reach the
-    // first node with surrounding pairs.
+    let node = match tree
+        .root_node()
+        .named_descendant_for_byte_range(byte_pos, byte_pos)
+    {
+        Some(node) if !node.is_error() => node,
+        _ => return None,
+    };
+
+    let (start_byte, end_byte) = surrounding_bytes(&doc, &node)?;
+    let (start_char, end_char) = (doc.byte_to_char(start_byte), doc.byte_to_char(end_byte));
+
+    if is_valid_pair(&doc, start_char, end_char) {
+        if start_byte == byte_pos {
+            return Some(end_char);
+        }
+        if end_byte == byte_pos {
+            return Some(start_char);
+        }
+    }
+
+    None
+}
+
+// Returns the position of the bracket that is closing the current scope.
+//
+// If the cursor is on an opening or closing bracket, the function
+// behaves equivalent to [`find_matching_bracket`].
+//
+// If the cursor position is within a scope, the function searches
+// for the surrounding scope that is surrounded by brackets and
+// returns the position of the closing bracket for that scope.
+//
+// If no surrounding scope is found, the function returns `None`.
+#[must_use]
+pub fn find_matching_bracket_fuzzy(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
+    let tree = syntax.tree();
+    let byte_pos = doc.char_to_byte(pos);
 
     let mut cursor = tree.walk();
     let mut node = None;
 
-    while let Some(_) = cursor.goto_first_child_for_byte(byte_pos) {
-        if cursor.node().is_named() {
+    // Walk the tree until we find the node for the given byte position.
+    while cursor.goto_first_child_for_byte(byte_pos).is_some() {
+        if cursor.node().is_named() && !cursor.node().is_error() {
             node = Some(cursor.node());
         }
     }
 
     let mut node = node?;
 
-    if node.is_error() {
-        return None;
-    }
-
-    let len = doc.len_bytes();
-
-    // Travere the tree upwards to find first node with enclosing brackets.
+    // Travere the tree upwards to find first node with surrounding brackets.
     loop {
-        let start_byte = node.start_byte();
-        let end_byte = node.end_byte().saturating_sub(1); // it's end exclusive
+        let (start_byte, end_byte) = surrounding_bytes(&doc, &node)?;
+        let (start_char, end_char) = (doc.byte_to_char(start_byte), doc.byte_to_char(end_byte));
 
-        if start_byte >= len || end_byte >= len {
-            return None;
-        }
-
-        let start_char = doc.byte_to_char(start_byte);
-        let end_char = doc.byte_to_char(end_byte);
-
-        if PAIRS.contains(&(doc.char(start_char), doc.char(end_char))) {
+        if is_valid_pair(&doc, start_char, end_char) {
             if start_byte == byte_pos {
                 return Some(end_char);
             }
-
             if end_byte == byte_pos {
                 return Some(start_char);
             }
-
+            // We found a surrounding node, but the cursor
+            // is within the scope of that node. Hence, we
+            // return the closing bracket.
             return Some(end_char);
         }
 
@@ -67,4 +98,21 @@ pub fn find(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
             return None;
         }
     }
+}
+
+fn is_valid_pair(doc: &Rope, start_char: usize, end_char: usize) -> bool {
+    PAIRS.contains(&(doc.char(start_char), doc.char(end_char)))
+}
+
+fn surrounding_bytes(doc: &Rope, node: &Node) -> Option<(usize, usize)> {
+    let len = doc.len_bytes();
+
+    let start_byte = node.start_byte();
+    let end_byte = node.end_byte().saturating_sub(1);
+
+    if start_byte >= len || end_byte >= len {
+        return None;
+    }
+
+    Some((start_byte, end_byte))
 }

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -23,19 +23,6 @@ const PAIRS: &[(char, char)] = &[
     (DOUBLE_QUOTE, DOUBLE_QUOTE),
 ];
 
-const VALID_CHARS: &[char] = &[
-    O_PAREN,
-    C_PAREN,
-    O_CURLY,
-    C_CURLY,
-    O_BRCKT,
-    C_BRCKT,
-    O_ANGLE,
-    C_ANGLE,
-    SINGLE_QUOTE,
-    DOUBLE_QUOTE,
-];
-
 // limit matching pairs to only ( ) { } [ ] < >
 
 // Returns the position of the matching bracket under cursor.
@@ -49,7 +36,7 @@ const VALID_CHARS: &[char] = &[
 pub fn find_matching_bracket(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
     let tree = syntax.tree();
 
-    if pos >= doc.len_chars() || !VALID_CHARS.contains(&doc.char(pos)) {
+    if pos >= doc.len_chars() || !is_valid_bracket(doc.char(pos)) {
         return None;
     }
 
@@ -129,6 +116,10 @@ pub fn find_matching_bracket_fuzzy(syntax: &Syntax, doc: &Rope, pos: usize) -> O
             return None;
         }
     }
+}
+
+fn is_valid_bracket(c: char) -> bool {
+    PAIRS.iter().any(|(l, r)| *l == c || *r == c)
 }
 
 fn is_valid_pair(doc: &Rope, start_char: usize, end_char: usize) -> bool {

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -23,6 +23,19 @@ const PAIRS: &[(char, char)] = &[
     (DOUBLE_QUOTE, DOUBLE_QUOTE),
 ];
 
+const VALID_CHARS: &[char] = &[
+    O_PAREN,
+    C_PAREN,
+    O_CURLY,
+    C_CURLY,
+    O_BRCKT,
+    C_BRCKT,
+    O_ANGLE,
+    C_ANGLE,
+    SINGLE_QUOTE,
+    DOUBLE_QUOTE,
+];
+
 // limit matching pairs to only ( ) { } [ ] < >
 
 // Returns the position of the matching bracket under cursor.
@@ -35,6 +48,11 @@ const PAIRS: &[(char, char)] = &[
 #[must_use]
 pub fn find_matching_bracket(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
     let tree = syntax.tree();
+
+    if pos >= doc.len_chars() || !VALID_CHARS.contains(&doc.char(pos)) {
+        return None;
+    }
+
     let byte_pos = doc.char_to_byte(pos);
 
     let node = match tree

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -16,40 +16,55 @@ pub fn find(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
 
     let byte_pos = doc.char_to_byte(pos);
 
-    // most naive implementation: find the innermost syntax node, if we're at the edge of a node,
-    // return the other edge.
+    // a little less naive implementation: find the innermost syntax node at
+    // the given byte position. Traverse up the syntax tree until we reach the
+    // first node with surrounding pairs.
 
-    let node = match tree
-        .root_node()
-        .named_descendant_for_byte_range(byte_pos, byte_pos)
-    {
-        Some(node) => node,
-        None => return None,
-    };
+    let mut cursor = tree.walk();
+    let mut node = None;
+
+    while let Some(_) = cursor.goto_first_child_for_byte(byte_pos) {
+        if cursor.node().is_named() {
+            node = Some(cursor.node());
+        }
+    }
+
+    let mut node = node?;
 
     if node.is_error() {
         return None;
     }
 
     let len = doc.len_bytes();
-    let start_byte = node.start_byte();
-    let end_byte = node.end_byte().saturating_sub(1); // it's end exclusive
-    if start_byte >= len || end_byte >= len {
-        return None;
-    }
 
-    let start_char = doc.byte_to_char(start_byte);
-    let end_char = doc.byte_to_char(end_byte);
+    // Travere the tree upwards to find first node with enclosing brackets.
+    loop {
+        let start_byte = node.start_byte();
+        let end_byte = node.end_byte().saturating_sub(1); // it's end exclusive
 
-    if PAIRS.contains(&(doc.char(start_char), doc.char(end_char))) {
-        if start_byte == byte_pos {
+        if start_byte >= len || end_byte >= len {
+            return None;
+        }
+
+        let start_char = doc.byte_to_char(start_byte);
+        let end_char = doc.byte_to_char(end_byte);
+
+        if PAIRS.contains(&(doc.char(start_char), doc.char(end_char))) {
+            if start_byte == byte_pos {
+                return Some(end_char);
+            }
+
+            if end_byte == byte_pos {
+                return Some(start_char);
+            }
+
             return Some(end_char);
         }
 
-        if end_byte == byte_pos {
-            return Some(start_char);
+        if cursor.goto_parent() {
+            node = cursor.node();
+        } else {
+            return None;
         }
     }
-
-    None
 }

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -2,14 +2,27 @@ use tree_sitter::Node;
 
 use crate::{Rope, Syntax};
 
+const O_PAREN: char = '(';
+const C_PAREN: char = ')';
+const O_CURLY: char = '{';
+const C_CURLY: char = '}';
+const O_BRCKT: char = '[';
+const C_BRCKT: char = ']';
+const O_ANGLE: char = '<';
+const C_ANGLE: char = '>';
+
+const SINGLE_QUOTE: char = '\'';
+const DOUBLE_QUOTE: char = '\"';
+
 const PAIRS: &[(char, char)] = &[
-    ('(', ')'),
-    ('{', '}'),
-    ('[', ']'),
-    ('<', '>'),
-    ('\'', '\''),
-    ('"', '"'),
+    (O_PAREN, C_PAREN),
+    (O_CURLY, C_CURLY),
+    (O_BRCKT, C_BRCKT),
+    (O_ANGLE, C_ANGLE),
+    (SINGLE_QUOTE, SINGLE_QUOTE),
+    (DOUBLE_QUOTE, DOUBLE_QUOTE),
 ];
+
 // limit matching pairs to only ( ) { } [ ] < >
 
 // Returns the position of the matching bracket under cursor.

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -2,25 +2,13 @@ use tree_sitter::Node;
 
 use crate::{Rope, Syntax};
 
-const O_PAREN: char = '(';
-const C_PAREN: char = ')';
-const O_CURLY: char = '{';
-const C_CURLY: char = '}';
-const O_BRCKT: char = '[';
-const C_BRCKT: char = ']';
-const O_ANGLE: char = '<';
-const C_ANGLE: char = '>';
-
-const SINGLE_QUOTE: char = '\'';
-const DOUBLE_QUOTE: char = '\"';
-
 const PAIRS: &[(char, char)] = &[
-    (O_PAREN, C_PAREN),
-    (O_CURLY, C_CURLY),
-    (O_BRCKT, C_BRCKT),
-    (O_ANGLE, C_ANGLE),
-    (SINGLE_QUOTE, SINGLE_QUOTE),
-    (DOUBLE_QUOTE, DOUBLE_QUOTE),
+    ('(', ')'),
+    ('{', '}'),
+    ('[', ']'),
+    ('<', '>'),
+    ('\'', '\''),
+    ('\"', '\"'),
 ];
 
 // limit matching pairs to only ( ) { } [ ] < >

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4909,7 +4909,9 @@ fn match_brackets(cx: &mut Context) {
     if let Some(syntax) = doc.syntax() {
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id).clone().transform(|range| {
-            if let Some(pos) = match_brackets::find(syntax, doc.text(), range.anchor) {
+            if let Some(pos) =
+                match_brackets::find_matching_bracket_fuzzy(syntax, doc.text(), range.anchor)
+            {
                 range.put_cursor(text, pos, doc.mode == Mode::Select)
             } else {
                 range

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -377,7 +377,7 @@ impl EditorView {
             use helix_core::match_brackets;
             let pos = doc.selection(view.id).primary().cursor(text);
 
-            let pos = match_brackets::find(syntax, doc.text(), pos)
+            let pos = match_brackets::find_matching_bracket(syntax, doc.text(), pos)
                 .and_then(|pos| view.screen_coords_at_pos(doc, text, pos));
 
             if let Some(pos) = pos {


### PR DESCRIPTION
This partially solves #1072

The change allows the user to use `mm` from any position between the surrounding pair.
The idea is to traverse the tree until the leaf node for the given cursor position is found.
Once the leaf is found, we traverse the parents until we find the first surrounded parent.

This PR does not solve `m[i,a]m` from an arbitrary cursor position.
