### PR TITLE
Whichnowrap

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -24,6 +24,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
+| `line-wrap` | Whether to wrap the cursor when moving past the end of the line. | `true` |
 
 `[editor.filepicker]` section of the config. Sets options for file picker and global search. All but the last key listed in the default file-picker configuration below are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default.
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -207,11 +207,15 @@ impl MappableCommand {
     static_commands!(
         no_op, "Do nothing",
         move_char_left, "Move left",
+        move_char_left_no_wrap, "Move left no wrap",
         move_char_right, "Move right",
+        move_char_right_no_wrap, "Move right no wrap",
         move_line_up, "Move up",
         move_line_down, "Move down",
         extend_char_left, "Extend left",
+        extend_char_left_no_wrap, "Extend left no wrap",
         extend_char_right, "Extend right",
+        extend_char_right_no_wrap, "Extend right no wrap",
         extend_line_up, "Extend up",
         extend_line_down, "Extend down",
         copy_selection_on_next_line, "Copy selection on next line",
@@ -501,8 +505,26 @@ fn move_char_left(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Backward, Movement::Move)
 }
 
+fn move_char_left_no_wrap(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally,
+        Direction::Backward,
+        Movement::MoveNoWrap,
+    )
+}
+
 fn move_char_right(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Forward, Movement::Move)
+}
+
+fn move_char_right_no_wrap(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally,
+        Direction::Forward,
+        Movement::MoveNoWrap,
+    )
 }
 
 fn move_line_up(cx: &mut Context) {
@@ -517,8 +539,26 @@ fn extend_char_left(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Backward, Movement::Extend)
 }
 
+fn extend_char_left_no_wrap(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally,
+        Direction::Backward,
+        Movement::ExtendNoWrap,
+    )
+}
+
 fn extend_char_right(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Forward, Movement::Extend)
+}
+
+fn extend_char_right_no_wrap(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally,
+        Direction::Forward,
+        Movement::ExtendNoWrap,
+    )
 }
 
 fn extend_line_up(cx: &mut Context) {
@@ -1510,6 +1550,10 @@ fn search_impl(
         let selection = match movement {
             Movement::Extend => selection.clone().push(range),
             Movement::Move => selection.clone().replace(selection.primary_index(), range),
+
+            Movement::ExtendNoWrap | Movement::MoveNoWrap => {
+                panic!("No wrapping movement not implemened for search")
+            }
         };
 
         doc.set_selection(view.id, selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -207,15 +207,11 @@ impl MappableCommand {
     static_commands!(
         no_op, "Do nothing",
         move_char_left, "Move left",
-        move_char_left_no_wrap, "Move left no wrap",
         move_char_right, "Move right",
-        move_char_right_no_wrap, "Move right no wrap",
         move_line_up, "Move up",
         move_line_down, "Move down",
         extend_char_left, "Extend left",
-        extend_char_left_no_wrap, "Extend left no wrap",
         extend_char_right, "Extend right",
-        extend_char_right_no_wrap, "Extend right no wrap",
         extend_line_up, "Extend up",
         extend_line_down, "Extend down",
         copy_selection_on_next_line, "Copy selection on next line",
@@ -499,32 +495,20 @@ where
     doc.set_selection(view.id, selection);
 }
 
-use helix_core::movement::{move_horizontally, move_vertically};
+use helix_core::movement::{move_horizontally, move_vertically, move_horizontally_no_wrap};
 
 fn move_char_left(cx: &mut Context) {
-    move_impl(cx, move_horizontally, Direction::Backward, Movement::Move)
-}
-
-fn move_char_left_no_wrap(cx: &mut Context) {
-    move_impl(
-        cx,
-        move_horizontally,
-        Direction::Backward,
-        Movement::MoveNoWrap,
-    )
+    match cx.editor.config.line_wrap {
+        true => move_impl(cx, move_horizontally, Direction::Backward, Movement::Move),
+        false => move_impl(cx, move_horizontally_no_wrap, Direction::Backward, Movement::Move),
+    };
 }
 
 fn move_char_right(cx: &mut Context) {
-    move_impl(cx, move_horizontally, Direction::Forward, Movement::Move)
-}
-
-fn move_char_right_no_wrap(cx: &mut Context) {
-    move_impl(
-        cx,
-        move_horizontally,
-        Direction::Forward,
-        Movement::MoveNoWrap,
-    )
+    match cx.editor.config.line_wrap {
+        true => move_impl(cx, move_horizontally, Direction::Forward, Movement::Move),
+        false => move_impl(cx, move_horizontally_no_wrap, Direction::Forward, Movement::Move),
+    };
 }
 
 fn move_line_up(cx: &mut Context) {
@@ -536,29 +520,17 @@ fn move_line_down(cx: &mut Context) {
 }
 
 fn extend_char_left(cx: &mut Context) {
-    move_impl(cx, move_horizontally, Direction::Backward, Movement::Extend)
-}
-
-fn extend_char_left_no_wrap(cx: &mut Context) {
-    move_impl(
-        cx,
-        move_horizontally,
-        Direction::Backward,
-        Movement::ExtendNoWrap,
-    )
+    match cx.editor.config.line_wrap {
+        true => move_impl(cx, move_horizontally, Direction::Backward, Movement::Extend),
+        false => move_impl(cx, move_horizontally_no_wrap, Direction::Backward, Movement::Extend),
+    };
 }
 
 fn extend_char_right(cx: &mut Context) {
-    move_impl(cx, move_horizontally, Direction::Forward, Movement::Extend)
-}
-
-fn extend_char_right_no_wrap(cx: &mut Context) {
-    move_impl(
-        cx,
-        move_horizontally,
-        Direction::Forward,
-        Movement::ExtendNoWrap,
-    )
+    match cx.editor.config.line_wrap {
+        true => move_impl(cx, move_horizontally, Direction::Forward, Movement::Extend),
+        false => move_impl(cx, move_horizontally_no_wrap, Direction::Forward, Movement::Extend),
+    };
 }
 
 fn extend_line_up(cx: &mut Context) {
@@ -1550,10 +1522,6 @@ fn search_impl(
         let selection = match movement {
             Movement::Extend => selection.clone().push(range),
             Movement::Move => selection.clone().replace(selection.primary_index(), range),
-
-            Movement::ExtendNoWrap | Movement::MoveNoWrap => {
-                panic!("No wrapping movement not implemened for search")
-            }
         };
 
         doc.set_selection(view.id, selection);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -107,7 +107,7 @@ pub struct Config {
     pub file_picker: FilePickerConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
-    /// Whether to wrap the cursor at the end of the line. Defaults to true.
+    /// Whether to wrap the cursor when moving past the end of the line. Defaults to true.
     pub line_wrap: bool,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -107,6 +107,8 @@ pub struct Config {
     pub file_picker: FilePickerConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
+    /// Whether to wrap the cursor at the end of the line. Defaults to true.
+    pub line_wrap: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -152,6 +154,7 @@ impl Default for Config {
             auto_info: true,
             file_picker: FilePickerConfig::default(),
             true_color: false,
+            line_wrap: true,
         }
     }
 }


### PR DESCRIPTION
Hello, this adds the option to not wrap lines on horizontal movements.

It adds 2 new Movement types: MoveNoWrap and ExtendNoWrap and appropriate move/extend char commands that can be mapped.

Issue:  #768 