### PR TITLE
feat(commands): sort command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -42,5 +42,5 @@
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
 | `:set-option`, `:set` | Set a config option at runtime |
-| `:sort` | Sort lines in selection. |
-| `:sort!` | Sort lines in selection in reverse order. |
+| `:sort` | Sort ranges in selection. |
+| `:rsort` | Sort ranges in selection in reverse order. |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -42,3 +42,5 @@
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
 | `:set-option`, `:set` | Set a config option at runtime |
+| `:sort` | Sort lines in selection. |
+| `:sort!` | Sort lines in selection in reverse order. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3019,14 +3019,14 @@ pub mod cmd {
         TypableCommand {
             name: "sort",
             aliases: &[],
-            doc: "Sort lines in selection.",
+            doc: "Sort ranges in selection.",
             fun: sort,
             completer: None,
         },
         TypableCommand {
-            name: "sort!",
+            name: "rsort",
             aliases: &[],
-            doc: "Sort lines in selection in reverse order.",
+            doc: "Sort ranges in selection in reverse order.",
             fun: sort_reverse,
             completer: None,
         },


### PR DESCRIPTION
Add basic implementation of sort command.

This PR adds `sort` and `sort!` (reverse sort) commands that sort _selections_. This can be used to not only sort data on separate lines (select -> split on new line `Alt-s` -> `:sort`) but also any arbitrary list (select -> select all matches, for example numbers `\d+` -> `:sort`).

Additional functionality can be added in the future such as removing duplicates, case insensitivity, etc.

---

edit: provide better description for the PR