### PR TITLE
impl auto pairs config

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -36,7 +36,6 @@ hidden = false
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
-| `auto-pairs` | Enable automatic insertion of pairs to parenthese, brackets, etc. | `true` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
@@ -75,6 +74,48 @@ available, which is not defined by default.
 |`git-global` | Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option. | true
 |`git-exclude` | Enables reading `.git/info/exclude` files. | true
 |`max-depth` | Set with an integer value for maximum depth to recurse. | Defaults to `None`.
+
+### `[editor.auto-pairs]` Section
+
+Enable automatic insertion of pairs to parentheses, brackets, etc. Can be
+a simple boolean value, or a specific mapping of pairs of single characters.
+
+| Key | Description |
+| --- | ----------- |
+| `false` | Completely disable auto pairing
+| `true` | Use the default pairs: <code>(){}[]''""``</code>
+| Mapping of pairs | e.g. `{ "(" =  ")", "{" = "}", ... }`
+
+Example
+
+```toml
+[editor.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'`' = '`'
+'<' = '>'
+```
+
+Additionally, this setting can be used in a language config. This will
+override the editor config in documents with this language.
+
+Example `languages.toml` that adds <> and removes ''
+
+```toml
+[[language]]
+name = "rust"
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'`' = '`'
+'<' = '>'
+```
+
 
 ## LSP
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -82,7 +82,7 @@ a simple boolean value, or a specific mapping of pairs of single characters.
 
 | Key | Description |
 | --- | ----------- |
-| `false` | Completely disable auto pairing
+| `false` | Completely disable auto pairing, regardless of language-specific settings
 | `true` | Use the default pairs: <code>(){}[]''""``</code>
 | Mapping of pairs | e.g. `{ "(" =  ")", "{" = "}", ... }`
 
