### PR TITLE
refactor: postpone the clone of iterator

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -445,8 +445,8 @@ impl std::str::FromStr for MappableCommand {
         } else {
             MappableCommand::STATIC_COMMAND_LIST
                 .iter()
-                .cloned()
                 .find(|cmd| cmd.name() == s)
+                .cloned()
                 .ok_or_else(|| anyhow!("No command named '{}'", s))
         }
     }


### PR DESCRIPTION
I've been reading the source code of the helix and noticed that there is one unnecessary clone of the iterator. The clone can be placed after the name is matched to make the matching more efficient. 