### PR TITLE
Typo fix in ocaml indents.toml

### DIFF
--- a/runtime/queries/ocaml/indents.toml
+++ b/runtime/queries/ocaml/indents.toml
@@ -8,6 +8,6 @@ indent = [
     "match_case",
 ]
 
-oudent = [
+outdent = [
     "}",
 ]


### PR DESCRIPTION
`oudent` -> `outdent`