### PR TITLE
capture markdown link text as markup.link.text

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -171,8 +171,9 @@ We use a similar set of scopes as
   - `bold`
   - `italic`
   - `link`
-    - `url`
-    - `label`
+    - `url` - urls pointed to by links
+    - `label` - non-url link references
+    - `text` - url and image descriptions in links
   - `quote`
   - `raw`
     - `inline`

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -22,6 +22,11 @@
 (link_label) @markup.link.label
 
 [
+  (link_text)
+  (image_description)
+] @markup.link.text
+
+[
   (list_marker_plus)
   (list_marker_minus)
   (list_marker_star)

--- a/theme.toml
+++ b/theme.toml
@@ -32,6 +32,7 @@ label = "honey"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.link.url" = { fg = "silver", modifiers = ["underlined"] }
+"markup.link.text" = "almond"
 "markup.raw" = "almond"
 
 "diff.plus" = "#35bf86"


### PR DESCRIPTION
captures the [text](https://github.github.com/gfm/#link-text) part of a link as a new scope, such as in these examples

```
[documentation](http://example.org)
# ^ markup.link.text
#                 ^ markup.link.url
![screenshot][screenshot_ref]
# ^ markup.link.text
#                 ^ markup.link.label
```

cc @sudormrfbin (since I saw you on https://github.com/helix-editor/helix/pull/1296)