### PR TITLE
Truncate the start of file paths in the StatusLine

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -643,15 +643,18 @@ impl EditorView {
                 .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
             format!("{}{}", path, if doc.is_modified() { "[+]" } else { "" })
         };
-        
+
         surface.set_string_truncated(
             viewport.x + 8, // 8: 1 space + 3 char mode string + 1 space + 1 spinner + 1 space
             viewport.y,
             title,
-            viewport.width.saturating_sub(6).saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
-            base_style, 
-            true, 
-            true
+            viewport
+                .width
+                .saturating_sub(6)
+                .saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
+            base_style,
+            true,
+            true,
         );
     }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -548,21 +548,6 @@ impl EditorView {
         }
         surface.set_string(viewport.x + 5, viewport.y, progress, base_style);
 
-        let rel_path = doc.relative_path();
-        let path = rel_path
-            .as_ref()
-            .map(|p| p.to_string_lossy())
-            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
-
-        let title = format!("{}{}", path, if doc.is_modified() { "[+]" } else { "" });
-        surface.set_stringn(
-            viewport.x + 8,
-            viewport.y,
-            title,
-            viewport.width.saturating_sub(6) as usize,
-            base_style,
-        );
-
         //-------------------------------
         // Right side of the status line.
         //-------------------------------
@@ -645,6 +630,28 @@ impl EditorView {
             viewport.y,
             &right_side_text,
             right_side_text.width() as u16,
+        );
+
+        //-------------------------------
+        // Middle / File path / Title
+        //-------------------------------
+        let title = {
+            let rel_path = doc.relative_path();
+            let path = rel_path
+                .as_ref()
+                .map(|p| p.to_string_lossy())
+                .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+            format!("{}{}", path, if doc.is_modified() { "[+]" } else { "" })
+        };
+        
+        surface.set_string_truncated(
+            viewport.x + 8, // 8: 1 space + 3 char mode string + 1 space + 1 spinner + 1 space
+            viewport.y,
+            title,
+            viewport.width.saturating_sub(6).saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
+            base_style, 
+            true, 
+            true
         );
     }
 


### PR DESCRIPTION
Fixes the same issue as in [#945](https://github.com/helix-editor/helix/issues/945) but for the StatusLine.

Before:
![image](https://user-images.githubusercontent.com/2362136/147347233-662ad464-ef51-4e21-9e17-389871c01119.png)

We can see that the file name is truncated, while this is more important to the user than the path.

And in the second red rectangle, we can see that the letters "od" from the path is rendered outside of the statusline area.

After:
![image](https://user-images.githubusercontent.com/2362136/147347098-40bd406d-57dc-424e-8faf-98b0ea4308c1.png)

