### PR TITLE
Improve yaml syntax highlighting

### DIFF
--- a/runtime/queries/yaml/highlights.scm
+++ b/runtime/queries/yaml/highlights.scm
@@ -1,9 +1,19 @@
-(block_mapping_pair key: (_) @variable.other.member)
-(flow_mapping (_ key: (_) @variable.other.member))
+(block_mapping_pair
+  key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable.other.member))
+(block_mapping_pair
+  key: (flow_node (plain_scalar (string_scalar) @variable.other.member)))
+
+(flow_mapping
+  (_ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable.other.member)))
+(flow_mapping
+  (_ key: (flow_node (plain_scalar (string_scalar) @variable.other.member))))
+
 (boolean_scalar) @constant.builtin.boolean
 (null_scalar) @constant.builtin
 (double_quote_scalar) @string
 (single_quote_scalar) @string
+(block_scalar) @string
+(string_scalar) @string
 (escape_sequence) @constant.character.escape
 (integer_scalar) @constant.numeric.integer
 (float_scalar) @constant.numeric.float
@@ -30,4 +40,4 @@
 "}"
 ] @punctuation.bracket
 
-["*" "&"] @punctuation.special
+["*" "&" "---" "..."] @punctuation.special


### PR DESCRIPTION
Unquoted values that can't be interpreted as another datatype are strings, so this change highlights them as strings.

Before:
![before-yaml](https://user-images.githubusercontent.com/23398472/146650380-938f9b3b-2e39-4604-82f2-044236e6be9e.png)

After:
![after-yaml](https://user-images.githubusercontent.com/23398472/146650387-a19e8465-e468-443c-b232-636baa960f34.png)
