### PR TITLE
Refactor macros and mark as experimental

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -78,7 +78,7 @@
 | `Ctrl-a`    | Increment object (number) under cursor                           | `increment`               |
 | `Ctrl-x`    | Decrement object (number) under cursor                           | `decrement`               |
 | `Q`         | Start/stop macro recording to the selected register              | `record_macro`            |
-| `q`         | Play back a recorded macro from the selected register            | `play_macro`              |
+| `q`         | Play back a recorded macro from the selected register            | `replay_macro`            |
 
 #### Shell
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -46,39 +46,39 @@
 
 ### Changes
 
-| Key         | Description                                                      | Command                   |
-| -----       | -----------                                                      | -------                   |
-| `r`         | Replace with a character                                         | `replace`                 |
-| `R`         | Replace with yanked text                                         | `replace_with_yanked`     |
-| `~`         | Switch case of the selected text                                 | `switch_case`             |
-| `` ` ``     | Set the selected text to lower case                              | `switch_to_lowercase`     |
-| `` Alt-` `` | Set the selected text to upper case                              | `switch_to_uppercase`     |
-| `i`         | Insert before selection                                          | `insert_mode`             |
-| `a`         | Insert after selection (append)                                  | `append_mode`             |
-| `I`         | Insert at the start of the line                                  | `prepend_to_line`         |
-| `A`         | Insert at the end of the line                                    | `append_to_line`          |
-| `o`         | Open new line below selection                                    | `open_below`              |
-| `O`         | Open new line above selection                                    | `open_above`              |
-| `.`         | Repeat last change                                               | N/A                       |
-| `u`         | Undo change                                                      | `undo`                    |
-| `U`         | Redo change                                                      | `redo`                    |
-| `Alt-u`     | Move backward in history                                         | `earlier`                 |
-| `Alt-U`     | Move forward in history                                          | `later`                   |
-| `y`         | Yank selection                                                   | `yank`                    |
-| `p`         | Paste after selection                                            | `paste_after`             |
-| `P`         | Paste before selection                                           | `paste_before`            |
-| `"` `<reg>` | Select a register to yank to or paste from                       | `select_register`         |
-| `>`         | Indent selection                                                 | `indent`                  |
-| `<`         | Unindent selection                                               | `unindent`                |
-| `=`         | Format selection (currently nonfunctional/disabled) (**LSP**)    | `format_selections`       |
-| `d`         | Delete selection                                                 | `delete_selection`        |
-| `Alt-d`     | Delete selection, without yanking                                | `delete_selection_noyank` |
-| `c`         | Change selection (delete and enter insert mode)                  | `change_selection`        |
-| `Alt-c`     | Change selection (delete and enter insert mode, without yanking) | `change_selection_noyank` |
-| `Ctrl-a`    | Increment object (number) under cursor                           | `increment`               |
-| `Ctrl-x`    | Decrement object (number) under cursor                           | `decrement`               |
-| `Q`         | Start/stop macro recording to the selected register              | `record_macro`            |
-| `q`         | Play back a recorded macro from the selected register            | `replay_macro`            |
+| Key         | Description                                                          | Command                   |
+| -----       | -----------                                                          | -------                   |
+| `r`         | Replace with a character                                             | `replace`                 |
+| `R`         | Replace with yanked text                                             | `replace_with_yanked`     |
+| `~`         | Switch case of the selected text                                     | `switch_case`             |
+| `` ` ``     | Set the selected text to lower case                                  | `switch_to_lowercase`     |
+| `` Alt-` `` | Set the selected text to upper case                                  | `switch_to_uppercase`     |
+| `i`         | Insert before selection                                              | `insert_mode`             |
+| `a`         | Insert after selection (append)                                      | `append_mode`             |
+| `I`         | Insert at the start of the line                                      | `prepend_to_line`         |
+| `A`         | Insert at the end of the line                                        | `append_to_line`          |
+| `o`         | Open new line below selection                                        | `open_below`              |
+| `O`         | Open new line above selection                                        | `open_above`              |
+| `.`         | Repeat last change                                                   | N/A                       |
+| `u`         | Undo change                                                          | `undo`                    |
+| `U`         | Redo change                                                          | `redo`                    |
+| `Alt-u`     | Move backward in history                                             | `earlier`                 |
+| `Alt-U`     | Move forward in history                                              | `later`                   |
+| `y`         | Yank selection                                                       | `yank`                    |
+| `p`         | Paste after selection                                                | `paste_after`             |
+| `P`         | Paste before selection                                               | `paste_before`            |
+| `"` `<reg>` | Select a register to yank to or paste from                           | `select_register`         |
+| `>`         | Indent selection                                                     | `indent`                  |
+| `<`         | Unindent selection                                                   | `unindent`                |
+| `=`         | Format selection (currently nonfunctional/disabled) (**LSP**)        | `format_selections`       |
+| `d`         | Delete selection                                                     | `delete_selection`        |
+| `Alt-d`     | Delete selection, without yanking                                    | `delete_selection_noyank` |
+| `c`         | Change selection (delete and enter insert mode)                      | `change_selection`        |
+| `Alt-c`     | Change selection (delete and enter insert mode, without yanking)     | `change_selection_noyank` |
+| `Ctrl-a`    | Increment object (number) under cursor                               | `increment`               |
+| `Ctrl-x`    | Decrement object (number) under cursor                               | `decrement`               |
+| `Q`         | Start/stop macro recording to the selected register (experimental)   | `record_macro`            |
+| `q`         | Play back a recorded macro from the selected register (experimental) | `replay_macro`            |
 
 #### Shell
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -77,8 +77,8 @@
 | `Alt-c`     | Change selection (delete and enter insert mode, without yanking) | `change_selection_noyank` |
 | `Ctrl-a`    | Increment object (number) under cursor                           | `increment`               |
 | `Ctrl-x`    | Decrement object (number) under cursor                           | `decrement`               |
