### PR TITLE
Exclude xtask from alias c and b

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,4 @@
 [alias]
 xtask = "run --package xtask --"
+b = "build --workspace --exclude xtask"
+c = "check --workspace --exclude xtask"


### PR DESCRIPTION
xtask is not needed for normal check and build and only used during
cargo xtask, it would be nice to exclude it

See https://github.com/matklad/cargo-xtask/issues/18