### PR TITLE
Improve Dedent behavior, make kill_to_line_end behaves like emacs

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -603,8 +603,15 @@ fn kill_to_line_end(cx: &mut Context) {
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         let line = range.cursor_line(text);
-        let pos = line_end_char_index(&text, line);
-        range.put_cursor(text, pos, true)
+        let line_end_pos = line_end_char_index(&text, line);
+        let pos = range.cursor(text);
+
+        let mut new_range = range.put_cursor(text, line_end_pos, true);
+        // don't want to remove the line itself if the cursor doesn't at the end of line.
+        if pos != line_end_pos {
+            new_range.head = line_end_pos;
+        }
+        new_range
     });
     delete_selection_insert_mode(doc, view, &selection);
 }
@@ -3539,6 +3546,7 @@ fn normal_mode(cx: &mut Context) {
     }
 
     if doc.restore_indent {
+        doc.restore_indent = false;
         goto_line_start(cx);
         kill_to_line_end(cx);
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -134,7 +134,6 @@ fn align_view(doc: &Document, view: &mut View, align: Align) {
     view.offset.row = line.saturating_sub(relative);
 }
 
-pub type CommandFun = fn(&mut Context);
 /// A command is composed of a static name, and a function that takes the current state plus a count,
 /// and does a side-effect on the state (usually by creating and applying a transaction).
 #[derive(Copy, Clone)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -134,6 +134,7 @@ fn align_view(doc: &Document, view: &mut View, align: Align) {
     view.offset.row = line.saturating_sub(relative);
 }
 
+pub type CommandFun = fn(&mut Context);
 /// A command is composed of a static name, and a function that takes the current state plus a count,
 /// and does a side-effect on the state (usually by creating and applying a transaction).
 #[derive(Copy, Clone)]
@@ -171,6 +172,10 @@ impl Command {
 
     pub fn doc(&self) -> &'static str {
         self.doc
+    }
+
+    pub fn fun(&self) -> fn(&mut Context) {
+        self.fun
     }
 
     #[rustfmt::skip]
@@ -3510,12 +3515,12 @@ fn open(cx: &mut Context, open: Open) {
 }
 
 // o inserts a new line after each line with a selection
-fn open_below(cx: &mut Context) {
+pub(crate) fn open_below(cx: &mut Context) {
     open(cx, Open::Below)
 }
 
 // O inserts a new line before each line with a selection
-fn open_above(cx: &mut Context) {
+pub(crate) fn open_above(cx: &mut Context) {
     open(cx, Open::Above)
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3507,7 +3507,6 @@ fn open(cx: &mut Context, open: Open) {
     transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
 
     doc.apply(&transaction, view.id);
-    doc.restore_indent = true;
 }
 
 // o inserts a new line after each line with a selection
@@ -3543,12 +3542,6 @@ fn normal_mode(cx: &mut Context) {
         doc.set_selection(view.id, selection);
 
         doc.restore_cursor = false;
-    }
-
-    if doc.restore_indent {
-        doc.restore_indent = false;
-        goto_line_start(cx);
-        kill_to_line_end(cx);
     }
 }
 
@@ -5761,9 +5754,4 @@ fn increment_impl(cx: &mut Context, amount: i64) {
         doc.apply(&transaction, view.id);
         doc.append_changes_to_history(view.id);
     }
-}
-
-pub(crate) fn cancel_restore_indent(cx: &mut Context) {
-    let (_, doc) = current!(cx.editor);
-    doc.restore_indent = false;
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3500,6 +3500,7 @@ fn open(cx: &mut Context, open: Open) {
     transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
 
     doc.apply(&transaction, view.id);
+    doc.restore_indent = true;
 }
 
 // o inserts a new line after each line with a selection
@@ -3535,6 +3536,11 @@ fn normal_mode(cx: &mut Context) {
         doc.set_selection(view.id, selection);
 
         doc.restore_cursor = false;
+    }
+
+    if doc.restore_indent {
+        goto_line_start(cx);
+        kill_to_line_end(cx);
     }
 }
 
@@ -4122,6 +4128,7 @@ pub mod insert {
             }
         }
 
