### PR TITLE
Allow to assign write to a keybinding

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -169,6 +169,8 @@ macro_rules! static_commands {
     }
 }
 
+use cmd::write_command as write;
+
 impl MappableCommand {
     pub fn execute(&self, cx: &mut Context) {
         match &self {
@@ -394,6 +396,7 @@ impl MappableCommand {
         rename_symbol, "Rename symbol",
         increment, "Increment",
         decrement, "Decrement",
+        write, "Write current file",
     );
 }
 
@@ -2065,6 +2068,18 @@ mod cmd {
     ) -> anyhow::Result<()> {
         write_impl(cx, args.first())
     }
+
+    pub fn write_command(cx: &mut Context) {
+        let mut cx = compositor::Context {
+            editor: cx.editor,
+            scroll: None,
+            jobs: &mut Jobs::new(),
+        };
+
+        let path: Option<Box<Path>> = None;
+        write_impl(&mut cx, path).unwrap();
+    }
+
 
     fn new_file(
         cx: &mut compositor::Context,


### PR DESCRIPTION
I like to assign a keybinding to a `write` command to use sth like `C-s` to save a file. I know how to fix it (and I actually made a crappy hacky fix locally to check it), but there are a few things I'm not sure about, so I wanted to open a draft.

Basically I want to do sth like that:

```
[keys.normal]
"C-s" = ["write"]

[keys.insert]
"C-s" = ["normal_mode", "write"]
```

One thing in this PR that definitely needs fixing is the `unwrap()` call. As static commands can't return an error I guess I would have to log the error right there in the implementation? Not sure what's the best thing to do here.