### PR TITLE
Improve Dedent behavior

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3597,8 +3597,16 @@ fn normal_mode(cx: &mut Context) {
     doc.mode = Mode::Normal;
 
     if doc.normal_mode_restore_indent {
+        // remove whitespaces added by `open_below` or `open_above` command.
         doc.normal_mode_restore_indent = false;
-        kill_to_line_start(cx);
+        let text = doc.text().slice(..);
+        let transaction =
+            Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
+                let pos = range.cursor(text);
+                let line_start_pos = text.line_to_char(range.cursor_line(text));
+                (line_start_pos, pos, None)
+            });
+        doc.apply(&transaction, view.id);
     }
     doc.append_changes_to_history(view.id);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3574,6 +3574,7 @@ fn open(cx: &mut Context, open: Open) {
     transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
 
     doc.apply(&transaction, view.id);
+    doc.normal_mode_restore_indent = true;
 }
 
 // o inserts a new line after each line with a selection
@@ -3595,6 +3596,10 @@ fn normal_mode(cx: &mut Context) {
 
     doc.mode = Mode::Normal;
 
+    if doc.normal_mode_restore_indent {
+        doc.normal_mode_restore_indent = false;
+        kill_to_line_start(cx);
+    }
     doc.append_changes_to_history(view.id);
 
     // if leaving append mode, move cursor back by 1
@@ -5866,4 +5871,9 @@ fn increment_impl(cx: &mut Context, amount: i64) {
         doc.apply(&transaction, view.id);
         doc.append_changes_to_history(view.id);
     }
+}
+
+pub(crate) fn cancel_restore_indent(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    doc.normal_mode_restore_indent = false;
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3606,13 +3606,17 @@ fn normal_mode(cx: &mut Context) {
     // NOTE: when open a new line, changes will only contains 3 elements:
     // retain(pos) -> insert(something) -> retain(remaining_length), the last retain is useless, we
     // only concerned about the first two changes.
+    use helix_core::chars::char_is_whitespace;
     use helix_core::Operation;
     if let [Operation::Retain(move_pos), Operation::Insert(ref inserted_str), Operation::Retain(_)] =
         doc_changes
     {
         if move_pos + inserted_str.len32() as usize == pos
             && inserted_str.starts_with('\n')
-            && inserted_str.chars().all(|ch| ch.is_whitespace())
+            && inserted_str
+                .chars()
+                .skip(1)
+                .all(|ch| char_is_whitespace(ch))
         {
             can_restore_indent = true;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3606,18 +3606,15 @@ fn normal_mode(cx: &mut Context) {
     // NOTE: when open a new line, changes will only contains 3 elements:
     // retain(pos) -> insert(something) -> retain(remaining_length), the last retain is useless, we
     // only concerned about the first two changes.
-    if doc_changes.len() == 3 {
-        if let helix_core::Operation::Retain(move_pos) = doc_changes[0] {
-            if let helix_core::Operation::Insert(ref inserted_str) = doc_changes[1] {
-                if move_pos + inserted_str.len32() as usize == pos
-                    && inserted_str.starts_with('\n')
-                    && inserted_str.chars().all(|ch| ch.is_whitespace())
-                {
-                    can_restore_indent = true;
-                }
-            }
+    use helix_core::Operation;
+    if let [Operation::Retain(move_pos), Operation::Insert(ref inserted_str), _] = doc_changes {
+        if move_pos + inserted_str.len32() as usize == pos
+            && inserted_str.starts_with('\n')
+            && inserted_str.chars().all(|ch| ch.is_whitespace())
+        {
+            can_restore_indent = true;
         }
-    };
+    }
 
     if can_restore_indent {
         let transaction =

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -203,8 +203,11 @@ impl MappableCommand {
         }
     }
 
-    pub fn fun(&self) -> fn(&mut Context) {
-        self.fun
+    pub fn get_static_fun(&self) -> fn(&mut Context) {
+        match &self {
+            MappableCommand::Static { fun, .. } => *fun,
+            _ => panic!("please ensure that the command is static command"),
+        }
     }
 
     #[rustfmt::skip]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3613,10 +3613,7 @@ fn normal_mode(cx: &mut Context) {
     {
         if move_pos + inserted_str.len32() as usize == pos
             && inserted_str.starts_with('\n')
-            && inserted_str
-                .chars()
-                .skip(1)
-                .all(|ch| char_is_whitespace(ch))
+            && inserted_str.chars().skip(1).all(char_is_whitespace)
         {
             can_restore_indent = true;
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3607,7 +3607,9 @@ fn normal_mode(cx: &mut Context) {
     // retain(pos) -> insert(something) -> retain(remaining_length), the last retain is useless, we
     // only concerned about the first two changes.
     use helix_core::Operation;
-    if let [Operation::Retain(move_pos), Operation::Insert(ref inserted_str), _] = doc_changes {
+    if let [Operation::Retain(move_pos), Operation::Insert(ref inserted_str), Operation::Retain(_)] =
+        doc_changes
+    {
         if move_pos + inserted_str.len32() as usize == pos
             && inserted_str.starts_with('\n')
             && inserted_str.chars().all(|ch| ch.is_whitespace())

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -203,6 +203,10 @@ impl MappableCommand {
         }
     }
 
+    pub fn fun(&self) -> fn(&mut Context) {
+        self.fun
+    }
+
     #[rustfmt::skip]
     static_commands!(
         no_op, "Do nothing",
@@ -3587,7 +3591,7 @@ fn open_above(cx: &mut Context) {
     open(cx, Open::Above)
 }
 
-fn normal_mode(cx: &mut Context) {
+pub(crate) fn normal_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     if doc.mode == Mode::Normal {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -664,7 +664,7 @@ impl EditorView {
         match &key_result.kind {
             KeymapResultKind::Matched(command) => {
                 const NORMAL_MODE_FUNC: fn(&mut commands::Context) = commands::normal_mode;
-                if !matches!(command.fun(), NORMAL_MODE_FUNC) {
+                if !matches!(command.get_static_fun(), NORMAL_MODE_FUNC) {
                     commands::cancel_restore_indent(cxt);
                 }
             }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -660,17 +660,6 @@ impl EditorView {
         let key_result = self.keymaps.get_mut(&mode).unwrap().get(event);
         self.autoinfo = key_result.sticky.map(|node| node.infobox());
 
-        // may cancel restore indent.
-        match &key_result.kind {
-            KeymapResultKind::Matched(command) => {
-                const NORMAL_MODE_FUNC: fn(&mut commands::Context) = commands::normal_mode;
-                if !matches!(command.get_static_fun(), NORMAL_MODE_FUNC) {
-                    commands::cancel_restore_indent(cxt);
-                }
-            }
-            _ => commands::cancel_restore_indent(cxt),
-        }
-
         match &key_result.kind {
             KeymapResultKind::Matched(command) => command.execute(cxt),
             KeymapResultKind::Pending(node) => self.autoinfo = Some(node.infobox()),

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -660,9 +660,11 @@ impl EditorView {
         let key_result = self.keymaps.get_mut(&mode).unwrap().get(event);
         self.autoinfo = key_result.sticky.map(|node| node.infobox());
 
+        // may cancel restore indent.
         match &key_result.kind {
             KeymapResultKind::Matched(command) => {
-                if command.name() != "normal_mode" {
+                const NORMAL_MODE_FUNC: fn(&mut commands::Context) = commands::normal_mode;
+                if !matches!(command.fun(), NORMAL_MODE_FUNC) {
                     commands::cancel_restore_indent(cxt);
                 }
             }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -661,6 +661,15 @@ impl EditorView {
         self.autoinfo = key_result.sticky.map(|node| node.infobox());
 
         match &key_result.kind {
+            KeymapResultKind::Matched(command) => {
+                if command.name() != "normal_mode" {
+                    commands::cancel_restore_indent(cxt);
+                }
+            }
+            _ => commands::cancel_restore_indent(cxt),
+        }
+
+        match &key_result.kind {
             KeymapResultKind::Matched(command) => command.execute(cxt),
             KeymapResultKind::Pending(node) => self.autoinfo = Some(node.infobox()),
             KeymapResultKind::MatchedSequence(commands) => {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,6 +79,9 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
+    /// Control if helix can remove whitespaces if we go from insert mode to normal mode without any keys in between.
+    /// Example: `o<esc>`.
+    pub normal_mode_restore_indent: bool,
 
     /// Current indent style.
     pub indent_style: IndentStyle,
@@ -337,6 +340,7 @@ impl Document {
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
             restore_cursor: false,
+            normal_mode_restore_indent: false,
             syntax: None,
             language: None,
             changes,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -79,9 +79,6 @@ pub struct Document {
     /// Current editing mode.
     pub mode: Mode,
     pub restore_cursor: bool,
-    /// Control if helix can remove whitespaces if we go from insert mode to normal mode without any keys in between.
-    /// Example: `o<esc>`.
-    pub normal_mode_restore_indent: bool,
 
     /// Current indent style.
     pub indent_style: IndentStyle,
@@ -340,7 +337,6 @@ impl Document {
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
             restore_cursor: false,
-            normal_mode_restore_indent: false,
             syntax: None,
             language: None,
             changes,
@@ -891,6 +887,10 @@ impl Document {
     /// is conveniently available in `Document::indent_style` now.
     pub fn indent_unit(&self) -> &'static str {
         self.indent_style.as_str()
+    }
+
+    pub fn changes(&self) -> &ChangeSet {
+        &self.changes
     }
 
     #[inline]


### PR DESCRIPTION
handle the remaining of #1046 :  Hitting o to go to a new line auto indents. If you then immediately hit Esc, it should delete all of the whitespace and just leave a blank line.