### PR TITLE
expand_selection to current node with no children

### DIFF
--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -12,7 +12,7 @@ pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection)
             .root_node()
             .descendant_for_byte_range(from, to)
             .and_then(|node| {
-                if node.child_count() == 0 || (node.start_byte() == from && node.end_byte() == to) {
+                if node.start_byte() == from && node.end_byte() == to {
                     node.parent()
                 } else {
                     Some(node)


### PR DESCRIPTION
builds on the work in #919 so we can expand selections when on a terminal node of the tree.

before:

https://user-images.githubusercontent.com/21230295/148426748-8c176c09-db2f-4faf-b948-f44035cc9c80.mp4

after:

https://user-images.githubusercontent.com/21230295/148426755-383cf8c9-a3b2-4923-92f3-703ab18541b0.mp4

Where in this case the tree looks like

```tsq
(arguments (identifier) (identifier))
```

So expand_selection will grow the current selection to fit the node (`(identifier)`), or grow to the parent (`(arguments (identifier) (identifier))`) if the current node is already _fully_ selected. IMHO this is more intuitive. What do you think?

