### PR TITLE
Add scala syntax highlights

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -31,6 +31,7 @@
 | racket |  |  |  | `racket` |
 | ruby | ✓ |  |  | `solargraph` |
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |
+| scala | ✓ |  |  | `metals` |
 | svelte | ✓ |  | ✓ | `svelteserver` |
 | toml | ✓ |  |  |  |
 | tsq | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -430,3 +430,12 @@ file-types = ["md"]
 roots = []
 
 indent = { tab-width = 2, unit = "  " }
+
+[[language]]
+name = "scala"
+scope = "source.scala"
+roots = ["build.sbt"]
+file-types = ["scala", "sbt"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "metals" }

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -39,15 +39,15 @@
 (class_definition
   body: (template_body
     (function_definition
-      name: (identifier) @method)))
+      name: (identifier) @function.method)))
 (object_definition
   body: (template_body
     (function_definition
-      name: (identifier) @method)))
+      name: (identifier) @function.method)))
 (trait_definition
   body: (template_body
     (function_definition
-      name: (identifier) @method)))
+      name: (identifier) @function.method)))
 
 ; imports
 
@@ -72,8 +72,8 @@
     field: (identifier) @method))
 
 ((call_expression
-   function: (identifier) @constructor)
- (#match? @constructor "^[A-Z]"))
+   function: (identifier) @variable.other.member)
+ (#match? @variable.other.member "^[A-Z]"))
 
 (generic_function
   function: (identifier) @function)
@@ -105,11 +105,8 @@
 
 ; literals
 (boolean_literal) @constant.builtin.boolean
-
-; [
-;   (decimal_integer_literal) 
-;   (decimal_floating_point_literal) 
-; ] @constant.numeric.integer
+(integer_literal) @constant.numeric.integer
+(floating_point_literal) @constant.numeric.float
 
 [
 (symbol_literal)
@@ -146,7 +143,7 @@
   "with"
 ] @keyword
 
-; (null_literal) @constant.builtin
+(null_literal) @constant.builtin
 (wildcard) @keyword
 
 ;; special keywords
@@ -157,7 +154,10 @@
   "else"
   "if"
   "match"
-] @conditional
+ "try"
+ "catch"
+ "throw"
+] @keyword.control.conditional
 
 [
  "("
@@ -173,34 +173,28 @@
  ","
 ] @punctuation.delimiter
 
-; [
-;  "do"
-;  "for"
-;  "while"
-;  "yield"
-; ] @keyword.control.repeat
+[
+ "do"
+ "for"
+ "while"
+ "yield"
+] @keyword.control.repeat
 
 "def" @keyword.function
 
-; [
-;   "=>"
-;   "<-"
-;   "@"
-; ] @keyword.operator
+[
+  "=>"
+  "<-"
+  "@"
+] @keyword.operator
 
 "import" @include
 
-; [
-;  "try"
-;  "catch"
-;  "throw"
-; ] @keyword.control.exception
-
-; "return" @keyword.control.return
+"return" @keyword.control.return
 
 (comment) @comment
 
 ;; `case` is a conditional keyword in case_block
 
 (case_block
-  (case_clause ("case") @conditional))
+  (case_clause ("case") @keyword.conditional))

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -2,7 +2,6 @@
 
 ;; variables
 
-(identifier) @variable
 
 ((identifier) @variable.builtin
  (#match? @variable.builtin "^this$"))
@@ -109,7 +108,7 @@
 (floating_point_literal) @constant.numeric.float
 
 
-(symbol_literal) @string_special_symbol
+(symbol_literal) @string.special.symbol
  
 [
 (string)
@@ -200,3 +199,5 @@
 
 (case_block
   (case_clause ("case") @keyword.control.conditional))
+
+(identifier) @variable

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -69,7 +69,7 @@
 
 (call_expression
   function: (field_expression
-    field: (identifier) @method))
+    field: (identifier) @function.method))
 
 ((call_expression
    function: (identifier) @variable.other.member)
@@ -89,12 +89,12 @@
   name: (identifier) @function)
 
 (parameter
-  name: (identifier) @parameter)
+  name: (identifier) @variable.parameter)
 
 ; expressions
 
 
-(field_expression field: (identifier) @property)
+(field_expression field: (identifier) @variable.other.member)
 (field_expression value: (identifier) @type
  (#match? @type "^[A-Z]"))
 
@@ -108,8 +108,10 @@
 (integer_literal) @constant.numeric.integer
 (floating_point_literal) @constant.numeric.float
 
+
+(symbol_literal) @string_special_symbol
+ 
 [
-(symbol_literal)
 (string)
 (character_literal)
 (interpolated_string_expression)
@@ -151,9 +153,9 @@
 "new" @keyword.operator
 
 [
-  "else"
-  "if"
-  "match"
+ "else"
+ "if"
+ "match"
  "try"
  "catch"
  "throw"
@@ -166,7 +168,7 @@
  "]"
  "{"
  "}"
-]  @punctuation.bracket
+] @punctuation.bracket
 
 [
  "."
@@ -188,7 +190,7 @@
   "@"
 ] @keyword.operator
 
-"import" @include
+"import" @keyword.control.import
 
 "return" @keyword.control.return
 
@@ -197,4 +199,4 @@
 ;; `case` is a conditional keyword in case_block
 
 (case_block
-  (case_clause ("case") @keyword.conditional))
+  (case_clause ("case") @keyword.control.conditional))

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -104,10 +104,12 @@
 (infix_type operator: (operator_identifier) @operator)
 
 ; literals
-
 (boolean_literal) @constant.builtin.boolean
-; (integer_literal) @constant.numeric.integer
-; (floating_point_literal) @constant.builtin.boolean
+
+; [
+;   (decimal_integer_literal) 
+;   (decimal_floating_point_literal) 
+; ] @constant.numeric.integer
 
 [
 (symbol_literal)
@@ -144,7 +146,7 @@
   "with"
 ] @keyword
 
-; (null_literal) @keyword
+; (null_literal) @constant.builtin
 (wildcard) @keyword
 
 ;; special keywords
@@ -172,29 +174,29 @@
 ] @punctuation.delimiter
 
 ; [
- ; "do"
- ; "for"
- ; "while"
- ; "yield"
-; ] @repeat
+;  "do"
+;  "for"
+;  "while"
+;  "yield"
+; ] @keyword.control.repeat
 
 "def" @keyword.function
 
