### PR TITLE
add select_next_sibling and select_prev_sibling commands

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -118,6 +118,10 @@
 | `Alt-K`  | Remove selections matching the regex                              | `remove_selections`                  |
 | `$`      | Pipe each selection into shell command, keep selections where command returned 0 | `shell_keep_pipe`     |
 | `Ctrl-c` | Comment/uncomment the selections                                  | `toggle_comments`                    |
+| `Alt-k`  | Expand selection to parent syntax node                            | `expand_selection`                   |
+| `Alt-j`  | Shrink syntax tree object selection                               | `shrink_selection`                   |
+| `Alt-h`  | Select previous sibling node in syntax tree                       | `select_prev_sibling`                |
+| `Alt-l`  | Select next sibling node in syntax tree                           | `select_next_sibling`                |
 
 ### Search
 
@@ -261,8 +265,6 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`    |
 | `[space` | Add newline above                            | `add_newline_above` |
 | `]space` | Add newline below                            | `add_newline_below` |
-| `]o`     | Expand syntax tree object selection.         | `expand_selection`  |
-| `[o`     | Shrink syntax tree object selection.         | `shrink_selection`  |
 
 ## Insert Mode
 

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -13,7 +13,7 @@ pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection)
 
 pub fn shrink_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
     select_node_impl(syntax, text, selection, |descendant, _from, _to| {
-        descendant.child(0).or_else(|| Some(descendant))
+        descendant.child(0).or(Some(descendant))
     })
 }
 

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -1,7 +1,7 @@
 use crate::{Range, RopeSlice, Selection, Syntax};
 use tree_sitter::Node;
 
-pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
+pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
     select_node_impl(syntax, text, selection, |descendant, from, to| {
         if descendant.start_byte() == from && descendant.end_byte() == to {
             descendant.parent()
@@ -11,19 +11,19 @@ pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection)
     })
 }
 
-pub fn shrink_selection(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
+pub fn shrink_selection(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
     select_node_impl(syntax, text, selection, |descendant, _from, _to| {
         descendant.child(0).or(Some(descendant))
     })
 }
 
-pub fn select_next_sibling(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
+pub fn select_next_sibling(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
     select_node_impl(syntax, text, selection, |descendant, _from, _to| {
         find_sibling_recursive(descendant, |node| node.next_sibling())
     })
 }
 
-pub fn select_prev_sibling(syntax: &Syntax, text: RopeSlice, selection: &Selection) -> Selection {
+pub fn select_prev_sibling(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
     select_node_impl(syntax, text, selection, |descendant, _from, _to| {
         find_sibling_recursive(descendant, |node| node.prev_sibling())
     })
@@ -42,7 +42,7 @@ where
 fn select_node_impl<F>(
     syntax: &Syntax,
     text: RopeSlice,
-    selection: &Selection,
+    selection: Selection,
     select_fn: F,
 ) -> Selection
 where
@@ -50,7 +50,7 @@ where
 {
     let tree = syntax.tree();
 
-    selection.clone().transform(|range| {
+    selection.transform(|range| {
         let from = text.char_to_byte(range.from());
         let to = text.char_to_byte(range.to());
 

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -17,15 +17,17 @@ pub fn shrink_selection(syntax: &Syntax, text: RopeSlice, selection: Selection) 
     })
 }
 
-pub fn select_next_sibling(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
+pub fn select_sibling<F>(
+    syntax: &Syntax,
+    text: RopeSlice,
+    selection: Selection,
+    sibling_fn: &F,
+) -> Selection
+where
+    F: Fn(Node) -> Option<Node>,
+{
     select_node_impl(syntax, text, selection, |descendant, _from, _to| {
-        find_sibling_recursive(descendant, |node| node.next_sibling())
-    })
-}
-
-pub fn select_prev_sibling(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
-    select_node_impl(syntax, text, selection, |descendant, _from, _to| {
-        find_sibling_recursive(descendant, |node| node.prev_sibling())
+        find_sibling_recursive(descendant, sibling_fn)
     })
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5492,7 +5492,7 @@ fn expand_selection(cx: &mut Context) {
             // save current selection so it can be restored using shrink_selection
             view.object_selections.push(current_selection.clone());
 
-            let selection = object::expand_selection(syntax, text, current_selection);
+            let selection = object::expand_selection(syntax, text, current_selection.clone());
             doc.set_selection(view.id, selection);
         }
     };
@@ -5518,7 +5518,7 @@ fn shrink_selection(cx: &mut Context) {
         // if not previous selection, shrink to first child
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
-            let selection = object::shrink_selection(syntax, text, current_selection);
+            let selection = object::shrink_selection(syntax, text, current_selection.clone());
             doc.set_selection(view.id, selection);
         }
     };
@@ -5532,10 +5532,8 @@ fn select_next_sibling(cx: &mut Context) {
 
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
-
             let current_selection = doc.selection(view.id);
-
-            let selection = object::select_next_sibling(syntax, text, current_selection);
+            let selection = object::select_next_sibling(syntax, text, current_selection.clone());
             doc.set_selection(view.id, selection);
         }
     };
@@ -5549,10 +5547,8 @@ fn select_prev_sibling(cx: &mut Context) {
 
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
-
             let current_selection = doc.selection(view.id);
-
-            let selection = object::select_prev_sibling(syntax, text, current_selection);
+            let selection = object::select_prev_sibling(syntax, text, current_selection.clone());
             doc.set_selection(view.id, selection);
         }
     };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -363,6 +363,8 @@ impl MappableCommand {
         rotate_selection_contents_backward, "Rotate selections contents backward",
         expand_selection, "Expand selection to parent syntax node",
         shrink_selection, "Shrink selection to previously expanded syntax node",
+        select_next_sibling, "Select the next sibling in the syntax tree",
+        select_prev_sibling, "Select the previous sibling in the syntax tree",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save the current selection to the jumplist",
@@ -5517,6 +5519,40 @@ fn shrink_selection(cx: &mut Context) {
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
             let selection = object::shrink_selection(syntax, text, current_selection);
+            doc.set_selection(view.id, selection);
+        }
+    };
+    motion(cx.editor);
+    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+}
+
+fn select_next_sibling(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+
+        if let Some(syntax) = doc.syntax() {
+            let text = doc.text().slice(..);
+
+            let current_selection = doc.selection(view.id);
+
+            let selection = object::select_next_sibling(syntax, text, current_selection);
+            doc.set_selection(view.id, selection);
+        }
+    };
+    motion(cx.editor);
+    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+}
+
+fn select_prev_sibling(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+
+        if let Some(syntax) = doc.syntax() {
+            let text = doc.text().slice(..);
+
+            let current_selection = doc.selection(view.id);
+
+            let selection = object::select_prev_sibling(syntax, text, current_selection);
             doc.set_selection(view.id, selection);
         }
     };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -11,6 +11,7 @@ use helix_core::{
     object, pos_at_coords,
     regex::{self, Regex, RegexBuilder},
     search, selection, shellwords, surround, textobject,
+    tree_sitter::Node,
     unicode::width::UnicodeWidthChar,
     LineEnding, Position, Range, Rope, RopeGraphemes, RopeSlice, Selection, SmallVec, Tendril,
     Transaction,
@@ -5528,7 +5529,7 @@ fn shrink_selection(cx: &mut Context) {
 
 fn select_sibling_impl<F>(cx: &mut Context, sibling_fn: &'static F)
 where
-    F: Fn(helix_core::tree_sitter::Node) -> Option<helix_core::tree_sitter::Node>,
+    F: Fn(Node) -> Option<Node>,
 {
     let motion = |editor: &mut Editor| {
         let (view, doc) = current!(editor);
@@ -5546,15 +5547,11 @@ where
 }
 
 fn select_next_sibling(cx: &mut Context) {
-    select_sibling_impl(cx, &|node| {
-        helix_core::tree_sitter::Node::next_sibling(&node)
-    })
+    select_sibling_impl(cx, &|node| Node::next_sibling(&node))
 }
 
 fn select_prev_sibling(cx: &mut Context) {
-    select_sibling_impl(cx, &|node| {
-        helix_core::tree_sitter::Node::prev_sibling(&node)
-    })
+    select_sibling_impl(cx, &|node| Node::prev_sibling(&node))
 }
 
 fn match_brackets(cx: &mut Context) {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -570,12 +570,14 @@ impl Default for Keymaps {
                 "D" => goto_first_diag,
                 "space" => add_newline_above,
                 "o" => shrink_selection,
+                "s" => select_prev_sibling,
             },
             "]" => { "Right bracket"
                 "d" => goto_next_diag,
                 "D" => goto_last_diag,
                 "space" => add_newline_below,
                 "o" => expand_selection,
+                "s" => select_next_sibling,
             },
 
             "/" => search,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -552,6 +552,11 @@ impl Default for Keymaps {
             "S" => split_selection,
             ";" => collapse_selection,
             "A-;" => flip_selections,
+            "A-k" => expand_selection,
+            "A-j" => shrink_selection,
+            "A-h" => select_prev_sibling,
+            "A-l" => select_next_sibling,
+
             "%" => select_all,
             "x" => extend_line,
             "X" => extend_to_line_bounds,
@@ -569,15 +574,11 @@ impl Default for Keymaps {
                 "d" => goto_prev_diag,
                 "D" => goto_first_diag,
                 "space" => add_newline_above,
-                "o" => shrink_selection,
-                "t" => select_prev_sibling,
             },
             "]" => { "Right bracket"
                 "d" => goto_next_diag,
                 "D" => goto_last_diag,
                 "space" => add_newline_below,
-                "o" => expand_selection,
-                "t" => select_next_sibling,
             },
 
             "/" => search,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -570,14 +570,14 @@ impl Default for Keymaps {
                 "D" => goto_first_diag,
                 "space" => add_newline_above,
                 "o" => shrink_selection,
-                "s" => select_prev_sibling,
+                "t" => select_prev_sibling,
             },
             "]" => { "Right bracket"
                 "d" => goto_next_diag,
                 "D" => goto_last_diag,
                 "space" => add_newline_below,
                 "o" => expand_selection,
-                "s" => select_next_sibling,
+                "t" => select_next_sibling,
             },
 
             "/" => search,


### PR DESCRIPTION
builds on expand_selection and shrink_selection to move to next and previous sibling nodes in the syntax tree

mostly I'm interested in all four of those together an alternate means of motion, like so:

https://user-images.githubusercontent.com/21230295/149166562-e79d1717-87c2-4d95-af04-9812c3c0a998.mp4

Where I have

- `A-j` shrink selection
- `A-k` expand selection
- `A-h` select prev sibling
- `A-l` select next sibling

in my personal config. I don't know if these commands are worthy of a default keybind :thinking:

What do you think?