### PR TITLE
feat(commands): shrink_selection

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -261,6 +261,8 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`    |
 | `[space` | Add newline above                            | `add_newline_above` |
 | `]space` | Add newline below                            | `add_newline_below` |
+| `]o`     | Expand syntax tree object selection.         | `expand_selection`  |
+| `[o`     | Shrink syntax tree object selection.         | `shrink_selection`  |
 
 ## Insert Mode
 

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -1,7 +1,5 @@
 use crate::{Range, RopeSlice, Selection, Syntax};
 
-// TODO: to contract_selection we'd need to store the previous ranges before expand.
-// Maybe just contract to the first child node?
 pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
     let tree = syntax.tree();
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -140,6 +140,12 @@ impl Range {
         self.from() == other.from() || (self.to() > other.from() && other.to() > self.from())
     }
 
+    /// Check that this range contains other range
+    #[inline]
+    pub fn contains_range(&self, other: &Self) -> bool {
+        self.from() <= other.from() && self.to() >= other.to()
+    }
+
     pub fn contains(&self, pos: usize) -> bool {
         self.from() <= pos && pos < self.to()
     }
@@ -543,6 +549,12 @@ impl Selection {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.ranges.len()
+    }
+
+    pub fn contains(&self, other: &Selection) -> bool {
+        self.iter()
+            .zip(other.iter())
+            .all(|(r1, r2)| r1.contains_range(r2))
     }
 }
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -140,7 +140,6 @@ impl Range {
         self.from() == other.from() || (self.to() > other.from() && other.to() > self.from())
     }
 
-    /// Check that this range contains other range
     #[inline]
     pub fn contains_range(&self, other: &Self) -> bool {
         self.from() <= other.from() && self.to() >= other.to()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -362,6 +362,7 @@ impl MappableCommand {
         rotate_selection_contents_forward, "Rotate selection contents forward",
         rotate_selection_contents_backward, "Rotate selections contents backward",
         expand_selection, "Expand selection to parent syntax node",
+        shrink_selection, "Shrink selection to previously expanded syntax node",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save the current selection to the jumplist",
@@ -5458,6 +5459,7 @@ fn rotate_selection_contents(cx: &mut Context, direction: Direction) {
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view.id);
 }
+
 fn rotate_selection_contents_forward(cx: &mut Context) {
     rotate_selection_contents(cx, Direction::Forward)
 }
@@ -5474,8 +5476,17 @@ fn expand_selection(cx: &mut Context) {
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
             let selection = object::expand_selection(syntax, text, doc.selection(view.id));
-            doc.set_selection(view.id, selection);
+            doc.push_selection(view.id, selection);
         }
+    };
+    motion(cx.editor);
+    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+}
+
+fn shrink_selection(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+        doc.pop_selection(view.id);
     };
     motion(cx.editor);
     cx.editor.last_motion = Some(Motion(Box::new(motion)));

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -569,11 +569,13 @@ impl Default for Keymaps {
                 "d" => goto_prev_diag,
                 "D" => goto_first_diag,
                 "space" => add_newline_above,
+                "o" => shrink_selection,
             },
             "]" => { "Right bracket"
                 "d" => goto_next_diag,
                 "D" => goto_last_diag,
                 "space" => add_newline_below,
+                "o" => expand_selection,
             },
 
             "/" => search,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -73,6 +73,7 @@ pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
     pub(crate) selections: HashMap<ViewId, Selection>,
+    pub(crate) selections_history: HashMap<ViewId, Vec<Selection>>,
 
     path: Option<PathBuf>,
     encoding: &'static encoding::Encoding,
@@ -334,6 +335,7 @@ impl Document {
             encoding,
             text,
             selections: HashMap::default(),
+            selections_history: HashMap::default(),
             indent_style: DEFAULT_INDENT,
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
@@ -615,9 +617,35 @@ impl Document {
 
     /// Select text within the [`Document`].
     pub fn set_selection(&mut self, view_id: ViewId, selection: Selection) {
+        // clear selection history created by [`push_selection`]
+        self.selections_history
+            .entry(view_id)
+            .and_modify(|hist| hist.clear());
         // TODO: use a transaction?
         self.selections
             .insert(view_id, selection.ensure_invariants(self.text().slice(..)));
+    }
+
+    /// Push selection selects text within the [`Document`] and persists the previous
+    /// selection on stack. Previous selection can be restored using [`pop_selection`].
+    /// If selection if modified using [`set_selection`] the history is cleared.
+    pub fn push_selection(&mut self, view_id: ViewId, selection: Selection) {
+        let prev_selection = self.selection(view_id).clone();
+        self.selections_history
+            .entry(view_id)
+            .or_insert_with(Vec::default)
+            .push(prev_selection);
+        self.selections
+            .insert(view_id, selection.ensure_invariants(self.text().slice(..)));
+    }
+
+    // Restores previous [`Document`] selection from the stack.
+    pub fn pop_selection(&mut self, view_id: ViewId) {
+        if let Some(hist) = self.selections_history.get_mut(&view_id) {
+            if let Some(prev_selection) = hist.pop() {
+                self.selections.insert(view_id, prev_selection);
+            }
+        }
     }
 
     /// Apply a [`Transaction`] to the [`Document`] to change its text.

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -80,6 +80,8 @@ pub struct View {
     // uses two docs because we want to be able to swap between the
     // two last modified docs which we need to manually keep track of
     pub last_modified_docs: [Option<DocumentId>; 2],
+    /// used to store previous selections of tree-sitter objecs
+    pub object_selections: Vec<Selection>,
 }
 
 impl View {
@@ -92,6 +94,7 @@ impl View {
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
             last_accessed_doc: None,
             last_modified_docs: [None, None],
+            object_selections: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Add `shrink_selection` command that can be used to shrink previously expanded selection.

To make `shrink_selection` work it was necessary to add selection history to the Document since we want to shrink the selection towards the syntax tree node that was initially selected.

Selection history is cleared any time the user changes selection other way than by `expand_selection`. This ensures that we don't get some funky edge cases when user calls `shrink_selection`.

Related: https://github.com/helix-editor/helix/discussions/1328