### PR TITLE
Add `PageUp`, `PageDown`, `Ctrl-u`, `Ctrl-d`, `Home`, `End` keyboard shortcuts to file picker

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -304,7 +304,11 @@ Keys to use within picker. Remapping currently not supported.
 | Key                          | Description       |
 | -----                        | -------------     |
 | `Up`, `Ctrl-k`, `Ctrl-p`     | Previous entry    |
+| `PageUp`, `Ctrl-u`           | Page up           |
 | `Down`, `Ctrl-j`, `Ctrl-n`   | Next entry        |
+| `PageDown`, `Ctrl-d`         | Page down         |
+| `Home`                       | Go to first entry |
+| `End`                        | Go to last entry  |
 | `Ctrl-space`                 | Filter options    |
 | `Enter`                      | Open selected     |
 | `Ctrl-s`                     | Open horizontally |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -304,9 +304,9 @@ Keys to use within picker. Remapping currently not supported.
 | Key                          | Description       |
 | -----                        | -------------     |
 | `Up`, `Ctrl-k`, `Ctrl-p`     | Previous entry    |
-| `PageUp`, `Ctrl-u`           | Page up           |
+| `PageUp`, `Ctrl-b`           | Page up           |
 | `Down`, `Ctrl-j`, `Ctrl-n`   | Next entry        |
-| `PageDown`, `Ctrl-d`         | Page down         |
+| `PageDown`, `Ctrl-f`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |
 | `Ctrl-space`                 | Filter options    |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -9,7 +9,7 @@ use crate::{
     compositor::Compositor,
     config::Config,
     job::Jobs,
-    ui,
+    ui::{self, overlay::overlayed},
 };
 
 use log::{error, warn};
@@ -138,7 +138,8 @@ impl Application {
             if first.is_dir() {
                 std::env::set_current_dir(&first)?;
                 editor.new_file(Action::VerticalSplit);
-                compositor.push(Box::new(ui::file_picker(".".into(), &config.editor)));
+                let picker = ui::file_picker(".".into(), &config.editor);
+                compositor.push(Box::new(overlayed(picker)));
             } else {
                 let nr_of_files = args.files.len();
                 editor.open(first.to_path_buf(), Action::VerticalSplit)?;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3396,7 +3396,7 @@ fn symbol_picker(cx: &mut Context) {
                         Some((path, line))
                     },
                 );
-                picker.truncate_start = false;
+                picker.content.truncate_start = false;
                 compositor.push(Box::new(picker))
             }
         },
@@ -3456,7 +3456,7 @@ fn workspace_symbol_picker(cx: &mut Context) {
                         Some((path, line))
                     },
                 );
-                picker.truncate_start = false;
+                picker.content.truncate_start = false;
                 compositor.push(Box::new(picker))
             }
         },

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -39,7 +39,7 @@ use movement::Movement;
 use crate::{
     args,
     compositor::{self, Component, Compositor},
-    ui::{self, FilePicker, Popup, Prompt, PromptEvent},
+    ui::{self, overlay::overlayed, FilePicker, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Job, Jobs};
@@ -1785,7 +1785,7 @@ fn global_search(cx: &mut Context) {
                     },
                     |_editor, (line_num, path)| Some((path.clone(), Some((*line_num, *line_num)))),
                 );
-                compositor.push(Box::new(picker));
+                compositor.push(Box::new(overlayed(picker)));
             });
         Ok(call)
     };
@@ -3251,7 +3251,7 @@ fn file_picker(cx: &mut Context) {
     // We don't specify language markers, root will be the root of the current git repo
     let root = find_root(None, &[]).unwrap_or_else(|| PathBuf::from("./"));
     let picker = ui::file_picker(root, &cx.editor.config);
-    cx.push_layer(Box::new(picker));
+    cx.push_layer(Box::new(overlayed(picker)));
 }
 
 fn buffer_picker(cx: &mut Context) {
@@ -3319,7 +3319,7 @@ fn buffer_picker(cx: &mut Context) {
             Some((meta.path.clone()?, Some((line, line))))
         },
     );
-    cx.push_layer(Box::new(picker));
+    cx.push_layer(Box::new(overlayed(picker)));
 }
 
 fn symbol_picker(cx: &mut Context) {
@@ -3396,8 +3396,8 @@ fn symbol_picker(cx: &mut Context) {
                         Some((path, line))
                     },
                 );
