### PR TITLE
Always ignore the .git directory in file picker

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -111,7 +111,11 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
-        .max_depth(config.file_picker.max_depth);
+        .max_depth(config.file_picker.max_depth)
+        // We always want to ignore the .git directory, otherwise if
+        // `ignore` is turned off above, we end up with a lot of noise
+        // in our picker.
+        .filter_entry(|entry| entry.file_name() != ".git");
 
     let walk_builder = match type_builder.add(
         "compressed",


### PR DESCRIPTION
Some users (including myself) want to turn off filtering of files
prefixed with `.`, as they are often useful to edit. For example, `.env`
files, configuration for linters `.eslint.json` and the like.
