### PR TITLE
[theme] Serika light and dark

### DIFF
--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -35,8 +35,8 @@
 
 "ui.background" = { bg = "bg0" }
 "ui.cursor" = { fg = "bg0", bg = "fg" }
-"ui.cursor.match" = { fg = "grey3", bg = "bg_yellow" }
-"ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
+"ui.cursor.match" = { fg = "grey3", bg = "grey2" }
+"ui.cursor.insert" = { fg = "bg0", bg = "bg_yellow" }
 "ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
 "ui.linenr" = "yellow"
 "ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
@@ -54,9 +54,21 @@
 "hint" = "blue"
 "info" = "aqua"
 "warning" = "yellow"
-"error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"error" = "nasty-red"
+"diagnostic" = { fg = "dark-red", Modifiers = ["underlined"] }
 
+"diff.plus" = { fg = "green" }
+"diff.delta" = { fg = "orange" }
+"diff.minus" = { fg = "red" }
+
+"markup.heading" = { fg = "purple", modifiers = ["bold"] }
+"markup.list" = "cyan"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.url" = "cyan"
+"markup.link.text" = "pink"
+"markup.quote" = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw" = { fg = "foreground" }
 
 [palette]
 
@@ -74,6 +86,8 @@ bg_yellow = "#e2b714"
 
 fg = "#d1d0c5"
 red = "#f9ebed"
+nasty-red = "#ca4754"
+dark-red = "#7e2a33"
 orange = "#dd8a3c"
 yellow = "#e2b714"
 green = "#e5eae1"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -1,0 +1,85 @@
+# Serika (Dark)
+# Author: VuiMuich
+
+# Original Author:
+# URL: https://github.com/arturoalviar/serika-syntax
+# Author: arturoalviar
+# License: MIT License
+
+"escape" = "orange"
+"type" = "yellow"
+"constant" = "purple"
+"number" = "purple"
+"string" = "fg"
+"comment" = "grey2"
+"variable" = "yellow"
+"variable.builtin" = "blue"
+"variable.parameter" = "yellow"
+"variable.property" = "yellow"
+"label" = "aqua"
+"punctuation" = "grey0"
+"punctuation.delimiter" = "grey2"
+"punctuation.bracket" = "fg"
+"keyword" = "red"
+"operator" = "grey0"
+"function" = "green"
+"function.builtin" = "blue"
+"function.macro" = "aqua"
+"tag" = "yellow"
+"namespace" = "fg"
+"attribute" = "aqua"
+"constructor" = "yellow"
+"module" = "blue"
+"property" = "yellow"
+"special" = "orange"
+
+"ui.background" = { bg = "bg0" }
+"ui.cursor" = { fg = "bg0", bg = "fg" }
+"ui.cursor.match" = { fg = "grey3", bg = "bg_yellow" }
+"ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
+"ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
+"ui.linenr" = "yellow"
+"ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
+"ui.statusline" = { fg = "grey1", bg = "bg2" }
+"ui.statusline.inactive" = { fg = "grey2", bg = "bg1" }
+"ui.popup" = { fg = "grey2", bg = "bg1" }
+"ui.window" = { fg = "grey2", bg = "bg1" }
+"ui.help" = { fg = "fg", bg = "bg1" }
+"ui.text" = "fg"
+"ui.text.focus" = "yellow"
+"ui.menu" = { fg = "fg", bg = "bg2" }
+"ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
+"ui.selection" = { bg = "bg3" }
+
+"hint" = "blue"
+"info" = "aqua"
+"warning" = "yellow"
+"error" = "red"
+"diagnostic" = { modifiers = ["underlined"] }
+
+
+[palette]
+
+bg0 = "#323437"
+bg1 = "#494c50"
+bg2 = "#55585e"
+bg3 = "#61656b"
+bg4 = "#6d7278"
+bg5 = "#797e86"
+bg_visual = "#646669"
+bg_red = "#7e2a33"
+bg_green = "#86b365"
+bg_blue = "#6a89af"
+bg_yellow = "#e2b714"
+
+fg = "#d1d0c5"
+red = "#f9ebed"
+orange = "#dd8a3c"
+yellow = "#e2b714"
+green = "#e5eae1"
+aqua = "#b9c2c6"
+blue = "#bdcadb"
+purple = "#d0c4d4"
+grey0 = "#aaaeb3"
+grey1 = "#e1e1e3"
+grey2 = "#646669"

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -35,27 +35,40 @@
 
 "ui.background" = { bg = "bg0" }
 "ui.cursor" = { fg = "bg0", bg = "fg" }
-"ui.cursor.match" = { fg = "grey3", bg = "bg_yellow" }
-"ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
+"ui.cursor.match" = { fg = "grey1", bg = "grey2" }
+"ui.cursor.insert" = { fg = "bg0", bg = "bg_yellow" }
 "ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
 "ui.linenr" = "yellow"
 "ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
-"ui.statusline" = { fg = "grey1", bg = "bg2" }
+"ui.statusline" = { fg = "grey1", bg = "bg5" }
 "ui.statusline.inactive" = { fg = "grey2", bg = "bg1" }
