### PR TITLE
fix(theme): cursor colors

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -225,16 +225,17 @@ impl EditorView {
             .find_scope_index("ui.cursor")
             .unwrap_or(selection_scope);
 
+        let primary_cursor_scope = theme
+            .find_scope_index("ui.cursor.primary")
+            .unwrap_or(base_cursor_scope);
+
         let cursor_scope = match doc.mode() {
             Mode::Insert => theme.find_scope_index("ui.cursor.insert"),
             Mode::Select => theme.find_scope_index("ui.cursor.select"),
-            Mode::Normal => Some(base_cursor_scope),
+            Mode::Normal => Some(primary_cursor_scope),
         }
         .unwrap_or(base_cursor_scope);
 
-        let primary_cursor_scope = theme
-            .find_scope_index("ui.cursor.primary")
-            .unwrap_or(cursor_scope);
         let primary_selection_scope = theme
             .find_scope_index("ui.selection.primary")
             .unwrap_or(selection_scope);


### PR DESCRIPTION
When calculating color for the cursor, give precedence
to more specific cursor styles (e.g. `ui.cursor.insert`)
over the more generic `ui.cursor.primary`.

Fixes: https://github.com/helix-editor/helix/issues/1337