### PR TITLE
Add `goto_last_char_of_file` key

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -312,6 +312,7 @@ impl MappableCommand {
         // TODO: different description ?
         goto_line_end_newline, "Goto line end",
         goto_first_nonwhitespace, "Goto first non-blank in line",
+        goto_last_char_of_file, "Goto last char of the file",
         trim_selections, "Trim whitespace from selections",
         extend_to_line_start, "Extend to line start",
         extend_to_line_end, "Extend to line end",
@@ -904,6 +905,11 @@ fn goto_file_start(cx: &mut Context) {
             .transform(|range| range.put_cursor(text, 0, doc.mode == Mode::Select));
         doc.set_selection(view.id, selection);
     }
+}
+
+fn goto_last_char_of_file(cx: &mut Context) {
+    goto_last_line(cx);
+    goto_line_end(cx);
 }
 
 fn goto_file_end(cx: &mut Context) {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -528,6 +528,7 @@ impl Default for Keymaps {
                 "n" => goto_next_buffer,
                 "p" => goto_previous_buffer,
                 "." => goto_last_modification,
+                "E" => goto_last_char_of_file,
             },
             ":" => command_mode,
 


### PR DESCRIPTION
Resolves #1335.

This adds a `goto_file_end` key (`gE`).

I named it `goto_last_char_of_file` because `goto_file_end` was already taken, but not in use.