-"ui.popup" = { fg = "grey2", bg = "bg1" }
-"ui.window" = { fg = "grey2", bg = "bg1" }
-"ui.help" = { fg = "fg", bg = "bg1" }
+"ui.popup" = { fg = "bg0", bg = "bg5" }
+"ui.window" = { fg = "bg0", bg = "bg5" }
+"ui.help" = { fg = "bg0", bg = "bg5" }
 "ui.text" = "fg"
 "ui.text.focus" = "yellow"
-"ui.menu" = { fg = "fg", bg = "bg2" }
+"ui.menu" = { fg = "bg0", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
-"ui.selection" = { bg = "bg3" }
+"ui.selection" = { fg = "bg0", bg = "bg3" }
 
 "hint" = "blue"
 "info" = "aqua"
 "warning" = "yellow"
-"error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"error" = "nasty-red"
+"diagnostic" = { fg = "dark-red", Modifiers = ["underlined"] }
+
+"diff.plus" = { fg = "green" }
+"diff.delta" = { fg = "orange" }
+"diff.minus" = { fg = "red" }
+
+"markup.heading" = { fg = "purple", modifiers = ["bold"] }
+"markup.list" = "cyan"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.url" = "cyan"
+"markup.link.text" = "pink"
+"markup.quote" = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw" = { fg = "foreground" }
 
 
 [palette]
@@ -74,6 +87,8 @@ bg_yellow = "#e2b714"
 
 fg = "#323437"
 red = "#621d28"
+nasty-red = "#da3333"
+dark-red = "#791717"
 orange = "#57320f"
 yellow = "#e2b714"
 green = "#3f4b34"

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -1,0 +1,85 @@
+# Serika (Light)
+# Author: VuiMuich
+
+# Original Author:
+# URL: https://github.com/arturoalviar/serika-syntax
+# Author: arturoalviar
+# License: MIT License
+
+"escape" = "orange"
+"type" = "yellow"
+"constant" = "purple"
+"number" = "purple"
+"string" = "fg"
+"comment" = "grey2"
+"variable" = "yellow"
+"variable.builtin" = "blue"
+"variable.parameter" = "yellow"
+"variable.property" = "yellow"
+"label" = "aqua"
+"punctuation" = "grey0"
+"punctuation.delimiter" = "grey2"
+"punctuation.bracket" = "fg"
+"keyword" = "red"
+"operator" = "grey0"
+"function" = "green"
+"function.builtin" = "blue"
+"function.macro" = "aqua"
+"tag" = "yellow"
+"namespace" = "fg"
+"attribute" = "aqua"
+"constructor" = "yellow"
+"module" = "blue"
+"property" = "yellow"
+"special" = "orange"
+
+"ui.background" = { bg = "bg0" }
+"ui.cursor" = { fg = "bg0", bg = "fg" }
+"ui.cursor.match" = { fg = "grey3", bg = "bg_yellow" }
+"ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
+"ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
+"ui.linenr" = "yellow"
+"ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
+"ui.statusline" = { fg = "grey1", bg = "bg2" }
+"ui.statusline.inactive" = { fg = "grey2", bg = "bg1" }
+"ui.popup" = { fg = "grey2", bg = "bg1" }
+"ui.window" = { fg = "grey2", bg = "bg1" }
+"ui.help" = { fg = "fg", bg = "bg1" }
+"ui.text" = "fg"
+"ui.text.focus" = "yellow"
+"ui.menu" = { fg = "fg", bg = "bg2" }
+"ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
+"ui.selection" = { bg = "bg3" }
+
+"hint" = "blue"
+"info" = "aqua"
+"warning" = "yellow"
+"error" = "red"
+"diagnostic" = { modifiers = ["underlined"] }
+
+
+[palette]
+
+bg0 = "#e1e1e3"
+bg1 = "#494c50"
+bg2 = "#55585e"
+bg3 = "#61656b"
+bg4 = "#6d7278"
+bg5 = "#797e86"
+bg_visual = "#646669"
+bg_red = "#7e2a33"
+bg_green = "#86b365"
+bg_blue = "#6a89af"
+bg_yellow = "#e2b714"
+
+fg = "#323437"
+red = "#621d28"
+orange = "#57320f"
+yellow = "#e2b714"
+green = "#3f4b34"
+aqua = "#455054"
+blue = "#3f5673"
+purple = "#534059"
+grey0 = "#aaaeb3"
+grey1 = "#e1e1e3"
+grey2 = "#646669"


### PR DESCRIPTION
A theme inspired by [monkeytype](https://monkeytype.com/) and [this Atom theme](https://github.com/arturoalviar/serika-syntax) which was based off the [GMK Serika keycap](https://zambumon.com/serika/) set by Zambumon.

A slight twist on the other takes I took was to use quite subtle shades on the colors as I did want to interfer with the dichromacity of the theme base as less as possible.
This might change a bit over a few future iterations to optimise the experience over time.

Any feedback welcome.