### PR TITLE
Add `markup.` scopes in `gruvbox` themes

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -55,6 +55,13 @@
 
 "diagnostic" = { modifiers = ["underlined"] }
 
+"markup.heading" = "aqua1"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
+"markup.link.text" = "red1"
+"markup.raw" = "red1"
+
 [palette]
 bg0 = "#282828" # main background
 bg1 = "#3c3836"

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -20,6 +20,7 @@
 "function" = { fg = "green1", modifiers = ["bold"] }
 "function.macro" = "aqua1"
 "function.builtin" = "yellow1"
+"tag" = "red1"
 "comment" = { fg = "gray1", modifiers = ["italic"]  }
 "constant" = { fg = "purple1" }
 "constant.builtin" = { fg = "purple1", modifiers = ["bold"] }
@@ -55,6 +56,13 @@
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 
 "diagnostic" = { modifiers = ["underlined"] }
+
+"markup.heading" = "aqua1"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
+"markup.link.text" = "red1"
+"markup.raw" = "red1"
 
 [palette]
 bg0 = "#fbf1c7" # main background


### PR DESCRIPTION
As recommended by @archseer in https://github.com/helix-editor/helix/pull/1509#issuecomment-1013583069