### PR TITLE
Auto pairs selection

### DIFF
--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -78,19 +78,16 @@ fn get_next_range(
 
         // if we are inserting for a regular one-width cursor, the anchor
         // moves with the head
-        (1, Some(Direction::Forward)) => end_head - 1,
-        (1, Some(Direction::Backward)) => end_head + 1,
+        (1, Direction::Forward) => end_head - 1,
+        (1, Direction::Backward) => end_head + 1,
 
         // if we are appending, the anchor stays where it is; only offset
         // for multiple range insertions
-        (_, Some(Direction::Forward)) => start_range.anchor + offset,
+        (_, Direction::Forward) => start_range.anchor + offset,
 
         // when we are inserting in front of a selection, we need to move
         // the anchor over by however many characters were inserted overall
-        (_, Some(Direction::Backward)) => start_range.anchor + offset + len_inserted,
-
-        // None means 0 width
-        _ => unreachable!(),
+        (_, Direction::Backward) => start_range.anchor + offset + len_inserted,
     };
 
     Range::new(end_anchor, end_head)

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -7,6 +7,7 @@ use crate::{
         ensure_grapheme_boundary_next, ensure_grapheme_boundary_prev, next_grapheme_boundary,
         prev_grapheme_boundary,
     },
+    movement::Direction,
     Assoc, ChangeSet, RopeSlice,
 };
 use smallvec::{smallvec, SmallVec};
@@ -109,18 +110,19 @@ impl Range {
         self.anchor == self.head
     }
 
-    /// `true` when head > anchor.
+    /// `Some(Direction::Forward)` when head > anchor.
+    /// `Some(Direction::Backward)` when head < anchor.
+    /// None otherwise.
     #[inline]
     #[must_use]
-    pub fn is_forward(&self) -> bool {
-        self.head > self.anchor
-    }
-
-    /// `true` when head < anchor.
-    #[inline]
-    #[must_use]
-    pub fn is_backward(&self) -> bool {
-        self.head < self.anchor
+    pub fn direction(&self) -> Option<Direction> {
+        if self.head < self.anchor {
+            Some(Direction::Backward)
+        } else if self.head > self.anchor {
+            Some(Direction::Forward)
+        } else {
+            None
+        }
     }
 
     /// Check two ranges for overlap.

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -82,6 +82,13 @@ impl Range {
         std::cmp::max(self.anchor, self.head)
     }
 
+    /// Total length of the range.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.to() - self.from()
+    }
+
     /// The (inclusive) range of lines that the range overlaps.
     #[inline]
     #[must_use]
@@ -100,6 +107,20 @@ impl Range {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.anchor == self.head
+    }
+
+    /// `true` when head > anchor.
+    #[inline]
+    #[must_use]
+    pub fn is_forward(&self) -> bool {
+        self.head > self.anchor
+    }
+
+    /// `true` when head < anchor.
+    #[inline]
+    #[must_use]
+    pub fn is_backward(&self) -> bool {
+        self.head < self.anchor
     }
 
     /// Check two ranges for overlap.

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -110,18 +110,15 @@ impl Range {
         self.anchor == self.head
     }
 
-    /// `Some(Direction::Forward)` when head > anchor.
-    /// `Some(Direction::Backward)` when head < anchor.
-    /// None otherwise.
+    /// `Direction::Backward` when head < anchor.
+    /// `Direction::Backward` otherwise.
     #[inline]
     #[must_use]
-    pub fn direction(&self) -> Option<Direction> {
+    pub fn direction(&self) -> Direction {
         if self.head < self.anchor {
-            Some(Direction::Backward)
-        } else if self.head > self.anchor {
-            Some(Direction::Forward)
+            Direction::Backward
         } else {
-            None
+            Direction::Forward
         }
     }
 


### PR DESCRIPTION
Previously, the auto pairs code was converting the user selection into its cursor form, and setting the transaction's selection to that cursor. This has the effect of destroying the user's selection if they type a pair character that gets auto completed.

This fixes the code to work with the user's selection, inserting auto pairs where appropriate, but either keeping or extending the user's selection.

This PR is built on top of #1219, so this PR includes commits from there as well until it is merged. I'll mark it as a draft until then.