### PR TITLE
Do not crash when run goto command without line number

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2485,7 +2485,7 @@ mod cmd {
         args: &[&str],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        if args.len() == 0 {
+        if args.is_empty() {
             bail!("Line number required");
         }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2485,6 +2485,10 @@ mod cmd {
         args: &[&str],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
+        if args.len() == 0 {
+            bail!("Line number required");
+        }
+
         let line = args[0].parse::<usize>()?;
 
         goto_line_impl(&mut cx.editor, NonZeroUsize::new(line));


### PR DESCRIPTION
Report an error when running goto command without entering a
line number.

Fixes #1159 