### PR TITLE
Add indents.toml to perl

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -23,7 +23,7 @@
 | nix | ✓ |  | ✓ | `rnix-lsp` |
 | ocaml | ✓ |  | ✓ |  |
 | ocaml-interface | ✓ |  |  |  |
-| perl | ✓ | ✓ |  |  |
+| perl | ✓ | ✓ | ✓ |  |
 | php | ✓ |  | ✓ |  |
 | prolog |  |  |  | `swipl` |
 | protobuf | ✓ |  | ✓ |  |

--- a/runtime/queries/perl/indents.toml
+++ b/runtime/queries/perl/indents.toml
@@ -1,0 +1,17 @@
+indent = [
+  "function",
+  "identifier",
+  "method_invocation",
+  "if_statement",
+  "unless_statement",
+  "if_simple_statement",
+  "unless_simple_statement",
+  "variable_declaration",
+  "block",
+  "list_item",
+  "word_list_qw"
+]
+
+outdent = [
+ "}"
+]


### PR DESCRIPTION
It has sometimes problem indenting/outdenting the first line after a block starts/ends.