### PR TITLE
Add `:<line>` and `:goto <line>` commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2758,7 +2758,7 @@ mod cmd {
             completer: None,
         },
         TypableCommand {
-            name: "goto",
+            name: cmd::GOTO_CMD,
             aliases: &["g"],
             doc: "Go to line number.",
             fun: goto_line_number,
@@ -2775,6 +2775,8 @@ mod cmd {
             })
             .collect()
     });
+
+    pub(super) const GOTO_CMD: &str = "goto";
 }
 
 fn command_mode(cx: &mut Context) {
@@ -2821,11 +2823,17 @@ fn command_mode(cx: &mut Context) {
                 return;
             }
 
-            let parts = input.split_whitespace().collect::<Vec<&str>>();
+            let mut parts = input.split_whitespace().collect::<Vec<&str>>();
             if parts.is_empty() {
                 return;
             }
 
+            // If command is numeric, insert goto command.
+            if parts.len() == 1 && parts[0].parse::<usize>().ok().is_some() {
+                parts.insert(0, cmd::GOTO_CMD);
+            }
+
+            // Handle typable commands
             if let Some(cmd) = cmd::COMMANDS.get(parts[0]) {
                 if let Err(e) = (cmd.fun)(cx, &parts[1..], event) {
                     cx.editor.set_error(format!("{}", e));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2467,7 +2467,7 @@ mod cmd {
     ) -> anyhow::Result<()> {
         let line = args[0].parse::<usize>()?;
 
-        goto_line_internal(&mut cx.editor, NonZeroUsize::new(line));
+        goto_line_impl(&mut cx.editor, NonZeroUsize::new(line));
 
         let (view, doc) = current!(cx.editor);
 
@@ -3467,10 +3467,10 @@ fn push_jump(editor: &mut Editor) {
 }
 
 fn goto_line(cx: &mut Context) {
-    goto_line_internal(&mut cx.editor, cx.count)
+    goto_line_impl(&mut cx.editor, cx.count)
 }
 
-fn goto_line_internal(editor: &mut Editor, count: Option<NonZeroUsize>) {
+fn goto_line_impl(editor: &mut Editor, count: Option<NonZeroUsize>) {
     if let Some(count) = count {
         push_jump(editor);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2460,7 +2460,7 @@ mod cmd {
         Ok(())
     }
 
-    fn goto_line_number(
+    pub(super) fn goto_line_number(
         cx: &mut compositor::Context,
         args: &[&str],
         _event: PromptEvent,
@@ -2758,7 +2758,7 @@ mod cmd {
             completer: None,
         },
         TypableCommand {
-            name: cmd::GOTO_CMD,
+            name: "goto",
             aliases: &["g"],
             doc: "Go to line number.",
             fun: goto_line_number,
@@ -2775,8 +2775,6 @@ mod cmd {
             })
             .collect()
     });
-
-    pub(super) const GOTO_CMD: &str = "goto";
 }
 
 fn command_mode(cx: &mut Context) {
@@ -2823,14 +2821,17 @@ fn command_mode(cx: &mut Context) {
                 return;
             }
 
-            let mut parts = input.split_whitespace().collect::<Vec<&str>>();
+            let parts = input.split_whitespace().collect::<Vec<&str>>();
             if parts.is_empty() {
                 return;
             }
 
-            // If command is numeric, insert goto command.
+            // If command is numeric, interpret as line number and go there.
             if parts.len() == 1 && parts[0].parse::<usize>().ok().is_some() {
-                parts.insert(0, cmd::GOTO_CMD);
+                if let Err(e) = cmd::goto_line_number(cx, &parts[0..], event) {
+                    cx.editor.set_error(format!("{}", e));
+                }
+                return;
             }
 
             // Handle typable commands


### PR DESCRIPTION
I thought this might be useful.

Digging through the code, I realized that `<line>gg` also works,
but I thought this is more convenient for *vim users.

