### PR TITLE
impl auto pairs config

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4406,7 +4406,7 @@ pub mod insert {
 
         let transaction = match &cx.editor.config.auto_pairs {
             AutoPairConfig::Pairs(pairs) => {
-                auto_pairs::hook(text, selection, c, Some(AutoPairs::new(pairs)))
+                auto_pairs::hook(text, selection, c, Some(AutoPairs::new(pairs.clone())))
             }
             AutoPairConfig::Enable(true) => auto_pairs::hook(text, selection, c, None),
             AutoPairConfig::Enable(false) => None,


### PR DESCRIPTION
This is a draft implementation of configuration for which pairs of tokens get auto completed. It is intended to address #1347 and at least put into place the machinery for #992.

In order to help with this, the logic for when *not* to auto complete has been generalized to compute an arbitrary predicate for any given pairing. This gets rid of necessarily hard coding which tokens should allow a pairing, although it
still keeps this behavior as a default. The intention is to allow future flexibility with controlling the conditions for when any particular pairing should or should not happen, e.g. only if immediately following a word character, not when inside a certain tree-sitter node, etc. This will help with cases like avoiding pairing ' in Rust's lifetime
annotations, and allowing pairing <> after type names, but not in a "less than" expression.

I am opening a draft first to see if you agree with the general approach here before moving on to docs, and perhaps some of the aforementioned pairing conditions.