### PR TITLE
Add textobjects and indents to c and cpp

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -1,11 +1,11 @@
 | Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Default LSP |
 | --- | --- | --- | --- | --- |
 | bash | ✓ |  |  | `bash-language-server` |
-| c | ✓ |  |  | `clangd` |
+| c | ✓ | ✓ | ✓ | `clangd` |
 | c-sharp | ✓ |  |  |  |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | comment | ✓ |  |  |  |
-| cpp | ✓ |  |  | `clangd` |
+| cpp | ✓ | ✓ | ✓ | `clangd` |
 | css | ✓ |  |  |  |
 | dart | ✓ |  | ✓ | `dart` |
 | dockerfile | ✓ |  |  | `docker-langserver` |

--- a/runtime/queries/c/indents.toml
+++ b/runtime/queries/c/indents.toml
@@ -1,0 +1,16 @@
+indent = [
+  "compound_statement",
+  "field_declaration_list",
+  "enumerator_list",
+  "parameter_list",
+  "init_declarator",
+  "case_statement",
+  "condition_clause",
+  "expression_statement",
+]
+
+outdent = [
+  "case",
+  "}",
+  "]",
+]

--- a/runtime/queries/c/textobjects.scm
+++ b/runtime/queries/c/textobjects.scm
@@ -1,0 +1,13 @@
+(function_definition
+  body: (_) @function.inside) @function.around
+
+(struct_specifier
+  body: (_) @class.inside) @class.around
+
+(enum_specifier
+  body: (_) @class.inside) @class.around
+
+(union_specifier
+  body: (_) @class.inside) @class.around
+
+(parameter_declaration) @parameter.inside

--- a/runtime/queries/cpp/indents.toml
+++ b/runtime/queries/cpp/indents.toml
@@ -1,0 +1,17 @@
+indent = [
+  "compound_statement",
+  "field_declaration_list",
+  "enumerator_list",
+  "parameter_list",
+  "init_declarator",
+  "case_statement",
+  "condition_clause",
+  "expression_statement",
+]
+
+outdent = [
+  "case",
+  "access_specifier",
+  "}",
+  "]",
+]

--- a/runtime/queries/cpp/textobjects.scm
+++ b/runtime/queries/cpp/textobjects.scm
@@ -1,0 +1,7 @@
+; inherits: c
+
+(lambda_expression
+  body: (_) @function.inside) @function.around
+
+(class_specifier
+  body: (_) @class.inside) @class.around


### PR DESCRIPTION
Somehow, indentation inside conditions doesn't work, i.e.
```
  while (1 +<hit enter>)
```
leads to
```
  while (1 +
  )
```
but the expected result should be
```
  while (1 +
    )
```

But it is a lot better than before.