### PR TITLE
Improve rust macro highlighting

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -242,10 +242,9 @@
 ; ---
 ; Macros
 ; ---
-
 (meta_item
-  (identifier) @attribute)
-(attribute_item) @attribute
+  (identifier) @function.macro)
+
 (inner_attribute_item) @attribute
 
 (macro_definition
@@ -259,7 +258,7 @@
   "!" @function.macro)
 
 (metavariable) @variable.parameter
-(fragment_specifier) @variable.parameter
+(fragment_specifier) @type
 
 
 


### PR DESCRIPTION
- Highlight fragment specifiers (expr, tt, in macro definitions) with @type.
- Highlight attributes as macros.

| Before | After |
| --- | --- |
| ![before-rust](https://user-images.githubusercontent.com/23398472/146651130-019036c6-3245-4a49-9454-e18d4db92538.png) | ![after-rust](https://user-images.githubusercontent.com/23398472/146651133-44ba5d63-0896-43de-9547-ade09db8bd0e.png) |

Note that it looks drastic for onedark only from what I tested since it doesn't define some punctuation highlights.