### PR TITLE
Add haskell-language-server-wrapper --lsp to default `languages.toml`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -19,7 +19,7 @@
 | glsl | ✓ |  | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
 | graphql | ✓ |  |  |  |
-| haskell | ✓ |  |  |  |
+| haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | html | ✓ |  |  |  |
 | java | ✓ |  |  |  |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -355,7 +355,7 @@ injection-regex = "haskell"
 file-types = ["hs"]
 roots = []
 comment-token = "--"
-
+language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]


### PR DESCRIPTION
After the changes to upgrade and reenable tree-sitter-haskell #1417
for the purpose of enabling Haskell syntax highlighting #1384, we
might as well take the final step.