### PR TITLE
Add comment textobject for surround selection and navigation

### DIFF
--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -21,6 +21,8 @@ The following [captures][tree-sitter-captures] are recognized:
 | `class.inside`     |
 | `class.around`     |
 | `parameter.inside` |
+| `comment.inside`   |
+| `comment.around`   |
 
 [Example query files][textobject-examples] can be found in the helix GitHub repository.
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -270,6 +270,8 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `[c`     | Go to previous class (**TS**)                | `goto_prev_class`     |
 | `]p`     | Go to next parameter (**TS**)                | `goto_next_parameter` |
 | `[p`     | Go to previous parameter (**TS**)            | `goto_prev_parameter` |
+| `]o`     | Go to next comment (**TS**)                  | `goto_next_comment`   |
+| `[o`     | Go to previous comment (**TS**)              | `goto_prev_comment`   |
 | `[space` | Add newline above                            | `add_newline_above`   |
 | `]space` | Add newline below                            | `add_newline_below`   |
 

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -69,6 +69,7 @@ Currently supported: `word`, `surround`, `function`, `class`, `parameter`.
 | `f`                    | Function                 |
 | `c`                    | Class                    |
 | `p`                    | Parameter                |
+| `o`                    | Comment                  |
 
 > NOTE: `f`, `c`, etc need a tree-sitter grammar active for the current
 document and a special tree-sitter query file to work properly. [Only

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5422,6 +5422,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'c' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'p' => textobject_treesitter("parameter", range),
+                        '/' => textobject_treesitter("comment", range),
                         'm' => {
                             let ch = text.char(range.cursor(text));
                             if !ch.is_ascii_alphanumeric() {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5466,6 +5466,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("c", "Class (tree-sitter)"),
             ("f", "Function (tree-sitter)"),
             ("p", "Parameter (tree-sitter)"),
+            ("o", "Comment (tree-sitter)"),
             ("m", "Matching delimiter under cursor"),
             (" ", "... or any character acting as a pair"),
         ];

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -401,6 +401,8 @@ impl MappableCommand {
         goto_prev_class, "Goto previous class",
         goto_next_parameter, "Goto next parameter",
         goto_prev_parameter, "Goto previous parameter",
+        goto_next_comment, "Goto next comment",
+        goto_prev_comment, "Goto previous comment",
         dap_launch, "Launch debug target",
         dap_toggle_breakpoint, "Toggle breakpoint",
         dap_continue, "Continue program execution",
@@ -5378,6 +5380,14 @@ fn goto_next_parameter(cx: &mut Context) {
 
 fn goto_prev_parameter(cx: &mut Context) {
     goto_ts_object_impl(cx, "parameter", Direction::Backward)
+}
+
+fn goto_next_comment(cx: &mut Context) {
+    goto_ts_object_impl(cx, "comment", Direction::Forward)
+}
+
+fn goto_prev_comment(cx: &mut Context) {
+    goto_ts_object_impl(cx, "comment", Direction::Backward)
 }
 
 fn select_textobject_around(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5422,7 +5422,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'c' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'p' => textobject_treesitter("parameter", range),
-                        '/' => textobject_treesitter("comment", range),
+                        'o' => textobject_treesitter("comment", range),
                         'm' => {
                             let ch = text.char(range.cursor(text));
                             if !ch.is_ascii_alphanumeric() {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -608,6 +608,7 @@ impl Default for Keymaps {
                 "f" => goto_prev_function,
                 "c" => goto_prev_class,
                 "p" => goto_prev_parameter,
+                "o" => goto_prev_comment,
                 "space" => add_newline_above,
             },
             "]" => { "Right bracket"
@@ -616,6 +617,7 @@ impl Default for Keymaps {
                 "f" => goto_next_function,
                 "c" => goto_next_class,
                 "p" => goto_next_parameter,
+                "o" => goto_next_comment,
                 "space" => add_newline_below,
             },
 

--- a/runtime/queries/c/textobjects.scm
+++ b/runtime/queries/c/textobjects.scm
@@ -11,3 +11,5 @@
   body: (_) @class.inside) @class.around
 
 (parameter_declaration) @parameter.inside
+
+(comment) @comment.inside

--- a/runtime/queries/c/textobjects.scm
+++ b/runtime/queries/c/textobjects.scm
@@ -13,3 +13,5 @@
 (parameter_declaration) @parameter.inside
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/cmake/textobjects.scm
+++ b/runtime/queries/cmake/textobjects.scm
@@ -1,3 +1,8 @@
 (macro_def) @function.around
 
 (argument) @parameter.inside
+
+[
+  (bracket_comment)
+  (line_comment)
+] @comment.inside

--- a/runtime/queries/cmake/textobjects.scm
+++ b/runtime/queries/cmake/textobjects.scm
@@ -6,3 +6,7 @@
   (bracket_comment)
   (line_comment)
 ] @comment.inside
+
+(line_comment)+ @comment.around
+
+(bracket_comment) @comment.around

--- a/runtime/queries/fish/textobjects.scm
+++ b/runtime/queries/fish/textobjects.scm
@@ -1,3 +1,5 @@
 (function_definition) @function.around
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/fish/textobjects.scm
+++ b/runtime/queries/fish/textobjects.scm
@@ -1,1 +1,3 @@
 (function_definition) @function.around
+
+(comment) @comment.inside

--- a/runtime/queries/go/textobjects.scm
+++ b/runtime/queries/go/textobjects.scm
@@ -21,3 +21,5 @@
   (_) @parameter.inside)
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/go/textobjects.scm
+++ b/runtime/queries/go/textobjects.scm
@@ -19,3 +19,5 @@
 
 (argument_list
   (_) @parameter.inside)
+
+(comment) @comment.inside

--- a/runtime/queries/llvm-mir/textobjects.scm
+++ b/runtime/queries/llvm-mir/textobjects.scm
@@ -6,3 +6,7 @@
   (comment)
   (multiline_comment)
 ] @comment.inside
+
+(comment)+ @comment.around
+
+(multiline_comment) @comment.around

--- a/runtime/queries/llvm-mir/textobjects.scm
+++ b/runtime/queries/llvm-mir/textobjects.scm
@@ -1,3 +1,8 @@
 (basic_block) @function.around
 
 (argument) @parameter.inside
+
+[
+  (comment)
+  (multiline_comment)
+] @comment.inside

--- a/runtime/queries/llvm/textobjects.scm
+++ b/runtime/queries/llvm/textobjects.scm
@@ -16,3 +16,5 @@
 (argument) @parameter.inside
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/llvm/textobjects.scm
+++ b/runtime/queries/llvm/textobjects.scm
@@ -14,3 +14,5 @@
   (array_vector_body) @class.inside) @class.around
 
 (argument) @parameter.inside
+
+(comment) @comment.inside

--- a/runtime/queries/perl/textobjects.scm
+++ b/runtime/queries/perl/textobjects.scm
@@ -6,3 +6,8 @@
 
 (argument 
   (_) @parameter.inside)
+
+[
+  (comments)
+  (pod_statement)
+] @comment.inside

--- a/runtime/queries/perl/textobjects.scm
+++ b/runtime/queries/perl/textobjects.scm
@@ -11,3 +11,7 @@
   (comments)
   (pod_statement)
 ] @comment.inside
+
+(comments)+ @comment.around
+
+(pod_statement) @comment.around

--- a/runtime/queries/php/textobjects.scm
+++ b/runtime/queries/php/textobjects.scm
@@ -28,3 +28,7 @@
     (variadic_parameter)
     (property_promotion_parameter)
   ] @parameter.inside)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/php/textobjects.scm
