### PR TITLE
add tree-sitter-git-config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -198,3 +198,7 @@
 	path = helix-syntax/languages/tree-sitter-make
 	url = https://github.com/alemuller/tree-sitter-make
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-git-config"]
+	path = helix-syntax/languages/tree-sitter-git-config
+	url = https://github.com/the-mikedavis/tree-sitter-git-config.git
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -12,6 +12,7 @@
 | elixir | ✓ |  |  | `elixir-ls` |
 | fish | ✓ | ✓ | ✓ |  |
 | git-commit | ✓ |  |  |  |
+| git-config | ✓ |  |  |  |
 | git-diff | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
 | glsl | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -545,3 +545,12 @@ scope = "source.regex"
 injection-regex = "regex"
 file-types = ["regex"]
 roots = []
+
+[[language]]
+name = "git-config"
+scope = "source.gitconfig"
+roots = []
+file-types = [".gitmodules", ".gitconfig"]
+injection-regex = "git-config"
+comment-token = "#"
+indent = { tab-width = 4, unit = "\t" }

--- a/languages.toml
+++ b/languages.toml
@@ -550,6 +550,7 @@ roots = []
 name = "git-config"
 scope = "source.gitconfig"
 roots = []
+# TODO: allow specifying file-types as a regex so we can read directory names (e.g. `.git/config`)
 file-types = [".gitmodules", ".gitconfig"]
 injection-regex = "git-config"
 comment-token = "#"

--- a/runtime/queries/git-config/highlights.scm
+++ b/runtime/queries/git-config/highlights.scm
@@ -1,0 +1,27 @@
+((section_name) @keyword.directive
+ (#eq? @keyword.directive "include"))
+
+((section_header
+   (section_name) @keyword.directive
+   (subsection_name))
+ (#eq? @keyword.directive "includeIf"))
+
+(section_name) @markup.heading
+(variable (name) @variable.other.member)
+[(true) (false)] @constant.builtin.boolean
+(integer) @constant.numeric.integer
+
+((string) @string.special.path
+ (#match? @string.special.path "^(~|./|/)"))
+
+[(string) (subsection_name)] @string
+
+[
+  "["
+  "]"
+  "\""
+] @punctuation.bracket
+
+"=" @punctuation.delimiter
+
+(comment) @comment


### PR DESCRIPTION
Since I spend so much time looking at `.gitmodules` I thought it should have some highlighting :smile:

![git-modules](https://user-images.githubusercontent.com/21230295/147930013-dd912ad0-ea80-41cb-9d8a-75ceb4c7e154.png)

Luckily git uses this config syntax for virtually all config, so this grammar applies to things like `~/.gitconfig` as well.

![git-config](https://user-images.githubusercontent.com/21230295/147930067-23dbd83b-3589-41c3-a9d2-4bde32073a6a.png)

I think this is a good grammar to start asking questions about expanding the `file-types` config in `languages.toml`. Ideally this grammar would apply for `.git/config`, `~/.config/git/config`, and other `config` files under a git directory (for example: `.git/modules/helix-syntax/languages/tree-sitter-git-config/config`). I'm fine leaving off changes to language detection in this PR but it's something to think about.

Playground for the grammar: https://the-mikedavis.github.io/tree-sitter-git-config/