### PR TITLE
Add `default-run = "hx"` to `helix-term/Cargo.toml`

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["editor", "command-line-utilities"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
+default-run = "hx"
 
 [package.metadata.nix]
 build = true


### PR DESCRIPTION
Following the addition of `xtask`, `cargo run` has multiple possible targets, necessitating the usage of the less convenient `cargo run --bin hx` to run Helix during development. This allows `cargo run` to be used to run `hx`.