### PR TITLE
Add rust injections for c, c++, html, js, py

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -1,14 +1,52 @@
 ([(line_comment) (block_comment)] @injection.content
  (#set! injection.language "comment"))
 
-((macro_invocation
+((macro_rule
   (token_tree) @injection.content)
  (#set! injection.language "rust")
  (#set! injection.include-children))
 
-((macro_rule
+; inline_c::assert_c
+((macro_invocation
+  macro: (identifier) @_c (#eq? @_c "assert_c")
   (token_tree) @injection.content)
- (#set! injection.language "rust")
+ (#set! injection.language "c")
+ (#set! injection.include-children))
+
+; inline_c::assert_cxx
+((macro_invocation
+  macro: (identifier) @_cxx (#eq? @_cxx "assert_cxx")
+  (token_tree) @injection.content)
+ (#set! injection.language "cpp")
+ (#set! injection.include-children))
+
+; typed_html::html
+((macro_invocation
+  macro: (identifier) @_html (#eq? @_html "html")
+  (token_tree) @injection.content)
+ (#set! injection.language "html")
+ (#set! injection.include-children))
+
+; inline_python::python
+; TODO: fix bug where first import is not highlighted
+((macro_invocation
+  macro: (scoped_identifier
+    name: (identifier) @_python (#eq? @_python "python"))
+  (token_tree) @injection.content)
+ (#set! injection.language "python")
+ (#set! injection.include-children))
+
+((macro_invocation
+  macro: (identifier) @_python (#eq? @_python "python")
+  (token_tree) @injection.content)
+ (#set! injection.language "python")
+ (#set! injection.include-children))
+
+; embed_js::inline_js
+((macro_invocation
+  macro: (identifier) @_js (#eq? @_js "include_js")
+  (token_tree) @injection.content)
+ (#set! injection.language "javascript")
  (#set! injection.include-children))
 
 (call_expression


### PR DESCRIPTION
cc @the-mikedavis 

Example
```rust
use inline_python::python;

fn main() {
    let who = "world";
    let n = 5;
    python! {
        import csv  # first import highlight won't work, not sure why
        for i in range('n):
            print(i, "Hello", 'who)
        print("Goodbye")
    }
}
```