### PR TITLE
Remove defunct helix-bin AUR link

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -25,9 +25,7 @@ shell for working on Helix.
 
 Releases are available in the `community` repository.
 
-Packages are also available on AUR:
-- [helix-bin](https://aur.archlinux.org/packages/helix-bin/) contains the pre-built release
-- [helix-git](https://aur.archlinux.org/packages/helix-git/) builds the master branch
+A [helix-git](https://aur.archlinux.org/packages/helix-git/) package is also available on the AUR, which builds the master branch.
 
 ## Build from source
 


### PR DESCRIPTION
The helix-bin package has been removed from the AUR, presumably as the community package makes it redundant. This PR removes the broken link from the install page