### PR TITLE
Add LLVM TableGen highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -178,3 +178,7 @@
 	path = helix-syntax/languages/tree-sitter-git-diff
 	url = https://github.com/the-mikedavis/tree-sitter-git-diff.git
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-tablegen"]
+	path = helix-syntax/languages/tree-sitter-tablegen
+	url = https://github.com/Flakebi/tree-sitter-tablegen
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -39,6 +39,7 @@
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |
 | scala | ✓ |  | ✓ | `metals` |
 | svelte | ✓ |  | ✓ | `svelteserver` |
+| tablegen | ✓ | ✓ | ✓ |  |
 | toml | ✓ |  |  |  |
 | tsq | ✓ |  |  |  |
 | tsx | ✓ |  |  | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -437,6 +437,15 @@ comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]
+name = "tablegen"
+scope = "source.tablegen"
+roots = []
+file-types = ["td"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+injection-regex = "tablegen"
+
+[[language]]
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"

--- a/runtime/queries/tablegen/highlights.scm
+++ b/runtime/queries/tablegen/highlights.scm
@@ -1,0 +1,90 @@
+[
+  (comment)
+  (multiline_comment)
+] @comment
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<"
+  ">"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  "."
+] @punctuation.delimiter
+
+[
+  "#"
+  "-"
+  "..."
+  ":"
+] @operator
+
+[
+  "="
+  "!cond"
+  (operator_keyword)
+] @function
+
+[
+  "true"
+  "false"
+] @constant.builtin.boolean
+
+[
+  "?"
+] @constant.builtin
+
+(var) @variable
+
+(template_arg (identifier) @variable.parameter)
+
+(_ argument: (value (identifier) @variable.parameter))
+
+(type) @type
+
+"code" @type.builtin
+
+(number) @constant.numeric.integer
+[
+  (string_string)
+  (code_string)
+] @string
+
+(preprocessor) @keyword.directive
+
+[
+  "class"
+  "field"
+  "let"
+  "defvar"
+  "def"
+  "defset"
+  "defvar"
+  "assert"
+] @keyword
+
+[
+  "let"
+  "in"
+  "foreach"
+  "if"
+  "then"
+  "else"
+] @keyword.operator
+
+"include" @keyword.control.import
+
+[
+  "multiclass"
+  "defm"
+] @namespace
+
+(ERROR) @error

--- a/runtime/queries/tablegen/indents.toml
+++ b/runtime/queries/tablegen/indents.toml
@@ -1,0 +1,7 @@
+indent = [
+  "statement",
+]
+
+outdent = [
+  "}",
+]

--- a/runtime/queries/tablegen/injections.scm
+++ b/runtime/queries/tablegen/injections.scm
@@ -1,0 +1,2 @@
+([ (comment) (multiline_comment)] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/tablegen/textobjects.scm
+++ b/runtime/queries/tablegen/textobjects.scm
@@ -1,0 +1,7 @@
+(class
+  body: (_) @class.inside) @class.around
+
+(multiclass
+  body: (_) @class.inside) @class.around
+
+(_ argument: _ @parameter.inside)


### PR DESCRIPTION
Here comes yet another llvm grammar.

Add a tree-sitter grammar and highlights for TableGen files.
TableGen and its grammar are described here:
https://llvm.org/docs/TableGen/index.html

![2021-12-31](https://user-images.githubusercontent.com/6499211/147793767-805acfc8-7b17-42e5-9042-327db8b1a7c8.png)