### PR TITLE
Update config docs: editor.filepicker -> editor.file-picker

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -25,7 +25,7 @@ To override global configuration parameters, create a `config.toml` file located
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 
-`[editor.filepicker]` section of the config. Sets options for file picker and global search. All but the last key listed in the default file-picker configuration below are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default.
+`[editor.file-picker]` section of the config. Sets options for file picker and global search. All but the last key listed in the default file-picker configuration below are IgnoreOptions: whether hidden files and files listed within ignore files are ignored by (not visible in) the helix file picker and global search. There is also one other key, `max-depth` available, which is not defined by default.
 
 | Key | Description | Default |
 |--|--|---------|


### PR DESCRIPTION
Using `editor.filepicker` results in this error:

```
Bad config: unknown field `filepicker`, expected one of `scrolloff`, `scroll-lines`, `mouse`, `shell`, `line-number`, `middle-click-paste`, `smart-case`, `auto-pairs`, `auto-completion`, `idle-timeout`, `completion-trigger-len`, `auto-info`, `file-picker`, `true-color` for key `editor` at line 6 column 1
Press <ENTER> to continue with default config
```