### PR TITLE
Fix tree-sitter-llvm submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -146,7 +146,7 @@
 	path = helix-syntax/languages/tree-sitter-wgsl
 	url = https://github.com/szebniok/tree-sitter-wgsl
 	shallow = true
-[submodule "helix-syntax/tree-sitter-llvm"]
+[submodule "helix-syntax/languages/tree-sitter-llvm"]
 	path = helix-syntax/languages/tree-sitter-llvm
 	url = https://github.com/benwilliamgraham/tree-sitter-llvm
 	shallow = true


### PR DESCRIPTION
Fix the path to the submodule and init the submodule.