@@ -98,8 +98,9 @@ Example
 '<' = '>'
 ```
 
-Additionally, this setting can be used in a language config. This will
-override the editor config in documents with this language.
+Additionally, this setting can be used in a language config. Unless
+the editor setting is `false`, this will override the editor config in
+documents with this language.
 
 Example `languages.toml` that adds <> and removes ''
 

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -415,7 +415,7 @@ mod test {
         expected_sel: &Selection,
     ) {
         let pairs = AutoPairs::new(pairs.iter());
-        let trans = hook(&in_doc, &in_sel, ch, &pairs).unwrap();
+        let trans = hook(in_doc, in_sel, ch, &pairs).unwrap();
         let mut actual_doc = in_doc.clone();
         assert!(trans.apply(&mut actual_doc));
         assert_eq!(expected_doc, &actual_doc);

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -4,7 +4,7 @@
 use crate::{
     graphemes, movement::Direction, Range, Rope, RopeGraphemes, Selection, Tendril, Transaction,
 };
-use std::{collections::HashMap, rc::Rc};
+use std::collections::HashMap;
 
 use log::debug;
 use smallvec::SmallVec;
@@ -23,10 +23,10 @@ pub const DEFAULT_PAIRS: &[(char, char)] = &[
 /// The type that represents the collection of auto pairs,
 /// keyed by the opener.
 #[derive(Debug, Clone)]
-pub struct AutoPairs(HashMap<char, Rc<Pair>>);
+pub struct AutoPairs(HashMap<char, Pair>);
 
 /// Represents the config for a particular pairing.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pair {
     pub open: char,
     pub close: char,
@@ -90,7 +90,7 @@ impl AutoPairs {
         let mut auto_pairs = HashMap::new();
 
         for pair in pairs.into_iter() {
-            let auto_pair = Rc::new(pair.into());
+            let auto_pair = pair.into();
 
             auto_pairs.insert(auto_pair.open, auto_pair.clone());
 
@@ -103,7 +103,7 @@ impl AutoPairs {
     }
 
     pub fn get(&self, ch: char) -> Option<&Pair> {
-        self.0.get(&ch).map(Rc::as_ref)
+        self.0.get(&ch)
     }
 }
 

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -4,12 +4,14 @@
 use crate::{
     graphemes, movement::Direction, Range, Rope, RopeGraphemes, Selection, Tendril, Transaction,
 };
+use std::{collections::HashMap, rc::Rc};
+
 use log::debug;
 use smallvec::SmallVec;
 
 // Heavily based on https://github.com/codemirror/closebrackets/
 
-pub const PAIRS: &[(char, char)] = &[
+pub const DEFAULT_PAIRS: &[(char, char)] = &[
     ('(', ')'),
     ('{', '}'),
     ('[', ']'),
@@ -18,9 +20,98 @@ pub const PAIRS: &[(char, char)] = &[
     ('`', '`'),
 ];
 
-// [TODO] build this dynamically in language config. see #992
-const OPEN_BEFORE: &str = "([{'\":;,> \n\r\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}";
-const CLOSE_BEFORE: &str = ")]}'\":;,> \n\r\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}"; // includes space and newlines
+/// The type that represents the collection of auto pairs,
+/// keyed by the opener.
+#[derive(Debug, Clone)]
+pub struct AutoPairs(HashMap<char, Rc<AutoPair>>);
+
+/// Represents the config for a particular pairing.
+#[derive(Debug)]
+pub struct AutoPair {
+    pub open: char,
+    pub close: char,
+}
+
+impl AutoPair {
+    /// true if open == close
+    pub fn same(&self) -> bool {
+        self.open == self.close
+    }
+
+    /// true if all of the pair's conditions hold for the given document and range
+    pub fn should_close(&self, doc: &Rope, range: &Range) -> bool {
+        let mut should_close = Self::next_is_not_alpha(doc, range);
+
+        if self.same() {
+            should_close &= Self::prev_is_not_alpha(doc, range);
+        }
+
+        should_close
+    }
+
+    pub fn next_is_not_alpha(doc: &Rope, range: &Range) -> bool {
+        let cursor = range.cursor(doc.slice(..));
+        let next_char = doc.get_char(cursor);
+        next_char.map(|c| !c.is_alphanumeric()).unwrap_or(true)
+    }
+
+    pub fn prev_is_not_alpha(doc: &Rope, range: &Range) -> bool {
+        let cursor = range.cursor(doc.slice(..));
+        let prev_char = prev_char(doc, cursor);
+        prev_char.map(|c| !c.is_alphanumeric()).unwrap_or(true)
+    }
+}
+
+impl From<(char, char)> for AutoPair {
+    fn from(pair: (char, char)) -> Self {
+        Self {
+            open: pair.0,
+            close: pair.1,
+        }
+    }
+}
+
+impl From<(&char, &char)> for AutoPair {
+    fn from(pair: (&char, &char)) -> Self {
+        Self {
+            open: *pair.0,
+            close: *pair.1,
+        }
+    }
+}
+
+impl AutoPairs {
+    /// Make a new AutoPairs set with the given pairs and default conditions.
+    pub fn new<'a, V: 'a, A>(pairs: V) -> Self
+    where
+        V: IntoIterator<Item = A>,
+        A: Into<AutoPair>,
+    {
+        let mut auto_pairs = HashMap::new();
+
+        for pair in pairs.into_iter() {
+            let auto_pair = Rc::new(pair.into());
+
+            auto_pairs.insert(auto_pair.open, auto_pair.clone());
+
+            if auto_pair.open != auto_pair.close {
+                auto_pairs.insert(auto_pair.close, auto_pair);
+            }
+        }
+
+        Self(auto_pairs)
+    }
+
+    pub fn get(&self, ch: char) -> Option<&AutoPair> {
+        self.0.get(&ch).map(Rc::as_ref)
+    }
+}
+
+impl Default for AutoPairs {
+    fn default() -> Self {
+        AutoPairs::new(DEFAULT_PAIRS.iter().cloned())
+    }
+}
 
 // insert hook:
 // Fn(doc, selection, char) => Option<Transaction>
@@ -36,21 +127,17 @@ const CLOSE_BEFORE: &str = ")]}'\":;,> \n\r\u{000B}\u{000C}\u{0085}\u{2028}\u{20
 //   middle of triple quotes, and more exotic pairs like Jinja's {% %}
 
 #[must_use]
-pub fn hook(doc: &Rope, selection: &Selection, ch: char) -> Option<Transaction> {
+pub fn hook(doc: &Rope, selection: &Selection, ch: char, pairs: &AutoPairs) -> Option<Transaction> {
     debug!("autopairs hook selection: {:#?}", selection);
 
-    for &(open, close) in PAIRS {
-        if open == ch {
-            if open == close {
-                return Some(handle_same(doc, selection, open, CLOSE_BEFORE, OPEN_BEFORE));
-            } else {
-                return Some(handle_open(doc, selection, open, close, CLOSE_BEFORE));
-            }
-        }
-
-        if close == ch {
+    if let Some(pair) = pairs.get(ch) {
+        if pair.same() {
+            return Some(handle_same(doc, selection, pair));
+        } else if pair.open == ch {
+            return Some(handle_open(doc, selection, pair));
+        } else if pair.close == ch {
             // && char_at pos == close
-            return Some(handle_close(doc, selection, open, close));
+            return Some(handle_close(doc, selection, pair));
         }
     }
 
@@ -196,13 +283,7 @@ fn get_next_range(
     Range::new(end_anchor, end_head)
 }
 
-fn handle_open(
-    doc: &Rope,
-    selection: &Selection,
-    open: char,
-    close: char,
-    close_before: &str,
-) -> Transaction {
+fn handle_open(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
     let mut offs = 0;
 
@@ -212,22 +293,21 @@ fn handle_open(
         let len_inserted;
 
         let change = match next_char {
-            Some(ch) if !close_before.contains(ch) => {
-                len_inserted = open.len_utf8();
+            Some(_) if !pair.should_close(doc, start_range) => {
+                len_inserted = pair.open.len_utf8();
                 let mut tendril = Tendril::new();
-                tendril.push(open);
+                tendril.push(pair.open);
                 (cursor, cursor, Some(tendril))
             }
-            // None | Some(ch) if close_before.contains(ch) => {}
             _ => {
                 // insert open & close
-                let pair = Tendril::from_iter([open, close]);
-                len_inserted = open.len_utf8() + close.len_utf8();
-                (cursor, cursor, Some(pair))
+                let pair_str = Tendril::from_iter([pair.open, pair.close]);
+                len_inserted = pair.open.len_utf8() + pair.close.len_utf8();
+                (cursor, cursor, Some(pair_str))
             }
         };
 
-        let next_range = get_next_range(doc, start_range, offs, open, len_inserted);
+        let next_range = get_next_range(doc, start_range, offs, pair.open, len_inserted);
         end_ranges.push(next_range);
         offs += len_inserted;
 
@@ -239,7 +319,7 @@ fn handle_open(
     t
 }
 
-fn handle_close(doc: &Rope, selection: &Selection, _open: char, close: char) -> Transaction {
+fn handle_close(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
 
     let mut offs = 0;
@@ -249,17 +329,17 @@ fn handle_close(doc: &Rope, selection: &Selection, _open: char, close: char) -> 
         let next_char = doc.get_char(cursor);
         let mut len_inserted = 0;
 
-        let change = if next_char == Some(close) {
+        let change = if next_char == Some(pair.close) {
             // return transaction that moves past close
             (cursor, cursor, None) // no-op
         } else {
-            len_inserted += close.len_utf8();
+            len_inserted += pair.close.len_utf8();
             let mut tendril = Tendril::new();
-            tendril.push(close);
+            tendril.push(pair.close);
             (cursor, cursor, Some(tendril))
         };
 
-        let next_range = get_next_range(doc, start_range, offs, close, len_inserted);
+        let next_range = get_next_range(doc, start_range, offs, pair.close, len_inserted);
         end_ranges.push(next_range);
         offs += len_inserted;
 
@@ -272,13 +352,7 @@ fn handle_close(doc: &Rope, selection: &Selection, _open: char, close: char) -> 
 }
 
 /// handle cases where open and close is the same, or in triples ("""docstring""")
-fn handle_same(
-    doc: &Rope,
-    selection: &Selection,
-    token: char,
-    close_before: &str,
-    open_before: &str,
-) -> Transaction {
+fn handle_same(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
 
     let mut offs = 0;
@@ -286,30 +360,26 @@ fn handle_same(
     let transaction = Transaction::change_by_selection(doc, selection, |start_range| {
         let cursor = start_range.cursor(doc.slice(..));
         let mut len_inserted = 0;
-
         let next_char = doc.get_char(cursor);
-        let prev_char = prev_char(doc, cursor);
 
-        let change = if next_char == Some(token) {
+        let change = if next_char == Some(pair.open) {
             //  return transaction that moves past close
             (cursor, cursor, None) // no-op
         } else {
-            let mut pair = Tendril::new();
-            pair.push(token);
+            let mut pair_str = Tendril::new();
+            pair_str.push(pair.open);
 
             // for equal pairs, don't insert both open and close if either
             // side has a non-pair char
-            if (next_char.is_none() || close_before.contains(next_char.unwrap()))
-                && (prev_char.is_none() || open_before.contains(prev_char.unwrap()))
-            {
-                pair.push(token);
+            if pair.should_close(doc, start_range) {
+                pair_str.push(pair.close);
             }
 
-            len_inserted += pair.len();
-            (cursor, cursor, Some(pair))
+            len_inserted += pair_str.len();
+            (cursor, cursor, Some(pair_str))
         };
 
-        let next_range = get_next_range(doc, start_range, offs, token, len_inserted);
+        let next_range = get_next_range(doc, start_range, offs, pair.open, len_inserted);
         end_ranges.push(next_range);
         offs += len_inserted;
 
@@ -329,21 +399,23 @@ mod test {
     const LINE_END: &str = crate::DEFAULT_LINE_ENDING.as_str();
 
     fn differing_pairs() -> impl Iterator<Item = &'static (char, char)> {
-        PAIRS.iter().filter(|(open, close)| open != close)
+        DEFAULT_PAIRS.iter().filter(|(open, close)| open != close)
     }
 
     fn matching_pairs() -> impl Iterator<Item = &'static (char, char)> {
-        PAIRS.iter().filter(|(open, close)| open == close)
+        DEFAULT_PAIRS.iter().filter(|(open, close)| open == close)
     }
 
     fn test_hooks(
         in_doc: &Rope,
         in_sel: &Selection,
         ch: char,
+        pairs: &[(char, char)],
         expected_doc: &Rope,
         expected_sel: &Selection,
     ) {
-        let trans = hook(in_doc, in_sel, ch).unwrap();
+        let pairs = AutoPairs::new(pairs.iter().cloned());
+        let trans = hook(&in_doc, &in_sel, ch, &pairs).unwrap();
         let mut actual_doc = in_doc.clone();
         assert!(trans.apply(&mut actual_doc));
         assert_eq!(expected_doc, &actual_doc);
@@ -353,7 +425,8 @@ mod test {
     fn test_hooks_with_pairs<I, F, R>(
         in_doc: &Rope,
         in_sel: &Selection,
-        pairs: I,
+        test_pairs: I,
+        pairs: &[(char, char)],
         get_expected_doc: F,
         actual_sel: &Selection,
     ) where
@@ -362,11 +435,12 @@ mod test {
         R: Into<Rope>,
         Rope: From<R>,
     {
-        pairs.into_iter().for_each(|(open, close)| {
+        test_pairs.into_iter().for_each(|(open, close)| {
             test_hooks(
                 in_doc,
                 in_sel,
                 *open,
+                pairs,
                 &Rope::from(get_expected_doc(*open, *close)),
                 actual_sel,
             )
@@ -381,7 +455,8 @@ mod test {
         test_hooks_with_pairs(
             &Rope::from(LINE_END),
             &Selection::single(1, 0),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| format!("{}{}{}", open, close, LINE_END),
             &Selection::single(2, 1),
         );
@@ -391,7 +466,8 @@ mod test {
         test_hooks_with_pairs(
             &empty_doc,
             &Selection::single(empty_doc.len_chars(), LINE_END.len()),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| {
                 format!(
                     "{line_end}{open}{close}{line_end}",
@@ -406,13 +482,16 @@ mod test {
 
     #[test]
     fn test_insert_before_multi_code_point_graphemes() {
-        test_hooks_with_pairs(
-            &Rope::from(format!("hello 👨‍👩‍👧‍👦 goodbye{}", LINE_END)),
-            &Selection::single(13, 6),
-            PAIRS,
-            |open, _| format!("hello {}👨‍👩‍👧‍👦 goodbye{}", open, LINE_END),
-            &Selection::single(14, 7),
-        );
+        for (_, close) in differing_pairs() {
+            test_hooks(
+                &Rope::from(format!("hello 👨‍👩‍👧‍👦 goodbye{}", LINE_END)),
+                &Selection::single(13, 6),
+                *close,
+                DEFAULT_PAIRS,
+                &Rope::from(format!("hello {}👨‍👩‍👧‍👦 goodbye{}", close, LINE_END)),
+                &Selection::single(14, 7),
+            );
+        }
     }
 
     #[test]
@@ -420,7 +499,8 @@ mod test {
         test_hooks_with_pairs(
             &Rope::from(LINE_END),
             &Selection::single(LINE_END.len(), LINE_END.len()),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| format!("{}{}{}", LINE_END, open, close),
             &Selection::single(LINE_END.len() + 1, LINE_END.len() + 1),
         );
@@ -428,7 +508,8 @@ mod test {
         test_hooks_with_pairs(
             &Rope::from(format!("foo{}", LINE_END)),
             &Selection::single(3 + LINE_END.len(), 3 + LINE_END.len()),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| format!("foo{}{}{}", LINE_END, open, close),
             &Selection::single(LINE_END.len() + 4, LINE_END.len() + 4),
         );
@@ -442,7 +523,8 @@ mod test {
             &Rope::from(format!("{line_end}{line_end}", line_end = LINE_END)),
             // before inserting the pair, the cursor covers all of both empty lines
             &Selection::single(0, LINE_END.len() * 2),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| {
                 format!(
                     "{line_end}{open}{close}{line_end}",
@@ -467,7 +549,8 @@ mod test {
                 smallvec!(Range::new(1, 0), Range::new(2, 1), Range::new(3, 2),),
                 0,
             ),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, close| {
                 format!(
                     "{open}{close}\n{open}{close}\n{open}{close}\n",
@@ -489,6 +572,7 @@ mod test {
             &Rope::from("foo\n"),
             &Selection::single(2, 4),
             differing_pairs(),
+            DEFAULT_PAIRS,
             |open, close| format!("foo{}{}\n", open, close),
             &Selection::single(2, 5),
         );
@@ -501,6 +585,7 @@ mod test {
             &Rope::from(format!("foo{}", LINE_END)),
             &Selection::single(3, 3 + LINE_END.len()),
             differing_pairs(),
+            DEFAULT_PAIRS,
             |open, close| format!("foo{}{}{}", open, close, LINE_END),
             &Selection::single(4, 5),
         );
@@ -518,6 +603,7 @@ mod test {
                 0,
             ),
             differing_pairs(),
+            DEFAULT_PAIRS,
             |open, close| {
                 format!(
                     "foo{open}{close}\nfoo{open}{close}\nfoo{open}{close}\n",
@@ -535,13 +621,14 @@ mod test {
     /// ([)] -> insert ) -> ()[]
     #[test]
     fn test_insert_close_inside_pair() {
-        for (open, close) in PAIRS {
+        for (open, close) in DEFAULT_PAIRS {
             let doc = Rope::from(format!("{}{}{}", open, close, LINE_END));
 
             test_hooks(
                 &doc,
                 &Selection::single(2, 1),
                 *close,
+                DEFAULT_PAIRS,
                 &doc,
                 &Selection::single(2 + LINE_END.len(), 2),
             );
@@ -551,13 +638,14 @@ mod test {
     /// [(]) -> append ) -> [()]
     #[test]
     fn test_append_close_inside_pair() {
-        for (open, close) in PAIRS {
+        for (open, close) in DEFAULT_PAIRS {
             let doc = Rope::from(format!("{}{}{}", open, close, LINE_END));
 
             test_hooks(
                 &doc,
                 &Selection::single(0, 2),
                 *close,
+                DEFAULT_PAIRS,
                 &doc,
                 &Selection::single(0, 2 + LINE_END.len()),
             );
@@ -579,14 +667,14 @@ mod test {
             0,
         );
 
-        for (open, close) in PAIRS {
+        for (open, close) in DEFAULT_PAIRS {
             let doc = Rope::from(format!(
                 "{open}{close}\n{open}{close}\n{open}{close}\n",
                 open = open,
                 close = close
             ));
 
-            test_hooks(&doc, &sel, *close, &doc, &expected_sel);
+            test_hooks(&doc, &sel, *close, DEFAULT_PAIRS, &doc, &expected_sel);
         }
     }
 
@@ -605,14 +693,14 @@ mod test {
             0,
         );
 
-        for (open, close) in PAIRS {
+        for (open, close) in DEFAULT_PAIRS {
             let doc = Rope::from(format!(
                 "{open}{close}\n{open}{close}\n{open}{close}\n",
                 open = open,
                 close = close
             ));
 
-            test_hooks(&doc, &sel, *close, &doc, &expected_sel);
+            test_hooks(&doc, &sel, *close, DEFAULT_PAIRS, &doc, &expected_sel);
         }
     }
 
@@ -630,7 +718,14 @@ mod test {
                 close = close
             ));
 
-            test_hooks(&doc, &sel, *open, &expected_doc, &expected_sel);
+            test_hooks(
+                &doc,
+                &sel,
+                *open,
+                DEFAULT_PAIRS,
+                &expected_doc,
+                &expected_sel,
+            );
         }
     }
 
@@ -648,7 +743,14 @@ mod test {
                 close = close
             ));
 
-            test_hooks(&doc, &sel, *open, &expected_doc, &expected_sel);
+            test_hooks(
+                &doc,
+                &sel,
+                *open,
+                DEFAULT_PAIRS,
+                &expected_doc,
+                &expected_sel,
+            );
         }
     }
 
@@ -667,7 +769,14 @@ mod test {
                     outer_open, inner_open, inner_close, outer_close
                 ));
 
-                test_hooks(&doc, &sel, *inner_open, &expected_doc, &expected_sel);
+                test_hooks(
+                    &doc,
+                    &sel,
+                    *inner_open,
+                    DEFAULT_PAIRS,
+                    &expected_doc,
+                    &expected_sel,
+                );
             }
         }
     }
@@ -687,7 +796,14 @@ mod test {
                     outer_open, inner_open, inner_close, outer_close
                 ));
 
-                test_hooks(&doc, &sel, *inner_open, &expected_doc, &expected_sel);
+                test_hooks(
+                    &doc,
+                    &sel,
+                    *inner_open,
+                    DEFAULT_PAIRS,
+                    &expected_doc,
+                    &expected_sel,
+                );
             }
         }
     }
@@ -698,7 +814,8 @@ mod test {
         test_hooks_with_pairs(
             &Rope::from("word"),
             &Selection::single(1, 0),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, _| format!("{}word", open),
             &Selection::single(2, 1),
         )
@@ -710,7 +827,8 @@ mod test {
         test_hooks_with_pairs(
             &Rope::from("word"),
             &Selection::single(3, 0),
-            PAIRS,
+            DEFAULT_PAIRS,
+            DEFAULT_PAIRS,
             |open, _| format!("{}word", open),
             &Selection::single(4, 1),
         )
@@ -722,10 +840,17 @@ mod test {
         let sel = Selection::single(0, 4);
         let expected_sel = Selection::single(0, 5);
 
-        for (_, close) in PAIRS {
+        for (_, close) in DEFAULT_PAIRS {
             let doc = Rope::from("word");
             let expected_doc = Rope::from(format!("wor{}d", close));
-            test_hooks(&doc, &sel, *close, &expected_doc, &expected_sel);
+            test_hooks(
+                &doc,
+                &sel,
+                *close,
+                DEFAULT_PAIRS,
+                &expected_doc,
+                &expected_sel,
+            );
         }
     }
 
@@ -736,6 +861,7 @@ mod test {
             &Rope::from("foo word"),
             &Selection::single(7, 3),
             differing_pairs(),
+            DEFAULT_PAIRS,
             |open, close| format!("foo{}{} word", open, close),
             &Selection::single(9, 4),
         )
@@ -749,6 +875,7 @@ mod test {
                 &Rope::from(format!("foo{}{} word{}", open, close, LINE_END)),
                 &Selection::single(9, 4),
                 *close,
+                DEFAULT_PAIRS,
                 &Rope::from(format!("foo{}{} word{}", open, close, LINE_END)),
                 &Selection::single(9, 5),
             )
@@ -771,6 +898,7 @@ mod test {
             &doc,
             &sel,
             differing_pairs(),
+            DEFAULT_PAIRS,
             |open, close| format!("word{}{}{}", open, close, LINE_END),
             &expected_sel,
         );
@@ -779,8 +907,34 @@ mod test {
             &doc,
             &sel,
             matching_pairs(),
+            DEFAULT_PAIRS,
             |open, _| format!("word{}{}", open, LINE_END),
             &expected_sel,
         );
+    }
+
+    #[test]
+    fn test_configured_pairs() {
+        let test_pairs = &[('`', ':'), ('+', '-')];
+
+        test_hooks_with_pairs(
+            &Rope::from(LINE_END),
+            &Selection::single(1, 0),
+            test_pairs,
+            test_pairs,
+            |open, close| format!("{}{}{}", open, close, LINE_END),
+            &Selection::single(2, 1),
+        );
+
+        let doc = Rope::from(format!("foo`: word{}", LINE_END));
+
+        test_hooks(
+            &doc,
+            &Selection::single(9, 4),
+            ':',
+            test_pairs,
+            &doc,
+            &Selection::single(9, 5),
+        )
     }
 }

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -23,16 +23,16 @@ pub const DEFAULT_PAIRS: &[(char, char)] = &[
 /// The type that represents the collection of auto pairs,
 /// keyed by the opener.
 #[derive(Debug, Clone)]
-pub struct AutoPairs(HashMap<char, Rc<AutoPair>>);
+pub struct AutoPairs(HashMap<char, Rc<Pair>>);
 
 /// Represents the config for a particular pairing.
 #[derive(Debug)]
-pub struct AutoPair {
+pub struct Pair {
     pub open: char,
     pub close: char,
 }
 
-impl AutoPair {
+impl Pair {
     /// true if open == close
     pub fn same(&self) -> bool {
         self.open == self.close
@@ -62,7 +62,7 @@ impl AutoPair {
     }
 }
 
-impl From<(char, char)> for AutoPair {
+impl From<(char, char)> for Pair {
     fn from(pair: (char, char)) -> Self {
         Self {
             open: pair.0,
@@ -71,7 +71,7 @@ impl From<(char, char)> for AutoPair {
     }
 }
 
-impl From<(&char, &char)> for AutoPair {
+impl From<(&char, &char)> for Pair {
     fn from(pair: (&char, &char)) -> Self {
         Self {
             open: *pair.0,
@@ -85,7 +85,7 @@ impl AutoPairs {
     pub fn new<'a, V: 'a, A>(pairs: V) -> Self
     where
         V: IntoIterator<Item = A>,
-        A: Into<AutoPair>,
+        A: Into<Pair>,
     {
         let mut auto_pairs = HashMap::new();
 
@@ -102,7 +102,7 @@ impl AutoPairs {
         Self(auto_pairs)
     }
 
-    pub fn get(&self, ch: char) -> Option<&AutoPair> {
+    pub fn get(&self, ch: char) -> Option<&Pair> {
         self.0.get(&ch).map(Rc::as_ref)
     }
 }
@@ -283,7 +283,7 @@ fn get_next_range(
     Range::new(end_anchor, end_head)
 }
 
-fn handle_open(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
+fn handle_open(doc: &Rope, selection: &Selection, pair: &Pair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
     let mut offs = 0;
 
@@ -319,7 +319,7 @@ fn handle_open(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transactio
     t
 }
 
-fn handle_close(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
+fn handle_close(doc: &Rope, selection: &Selection, pair: &Pair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
 
     let mut offs = 0;
@@ -352,7 +352,7 @@ fn handle_close(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transacti
 }
 
 /// handle cases where open and close is the same, or in triples ("""docstring""")
-fn handle_same(doc: &Rope, selection: &Selection, pair: &AutoPair) -> Transaction {
+fn handle_same(doc: &Rope, selection: &Selection, pair: &Pair) -> Transaction {
     let mut end_ranges = SmallVec::with_capacity(selection.len());
 
     let mut offs = 0;

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_PAIRS: &[(char, char)] = &[
 pub struct AutoPairs(HashMap<char, Pair>);
 
 /// Represents the config for a particular pairing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Pair {
     pub open: char,
     pub close: char,
@@ -62,8 +62,8 @@ impl Pair {
     }
 }
 
-impl From<(char, char)> for Pair {
-    fn from(pair: (char, char)) -> Self {
+impl From<&(char, char)> for Pair {
+    fn from(pair: &(char, char)) -> Self {
         Self {
             open: pair.0,
             close: pair.1,
@@ -92,7 +92,7 @@ impl AutoPairs {
         for pair in pairs.into_iter() {
             let auto_pair = pair.into();
 
-            auto_pairs.insert(auto_pair.open, auto_pair.clone());
+            auto_pairs.insert(auto_pair.open, auto_pair);
 
             if auto_pair.open != auto_pair.close {
                 auto_pairs.insert(auto_pair.close, auto_pair);
@@ -109,7 +109,7 @@ impl AutoPairs {
 
 impl Default for AutoPairs {
     fn default() -> Self {
-        AutoPairs::new(DEFAULT_PAIRS.iter().cloned())
+        AutoPairs::new(DEFAULT_PAIRS.iter())
     }
 }
 
@@ -414,7 +414,7 @@ mod test {
         expected_doc: &Rope,
         expected_sel: &Selection,
     ) {
-        let pairs = AutoPairs::new(pairs.iter().cloned());
+        let pairs = AutoPairs::new(pairs.iter());
         let trans = hook(&in_doc, &in_sel, ch, &pairs).unwrap();
         let mut actual_doc = in_doc.clone();
         assert!(trans.apply(&mut actual_doc));

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -63,19 +63,16 @@ impl Pair {
 }
 
 impl From<&(char, char)> for Pair {
-    fn from(pair: &(char, char)) -> Self {
-        Self {
-            open: pair.0,
-            close: pair.1,
-        }
+    fn from(&(open, close): &(char, char)) -> Self {
+        Self { open, close }
     }
 }
 
 impl From<(&char, &char)> for Pair {
-    fn from(pair: (&char, &char)) -> Self {
+    fn from((open, close): (&char, &char)) -> Self {
         Self {
-            open: *pair.0,
-            close: *pair.1,
+            open: *open,
+            close: *close,
         }
     }
 }

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -442,6 +442,7 @@ where
                 indent_query: OnceCell::new(),
                 textobject_query: OnceCell::new(),
                 debugger: None,
+                auto_pairs: None,
             }],
         });
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -10,7 +10,6 @@ use crate::{
 pub use helix_syntax::get_language;
 
 use arc_swap::{ArcSwap, Guard};
-use log::debug;
 use slotmap::{DefaultKey as LayerId, HopSlotMap};
 
 use std::{
@@ -198,15 +197,11 @@ impl Default for AutoPairConfig {
 
 impl From<&AutoPairConfig> for Option<AutoPairs> {
     fn from(auto_pair_config: &AutoPairConfig) -> Self {
-        let auto_pairs = match auto_pair_config {
+        match auto_pair_config {
             AutoPairConfig::Enable(false) => None,
             AutoPairConfig::Enable(true) => Some(AutoPairs::default()),
             AutoPairConfig::Pairs(pairs) => Some(AutoPairs::new(pairs.iter())),
-        };
-
-        debug!("auto pairs: {:#?}", auto_pairs);
-
-        auto_pairs
+        }
     }
 }
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -48,10 +48,7 @@ pub fn deserialize_auto_pairs<'de, D>(deserializer: D) -> Result<Option<AutoPair
 where
     D: serde::Deserializer<'de>,
 {
-    Ok(match Option::<AutoPairConfig>::deserialize(deserializer)? {
-        Some(auto_pairs_config) => Option::<AutoPairs>::from(&auto_pairs_config),
-        None => None,
-    })
+    Ok(Option::<AutoPairConfig>::deserialize(deserializer)?.and_then(AutoPairConfig::into))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -210,6 +207,12 @@ impl From<&AutoPairConfig> for Option<AutoPairs> {
         debug!("auto pairs: {:#?}", auto_pairs);
 
         auto_pairs
+    }
+}
+
+impl From<AutoPairConfig> for Option<AutoPairs> {
+    fn from(auto_pairs_config: AutoPairConfig) -> Self {
+        (&auto_pairs_config).into()
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4048,7 +4048,7 @@ pub mod insert {
         let (view, doc) = current_ref!(cx.editor);
         let text = doc.text();
         let selection = doc.selection(view.id);
-        let auto_pairs = cx.editor.get_document_auto_pairs(doc.id());
+        let auto_pairs = doc.auto_pairs(cx.editor);
 
         let transaction = auto_pairs
             .as_ref()
@@ -4122,9 +4122,8 @@ pub mod insert {
             // If we are between pairs (such as brackets), we want to
             // insert an additional line which is indented one level
             // more and place the cursor there
-            let on_auto_pair = cx
-                .editor
-                .get_document_auto_pairs(doc.id())
+            let on_auto_pair = doc
+                .auto_pairs(cx.editor)
                 .and_then(|pairs| pairs.get(prev))
                 .and_then(|pair| if pair.close == curr { Some(pair) } else { None })
                 .is_some();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4043,7 +4043,6 @@ pub mod insert {
     }
 
     use helix_core::auto_pairs;
-    use log::debug;
 
     pub fn insert_char(cx: &mut Context, c: char) {
         let (view, doc) = current_ref!(cx.editor);
@@ -4053,16 +4052,8 @@ pub mod insert {
 
         let transaction = auto_pairs
             .as_ref()
-            .and_then(|ap| {
-                let ap_result = auto_pairs::hook(text, selection, c, ap);
-                debug!("ap_result: {:#?}", ap_result);
-                ap_result
-            })
-            .or_else(|| {
-                let ins_result = insert(text, selection, c);
-                debug!("ins_result: {:#?}", ins_result);
-                ins_result
-            });
+            .and_then(|ap| auto_pairs::hook(text, selection, c, ap))
+            .or_else(|| insert(text, selection, c));
 
         let (view, doc) = current!(cx.editor);
         if let Some(t) = transaction {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -83,6 +83,7 @@ pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
     pub(crate) selections: HashMap<ViewId, Selection>,
+
     path: Option<PathBuf>,
     encoding: &'static encoding::Encoding,
 
@@ -95,26 +96,27 @@ pub struct Document {
 
     /// The document's default line ending.
     pub line_ending: LineEnding,
-    syntax: Option<Syntax>,
 
+    syntax: Option<Syntax>,
     /// Corresponding language scope name. Usually `source.<lang>`.
     pub(crate) language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,
-
     /// State at last commit. Used for calculating reverts.
     old_state: Option<State>,
-
     /// Undo tree.
     // It can be used as a cell where we will take it out to get some parts of the history and put
     // it back as it separated from the edits. We could split out the parts manually but that will
     // be more troublesome.
     pub history: Cell<History>,
+
     pub savepoint: Option<Transaction>,
+
     last_saved_revision: usize,
     version: i32, // should be usize?
     pub(crate) modified_since_accessed: bool,
+
     diagnostics: Vec<Diagnostic>,
     language_server: Option<Arc<helix_lsp::Client>>,
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -83,7 +83,6 @@ pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
     pub(crate) selections: HashMap<ViewId, Selection>,
-
     path: Option<PathBuf>,
     encoding: &'static encoding::Encoding,
 
@@ -96,27 +95,26 @@ pub struct Document {
 
     /// The document's default line ending.
     pub line_ending: LineEnding,
-
     syntax: Option<Syntax>,
-    // /// Corresponding language scope name. Usually `source.<lang>`.
+
+    /// Corresponding language scope name. Usually `source.<lang>`.
     pub(crate) language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,
+
     /// State at last commit. Used for calculating reverts.
     old_state: Option<State>,
+
     /// Undo tree.
     // It can be used as a cell where we will take it out to get some parts of the history and put
     // it back as it separated from the edits. We could split out the parts manually but that will
     // be more troublesome.
     pub history: Cell<History>,
-
     pub savepoint: Option<Transaction>,
-
     last_saved_revision: usize,
     version: i32, // should be usize?
     pub(crate) modified_since_accessed: bool,
-
     diagnostics: Vec<Diagnostic>,
     language_server: Option<Arc<helix_lsp::Client>>,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -103,8 +103,8 @@ pub struct Config {
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
     /// Automatic insertion of pairs to parentheses, brackets,
-    /// etc. Defaults to true. Optionally, this can be a list of 2-tuples
-    /// to specify a global list of characters to pair.
+    /// etc. Optionally, this can be a list of 2-tuples to specify a
+    /// global list of characters to pair. Defaults to true.
     pub auto_pairs: AutoPairConfig,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
     pub auto_completion: bool,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -729,8 +729,11 @@ impl Editor {
 
         // NOTE: If the user specifies the global auto pairs config as false, then
         //       we want to disable it globally regardless of language settings
-        if global_config.is_none() {
-            return None;
+        #[allow(clippy::question_mark)]
+        {
+            if global_config.is_none() {
+                return None;
+            }
         }
 
         let doc = self.document(id)?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -318,7 +318,7 @@ impl Editor {
         config: Config,
     ) -> Self {
         let language_servers = helix_lsp::Registry::new();
-        let auto_pairs = Option::<AutoPairs>::from(&config.auto_pairs);
+        let auto_pairs = (&config.auto_pairs).into();
 
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -724,12 +724,8 @@ impl Editor {
     /// language config with auto pairs configured, returns that;
     /// otherwise, falls back to the global auto pairs config.
     pub fn get_document_auto_pairs(&self, id: DocumentId) -> Option<&AutoPairs> {
-        if self.document(id).is_none() {
-            return None;
-        }
-
         let global_config = (&self.auto_pairs).as_ref();
-        let doc = self.document(id).unwrap();
+        let doc = self.document(id)?;
 
         match &doc.language {
             Some(lang) => lang.as_ref().auto_pairs.as_ref().or(global_config),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -722,9 +722,17 @@ impl Editor {
 
     /// Get the document's auto pairs. If the document has a recognized
     /// language config with auto pairs configured, returns that;
-    /// otherwise, falls back to the global auto pairs config.
+    /// otherwise, falls back to the global auto pairs config. If the global
+    /// config is false, then ignore language settings.
     pub fn get_document_auto_pairs(&self, id: DocumentId) -> Option<&AutoPairs> {
         let global_config = (&self.auto_pairs).as_ref();
+
+        // NOTE: If the user specifies the global auto pairs config as false, then
+        //       we want to disable it globally regardless of language settings
+        if global_config.is_none() {
+            return None;
+        }
+
         let doc = self.document(id)?;
 
         match &doc.language {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -723,30 +723,6 @@ impl Editor {
             .find(|doc| doc.path().map(|p| p == path.as_ref()).unwrap_or(false))
     }
 
-    /// Get the document's auto pairs. If the document has a recognized
-    /// language config with auto pairs configured, returns that;
-    /// otherwise, falls back to the global auto pairs config. If the global
-    /// config is false, then ignore language settings.
-    pub fn get_document_auto_pairs(&self, id: DocumentId) -> Option<&AutoPairs> {
-        let global_config = (&self.auto_pairs).as_ref();
-
-        // NOTE: If the user specifies the global auto pairs config as false, then
-        //       we want to disable it globally regardless of language settings
-        #[allow(clippy::question_mark)]
-        {
-            if global_config.is_none() {
-                return None;
-            }
-        }
-
-        let doc = self.document(id)?;
-
-        match &doc.language {
-            Some(lang) => lang.as_ref().auto_pairs.as_ref().or(global_config),
-            None => global_config,
-        }
-    }
-
     pub fn cursor(&self) -> (Option<Position>, CursorKind) {
         let (view, doc) = current_ref!(self);
         let cursor = doc

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -13,6 +13,7 @@ use futures_util::future;
 use futures_util::stream::select_all::SelectAll;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
+use log::debug;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
@@ -319,6 +320,8 @@ impl Editor {
     ) -> Self {
         let language_servers = helix_lsp::Registry::new();
         let auto_pairs = (&config.auto_pairs).into();
+
+        debug!("Editor config: {config:#?}");
 
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;

--- a/languages.toml
+++ b/languages.toml
@@ -9,6 +9,13 @@ comment-token = "//"
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'`' = '`'
+
 [language.debugger]
 name = "lldb-vscode"
 transport = "stdio"


### PR DESCRIPTION
Implements configuration for which pairs of tokens get auto completed.

In order to help with this, the logic for when *not* to auto complete has been generalized from a specific hardcoded list of characters to simply testing if the next/prev char is alphanumeric.

It is possible to configure a global list of pairs as well as at the language level. The language config will take precedence over the global config. This is specifically intended to address and close #992 and #1347; it adds a pair mapping to the Rust section of the default `languages.toml` that excludes single quotes.

I had some ideas for more sophisticated configs for pairings, such as lexical rules, tree-sitter node lineage, etc, but I think these can be separate PRs. In particular, I'd really like to add a rule for checking a regex pattern on the line before and/or after the cursor to determine if a closer should be paired; e.g. pair <> but only if the < is directly adjacent to an alphabetic char to avoid pairing in "less than" expressions.