### PR TITLE
chore(theme): fix rose_pine/rose_pine_dawn themes' popup bg color

### DIFF
--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -2,11 +2,9 @@
 # Author: ChrisHa<chunghha@users.noreply.github.com>
 
 "ui.background" = { bg = "base" }
-"ui.menu" = "surface"
+"ui.menu" = { fg = "text", bg = "overlay" }
 "ui.menu.selected" = { fg = "iris", bg = "surface" }
 "ui.linenr" = {fg = "subtle" }
-"ui.popup" = { bg = "overlay" }
-"ui.window" = { bg = "overlay" }
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = "highlight"
 "comment" = "subtle"
@@ -34,7 +32,7 @@
 "keyword" = "pine"
 "label" = "iris"
 "namespace" = "pine"
-"ui.popup" = { bg = "overlay" }
+"ui.popup" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
 "text" = "text"

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -2,11 +2,9 @@
 # Author: ChrisHa<chunghha@users.noreply.github.com>
 
 "ui.background" = { bg = "surface" }
-"ui.menu" = "base"
+"ui.menu" = { fg = "text", bg = "overlay" }
 "ui.menu.selected" = { fg = "iris", bg = "surface" }
 "ui.linenr" = {fg = "subtle" }
-"ui.popup" = { bg = "overlay" }
-"ui.window" = { bg = "overlay" }
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = "highlight"
 "comment" = "subtle"
@@ -34,7 +32,7 @@
 "keyword" = "pine"
 "label" = "iris"
 "namespace" = "pine"
-"ui.popup" = { bg = "overlay" }
+"ui.popup" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
 "text" = "text"


### PR DESCRIPTION
To fix the 2 rose_pine themes' popup bg color as

<img width="868" alt="Screen Shot 2022-01-30 at 8 04 56 PM" src="https://user-images.githubusercontent.com/24458075/151729566-df4570e7-1cbc-4366-ac62-cf5cd7f857d5.png">
