### PR TITLE
add alt-backspace, alt-<, alt->, ctrl-j keymap to delete word backward, goto file start, goto file end, insert newline

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -768,6 +768,8 @@ impl Default for Keymaps {
             "A-left" => move_prev_word_end,
             "A-f" => move_next_word_start,
             "A-right" => move_next_word_start,
+            "A-<" => goto_file_start,
+            "A->" => goto_last_line,
             "pageup" => page_up,
             "pagedown" => page_down,
             "home" => goto_line_start,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -753,6 +753,7 @@ impl Default for Keymaps {
             "ret" => insert_newline,
             "tab" => insert_tab,
             "C-w" => delete_word_backward,
+            "A-backspace" => delete_word_backward,
             "A-d" => delete_word_forward,
 
             "left" => move_char_left,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -769,7 +769,7 @@ impl Default for Keymaps {
             "A-f" => move_next_word_start,
             "A-right" => move_next_word_start,
             "A-<" => goto_file_start,
-            "A->" => goto_last_line,
+            "A->" => goto_file_end,
             "pageup" => page_up,
             "pagedown" => page_down,
             "home" => goto_line_start,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -751,6 +751,7 @@ impl Default for Keymaps {
             "del" => delete_char_forward,
             "C-d" => delete_char_forward,
             "ret" => insert_newline,
+            "C-j" => insert_newline,
             "tab" => insert_tab,
             "C-w" => delete_word_backward,
             "A-backspace" => delete_word_backward,


### PR DESCRIPTION
I'm missing [M-BACKSPACE](https://www.gnu.org/software/emacs/manual/html_node/emacs/Erasing.html), [M-< and M->](https://www.gnu.org/software/emacs/manual/html_node/emacs/Moving-Point.html) in emacs..

With `M-<` and `M->`, we can move cursor without goto normal mode.

Although they can be configured in config, I still want to make it builtin.....