### PR TITLE
add tree-sitter-regex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -182,3 +182,7 @@
 	path = helix-syntax/languages/tree-sitter-git-rebase
 	url = https://github.com/the-mikedavis/tree-sitter-git-rebase.git
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-regex"]
+	path = helix-syntax/languages/tree-sitter-regex
+	url = https://github.com/tree-sitter/tree-sitter-regex.git
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -36,6 +36,7 @@
 | protobuf | ✓ |  | ✓ |  |
 | python | ✓ | ✓ | ✓ | `pylsp` |
 | racket |  |  |  | `racket` |
+| regex | ✓ |  |  |  |
 | ruby | ✓ |  | ✓ | `solargraph` |
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |
 | scala | ✓ |  | ✓ | `metals` |

--- a/languages.toml
+++ b/languages.toml
@@ -499,3 +499,10 @@ file-types = ["git-rebase-todo"]
 injection-regex = "git-rebase"
 comment-token = "#"
 indent = { tab-width = 2, unit = " " }
+
+[[language]]
+name = "regex"
+scope = "source.regex"
+injection-regex = "regex"
+file-types = ["regex"]
+roots = []

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -1,2 +1,8 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(r|R)$")
+ (#set! injection.language "regex"))

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -5,4 +5,5 @@
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
  (#match? @_sigil_name "^(r|R)$")
- (#set! injection.language "regex"))
+ (#set! injection.language "regex")
+ (#set! injection.combined))

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -1,0 +1,35 @@
+[
+  "("
+  ")"
+  "(?"
+  "(?:"
+  "(?<"
+  ">"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "*"
+  "+"
+  "|"
+  "="
+  "<="
+  "!"
+  "<!"
+] @operator
+
+[
+  (identity_escape)
+  (control_letter_escape)
+  (character_class_escape)
+  (control_escape)
+  (start_assertion)
+  (end_assertion)
+  (boundary_assertion)
+  (non_boundary_assertion)
+] @constant.character.escape
+
+(group_name) @property

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -19,6 +19,7 @@
   "<="
   "!"
   "<!"
+  "?"
 ] @operator
 
 [
@@ -41,9 +42,8 @@
   ])
 
 (character_class
-  (class_range [
+  [
+    "^" @operator
+    (class_range "-" @operator)
     (class_character) @constant.character
-    "-" @operator
-  ]))
-
-(class_character) @string
+  ])

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -1,3 +1,5 @@
+; upstream: https://github.com/tree-sitter/tree-sitter-regex/blob/e1cfca3c79896ff79842f057ea13e529b66af636/queries/highlights.scm
+
 [
   "("
   ")"

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -45,5 +45,6 @@
   [
     "^" @operator
     (class_range "-" @operator)
-    (class_character) @constant.character
   ])
+
+(class_character) @constant.character

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -48,3 +48,4 @@
   ])
 
 (class_character) @constant.character
+(pattern_character) @string

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -33,3 +33,17 @@
 ] @constant.character.escape
 
 (group_name) @property
+
+(count_quantifier
+  [
+    (decimal_digits) @constant.numeric
+    "," @punctuation.delimiter
+  ])
+
+(character_class
+  (class_range [
+    (class_character) @constant.character
+    "-" @operator
+  ]))
+
+(class_character) @string

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -10,3 +10,17 @@
   (token_tree) @injection.content)
  (#set! injection.language "rust")
  (#set! injection.include-children))
+
+(call_expression
+  function: (scoped_identifier
+    path: (identifier) @_regex (#eq? @_regex "Regex")
+    name: (identifier) @_new (#eq? @_new "new"))
+  arguments: (arguments (raw_string_literal) @injection.content)
+  (#set! injection.language "regex"))
+
+(call_expression
+  function: (scoped_identifier
+    path: (scoped_identifier (identifier) @_regex (#eq? @_regex "Regex") .)
+    name: (identifier) @_new (#eq? @_new "new"))
+  arguments: (arguments (raw_string_literal) @injection.content)
+  (#set! injection.language "regex"))


### PR DESCRIPTION
Example injected into elixir

![regex](https://user-images.githubusercontent.com/21230295/147375735-ce41e736-6e89-4708-8bff-444040265038.png)

it's a pretty subtle improvement; I'm not too impressed yet. Let me dig into the grammar and see if we can write some more interesting queries beyond brackets and quantifiers.