### PR TITLE
Add command for picking files from CWD

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -259,6 +259,7 @@ impl MappableCommand {
         append_mode, "Insert after selection (append)",
         command_mode, "Enter command mode",
         file_picker, "Open file picker",
+        file_picker_in_current_directory, "Open file picker at current working directory",
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         symbol_picker, "Open symbol picker",
@@ -2045,6 +2046,12 @@ fn file_picker(cx: &mut Context) {
     let root = find_root(None, &[]).unwrap_or_else(|| PathBuf::from("./"));
     let picker = ui::file_picker(root, &cx.editor.config());
     cx.push_layer(Box::new(overlayed(picker)));
+}
+
+fn file_picker_in_current_directory(cx: &mut Context) {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("./"));
+    let picker = ui::file_picker(cwd, &cx.editor.config());
+    cx.push_layer(Box::new(picker));
 }
 
 fn buffer_picker(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -196,6 +196,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "space" => { "Space"
             "f" => file_picker,
+            "F" => file_picker_in_current_directory,
             "b" => buffer_picker,
             "s" => symbol_picker,
             "S" => workspace_symbol_picker,


### PR DESCRIPTION
The `file_picker_at_cwd` command opens the file picker at the current
working directory (CWD). This can be useful when paired with the
built-in `:cd` command which changes the CWD.