### PR TITLE
feat(languages): enable css tree-sitter for scss files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -158,7 +158,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "css"
 scope = "source.css"
 injection-regex = "css"
-file-types = ["css"]
+file-types = ["css", "scss"]
 roots = []
 
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
(super tiny PR)

The grammer works fine for scss files to and it is better than no hihglighting at all.