### PR TITLE
feat: add tree-sitter-make

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -177,7 +177,7 @@
 [submodule "helix-syntax/languages/tree-sitter-llvm-mir"]
 	path = helix-syntax/languages/tree-sitter-llvm-mir
 	url = https://github.com/Flakebi/tree-sitter-llvm-mir.git
-  shallow = true
+    shallow = true
 [submodule "helix-syntax/languages/tree-sitter-git-diff"]
 	path = helix-syntax/languages/tree-sitter-git-diff
 	url = https://github.com/the-mikedavis/tree-sitter-git-diff.git
@@ -193,4 +193,8 @@
 [submodule "helix-syntax/languages/tree-sitter-regex"]
 	path = helix-syntax/languages/tree-sitter-regex
 	url = https://github.com/tree-sitter/tree-sitter-regex.git
+	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-make"]
+	path = helix-syntax/languages/tree-sitter-make
+	url = https://github.com/alemuller/tree-sitter-make
 	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -27,6 +27,7 @@
 | llvm-mir | ✓ | ✓ | ✓ |  |
 | llvm-mir-yaml | ✓ |  | ✓ |  |
 | lua | ✓ |  | ✓ |  |
+| make | ✓ |  |  |  |
 | markdown | ✓ |  |  |  |
 | mint |  |  |  | `mint` |
 | nix | ✓ |  | ✓ | `rnix-lsp` |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -147,6 +147,7 @@ We use a similar set of scopes as
     - `repeat` - `for`, `while`, `loop`
     - `import` - `import`, `export`
     - `return`
+    - `exception`
   - `operator` - `or`, `in`
   - `directive` - Preprocessor directives (`#if` in C) 
   - `function` - `fn`, `func`

--- a/languages.toml
+++ b/languages.toml
@@ -390,6 +390,13 @@ language-server = { command = "cmake-language-server" }
 injection-regex = "cmake"
 
 [[language]]
+name = "make"
+scope = "source.make"
+file-types = ["Makefile", "makefile", "justfile", ".justfile"]
+roots =[]
+comment-token = "#"
+
+[[language]]
 name = "glsl"
 scope = "source.glsl"
 file-types = ["glsl", "vert", "tesc", "tese", "geom", "frag", "comp" ]

--- a/runtime/queries/make/highlights.scm
+++ b/runtime/queries/make/highlights.scm
@@ -1,0 +1,170 @@
+[
+ "("
+ ")"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ ":"
+ "&:"
+ "::"
+ "|"
+ ";"
+ "\""
+ "'"
+ ","
+] @punctuation.delimiter
+
+[
+ "$"
+ "$$"
+] @punctuation.special
+
+(automatic_variable
+ [ "@" "%" "<" "?" "^" "+" "/" "*" "D" "F"] @punctuation.special)
+
+(automatic_variable
+ "/" @error . ["D" "F"])
+
+[
+ "="
+ ":="
+ "::="
+ "?="
+ "+="
+ "!="
+ "@"
+ "-"
+ "+"
+] @operator
+
+[
+ (text)
+ (string)
+ (raw_text)
+] @string
+
+(variable_assignment (word) @string)
+
+[
+ "ifeq"
+ "ifneq"
+ "ifdef"
+ "ifndef"
+ "else"
+ "endif"
+ "if"
+ "or"  ; boolean functions are conditional in make grammar
+ "and"
+] @keyword.control.conditional
+
+"foreach" @keyword.control.repeat
+
+[
+ "define"
+ "endef"
+ "vpath"
+ "undefine"
+ "export"
+ "unexport"
+ "override"
+ "private"
+; "load"
+] @keyword
+
+[
+ "include"
+ "sinclude"
+ "-include"
+] @keyword.control.import
+
+[
+ "subst"
+ "patsubst"
+ "strip"
+ "findstring"
+ "filter"
+ "filter-out"
+ "sort"
+ "word"
+ "words"
+ "wordlist"
+ "firstword"
+ "lastword"
+ "dir"
+ "notdir"
+ "suffix"
+ "basename"
+ "addsuffix"
+ "addprefix"
+ "join"
+ "wildcard"
+ "realpath"
+ "abspath"
+ "call"
+ "eval"
+ "file"
+ "value"
+ "shell"
+] @keyword.function
+
+[
+ "error"
+ "warning"
+ "info"
+] @keyword.control.exception
+
+;; Variable
+(variable_assignment
+  name: (word) @variable)
+
+(variable_reference
+  (word) @variable)
+
+(comment) @comment
+
+((word) @clean @string.regexp
+ (#match? @clean "[%\*\?]"))
+
+(function_call
+  function: "error"
+  (arguments (text) @error))
+
+(function_call
+  function: "warning"
+  (arguments (text) @warning))
+
+(function_call
+  function: "info"
+  (arguments (text) @info))
+
+;; Install Command Categories
+;; Others special variables
+;; Variables Used by Implicit Rules
+[
+ "VPATH"
+ ".RECIPEPREFIX"
+] @constant.builtin
+
+(variable_assignment
+  name: (word) @clean @constant.builtin
+        (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS)$"))
+
+(variable_reference
+  (word) @clean @constant.builtin
+  (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS\.VARIABLES|\.FEATURES|\.INCLUDE_DIRS|\.LOADED)$"))
+
+;; Standart targets
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+
+;; Builtin targets
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX)$"))


### PR DESCRIPTION
This commit adds syntax highlighting for GNU Make[^1] makefiles
via tree-sitter-make[^2].

[^1]: https://www.gnu.org/software/make/
[^2]: https://github.com/alemuller/tree-sitter-make