-| `q`         | Start/stop macro recording to the selected register              | `record_macro`            |
-| `Q`         | Play back a recorded macro from the selected register            | `play_macro`              |
+| `Q`         | Start/stop macro recording to the selected register              | `record_macro`            |
+| `q`         | Play back a recorded macro from the selected register            | `play_macro`              |
 
 #### Shell
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5983,12 +5983,12 @@ fn record_macro(cx: &mut Context) {
             .join(" ");
         cx.editor.registers.get_mut(reg).write(vec![s]);
         cx.editor
-            .set_status(format!("Recorded to register {}", reg));
+            .set_status(format!("Recorded to register [{}]", reg));
     } else {
         let reg = cx.register.take().unwrap_or('@');
         cx.editor.macro_recording = Some((reg, Vec::new()));
         cx.editor
-            .set_status(format!("Recording to register {}", reg));
+            .set_status(format!("Recording to register [{}]", reg));
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -396,7 +396,7 @@ impl MappableCommand {
         increment, "Increment",
         decrement, "Decrement",
         record_macro, "Record macro",
-        play_macro, "Play macro",
+        replay_macro, "Replay macro",
     );
 }
 
@@ -5978,7 +5978,7 @@ fn record_macro(cx: &mut Context) {
         keys.pop();
         let s = keys
             .into_iter()
-            .map(|key| format!("{}", key))
+            .map(|key| key.to_string())
             .collect::<Vec<_>>()
             .join(" ");
         cx.editor.registers.get_mut(reg).write(vec![s]);
@@ -5992,7 +5992,7 @@ fn record_macro(cx: &mut Context) {
     }
 }
 
-fn play_macro(cx: &mut Context) {
+fn replay_macro(cx: &mut Context) {
     let reg = cx.register.unwrap_or('@');
     let keys: Vec<KeyEvent> = if let Some([keys]) = cx.editor.registers.read(reg) {
         match keys.split_whitespace().map(str::parse).collect() {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5994,6 +5994,7 @@ fn record_macro(cx: &mut Context) {
 
 fn replay_macro(cx: &mut Context) {
     let reg = cx.register.unwrap_or('@');
+    // TODO: macro keys should be parsed one by one and not space delimited (see kak)
     let keys: Vec<KeyEvent> = if let Some([keys]) = cx.editor.registers.read(reg) {
         match keys.split_whitespace().map(str::parse).collect() {
             Ok(keys) => keys,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5978,9 +5978,15 @@ fn record_macro(cx: &mut Context) {
         keys.pop();
         let s = keys
             .into_iter()
-            .map(|key| key.to_string())
-            .collect::<Vec<_>>()
-            .join(" ");
+            .map(|key| {
+                let s = key.to_string();
+                if s.chars().count() == 1 {
+                    s
+                } else {
+                    format!("<{}>", s)
+                }
+            })
+            .collect::<String>();
         cx.editor.registers.get_mut(reg).write(vec![s]);
         cx.editor
             .set_status(format!("Recorded to register [{}]", reg));
@@ -5995,8 +6001,38 @@ fn record_macro(cx: &mut Context) {
 fn replay_macro(cx: &mut Context) {
     let reg = cx.register.unwrap_or('@');
     // TODO: macro keys should be parsed one by one and not space delimited (see kak)
-    let keys: Vec<KeyEvent> = if let Some([keys]) = cx.editor.registers.read(reg) {
-        match keys.split_whitespace().map(str::parse).collect() {
+    let keys: Vec<KeyEvent> = if let Some([keys_str]) = cx.editor.registers.read(reg) {
+        let mut keys_res: anyhow::Result<_> = Ok(Vec::new());
+        let mut i = 0;
+        while let Ok(keys) = &mut keys_res {
+            if i >= keys_str.len() {
+                break;
+            }
+            if !keys_str.is_char_boundary(i) {
+                i += 1;
+                continue;
+            }
+
+            let s = &keys_str[i..];
+            let mut end_i = 1;
+            while !s.is_char_boundary(end_i) {
+                end_i += 1;
+            }
+            let c = &s[..end_i];
+            if c != "<" {
+                keys.push(c);
+                i += end_i;
+            } else {
+                match s.find('>').context("'>' expected") {
+                    Ok(end_i) => {
+                        keys.push(&s[1..end_i]);
+                        i += end_i + 1;
+                    }
+                    Err(err) => keys_res = Err(err),
+                }
+            }
+        }
+        match keys_res.and_then(|keys| keys.into_iter().map(str::parse).collect()) {
             Ok(keys) => keys,
             Err(err) => {
                 cx.editor.set_error(format!("Invalid macro: {}", err));

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -593,8 +593,8 @@ impl Default for Keymaps {
             // paste_all
             "P" => paste_before,
 
-            "q" => record_macro,
-            "Q" => play_macro,
+            "Q" => record_macro,
+            "q" => play_macro,
 
             ">" => indent,
             "<" => unindent,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -594,7 +594,7 @@ impl Default for Keymaps {
             "P" => paste_before,
 
             "Q" => record_macro,
-            "q" => play_macro,
+            "q" => replay_macro,
 
             ">" => indent,
             "<" => unindent,


### PR DESCRIPTION
cc @Omnikar 

This does not solve the macro internal representation issues but it should be a quick fix for now for some of the issues mentioned in #1234 

Leftover

- [x] ~~move macro display to status bar (not sure if it's better since doom emacs move to normal status line unlike vim)~~
- [x] better internal macro representation, to be done by @Omnikar, he say in this pull request, not sure if we want to wait