### PR TITLE
Fix typo on docs

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -2,7 +2,7 @@
 
 ## Submodules
 
-To add a new langauge, you should first add a tree-sitter submodule. To do this,
+To add a new language, you should first add a tree-sitter submodule. To do this,
 you can run the command
 ```sh
 git submodule add -f <repository> helix-syntax/languages/tree-sitter-<name>

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -158,7 +158,7 @@ mod merge_toml_tests {
         ";
 
         let base: Value = toml::from_slice(include_bytes!("../../languages.toml"))
-            .expect("Couldn't parse built-in langauges config");
+            .expect("Couldn't parse built-in languages config");
         let user: Value = toml::from_str(USER).unwrap();
 
         let merged = merge_toml_values(base, user);


### PR DESCRIPTION
small typo on guide and `main.rs`