### PR TITLE
languages: add .dockerfile extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -473,7 +473,7 @@ name = "dockerfile"
 scope = "source.dockerfile"
 injection-regex = "docker|dockerfile"
 roots = ["Dockerfile"]
-file-types = ["Dockerfile"]
+file-types = ["Dockerfile", "dockerfile"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "docker-langserver", args = ["--stdio"] }


### PR DESCRIPTION
Many folks use `.dockerfile` as an extension for dockerfiles in addition to plain `Dockerfile`. This change associates both file extensions with dockerfile syntax highlighting