### PR TITLE
Improve llvm highlighting and queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,7 +21,7 @@
 | julia | ✓ |  |  | `julia` |
 | latex | ✓ |  |  |  |
 | ledger | ✓ |  |  |  |
-| llvm | ✓ |  |  |  |
+| llvm | ✓ | ✓ | ✓ |  |
 | lua | ✓ |  | ✓ |  |
 | markdown | ✓ |  |  |  |
 | mint |  |  |  | `mint` |

--- a/runtime/queries/llvm/highlights.scm
+++ b/runtime/queries/llvm/highlights.scm
@@ -1,14 +1,156 @@
 (type) @type
-(statement) @keyword.operator
+(type_keyword) @type.builtin
+
+(type [
+    (local_var)
+    (global_var)
+  ] @type)
+
+(argument) @variable.parameter
+
+(_ inst_name: _ @keyword.operator)
+
+[
+  "catch"
+  "filter"
+] @keyword.operator
+
+[
+  "to"
+  "nuw"
+  "nsw"
+  "exact"
+  "unwind"
+  "from"
+  "cleanup"
+  "swifterror"
+  "volatile"
+  "inbounds"
+  "inrange"
+] @keyword.control
+(icmp_cond) @keyword.control
+(fcmp_cond) @keyword.control
+
+(fast_math) @keyword.control
+
+(_ callee: _ @function)
+(function_header name: _ @function)
+
+[
+  "declare"
+  "define"
+] @keyword.function
+(calling_conv) @keyword.function
+
+[
+  "target"
+  "triple"
+  "datalayout"
+  "source_filename"
+  "addrspace"
+  "blockaddress"
+  "align"
+  "syncscope"
+  "within"
+  "uselistorder"
+  "uselistorder_bb"
+  "module"
+  "asm"
+  "sideeffect"
+  "alignstack"
+  "inteldialect"
+  "unwind"
+  "type"
+  "global"
+  "constant"
+  "externally_initialized"
+  "alias"
+  "ifunc"
+  "section"
+  "comdat"
+  "thread_local"
+  "localdynamic"
+  "initialexec"
+  "localexec"
+  "any"
+  "exactmatch"
+  "largest"
+  "nodeduplicate"
+  "samesize"
+  "distinct"
+  "attributes"
+  "vscale"
+  "no_cfi"
+] @keyword
+
+(linkage_aux) @keyword
+(dso_local) @keyword
+(visibility) @keyword
+(dll_storage_class) @keyword
+(unnamed_addr) @keyword
+(attribute_name) @keyword
+
+(function_header [
+    (linkage)
+    (calling_conv)
+    (unnamed_addr)
+  ] @keyword.function)
+
 (number) @constant.numeric.integer
 (comment) @comment
 (string) @string
+(cstring) @string
 (label) @label
-(keyword) @keyword
-"ret" @keyword.control.return
-(boolean) @constant.builtin.boolean
+(_ inst_name: "ret" @keyword.control.return)
 (float) @constant.numeric.float
-(constant) @constant
-(identifier) @variable
-(symbol) @punctuation.delimiter
-(bracket) @punctuation.bracket
+
+[
+  (local_var)
+  (global_var)
+] @variable
+
+[
+  (struct_value)
+  (array_value)
+  (vector_value)
+] @constructor
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<"
+  ">"
+  "<{"
+  "}>"
+] @punctuation.bracket
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "="
+  "|"
+  "x"
+  "..."
+] @operator
+
+[
+  "true"
+  "false"
+] @constant.builtin.boolean
+
+[
+  "undef"
+  "poison"
+  "null"
+  "none"
+  "zeroinitializer"
+] @constant.builtin
+
+(ERROR) @error

--- a/runtime/queries/llvm/highlights.scm
+++ b/runtime/queries/llvm/highlights.scm
@@ -27,11 +27,10 @@
   "volatile"
   "inbounds"
   "inrange"
+  (icmp_cond)
+  (fcmp_cond)
+  (fast_math)
 ] @keyword.control
-(icmp_cond) @keyword.control
-(fcmp_cond) @keyword.control
-
-(fast_math) @keyword.control
 
 (_ callee: _ @function)
 (function_header name: _ @function)
@@ -39,8 +38,8 @@
 [
   "declare"
   "define"
+  (calling_conv)
 ] @keyword.function
-(calling_conv) @keyword.function
 
 [
   "target"
@@ -81,14 +80,14 @@
   "attributes"
   "vscale"
   "no_cfi"
+  (linkage_aux)
+  (dso_local)
+  (visibility)
+  (dll_storage_class)
+  (unnamed_addr)
+  (attribute_name)
 ] @keyword
 
-(linkage_aux) @keyword
-(dso_local) @keyword
-(visibility) @keyword
-(dll_storage_class) @keyword
-(unnamed_addr) @keyword
-(attribute_name) @keyword
 
 (function_header [
     (linkage)
@@ -96,10 +95,13 @@
     (unnamed_addr)
   ] @keyword.function)
 
+[
+  (string)
+  (cstring)
+] @string
+
 (number) @constant.numeric.integer
 (comment) @comment
-(string) @string
-(cstring) @string
 (label) @label
 (_ inst_name: "ret" @keyword.control.return)
 (float) @constant.numeric.float

--- a/runtime/queries/llvm/indents.toml
+++ b/runtime/queries/llvm/indents.toml
@@ -1,0 +1,8 @@
+indent = [
+ "function_body",
+ "instruction",
+]
+
+outdent = [
+ "}",
+]

--- a/runtime/queries/llvm/locals.scm
+++ b/runtime/queries/llvm/locals.scm
@@ -1,0 +1,14 @@
+; Scopes
+
+(function_body) @local.scope
+
+; Definitions
+
+(argument
+  (value (var (local_var) @local.definition)))
+
+(instruction
+  (local_var) @local.definition)
+
+; References
+(local_var) @local.reference

--- a/runtime/queries/llvm/textobjects.scm
+++ b/runtime/queries/llvm/textobjects.scm
@@ -1,0 +1,16 @@
+(define
+  body: (_) @function.inside) @function.around
+
+(struct_type
+  (struct_body) @class.inside) @class.around
+
+(packed_struct_type
+  (struct_body) @class.inside) @class.around
+
+(array_type
+  (array_vector_body) @class.inside) @class.around
+
+(vector_type
+  (array_vector_body) @class.inside) @class.around
+
+(argument) @parameter.inside


### PR DESCRIPTION
The llvm tree-sitter parser was updated to support scopes and more
accurate highlighting: https://github.com/benwilliamgraham/tree-sitter-llvm/pull/1