### PR TITLE
Allow separate styles for markup headings

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -166,6 +166,8 @@ We use a similar set of scopes as
 
 - `markup`
   - `heading`
+    - `marker`
+    - `1`, `2`, `3`, `4`, `5`, `6` - heading text for h1 through h6
   - `list`
     - `unnumbered`
     - `numbered`

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -632,8 +632,7 @@ pub fn hover(cx: &mut Context) {
 
                 // skip if contents empty
 
-                let contents =
-                    ui::Markdown::new(contents, editor.syn_loader.clone()).style_group("hover");
+                let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                 let popup = Popup::new("hover", contents);
                 compositor.replace_or_push("hover", Box::new(popup));
             }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -305,8 +305,6 @@ impl Component for Completion {
             let coords = helix_core::visual_coords_at_pos(text, cursor_pos, doc.tab_width());
             let cursor_pos = (coords.row - view.offset.row) as u16;
 
-            let markdown_ui =
-                |content, syn_loader| Markdown::new(content, syn_loader).style_group("completion");
             let mut markdown_doc = match &option.documentation {
                 Some(lsp::Documentation::String(contents))
                 | Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
@@ -314,7 +312,7 @@ impl Component for Completion {
                     value: contents,
                 })) => {
                     // TODO: convert to wrapped text
-                    markdown_ui(
+                    Markdown::new(
                         format!(
                             "```{}\n{}\n```\n{}",
                             language,
@@ -329,7 +327,7 @@ impl Component for Completion {
                     value: contents,
                 })) => {
                     // TODO: set language based on doc scope
-                    markdown_ui(
+                    Markdown::new(
                         format!(
                             "```{}\n{}\n```\n{}",
                             language,
@@ -343,7 +341,7 @@ impl Component for Completion {
                     // TODO: copied from above
 
                     // TODO: set language based on doc scope
-                    markdown_ui(
+                    Markdown::new(
                         format!(
                             "```{}\n{}\n```",
                             language,

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -1,7 +1,12 @@
-[
-  (atx_heading)
-  (setext_heading)
-] @markup.heading
+(setext_heading (heading_content) @markup.heading.1 (setext_h1_underline) @markup.heading.marker)
+(setext_heading (heading_content) @markup.heading.2 (setext_h2_underline) @markup.heading.marker)
+
+(atx_heading (atx_h1_marker) @markup.heading.marker (heading_content) @markup.heading.1)
+(atx_heading (atx_h2_marker) @markup.heading.marker (heading_content) @markup.heading.2)
+(atx_heading (atx_h3_marker) @markup.heading.marker (heading_content) @markup.heading.3)
+(atx_heading (atx_h4_marker) @markup.heading.marker (heading_content) @markup.heading.4)
+(atx_heading (atx_h5_marker) @markup.heading.marker (heading_content) @markup.heading.5)
+(atx_heading (atx_h6_marker) @markup.heading.marker (heading_content) @markup.heading.6)
 
 (code_fence_content) @none
 


### PR DESCRIPTION
This makes it possible to use separate styles for each markup heading level:

![image](https://user-images.githubusercontent.com/3957610/152316891-008d401c-a608-4590-a3e8-8c2bf2e4bc61.png)

I've never worked with tree sitter before, so someone might want to confirm that `highlights.scm` is okay.

adresses #1597