### PR TITLE
Resolve completion item

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -556,6 +556,14 @@ impl Client {
         self.call::<lsp::request::Completion>(params)
     }
 
+    pub async fn resolve_completion_item(
+        &self,
+        completion_item: lsp::CompletionItem,
+    ) -> Result<lsp::CompletionItem> {
+        self.request::<lsp::request::ResolveCompletionItem>(completion_item)
+            .await
+    }
+
     pub fn text_document_signature_help(
         &self,
         text_document: lsp::TextDocumentIdentifier,

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -154,8 +154,19 @@ impl Completion {
                     );
                     doc.apply(&transaction, view.id);
 
-                    if let Some(additional_edits) = &item.additional_text_edits {
-                        // gopls uses this to add extra imports
+                    // apply additional edits, mostly used to auto import unqualified types
+                    let resolved_additional_text_edits = if item.additional_text_edits.is_some() {
+                        None
+                    } else {
+                        Completion::resolve_completion_item(doc, item.clone())
+                            .and_then(|item| item.additional_text_edits)
+                    };
+
+                    if let Some(additional_edits) = item
+                        .additional_text_edits
+                        .as_ref()
+                        .or_else(|| resolved_additional_text_edits.as_ref())
+                    {
                         if !additional_edits.is_empty() {
                             let transaction = util::generate_transaction_from_edits(
                                 doc.text(),
@@ -179,6 +190,31 @@ impl Completion {
         completion.recompute_filter(editor);
 
         completion
+    }
+
+    fn resolve_completion_item(
+        doc: &Document,
+        completion_item: lsp::CompletionItem,
+    ) -> Option<CompletionItem> {
+        let language_server = doc.language_server()?;
+        let completion_resolve_provider = language_server
+            .capabilities()
+            .completion_provider
+            .as_ref()?
+            .resolve_provider;
+        if completion_resolve_provider != Some(true) {
+            return None;
+        }
+
+        let future = language_server.resolve_completion_item(completion_item);
+        let response = helix_lsp::block_on(future);
+        match response {
+            Ok(completion_item) => Some(completion_item),
+            Err(err) => {
+                log::error!("execute LSP command: {}", err);
+                None
+            }
+        }
     }
 
     pub fn recompute_filter(&mut self, editor: &Editor) {


### PR DESCRIPTION
This one solves the issue: [1313](https://github.com/helix-editor/helix/issues/1313)

That is my first contribution to a Rust project, and to this project, so I'm really open to receive suggestions 😄 

Talking about the solution, I adopted the suggestions that I received on the Matrix chat, from the user "archseer".

The suggestion was to request the language server directly from `Completion` component, and use `block_on` since this component does not have any way of enqueuing async jobs yet.