### PR TITLE
WIP: Utility Gutter

### DIFF
--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -12,12 +12,35 @@ pub struct Config {
     pub keys: Keymaps,
     #[serde(default)]
     pub editor: helix_view::editor::Config,
+    pub gutters: GuttersConfig,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
     pub display_messages: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct GuttersConfig {
+    pub utility: usize,
+    pub line_number: usize,
+    pub lsp: usize,
+    //  pub gutter.diagnostic.width: usize
+    //  pub gutter.line_number.width: usize
+}
+
+impl Default for GuttersConfig {
+    fn default() -> Self {
+        Self {
+            utility: 13,
+            line_number: 11,
+            lsp: 3,
+            //hidden: true,
+            //max_depth: None,
+        }
+    }
 }
 
 #[test]

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -90,6 +90,8 @@ FLAGS:
         std::fs::create_dir_all(&conf_dir).ok();
     }
 
+    // once_cell ?
+    // use once_cell::sync::Lazy;
     let config = match std::fs::read_to_string(conf_dir.join("config.toml")) {
         Ok(config) => toml::from_str(&config)
             .map(merge_keys)

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -6,6 +6,18 @@ pub type GutterFn<'doc> = Box<dyn Fn(usize, bool, &mut String) -> Option<Style> 
 pub type Gutter =
     for<'doc> fn(&'doc Document, &View, &Theme, &Config, bool, usize) -> GutterFn<'doc>;
 
+//pub fn build_gutters() -> [(Gutter, usize)] {
+//let ret = [
+// TODO: adaptive?
+// only create if width > 0?
+// width three for now to demonstrate.
+//  (utility(), 3),
+//  (diagnostic(), 1),
+//  (line_number(), 5),
+// ];
+//return ret;
+//}
+
 pub fn utility<'doc>(
     _doc: &'doc Document,
     _view: &View,

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -15,8 +15,10 @@ pub fn utility<'doc>(
     width: usize,
 ) -> GutterFn<'doc> {
     // matches line number styling.
+    // default style usage. Styling could be configurable also.
     let linenr: Style = theme.get("ui.linenr");
     let linenr_select: Style = theme.try_get("ui.linenr.selected").unwrap_or(linenr);
+    let warn_style: Style = theme.try_get("warning").unwrap_or(linenr);
 
     Box::new(move |_line: usize, selected: bool, out: &mut String| {
         let utility_style: Style = if selected && is_focused {
@@ -26,12 +28,13 @@ pub fn utility<'doc>(
         };
         //write! may have to be replaced for highly variable messages or signs?
         write!(out, "µµµ").unwrap();
-        if out.len() > width {
-            // TODO: status message warning - via editor?
+        if out.chars().count() > width {
+            // TODO: stronger warning: if possible
+            // status message warning - via editor? document?
             // width already limits number of `out` chars to display.
-            return Some(utility_style);
+            Some(warn_style)
         } else {
-            return Some(utility_style);
+            Some(utility_style)
         }
     })
 }
@@ -86,7 +89,7 @@ pub fn line_number<'doc>(
         .text()
         .char_to_line(doc.selection(view.id).primary().cursor(text));
 
