### PR TITLE
Sync tmux clipboard and system clipboard

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -47,6 +47,7 @@ You may also specify a file to use for configuration with the `-c` or
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
+| `tmux-system-clipboard` | Sync with the system clipboard when running in tmux. | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -5,6 +5,7 @@ use crossterm::{
 use helix_core::config::{default_syntax_loader, user_syntax_loader};
 use helix_loader::grammar::load_runtime_file;
 use helix_view::clipboard::get_clipboard_provider;
+use helix_view::editor::Config;
 use std::io::Write;
 
 #[derive(Copy, Clone)]
@@ -53,7 +54,7 @@ pub fn general() -> std::io::Result<()> {
     let lang_file = helix_loader::lang_config_file();
     let log_file = helix_loader::log_file();
     let rt_dir = helix_loader::runtime_dir();
-    let clipboard_provider = get_clipboard_provider();
+    let clipboard_provider = get_clipboard_provider(&Config::default());
 
     if config_file.exists() {
         writeln!(stdout, "Config file: {}", config_file.display())?;
@@ -87,7 +88,7 @@ pub fn clipboard() -> std::io::Result<()> {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
 
-    let board = get_clipboard_provider();
+    let board = get_clipboard_provider(&Config::default());
     match board.name().as_ref() {
         "none" => {
             writeln!(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -151,6 +151,8 @@ pub struct Config {
     pub statusline: StatusLineConfig,
     /// Shape for cursor in each mode
     pub cursor_shape: CursorShapeConfig,
+    /// Sync with the system clipboard when running in tmux. Defaults to `true`.
+    pub tmux_system_clipboard: bool,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
     /// Search configuration.
@@ -548,6 +550,7 @@ impl Default for Config {
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),
+            tmux_system_clipboard: true,
             true_color: false,
             search: SearchConfig::default(),
             lsp: LspConfig::default(),
@@ -697,7 +700,7 @@ impl Editor {
             theme_loader,
             last_theme: None,
             registers: Registers::default(),
-            clipboard_provider: get_clipboard_provider(),
+            clipboard_provider: get_clipboard_provider(&*conf),
             status_msg: None,
             autoinfo: None,
             idle_timer: Box::pin(sleep(conf.idle_timeout)),


### PR DESCRIPTION
When copying, also write the content into the system clipboard.
When pasting, request tmux to refresh its paste buffer from the system
clipboard, wait for the update to propagate and the request the
clipboard content from tmux.

With `set -g set-clipboard on` in tmux, this enables sharing the
system clipboard with a helix running in tmux, running in an ssh
session, running in alacritty.

The need for a wait is unfortunate, but I didn't find a better way.
Tmux asks the terminal for the clipboard content and updates its buffer
after it got an answer. The answer may come or may not. It may take
long, e.g. when running through a slow ssh connection.

The feature works well on alacritty. On konsole, it doesn't do
anything, but doesn't harm either. On xterm, `tmux refresh-client -l`
prints gibberish for me, also without using helix, so I added an
option to disable this feature.