### PR TITLE
Fix incorrect last modified behavior

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -442,7 +442,7 @@ impl Editor {
                         view.last_accessed_doc = Some(view.doc);
                         // Set last modified doc if modified and last modified doc is different
                         if std::mem::take(&mut doc.modified_since_accessed)
-                            && view.last_modified_docs[0] != Some(id)
+                            && view.last_modified_docs[0] != Some(view.doc)
                         {
                             view.last_modified_docs = [Some(view.doc), view.last_modified_docs[0]];
                         }


### PR DESCRIPTION
Looks like it checked the wrong doc id when setting last modified doc.