### PR TITLE
Enable tree-sitter for .bash_profile

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -213,7 +213,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "bash"
 scope = "source.bash"
 injection-regex = "bash"
-file-types = ["sh", "bash", ".bashrc", ".zshrc"]
+file-types = ["sh", "bash", ".bash_profile", ".bashrc", ".zshrc"]
 shebangs = ["sh", "bash", "dash"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
https://github.com/helix-editor/helix/commit/7d510429c564d216b4f1419b37a37cf7384f49c0 missed .bash_profile