### PR TITLE
Add link and quote queries for markdown

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -105,6 +105,7 @@ We use a similar set of scopes as
 
 - `type` - Types
   - `builtin` - Primitive types provided by the language (`int`, `usize`)
+- `constructor`
 
 - `constant` (TODO: constant.other.placeholder for %v)
   - `builtin` Special constants provided by the language (`true`, `false`, `nil` etc)
@@ -169,8 +170,9 @@ We use a similar set of scopes as
     - `numbered`
   - `bold`
   - `italic`
-  - `underline`
-    - `link`
+  - `link`
+    - `url`
+    - `label`
   - `quote`
   - `raw`
     - `inline`

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -371,7 +371,7 @@
 ((generic_command
   name:(generic_command_name) @_name
   .
-  arg: (_) @markup.underline.link)
+  arg: (_) @markup.link.url)
  (#match? @_name "^(\\\\url|\\\\href)$"))
 
 (ERROR) @error

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -10,15 +10,16 @@
   (fenced_code_block)
 ] @markup.raw.block
 
+(block_quote) @markup.quote
+
 (code_span) @markup.raw.inline
 
 (emphasis) @markup.italic
 
 (strong_emphasis) @markup.bold
 
-(link_destination) @markup.underline.link
-
-; (link_label) @markup.label ; TODO: rename
+(link_destination) @markup.link.url
+(link_label) @markup.link.label
 
 [
   (list_marker_plus)

--- a/runtime/queries/svelte/highlights.scm
+++ b/runtime/queries/svelte/highlights.scm
@@ -20,12 +20,12 @@
 ((element (start_tag (tag_name) @_tag) (text) @markup.inline)
  (#match? @_tag "^(code|kbd)$"))
 
-((element (start_tag (tag_name) @_tag) (text) @markup.underline.link)
+((element (start_tag (tag_name) @_tag) (text) @markup.link.url)
  (#eq? @_tag "a"))
 
 ((attribute
    (attribute_name) @_attr
-   (quoted_attribute_value (attribute_value) @markup.underline.link))
+   (quoted_attribute_value (attribute_value) @markup.link.url))
  (#match? @_attr "^(href|src)$"))
 
 (tag_name) @tag

--- a/theme.toml
+++ b/theme.toml
@@ -31,7 +31,7 @@ label = "honey"
 "markup.heading" = "lilac"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.underline.link" = { fg = "silver", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "silver", modifiers = ["underlined"] }
 "markup.raw" = "almond"
 
 # TODO: diferentiate doc comment


### PR DESCRIPTION
- Rename markup.underline.link to markup.link.url
- Add markup.link.label
- Add markup.quote

(The constructor theme scope was missing from the docs, so unrelated to this PR).
