### PR TITLE
Add tree-sitter based function, class navigation

### DIFF
--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -24,7 +24,22 @@ The following [captures][tree-sitter-captures] are recognized:
 
 [Example query files][textobject-examples] can be found in the helix GitHub repository.
 
+## Queries for Textobject Based Navigation
+
+[Tree-sitter based navigation][textobjects-nav] is done using captures in the
+following order:
+
+- `object.movement`
+- `object.around`
+- `object.inside`
+
+For example if a `function.around` capture has been already defined for a language
+in it's `textobjects.scm` file, function navigation should also work automatically.
+`function.movement` should be defined only if the node captured by `function.around`
+doesn't make sense in a navigation context.
+
 [textobjects]: ../usage.md#textobjects
+[textobjects-nav]: ../usage.md#tree-sitter-textobject-based-navigation
 [tree-sitter-queries]: https://tree-sitter.github.io/tree-sitter/using-parsers#query-syntax
 [tree-sitter-captures]: https://tree-sitter.github.io/tree-sitter/using-parsers#capturing-nodes
 [textobject-examples]: https://github.com/search?q=repo%3Ahelix-editor%2Fhelix+filename%3Atextobjects.scm&type=Code&ref=advsearch&l=&l=

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -258,14 +258,20 @@ Displays documentation for item under cursor.
 
 Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaired).
 
-| Key      | Description                                  | Command             |
-| -----    | -----------                                  | -------             |
-| `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`    |
-| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`    |
-| `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`   |
-| `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`    |
-| `[space` | Add newline above                            | `add_newline_above` |
-| `]space` | Add newline below                            | `add_newline_below` |
+| Key      | Description                                  | Command               |
+| -----    | -----------                                  | -------               |
+| `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`      |
+| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`      |
+| `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`     |
+| `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`      |
+| `]f`     | Go to next function (**TS**)                 | `goto_next_function`  |
+| `[f`     | Go to previous function (**TS**)             | `goto_prev_function`  |
+| `]c`     | Go to next class (**TS**)                    | `goto_next_class`     |
+| `[c`     | Go to previous class (**TS**)                | `goto_prev_class`     |
+| `]p`     | Go to next parameter (**TS**)                | `goto_next_parameter` |
+| `[p`     | Go to previous parameter (**TS**)            | `goto_prev_parameter` |
+| `[space` | Add newline above                            | `add_newline_above`   |
+| `]space` | Add newline below                            | `add_newline_below`   |
 
 ## Insert Mode
 

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -75,7 +75,7 @@ document and a special tree-sitter query file to work properly. [Only
 some grammars][lang-support] currently have the query file implemented.
 Contributions are welcome!
 
-## Tree-sitter Based Navigation
+## Tree-sitter Textobject Based Navigation
 
 Navigating between functions, classes, parameters, etc is made
 possible by leveraging tree-sitter and textobjects queries. For

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -70,7 +70,26 @@ Currently supported: `word`, `surround`, `function`, `class`, `parameter`.
 | `c`                    | Class                    |
 | `p`                    | Parameter                |
 
