### PR TITLE
feat: add a new command to yank joined selections

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -239,6 +239,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `p`     | Paste system clipboard after selections                                 | `paste_clipboard_after`             |
 | `P`     | Paste system clipboard before selections                                | `paste_clipboard_before`            |
 | `y`     | Join and yank selections to clipboard                                   | `yank_joined_to_clipboard`          |
+| `A-y`   | Join and yank selections                                                | `yank_joined`                       |
 | `Y`     | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`  |
 | `R`     | Replace selections by clipboard contents                                | `replace_selections_with_clipboard` |
 | `/`     | Global search in workspace folder                                       | `global_search`                     |

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -674,6 +674,7 @@ impl Default for Keymaps {
                     "C-l" | "l" | "right" => jump_view_right,
                 },
                 "y" => yank_joined_to_clipboard,
+                "A-y" => yank_joined,
                 "Y" => yank_main_selection_to_clipboard,
                 "p" => paste_clipboard_after,
                 "P" => paste_clipboard_before,


### PR DESCRIPTION
Copies the functionality of a similar command for the system clipboard (`yank_joined_to_clipboard`), but using a Helix register instead

Partially covers issue #1591, but doesn't change the default behavior of a regular paste of multiline selection, which would be superior to this as would allow you to not worry about a special command before you decide to paste