### PR TITLE
Add dart lsp config and queries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -154,3 +154,7 @@
 	path = helix-syntax/languages/tree-sitter-markdown
 	url = https://github.com/MDeiml/tree-sitter-markdown
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-dart"]
+	path = helix-syntax/languages/tree-sitter-dart
+	url = https://github.com/UserNobody14/tree-sitter-dart.git
+	shallow = true

--- a/languages.toml
+++ b/languages.toml
@@ -430,3 +430,12 @@ file-types = ["md"]
 roots = []
 
 indent = { tab-width = 2, unit = "  " }
+
+name = "dart"
+scope = "source.dart"
+file-types = ["dart"]
+roots = ["pubspec.yaml"]
+auto-format = true
+comment-token = "//"
+language-server = { command = "dart", args = ["language-server", "--client-id=helix"] }
+indent = { tab-width = 2, unit = "  " }

--- a/languages.toml
+++ b/languages.toml
@@ -431,6 +431,7 @@ roots = []
 
 indent = { tab-width = 2, unit = "  " }
 
+[[language]]
 name = "dart"
 scope = "source.dart"
 file-types = ["dart"]

--- a/runtime/queries/dart/highlights.scm
+++ b/runtime/queries/dart/highlights.scm
@@ -228,6 +228,10 @@
     "with"
 ] @keyword
 
+; when used as an identifier:
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(abstract|as|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|set|static|typedef)$"))
+
 ; Error
 (ERROR) @error
 

