### PR TITLE
Word movement select from first range, remove unnecessary v

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -251,14 +251,20 @@ fn word_move(slice: RopeSlice, range: Range, count: usize, target: WordMotionTar
 
     // Do the main work.
     let mut range = start_range;
+    let mut first_range = None;
     for _ in 0..count {
         let next_range = slice.chars_at(range.head).range_to_target(target, range);
         if range == next_range {
             break;
         }
         range = next_range;
+        if first_range.is_none() {
+            first_range = Some(range);
+        }
     }
-    range
+    let first_range = first_range.unwrap_or(range);
+    let last_range = range;
+    Range::new(first_range.anchor, last_range.head)
 }
 
 pub fn move_prev_paragraph(
@@ -1047,11 +1053,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(0, 0), Range::new(17, 20)),
+                    (3, Range::new(0, 0), Range::new(0, 20)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(0, 0), Range::new(32, 41)),
+                    (999, Range::new(0, 0), Range::new(0, 41)),
                 ]),
             ("", // Edge case of moving forward in empty string
                 vec![
@@ -1303,11 +1309,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(0, 0), Range::new(17, 20)),
+                    (3, Range::new(0, 0), Range::new(0, 20)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(0, 0), Range::new(32, 41)),
+                    (999, Range::new(0, 0), Range::new(0, 41)),
                 ]),
             ("", // Edge case of moving forward in empty string
                 vec![
@@ -1388,11 +1394,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(18, 18), Range::new(9, 0)),
+                    (3, Range::new(18, 18), Range::new(19, 0)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(40, 40), Range::new(10, 0)),
+                    (999, Range::new(40, 40), Range::new(41, 0)),
                 ]),
             ("", // Edge case of moving backwards in empty string
                 vec![
@@ -1571,11 +1577,11 @@ mod test {
             ),
             (
                 "Multiple motions at once resolve correctly",
-                vec![(3, Range::new(19, 19), Range::new(9, 0))],
+                vec![(3, Range::new(0, 19), Range::new(19, 0))],
             ),
             (
                 "Excessive motions are performed partially",
-                vec![(999, Range::new(40, 40), Range::new(10, 0))],
+                vec![(999, Range::new(40, 40), Range::new(41, 0))],
             ),
             (
                 "", // Edge case of moving backwards in empty string
@@ -1655,11 +1661,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(0, 0), Range::new(16, 19)),
+                    (3, Range::new(0, 0), Range::new(0, 19)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(0, 0), Range::new(31, 41)),
+                    (999, Range::new(0, 0), Range::new(0, 41)),
                 ]),
             ("", // Edge case of moving forward in empty string
                 vec![
@@ -1737,11 +1743,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(24, 24), Range::new(16, 8)),
+                    (3, Range::new(24, 24), Range::new(24, 8)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(40, 40), Range::new(9, 0)),
+                    (999, Range::new(40, 40), Range::new(41, 0)),
                 ]),
             ("", // Edge case of moving backwards in empty string
                 vec![
@@ -1905,11 +1911,11 @@ mod test {
                 ]),
             ("Multiple motions at once resolve correctly",
                 vec![
-                    (3, Range::new(0, 0), Range::new(16, 19)),
+                    (3, Range::new(0, 0), Range::new(0, 19)),
                 ]),
             ("Excessive motions are performed partially",
                 vec![
-                    (999, Range::new(0, 0), Range::new(31, 41)),
+                    (999, Range::new(0, 0), Range::new(0, 41)),
                 ]),
             ("", // Edge case of moving forward in empty string
                 vec![
@@ -1999,11 +2005,11 @@ mod test {
             ),
             (
                 "Multiple motions at once resolve correctly",
-                vec![(3, Range::new(19, 19), Range::new(8, 0))],
+                vec![(3, Range::new(19, 19), Range::new(19, 0))],
             ),
             (
                 "Excessive motions are performed partially",
-                vec![(999, Range::new(40, 40), Range::new(9, 0))],
+                vec![(999, Range::new(40, 40), Range::new(41, 0))],
             ),
             (
                 "", // Edge case of moving backwards in empty string


### PR DESCRIPTION
3w currently selects the 3rd word, this changes the behavior to select
all 3 words rather than just the last.

One of the thing mentioned in https://github.com/helix-editor/helix/issues/165.

Fix #536

## Motivation
Many common motions require prefixing with `v` for count-based operations. For example, `v3wd` deletes three words.

This PR removes unnecessary uses of `v` where its presence makes no functional difference. It's unlikely users interpret `3wd` as "delete the third word", `2wwd` aligns better with typical mental models while using the same number of keystrokes.

## Consistency check
- [x] `f` / `t` / `F` / `T`
- [x] `]p`
- [x] `]f` - no preference on this, not changing it, I feel like it's weird to 2]f to select 2 functions down from current position
- [x] `A-n` / `A-p` / `A-i` / `A-o` - keeping, it seemed like these tree-sitter movements affect the whole current selection, I don't get the use case to select **until** the next two tree-sitter nodes
- [x] `gh` / `gs` / `gl` - previous behavior kept, rationale not very useful to have a count for these, and quite often I noticed I need to navigate there without select

## Common operations

| Operation | hx new | hx | vim | kak |
| --- | --- | --- | --- | --- |
| Delete 3 word | `3wd` | `v3wd` | `3dw` | `3Wd` |
| Delete 3 lines down | `3xd` | `3xd` | `3dj` | `2Jxd` |
| Delete 3 lines up | `v2kxd` | `v2kxd` | `3dk` | `2Kxd` |

## Usage notes

After using it for some time, `gl` sometimes I do need to delete or replace until end or start, but quite often I find myself having to edit the character just before `;` and muscle memory I would have to `gl` to navigate to last character then press `i`, and because count is not really useful for `gl` so I kept the old behavior.

Side note: https://delapouite.github.io/kakoune-explain/ and https://delapouite.github.io/kakoune-explain/keys.html seems cool