+        doc.restore_indent = false;
         // TODO: need a post insert hook too for certain triggers (autocomplete, signature help, etc)
         // this could also generically look at Transaction, but it's a bit annoying to look at
         // Operation instead of Change.

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -607,7 +607,7 @@ fn kill_to_line_end(cx: &mut Context) {
         let pos = range.cursor(text);
 
         let mut new_range = range.put_cursor(text, line_end_pos, true);
-        // don't want to remove the line itself if the cursor doesn't at the end of line.
+        // don't want to remove the line itself if the cursor doesn't reach the end of line.
         if pos != line_end_pos {
             new_range.head = line_end_pos;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -607,7 +607,7 @@ fn kill_to_line_end(cx: &mut Context) {
         let pos = range.cursor(text);
 
         let mut new_range = range.put_cursor(text, line_end_pos, true);
-        // don't want to remove the line itself if the cursor doesn't reach the end of line.
+        // don't want to remove the line separator itself if the cursor doesn't reach the end of line.
         if pos != line_end_pos {
             new_range.head = line_end_pos;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4136,7 +4136,6 @@ pub mod insert {
             }
         }
 
-        doc.restore_indent = false;
         // TODO: need a post insert hook too for certain triggers (autocomplete, signature help, etc)
         // this could also generically look at Transaction, but it's a bit annoying to look at
         // Operation instead of Change.
@@ -5762,4 +5761,9 @@ fn increment_impl(cx: &mut Context, amount: i64) {
         doc.apply(&transaction, view.id);
         doc.append_changes_to_history(view.id);
     }
+}
+
+pub(crate) fn cancel_restore_indent(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    doc.restore_indent = false;
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -657,6 +657,17 @@ impl EditorView {
         let key_result = self.keymaps.get_mut(&mode).unwrap().get(event);
         self.autoinfo = key_result.sticky.map(|node| node.infobox());
 
+        // `restore_indent` tag may be set by `commands::open`, we need to cancel it
+        // when we are not enter normal_mode command.
+        match &key_result.kind {
+            KeymapResultKind::Matched(command) => {
+                if command.name() != "normal_mode" {
+                    commands::cancel_restore_indent(cxt);
+                }
+            }
+            _ => commands::cancel_restore_indent(cxt),
+        }
+
         match &key_result.kind {
             KeymapResultKind::Matched(command) => command.execute(cxt),
             KeymapResultKind::Pending(node) => self.autoinfo = Some(node.infobox()),

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -657,17 +657,6 @@ impl EditorView {
         let key_result = self.keymaps.get_mut(&mode).unwrap().get(event);
         self.autoinfo = key_result.sticky.map(|node| node.infobox());
 
-        // `restore_indent` tag may be set by `commands::open`, we need to cancel it
-        // when we are not enter normal_mode command.
-        match &key_result.kind {
-            KeymapResultKind::Matched(command) => {
-                if command.name() != "normal_mode" {
-                    commands::cancel_restore_indent(cxt);
-                }
-            }
-            _ => commands::cancel_restore_indent(cxt),
-        }
-
         match &key_result.kind {
             KeymapResultKind::Matched(command) => command.execute(cxt),
             KeymapResultKind::Pending(node) => self.autoinfo = Some(node.infobox()),
@@ -1034,6 +1023,16 @@ impl Component for EditorView {
                     (Mode::Insert, Mode::Normal) => {
                         // if exiting insert mode, remove completion
                         self.completion = None;
+
+                        // For user friendly,
+                        // If we go from insert mode to normal node, and press no extra keys,
+                        // should try to make current line empty(restore pre-inserted indent).
+                        //
+                        // When we press no extra keys to normal mode, the `last_insert.1` just contains one key(ESC).
+                        if self.last_insert.1.len() == 1 {
+                            commands::Command::goto_line_start.execute(&mut cxt);
+                            commands::Command::kill_to_line_end.execute(&mut cxt);
+                        }
                     }
                     _ => (),
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1024,11 +1024,14 @@ impl Component for EditorView {
                         // if exiting insert mode, remove completion
                         self.completion = None;
 
-                        let last_cmd = self.last_insert.0;
+                        let last_cmd = self.last_insert.0.fun();
+                        use commands::CommandFun;
+                        const OPEN_BELOW_FUN: CommandFun = commands::open_below;
+                        const OPEN_ABOVE_FUN: CommandFun = commands::open_above;
                         // For user friendly,
                         // Remove whitespaces if we go from insert mode(through open below/above) to normal mode without any keys in between.
                         // Example: `o<esc>`.
-                        if (last_cmd.name() == "open_below" || last_cmd.name() == "open_above")
+                        if matches!(last_cmd, OPEN_BELOW_FUN | OPEN_ABOVE_FUN)
                             && self.last_insert.1.len() == 1
                         {
                             commands::Command::goto_line_start.execute(&mut cxt);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1026,7 +1026,7 @@ impl Component for EditorView {
 
                         let last_cmd = self.last_insert.0;
                         // For user friendly,
-                        // Remove whitespaces if we go from insert mode to normal mode without any keys in between.
+                        // Remove whitespaces if we go from insert mode(through open below/above) to normal mode without any keys in between.
                         // Example: `o<esc>`.
                         if (last_cmd.name() == "open_below" || last_cmd.name() == "open_above")
                             && self.last_insert.1.len() == 1

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1025,9 +1025,8 @@ impl Component for EditorView {
                         self.completion = None;
 
                         let last_cmd = self.last_insert.0.fun();
-                        use commands::CommandFun;
-                        const OPEN_BELOW_FUN: CommandFun = commands::open_below;
-                        const OPEN_ABOVE_FUN: CommandFun = commands::open_above;
+                        const OPEN_BELOW_FUN: fn(&mut commands::Context) = commands::open_below;
+                        const OPEN_ABOVE_FUN: fn(&mut commands::Context) = commands::open_above;
                         // For user friendly,
                         // Remove whitespaces if we go from insert mode(through open below/above) to normal mode without any keys in between.
                         // Example: `o<esc>`.

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1025,10 +1025,8 @@ impl Component for EditorView {
                         self.completion = None;
 
                         // For user friendly,
-                        // If we go from insert mode to normal node, and press no extra keys,
-                        // should try to make current line empty(restore pre-inserted indent).
-                        //
-                        // When we press no extra keys to normal mode, the `last_insert.1` just contains one key(ESC).
+                        // Remove whitespaces if we go from insert mode to normal mode without any keys in between.
+                        // Example: `o<esc>`.
                         if self.last_insert.1.len() == 1 {
                             commands::Command::goto_line_start.execute(&mut cxt);
                             commands::Command::kill_to_line_end.execute(&mut cxt);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1024,10 +1024,13 @@ impl Component for EditorView {
                         // if exiting insert mode, remove completion
                         self.completion = None;
 
+                        let last_cmd = self.last_insert.0;
                         // For user friendly,
                         // Remove whitespaces if we go from insert mode to normal mode without any keys in between.
                         // Example: `o<esc>`.
-                        if self.last_insert.1.len() == 1 {
+                        if (last_cmd.name() == "open_below" || last_cmd.name() == "open_above")
+                            && self.last_insert.1.len() == 1
+                        {
                             commands::Command::goto_line_start.execute(&mut cxt);
                             commands::Command::kill_to_line_end.execute(&mut cxt);
                         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,6 +79,7 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+    pub restore_indent: bool,
 
     /// Current indent style.
     pub indent_style: IndentStyle,
@@ -335,6 +336,7 @@ impl Document {
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
             restore_cursor: false,
+            restore_indent: false,
             syntax: None,
             language: None,
             changes,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,8 +79,6 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
-    /// Controls if going to normal mode, the previous open-line indent can be restore.
-    pub restore_indent: bool,
 
     /// Current indent style.
     pub indent_style: IndentStyle,
@@ -337,7 +335,6 @@ impl Document {
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
             restore_cursor: false,
-            restore_indent: false,
             syntax: None,
             language: None,
             changes,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,6 +79,7 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+    /// Controls if going to normal mode, the previous open-line indent can be restore.
     pub restore_indent: bool,
 
     /// Current indent style.


### PR DESCRIPTION
close:  #1046

-------------------
And make `kill_to_line_end` behave like emacs. I found it's easiler to use for me.. And it helps resolving the issue.
> C-k kills from point up to the end of the line, unless it is at the end of a line. In that case it kills the newline following point, thus merging the next line into the current one.

here is emacs kill by line [reference](https://home.cs.colorado.edu/~main/cs1300-old/cs1300/doc/emacs/emacs_14.html#SEC56)

