### PR TITLE
Fix null and boolean constants in tree-sitter-nix highlights queries

### DIFF
--- a/runtime/queries/nix/highlights.scm
+++ b/runtime/queries/nix/highlights.scm
@@ -13,7 +13,7 @@
 ] @keyword
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^(__currentSystem|__currentTime|__nixPath|__nixVersion|__storeDir|builtins|false|null|true)$")
+ (#match? @variable.builtin "^(__currentSystem|__currentTime|__nixPath|__nixVersion|__storeDir|builtins)$")
  (#is-not? local))
 
 ((identifier) @function.builtin
@@ -32,6 +32,11 @@
 ] @string.special.path
 
 (uri) @string.special.uri
+
+; boolean
+((identifier) @constant.builtin.boolean (#match? @constant.builtin.boolean "^(true|false)$")) @constant.builtin.boolean
+; null
+((identifier) @constant.builtin (#eq? @constant.builtin "null")) @constant.builtin
 
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float


### PR DESCRIPTION
null and boolean literals were previously detected as `variable.builtin`. This PR fixes this and detects these as:
`constant.builtin` and `constant.builtin.boolean` respectively