-;[
-; "=>"
-; "<-"
-; "@"
-;] @operator
+; [
+;   "=>"
+;   "<-"
+;   "@"
+; ] @keyword.operator
 
 "import" @include
 
-;[
+; [
 ;  "try"
 ;  "catch"
 ;  "throw"
-;] @exception
+; ] @keyword.control.exception
 
-;"return" @keyword.return
+; "return" @keyword.control.return
 
 (comment) @comment
 

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -1,0 +1,204 @@
+; CREDITS @stumash (stuart.mashaal@gmail.com)
+
+;; variables
+
+(identifier) @variable
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^this$"))
+
+(interpolation) @none
+
+; Assume other uppercase names constants.
+; NOTE: In order to distinguish constants we highlight
+; all the identifiers that are uppercased. But this solution
+; is not suitable for all occurrences e.g. it will highlight
+; an uppercased method as a constant if used with no params.
+; Introducing highlighting for those specific cases, is probably
+; best way to resolve the issue.
+((identifier) @constant (#match? @constant "^[A-Z]"))
+
+;; types
+
+(type_identifier) @type
+
+(class_definition
+  name: (identifier) @type)
+
+(object_definition
+  name: (identifier) @type)
+
+(trait_definition
+  name: (identifier) @type)
+
+(type_definition
+  name: (type_identifier) @type)
+
+; method definition
+
+(class_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+(object_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+(trait_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+
+; imports
+
+(import_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((import_declaration
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
+
+((import_selectors (identifier) @type) (#match? @type "^[A-Z]"))
+
+; method invocation
+
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (field_expression
+    field: (identifier) @method))
+
+((call_expression
+   function: (identifier) @constructor)
+ (#match? @constructor "^[A-Z]"))
+
+(generic_function
+  function: (identifier) @function)
+
+(
+  (identifier) @function.builtin
+  (#match? @function.builtin "^super$")
+)
+
+; function definitions
+
+(function_definition
+  name: (identifier) @function)
+
+(parameter
+  name: (identifier) @parameter)
+
+; expressions
+
+
+(field_expression field: (identifier) @property)
+(field_expression value: (identifier) @type
+ (#match? @type "^[A-Z]"))
+
+(infix_expression operator: (identifier) @operator)
+(infix_expression operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+
+; literals
+
+(boolean_literal) @constant.builtin.boolean
+; (integer_literal) @constant.numeric.integer
+; (floating_point_literal) @constant.builtin.boolean
+
+[
+(symbol_literal)
+(string)
+(character_literal)
+(interpolated_string_expression)
+] @string
+
+(interpolation "$" @punctuation.special)
+
+;; keywords
+
+[
+  "abstract"
+  "case"
+  "class"
+  "extends"
+  "final"
+  "finally"
+;; `forSome` existential types not implemented yet
+  "implicit"
+  "lazy"
+;; `macro` not implemented yet
+  "object"
+  "override"
+  "package"
+  "private"
+  "protected"
+  "sealed"
+  "trait"
+  "type"
+  "val"
+  "var"
+  "with"
+] @keyword
+
+; (null_literal) @keyword
+(wildcard) @keyword
+
+;; special keywords
+
+"new" @keyword.operator
+
+[
+  "else"
+  "if"
+  "match"
+] @conditional
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+]  @punctuation.bracket
+
+[
+ "."
+ ","
+] @punctuation.delimiter
+
+; [
+ ; "do"
+ ; "for"
+ ; "while"
+ ; "yield"
+; ] @repeat
+
+"def" @keyword.function
+
+;[
+; "=>"
+; "<-"
+; "@"
+;] @operator
+
+"import" @include
+
+;[
+;  "try"
+;  "catch"
+;  "throw"
+;] @exception
+
+;"return" @keyword.return
+
+(comment) @comment
+
+;; `case` is a conditional keyword in case_block
+
+(case_block
+  (case_clause ("case") @conditional))

--- a/runtime/queries/scala/indents.toml
+++ b/runtime/queries/scala/indents.toml
@@ -1,0 +1,23 @@
+
+indent = [
+ "block",
+ "arguments",
+ "parameter",
+ "class_definition",
+ "trait_definition",
+ "object_definition",
+ "function_definition",
+ "val_definition",
+ "import_declaration",
+ "while_expression",
+ "do_while_expression",
+ "for_expression",
+ "try_expression",
+ "match_expression"
+]
+
+outdent = [
+ "}",
+ "]",
+ ")"
+]

--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
Hi!

I really like helix, so I'd like to add scala syntax highlight and LSP support for it.
Amazingly, LSP support with metals works out-of-the-box, although additional metals commands like import build and others obviously needs to be added. 

I've copied the tree-sitter highlights and injections from nvim-treesitter, but found a couple of issues with it, and couldn't figure out it yet, so the syntax highlighting is partial currently. I'm happy to receive suggestions how to migrate the whole from nvim.