### PR TITLE
use PathBuf::to_string_lossy() instead of to_str()

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1774,9 +1774,8 @@ fn global_search(cx: &mut Context) {
                     all_matches,
                     move |(_line_num, path)| {
                         let relative_path = helix_core::path::get_relative_path(path)
-                            .to_str()
-                            .unwrap()
-                            .to_owned();
+                            .to_string_lossy()
+                            .into_owned();
                         if current_path.as_ref().map(|p| p == path).unwrap_or(false) {
                             format!("{} (*)", relative_path).into()
                         } else {
@@ -3446,9 +3445,8 @@ fn workspace_symbol_picker(cx: &mut Context) {
                             (&symbol.name).into()
                         } else {
                             let relative_path = helix_core::path::get_relative_path(path.as_path())
-                                .to_str()
-                                .unwrap()
-                                .to_owned();
+                                .to_string_lossy()
+                                .into_owned();
                             format!("{} ({})", &symbol.name, relative_path).into()
                         }
                     },
@@ -4119,8 +4117,8 @@ fn goto_impl(
                                         .map(|path| path.to_path_buf())
                                         .unwrap_or(path)
                                 })
+                                .map(|path| Cow::from(path.to_string_lossy().into_owned()))
                                 .ok()
-                                .and_then(|path| path.to_str().map(|path| path.to_owned().into()))
                         })
                         .flatten()
                         .unwrap_or_else(|| location.uri.as_str().into());

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -155,11 +155,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
         files,
         move |path: &PathBuf| {
             // format_fn
-            path.strip_prefix(&root)
-                .unwrap_or(path)
-                .to_str()
-                .unwrap()
-                .into()
+            path.strip_prefix(&root).unwrap_or(path).to_string_lossy()
         },
         move |editor: &mut Editor, path: &PathBuf, action| {
             editor
@@ -288,7 +284,7 @@ pub mod completers {
         } else {
             let file_name = path
                 .file_name()
-                .map(|file| file.to_str().unwrap().to_owned());
+                .and_then(|file| file.to_str().map(|path| path.to_owned()));
 
             let path = match path.parent() {
                 Some(path) if !path.as_os_str().is_empty() => path.to_path_buf(),
@@ -331,7 +327,7 @@ pub mod completers {
                         path.push("");
                     }
 
-                    let path = path.to_str().unwrap().to_owned();
+                    let path = path.to_str()?.to_owned();
                     Some((end.clone(), Cow::from(path)))
                 })
             }) // TODO: unwrap or skip


### PR DESCRIPTION
Fixes #1646 #1569

Also preemptively changes other uses of `as_str()` because they look like places where a similar panic would happen.