### PR TITLE
Add language support for WGSL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,7 @@
 	path = helix-syntax/languages/tree-sitter-perl
 	url = https://github.com/ganezdragon/tree-sitter-perl
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-wgsl"]
+	path = helix-syntax/languages/tree-sitter-wgsl
+	url = https://github.com/szebniok/tree-sitter-wgsl
+	shallow = true

--- a/languages.toml
+++ b/languages.toml
@@ -405,3 +405,11 @@ file-types = ["rkt"]
 shebangs = ["racket"]
 comment-token = ";"
 language-server = { command = "racket", args = ["-l", "racket-langserver"] }
+
+[[language]]
+name = "wgsl"
+scope = "source.wgsl"
+file-types = ["wgsl"]
+roots = []
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -1,0 +1,102 @@
+(const_literal) @constant.numeric
+
+(type_declaration) @type
+
+(function_declaration
+    (identifier) @function)
+
+(struct_declaration
+    (identifier) @type)
+
+(type_constructor_or_function_call_expression
+    (type_declaration) @function)
+
+(parameter
+    (variable_identifier_declaration (identifier) @variable.parameter))
+
+[
+    "struct"
+    "bitcast"
+    ; "block"
+    "discard"
+    "enable"
+    "fallthrough"
+    "fn"
+    "let"
+    "private"
+    "read"
+    "read_write"
+    "return"
+    "storage"
+    "type"
+    "uniform"
+    "var"
+    "workgroup"
+    "write"
+    (texel_format)
+] @keyword ; TODO reserved keywords
+
+[
+    (true)
+    (false)
+] @constant.builtin.boolean
+
+[ "," "." ":" ";" ] @punctuation.delimiter
+
+;; brackets
+[
+    "("
+    ")"
+    "["
+    "]"
+    "{"
+    "}"
+] @punctuation.bracket
+
+[
+    "loop"
+    "for"
+    "break"
+    "continue"
+    "continuing"
+] @keyword.control.repeat
+
+[
+    "if"
+    "else"
+    "elseif"
+    "switch"
+    "case"
+    "default"
+] @keyword.control.conditional
+
+[
+    "&"
+    "&&"
+    "/"
+    "!"
+    "="
+    "=="
+    "!="
+    ">"
+    ">="
+    ">>"
+    "<"
+    "<="
+    "<<"
+    "%"
+    "-"
+    "+"
+    "|"
+    "||"
+    "*"
+    "~"
+    "^"
+] @operator
+
+(attribute
+    (identifier) @variable.other.member)
+
+(comment) @comment
+
+(ERROR) @error


### PR DESCRIPTION
Tested w/ https://raw.githubusercontent.com/bevyengine/bevy/db3258264a2d2c838640cb5347ea03ec54cd9696/pipelined/bevy_pbr2/src/render/pbr.wgsl
![Capture](https://user-images.githubusercontent.com/67773714/143488545-8bf10c43-68fb-41e9-8bf9-3f6c813d1c10.PNG)

Not totally accurate, but it should work well enough (note that line 36 is incorrectly highlighted as `@error`).