-                picker.content.truncate_start = false;
-                compositor.push(Box::new(picker))
+                picker.truncate_start = false;
+                compositor.push(Box::new(overlayed(picker)))
             }
         },
     )
@@ -3456,8 +3456,8 @@ fn workspace_symbol_picker(cx: &mut Context) {
                         Some((path, line))
                     },
                 );
-                picker.content.truncate_start = false;
-                compositor.push(Box::new(picker))
+                picker.truncate_start = false;
+                compositor.push(Box::new(overlayed(picker)))
             }
         },
     )
@@ -4117,7 +4117,7 @@ fn goto_impl(
                     Some((path, line))
                 },
             );
-            compositor.push(Box::new(picker));
+            compositor.push(Box::new(overlayed(picker)));
         }
     }
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod editor;
 mod info;
 mod markdown;
 pub mod menu;
-mod overlay;
+pub mod overlay;
 mod picker;
 mod popup;
 mod prompt;
@@ -25,8 +25,6 @@ use helix_core::regex::RegexBuilder;
 use helix_view::{Document, Editor, View};
 
 use std::path::PathBuf;
-
-use self::overlay::Overlay;
 
 pub fn regex_prompt(
     cx: &mut crate::commands::Context,
@@ -96,10 +94,7 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(
-    root: PathBuf,
-    config: &helix_view::editor::Config,
-) -> Overlay<FilePicker<PathBuf>> {
+pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePicker<PathBuf> {
     use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time;
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod editor;
 mod info;
 mod markdown;
 pub mod menu;
+mod overlay;
 mod picker;
 mod popup;
 mod prompt;
@@ -24,6 +25,8 @@ use helix_core::regex::RegexBuilder;
 use helix_view::{Document, Editor, View};
 
 use std::path::PathBuf;
+
+use self::overlay::Overlay;
 
 pub fn regex_prompt(
     cx: &mut crate::commands::Context,
@@ -93,7 +96,10 @@ pub fn regex_prompt(
     )
 }
 
-pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePicker<PathBuf> {
+pub fn file_picker(
+    root: PathBuf,
+    config: &helix_view::editor::Config,
+) -> Overlay<FilePicker<PathBuf>> {
     use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time;
 

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -9,65 +9,49 @@ use tui::buffer::Buffer;
 use crate::compositor::{Component, Context, EventResult};
 
 /// Contains a component placed in the center of the parent component
-#[derive(Debug)]
 pub struct Overlay<T> {
     /// Child component
     pub content: T,
-    /// Value between 0 and 100 that indicates how much of the vertical space is used
-    pub vertical_size: u8,
-    /// Value between 0 and 100 that indicates how much of the horizontal space is used
-    pub horizontal_size: u8,
+    /// Function to compute the size and position of the child component
+    pub calc_child_size: Box<dyn Fn(Rect) -> Rect>,
 }
 
-impl<T> Overlay<T> {
-    const MARGIN_BOTTOM: u16 = 2;
-
-    fn get_dimensions(&self, viewport: (u16, u16)) -> Rect {
-        fn mul_and_cast(size: u16, factor: u8) -> u16 {
-            ((size as u32) * (factor as u32) / 100).try_into().unwrap()
-        }
-
-        let (outer_w, outer_h) = viewport;
-        let outer_h = outer_h.saturating_sub(Self::MARGIN_BOTTOM);
-
-        let inner_w = mul_and_cast(outer_w, self.horizontal_size);
-        let inner_h = mul_and_cast(outer_h, self.vertical_size);
-
-        let pos_x = outer_w.saturating_sub(inner_w) / 2;
-        let pos_y = outer_h.saturating_sub(inner_h) / 2;
-
-        Rect {
-            x: pos_x,
-            y: pos_y,
-            width: inner_w,
-            height: inner_h,
-        }
+pub(super) fn clip_rect_relative(rect: Rect, percent_horizontal: u8, percent_vertical: u8) -> Rect {
+    fn mul_and_cast(size: u16, factor: u8) -> u16 {
+        ((size as u32) * (factor as u32) / 100).try_into().unwrap()
     }
 
-    fn get_outer_size_from_inner_size(&self, inner: (u16, u16)) -> (u16, u16) {
-        fn div_and_cast(size: u16, divisor: u8) -> u16 {
-            ((size as u32) * 100 / (divisor as u32)).try_into().unwrap()
-        }
+    let inner_w = mul_and_cast(rect.width, percent_horizontal);
+    let inner_h = mul_and_cast(rect.height, percent_vertical);
 
-        let (inner_w, inner_h) = inner;
-        (
-            div_and_cast(inner_w, self.horizontal_size),
-            div_and_cast(inner_h, self.vertical_size) + Self::MARGIN_BOTTOM,
-        )
+    let offset_x = rect.width.saturating_sub(inner_w) / 2;
+    let offset_y = rect.height.saturating_sub(inner_h) / 2;
+
+    Rect {
+        x: rect.x + offset_x,
+        y: rect.y + offset_y,
+        width: inner_w,
+        height: inner_h,
     }
 }
 
 impl<T: Component + 'static> Component for Overlay<T> {
     fn render(&mut self, area: Rect, frame: &mut Buffer, ctx: &mut Context) {
-        let dimensions = self.get_dimensions((area.width, area.height));
+        let dimensions = (self.calc_child_size)(area);
         self.content.render(dimensions, frame, ctx)
     }
 
-    fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
-        let dimensions = self.get_dimensions(viewport);
+    fn required_size(&mut self, (width, height): (u16, u16)) -> Option<(u16, u16)> {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        };
+        let dimensions = (self.calc_child_size)(area);
         let viewport = (dimensions.width, dimensions.height);
-        let required = self.content.required_size(viewport)?;
-        Some(self.get_outer_size_from_inner_size(required))
+        let _ = self.content.required_size(viewport)?;
+        Some((width, height))
     }
 
     fn handle_event(&mut self, event: Event, ctx: &mut Context) -> EventResult {
@@ -75,7 +59,7 @@ impl<T: Component + 'static> Component for Overlay<T> {
     }
 
     fn cursor(&self, area: Rect, ctx: &Editor) -> (Option<Position>, CursorKind) {
-        let dimensions = self.get_dimensions((area.width, area.height));
+        let dimensions = (self.calc_child_size)(area);
         self.content.cursor(dimensions, ctx)
     }
 }

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -16,7 +16,15 @@ pub struct Overlay<T> {
     pub calc_child_size: Box<dyn Fn(Rect) -> Rect>,
 }
 
-pub(super) fn clip_rect_relative(rect: Rect, percent_horizontal: u8, percent_vertical: u8) -> Rect {
+/// Surrounds the component with a margin of 5% on each side, and an additional 2 rows at the bottom
+pub fn overlayed<T>(content: T) -> Overlay<T> {
+    Overlay {
+        content,
+        calc_child_size: Box::new(|rect: Rect| clip_rect_relative(rect.clip_bottom(2), 90, 90)),
+    }
+}
+
+fn clip_rect_relative(rect: Rect, percent_horizontal: u8, percent_vertical: u8) -> Rect {
     fn mul_and_cast(size: u16, factor: u8) -> u16 {
         ((size as u32) * (factor as u32) / 100).try_into().unwrap()
     }

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -1,0 +1,81 @@
+use crossterm::event::Event;
+use helix_core::Position;
+use helix_view::{
+    graphics::{CursorKind, Rect},
+    Editor,
+};
+use tui::buffer::Buffer;
+
+use crate::compositor::{Component, Context, EventResult};
+
+/// Contains a component placed in the center of the parent component
+#[derive(Debug)]
+pub struct Overlay<T> {
+    /// Child component
+    pub content: T,
+    /// Value between 0 and 100 that indicates how much of the vertical space is used
+    pub vertical_size: u8,
+    /// Value between 0 and 100 that indicates how much of the horizontal space is used
+    pub horizontal_size: u8,
+}
+
+impl<T> Overlay<T> {
+    const MARGIN_BOTTOM: u16 = 2;
+
+    fn get_dimensions(&self, viewport: (u16, u16)) -> Rect {
+        fn mul_and_cast(size: u16, factor: u8) -> u16 {
+            ((size as u32) * (factor as u32) / 100).try_into().unwrap()
+        }
+
+        let (outer_w, outer_h) = viewport;
+        let outer_h = outer_h.saturating_sub(Self::MARGIN_BOTTOM);
+
+        let inner_w = mul_and_cast(outer_w, self.horizontal_size);
+        let inner_h = mul_and_cast(outer_h, self.vertical_size);
+
+        let pos_x = outer_w.saturating_sub(inner_w) / 2;
+        let pos_y = outer_h.saturating_sub(inner_h) / 2;
+
+        Rect {
+            x: pos_x,
+            y: pos_y,
+            width: inner_w,
+            height: inner_h,
+        }
+    }
+
+    fn get_outer_size_from_inner_size(&self, inner: (u16, u16)) -> (u16, u16) {
+        fn div_and_cast(size: u16, divisor: u8) -> u16 {
+            ((size as u32) * 100 / (divisor as u32)).try_into().unwrap()
+        }
+
+        let (inner_w, inner_h) = inner;
+        (
+            div_and_cast(inner_w, self.horizontal_size),
+            div_and_cast(inner_h, self.vertical_size) + Self::MARGIN_BOTTOM,
+        )
+    }
+}
+
+impl<T: Component + 'static> Component for Overlay<T> {
+    fn render(&mut self, area: Rect, frame: &mut Buffer, ctx: &mut Context) {
+        let dimensions = self.get_dimensions((area.width, area.height));
+        self.content.render(dimensions, frame, ctx)
+    }
+
+    fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
+        let dimensions = self.get_dimensions(viewport);
+        let viewport = (dimensions.width, dimensions.height);
+        let required = self.content.required_size(viewport)?;
+        Some(self.get_outer_size_from_inner_size(required))
+    }
+
+    fn handle_event(&mut self, event: Event, ctx: &mut Context) -> EventResult {
+        self.content.handle_event(event, ctx)
+    }
+
+    fn cursor(&self, area: Rect, ctx: &Editor) -> (Option<Position>, CursorKind) {
+        let dimensions = self.get_dimensions((area.width, area.height));
+        self.content.cursor(dimensions, ctx)
+    }
+}

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -28,8 +28,6 @@ use helix_view::{
     Document, Editor,
 };
 
-use super::overlay::{clip_rect_relative, Overlay};
-
 pub const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
 /// Biggest file size to preview in bytes
 pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
@@ -90,16 +88,13 @@ impl<T> FilePicker<T> {
         format_fn: impl Fn(&T) -> Cow<str> + 'static,
         callback_fn: impl Fn(&mut Editor, &T, Action) + 'static,
         preview_fn: impl Fn(&Editor, &T) -> Option<FileLocation> + 'static,
-    ) -> Overlay<Self> {
-        Overlay {
-            content: Self {
-                picker: Picker::new(options, format_fn, callback_fn),
-                truncate_start: true,
-                preview_cache: HashMap::new(),
-                read_buffer: Vec::with_capacity(1024),
-                file_fn: Box::new(preview_fn),
-            },
-            calc_child_size: Box::new(|rect: Rect| clip_rect_relative(rect.clip_bottom(2), 90, 90)),
+    ) -> Self {
+        Self {
+            picker: Picker::new(options, format_fn, callback_fn),
+            truncate_start: true,
+            preview_cache: HashMap::new(),
+            read_buffer: Vec::with_capacity(1024),
+            file_fn: Box::new(preview_fn),
         }
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -460,10 +460,10 @@ impl<T: 'static> Component for Picker<T> {
             key!(Tab) | key!(Down) | ctrl!('n') | ctrl!('j') => {
                 self.move_by(1);
             }
-            key!(PageDown) | ctrl!('d') => {
+            key!(PageDown) | ctrl!('f') => {
                 self.page_down();
             }
-            key!(PageUp) | ctrl!('u') => {
+            key!(PageUp) | ctrl!('b') => {
                 self.page_up();
             }
             key!(Home) => {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -28,7 +28,7 @@ use helix_view::{
     Document, Editor,
 };
 
-use super::overlay::Overlay;
+use super::overlay::{clip_rect_relative, Overlay};
 
 pub const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
 /// Biggest file size to preview in bytes
@@ -99,8 +99,7 @@ impl<T> FilePicker<T> {
                 read_buffer: Vec::with_capacity(1024),
                 file_fn: Box::new(preview_fn),
             },
-            vertical_size: 90,   // percent
-            horizontal_size: 90, // percent
+            calc_child_size: Box::new(|rect: Rect| clip_rect_relative(rect.clip_bottom(2), 90, 90)),
         }
     }
 


### PR DESCRIPTION
Fixes #1467.