### PR TITLE
Add modified background to dracula popup

### DIFF
--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -28,7 +28,7 @@
 "ui.linenr.selected" = { fg = "foreground" }
 "ui.menu" = { fg = "foreground", bg = "background_dark" }
 "ui.menu.selected" = { fg = "cyan", bg = "background_dark" }
-"ui.popup" = { fg = "foreground" }
+"ui.popup" = { fg = "foreground", bg = "background_dark" }
 "ui.selection" = { fg = "background", bg = "purple", modifiers = ["dim"] }
 "ui.selection.primary" = { fg = "background", bg = "pink" }
 "ui.statusline" = { fg = "foreground", bg = "background_dark" }


### PR DESCRIPTION
Modifies the background color in the dracula theme so popup boundaries are clear. 

Before

<img width="587" alt="Screen Shot 2022-01-03 at 9 54 33 PM" src="https://user-images.githubusercontent.com/7055/148003687-98ff633d-126a-452d-9da6-883419ccd145.png">

After

<img width="578" alt="Screen Shot 2022-01-03 at 9 53 29 PM" src="https://user-images.githubusercontent.com/7055/148003668-71cc2536-cced-44ed-9e87-3718a59148f2.png">

Still a bit low contrast, so happy to iterate on color, but vastly better having it distinguished. cc @loewenheim 