### PR TITLE
feat(commands): ensure_selections_forward

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -122,6 +122,15 @@ impl Range {
         }
     }
 
+    // flips the direction of the selection
+    pub fn flip(&self) -> Self {
+        Self {
+            anchor: self.head,
+            head: self.anchor,
+            horiz: self.horiz,
+        }
+    }
+
     /// Check two ranges for overlap.
     #[must_use]
     pub fn overlaps(&self, other: &Self) -> bool {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -266,6 +266,7 @@ impl MappableCommand {
         change_selection_noyank, "Change selection (delete and enter insert mode, without yanking)",
         collapse_selection, "Collapse selection onto a single cursor",
         flip_selections, "Flip selection cursor and anchor",
+        ensure_selections_forward, "Ensure the selection is in forward direction",
         insert_mode, "Insert before selection",
         append_mode, "Insert after selection (append)",
         command_mode, "Enter command mode",
@@ -1905,6 +1906,20 @@ fn flip_selections(cx: &mut Context) {
         .selection(view.id)
         .clone()
         .transform(|range| Range::new(range.head, range.anchor));
+    doc.set_selection(view.id, selection);
+}
+
+fn ensure_selections_forward(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|r| match r.direction() {
+            Direction::Forward => r,
+            Direction::Backward => r.flip(),
+        });
+
     doc.set_selection(view.id, selection);
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1905,7 +1905,7 @@ fn flip_selections(cx: &mut Context) {
     let selection = doc
         .selection(view.id)
         .clone()
-        .transform(|range| Range::new(range.head, range.anchor));
+        .transform(|range| range.flip());
     doc.set_selection(view.id, selection);
 }
 

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -617,6 +617,8 @@ impl Default for Keymaps {
             "A-(" => rotate_selection_contents_backward,
             "A-)" => rotate_selection_contents_forward,
 
+            "A-:" => ensure_selections_forward,
+
             "esc" => normal_mode,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,


### PR DESCRIPTION
Add `ensure_selections_forward` command and bind it to `A-:` by default.

Fixes: https://github.com/helix-editor/helix/issues/1332