### PR TITLE
Convert Windows style path separator in completers to Unix style

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -313,7 +313,7 @@ pub mod completers {
                         return None;
                     }
 
-                    //let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
+                    let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
 
                     let path = entry.path();
                     let mut path = if is_tilde {
@@ -331,7 +331,12 @@ pub mod completers {
                         path.push("");
                     }
 
-                    let path = path.to_str().unwrap().to_owned();
+                    let path = if cfg!(windows) && is_dir {
+                        // Convert Windows style path separator to Unix style
+                        path.to_str().unwrap().replace("\\", "/")
+                    } else {
+                        path.to_str().unwrap().to_owned()
+                    };
                     Some((end.clone(), Cow::from(path)))
                 })
             }) // TODO: unwrap or skip


### PR DESCRIPTION
The addition of shellwords included support for escaping, which breaks windows style paths in the prompt.
This change converts backslashes to slashes for directories if helix is on windows.
According to the video in the issue tracker, unix style paths work fine there too.

I couldnt test this. 

Issue #1380