### PR TITLE
fix goto_window offset crash

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -762,8 +762,8 @@ fn goto_window(cx: &mut Context, align: Align) {
         Align::Center => (view.offset.row + ((last_line - view.offset.row) / 2)),
         Align::Bottom => last_line.saturating_sub(scrolloff + count),
     }
-    .min(last_line.saturating_sub(scrolloff))
-    .max(view.offset.row + scrolloff);
+    .max(view.offset.row + scrolloff)
+    .min(last_line.saturating_sub(scrolloff));
 
     let pos = doc.text().line_to_char(line);
 


### PR DESCRIPTION
This is very straightforward fix for    #1205 , we can only go to a line in the range from `first_line + scrolloff ` to `min(last_line, first_line + height) - scrolloff`.

@archseer , let me know if we want to consider more cases, thanks!