### PR TITLE
Fix markdown code-block highlighting

### DIFF
--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,6 +1,7 @@
 (fenced_code_block
   (info_string) @injection.language
-  (code_fence_content) @injection.content)
+  (code_fence_content) @injection.content
+  (#set! injection.include-children))
 
 ((html_block) @injection.content
  (#set! injection.language "html"))


### PR DESCRIPTION
Markdown code blocks should be highlighted as a single block, so set
`injection.include-children`.

**Before**
![Before](https://user-images.githubusercontent.com/6499211/147683534-4f6af03f-8c45-461f-8a3f-8ecb3e4e9552.png)

**After**
![After](https://user-images.githubusercontent.com/6499211/147683540-b9135fc4-fd9c-422b-a1fe-a8c75f7e7806.png)