### PR TITLE
feat(commands): command palette

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -430,6 +430,7 @@ impl MappableCommand {
         decrement, "Decrement",
         record_macro, "Record macro",
         replay_macro, "Replay macro",
+        command_palette, "Open command pallete",
     );
 }
 
@@ -3652,6 +3653,30 @@ pub fn code_action(cx: &mut Context) {
             compositor.replace_or_push("code-action", Box::new(popup));
         },
     )
+}
+
+pub fn command_palette(cx: &mut Context) {
+    cx.callback = Some(Box::new(
+        move |compositor: &mut Compositor, _cx: &mut compositor::Context| {
+            let commands = MappableCommand::STATIC_COMMAND_LIST.iter().collect();
+            let picker = Picker::new(
+                true,
+                commands,
+                |command| match command {
+                    MappableCommand::Typable { name, args, doc } => {
+                        format!("{}: {}", name, doc).into()
+                    }
+                    MappableCommand::Static { name, fun, doc } => {
+                        format!("{}: {}", name, doc).into()
+                    }
+                },
+                move |_editor, command, _action| {
+                    log::info!("would execute: {}", command.name());
+                },
+            );
+            compositor.push(Box::new(picker));
+        },
+    ));
 }
 
 pub fn execute_lsp_command(editor: &mut Editor, cmd: lsp::Command) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -44,7 +44,7 @@ use movement::Movement;
 use crate::{
     args,
     compositor::{self, Component, Compositor},
-    ui::{self, overlay::overlayed, FilePicker, Popup, Prompt, PromptEvent},
+    ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -3670,8 +3670,17 @@ pub fn command_palette(cx: &mut Context) {
                         format!("{}: {}", name, doc).into()
                     }
                 },
-                move |_editor, command, _action| {
+                move |cx, command, _action| {
+                    let mut ctx = Context {
+                        register: None,
+                        count: std::num::NonZeroUsize::new(1 as usize),
+                        editor: cx.editor,
+                        callback: None,
+                        on_next_key_callback: None,
+                        jobs: cx.jobs,
+                    };
                     log::info!("would execute: {}", command.name());
+                    command.execute(&mut ctx);
                 },
             );
             compositor.push(Box::new(picker));
@@ -4853,7 +4862,7 @@ pub mod insert {
             .transform(|range| movement::move_next_word_start(text, range, count));
         delete_selection_insert_mode(doc, view, &selection);
     }
