### PR TITLE
feat(lsp): configurable diagnostic severity

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -36,7 +36,7 @@ These are the available keys and descriptions for the file.
 | shebangs            | The interpreters from the shebang line, for example `["sh", "bash"]` |
 | roots               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | auto-format         | Whether to autoformat this language when saving               |
-| diagnostic_severity | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
+| diagnostic-severity | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
 | comment-token       | The token to use as a comment-token                           |
 | indent              | The indent to use. Has sub keys `tab-width` and `unit`        |
 | config              | Language server configuration                                 |

--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -27,18 +27,19 @@ directory](../configuration.md).
 
 These are the available keys and descriptions for the file.
 
-| Key           | Description                                                   |
-| ----          | -----------                                                   |
-| name          | The name of the language                                      |
-| scope         | A string like `source.js` that identifies the language. Currently, we strive to match the scope names used by popular TextMate grammars and by the Linguist library. Usually `source.<name>` or `text.<name>` in case of markup languages |
-| injection-regex | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
-| file-types    | The filetypes of the language, for example `["yml", "yaml"]`  |
-| shebangs      | The interpreters from the shebang line, for example `["sh", "bash"]` |
-| roots         | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
-| auto-format   | Whether to autoformat this language when saving               |
-| comment-token | The token to use as a comment-token                           |
-| indent        | The indent to use. Has sub keys `tab-width` and `unit`        |
-| config        | Language server configuration                                 |
+| Key                 | Description                                                   |
+| ----                | -----------                                                   |
+| name                | The name of the language                                      |
+| scope               | A string like `source.js` that identifies the language. Currently, we strive to match the scope names used by popular TextMate grammars and by the Linguist library. Usually `source.<name>` or `text.<name>` in case of markup languages |
+| injection-regex     | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
+| file-types          | The filetypes of the language, for example `["yml", "yaml"]`  |
+| shebangs            | The interpreters from the shebang line, for example `["sh", "bash"]` |
+| roots               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
+| auto-format         | Whether to autoformat this language when saving               |
+| diagnostic_severity | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
+| comment-token       | The token to use as a comment-token                           |
+| indent              | The indent to use. Has sub keys `tab-width` and `unit`        |
+| config              | Language server configuration                                 |
 
 ## Queries
 

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -11,4 +11,3 @@ Changes made to the `languages.toml` file in a user's [configuration directory](
 name = "rust"
 auto-format = false
 ```
-

--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -1,12 +1,19 @@
 //! LSP diagnostic utility types.
+use serde::{Deserialize, Serialize};
 
 /// Describes the severity level of a [`Diagnostic`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum Severity {
-    Error,
-    Warning,
-    Info,
     Hint,
+    Info,
+    Warning,
+    Error,
+}
+
+impl Default for Severity {
+    fn default() -> Self {
+        Self::Hint
+    }
 }
 
 /// A range of `char`s within the text.

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -442,6 +442,7 @@ where
         );
 
         let doc = Rope::from(doc);
+        use crate::diagnostic::Severity;
         use crate::syntax::{
             Configuration, IndentationConfiguration, LanguageConfiguration, Loader,
         };
@@ -459,6 +460,7 @@ where
                 roots: vec![],
                 comment_token: None,
                 auto_format: false,
+                diagnostic_severity: Severity::Warning,
                 language_server: None,
                 indent: Some(IndentationConfiguration {
                     tab_width: 4,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1,5 +1,6 @@
 use crate::{
     chars::char_is_line_ending,
+    diagnostic::Severity,
     regex::Regex,
     transaction::{ChangeSet, Operation},
     Rope, RopeSlice, Tendril,
@@ -63,6 +64,8 @@ pub struct LanguageConfiguration {
 
     #[serde(default)]
     pub auto_format: bool,
+    #[serde(default)]
+    pub diagnostic_severity: Severity,
 
     // content_regex
     #[serde(default, skip_serializing, deserialize_with = "deserialize_regex")]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -422,7 +422,10 @@ impl Application {
                                             DiagnosticSeverity::WARNING => Warning,
                                             DiagnosticSeverity::INFORMATION => Info,
                                             DiagnosticSeverity::HINT => Hint,
-                                            severity => unimplemented!("{:?}", severity),
+                                            severity => unreachable!(
+                                                "unrecognized diagnostic severity: {:?}",
+                                                severity
+                                            ),
                                         });
 
                                     if let Some(lang_conf) = lang_conf {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -378,7 +378,7 @@ impl Application {
                         let doc = self.editor.document_by_path_mut(&path);
 
                         if let Some(doc) = doc {
-                            let lang_conf = &doc.language;
+                            let lang_conf = doc.language_config();
                             let text = doc.text();
 
                             let diagnostics = params

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -88,7 +88,7 @@ pub struct Document {
 
     syntax: Option<Syntax>,
     // /// Corresponding language scope name. Usually `source.<lang>`.
-    pub(crate) language: Option<Arc<LanguageConfiguration>>,
+    pub language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -88,7 +88,7 @@ pub struct Document {
 
     syntax: Option<Syntax>,
     // /// Corresponding language scope name. Usually `source.<lang>`.
-    pub language: Option<Arc<LanguageConfiguration>>,
+    pub(crate) language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,


### PR DESCRIPTION
Allow severity of diagnostic messages to be configured.
E.g. allow turning of Hint level diagnostics.

Fixes: https://github.com/helix-editor/helix/issues/1007