### PR TITLE
Add default language server for JavaScript

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -18,7 +18,7 @@
 | go | ✓ | ✓ | ✓ | `gopls` |
 | html | ✓ |  |  |  |
 | java | ✓ |  |  |  |
-| javascript | ✓ |  | ✓ |  |
+| javascript | ✓ |  | ✓ | `typescript-language-server` |
 | json | ✓ |  | ✓ |  |
 | julia | ✓ |  |  | `julia` |
 | latex | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -128,6 +128,7 @@ roots = []
 comment-token = "//"
 # TODO: highlights-jsx, highlights-params
 
+language-server = { command = "typescript-language-server", args = ["--stdio"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]


### PR DESCRIPTION
The [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server) supports both JavaScript and TypeScript. We can use it as the default language server for JavaScript as well.