-Note: `f`, `c`, etc need a tree-sitter grammar active for the current
+> NOTE: `f`, `c`, etc need a tree-sitter grammar active for the current
 document and a special tree-sitter query file to work properly. [Only
-some grammars](https://github.com/search?q=repo%3Ahelix-editor%2Fhelix+filename%3Atextobjects.scm&type=Code&ref=advsearch&l=&l=)
-currently have the query file implemented. Contributions are welcome !
+some grammars][lang-support] currently have the query file implemented.
+Contributions are welcome!
+
+## Tree-sitter Based Navigation
+
+Navigating between functions, classes, parameters, etc is made
+possible by leveraging tree-sitter and textobjects queries. For
+example to move to the next function use `]f`, to move to previous
+class use `[c`, and so on.
+
+![tree-sitter-nav-demo][tree-sitter-nav-demo]
+
+See the [unimpaired][unimpaired-keybinds] section of the keybind
+documentation for the full reference.
+
+> NOTE: This feature is dependent on tree-sitter based textobjects
+and therefore requires the corresponding query file to work properly.
+
+[lang-support]: ./lang-support.md
+[unimpaired-keybinds]: ./keymap.md#unimpaired
+[tree-sitter-nav-demo]: https://user-images.githubusercontent.com/23398472/152332550-7dfff043-36a2-4aec-b8f2-77c13eb56d6f.gif

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -321,10 +321,14 @@ pub fn goto_treesitter_object(
     let get_range = move || -> Option<Range> {
         let byte_pos = slice.char_to_byte(range.cursor(slice));
 
-        let capture_name = format!("{}.{}", object_name, TextObject::Around);
+        let cap_name = |t: TextObject| format!("{}.{}", object_name, t);
         let mut cursor = QueryCursor::new();
-        let nodes = lang_config.textobject_query()?.capture_nodes(
-            &capture_name,
+        let nodes = lang_config.textobject_query()?.capture_nodes_any(
+            &[
+                &cap_name(TextObject::Movement),
+                &cap_name(TextObject::Around),
+                &cap_name(TextObject::Inside),
+            ],
             slice_tree,
             slice,
             &mut cursor,

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1,6 +1,7 @@
 use std::iter;
 
 use ropey::iter::Chars;
+use tree_sitter::{Node, QueryCursor};
 
 use crate::{
     chars::{categorize_char, char_is_line_ending, CharCategory},
@@ -9,7 +10,10 @@ use crate::{
         next_grapheme_boundary, nth_next_grapheme_boundary, nth_prev_grapheme_boundary,
         prev_grapheme_boundary,
     },
-    pos_at_coords, Position, Range, RopeSlice,
+    pos_at_coords,
+    syntax::LanguageConfiguration,
+    textobject::TextObject,
+    Position, Range, RopeSlice,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -303,6 +307,52 @@ fn reached_target(target: WordMotionTarget, prev_ch: char, next_ch: char) -> boo
                 && (!prev_ch.is_whitespace() || char_is_line_ending(next_ch))
         }
     }
+}
+
+pub fn goto_treesitter_object(
+    slice: RopeSlice,
+    range: Range,
+    object_name: &str,
+    dir: Direction,
+    slice_tree: Node,
+    lang_config: &LanguageConfiguration,
+    _count: usize,
+) -> Range {
+    let get_range = move || -> Option<Range> {
+        let byte_pos = slice.char_to_byte(range.cursor(slice));
+
+        let capture_name = format!("{}.{}", object_name, TextObject::Around);
+        let mut cursor = QueryCursor::new();
+        let nodes = lang_config.textobject_query()?.capture_nodes(
+            &capture_name,
+            slice_tree,
+            slice,
+            &mut cursor,
+        )?;
+
+        let node = match dir {
+            Direction::Forward => nodes
+                .filter(|n| n.start_byte() > byte_pos)
+                .min_by_key(|n| n.start_byte())?,
+            Direction::Backward => nodes
+                .filter(|n| n.start_byte() < byte_pos)
+                .max_by_key(|n| n.start_byte())?,
+        };
+
+        let len = slice.len_bytes();
+        let start_byte = node.start_byte();
+        let end_byte = node.end_byte();
+        if start_byte >= len || end_byte >= len {
+            return None;
+        }
+
+        let start_char = slice.byte_to_char(start_byte);
+        let end_char = slice.byte_to_char(end_byte);
+
+        // head of range should be at beginning
+        Some(Range::new(end_char, start_char))
+    };
+    get_range().unwrap_or(range)
 }
 
 #[cfg(test)]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -188,7 +188,21 @@ impl TextObjectQuery {
         slice: RopeSlice<'a>,
         cursor: &'a mut QueryCursor,
     ) -> Option<impl Iterator<Item = Node<'a>>> {
-        let capture_idx = self.query.capture_index_for_name(capture_name)?;
+        self.capture_nodes_any(&[capture_name], node, slice, cursor)
+    }
+
+    /// Find the first capture that exists out of all given `capture_names`
+    /// and return sub nodes that match this capture.
+    pub fn capture_nodes_any<'a>(
+        &'a self,
+        capture_names: &[&str],
+        node: Node<'a>,
+        slice: RopeSlice<'a>,
+        cursor: &'a mut QueryCursor,
+    ) -> Option<impl Iterator<Item = Node<'a>>> {
+        let capture_idx = capture_names
+            .iter()
+            .find_map(|cap| self.query.capture_index_for_name(cap))?;
         let captures = cursor.captures(&self.query, node, RopeProvider(slice));
 
         captures

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -53,6 +53,8 @@ fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, lo
 pub enum TextObject {
     Around,
     Inside,
+    /// Used for moving between objects.
+    Movement,
 }
 
 impl Display for TextObject {
@@ -60,6 +62,7 @@ impl Display for TextObject {
         f.write_str(match self {
             Self::Around => "around",
             Self::Inside => "inside",
+            Self::Movement => "movement",
         })
     }
 }
