### PR TITLE
Add llvm-mir highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -174,3 +174,7 @@
 	path = helix-syntax/languages/tree-sitter-git-commit
 	url = https://github.com/the-mikedavis/tree-sitter-git-commit.git
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-llvm-mir"]
+	path = helix-syntax/languages/tree-sitter-llvm-mir
+	url = https://github.com/Flakebi/tree-sitter-llvm-mir.git
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -22,6 +22,8 @@
 | latex | ✓ |  |  |  |
 | ledger | ✓ |  |  |  |
 | llvm | ✓ | ✓ | ✓ |  |
+| llvm-mir | ✓ | ✓ | ✓ |  |
+| llvm-mir-yaml | ✓ |  | ✓ |  |
 | lua | ✓ |  | ✓ |  |
 | markdown | ✓ |  |  |  |
 | mint |  |  |  | `mint` |

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -461,6 +461,7 @@ where
                 comment_token: None,
                 auto_format: false,
                 diagnostic_severity: Severity::Warning,
+                tree_sitter_library: None,
                 language_server: None,
                 indent: Some(IndentationConfiguration {
                     tab_width: 4,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -67,6 +67,8 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub diagnostic_severity: Severity,
 
+    pub tree_sitter_library: Option<String>, // tree-sitter library name, defaults to language_id
+
     // content_regex
     #[serde(default, skip_serializing, deserialize_with = "deserialize_regex")]
     pub injection_regex: Option<Regex>,
@@ -192,9 +194,14 @@ impl LanguageConfiguration {
         if highlights_query.is_empty() {
             None
         } else {
-            let language = get_language(&crate::RUNTIME_DIR, &self.language_id)
-                .map_err(|e| log::info!("{}", e))
-                .ok()?;
+            let language = get_language(
+                &crate::RUNTIME_DIR,
+                self.tree_sitter_library
+                    .as_deref()
+                    .unwrap_or(&self.language_id),
+            )
+            .map_err(|e| log::info!("{}", e))
+            .ok()?;
             let config = HighlightConfiguration::new(
                 language,
                 &highlights_query,

--- a/languages.toml
+++ b/languages.toml
@@ -334,6 +334,7 @@ file-types = ["yml", "yaml"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
+injection-regex = "yml|yaml"
 
 # [[language]]
 # name = "haskell"
@@ -386,6 +387,7 @@ roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "cmake-language-server" }
+injection-regex = "cmake"
 
 [[language]]
 name = "glsl"
@@ -394,6 +396,7 @@ file-types = ["glsl", "vert", "tesc", "tese", "geom", "frag", "comp" ]
 roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
+injection-regex = "glsl"
 
 [[language]]
 name = "perl"
@@ -435,6 +438,7 @@ roots = []
 file-types = ["ll"]
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
+injection-regex = "llvm"
 
 [[language]]
 name = "markdown"

--- a/languages.toml
+++ b/languages.toml
@@ -441,6 +441,24 @@ indent = { tab-width = 2, unit = "  " }
 injection-regex = "llvm"
 
 [[language]]
+name = "llvm-mir"
+scope = "source.llvm_mir"
+roots = []
+file-types = []
+comment-token = ";"
+indent = { tab-width = 2, unit = "  " }
+injection-regex = "mir"
+
+[[language]]
+name = "llvm-mir-yaml"
+tree-sitter-library = "yaml"
+scope = "source.yaml"
+roots = []
+file-types = ["mir"]
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }
+
+[[language]]
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"

--- a/runtime/queries/llvm-mir-yaml/highlights.scm
+++ b/runtime/queries/llvm-mir-yaml/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/llvm-mir-yaml/indents.toml
+++ b/runtime/queries/llvm-mir-yaml/indents.toml
@@ -1,0 +1,3 @@
+indent = [
+    "block_mapping_pair",
+]

--- a/runtime/queries/llvm-mir-yaml/injections.scm
+++ b/runtime/queries/llvm-mir-yaml/injections.scm
@@ -1,0 +1,9 @@
+; inherits: yaml
+
+((document (block_node (block_scalar) @injection.content))
+ (#set! injection.language "llvm"))
+
+((document (block_node (block_mapping (block_mapping_pair
+  key: (flow_node (plain_scalar (string_scalar))) ; "body"
+  value: (block_node (block_scalar) @injection.content)))))
+  (#set! injection.language "mir"))

--- a/runtime/queries/llvm-mir/highlights.scm
+++ b/runtime/queries/llvm-mir/highlights.scm
@@ -1,0 +1,136 @@
+[
+  (label)
+  (bb_ref)
+] @label
+
+[
+  (comment)
+  (multiline_comment)
+] @comment
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<"
+  ">"
+] @punctuation.bracket
+
+[
+  ","
+  ":"
+  "|"
+  "*"
+] @punctuation.delimiter
+
+[
+  "="
+  "x"
+] @operator
+
+[
+  "true"
+  "false"
+] @constant.builtin.boolean
+
+[
+  "null"
+  "_"
+  "unknown-address"
+] @constant.builtin
+
+[
+  (stack_object)
+  (constant_pool_index)
+  (jump_table_index)
+  (var)
+  (physical_register)
+  (ir_block)
+  (external_symbol)
+  (global_var)
+  (ir_local_var)
+  (metadata_ref)
+  (mnemonic)
+] @variable
+
+(low_level_type) @type
+
+[
+  (immediate_type)
+  (primitive_type)
+] @type.builtin
+
+(number) @constant.numeric.integer
+(float) @constant.numeric.float
+(string) @string
+
+(instruction name: _ @keyword.operator)
+
+[
+  "successors"
+  "liveins"
+  "pre-instr-symbol"
+  "post-instr-symbol"
+  "heap-alloc-marker"
+  "debug-instr-number"
+  "debug-location"
+  "mcsymbol"
+  "tied-def"
+  "target-flags"
+  "CustomRegMask"
+  "same_value"
+  "def_cfa_register"
+  "restore"
+  "undefined"
+  "offset"
+  "rel_offset"
+  "def_cfa"
+  "llvm_def_aspace_cfa"
+  "register"
+  "escape"
+  "remember_state"
+  "restore_state"
+  "window_save"
+  "negate_ra_sign_state"
+  "intpred"
+  "floatpred"
+  "shufflemask"
+  "liveout"
+  "target-index"
+  "blockaddress"
+  "intrinsic"
+  "load"
+  "store"
+  "unknown-size"
+  "on"
+  "from"
+  "into"
+  "align"
+  "basealign"
+  "addrspace"
+  "call-entry"
+  "custom"
+  "constant-pool"
+  "stack"
+  "got"
+  "jump-table"
+  "syncscope"
+  "address-taken"
+  "landing-pad"
+  "inlineasm-br-indirect-target"
+  "ehfunclet-entry"
+  "bbsections"
+
+  (intpred)
+  (floatpred)
+  (memory_operand_flag)
+  (atomic_ordering)
+  (register_flag)
+  (instruction_flag)
+  (float_keyword)
+] @keyword
+
+(ERROR) @error

--- a/runtime/queries/llvm-mir/indents.toml
+++ b/runtime/queries/llvm-mir/indents.toml
@@ -1,0 +1,7 @@
+indent = [
+  "basic_block",
+]
+
+outdent = [
+  "label",
+]

--- a/runtime/queries/llvm-mir/injections.scm
+++ b/runtime/queries/llvm-mir/injections.scm
@@ -1,0 +1,2 @@
+([ (comment) (multiline_comment)] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/llvm-mir/textobjects.scm
+++ b/runtime/queries/llvm-mir/textobjects.scm
@@ -1,0 +1,3 @@
+(basic_block) @function.around
+
+(argument) @parameter.inside

--- a/runtime/queries/yaml/injections.scm
+++ b/runtime/queries/yaml/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content         
+ (#set! injection.language "comment"))


### PR DESCRIPTION
LLVM Machine IR is dumped as yaml files that can embed LLVM IR and
Machine IR.

To support this, add a llvm-mir-yaml language that uses the yaml
parser, but uses different injections to highlight IR and MIR.

![Screenshot](https://user-images.githubusercontent.com/6499211/147673326-6c996a1c-ee85-48da-b533-1e25af0cbc78.png)