### PR TITLE
dracula theme: add markup support

### DIFF
--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -40,6 +40,15 @@
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }
 
+"markup.heading" = { fg = "purple", modifiers = ["bold"] }
+"markup.list" = "cyan"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.url" = "cyan"
+"markup.link.text" = "pink"
+"markup.quote" = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw" = { fg = "foreground" }
+
 [palette]
 background = "#282a36"
 background_dark = "#21222c"


### PR DESCRIPTION
This adds markup scopes to the dracula theme according to [the spec](https://spec.draculatheme.com/#sec-Markup-Markdown-RST-etc-).