### PR TITLE
(perf): Use aHash instead of std hashmap/hashset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +380,7 @@ dependencies = [
 name = "helix-core"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "arc-swap",
  "chrono",
  "encoding_rs",
@@ -394,6 +407,7 @@ dependencies = [
 name = "helix-lsp"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "futures-executor",
  "futures-util",
@@ -423,6 +437,7 @@ dependencies = [
 name = "helix-term"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "chrono",
  "content_inspector",
@@ -454,6 +469,7 @@ dependencies = [
 name = "helix-tui"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "bitflags",
  "cassowary",
  "crossterm",
@@ -467,6 +483,7 @@ dependencies = [
 name = "helix-view"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bitflags",
  "chardetng",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -15,6 +15,7 @@ include = ["src/**/*", "README.md"]
 [dependencies]
 helix-syntax = { version = "0.5", path = "../helix-syntax" }
 
+ahash = { version = "0.7", features = ["serde"] }
 ropey = "1.3"
 smallvec = "1.7"
 tendril = "0.4.2"

--- a/helix-core/src/macros.rs
+++ b/helix-core/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut _map = ::ahash::AHashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
             )*

--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::AHashMap;
 
 #[derive(Debug)]
 pub struct Register {
@@ -46,7 +46,7 @@ impl Register {
 /// Currently just wraps a `HashMap` of `Register`s
 #[derive(Debug, Default)]
 pub struct Registers {
-    inner: HashMap<char, Register>,
+    inner: AHashMap<char, Register>,
 }
 
 impl Registers {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -10,14 +10,8 @@ pub use helix_syntax::get_language;
 
 use arc_swap::ArcSwap;
 
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::{HashMap, HashSet},
-    fmt,
-    path::Path,
-    sync::Arc,
-};
+use ahash::{AHashMap, AHashSet};
+use std::{borrow::Cow, cell::RefCell, fmt, path::Path, sync::Arc};
 
 use once_cell::sync::{Lazy, OnceCell};
 use serde::{Deserialize, Serialize};
@@ -106,11 +100,11 @@ pub struct IndentationConfiguration {
 #[serde(rename_all = "kebab-case")]
 pub struct IndentQuery {
     #[serde(default)]
-    #[serde(skip_serializing_if = "HashSet::is_empty")]
-    pub indent: HashSet<String>,
+    #[serde(skip_serializing_if = "std::collections::HashSet::is_empty")]
+    pub indent: AHashSet<String>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "HashSet::is_empty")]
-    pub outdent: HashSet<String>,
+    #[serde(skip_serializing_if = "std::collections::HashSet::is_empty")]
+    pub outdent: AHashSet<String>,
 }
 
 #[derive(Debug)]
@@ -259,16 +253,16 @@ impl LanguageConfiguration {
 pub struct Loader {
     // highlight_names ?
     language_configs: Vec<Arc<LanguageConfiguration>>,
-    language_config_ids_by_file_type: HashMap<String, usize>, // Vec<usize>
-    language_config_ids_by_shebang: HashMap<String, usize>,
+    language_config_ids_by_file_type: AHashMap<String, usize>, // Vec<usize>
+    language_config_ids_by_shebang: AHashMap<String, usize>,
 }
 
 impl Loader {
     pub fn new(config: Configuration) -> Self {
         let mut loader = Self {
             language_configs: Vec::new(),
-            language_config_ids_by_file_type: HashMap::new(),
-            language_config_ids_by_shebang: HashMap::new(),
+            language_config_ids_by_file_type: AHashMap::new(),
+            language_config_ids_by_shebang: AHashMap::new(),
         };
 
         for config in config.language {

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://helix-editor.com"
 [dependencies]
 helix-core = { version = "0.5", path = "../helix-core" }
 
+ahash = "0.7"
 anyhow = "1.0"
 futures-executor = "0.3"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -11,8 +11,9 @@ pub use lsp_types as lsp;
 use futures_util::stream::select_all::SelectAll;
 use helix_core::syntax::LanguageConfiguration;
 
+use ahash::AHashMap;
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::hash_map::Entry,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -283,7 +284,7 @@ impl Notification {
 
 #[derive(Debug)]
 pub struct Registry {
-    inner: HashMap<LanguageId, (usize, Arc<Client>)>,
+    inner: AHashMap<LanguageId, (usize, Arc<Client>)>,
 
     counter: AtomicUsize,
     pub incoming: SelectAll<UnboundedReceiverStream<(usize, Call)>>,
@@ -298,7 +299,7 @@ impl Default for Registry {
 impl Registry {
     pub fn new() -> Self {
         Self {
-            inner: HashMap::new(),
+            inner: AHashMap::new(),
             counter: AtomicUsize::new(0),
             incoming: SelectAll::new(),
         }
@@ -388,7 +389,7 @@ impl ProgressStatus {
 /// Acts as a container for progress reported by language servers. Each server
 /// has a unique id assigned at creation through [`Registry`]. This id is then used
 /// to store the progress in this map.
-pub struct LspProgressMap(HashMap<usize, HashMap<lsp::ProgressToken, ProgressStatus>>);
+pub struct LspProgressMap(AHashMap<usize, AHashMap<lsp::ProgressToken, ProgressStatus>>);
 
 impl LspProgressMap {
     pub fn new() -> Self {
@@ -396,7 +397,7 @@ impl LspProgressMap {
     }
 
     /// Returns a map of all tokens coresponding to the lanaguage server with `id`.
-    pub fn progress_map(&self, id: usize) -> Option<&HashMap<lsp::ProgressToken, ProgressStatus>> {
+    pub fn progress_map(&self, id: usize) -> Option<&AHashMap<lsp::ProgressToken, ProgressStatus>> {
         self.0.get(&id)
     }
 

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -1,10 +1,10 @@
 use crate::{Error, Result};
+use ahash::AHashMap;
 use anyhow::Context;
 use jsonrpc_core as jsonrpc;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
@@ -39,7 +39,7 @@ enum ServerMessage {
 #[derive(Debug)]
 pub struct Transport {
     id: usize,
-    pending_requests: Mutex<HashMap<jsonrpc::Id, Sender<Result<Value>>>>,
+    pending_requests: Mutex<AHashMap<jsonrpc::Id, Sender<Result<Value>>>>,
 }
 
 impl Transport {
@@ -59,7 +59,7 @@ impl Transport {
 
         let transport = Self {
             id,
-            pending_requests: Mutex::new(HashMap::default()),
+            pending_requests: Mutex::new(AHashMap::default()),
         };
 
         let transport = Arc::new(transport);

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -26,6 +26,7 @@ helix-core = { version = "0.5", path = "../helix-core" }
 helix-view = { version = "0.5", path = "../helix-view" }
 helix-lsp = { version = "0.5", path = "../helix-lsp" }
 
+ahash = "0.7"
 anyhow = "1"
 once_cell = "1.9"
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -40,8 +40,9 @@ use crate::{
 };
 
 use crate::job::{self, Job, Jobs};
+use ahash::AHashSet;
 use futures_util::{FutureExt, StreamExt};
-use std::{collections::HashSet, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 use std::{fmt, future::Future};
 
 use std::{
@@ -1954,7 +1955,7 @@ fn append_mode(cx: &mut Context) {
 
 pub mod cmd {
     use super::*;
-    use std::collections::HashMap;
+    use ahash::AHashMap;
 
     use helix_view::editor::Action;
     use ui::completers::{self, Completer};
@@ -2968,7 +2969,7 @@ pub mod cmd {
         }
     ];
 
-    pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableCommand>> =
+    pub static TYPABLE_COMMAND_MAP: Lazy<AHashMap<&'static str, &'static TypableCommand>> =
         Lazy::new(|| {
             TYPABLE_COMMAND_LIST
                 .iter()
@@ -5985,7 +5986,7 @@ fn increment_impl(cx: &mut Context, amount: i64) {
     // incrementing will give overlapping changes, with each change incrementing a different part of
     // the date. Since these conflict with each other we remove these changes from the transaction
     // so nothing happens.
-    let mut overlapping_indexes = HashSet::new();
+    let mut overlapping_indexes = AHashSet::new();
     for (i, changes) in changes.windows(2).enumerate() {
         if changes[0].1 > changes[1].0 {
             overlapping_indexes.insert(i);

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -1,11 +1,12 @@
 pub use crate::commands::MappableCommand;
 use crate::config::Config;
+use ahash::AHashMap;
 use helix_core::hashmap;
 use helix_view::{document::Mode, info::Info, input::KeyEvent};
 use serde::Deserialize;
 use std::{
     borrow::Cow,
-    collections::{BTreeSet, HashMap},
+    collections::BTreeSet,
     ops::{Deref, DerefMut},
 };
 
@@ -111,7 +112,7 @@ macro_rules! keymap {
         // modified from the hashmap! macro
         {
             let _cap = hashmap!(@count $($($key),+),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut _map = ::ahash::AHashMap::with_capacity(_cap);
             let mut _order = ::std::vec::Vec::with_capacity(_cap);
             $(
                 $(
@@ -135,7 +136,7 @@ macro_rules! keymap {
 pub struct KeyTrieNode {
     /// A label for keys coming under this node, like "Goto mode"
     name: String,
-    map: HashMap<KeyEvent, KeyTrie>,
+    map: AHashMap<KeyEvent, KeyTrie>,
     order: Vec<KeyEvent>,
     pub is_sticky: bool,
 }
@@ -145,7 +146,7 @@ impl<'de> Deserialize<'de> for KeyTrieNode {
     where
         D: serde::Deserializer<'de>,
     {
-        let map = HashMap::<KeyEvent, KeyTrie>::deserialize(deserializer)?;
+        let map = AHashMap::<KeyEvent, KeyTrie>::deserialize(deserializer)?;
         let order = map.keys().copied().collect::<Vec<_>>(); // NOTE: map.keys() has arbitrary order
         Ok(Self {
             map,
@@ -156,7 +157,7 @@ impl<'de> Deserialize<'de> for KeyTrieNode {
 }
 
 impl KeyTrieNode {
-    pub fn new(name: &str, map: HashMap<KeyEvent, KeyTrie>, order: Vec<KeyEvent>) -> Self {
+    pub fn new(name: &str, map: AHashMap<KeyEvent, KeyTrie>, order: Vec<KeyEvent>) -> Self {
         Self {
             name: name.to_string(),
             map,
@@ -233,7 +234,7 @@ impl KeyTrieNode {
 
 impl Default for KeyTrieNode {
     fn default() -> Self {
-        Self::new("", HashMap::new(), Vec::new())
+        Self::new("", AHashMap::new(), Vec::new())
     }
 }
 
@@ -244,7 +245,7 @@ impl PartialEq for KeyTrieNode {
 }
 
 impl Deref for KeyTrieNode {
-    type Target = HashMap<KeyEvent, KeyTrie>;
+    type Target = AHashMap<KeyEvent, KeyTrie>;
 
     fn deref(&self) -> &Self::Target {
         &self.map
@@ -447,7 +448,7 @@ impl Default for Keymap {
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(transparent)]
-pub struct Keymaps(pub HashMap<Mode, Keymap>);
+pub struct Keymaps(pub AHashMap<Mode, Keymap>);
 
 impl Keymaps {
     /// Returns list of keys waiting to be disambiguated in current mode.
@@ -463,7 +464,7 @@ impl Keymaps {
 }
 
 impl Deref for Keymaps {
-    type Target = HashMap<Mode, Keymap>;
+    type Target = AHashMap<Mode, Keymap>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -9,13 +9,13 @@ use tui::{
     widgets::{Block, BorderType, Borders},
 };
 
+use ahash::AHashMap;
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
 use fuzzy_matcher::FuzzyMatcher;
 use tui::widgets::Widget;
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     io::Read,
     path::{Path, PathBuf},
 };
@@ -39,7 +39,7 @@ pub struct FilePicker<T> {
     picker: Picker<T>,
     pub truncate_start: bool,
     /// Caches paths to documents
-    preview_cache: HashMap<PathBuf, CachedPreview>,
+    preview_cache: AHashMap<PathBuf, CachedPreview>,
     read_buffer: Vec<u8>,
     /// Given an item in the picker, return the file path and line number to display.
     file_fn: Box<dyn Fn(&Editor, &T) -> Option<FileLocation>>,
@@ -92,7 +92,7 @@ impl<T> FilePicker<T> {
         Self {
             picker: Picker::new(false, options, format_fn, callback_fn),
             truncate_start: true,
-            preview_cache: HashMap::new(),
+            preview_cache: AHashMap::new(),
             read_buffer: Vec::with_capacity(1024),
             file_fn: Box::new(preview_fn),
         }

--- a/helix-term/src/ui/spinner.rs
+++ b/helix-term/src/ui/spinner.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, time::SystemTime};
+use ahash::AHashMap;
+use std::time::SystemTime;
 
 #[derive(Default, Debug)]
 pub struct ProgressSpinners {
-    inner: HashMap<usize, Spinner>,
+    inner: AHashMap<usize, Spinner>,
 }
 
 impl ProgressSpinners {

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**/*", "README.md"]
 default = ["crossterm"]
 
 [dependencies]
+ahash = "0.7"
 bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.8"

--- a/helix-tui/src/layout.rs
+++ b/helix-tui/src/layout.rs
@@ -1,9 +1,8 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use cassowary::strength::{REQUIRED, WEAK};
 use cassowary::WeightedRelation::*;
 use cassowary::{Constraint as CassowaryConstraint, Expression, Solver, Variable};
+use std::cell::RefCell;
 
 use helix_view::graphics::{Margin, Rect};
 
@@ -61,7 +60,7 @@ pub struct Layout {
 }
 
 thread_local! {
-    static LAYOUT_CACHE: RefCell<HashMap<(Rect, Layout), Vec<Rect>>> = RefCell::new(HashMap::new());
+    static LAYOUT_CACHE: RefCell<AHashMap<(Rect, Layout), Vec<Rect>>> = RefCell::new(AHashMap::new());
 }
 
 impl Default for Layout {
@@ -183,7 +182,7 @@ impl Layout {
 
 fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
     let mut solver = Solver::new();
-    let mut vars: HashMap<Variable, (usize, usize)> = HashMap::new();
+    let mut vars: AHashMap<Variable, (usize, usize)> = AHashMap::new();
     let elements = layout
         .constraints
         .iter()

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -4,6 +4,7 @@ use crate::{
     text::Text,
     widgets::{Block, Widget},
 };
+use ahash::AHashMap;
 use cassowary::{
     strength::{MEDIUM, REQUIRED, WEAK},
     WeightedRelation::*,
@@ -11,7 +12,6 @@ use cassowary::{
 };
 use helix_core::unicode::width::UnicodeWidthStr;
 use helix_view::graphics::{Rect, Style};
-use std::collections::HashMap;
 
 /// A [`Cell`] contains the [`Text`] to be displayed in a [`Row`] of a [`Table`].
 ///
@@ -261,7 +261,7 @@ impl<'a> Table<'a> {
 
     fn get_columns_widths(&self, max_width: u16, has_selection: bool) -> Vec<u16> {
         let mut solver = Solver::new();
-        let mut var_indices = HashMap::new();
+        let mut var_indices = AHashMap::new();
         let mut ccs = Vec::new();
         let mut variables = Vec::new();
         for i in 0..self.widths.len() {

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -16,6 +16,7 @@ term = ["crossterm"]
 [dependencies]
 bitflags = "1.3"
 anyhow = "1"
+ahash = "0.7"
 helix-core = { version = "0.5", path = "../helix-core" }
 helix-lsp = { version = "0.5", path = "../helix-lsp"}
 crossterm = { version = "0.22", optional = true }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1,12 +1,13 @@
 use anyhow::{anyhow, Context, Error};
 use serde::de::{self, Deserialize, Deserializer};
 use std::cell::Cell;
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+
+use ahash::AHashMap;
 
 use helix_core::{
     encoding,
@@ -72,7 +73,7 @@ impl<'de> Deserialize<'de> for Mode {
 pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
-    pub(crate) selections: HashMap<ViewId, Selection>,
+    pub(crate) selections: AHashMap<ViewId, Selection>,
 
     path: Option<PathBuf>,
     encoding: &'static encoding::Encoding,
@@ -333,7 +334,7 @@ impl Document {
             path: None,
             encoding,
             text,
-            selections: HashMap::default(),
+            selections: AHashMap::default(),
             indent_style: DEFAULT_INDENT,
             line_ending: DEFAULT_LINE_ENDING,
             mode: Mode::Normal,
@@ -915,7 +916,7 @@ impl Document {
         &self.selections[&view_id]
     }
 
-    pub fn selections(&self) -> &HashMap<ViewId, Selection> {
+    pub fn selections(&self) -> &AHashMap<ViewId, Selection> {
         &self.selections
     }
 

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -1,8 +1,6 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
+use ahash::AHashMap;
 use anyhow::Context;
 use helix_core::hashmap;
 use log::warn;
@@ -91,7 +89,7 @@ impl Loader {
 #[derive(Clone, Debug)]
 pub struct Theme {
     // UI styles are stored in a HashMap
-    styles: HashMap<String, Style>,
+    styles: AHashMap<String, Style>,
     // tree-sitter highlight styles are stored in a Vec to optimize lookups
     scopes: Vec<String>,
     highlights: Vec<Style>,
@@ -102,11 +100,11 @@ impl<'de> Deserialize<'de> for Theme {
     where
         D: Deserializer<'de>,
     {
-        let mut styles = HashMap::new();
+        let mut styles = AHashMap::new();
         let mut scopes = Vec::new();
         let mut highlights = Vec::new();
 
-        if let Ok(mut colors) = HashMap::<String, Value>::deserialize(deserializer) {
+        if let Ok(mut colors) = AHashMap::<String, Value>::deserialize(deserializer) {
             // TODO: alert user of parsing failures in editor
             let palette = colors
                 .remove("palette")
@@ -176,7 +174,7 @@ impl Theme {
 }
 
 struct ThemePalette {
-    palette: HashMap<String, Color>,
+    palette: AHashMap<String, Color>,
 }
 
 impl Default for ThemePalette {
@@ -205,7 +203,7 @@ impl Default for ThemePalette {
 }
 
 impl ThemePalette {
-    pub fn new(palette: HashMap<String, Color>) -> Self {
+    pub fn new(palette: AHashMap<String, Color>) -> Self {
         let ThemePalette {
             palette: mut default,
         } = ThemePalette::default();
@@ -285,7 +283,7 @@ impl TryFrom<Value> for ThemePalette {
             _ => return Ok(Self::default()),
         };
 
-        let mut palette = HashMap::with_capacity(map.len());
+        let mut palette = AHashMap::with_capacity(map.len());
         for (name, value) in map {
             let value = Self::parse_value_as_str(&value)?;
             let color = Self::hex_string_to_rgb(value)?;


### PR DESCRIPTION
The Hashing algorithm used by the ahash crate is up to [10 times faster](https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md#siphash) than the one std uses while still keeping DOS protection. It's just a single additional dependency that should definitely be worth it. Hard to benchmark in the context of helix to get a 1:1 comparison though.

I currently use the new type wrapper since this [pr](https://github.com/tkaitchuck/aHash/pull/105) hasn't yet been merged in the aHash crate. 