### PR TITLE
(perf): Cache Lsp position calculation

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -395,6 +395,7 @@ impl Application {
 
                                     // TODO: convert inside server
                                     let start = if let Some(start) = lsp_pos_to_pos(
+                                        Some(doc.id().into_inner()),
                                         text,
                                         diagnostic.range.start,
                                         language_server.offset_encoding(),
@@ -406,6 +407,7 @@ impl Application {
                                     };
 
                                     let end = if let Some(end) = lsp_pos_to_pos(
+                                        Some(doc.id().into_inner()),
                                         text,
                                         diagnostic.range.end,
                                         language_server.offset_encoding(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3284,9 +3284,12 @@ fn symbol_picker(cx: &mut Context) {
                         push_jump(editor);
                         let (view, doc) = current!(editor);
 
-                        if let Some(range) =
-                            lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding)
-                        {
+                        if let Some(range) = lsp_range_to_range(
+                            Some(doc.id().into_inner()),
+                            doc.text(),
+                            symbol.location.range,
+                            offset_encoding,
+                        ) {
                             // we flip the range so that the cursor sits on the start of the symbol
                             // (for example start of the function).
                             doc.set_selection(view.id, Selection::single(range.head, range.anchor));
@@ -3346,9 +3349,12 @@ fn workspace_symbol_picker(cx: &mut Context) {
                         editor.open(path, action).expect("editor.open failed");
                         let (view, doc) = current!(editor);
 
-                        if let Some(range) =
-                            lsp_range_to_range(doc.text(), symbol.location.range, offset_encoding)
-                        {
+                        if let Some(range) = lsp_range_to_range(
+                            Some(doc.id().into_inner()),
+                            doc.text(),
+                            symbol.location.range,
+                            offset_encoding,
+                        ) {
                             // we flip the range so that the cursor sits on the start of the symbol
                             // (for example start of the function).
                             doc.set_selection(view.id, Selection::single(range.head, range.anchor));
@@ -3533,6 +3539,7 @@ pub fn apply_workspace_edit(
         };
 
         let transaction = helix_lsp::util::generate_transaction_from_edits(
+            Some(doc.id().into_inner()),
             doc.text(),
             text_edits,
             offset_encoding,
@@ -3956,12 +3963,16 @@ fn goto_impl(
         let (view, doc) = current!(editor);
         let definition_pos = location.range.start;
         // TODO: convert inside server
-        let new_pos =
-            if let Some(new_pos) = lsp_pos_to_pos(doc.text(), definition_pos, offset_encoding) {
-                new_pos
-            } else {
-                return;
-            };
+        let new_pos = if let Some(new_pos) = lsp_pos_to_pos(
+            Some(doc.id().into_inner()),
+            doc.text(),
+            definition_pos,
+            offset_encoding,
+        ) {
+            new_pos
+        } else {
+            return;
+        };
         doc.set_selection(view.id, Selection::point(new_pos));
         align_view(doc, view, Align::Center);
     }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -100,6 +100,7 @@ impl Completion {
                         }
                     };
                     util::generate_transaction_from_edits(
+                        Some(doc.id().into_inner()),
                         doc.text(),
                         vec![edit],
                         offset_encoding, // TODO: should probably transcode in Client
@@ -169,6 +170,7 @@ impl Completion {
                     {
                         if !additional_edits.is_empty() {
                             let transaction = util::generate_transaction_from_edits(
+                                Some(doc.id().into_inner()),
                                 doc.text(),
                                 additional_edits.clone(),
                                 offset_encoding, // TODO: should probably transcode in Client

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -19,6 +19,12 @@ use std::num::NonZeroUsize;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct DocumentId(NonZeroUsize);
 
+impl DocumentId {
+    pub fn into_inner(self) -> NonZeroUsize {
+        self.0
+    }
+}
+
 impl Default for DocumentId {
     fn default() -> DocumentId {
         // Safety: 1 is non-zero


### PR DESCRIPTION
I noticed while refactoring the `command.rs` file using helix that there were significant performance slowdowns when doing larger changes. I've noticed the same thing when refactoring smaller files as well but there it's not as easy to reproduce. Since the same issue isn't present in neovim I decided to do some perf investigation and found the following:

### The problem (Notice the lagg when scrolling especially towards the end):

https://user-images.githubusercontent.com/22415885/147882681-1d1f68e9-fccb-4a0a-a954-e14a1fa73f12.mp4


### The cause:
![prechange](https://user-images.githubusercontent.com/22415885/147881827-7ee45cb5-1bc9-484c-94b0-7474c47f4326.png)

As you can see the `lsp_pos_to_pos` takes up a significant amount of the flamegraph and since I'm not as familiar with this part of the code I tried to see how much a cache would help with the problem. I turned out that gave significant performance improvments so I used that as the fix for the issue. I saw that there was a `TODO` about moving that to the LSP server which I wasn't sure would help. There might also be some other underlying issue which is causing all the extra calculations for the same positions but I'm not familiar enough with the lsp protocol to know. Since the cache seemed to solve the problem and was simple to implement I stuck with that for now but let me know if there is another underlying issue.

### The fix:
I implemented thread local cache which will cache the calculations if a `doc_id` is provided. I started with a global cache but that of course requires locking and it turns out the thread local cache worked just as fine. Thread local storage is of course faster to access without locking but since we use a tokio thread pool (which is also work stealing) some extra cache misses might incur depending on how the threads are scheduled. When testing though this never seemed to be a problem and I could never tell a difference between global cache vs thread local in performance. This is because its fine performance wise if each thread calculates a position once, its when it's recalculated thousands of times it becomes a problem. Thread local cache also takes up slightly more memory since there is one map per thread (and they may contain duplicates across threads) however this should be negligible since its a simple usize -> usize mapping. But I'm happy to change back to global cache if that's more preferable.

I'm also aware that the caches aren't cleared at the moment. My assumption was that they would never grow large enough during a single session to become a problem but let me know if you disagree. In that case a global cache would be preferable as well.

### After the fix: (lsp_pos_to_pos highlighted in purple)
![postchange](https://user-images.githubusercontent.com/22415885/147883244-4b1ee6ca-bb8e-4146-8ec4-6f48e83cd5b7.png)

### Video post fix, scrolling is smooth immediately 
https://user-images.githubusercontent.com/22415885/147883340-e9f596b8-0129-4473-80be-95f43f184baf.mp4



