### PR TITLE
restore indent when press esc right after open a new line, make kill_to_line_end behave like emacs

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -602,7 +602,7 @@ fn kill_to_line_end(cx: &mut Context) {
         let pos = range.cursor(text);
 
         let mut new_range = range.put_cursor(text, line_end_pos, true);
-        // don't want to remove the line itself if the cursor doesn't reach the end of line.
+        // don't want to remove the line separator itself if the cursor doesn't reach the end of line.
         if pos != line_end_pos {
             new_range.head = line_end_pos;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -602,7 +602,7 @@ fn kill_to_line_end(cx: &mut Context) {
         let pos = range.cursor(text);
 
         let mut new_range = range.put_cursor(text, line_end_pos, true);
-        // don't want to remove the line itself if the cursor doesn't at the end of line.
+        // don't want to remove the line itself if the cursor doesn't reach the end of line.
         if pos != line_end_pos {
             new_range.head = line_end_pos;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -598,8 +598,15 @@ fn kill_to_line_end(cx: &mut Context) {
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         let line = range.cursor_line(text);
-        let pos = line_end_char_index(&text, line);
-        range.put_cursor(text, pos, true)
+        let line_end_pos = line_end_char_index(&text, line);
+        let pos = range.cursor(text);
+
+        let mut new_range = range.put_cursor(text, line_end_pos, true);
+        // don't want to remove the line itself if the cursor doesn't at the end of line.
+        if pos != line_end_pos {
+            new_range.head = line_end_pos;
+        }
+        new_range
     });
     delete_selection_insert_mode(doc, view, &selection);
 }
@@ -3358,6 +3365,7 @@ fn normal_mode(cx: &mut Context) {
     }
 
     if doc.restore_indent {
+        doc.restore_indent = false;
         goto_line_start(cx);
         kill_to_line_end(cx);
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3319,6 +3319,7 @@ fn open(cx: &mut Context, open: Open) {
     transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
 
     doc.apply(&transaction, view.id);
+    doc.restore_indent = true;
 }
 
 // o inserts a new line after each line with a selection
@@ -3354,6 +3355,11 @@ fn normal_mode(cx: &mut Context) {
         doc.set_selection(view.id, selection);
 
         doc.restore_cursor = false;
+    }
+
+    if doc.restore_indent {
+        goto_line_start(cx);
+        kill_to_line_end(cx);
     }
 }
 
@@ -3937,6 +3943,7 @@ pub mod insert {
             }
         }
 
+        doc.restore_indent = false;
         // TODO: need a post insert hook too for certain triggers (autocomplete, signature help, etc)
         // this could also generically look at Transaction, but it's a bit annoying to look at
         // Operation instead of Change.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,6 +79,7 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+    pub restore_indent: bool,
 
     /// Current indent style.
     pub indent_style: IndentStyle,
@@ -335,6 +336,7 @@ impl Document {
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
             restore_cursor: false,
+            restore_indent: false,
             syntax: None,
             language: None,
             changes,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,6 +79,7 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+    /// Controls if going to normal mode, the previous open-line indent can be restore.
     pub restore_indent: bool,
 
     /// Current indent style.


### PR DESCRIPTION
1. Handle for the remaining part of #1046, and
2. make `kill_to_line_end` behave like emacs.  I found it's easiler to use for me..  And it helps resolving the issue.

Reference to emacs `kill_to_line_end` behavior (https://home.cs.colorado.edu/~main/cs1300-old/cs1300/doc/emacs/emacs_14.html):
>  C-k kills from point up to the end of the line, unless it is at the end of a line. In that case it kills the newline following point, thus merging the next line into the current one.