--- a/runtime/queries/dart/highlights.scm
+++ b/runtime/queries/dart/highlights.scm
@@ -1,0 +1,233 @@
+(dotted_identifier_list) @string
+
+; Methods
+; --------------------
+(super) @function.builtin
+
+(function_expression_body (identifier) @function.method)
+((identifier)(selector (argument_part)) @function.method)
+
+; Annotations
+; --------------------
+(annotation
+  name: (identifier) @attribute)
+(marker_annotation
+  name: (identifier) @attribute)
+
+; Types
+; --------------------
+(class_definition
+  name: (identifier) @type)
+  
+(constructor_signature
+  name: (identifier) @function.method)
+
+(function_signature
+  name: (identifier) @function.method)
+
+(getter_signature
+  (identifier) @function.builtin)
+
+(setter_signature
+  name: (identifier) @function.builtin)
+
+(enum_declaration
+  name: (identifier) @type)
+
+(enum_constant
+  name: (identifier) @type.builtin)
+
+(void_type) @type.builtin
+
+((scoped_identifier
+  scope: (identifier) @type)
+ (#match? @type "^[a-zA-Z]"))
+ 
+((scoped_identifier
+  scope: (identifier) @type
+  name: (identifier) @type)
+ (#match? @type "^[a-zA-Z]"))
+
+; the DisabledDrawerButtons in : const DisabledDrawerButtons(history: true),
+(type_identifier) @type.builtin
+
+; Variables
+; --------------------
+; the "File" in var file = File();
+((identifier) @namespace
+ (#match? @namespace "^_?[A-Z].*[a-z]")) ; catch Classes or IClasses not CLASSES
+
+("Function" @type.builtin)
+(inferred_type) @type.builtin
+
+; properties
+(unconditional_assignable_selector
+  (identifier) @variable.other.member)
+
+(conditional_assignable_selector
+  (identifier) @variable.other.member)
+
+; assignments
+; --------------------
+; the "strings" in : strings = "some string"
+(assignment_expression
+  left: (assignable_expression) @variable)
+
+(this) @variable.builtin
+
+; Parameters
+; --------------------
+(formal_parameter
+    name: (identifier) @variable)
+
+(named_argument
+  (label (identifier) @variable))
+
+; Literals
+; --------------------
+[
+  (hex_integer_literal)
+  (decimal_integer_literal)
+  (decimal_floating_point_literal)
+  ;(octal_integer_literal)
+  ;(hex_floating_point_literal)
+] @constant.numeric.integer
+
+(symbol_literal) @string.special.symbol
+(string_literal) @string
+
+[
+  (const_builtin)
+  (final_builtin)
+] @variable.builtin
+
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+(null_literal) @constant.builtin
+
+(comment) @comment.line
+(documentation_comment) @comment.block.documentation
+
+; Tokens
+; --------------------
+(template_substitution
+  "$" @punctuation.special
+  "{" @punctuation.special
+  "}" @punctuation.special
+) @embedded
+
+(template_substitution
+  "$" @punctuation.special
+  (identifier_dollar_escaped) @variable
+) @embedded
+
+(escape_sequence) @constant.character.escape
+
+; Punctuation
+;---------------------
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  ";"
+  "."
+  ","
+  ":"
+] @punctuation.delimiter
+  
+; Operators
+;---------------------
+[
+ "@"
+ "?"
+ "=>"
+ ".."
+ "=="
+ "&&"
+ "%"
+ "<"
+ ">"
+ "="
+ ">="
+ "<="
+ "||"
+ (multiplicative_operator)
+ (increment_operator)
+ (is_operator)
+ (prefix_operator)
+ (equality_operator)
+ (additive_operator)
+] @operator
+
+; Keywords
+; --------------------
+["import" "library" "export"] @keyword.control.import
+["do" "while" "continue" "for"] @keyword.control.repeat
+["return" "yield"] @keyword.control.return
+["as" "in" "is"] @keyword.operator
+
+[
+  "?."
+  "??"
+  "if"
+  "else"
+  "switch"
+  "default"
+  "late"
+] @keyword.control.conditional
+
+[
+  "try"
+  "throw"
+  "catch"
+  "finally"
+  (break_statement)
+] @keyword.control.exception
+
+; Reserved words (cannot be used as identifiers)
+[
+    (case_builtin)
+    "abstract"
+    "async"
+    "async*"
+    "await"
+    "class"
+    "covariant"
+    "deferred"
+    "dynamic"
+    "enum"
+    "extends"
+    "extension"
+    "external"
+    "factory"
+    "Function"
+    "get"
+    "implements"
+    "interface"
+    "mixin"
+    "new"
+    "on"
+    "operator"
+    "part"
+    "required"
+    "set"
+    "show"
+    "static"
+    "super"
+    "sync*"
+    "typedef"
+    "with"
+] @keyword
+
+; Error
+(ERROR) @error
+

--- a/runtime/queries/dart/indents.toml
+++ b/runtime/queries/dart/indents.toml
@@ -1,0 +1,20 @@
+indent = [
+  "class_body",
+  "function_body",
+  "function_expression_body",
+  "declaration",
+  "initializers",
+  "switch_block",
+  "if_statement",
+  "formal_parameter_list",
+  "formal_parameter",
+  "list_literal",
+  "return_statement",
+  "arguments"
+]
+
+outdent = [
+ "}",
+ "]",
+ ")"
+]

--- a/runtime/queries/dart/locals.scm
+++ b/runtime/queries/dart/locals.scm
@@ -1,0 +1,8 @@
+(class_definition
+ body: (_) @scope)
+
+ (block) @scope
+
+ (try_statement) @scope
+ (catch_clause) @scope
+ (finally_clause) @scope

--- a/runtime/queries/dart/locals.scm
+++ b/runtime/queries/dart/locals.scm
@@ -1,8 +1,20 @@
+; Scopes
+;-------
+
+[
+ (block)
+ (try_statement)
+ (catch_clause)
+ (finally_clause)
+] @local.scope
+
+; Definitions
+;------------
+
 (class_definition
- body: (_) @scope)
+ body: (_) @local.definition)
 
- (block) @scope
+; References
+;------------
 
- (try_statement) @scope
- (catch_clause) @scope
- (finally_clause) @scope
+(identifier) @local.reference


### PR DESCRIPTION
Add basic LSP config for dart. The queries are from:
https://github.com/theHamsta/nvim-treesitter/blob/master/queries/dart/highlights.scm

The setup requires that dart be in the users path, such as:
```
export PATH="$HOME/Android/flutter/bin/cache/dart-sdk/bin/:$PATH"
```