### PR TITLE
Auto pairs delete

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4263,7 +4263,7 @@ pub mod insert {
         Some(transaction)
     }
 
-    use helix_core::auto_pairs;
+    use helix_core::{auto_pairs, Change};
 
     pub fn insert_char(cx: &mut Context, c: char) {
         let (view, doc) = current!(cx.editor);
@@ -4369,77 +4369,86 @@ pub mod insert {
         });
 
         transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
-        //
-
         doc.apply(&transaction, view.id);
     }
 
     pub fn delete_char_backward(cx: &mut Context) {
         let count = cx.count();
         let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-        let indent_unit = doc.indent_unit();
-        let tab_size = doc.tab_width();
 
         let transaction =
             Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
-                let pos = range.cursor(text);
-                let line_start_pos = text.line_to_char(range.cursor_line(text));
-                // considier to delete by indent level if all characters before `pos` are indent units.
-                let fragment = Cow::from(text.slice(line_start_pos..pos));
-                if !fragment.is_empty() && fragment.chars().all(|ch| ch.is_whitespace()) {
-                    if text.get_char(pos.saturating_sub(1)) == Some('\t') {
-                        // fast path, delete one char
-                        (
-                            graphemes::nth_prev_grapheme_boundary(text, pos, 1),
-                            pos,
-                            None,
-                        )
-                    } else {
-                        let unit_len = indent_unit.chars().count();
-                        // NOTE: indent_unit always contains 'only spaces' or 'only tab' according to `IndentStyle` definition.
-                        let unit_size = if indent_unit.starts_with('\t') {
-                            tab_size * unit_len
-                        } else {
-                            unit_len
-                        };
-                        let width: usize = fragment
-                            .chars()
-                            .map(|ch| {
-                                if ch == '\t' {
-                                    tab_size
-                                } else {
-                                    // it can be none if it still meet control characters other than '\t'
-                                    // here just set the width to 1 (or some value better?).
-                                    ch.width().unwrap_or(1)
-                                }
-                            })
-                            .sum();
-                        let mut drop = width % unit_size; // round down to nearest unit
-                        if drop == 0 {
-                            drop = unit_size
-                        }; // if it's already at a unit, consume a whole unit
-                        let mut chars = fragment.chars().rev();
-                        let mut start = pos;
-                        for _ in 0..drop {
-                            // delete up to `drop` spaces
-                            match chars.next() {
-                                Some(' ') => start -= 1,
-                                _ => break,
-                            }
-                        }
-                        (start, pos, None) // delete!
-                    }
-                } else {
-                    // delete char
+                handle_backspace_dedent(doc, range).unwrap_or_else(|| {
+                    let text = doc.text().slice(..);
+                    let pos = range.cursor(text);
+
                     (
                         graphemes::nth_prev_grapheme_boundary(text, pos, count),
                         pos,
                         None,
                     )
-                }
+                })
             });
+
         doc.apply(&transaction, view.id);
+    }
+
+    fn handle_backspace_dedent(doc: &Document, range: &Range) -> Option<Change> {
+        let text = doc.text().slice(..);
+        let indent_unit = doc.indent_unit();
+        let tab_size = doc.tab_width();
+        let pos = range.cursor(text);
+
+        let line_start_pos = text.line_to_char(range.cursor_line(text));
+        // considier to delete by indent level if all characters before `pos` are indent units.
+        let fragment = Cow::from(text.slice(line_start_pos..pos));
+
+        if fragment.is_empty() || !fragment.chars().all(|ch| ch.is_whitespace()) {
+            return None;
+        }
+
+        // fast path, return None to delete one char with default handling
+        if text.get_char(pos.saturating_sub(1)) == Some('\t') {
+            return None;
+        }
+
+        let unit_len = indent_unit.chars().count();
+
+        // NOTE: indent_unit always contains 'only spaces' or 'only tab' according to `IndentStyle` definition.
+        let unit_size = if indent_unit.starts_with('\t') {
+            tab_size * unit_len
+        } else {
+            unit_len
+        };
+
+        let width: usize = fragment
+            .chars()
+            .map(|ch| {
+                if ch == '\t' {
+                    tab_size
+                } else {
+                    // it can be none if it still meet control characters other than '\t'
+                    // here just set the width to 1 (or some value better?).
+                    ch.width().unwrap_or(1)
+                }
+            })
+            .sum();
+
+        let mut drop = width % unit_size; // round down to nearest unit
+        if drop == 0 {
+            drop = unit_size
+        }; // if it's already at a unit, consume a whole unit
+        let mut chars = fragment.chars().rev();
+        let mut start = pos;
+        for _ in 0..drop {
+            // delete up to `drop` spaces
+            match chars.next() {
+                Some(' ') => start -= 1,
+                _ => break,
+            }
+        }
+
+        Some((start, pos, None)) // delete!
     }
 
     pub fn delete_char_forward(cx: &mut Context) {


### PR DESCRIPTION
I began trying to implement deleting pairs on backspace, and I ran into an issue that I think is best demonstrated by showing what I've tried first. This PR is mainly just context for a discussion at this stage; it made me think a more invasive change may be necessary to support it.

Looking over the current code for `delete_char_backward`, I can see that there is code there for handling dedenting as well. In order to preserve this behavior, we need to basically check for both conditions on a backspace: if the line is all whitespace to dedent, and if not, then check if both sides of the cursor are a pair, and finally proceeding to a regular single character deletion.

Now, the current code for auto pairs works by putting together an entire transaction, assuming its logic will either create the entire change or none of it. However, with multiple ranges in the selection, one cursor could end up being in position for an auto pair deletion while another is on a line that only contains whitespace, and thus should dedent. In order to support this, we need to produce changes for *individual ranges*, not on the whole selection.

So the PR here is what I tried to get it working. And it does work, but only for one-width cursors. If it's in a selection, the head ends up moving back two characters, when it should only move back once, e.g. `[word(]) -> [wor]d`. I think this is the same reason that the current auto pairs code works with entire `Transaction`s, since by doing this, we can calculate the correct resulting selection as well as the textual changes to the document.

So we have a conflict here: auto pairs needs to change selections as well as text, but we also cannot control the entire transaction, because auto pairs is not responsible for all of the changes that could happen.

So I had an idea that maybe [`Change`](https://github.com/helix-editor/helix/blob/a306a1052a51c686b24a6f339190878b8029a894/helix-core/src/transaction.rs#L5) could become a 4-tuple, with the last being an `Option<Range>` that explicitly sets what the new range should be after the textual change. Then we could have [`Transaction::change`](https://github.com/helix-editor/helix/blob/a306a1052a51c686b24a6f339190878b8029a894/helix-core/src/transaction.rs#L474) build up a selection as it iterates through the `Change`s. Then we could build the transactions the same way, but we'd get selection manipulation too.

So the hook functions would return `Option<Change>`, and operate only on a single range of text. I believe this would also, by extension, take care of the old todo that the auto pairs insert hook should just fall back on the default insert hook when it won't insert a pair.

What do you think?