-    let config = config.line_number;
+    let linenumber_config = config.line_number;
 
     Box::new(move |line: usize, selected: bool, out: &mut String| {
         if line == last_line && !draw_last {
@@ -94,7 +97,7 @@ pub fn line_number<'doc>(
             Some(linenr)
         } else {
             use crate::editor::LineNumber;
-            let line = match config {
+            let line = match linenumber_config {
                 LineNumber::Absolute => line + 1,
                 LineNumber::Relative => {
                     if current_line == line {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -6,6 +6,36 @@ pub type GutterFn<'doc> = Box<dyn Fn(usize, bool, &mut String) -> Option<Style> 
 pub type Gutter =
     for<'doc> fn(&'doc Document, &View, &Theme, &Config, bool, usize) -> GutterFn<'doc>;
 
+pub fn utility<'doc>(
+    _doc: &'doc Document,
+    _view: &View,
+    theme: &Theme,
+    _config: &Config,
+    is_focused: bool,
+    width: usize,
+) -> GutterFn<'doc> {
+    // matches line number styling.
+    let linenr: Style = theme.get("ui.linenr");
+    let linenr_select: Style = theme.try_get("ui.linenr.selected").unwrap_or(linenr);
+
+    Box::new(move |_line: usize, selected: bool, out: &mut String| {
+        let utility_style: Style = if selected && is_focused {
+            linenr_select
+        } else {
+            linenr
+        };
+        //write! may have to be replaced for highly variable messages or signs?
+        write!(out, "µµµ").unwrap();
+        if out.len() > width {
+            // TODO: status message warning - via editor?
+            // width already limits number of `out` chars to display.
+            return Some(utility_style);
+        } else {
+            return Some(utility_style);
+        }
+    })
+}
+
 pub fn diagnostic<'doc>(
     doc: &'doc Document,
     _view: &View,
@@ -49,7 +79,7 @@ pub fn line_number<'doc>(
     // document or not.  We only draw it if it's not an empty line.
     let draw_last = text.line_to_byte(last_line) < text.len_bytes();
 
-    let linenr = theme.get("ui.linenr");
+    let linenr: Style = theme.get("ui.linenr");
     let linenr_select: Style = theme.try_get("ui.linenr.selected").unwrap_or(linenr);
 
     let current_line = doc

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -64,7 +64,14 @@ impl JumpList {
     }
 }
 
-const GUTTERS: &[(Gutter, usize)] = &[(gutter::diagnostic, 1), (gutter::line_number, 5)];
+const GUTTERS: &[(Gutter, usize)] = &[
+    // TODO: adaptive?
+    // only create if width > 0?
+    // width three for now to demonstrate.
+    (gutter::utility, 3),
+    (gutter::diagnostic, 1),
+    (gutter::line_number, 5),
+];
 
 #[derive(Debug)]
 pub struct View {
@@ -296,8 +303,9 @@ impl View {
 mod tests {
     use super::*;
     use helix_core::Rope;
-    const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
-                           // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
+    // if gutter sizes are variable OFFSET must be variable and inherit the value from widths of gutter.
+    const OFFSET: u16 = 10; // 3 utility + 1 diagnostic + 5 linenr + 1 gutter
+                            //let OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
 
     #[test]
     fn test_text_pos_at_screen_coords() {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -64,14 +64,18 @@ impl JumpList {
     }
 }
 
-const GUTTERS: &[(Gutter, usize)] = &[
-    // TODO: adaptive?
-    // only create if width > 0?
-    // width three for now to demonstrate.
-    (gutter::utility, 3),
-    (gutter::diagnostic, 1),
-    (gutter::line_number, 5),
-];
+//const GUTTERS: &[(Gutter, usize)] = gutter::build_gutters();
+
+pub fn gutter_build_demo() -> [(Gutter, usize)] {
+    &[
+        // TODO: adaptive?
+        // only create if width > 0?
+        // width three for now to demonstrate.
+        (gutter::utility, 3),
+        (gutter::diagnostic, 1),
+        (gutter::line_number, 5),
+    ];
+}
 
 #[derive(Debug)]
 pub struct View {
@@ -102,8 +106,9 @@ impl View {
         }
     }
 
-    pub fn gutters(&self) -> &[(Gutter, usize)] {
-        GUTTERS
+    pub fn gutters(&self) -> [(Gutter, usize)] {
+        //GUTTERS
+        gutter_build_demo()
     }
 
     pub fn inner_area(&self) -> Rect {


### PR DESCRIPTION
DRAFT. Fixes #1188.

Working toward an additional, configurable gutter, and to make gutters more configurable generally.

The new `utility` gutter should be able to handle arbitrary text, likely corresponding to the opened document. For example, the gutter could display short commit hashes by line provided by `git annotate`.