### PR TITLE
Add languages with indentation definitions list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,25 @@ All shortcuts/keymaps can be found [in the documentation on the website](https:/
 It's a terminal-based editor first, but I'd like to explore a custom renderer
 (similar to emacs) in wgpu or skulpin.
 
-Note: Only certain languages have indentation definitions at the moment. Check
-`runtime/queries/<lang>/` for `indents.toml`.
+<details> <summary> Languages with indentation definitons </summary>
+ <ul>
+  <li> glsl </li>
+  <li> go </li>
+  <li> javascript </li>
+  <li> json </li>
+  <li> lua </li>
+  <li> nix </li>
+  <li> ocaml </li>
+  <li> php </li>
+  <li> protobuf </li>
+  <li> python </li>
+  <li> rust </li>
+  <li> svelte </li>
+  <li> typescript </li>
+  <li> yaml </li>
+  <li> zig </li>
+ </ul>
+</details>
 
 # Installation
 


### PR DESCRIPTION
This adds a `<details>` pane in the README for languages with indent definitions.

I thought it would be time-taking to go till `runtime/queries/<lang>` and search for `indents.toml` in the specific language. 
So, I made this pane in the README which will show all the languages with current indent definitions.

Here is a video of the same:

https://user-images.githubusercontent.com/82087036/142648280-6e4cd601-3f0d-40c0-a7a5-6909c06b11c5.mp4
