### PR TITLE
Add `tag` to gruvbox theme

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -19,6 +19,7 @@
 "function" = { fg = "green1", modifiers = ["bold"] }
 "function.macro" = "aqua1"
 "function.builtin" = "yellow1"
+"tag" = "red1"
 "comment" = { fg = "gray1", modifiers = ["italic"]  }
 "constant" = { fg = "purple1" }
 "constant.builtin" = { fg = "purple1", modifiers = ["bold"] }


### PR DESCRIPTION
Missed in the commit 943fca332e.

This is a follow up to: https://github.com/helix-editor/helix/pull/1518#discussion_r785316711