### PR TITLE
Enable tree-sitter for .zshrc and .bashrc

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -308,8 +308,13 @@ impl Loader {
             .and_then(|n| n.to_str())
             .and_then(|file_name| self.language_config_ids_by_file_type.get(file_name))
             .or_else(|| {
-                path.extension()
-                    .and_then(|extension| extension.to_str())
+                // we can't use the `extension` methods here because it ignore
+                // empty file name with only an extension like `.bashrc`.
+                path.file_name()
+                    .map(|file_name| file_name.to_str())
+                    .flatten()
+                    .map(|file_name| file_name.rsplit('.').next())
+                    .flatten()
                     .and_then(|extension| self.language_config_ids_by_file_type.get(extension))
             });
 

--- a/languages.toml
+++ b/languages.toml
@@ -212,8 +212,8 @@ indent = { tab-width = 2, unit = "  " }
 name = "bash"
 scope = "source.bash"
 injection-regex = "bash"
-file-types = ["sh", "bash"]
-shebangs = ["sh", "bash", "dash"]
+file-types = ["sh", "bash", "zsh", "bashrc", "zshrc"]
+shebangs = ["sh", "bash", "dash", "zsh"]
 roots = []
 comment-token = "#"
 


### PR DESCRIPTION
There is no « official » support for zsh [currently](https://github.com/nvim-treesitter/nvim-treesitter/issues/655) but tree-sitters for bash is quite good already, and they even accepted a PR one month ago that adds some [special handling for zsh](https://github.com/tree-sitter/tree-sitter-bash/pull/115) so I think we can use it as-is.