### PR TITLE
change save_filter shortcut from ctrl-space to space

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -437,7 +437,7 @@ impl<T: 'static> Component for Picker<T> {
                 }
                 return close_fn;
             }
-            ctrl!(' ') => {
+            key!(' ') => {
                 self.save_filter();
             }
             _ => {


### PR DESCRIPTION
Maybe picker's save_filter shortcut `ctrl-scpace` conflict with input method's shortcut. The key `space` use little when matcher and trigger `save_filter` more convenient.