### PR TITLE
Underline diagnostics in bogster theme

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -53,3 +53,6 @@
 "error" = "#dc597f"
 "info" = "#59dcb7"
 "hint" = "#59c0dc"
+
+# make diagnostic underlined, to distinguish with selection text.
+diagnostic = { modifiers = ["underlined"] }


### PR DESCRIPTION
Diagnostics (warnings, errors) are undisinguishable from selections when using the `bogster` theme.
This PR highlights diagnostics by underlining them instead.

I understand that this is subjective and personal taste, so feel free to ignore the PR.
