### PR TITLE
Add link to Keymap page in book.

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -54,4 +54,4 @@ Control, Shift and Alt modifiers are encoded respectively with the prefixes
 Keys can be disabled by binding them to the `no_op` command.
 
 Commands can be found at [Keymap](https://docs.helix-editor.com/keymap.html) Commands.(Right pane)
-> Commands can also be found in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs#L178)
+> Commands can also be found in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs) at the invocation of `commands!` macro.

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -53,4 +53,5 @@ Control, Shift and Alt modifiers are encoded respectively with the prefixes
 
 Keys can be disabled by binding them to the `no_op` command.
 
-Commands can be found in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs)
+Commands can be found at [Keymap](https://docs.helix-editor.com/keymap.html) Commands.(Right pane)
+> Commands can also be found in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs#L178)

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -53,5 +53,5 @@ Control, Shift and Alt modifiers are encoded respectively with the prefixes
 
 Keys can be disabled by binding them to the `no_op` command.
 
-Commands can be found at [Keymap](https://docs.helix-editor.com/keymap.html) Commands.(Right pane)
+Commands can be found at [Keymap](https://docs.helix-editor.com/keymap.html) Commands.
 > Commands can also be found in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs) at the invocation of `commands!` macro.


### PR DESCRIPTION
This updates the remapping page to open the Keymap page of book, rather than the commands file.

I have also updated the original link to open at line #L178(opens at the invocation of `commands!` macro)