### PR TITLE
feat(editor): add config for search wrap_around 

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1608,12 +1608,13 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
     if let Some(query) = registers.read('/') {
         let query = query.last().unwrap();
         let contents = doc.text().slice(..).to_string();
-        let case_insensitive = if cx.editor.config.smart_case {
+        let search_config = &cx.editor.config.search;
+        let case_insensitive = if search_config.smart_case {
             !query.chars().any(char::is_uppercase)
         } else {
             false
         };
-        let wrap_around = cx.editor.config.search.wrap_around;
+        let wrap_around = search_config.wrap_around;
         if let Ok(regex) = RegexBuilder::new(query)
             .case_insensitive(case_insensitive)
             .build()
@@ -1666,7 +1667,7 @@ fn search_selection(cx: &mut Context) {
 fn global_search(cx: &mut Context) {
     let (all_matches_sx, all_matches_rx) =
         tokio::sync::mpsc::unbounded_channel::<(usize, PathBuf)>();
-    let smart_case = cx.editor.config.smart_case;
+    let smart_case = cx.editor.config.search.smart_case;
     let file_picker_config = cx.editor.config.file_picker.clone();
 
     let completions = search_completions(cx, None);
@@ -2705,12 +2706,13 @@ pub mod cmd {
             "mouse" => runtime_config.mouse = arg.parse()?,
             "line-number" => runtime_config.line_number = arg.parse()?,
             "middle-click_paste" => runtime_config.middle_click_paste = arg.parse()?,
-            "smart-case" => runtime_config.smart_case = arg.parse()?,
             "auto-pairs" => runtime_config.auto_pairs = arg.parse()?,
             "auto-completion" => runtime_config.auto_completion = arg.parse()?,
             "completion-trigger-len" => runtime_config.completion_trigger_len = arg.parse()?,
             "auto-info" => runtime_config.auto_info = arg.parse()?,
             "true-color" => runtime_config.true_color = arg.parse()?,
+            "search.smart-case" => runtime_config.search.smart_case = arg.parse()?,
+            "search.wrap-around" => runtime_config.search.wrap_around = arg.parse()?,
             _ => anyhow::bail!("Unknown key `{}`.", args[0]),
         }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1457,6 +1457,7 @@ fn split_selection_on_newline(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn search_impl(
     doc: &mut Document,
     view: &mut View,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -65,7 +65,7 @@ pub fn regex_prompt(
                         return;
                     }
 
-                    let case_insensitive = if cx.editor.config.smart_case {
+                    let case_insensitive = if cx.editor.config.search.smart_case {
                         !input.chars().any(char::is_uppercase)
                     } else {
                         false

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -107,6 +107,16 @@ pub struct Config {
     pub file_picker: FilePickerConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
+    /// Search configuration.
+    #[serde(default)]
+    pub search: SearchConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct SearchConfig {
+    /// Whether the search should wrap after depleting the matches. Default to true.
+    pub wrap_around: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -152,7 +162,14 @@ impl Default for Config {
             auto_info: true,
             file_picker: FilePickerConfig::default(),
             true_color: false,
+            search: SearchConfig::default(),
         }
+    }
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self { wrap_around: true }
     }
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -92,8 +92,6 @@ pub struct Config {
     pub line_number: LineNumber,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
-    /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
-    pub smart_case: bool,
     /// Automatic insertion of pairs to parentheses, brackets, etc. Defaults to true.
     pub auto_pairs: bool,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
@@ -115,6 +113,8 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct SearchConfig {
+    /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
+    pub smart_case: bool,
     /// Whether the search should wrap after depleting the matches. Default to true.
     pub wrap_around: bool,
 }
@@ -154,7 +154,6 @@ impl Default for Config {
             },
             line_number: LineNumber::Absolute,
             middle_click_paste: true,
-            smart_case: true,
             auto_pairs: true,
             auto_completion: true,
             idle_timeout: Duration::from_millis(400),
@@ -169,7 +168,10 @@ impl Default for Config {
 
 impl Default for SearchConfig {
     fn default() -> Self {
-        Self { wrap_around: true }
+        Self {
+            wrap_around: true,
+            smart_case: true,
+        }
     }
 }
 


### PR DESCRIPTION
Adds configuration for search wrap around and moves search config into separate config struct.

Fixes: https://github.com/helix-editor/helix/issues/1489