### PR TITLE
Add paragraph motion and textobject

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -277,6 +277,8 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `[a`     | Go to previous argument/parameter (**TS**)   | `goto_prev_parameter` |
 | `]o`     | Go to next comment (**TS**)                  | `goto_next_comment`   |
 | `[o`     | Go to previous comment (**TS**)              | `goto_prev_comment`   |
+| `]p`     | Go to next paragraph                         | `goto_next_paragraph` |
+| `[p`     | Go to previous paragraph                     | `goto_prev_paragraph` |
 | `[space` | Add newline above                            | `add_newline_above`   |
 | `]space` | Add newline below                            | `add_newline_below`   |
 

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod shellwords;
 mod state;
 pub mod surround;
 pub mod syntax;
+pub mod test;
 pub mod textobject;
 mod transaction;
 

--- a/helix-core/src/line_ending.rs
+++ b/helix-core/src/line_ending.rs
@@ -119,6 +119,11 @@ pub fn str_is_line_ending(s: &str) -> bool {
     LineEnding::from_str(s).is_some()
 }
 
+#[inline]
+pub fn rope_is_line_ending(r: RopeSlice) -> bool {
+    r.chunks().all(str_is_line_ending)
+}
+
 /// Attempts to detect what line ending the passed document uses.
 pub fn auto_detect_line_ending(doc: &Rope) -> Option<LineEnding> {
     // Return first matched line ending. Not all possible line endings

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1255,15 +1255,24 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_prev_paragraph_single() {
         let tests = [
-            ("^@", "^@"),
-            ("^s@tart at\nfirst char\n", "@s^tart at\nfirst char\n"),
-            ("start at\nlast char^\n@", "@start at\nlast char\n^"),
-            ("goto\nfirst\n\n^p@aragraph", "@goto\nfirst\n\n^paragraph"),
-            ("goto\nfirst\n^\n@paragraph", "@goto\nfirst\n\n^paragraph"),
-            ("goto\nsecond\n\np^a@ragraph", "goto\nsecond\n\n@pa^ragraph"),
+            ("#[|]#", "#[|]#"),
+            ("#[s|]#tart at\nfirst char\n", "#[|s]#tart at\nfirst char\n"),
+            ("start at\nlast char#[\n|]#", "#[|start at\nlast char\n]#"),
             (
-                "here\n\nhave\nmultiple\nparagraph\n\n\n\n\n^@",
-                "here\n\n@have\nmultiple\nparagraph\n\n\n\n\n^",
+                "goto\nfirst\n\n#[p|]#aragraph",
+                "#[|goto\nfirst\n\n]#paragraph",
+            ),
+            (
+                "goto\nfirst\n#[\n|]#paragraph",
+                "#[|goto\nfirst\n\n]#paragraph",
+            ),
+            (
+                "goto\nsecond\n\np#[a|]#ragraph",
+                "goto\nsecond\n\n#[|pa]#ragraph",
+            ),
+            (
+                "here\n\nhave\nmultiple\nparagraph\n\n\n\n\n#[|]#",
+                "here\n\n#[|have\nmultiple\nparagraph\n\n\n\n\n]#",
             ),
         ];
 
@@ -1280,8 +1289,14 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_prev_paragraph_double() {
         let tests = [
-            ("on^e@\n\ntwo\n\nthree\n\n", "@one^\n\ntwo\n\nthree\n\n"),
-            ("one\n\ntwo\n\nth^r@ee\n\n", "one\n\n@two\n\nthr^ee\n\n"),
+            (
+                "on#[e|]#\n\ntwo\n\nthree\n\n",
+                "#[|one]#\n\ntwo\n\nthree\n\n",
+            ),
+            (
+                "one\n\ntwo\n\nth#[r|]#ee\n\n",
+                "one\n\n#[|two\n\nthr]#ee\n\n",
+            ),
         ];
 
         for (before, expected) in tests {
@@ -1297,8 +1312,14 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_prev_paragraph_extend() {
         let tests = [
-            ("one\n\n@two\n\n^three\n\n", "@one\n\ntwo\n\n^three\n\n"),
-            ("@one\n\ntwo\n\n^three\n\n", "@one\n\ntwo\n\n^three\n\n"),
+            (
+                "one\n\n#[|two\n\n]#three\n\n",
+                "#[|one\n\ntwo\n\n]#three\n\n",
+            ),
+            (
+                "#[|one\n\ntwo\n\n]#three\n\n",
+                "#[|one\n\ntwo\n\n]#three\n\n",
+            ),
         ];
 
         for (before, expected) in tests {
@@ -1314,24 +1335,24 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_next_paragraph_single() {
         let tests = [
-            ("^@", "^@"),
-            ("^s@tart at\nfirst char\n", "^start at\nfirst char\n@"),
-            ("start at\nlast char^\n@", "start at\nlast char^\n@"),
+            ("#[|]#", "#[|]#"),
+            ("#[s|]#tart at\nfirst char\n", "#[start at\nfirst char\n|]#"),
+            ("start at\nlast char#[\n|]#", "start at\nlast char#[\n|]#"),
             (
-                "a\nb\n\n^g@oto\nthird\n\nparagraph",
-                "a\nb\n\n^goto\nthird\n\n@paragraph",
+                "a\nb\n\n#[g|]#oto\nthird\n\nparagraph",
+                "a\nb\n\n#[goto\nthird\n\n|]#paragraph",
             ),
             (
-                "a\nb\n^\n@goto\nthird\n\nparagraph",
-                "a\nb\n\n^goto\nthird\n\n@paragraph",
+                "a\nb\n#[\n|]#goto\nthird\n\nparagraph",
+                "a\nb\n\n#[goto\nthird\n\n|]#paragraph",
             ),
             (
-                "a\nb^\n@\ngoto\nsecond\n\nparagraph",
-                "a\nb^\n\n@goto\nsecond\n\nparagraph",
+                "a\nb#[\n|]#\ngoto\nsecond\n\nparagraph",
+                "a\nb#[\n\n|]#goto\nsecond\n\nparagraph",
             ),
             (
-                "here\n\nhave\n^m@ultiple\nparagraph\n\n\n\n\n",
-                "here\n\nhave\n^multiple\nparagraph\n\n\n\n\n@",
+                "here\n\nhave\n#[m|]#ultiple\nparagraph\n\n\n\n\n",
+                "here\n\nhave\n#[multiple\nparagraph\n\n\n\n\n|]#",
             ),
         ];
 
@@ -1348,8 +1369,14 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_next_paragraph_double() {
         let tests = [
-            ("one\n\ntwo\n\nth^r@ee\n\n", "one\n\ntwo\n\nth^ree\n\n@"),
-            ("on^e@\n\ntwo\n\nthree\n\n", "on^e\n\ntwo\n\n@three\n\n"),
+            (
+                "one\n\ntwo\n\nth#[r|]#ee\n\n",
+                "one\n\ntwo\n\nth#[ree\n\n|]#",
+            ),
+            (
+                "on#[e|]#\n\ntwo\n\nthree\n\n",
+                "on#[e\n\ntwo\n\n|]#three\n\n",
+            ),
         ];
 
         for (before, expected) in tests {
@@ -1365,8 +1392,14 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_next_paragraph_extend() {
         let tests = [
-            ("one\n\n^two\n\n@three\n\n", "one\n\n^two\n\nthree\n\n@"),
-            ("one\n\n^two\n\nthree\n\n@", "one\n\n^two\n\nthree\n\n@"),
+            (
+                "one\n\n#[two\n\n|]#three\n\n",
+                "one\n\n#[two\n\nthree\n\n|]#",
+            ),
+            (
+                "one\n\n#[two\n\nthree\n\n|]#",
+                "one\n\n#[two\n\nthree\n\n|]#",
+            ),
         ];
 
         for (before, expected) in tests {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -150,7 +150,12 @@ fn word_move(slice: RopeSlice, range: Range, count: usize, target: WordMotionTar
     })
 }
 
-pub fn move_prev_para(slice: RopeSlice, range: Range, count: usize, behavior: Movement) -> Range {
+pub fn move_prev_paragraph(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    behavior: Movement,
+) -> Range {
     let mut line = range.cursor_line(slice);
     let first_char = slice.line_to_char(line) == range.cursor(slice);
     let prev_line_empty = rope_is_line_ending(slice.line(line.saturating_sub(1)));
@@ -187,7 +192,12 @@ pub fn move_prev_para(slice: RopeSlice, range: Range, count: usize, behavior: Mo
     Range::new(anchor, head)
 }
 
-pub fn move_next_para(slice: RopeSlice, range: Range, count: usize, behavior: Movement) -> Range {
+pub fn move_next_paragraph(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    behavior: Movement,
+) -> Range {
     let mut line = range.cursor_line(slice);
     let last_char =
         prev_grapheme_boundary(slice, slice.line_to_char(line + 1)) == range.cursor(slice);
@@ -1280,7 +1290,7 @@ mod test {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
             let selection =
-                selection.transform(|r| move_prev_para(text.slice(..), r, 1, Movement::Move));
+                selection.transform(|r| move_prev_paragraph(text.slice(..), r, 1, Movement::Move));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -1303,7 +1313,7 @@ mod test {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
             let selection =
-                selection.transform(|r| move_prev_para(text.slice(..), r, 2, Movement::Move));
+                selection.transform(|r| move_prev_paragraph(text.slice(..), r, 2, Movement::Move));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -1325,8 +1335,8 @@ mod test {
         for (before, expected) in tests {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
-            let selection =
-                selection.transform(|r| move_prev_para(text.slice(..), r, 1, Movement::Extend));
+            let selection = selection
+                .transform(|r| move_prev_paragraph(text.slice(..), r, 1, Movement::Extend));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -1360,7 +1370,7 @@ mod test {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
             let selection =
-                selection.transform(|r| move_next_para(text.slice(..), r, 1, Movement::Move));
+                selection.transform(|r| move_next_paragraph(text.slice(..), r, 1, Movement::Move));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -1383,7 +1393,7 @@ mod test {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
             let selection =
-                selection.transform(|r| move_next_para(text.slice(..), r, 2, Movement::Move));
+                selection.transform(|r| move_next_paragraph(text.slice(..), r, 2, Movement::Move));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -1405,8 +1415,8 @@ mod test {
         for (before, expected) in tests {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
-            let selection =
-                selection.transform(|r| move_next_para(text.slice(..), r, 1, Movement::Extend));
+            let selection = selection
+                .transform(|r| move_next_paragraph(text.slice(..), r, 1, Movement::Extend));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -5,8 +5,10 @@ use std::cmp::Reverse;
 
 /// Convert annotated test string to test string and selection.
 ///
-/// `^` for `anchor` and `|` for head (`@` for primary), both must appear
-/// or otherwise it will panic.
+/// `#[|` for primary selection with head before anchor followed by `]#`.
+/// `#(|` for secondary selection with head before anchor followed by `)#`.
+/// `#[` for primary selection with head after anchor followed by `|]#`.
+/// `#(` for secondary selection with head after anchor followed by `|)#`.
 ///
 /// # Examples
 ///
@@ -15,7 +17,7 @@ use std::cmp::Reverse;
 /// use smallvec::smallvec;
 ///
 /// assert_eq!(
-///     print("^a@b|c^"),
+///     print("#[a|]#b#(|c)#"),
 ///     ("abc".to_owned(), Selection::new(smallvec![Range::new(0, 1), Range::new(3, 2)], 0))
 /// );
 /// ```
@@ -26,56 +28,101 @@ use std::cmp::Reverse;
 /// Panics when missing head or anchor.
 /// Panics when head come after head or anchor come after anchor.
 pub fn print(s: &str) -> (String, Selection) {
-    let mut anchor = None;
-    let mut head = None;
     let mut primary = None;
     let mut ranges = SmallVec::new();
-    let mut i = 0;
-    let s = s
-        .chars()
-        .filter(|c| {
-            match c {
-                '^' if anchor != None => panic!("anchor without head {s:?}"),
-                '^' if head == None => anchor = Some(i),
-                '^' => ranges.push(Range::new(i, head.take().unwrap())),
-                '|' if head != None => panic!("head without anchor {s:?}"),
-                '|' if anchor == None => head = Some(i),
-                '|' => ranges.push(Range::new(anchor.take().unwrap(), i)),
-                '@' if primary != None => panic!("head (primary) already appeared {s:?}"),
-                '@' if head != None => panic!("head (primary) without anchor {s:?}"),
-                '@' if anchor == None => {
-                    primary = Some(ranges.len());
-                    head = Some(i);
+    let mut iter = s.chars().peekable();
+    let mut left = String::with_capacity(s.len());
+    'outer: while let Some(c) = iter.next() {
+        let start = left.len();
+        if c == '#' {
+            if iter.next_if_eq(&'[').is_some() {
+                if primary.is_some() {
+                    panic!("primary `#[` already appeared {left:?} {s:?}");
                 }
-                '@' => {
-                    primary = Some(ranges.len());
-                    ranges.push(Range::new(anchor.take().unwrap(), i));
+                if iter.next_if_eq(&'|').is_some() {
+                    while let Some(c) = iter.next() {
+                        if c == ']' && iter.next_if_eq(&'#').is_some() {
+                            primary = Some(ranges.len());
+                            ranges.push(Range::new(left.len(), start));
+                            continue 'outer;
+                        } else {
+                            left.push(c);
+                        }
+                    }
+                    panic!("missing primary end `]#` {left:?} {s:?}");
+                } else {
+                    while let Some(c) = iter.next() {
+                        if c == '|' {
+                            if let Some(cc) = iter.next_if_eq(&']') {
+                                if iter.next_if_eq(&'#').is_some() {
+                                    primary = Some(ranges.len());
+                                    ranges.push(Range::new(start, left.len()));
+                                    continue 'outer;
+                                } else {
+                                    left.push(c);
+                                    left.push(cc);
+                                }
+                            } else {
+                                left.push(c);
+                            }
+                        } else {
+                            left.push(c);
+                        }
+                    }
+                    panic!("missing primary end `|]#` {left:?} {s:?}");
                 }
-                _ => {
-                    i += 1;
-                    return true;
+            } else if iter.next_if_eq(&'(').is_some() {
+                if iter.next_if_eq(&'|').is_some() {
+                    while let Some(c) = iter.next() {
+                        if c == ')' && iter.next_if_eq(&'#').is_some() {
+                            ranges.push(Range::new(left.len(), start));
+                            continue 'outer;
+                        } else {
+                            left.push(c);
+                        }
+                    }
+                    panic!("missing end `)#` {left:?} {s:?}");
+                } else {
+                    while let Some(c) = iter.next() {
+                        if c == '|' {
+                            if let Some(cc) = iter.next_if_eq(&')') {
+                                if iter.next_if_eq(&'#').is_some() {
+                                    ranges.push(Range::new(start, left.len()));
+                                    continue 'outer;
+                                } else {
+                                    left.push(c);
+                                    left.push(cc);
+                                }
+                            } else {
+                                left.push(c);
+                            }
+                        } else {
+                            left.push(c);
+                        }
+                    }
+                    panic!("missing end `|)#` {left:?} {s:?}");
                 }
-            };
-            false
-        })
-        .collect();
-    if head.is_some() {
-        panic!("missing anchor (|) {s:?}");
-    }
-    if anchor.is_some() {
-        panic!("missing head (^) {s:?}");
+            } else {
+                left.push(c);
+            }
+        } else {
+            left.push(c);
+        }
     }
     let primary = match primary {
         Some(i) => i,
-        None => panic!("missing primary (@) {s:?}"),
+        None => panic!("missing primary `#[|]#` {s:?}"),
     };
     let selection = Selection::new(ranges, primary);
-    (s, selection)
+    (left, selection)
 }
 
 /// Convert test string and selection to annotated test string.
 ///
-/// `^` for `anchor` and `|` for head (`@` for primary).
+/// `#[|` for primary selection with head before anchor followed by `]#`.
+/// `#(|` for secondary selection with head before anchor followed by `)#`.
+/// `#[` for primary selection with head after anchor followed by `|]#`.
+/// `#(` for secondary selection with head after anchor followed by `|)#`.
 ///
 /// # Examples
 ///
@@ -85,28 +132,30 @@ pub fn print(s: &str) -> (String, Selection) {
 ///
 /// assert_eq!(
 ///     plain("abc", Selection::new(smallvec![Range::new(0, 1), Range::new(3, 2)], 0)),
-///     "^a@b|c^".to_owned()
+///     "#[a|]#b#(|c)#".to_owned()
 /// );
 /// ```
 pub fn plain(s: &str, selection: Selection) -> String {
     let primary = selection.primary_index();
-    let mut out = String::with_capacity(s.len() + 2 * selection.len());
+    let mut out = String::with_capacity(s.len() + 5 * selection.len());
     out.push_str(s);
     let mut insertion: Vec<_> = selection
         .iter()
         .enumerate()
         .flat_map(|(i, range)| {
-            [
-                // sort like this before reversed so anchor < head later
-                (range.head, if i == primary { '@' } else { '|' }),
-                (range.anchor, '^'),
-            ]
+            // sort like this before reversed so anchor < head later
+            match (range.anchor < range.head, i == primary) {
+                (true, true) => [(range.anchor, "#["), (range.head, "|]#")],
+                (true, false) => [(range.anchor, "#("), (range.head, "|)#")],
+                (false, true) => [(range.anchor, "]#"), (range.head, "#[|")],
+                (false, false) => [(range.anchor, ")#"), (range.head, "#(|")],
+            }
         })
         .collect();
     // insert in reverse order
     insertion.sort_unstable_by_key(|k| Reverse(k.0));
-    for (i, c) in insertion {
-        out.insert(i, c);
+    for (i, s) in insertion {
+        out.insert_str(i, s);
     }
     out
 }

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -45,6 +45,7 @@ pub fn print(s: &str) -> (String, Selection) {
             Some('[') => (true, ']'),
             Some('(') => (false, ')'),
             Some(ch) => {
+                left.push('#');
                 left.push(ch);
                 continue;
             }

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -97,8 +97,9 @@ pub fn plain(s: &str, selection: Selection) -> String {
         .enumerate()
         .flat_map(|(i, range)| {
             [
-                (range.anchor, '^'),
+                // sort like this before reversed so anchor < head later
                 (range.head, if i == primary { '@' } else { '|' }),
+                (range.anchor, '^'),
             ]
         })
         .collect();

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -1,0 +1,111 @@
+//! Test helpers.
+use crate::{Range, Selection};
+use smallvec::SmallVec;
+use std::cmp::Reverse;
+
+/// Convert annotated test string to test string and selection.
+///
+/// `^` for `anchor` and `|` for head (`@` for primary), both must appear
+/// or otherwise it will panic.
+///
+/// # Examples
+///
+/// ```
+/// use helix_core::{Range, Selection, test::print};
+/// use smallvec::smallvec;
+///
+/// assert_eq!(
+///     print("^a@b|c^"),
+///     ("abc".to_owned(), Selection::new(smallvec![Range::new(0, 1), Range::new(3, 2)], 0))
+/// );
+/// ```
+///
+/// # Panics
+///
+/// Panics when missing primary or appeared more than once.
+/// Panics when missing head or anchor.
+/// Panics when head come after head or anchor come after anchor.
+pub fn print(s: &str) -> (String, Selection) {
+    let mut anchor = None;
+    let mut head = None;
+    let mut primary = None;
+    let mut ranges = SmallVec::new();
+    let mut i = 0;
+    let s = s
+        .chars()
+        .filter(|c| {
+            match c {
+                '^' if anchor != None => panic!("anchor without head {s:?}"),
+                '^' if head == None => anchor = Some(i),
+                '^' => ranges.push(Range::new(i, head.take().unwrap())),
+                '|' if head != None => panic!("head without anchor {s:?}"),
+                '|' if anchor == None => head = Some(i),
+                '|' => ranges.push(Range::new(anchor.take().unwrap(), i)),
+                '@' if primary != None => panic!("head (primary) already appeared {s:?}"),
+                '@' if head != None => panic!("head (primary) without anchor {s:?}"),
+                '@' if anchor == None => {
+                    primary = Some(ranges.len());
+                    head = Some(i);
+                }
+                '@' => {
+                    primary = Some(ranges.len());
+                    ranges.push(Range::new(anchor.take().unwrap(), i));
+                }
+                _ => {
+                    i += 1;
+                    return true;
+                }
+            };
+            false
+        })
+        .collect();
+    if head.is_some() {
+        panic!("missing anchor (|) {s:?}");
+    }
+    if anchor.is_some() {
+        panic!("missing head (^) {s:?}");
+    }
+    let primary = match primary {
+        Some(i) => i,
+        None => panic!("missing primary (@) {s:?}"),
+    };
+    let selection = Selection::new(ranges, primary);
+    (s, selection)
+}
+
+/// Convert test string and selection to annotated test string.
+///
+/// `^` for `anchor` and `|` for head (`@` for primary).
+///
+/// # Examples
+///
+/// ```
+/// use helix_core::{Range, Selection, test::plain};
+/// use smallvec::smallvec;
+///
+/// assert_eq!(
+///     plain("abc", Selection::new(smallvec![Range::new(0, 1), Range::new(3, 2)], 0)),
+///     "^a@b|c^".to_owned()
+/// );
+/// ```
+pub fn plain(s: &str, selection: Selection) -> String {
+    let primary = selection.primary_index();
+    let mut out = String::with_capacity(s.len() + 2 * selection.len());
+    out.push_str(s);
+    let mut insertion: Vec<_> = selection
+        .iter()
+        .enumerate()
+        .flat_map(|(i, range)| {
+            [
+                (range.anchor, '^'),
+                (range.head, if i == primary { '@' } else { '|' }),
+            ]
+        })
+        .collect();
+    // insert in reverse order
+    insertion.sort_unstable_by_key(|k| Reverse(k.0));
+    for (i, c) in insertion {
+        out.insert(i, c);
+    }
+    out
+}

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -357,18 +357,21 @@ mod test {
     #[test]
     fn test_textobject_paragraph_inside_single() {
         let tests = [
-            ("^@", "^@"),
-            ("firs^t@\n\nparagraph\n\n", "^first\n@\nparagraph\n\n"),
-            ("second\n\npa^r@agraph\n\n", "second\n\n^paragraph\n@\n"),
-            ("^f@irst char\n\n", "^first char\n@\n"),
-            ("last char\n^\n@", "last char\n\n^@"),
+            ("#[|]#", "#[|]#"),
+            ("firs#[t|]#\n\nparagraph\n\n", "#[first\n|]#\nparagraph\n\n"),
             (
-                "empty to line\n^\n@paragraph boundary\n\n",
-                "empty to line\n\n^paragraph boundary\n@\n",
+                "second\n\npa#[r|]#agraph\n\n",
+                "second\n\n#[paragraph\n|]#\n",
+            ),
+            ("#[f|]#irst char\n\n", "#[first char\n|]#\n"),
+            ("last char\n#[\n|]#", "last char\n\n#[|]#"),
+            (
+                "empty to line\n#[\n|]#paragraph boundary\n\n",
+                "empty to line\n\n#[paragraph boundary\n|]#\n",
             ),
             (
-                "line to empty\n\n^p@aragraph boundary\n\n",
-                "line to empty\n\n^paragraph boundary\n@\n",
+                "line to empty\n\n#[p|]#aragraph boundary\n\n",
+                "line to empty\n\n#[paragraph boundary\n|]#\n",
             ),
         ];
 
@@ -386,12 +389,12 @@ mod test {
     fn test_textobject_paragraph_inside_double() {
         let tests = [
             (
-                "last two\n\n^p@aragraph\n\nwithout whitespaces\n\n",
-                "last two\n\n^paragraph\n\nwithout whitespaces\n@\n",
+                "last two\n\n#[p|]#aragraph\n\nwithout whitespaces\n\n",
+                "last two\n\n#[paragraph\n\nwithout whitespaces\n|]#\n",
             ),
             (
-                "last two\n^\n@paragraph\n\nwithout whitespaces\n\n",
-                "last two\n\n^paragraph\n\nwithout whitespaces\n@\n",
+                "last two\n#[\n|]#paragraph\n\nwithout whitespaces\n\n",
+                "last two\n\n#[paragraph\n\nwithout whitespaces\n|]#\n",
             ),
         ];
 
@@ -408,18 +411,21 @@ mod test {
     #[test]
     fn test_textobject_paragraph_around_single() {
         let tests = [
-            ("^@", "^@"),
-            ("firs^t@\n\nparagraph\n\n", "^first\n\n@paragraph\n\n"),
-            ("second\n\npa^r@agraph\n\n", "second\n\n^paragraph\n\n@"),
-            ("^f@irst char\n\n", "^first char\n\n@"),
-            ("last char\n^\n@", "last char\n\n^@"),
+            ("#[|]#", "#[|]#"),
+            ("firs#[t|]#\n\nparagraph\n\n", "#[first\n\n|]#paragraph\n\n"),
             (
-                "empty to line\n^\n@paragraph boundary\n\n",
-                "empty to line\n\n^paragraph boundary\n\n@",
+                "second\n\npa#[r|]#agraph\n\n",
+                "second\n\n#[paragraph\n\n|]#",
+            ),
+            ("#[f|]#irst char\n\n", "#[first char\n\n|]#"),
+            ("last char\n#[\n|]#", "last char\n\n#[|]#"),
+            (
+                "empty to line\n#[\n|]#paragraph boundary\n\n",
+                "empty to line\n\n#[paragraph boundary\n\n|]#",
             ),
             (
-                "line to empty\n\n^p@aragraph boundary\n\n",
-                "line to empty\n\n^paragraph boundary\n\n@",
+                "line to empty\n\n#[p|]#aragraph boundary\n\n",
+                "line to empty\n\n#[paragraph boundary\n\n|]#",
             ),
         ];
 

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -4,7 +4,8 @@ use ropey::RopeSlice;
 use tree_sitter::{Node, QueryCursor};
 
 use crate::chars::{categorize_char, char_is_whitespace, CharCategory};
-use crate::graphemes::next_grapheme_boundary;
+use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
+use crate::line_ending::rope_is_line_ending;
 use crate::movement::Direction;
 use crate::surround;
 use crate::syntax::LanguageConfiguration;
@@ -109,6 +110,71 @@ pub fn textobject_word(
         }
         TextObject::Movement => unreachable!(),
     }
+}
+
+pub fn textobject_para(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    count: usize,
+) -> Range {
+    let mut line = range.cursor_line(slice);
+    let prev_line_empty = rope_is_line_ending(slice.line(line.saturating_sub(1)));
+    let curr_line_empty = rope_is_line_ending(slice.line(line));
+    let next_line_empty = rope_is_line_ending(slice.line(line.saturating_sub(1)));
+    let last_char =
+        prev_grapheme_boundary(slice, slice.line_to_char(line + 1)) == range.cursor(slice);
+    let prev_empty_to_line = prev_line_empty && !curr_line_empty;
+    let curr_empty_to_line = curr_line_empty && !next_line_empty;
+
+    // skip character before paragraph boundary
+    let mut line_back = line; // line but backwards
+    if prev_empty_to_line || curr_empty_to_line {
+        line_back += 1;
+    }
+    let mut lines = slice.lines_at(line_back);
+    // do not include current paragraph on paragraph end (include next)
+    if !(curr_empty_to_line && last_char) {
+        lines.reverse();
+        let mut lines = lines.map(rope_is_line_ending).peekable();
+        while lines.next_if(|&e| e).is_some() {
+            line_back -= 1;
+        }
+        while lines.next_if(|&e| !e).is_some() {
+            line_back -= 1;
+        }
+    }
+
+    // skip character after paragraph boundary
+    if curr_empty_to_line && last_char {
+        line += 1;
+    }
+    let mut lines = slice.lines_at(line).map(rope_is_line_ending).peekable();
+    for _ in 0..count - 1 {
+        while lines.next_if(|&e| !e).is_some() {
+            line += 1;
+        }
+        while lines.next_if(|&e| e).is_some() {
+            line += 1;
+        }
+    }
+    while lines.next_if(|&e| !e).is_some() {
+        line += 1;
+    }
+    // handle last whitespaces part separately depending on textobject
+    match textobject {
+        TextObject::Around => {
+            while lines.next_if(|&e| e).is_some() {
+                line += 1;
+            }
+        }
+        TextObject::Inside => {}
+        TextObject::Movement => unreachable!(),
+    }
+
+    let anchor = slice.line_to_char(line_back);
+    let head = slice.line_to_char(line);
+    Range::new(anchor, head)
 }
 
 pub fn textobject_surround(
@@ -285,6 +351,85 @@ mod test {
                     case
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_textobject_paragraph_inside_single() {
+        let tests = [
+            ("^@", "^@"),
+            ("firs^t@\n\nparagraph\n\n", "^first\n@\nparagraph\n\n"),
+            ("second\n\npa^r@agraph\n\n", "second\n\n^paragraph\n@\n"),
+            ("^f@irst char\n\n", "^first char\n@\n"),
+            ("last char\n^\n@", "last char\n\n^@"),
+            (
+                "empty to line\n^\n@paragraph boundary\n\n",
+                "empty to line\n\n^paragraph boundary\n@\n",
+            ),
+            (
+                "line to empty\n\n^p@aragraph boundary\n\n",
+                "line to empty\n\n^paragraph boundary\n@\n",
+            ),
+        ];
+
+        for (before, expected) in tests {
+            let (s, selection) = crate::test::print(before);
+            let text = Rope::from(s.as_str());
+            let selection =
+                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Inside, 1));
+            let actual = crate::test::plain(&s, selection);
+            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+        }
+    }
+
+    #[test]
+    fn test_textobject_paragraph_inside_double() {
+        let tests = [
+            (
+                "last two\n\n^p@aragraph\n\nwithout whitespaces\n\n",
+                "last two\n\n^paragraph\n\nwithout whitespaces\n@\n",
+            ),
+            (
+                "last two\n^\n@paragraph\n\nwithout whitespaces\n\n",
+                "last two\n\n^paragraph\n\nwithout whitespaces\n@\n",
+            ),
+        ];
+
+        for (before, expected) in tests {
+            let (s, selection) = crate::test::print(before);
+            let text = Rope::from(s.as_str());
+            let selection =
+                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Inside, 2));
+            let actual = crate::test::plain(&s, selection);
+            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+        }
+    }
+
+    #[test]
+    fn test_textobject_paragraph_around_single() {
+        let tests = [
+            ("^@", "^@"),
+            ("firs^t@\n\nparagraph\n\n", "^first\n\n@paragraph\n\n"),
+            ("second\n\npa^r@agraph\n\n", "second\n\n^paragraph\n\n@"),
+            ("^f@irst char\n\n", "^first char\n\n@"),
+            ("last char\n^\n@", "last char\n\n^@"),
+            (
+                "empty to line\n^\n@paragraph boundary\n\n",
+                "empty to line\n\n^paragraph boundary\n\n@",
+            ),
+            (
+                "line to empty\n\n^p@aragraph boundary\n\n",
+                "line to empty\n\n^paragraph boundary\n\n@",
+            ),
+        ];
+
+        for (before, expected) in tests {
+            let (s, selection) = crate::test::print(before);
+            let text = Rope::from(s.as_str());
+            let selection =
+                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Around, 1));
+            let actual = crate::test::plain(&s, selection);
+            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
     }
 

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -112,7 +112,7 @@ pub fn textobject_word(
     }
 }
 
-pub fn textobject_para(
+pub fn textobject_paragraph(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
@@ -378,8 +378,8 @@ mod test {
         for (before, expected) in tests {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
-            let selection =
-                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Inside, 1));
+            let selection = selection
+                .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Inside, 1));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -401,8 +401,8 @@ mod test {
         for (before, expected) in tests {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
-            let selection =
-                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Inside, 2));
+            let selection = selection
+                .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Inside, 2));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }
@@ -432,8 +432,8 @@ mod test {
         for (before, expected) in tests {
             let (s, selection) = crate::test::print(before);
             let text = Rope::from(s.as_str());
-            let selection =
-                selection.transform(|r| textobject_para(text.slice(..), r, TextObject::Around, 1));
+            let selection = selection
+                .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Around, 1));
             let actual = crate::test::plain(&s, selection);
             assert_eq!(actual, expected, "\nbefore: `{before:?}`");
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -208,6 +208,8 @@ impl MappableCommand {
         move_next_long_word_start, "Move to beginning of next long word",
         move_prev_long_word_start, "Move to beginning of previous long word",
         move_next_long_word_end, "Move to end of next long word",
+        move_prev_para, "Move to previous paragraph",
+        move_next_para, "Move to next paragraph",
         extend_next_word_start, "Extend to beginning of next word",
         extend_prev_word_start, "Extend to beginning of previous word",
         extend_next_long_word_start, "Extend to beginning of next long word",
@@ -899,6 +901,34 @@ fn move_prev_long_word_start(cx: &mut Context) {
 
 fn move_next_long_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_long_word_end)
+}
+
+fn move_para_impl<F>(cx: &mut Context, move_fn: F)
+where
+    F: Fn(RopeSlice, Range, usize, Movement) -> Range,
+{
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let behavior = if doc.mode == Mode::Select {
+        Movement::Extend
+    } else {
+        Movement::Move
+    };
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|range| move_fn(text, range, count, behavior));
+    doc.set_selection(view.id, selection);
+}
+
+fn move_prev_para(cx: &mut Context) {
+    move_para_impl(cx, movement::move_prev_para)
+}
+
+fn move_next_para(cx: &mut Context) {
+    move_para_impl(cx, movement::move_next_para)
 }
 
 fn goto_file_start(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -208,8 +208,8 @@ impl MappableCommand {
         move_next_long_word_start, "Move to beginning of next long word",
         move_prev_long_word_start, "Move to beginning of previous long word",
         move_next_long_word_end, "Move to end of next long word",
-        move_prev_para, "Move to previous paragraph",
-        move_next_para, "Move to next paragraph",
+        move_prev_paragraph, "Move to previous paragraph",
+        move_next_paragraph, "Move to next paragraph",
         extend_next_word_start, "Extend to beginning of next word",
         extend_prev_word_start, "Extend to beginning of previous word",
         extend_next_long_word_start, "Extend to beginning of next long word",
@@ -923,12 +923,12 @@ where
     doc.set_selection(view.id, selection);
 }
 
-fn move_prev_para(cx: &mut Context) {
-    move_para_impl(cx, movement::move_prev_para)
+fn move_prev_paragraph(cx: &mut Context) {
+    move_para_impl(cx, movement::move_prev_paragraph)
 }
 
-fn move_next_para(cx: &mut Context) {
-    move_para_impl(cx, movement::move_next_para)
+fn move_next_paragraph(cx: &mut Context) {
+    move_para_impl(cx, movement::move_next_paragraph)
 }
 
 fn goto_file_start(cx: &mut Context) {
@@ -3992,7 +3992,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),
                         'o' => textobject_treesitter("comment", range),
-                        'p' => textobject::textobject_para(text, range, objtype, count),
+                        'p' => textobject::textobject_paragraph(text, range, objtype, count),
                         'm' => {
                             let ch = text.char(range.cursor(text));
                             if !ch.is_ascii_alphanumeric() {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3992,6 +3992,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),
                         'o' => textobject_treesitter("comment", range),
+                        'p' => textobject::textobject_para(text, range, objtype, count),
                         'm' => {
                             let ch = text.char(range.cursor(text));
                             if !ch.is_ascii_alphanumeric() {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -104,7 +104,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_prev_class,
             "a" => goto_prev_parameter,
             "o" => goto_prev_comment,
-            "p" => move_prev_para,
+            "p" => move_prev_paragraph,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -114,7 +114,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_next_class,
             "a" => goto_next_parameter,
             "o" => goto_next_comment,
-            "p" => move_next_para,
+            "p" => move_next_paragraph,
             "space" => add_newline_below,
         },
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -104,6 +104,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_prev_class,
             "a" => goto_prev_parameter,
             "o" => goto_prev_comment,
+            "p" => move_prev_para,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -113,6 +114,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_next_class,
             "a" => goto_next_parameter,
             "o" => goto_next_comment,
+            "p" => move_next_para,
             "space" => add_newline_below,
         },
 


### PR DESCRIPTION
Also improved testing facility.

Fix #1580
Superseeds #784

Although this is not done I think it would be good to help review the new test helpers.

# TODO

- [x] prev paragraph (test)
- [x] next paragraph
- [x] inside/around paragraph
- [ ] support extend mode?

Not sure if we want to support extend mode for this even though inspiration is taken from kakoune, kakoune does not have extend mode but we have that, maybe we can make use of it to extend an additional paragraph? I didn't do it since I don't think I need it.