### PR TITLE
Open the File Picker in the folder of the active buffer

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -270,6 +270,7 @@ impl MappableCommand {
         append_mode, "Insert after selection (append)",
         command_mode, "Enter command mode",
         file_picker, "Open file picker",
+        file_picker_in_directory_of_active_buffer, "Open file picker in the directory of the active buffer",
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         symbol_picker, "Open symbol picker",
@@ -3027,6 +3028,19 @@ fn command_mode(cx: &mut Context) {
 
 fn file_picker(cx: &mut Context) {
     let root = find_root(None).unwrap_or_else(|| PathBuf::from("./"));
+    let picker = ui::file_picker(root, &cx.editor.config);
+    cx.push_layer(Box::new(picker));
+}
+
+fn file_picker_in_directory_of_active_buffer(cx: &mut Context) {
+    let (_view, doc) = current!(cx.editor);
+    let root = if let Some(current_path) = doc.path() {
+        let mut p = current_path.clone();
+        p.pop();
+        p
+    } else {
+        find_root(None).unwrap_or_else(|| PathBuf::from("./"))
+    };
     let picker = ui::file_picker(root, &cx.editor.config);
     cx.push_layer(Box::new(picker));
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3033,7 +3033,7 @@ fn file_picker(cx: &mut Context) {
 }
 
 fn file_picker_in_directory_of_active_buffer(cx: &mut Context) {
-    let (_view, doc) = current!(cx.editor);
+    let doc = doc!(cx.editor);
     let root = if let Some(current_path) = doc.path() {
         let mut p = current_path.clone();
         p.pop();

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -648,6 +648,7 @@ impl Default for Keymaps {
 
             "space" => { "Space"
                 "f" => file_picker,
+                "F" => file_picker_in_directory_of_active_buffer,
                 "b" => buffer_picker,
                 "s" => symbol_picker,
                 "S" => workspace_symbol_picker,


### PR DESCRIPTION
In Programming languages with deeply nested directory hierarchies (e.g. Java or TypeScript in an Angular Project), files in the same folder/package level often needs to be easily accessed or explored.
The deep level of directory hierarchies and the long file names these projects usually use make it difficult to find those files via the default File Picker.

In IntelliJ, one can press `alt+home` to get a navigatable dialog widget to explore/access the files in the currently editing file's folder.
![image](https://user-images.githubusercontent.com/2362136/147347767-5698bddf-1ff9-4f67-b6b4-a42596d4750e.png)

A similar functionality could be achieved if there was a way to open the File Picker from the active file's folder.