### PR TITLE
Panics when resizing

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -97,8 +97,7 @@ impl EditorView {
             let x = area.right();
             let border_style = theme.get("ui.window");
             for y in area.top()..area.bottom() {
-                surface
-                    .get_mut(x, y)
+                surface[(x, y)]
                     .set_symbol(tui::symbols::line::VERTICAL)
                     //.set_symbol(" ")
                     .set_style(border_style);
@@ -393,8 +392,7 @@ impl EditorView {
                             .add_modifier(Modifier::DIM)
                     });
 
-                    surface
-                        .get_mut(viewport.x + pos.col as u16, viewport.y + pos.row as u16)
+                    surface[(viewport.x + pos.col as u16, viewport.y + pos.row as u16)]
                         .set_style(style);
                 }
             }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -301,7 +301,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             let is_marked = i >= scroll_line && i < scroll_line + scroll_height;
 
             if is_marked {
-                let cell = surface.get_mut(area.x + area.width - 2, area.y + i as u16);
+                let cell = &mut surface[(area.x + area.width - 2, area.y + i as u16)];
                 cell.set_symbol("▐ ");
                 // cell.set_style(selected);
                 // cell.set_style(if is_marked { selected } else { style });

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -505,7 +505,7 @@ impl<T: 'static> Component for Picker<T> {
         let selected = cx.editor.theme.get("ui.text.focus");
 
         let rows = inner.height;
-        let offset = self.cursor / std::cmp::max(1, rows as usize) * (rows as usize);
+        let offset = self.cursor / std::cmp::max(1, (rows as usize) * (rows as usize));
 
         let files = self.matches.iter().skip(offset).map(|(index, _score)| {
             (index, self.options.get(*index).unwrap()) // get_unchecked

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -159,6 +159,7 @@ impl<T: 'static> Component for FilePicker<T> {
         // |picker   | |         |
         // |         | |         |
         // +---------+ +---------+
+
         let render_preview = area.width > MIN_SCREEN_WIDTH_FOR_PREVIEW;
         let area = inner_rect(area);
         // -- Render the frame:
@@ -492,9 +493,9 @@ impl<T: 'static> Component for Picker<T> {
         let sep_style = Style::default().fg(Color::Rgb(90, 89, 119));
         let borders = BorderType::line_symbols(BorderType::Plain);
         for x in inner.left()..inner.right() {
-            surface[(x, inner.y + 1)]
-                .set_symbol(borders.horizontal)
-                .set_style(sep_style);
+            if let Some(cell) = surface.get_mut(x, inner.y + 1) {
+                cell.set_symbol(borders.horizontal).set_style(sep_style);
+            }
         }
 
         // -- Render the contents:
@@ -504,7 +505,7 @@ impl<T: 'static> Component for Picker<T> {
         let selected = cx.editor.theme.get("ui.text.focus");
 
         let rows = inner.height;
-        let offset = self.cursor / (rows as usize) * (rows as usize);
+        let offset = self.cursor / std::cmp::max(1, rows as usize) * (rows as usize);
 
         let files = self.matches.iter().skip(offset).map(|(index, _score)| {
             (index, self.options.get(*index).unwrap()) // get_unchecked
@@ -512,7 +513,7 @@ impl<T: 'static> Component for Picker<T> {
 
         for (i, (_index, option)) in files.take(rows as usize).enumerate() {
             if i == (self.cursor - offset) {
-                surface.set_string(inner.x - 2, inner.y + i as u16, ">", selected);
+                surface.set_string(inner.x.saturating_sub(2), inner.y + i as u16, ">", selected);
             }
 
             surface.set_string_truncated(

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -492,8 +492,7 @@ impl<T: 'static> Component for Picker<T> {
         let sep_style = Style::default().fg(Color::Rgb(90, 89, 119));
         let borders = BorderType::line_symbols(BorderType::Plain);
         for x in inner.left()..inner.right() {
-            surface
-                .get_mut(x, inner.y + 1)
+            surface[(x, inner.y + 1)]
                 .set_symbol(borders.horizontal)
                 .set_style(sep_style);
         }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -330,7 +330,7 @@ impl Prompt {
             .max(BASE_WIDTH);
 
         let cols = std::cmp::max(1, area.width / max_len);
-        let col_width = (area.width - (cols)) / cols;
+        let col_width = (area.width.saturating_sub(cols)) / cols;
 
         let height = ((self.completion.len() as u16 + cols - 1) / cols)
             .min(10) // at most 10 rows (or less)

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -111,8 +111,7 @@ impl Backend for TestBackend {
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
         for (x, y, c) in content {
-            let cell = self.buffer.get_mut(x, y);
-            *cell = c.clone();
+            self.buffer[(x, y)] = c.clone();
         }
         Ok(())
     }

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -163,14 +163,12 @@ impl Buffer {
 
     /// Returns a reference to Cell at the given coordinates
     pub fn get(&self, x: u16, y: u16) -> Option<&Cell> {
-        self.index_of_opt(x, y) 
-            .map(|i| &self.content[i])
+        self.index_of_opt(x, y).map(|i| &self.content[i])
     }
-    
+
     /// Returns a mutable reference to Cell at the given coordinates
     pub fn get_mut(&mut self, x: u16, y: u16) -> Option<&mut Cell> {
-        self.index_of_opt(x, y) 
-            .map(|i| &mut self.content[i])
+        self.index_of_opt(x, y).map(|i| &mut self.content[i])
     }
 
     /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates.
@@ -205,17 +203,16 @@ impl Buffer {
         ((y - self.area.y) * self.area.width + (x - self.area.x)) as usize
     }
 
-    /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates, 
+    /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates,
     /// or `None` if the coordinates are out of range.
     fn index_of_opt(&self, x: u16, y: u16) -> Option<usize> {
         if x >= self.area.left()
             && x < self.area.right()
             && y >= self.area.top()
-            && y < self.area.bottom() 
-        {       
+            && y < self.area.bottom()
+        {
             Some(self.index_of(x, y))
-        }
-        else {
+        } else {
             None
         }
     }
@@ -293,6 +290,11 @@ impl Buffer {
     where
         S: AsRef<str>,
     {
+        // prevent panic if out of range
+        if self.index_of_opt(x, y).is_none() || width == 0 {
+            return (x, y);
+        }
+
         let mut index = self.index_of(x, y);
         let mut x_offset = x as usize;
         let width = if ellipsis { width - 1 } else { width };
@@ -523,7 +525,6 @@ impl Buffer {
         updates
     }
 }
-
 
 impl std::ops::Index<(u16, u16)> for Buffer {
     type Output = Cell;

--- a/helix-tui/src/widgets/block.rs
+++ b/helix-tui/src/widgets/block.rs
@@ -140,14 +140,14 @@ impl<'a> Widget for Block<'a> {
         // Sides
         if self.borders.intersects(Borders::LEFT) {
             for y in area.top()..area.bottom() {
-                buf.get_mut(area.left(), y)
+                buf[(area.left(), y)]
                     .set_symbol(symbols.vertical)
                     .set_style(self.border_style);
             }
         }
         if self.borders.intersects(Borders::TOP) {
             for x in area.left()..area.right() {
-                buf.get_mut(x, area.top())
+                buf[(x, area.top())]
                     .set_symbol(symbols.horizontal)
                     .set_style(self.border_style);
             }
@@ -155,7 +155,7 @@ impl<'a> Widget for Block<'a> {
         if self.borders.intersects(Borders::RIGHT) {
             let x = area.right() - 1;
             for y in area.top()..area.bottom() {
-                buf.get_mut(x, y)
+                buf[(x, y)]
                     .set_symbol(symbols.vertical)
                     .set_style(self.border_style);
             }
@@ -163,7 +163,7 @@ impl<'a> Widget for Block<'a> {
         if self.borders.intersects(Borders::BOTTOM) {
             let y = area.bottom() - 1;
             for x in area.left()..area.right() {
-                buf.get_mut(x, y)
+                buf[(x, y)]
                     .set_symbol(symbols.horizontal)
                     .set_style(self.border_style);
             }
@@ -171,22 +171,22 @@ impl<'a> Widget for Block<'a> {
 
         // Corners
         if self.borders.contains(Borders::RIGHT | Borders::BOTTOM) {
-            buf.get_mut(area.right() - 1, area.bottom() - 1)
+            buf[(area.right() - 1, area.bottom() - 1)]
                 .set_symbol(symbols.bottom_right)
                 .set_style(self.border_style);
         }
         if self.borders.contains(Borders::RIGHT | Borders::TOP) {
-            buf.get_mut(area.right() - 1, area.top())
+            buf[(area.right() - 1, area.top())]
                 .set_symbol(symbols.top_right)
                 .set_style(self.border_style);
         }
         if self.borders.contains(Borders::LEFT | Borders::BOTTOM) {
-            buf.get_mut(area.left(), area.bottom() - 1)
+            buf[(area.left(), area.bottom() - 1)]
                 .set_symbol(symbols.bottom_left)
                 .set_style(self.border_style);
         }
         if self.borders.contains(Borders::LEFT | Borders::TOP) {
-            buf.get_mut(area.left(), area.top())
+            buf[(area.left(), area.top())]
                 .set_symbol(symbols.top_left)
                 .set_style(self.border_style);
         }

--- a/helix-tui/src/widgets/paragraph.rs
+++ b/helix-tui/src/widgets/paragraph.rs
@@ -176,7 +176,7 @@ impl<'a> Widget for Paragraph<'a> {
             if y >= self.scroll.0 {
                 let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
                 for StyledGrapheme { symbol, style } in current_line {
-                    buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll.0)
+                    buf[(text_area.left() + x, text_area.top() + y - self.scroll.0)]
                         .set_symbol(if symbol.is_empty() {
                             // If the symbol is empty, the last char which rendered last time will
                             // leave on the line. It's a quick fix.

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -323,7 +323,7 @@ impl FromStr for Modifier {
 /// ];
 /// let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
 /// for style in &styles {
-///   buffer.get_mut(0, 0).set_style(*style);
+///   buffer[(0, 0)].set_style(*style);
 /// }
 /// assert_eq!(
 ///     Style {
@@ -332,7 +332,7 @@ impl FromStr for Modifier {
 ///         add_modifier: Modifier::BOLD,
 ///         sub_modifier: Modifier::empty(),
 ///     },
-///     buffer.get(0, 0).style(),
+///     buffer[(0, 0)].style(),
 /// );
 /// ```
 ///
@@ -348,7 +348,7 @@ impl FromStr for Modifier {
 /// ];
 /// let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
 /// for style in &styles {
-///   buffer.get_mut(0, 0).set_style(*style);
+///   buffer[(0, 0)].set_style(*style);
 /// }
 /// assert_eq!(
 ///     Style {
@@ -357,7 +357,7 @@ impl FromStr for Modifier {
 ///         add_modifier: Modifier::empty(),
 ///         sub_modifier: Modifier::empty(),
 ///     },
-///     buffer.get(0, 0).style(),
+///     buffer[(0, 0)].style(),
 /// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
FIxes #1403

The editor crashes when the window is very small. Two reasons:
 - some widgets have a minimum size (e.g. boxes) -> integer calculations may overflow.  
 - buffer panics when accessed out-of-range

* Changed `Buffer::get` and `Buffer::get_mut` to return an Option, like `std::Vec`
* Implemented traits `Index` and `IndexMut` for Buffer with a pair of coordinates, i.e. `buf[(x, y)]`
* Replaced calls to `Buffer::get` and `Buffer.get_mut` with the Index, which is known to panic. Makes code clearer with the intent not to perform bounds checks.
* Fixed a few divisions by zero and integer substraction underflows.