### PR TITLE
feat(commands): better handling of buffer-close

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2472,8 +2472,8 @@ fn goto_last_line(cx: &mut Context) {
 }
 
 fn goto_last_accessed_file(cx: &mut Context) {
-    let alternate_file = view!(cx.editor).last_accessed_doc;
-    if let Some(alt) = alternate_file {
+    let view = view_mut!(cx.editor);
+    if let Some(alt) = view.docs_access_history.pop() {
         cx.editor.switch(alt, Action::Replace);
     } else {
         cx.editor.set_error("no last accessed buffer")
@@ -3779,10 +3779,6 @@ fn jump_backward(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
-        // manually set the alternate_file as we cannot use the Editor::switch function here.
-        if view.doc != *id {
-            view.last_accessed_doc = Some(view.doc)
-        }
         view.doc = *id;
         let selection = selection.clone();
         let (view, doc) = current!(cx.editor); // refetch doc

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -794,6 +794,9 @@ impl Editor {
             .tree
             .views_mut()
             .filter_map(|(view, _focus)| {
+                // remove the document from jump list of all views
+                view.jumps.remove(&doc_id);
+
                 if view.doc == doc_id {
                     // something was previously open in the view, switch to previous doc
                     if let Some(prev_doc) = view.docs_access_history.pop() {
@@ -815,9 +818,6 @@ impl Editor {
                 }
                 Action::ReplaceDoc(view_id, doc_id) => {
                     self.replace_document_in_view(view_id, doc_id);
-
-                    let view = self.tree.get_mut(view_id);
-                    view.jumps.remove(&doc_id);
                 }
             }
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -815,6 +815,9 @@ impl Editor {
                 }
                 Action::ReplaceDoc(view_id, doc_id) => {
                     self.replace_document_in_view(view_id, doc_id);
+
+                    let view = self.tree.get_mut(view_id);
+                    view.jumps.remove(&doc_id);
                 }
             }
         }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -72,8 +72,8 @@ pub struct View {
     pub area: Rect,
     pub doc: DocumentId,
     pub jumps: JumpList,
-    /// the last accessed file before the current one
-    pub last_accessed_doc: Option<DocumentId>,
+    // documents accessed from this view from the oldest one to last viewed one
+    pub docs_access_history: Vec<DocumentId>,
     /// the last modified files before the current one
     /// ordered from most frequent to least frequent
     // uses two docs because we want to be able to swap between the
@@ -110,11 +110,22 @@ impl View {
             offset: Position::new(0, 0),
             area: Rect::default(), // will get calculated upon inserting into tree
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
-            last_accessed_doc: None,
+            docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
             object_selections: Vec::new(),
             gutters,
         }
+    }
+
+    pub fn add_to_history(&mut self, id: DocumentId) {
+        if let Some(pos) = self.docs_access_history.iter().position(|&doc| doc == id) {
+            self.docs_access_history.remove(pos);
+        }
+        self.docs_access_history.push(id);
+    }
+
+    pub fn gutters(&self) -> &[(Gutter, usize)] {
+        GUTTERS
     }
 
     pub fn inner_area(&self) -> Rect {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -124,10 +124,6 @@ impl View {
         self.docs_access_history.push(id);
     }
 
-    pub fn gutters(&self) -> &[(Gutter, usize)] {
-        GUTTERS
-    }
-
     pub fn inner_area(&self) -> Rect {
         // TODO: cache this
         let offset = self


### PR DESCRIPTION
Previously, when closing buffer, you would loose cursor position in other docs. Also, all splits where the buffer was open would be closed.

This PR changes the behavior, if the view has also other buffer previously viewed it switches back to the last one instead of the view being closed. As a side effect, since the views are persisted, the cursor history is persisted as well.

Fixes: https://github.com/helix-editor/helix/issues/1186