### PR TITLE
Add precise rust queries for use, mod, as

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -127,11 +127,16 @@
   "await"
 ] @keyword.control
 
+"use" @keyword.control.import
+(mod_item "mod" @keyword.control.import !body)
+(use_as_clause "as" @keyword.control.import)
+
+(type_cast_expression "as" @keyword.operator)
+
 [
   (crate)
   (super)
   "as"
-  "use"
   "pub"
   "mod"
   "extern"


### PR DESCRIPTION
- Differentiates between `as` keyword as a binary type cast operator and import renamer.
- `mod` and `use` are now under `@keyword.control.import`, but `mod` is a `@keyword` if used as `mod name;`.
