### PR TITLE
Solarized theme: fix popup colors, adjust menu

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -55,7 +55,7 @@ fn parse<'a>(
     fn to_span(text: pulldown_cmark::CowStr) -> Span {
         use std::ops::Deref;
         Span::raw::<std::borrow::Cow<_>>(match text {
-            CowStr::Borrowed(s) => s.to_string().into(), // could retain borrow
+            CowStr::Borrowed(s) => s.into(),
             CowStr::Boxed(s) => s.to_string().into(),
             CowStr::Inlined(s) => s.deref().to_owned().into(),
         })
@@ -179,7 +179,9 @@ fn parse<'a>(
                 spans.push(Span::raw(" "));
             }
             Event::Rule => {
-                lines.push(Spans::from("---"));
+                let mut span = Span::raw("---");
+                span.style = code_style;
+                lines.push(Spans::from(span));
                 lines.push(Spans::default());
             }
             // TaskListMarker(bool) true if checked

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -28,18 +28,18 @@
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }
 # 当前行号栏
-"ui.linenr.selected" = { fg = "red", modifiers = ["bold"] }
+"ui.linenr.selected" = { fg = "blue", modifiers = ["bold"] }
 
 # 状态栏
-"ui.statusline" = { fg = "base02", bg = "base1" }
+"ui.statusline" = { fg = "base03", bg = "base0" }
 # 非活动状态栏
-"ui.statusline.inactive" = { fg = "base02", bg = "base00" }
+"ui.statusline.inactive" = { fg = "base1", bg = "base01" }
 
 # 补全窗口, preview窗口
-"ui.popup" = { bg = "base1" }
+"ui.popup" = { bg = "base02" }
 # 影响 补全选中 cmd弹出信息选中
-"ui.menu.selected" = { fg = "base02", bg = "violet"}
-"ui.menu" = { fg = "base02" }
+"ui.menu.selected" = { fg = "base02", bg = "base2"}
+"ui.menu" = { fg = "base1" }
 # ??
 "ui.window" = { fg = "base3" }
 # 命令行 补全的帮助信息

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -28,18 +28,18 @@
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }
 # 当前行号栏
-"ui.linenr.selected" = { fg = "red", modifiers = ["bold"] }
+"ui.linenr.selected" = { fg = "blue", modifiers = ["bold"] }
 
 # 状态栏
-"ui.statusline" = { fg = "base02", bg = "base1" }
+"ui.statusline" = { fg = "base03", bg = "base0" }
 # 非活动状态栏
-"ui.statusline.inactive" = { fg = "base02", bg = "base00" }
+"ui.statusline.inactive" = { fg = "base1", bg = "base01" }
 
 # 补全窗口, preview窗口
-"ui.popup" = { bg = "base1" }
+"ui.popup" = { bg = "base02" }
 # 影响 补全选中 cmd弹出信息选中
-"ui.menu.selected" = { fg = "base02", bg = "violet"}
-"ui.menu" = { fg = "base02" }
+"ui.menu.selected" = { fg = "base02", bg = "base2"}
+"ui.menu" = { fg = "base1" }
 # ??
 "ui.window" = { fg = "base3" }
 # 命令行 补全的帮助信息


### PR DESCRIPTION
Add mentioned by @rypervenche in [this comment](https://github.com/helix-editor/helix/pull/1105#issuecomment-971723023), the pop-up colors don't work well in the dark theme, and aren't great in the light theme either. I fixed the dark theme here. Apologies for the screenshots, I did this on my phone because I don't have my laptop with me at the moment.

![Screenshot_20211117-224820](https://user-images.githubusercontent.com/846275/142349389-8aade5f0-fc19-4725-95df-4a256af28f76.jpg)

And I also changed the foreground color in the menu to the base color.

![Screenshot_20211117-224839](https://user-images.githubusercontent.com/846275/142349465-b27dc6d2-f8c1-49ae-9798-cb7365cb704b.jpg)

I tried using the same colors in the light theme, but that did not work very well, as most of the text is violet or white, which doesn't contrast enough with the light background.

![Screenshot_20211117-225512](https://user-images.githubusercontent.com/846275/142349694-f07184bd-aa44-4316-b45c-ab024c1d93b8.jpg)

I wasn't able to find a good background color at all that worked with the theme of the docs content, and I'm not even sure what that theme is, whether it's markdown or something special. So instead, I opted to just use a dark background for popups. If anyone can find a better combo here, feel free to suggest it.

![Screenshot_20211117-224726](https://user-images.githubusercontent.com/846275/142349866-d886411a-6795-4f1e-bd42-4b25558bf9ff.jpg)

![Screenshot_20211117-224901](https://user-images.githubusercontent.com/846275/142349987-83295f99-f72d-44b4-a8d7-58e24a6b47f5.jpg)