+++ b/runtime/queries/php/textobjects.scm
@@ -30,5 +30,3 @@
   ] @parameter.inside)
 
 (comment) @comment.inside
-
-(comment)+ @comment.around

--- a/runtime/queries/php/textobjects.scm
+++ b/runtime/queries/php/textobjects.scm
@@ -30,3 +30,5 @@
   ] @parameter.inside)
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/python/textobjects.scm
+++ b/runtime/queries/python/textobjects.scm
@@ -12,3 +12,5 @@
 
 (argument_list
   (_) @parameter.inside)
+
+(comment) @comment.inside

--- a/runtime/queries/python/textobjects.scm
+++ b/runtime/queries/python/textobjects.scm
@@ -14,3 +14,5 @@
   (_) @parameter.inside)
 
 (comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/rescript/textobjects.scm
+++ b/runtime/queries/rescript/textobjects.scm
@@ -7,3 +7,10 @@
 ;----------
 
 (function body: (_) @function.inside) @function.around
+
+; Comments
+;---------
+
+(comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -24,3 +24,8 @@
 
 (arguments
   (_) @parameter.inside)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inside

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -29,3 +29,7 @@
   (line_comment)
   (block_comment)
 ] @comment.inside
+
+(line_comment)+ @comment.around
+
+(block_comment) @comment.around

--- a/runtime/queries/tablegen/textobjects.scm
+++ b/runtime/queries/tablegen/textobjects.scm
@@ -5,3 +5,8 @@
   body: (_) @class.inside) @class.around
 
 (_ argument: _ @parameter.inside)
+
+[
+  (comment)
+  (multiline_comment)
+] @comment.inside

--- a/runtime/queries/tablegen/textobjects.scm
+++ b/runtime/queries/tablegen/textobjects.scm
@@ -10,3 +10,7 @@
   (comment)
   (multiline_comment)
 ] @comment.inside
+
+(comment)+ @comment.around
+
+(multiline_comment) @comment.around


### PR DESCRIPTION
This attempts to add a comment textobject to the surround matching logic. This seems like it would be an easy add, but I'm having trouble getting it to behave at all in Rust. In PHP @comment.inside works fine, but @comment.around does not.

I'm intending to support both @comment.inside and @comment.around, where the difference is that @comment.around should select adjacent line comments, so line comments like the following will match in total:

```php
// This is some very long description of why some tricky logic works
// the way it does, split across lines rather than using block comments
```

.. whereas the .inside will only select one such line comment. Both methods are intended identical for block comments.

Once we figure this out it should partially address #1505.