-}
+
 
 // Undo / Redo
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3689,15 +3689,13 @@ pub fn command_palette(cx: &mut Context) {
             };
 
             let picker = Picker::new(
-                true,
                 commands,
                 move |command| match command {
-                    MappableCommand::Typable { doc, name, .. } => {
-                        match keymap.get(name as &String) {
-                            Some(bindings) => format!("{} ({})", doc, fmt_binding(bindings)).into(),
-                            None => doc.into(),
-                        }
-                    }
+                    MappableCommand::Typable { doc, name, .. } => match keymap.get(name as &String)
+                    {
+                        Some(bindings) => format!("{} ({})", doc, fmt_binding(bindings)).into(),
+                        None => doc.into(),
+                    },
                     MappableCommand::Static { doc, name, .. } => match keymap.get(*name) {
                         Some(bindings) => format!("{} ({})", doc, fmt_binding(bindings)).into(),
                         None => (*doc).into(),
@@ -4894,7 +4892,7 @@ pub mod insert {
             .transform(|range| movement::move_next_word_start(text, range, count));
         delete_selection_insert_mode(doc, view, &selection);
     }
-
+}
 
 // Undo / Redo
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3658,11 +3658,16 @@ pub fn code_action(cx: &mut Context) {
 pub fn command_palette(cx: &mut Context) {
     cx.callback = Some(Box::new(
         move |compositor: &mut Compositor, cx: &mut compositor::Context| {
-            let mut commands: Vec<MappableCommand> = MappableCommand::STATIC_COMMAND_LIST.into();
-            let ui = compositor.find::<ui::EditorView>().unwrap();
             let doc = doc_mut!(cx.editor);
-            let keymap = ui.keymaps.get(&doc.mode).unwrap();
-            let reverse_keymap = keymap.reverse_map.clone();
+            let keymap = compositor
+                .find::<ui::EditorView>()
+                .unwrap()
+                .keymaps
+                .get(&doc.mode)
+                .unwrap()
+                .reverse_map();
+
+            let mut commands: Vec<MappableCommand> = MappableCommand::STATIC_COMMAND_LIST.into();
             commands.extend(
                 cmd::TYPABLE_COMMAND_LIST
                     .iter()
@@ -3672,6 +3677,9 @@ pub fn command_palette(cx: &mut Context) {
                         args: Vec::new(),
                     }),
             );
+
+            // formats key bindings, multiple bindings are comma separated,
+            // individual key presses are joined with `+`
             let fmt_binding = |bindings: &Vec<Vec<KeyEvent>>| -> String {
                 bindings
                     .iter()
@@ -3684,17 +3692,18 @@ pub fn command_palette(cx: &mut Context) {
                     .collect::<Vec<String>>()
                     .join(", ")
             };
+
             let picker = Picker::new(
                 true,
                 commands,
                 move |command| match command {
                     MappableCommand::Typable { doc, name, .. } => {
-                        match reverse_keymap.get(name as &String) {
+                        match keymap.get(name as &String) {
                             Some(bindings) => format!("{} ({})", doc, fmt_binding(bindings)).into(),
                             None => doc.into(),
                         }
                     }
-                    MappableCommand::Static { doc, name, .. } => match reverse_keymap.get(*name) {
+                    MappableCommand::Static { doc, name, .. } => match keymap.get(*name) {
                         Some(bindings) => format!("{} ({})", doc, fmt_binding(bindings)).into(),
                         None => (*doc).into(),
                     },

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3659,13 +3659,8 @@ pub fn command_palette(cx: &mut Context) {
     cx.callback = Some(Box::new(
         move |compositor: &mut Compositor, cx: &mut compositor::Context| {
             let doc = doc_mut!(cx.editor);
-            let keymap = compositor
-                .find::<ui::EditorView>()
-                .unwrap()
-                .keymaps
-                .get(&doc.mode)
-                .unwrap()
-                .reverse_map();
+            let keymap =
+                compositor.find::<ui::EditorView>().unwrap().keymaps[&doc.mode].reverse_map();
 
             let mut commands: Vec<MappableCommand> = MappableCommand::STATIC_COMMAND_LIST.into();
             commands.extend(

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -367,7 +367,6 @@ impl Keymap {
                         .or_default()
                         .push(keys.clone()),
                 },
-                KeyTrie::Sequence(_) => todo!(),
                 KeyTrie::Node(next) => {
                     for (key, trie) in &next.map {
                         keys.push(*key);
@@ -375,6 +374,7 @@ impl Keymap {
                         keys.pop();
                     }
                 }
+                KeyTrie::Sequence(_) => {}
             };
         }
 

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -1009,7 +1009,7 @@ mod tests {
         // sort keybindings in order to have consistent tests
         // HashMaps can be compared but we can still get different ordering of bindings
         // for commands that have multiple bindings assigned
-        for (_k, v) in &mut reverse_map {
+        for v in reverse_map.values_mut() {
             v.sort()
         }
 

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -706,6 +706,7 @@ impl Default for Keymaps {
                 "/" => global_search,
                 "k" => hover,
                 "r" => rename_symbol,
+                "?" => command_palette,
             },
             "z" => { "View"
                 "z" | "c" => align_view_center,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,7 @@ use crossterm::event::{Event, MouseButton, MouseEvent, MouseEventKind};
 use tui::buffer::Buffer as Surface;
 
 pub struct EditorView {
-    keymaps: Keymaps,
+    pub keymaps: Keymaps,
     on_next_key: Option<Box<dyn FnOnce(&mut commands::Context, KeyEvent)>>,
     last_insert: (commands::MappableCommand, Vec<KeyEvent>),
     pub(crate) completion: Option<Completion>,


### PR DESCRIPTION
Add new command to display command pallete that can be used
to discover and execute available commands.

Fixes: https://github.com/helix-editor/helix/issues/559