### PR TITLE
feat(ui): file encoding in statusline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ version = "0.5.0"
 dependencies = [
  "arc-swap",
  "chrono",
+ "encoding_rs",
  "etcetera",
  "helix-syntax",
  "log",
@@ -426,7 +427,6 @@ dependencies = [
  "chrono",
  "content_inspector",
  "crossterm",
- "encoding_rs",
  "fern",
  "futures-util",
  "fuzzy-matcher",
@@ -472,7 +472,6 @@ dependencies = [
  "chardetng",
  "clipboard-win",
  "crossterm",
- "encoding_rs",
  "futures-util",
  "helix-core",
  "helix-lsp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "chrono",
  "content_inspector",
  "crossterm",
+ "encoding_rs",
  "fern",
  "futures-util",
  "fuzzy-matcher",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -35,6 +35,7 @@ toml = "0.5"
 similar = "2.1"
 
 etcetera = "0.3"
+encoding_rs = "0.8"
 
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -1,3 +1,5 @@
+pub use encoding_rs as encoding;
+
 pub mod auto_pairs;
 pub mod chars;
 pub mod comment;

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -50,6 +50,8 @@ pulldown-cmark = { version = "0.8", default-features = false }
 # file type detection
 content_inspector = "0.2.4"
 
+encoding_rs = "0.8"
+
 # config
 toml = "0.5"
 

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -50,8 +50,6 @@ pulldown-cmark = { version = "0.8", default-features = false }
 # file type detection
 content_inspector = "0.2.4"
 
-encoding_rs = "0.8"
-
 # config
 toml = "0.5"
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -636,6 +636,13 @@ impl EditorView {
             base_style,
         ));
 
+        let encoding = doc.encoding();
+        if encoding != encoding_rs::UTF_8 {
+            right_side_text
+                .0
+                .push(Span::styled(format!(" {} ", encoding.name()), base_style));
+        }
+
         // Render to the statusline.
         surface.set_spans(
             viewport.x

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use helix_core::{
-    coords_at_pos,
+    coords_at_pos, encoding,
     graphemes::{ensure_grapheme_boundary_next, next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
     syntax::{self, HighlightEvent},
@@ -636,11 +636,11 @@ impl EditorView {
             base_style,
         ));
 
-        let encoding = doc.encoding();
-        if encoding != encoding_rs::UTF_8 {
+        let enc = doc.encoding();
+        if enc != encoding::UTF_8 {
             right_side_text
                 .0
-                .push(Span::styled(format!(" {} ", encoding.name()), base_style));
+                .push(Span::styled(format!(" {} ", enc.name()), base_style));
         }
 
         // Render to the statusline.

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -29,7 +29,6 @@ futures-util = { version = "0.3", features = ["std", "async-await"], default-fea
 
 slotmap = "1"
 
-encoding_rs = "0.8"
 chardetng = "0.1"
 
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use helix_core::{
+    encoding,
     history::History,
     indent::{auto_detect_indent_style, IndentStyle},
     line_ending::auto_detect_line_ending,
@@ -74,7 +75,7 @@ pub struct Document {
     pub(crate) selections: HashMap<ViewId, Selection>,
 
     path: Option<PathBuf>,
-    encoding: &'static encoding_rs::Encoding,
+    encoding: &'static encoding::Encoding,
 
     /// Current editing mode.
     pub mode: Mode,
@@ -143,8 +144,8 @@ impl fmt::Debug for Document {
 /// be used to override encoding auto-detection.
 pub fn from_reader<R: std::io::Read + ?Sized>(
     reader: &mut R,
-    encoding: Option<&'static encoding_rs::Encoding>,
-) -> Result<(Rope, &'static encoding_rs::Encoding), Error> {
+    encoding: Option<&'static encoding::Encoding>,
+) -> Result<(Rope, &'static encoding::Encoding), Error> {
     // These two buffers are 8192 bytes in size each and are used as
     // intermediaries during the decoding process. Text read into `buf`
     // from `reader` is decoded into `buf_out` as UTF-8. Once either
@@ -212,11 +213,11 @@ pub fn from_reader<R: std::io::Read + ?Sized>(
             total_read += read;
             total_written += written;
             match result {
-                encoding_rs::CoderResult::InputEmpty => {
+                encoding::CoderResult::InputEmpty => {
                     debug_assert_eq!(slice.len(), total_read);
                     break;
                 }
-                encoding_rs::CoderResult::OutputFull => {
+                encoding::CoderResult::OutputFull => {
                     debug_assert!(slice.len() > total_read);
                     builder.append(&buf_str[..total_written]);
                     total_written = 0;
@@ -251,7 +252,7 @@ pub fn from_reader<R: std::io::Read + ?Sized>(
 /// replacement characters may appear in the encoded text.
 pub async fn to_writer<'a, W: tokio::io::AsyncWriteExt + Unpin + ?Sized>(
     writer: &'a mut W,
-    encoding: &'static encoding_rs::Encoding,
+    encoding: &'static encoding::Encoding,
     rope: &'a Rope,
 ) -> Result<(), Error> {
     // Text inside a `Rope` is stored as non-contiguous blocks of data called
@@ -286,12 +287,12 @@ pub async fn to_writer<'a, W: tokio::io::AsyncWriteExt + Unpin + ?Sized>(
             total_read += read;
             total_written += written;
             match result {
-                encoding_rs::CoderResult::InputEmpty => {
+                encoding::CoderResult::InputEmpty => {
                     debug_assert_eq!(chunk.len(), total_read);
                     debug_assert!(buf.len() >= total_written);
                     break;
                 }
-                encoding_rs::CoderResult::OutputFull => {
+                encoding::CoderResult::OutputFull => {
                     debug_assert!(chunk.len() > total_read);
                     writer.write_all(&buf[..total_written]).await?;
                     total_written = 0;
@@ -322,8 +323,8 @@ use helix_lsp::lsp;
 use url::Url;
 
 impl Document {
-    pub fn from(text: Rope, encoding: Option<&'static encoding_rs::Encoding>) -> Self {
-        let encoding = encoding.unwrap_or(encoding_rs::UTF_8);
+    pub fn from(text: Rope, encoding: Option<&'static encoding::Encoding>) -> Self {
+        let encoding = encoding.unwrap_or(encoding::UTF_8);
         let changes = ChangeSet::new(&text);
         let old_state = None;
 
@@ -356,7 +357,7 @@ impl Document {
     /// overwritten with the `encoding` parameter.
     pub fn open(
         path: &Path,
-        encoding: Option<&'static encoding_rs::Encoding>,
+        encoding: Option<&'static encoding::Encoding>,
         theme: Option<&Theme>,
         config_loader: Option<&syntax::Loader>,
     ) -> Result<Self, Error> {
@@ -366,7 +367,7 @@ impl Document {
                 std::fs::File::open(path).context(format!("unable to open {:?}", path))?;
             from_reader(&mut file, encoding)?
         } else {
-            let encoding = encoding.unwrap_or(encoding_rs::UTF_8);
+            let encoding = encoding.unwrap_or(encoding::UTF_8);
             (Rope::from(DEFAULT_LINE_ENDING.as_str()), encoding)
         };
 
@@ -548,7 +549,7 @@ impl Document {
 
     /// Sets the [`Document`]'s encoding with the encoding correspondent to `label`.
     pub fn set_encoding(&mut self, label: &str) -> Result<(), Error> {
-        match encoding_rs::Encoding::for_label(label.as_bytes()) {
+        match encoding::Encoding::for_label(label.as_bytes()) {
             Some(encoding) => self.encoding = encoding,
             None => return Err(anyhow::anyhow!("unknown encoding")),
         }
@@ -556,7 +557,7 @@ impl Document {
     }
 
     /// Returns the [`Document`]'s current encoding.
-    pub fn encoding(&self) -> &'static encoding_rs::Encoding {
+    pub fn encoding(&self) -> &'static encoding::Encoding {
         self.encoding
     }
 
@@ -1123,7 +1124,7 @@ mod test {
 
     macro_rules! test_decode {
         ($label:expr, $label_override:expr) => {
-            let encoding = encoding_rs::Encoding::for_label($label_override.as_bytes()).unwrap();
+            let encoding = encoding::Encoding::for_label($label_override.as_bytes()).unwrap();
             let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/encoding");
             let path = base_path.join(format!("{}_in.txt", $label));
             let ref_path = base_path.join(format!("{}_in_ref.txt", $label));
@@ -1142,7 +1143,7 @@ mod test {
 
     macro_rules! test_encode {
         ($label:expr, $label_override:expr) => {
-            let encoding = encoding_rs::Encoding::for_label($label_override.as_bytes()).unwrap();
+            let encoding = encoding::Encoding::for_label($label_override.as_bytes()).unwrap();
             let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/encoding");
             let path = base_path.join(format!("{}_out.txt", $label));
             let ref_path = base_path.join(format!("{}_out_ref.txt", $label));


### PR DESCRIPTION
Display file encoding in statusline if the encoding isn't UTF-8.

---

I assume this will be configurable in the future with the rest of the statusline but for now this seems like a reasonable step in between, hopefully with reasonable default.