### PR TITLE
add tree-sitter-iex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -216,5 +216,5 @@
 	shallow = true
 [submodule "helix-syntax/languages/tree-sitter-iex"]
 	path = helix-syntax/languages/tree-sitter-iex
-	url = https://github.com/the-mikedavis/tree-sitter-iex.git
+	url = https://github.com/elixir-lang/tree-sitter-iex
 	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -214,3 +214,7 @@
 	path = helix-syntax/languages/tree-sitter-elm
 	url = https://github.com/elm-tooling/tree-sitter-elm
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-iex"]
+	path = helix-syntax/languages/tree-sitter-iex
+	url = https://github.com/the-mikedavis/tree-sitter-iex.git
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,6 +21,7 @@
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | html | ✓ |  |  |  |
+| iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |
 | json | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -586,3 +586,10 @@ auto-format = true
 comment-token = "--"
 language-server = { command = "elm-language-server" }
 indent = { tab-width = 4, unit = "    " }
+
+[[language]]
+name = "iex"
+scope = "source.iex"
+injection-regex = "iex"
+file-types = ["iex"]
+roots = []

--- a/runtime/queries/iex/highlights.scm
+++ b/runtime/queries/iex/highlights.scm
@@ -1,0 +1,1 @@
+(prompt) @comment

--- a/runtime/queries/iex/injections.scm
+++ b/runtime/queries/iex/injections.scm
@@ -1,0 +1,6 @@
+((evaluation_block (prompt_line (expression) @injection.content))
+ (#set! injection.language "elixir")
+ (#set! injection.combined))
+
+((result) @injection.content
+ (#set! injection.language "elixir"))


### PR DESCRIPTION
This is a pretty small grammar for Interactive Elixir (IEx), the repl for elixir. It's perfect to add new because of the recently merged combined injections support :tada:. For example, these examples need combined injections in order to be properly parsed:

![iex](https://user-images.githubusercontent.com/21230295/150801793-719a65f1-f64d-449f-9859-f74664cbcdb4.png)

connects #1378 