### PR TITLE
small fix: buffer picker allow hsplit / vsplit

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3239,8 +3239,8 @@ fn buffer_picker(cx: &mut Context) {
             .map(|(_, doc)| new_meta(doc))
             .collect(),
         BufferMeta::format,
-        |editor: &mut Editor, meta, _action| {
-            editor.switch(meta.id, Action::Replace);
+        |editor: &mut Editor, meta, action| {
+            editor.switch(meta.id, action);
         },
         |editor, meta| {
             let doc = &editor.documents.get(&meta.id)?;


### PR DESCRIPTION
Allow using `Ctrl-v` and `Ctrl-s` in the buffer picker to open in a split view, just like in the file picker
(idk why it wasn't the case, probably an oversight during 5c2d2fda)