### PR TITLE
Enable Rust proc macro support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -8,10 +8,6 @@ auto-format = true
 comment-token = "//"
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
-[language.config]
-cargo = { loadOutDirsFromCheck = true }
-procMacro = { enable = false }
-diagnostics = { disabled = ["unresolved-proc-macro"] }
 
 [[language]]
 name = "toml"
@@ -477,4 +473,3 @@ file-types = ["Dockerfile", "dockerfile"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "docker-langserver", args = ["--stdio"] }
-


### PR DESCRIPTION
`loadOutDirsFromCheck` is now called `runBuildScripts` and has been enabled by default for 10 months. And proc macros are enabled in upstream by default, so maybe there's no particular reason to disable them?

https://user-images.githubusercontent.com/308347/147342914-e8643820-6d71-4ec6-85fc-032df5960eb5.mp4