@@ -104,6 +107,7 @@ pub fn textobject_word(
                 Range::new(word_start - whitespace_count_left, word_end)
             }
         }
+        TextObject::Movement => unreachable!(),
     }
 }
 
@@ -118,6 +122,7 @@ pub fn textobject_surround(
         .map(|(anchor, head)| match textobject {
             TextObject::Inside => Range::new(next_grapheme_boundary(slice, anchor), head),
             TextObject::Around => Range::new(anchor, next_grapheme_boundary(slice, head)),
+            TextObject::Movement => unreachable!(),
         })
         .unwrap_or(range)
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -398,6 +398,12 @@ impl MappableCommand {
         surround_delete, "Surround delete",
         select_textobject_around, "Select around object",
         select_textobject_inner, "Select inside object",
+        goto_next_function, "Goto next function",
+        goto_prev_function, "Goto previous function",
+        goto_next_class, "Goto next class",
+        goto_prev_class, "Goto previous class",
+        goto_next_parameter, "Goto next parameter",
+        goto_prev_parameter, "Goto previous parameter",
         dap_launch, "Launch debug target",
         dap_toggle_breakpoint, "Toggle breakpoint",
         dap_continue, "Continue program execution",
@@ -5907,6 +5913,52 @@ fn scroll_up(cx: &mut Context) {
 
 fn scroll_down(cx: &mut Context) {
     scroll(cx, cx.count(), Direction::Forward);
+}
+
+fn goto_ts_object_impl(cx: &mut Context, object: &str, direction: Direction) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let range = doc.selection(view.id).primary();
+
+    let new_range = match doc.language_config().zip(doc.syntax()) {
+        Some((lang_config, syntax)) => movement::goto_treesitter_object(
+            text,
+            range,
+            object,
+            direction,
+            syntax.tree().root_node(),
+            lang_config,
+            count,
+        ),
+        None => range,
+    };
+
+    doc.set_selection(view.id, Selection::single(new_range.anchor, new_range.head));
+}
+
+fn goto_next_function(cx: &mut Context) {
+    goto_ts_object_impl(cx, "function", Direction::Forward)
+}
+
+fn goto_prev_function(cx: &mut Context) {
+    goto_ts_object_impl(cx, "function", Direction::Backward)
+}
+
+fn goto_next_class(cx: &mut Context) {
+    goto_ts_object_impl(cx, "class", Direction::Forward)
+}
+
+fn goto_prev_class(cx: &mut Context) {
+    goto_ts_object_impl(cx, "class", Direction::Backward)
+}
+
+fn goto_next_parameter(cx: &mut Context) {
+    goto_ts_object_impl(cx, "parameter", Direction::Forward)
+}
+
+fn goto_prev_parameter(cx: &mut Context) {
+    goto_ts_object_impl(cx, "parameter", Direction::Backward)
 }
 
 fn select_textobject_around(cx: &mut Context) {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -572,11 +572,17 @@ impl Default for Keymaps {
             "[" => { "Left bracket"
                 "d" => goto_prev_diag,
                 "D" => goto_first_diag,
+                "f" => goto_prev_function,
+                "c" => goto_prev_class,
+                "p" => goto_prev_parameter,
                 "space" => add_newline_above,
             },
             "]" => { "Right bracket"
                 "d" => goto_next_diag,
                 "D" => goto_last_diag,
+                "f" => goto_next_function,
+                "c" => goto_next_class,
+                "p" => goto_next_parameter,
                 "space" => add_newline_below,
             },
 


### PR DESCRIPTION
Adds support for navigating between functions, classes, etc, using tree-sitter and textobjects. Requires that a `*.around` capture is defined for a filetype in it's correspoding `textobjects.scm` file. So for goto next function to work in Rust, `function.around` textobject has to be defined in Rust's `textobjects.scm`.


![helix-tree-sitter-navigation](https://user-images.githubusercontent.com/23398472/152332550-7dfff043-36a2-4aec-b8f2-77c13eb56d6f.gif)

<details>
<summary>Added keybinds (click to expand)</summary>

| Keybind | Description|
| ---| --- |
| `]f`     | Go to next function |
| `[f`     | Go to previous function |
| `]c`     | Go to next class |
| `[c`     | Go to previous class |
| `]p`     | Go to next parameter |
| `[p`     | Go to previous parameter |

</details>

#### Open questions

- Should we fall back to using the inside textobject if around is not defined ? Currently `parameter.around` is not defined in any query file, so `]p` is not very useful.
