### PR TITLE
Dynamically calculate tab render width

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -335,7 +335,8 @@ impl EditorView {
 
                             let (grapheme, width) = if grapheme == "\t" {
                                 // make sure we display tab as appropriate amount of spaces
-                                (tab.as_str(), tab_width)
+                                let dynamic_tab_width = tab_width - (visual_x as usize % tab_width);
+                                (&tab[0..dynamic_tab_width], dynamic_tab_width)
                             } else {
                                 // Cow will prevent allocations if span contained in a single slice
                                 // which should really be the majority case

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -335,8 +335,8 @@ impl EditorView {
 
                             let (grapheme, width) = if grapheme == "\t" {
                                 // make sure we display tab as appropriate amount of spaces
-                                let dynamic_tab_width = tab_width - (visual_x as usize % tab_width);
-                                (&tab[..dynamic_tab_width], dynamic_tab_width)
+                                let visual_tab_width = tab_width - (visual_x as usize % tab_width);
+                                (&tab[..visual_tab_width], visual_tab_width)
                             } else {
                                 // Cow will prevent allocations if span contained in a single slice
                                 // which should really be the majority case

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -336,7 +336,7 @@ impl EditorView {
                             let (grapheme, width) = if grapheme == "\t" {
                                 // make sure we display tab as appropriate amount of spaces
                                 let dynamic_tab_width = tab_width - (visual_x as usize % tab_width);
-                                (&tab[0..dynamic_tab_width], dynamic_tab_width)
+                                (&tab[..dynamic_tab_width], dynamic_tab_width)
                             } else {
                                 // Cow will prevent allocations if span contained in a single slice
                                 // which should really be the majority case


### PR DESCRIPTION
`[]` or `|` represents a tab
```
text[  ]foo
 text[ ]foo
  text[]foo
   text|foo
    text[  ]foo
```