### PR TITLE
add show_subtree command for viewing tree-sitter subtree in Popup

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5389,8 +5389,8 @@ fn hover(cx: &mut Context) {
                 // skip if contents empty
 
                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
-                let popup = Popup::new("documentation", contents);
-                if let Some(doc_popup) = compositor.find_id("documentation") {
+                let popup = Popup::new("hover", contents);
+                if let Some(doc_popup) = compositor.find_id("hover") {
                     *doc_popup = popup;
                 } else {
                     compositor.push(Box::new(popup));
@@ -6230,8 +6230,8 @@ fn show_subtree(cx: &mut Context) {
             cx.callback = Some(Box::new(
                 move |compositor: &mut Compositor, cx: &mut compositor::Context| {
                     let contents = ui::Markdown::new(contents, cx.editor.syn_loader.clone());
-                    let popup = Popup::new("tree", contents);
-                    if let Some(doc_popup) = compositor.find_id("tree") {
+                    let popup = Popup::new("hover", contents);
+                    if let Some(doc_popup) = compositor.find_id("hover") {
                         *doc_popup = popup;
                     } else {
                         compositor.push(Box::new(popup));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -400,6 +400,7 @@ impl MappableCommand {
         decrement, "Decrement",
         record_macro, "Record macro",
         replay_macro, "Replay macro",
+        show_subtree, "Show tree-sitter subtree under primary selection",
     );
 }
 
@@ -6209,4 +6210,34 @@ fn replay_macro(cx: &mut Context) {
             }
         },
     ));
+}
+
+fn show_subtree(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+
+    if let Some(syntax) = doc.syntax() {
+        let primary_selection = doc.selection(view.id).primary();
+        let text = doc.text().slice(..);
+        let from = text.char_to_byte(primary_selection.from());
+        let to = text.char_to_byte(primary_selection.to());
+        if let Some(selected_node) = syntax
+            .tree()
+            .root_node()
+            .descendant_for_byte_range(from, to)
+        {
+            let contents = format!("```tsq\n{}\n```", selected_node.to_sexp());
+
+            cx.callback = Some(Box::new(
+                move |compositor: &mut Compositor, cx: &mut compositor::Context| {
+                    let contents = ui::Markdown::new(contents, cx.editor.syn_loader.clone());
+                    let popup = Popup::new("tree", contents);
+                    if let Some(doc_popup) = compositor.find_id("tree") {
+                        *doc_popup = popup;
+                    } else {
+                        compositor.push(Box::new(popup));
+                    }
+                },
+            ));
+        }
+    }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6217,7 +6217,7 @@ fn show_subtree(cx: &mut Context) {
 
     if let Some(syntax) = doc.syntax() {
         let primary_selection = doc.selection(view.id).primary();
-        let text = doc.text().slice(..);
+        let text = doc.text();
         let from = text.char_to_byte(primary_selection.from());
         let to = text.char_to_byte(primary_selection.to());
         if let Some(selected_node) = syntax

--- a/languages.toml
+++ b/languages.toml
@@ -377,6 +377,7 @@ scope = "source.tsq"
 file-types = ["scm"]
 roots = []
 comment-token = ";"
+injection-regex = "tsq"
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]


### PR DESCRIPTION
https://user-images.githubusercontent.com/21230295/148418001-fde4c441-6f20-4365-9893-3696982f3670.mp4

I have this setup for testing but I'm not sure this command really deserves a default binding in the `space+<command>` submap:

```diff
diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
index 49f8469..3050315 100644
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -677,6 +677,7 @@ impl Default for Keymaps {
                 "R" => replace_selections_with_clipboard,
                 "/" => global_search,
                 "k" => hover,
+                "t" => show_subtree,
                 "r" => rename_symbol,
             },
             "z" => { "View"
```

I kinda just did whatever the rust compiler told me to do, there's probably some wacky stuff in here :sweat_smile:. In particular the two nested levels of `if let Some(...)` feel a little clumsy, no? Please feel free to pile on the rust style/nitpick reviews :+1: 

Also I think it'd be ideal to run the sexp through a pretty printer, but I left that off in this PR.

What do you think?