### PR TITLE
remove Enter keybinding from menu picker

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -228,12 +228,6 @@ impl<T: Item + 'static> Component for Menu<T> {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(Enter) => {
-                if let Some(selection) = self.selection() {
-                    (self.callback_fn)(cx.editor, Some(selection), MenuEvent::Validate);
-                }
-                return close_fn;
-            }
             // KeyEvent {
             //     code: KeyCode::Char(c),
             //     modifiers: KeyModifiers::NONE,


### PR DESCRIPTION
I've been running with this commit in my build for a bit, it fixes a wonky scenario where I want Enter to create a newline but instead it only closes the completion menu. It happens very often in Elixir because of `do/end` blocks:

```elixir
defmodule MyModule do
  def do_foo(x) do
    x
  end
  def other_function(y) do|
end
```

(Where I'm in insert mode after typing that 'do' next to the cursor '|'). The LSP will bring up the menu to suggest `do_foo/1`, so when I hit Enter to start a new line, the completion menu is closed but the newline isn't inserted.

I think this change also makes sense because

- Ctrl+n/p/j/k change the current token to the suggestion, so there's never a need to "confirm" a suggestion
- Ctrl+c or Esc currently have the same behavior as Enter (although this might be a bug, I suspect Ctrl+c and Esc are supposed to restore the text to what it was before any Ctrl+n/p/j/k changes?)