### PR TITLE
Add textobjects and indents to cmake

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -3,7 +3,7 @@
 | bash | ✓ |  |  | `bash-language-server` |
 | c | ✓ |  |  | `clangd` |
 | c-sharp | ✓ |  |  |  |
-| cmake | ✓ |  |  | `cmake-language-server` |
+| cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | comment | ✓ |  |  |  |
 | cpp | ✓ |  |  | `clangd` |
 | css | ✓ |  |  |  |

--- a/runtime/queries/cmake/indents.toml
+++ b/runtime/queries/cmake/indents.toml
@@ -1,0 +1,12 @@
+indent = [
+  "if_condition",
+  "foreach_loop",
+  "while_loop",
+  "function_def",
+  "macro_def",
+  "normal_command",
+]
+
+outdent = [
+  ")"
+]

--- a/runtime/queries/cmake/textobjects.scm
+++ b/runtime/queries/cmake/textobjects.scm
@@ -1,0 +1,3 @@
+(macro_def) @function.around
+
+(argument) @parameter.inside


### PR DESCRIPTION
Indentation and parameter selection works well.
Function selection doesn’t work, my guess is that something is weird with the cmake grammar.
(Also, I wasn’t able to add a matcher for `@function.inside` because there is no dedicated element for that. The tree is just `(macro_def (macro_command) (<body node>) (<more body nodes>) … (endmacro_command))`.)