### PR TITLE
add tree-sitter-erlang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,3 +226,6 @@
 	path = helix-syntax/languages/tree-sitter-rescript
 	url = https://github.com/jaredramirez/tree-sitter-rescript
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-erlang"]
+	path = helix-syntax/languages/tree-sitter-erlang
+	url = https://github.com/the-mikedavis/tree-sitter-erlang

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -11,6 +11,7 @@
 | dockerfile | ✓ |  |  | `docker-langserver` |
 | elixir | ✓ |  |  | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |
+| erlang | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
 | git-commit | ✓ |  |  |  |
 | git-config | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -613,3 +613,12 @@ auto-format = true
 comment-token = "//"
 language-server = { command = "rescript-language-server", args = ["--stdio"] }
 indent = { tab-width = 2, unit = "  " }
+
+[[language]]
+name = "erlang"
+scope = "source.erlang"
+injection-regex = "^erl$"
+file-types = ["erl", "hrl", "app", "rebar.config"]
+roots = ["rebar.config"]
+comment-token = "%%"
+indent = { tab-width = 4, unit = "    " }

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -1,0 +1,118 @@
+; Attributes
+; module declaration
+(attribute
+  name: (atom) @keyword
+  (arguments (atom) @module)
+ (#eq? @keyword "module"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    (atom) @module)
+ (#eq? @keyword "import"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    (atom) @type
+    [
+      (tuple (atom) @variable.other.member)
+      (tuple
+        (binary_operator
+          left: (atom) @variable.other.member
+          operator: "="))
+      (tuple
+        (binary_operator
+          left:
+            (binary_operator
+              left: (atom) @variable.other.member
+              operator: "=")
+          operator: "::"))
+      ])
+ (#eq? @keyword "record"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    [
+      (atom) @keyword.directive
+      (variable) @keyword.directive
+      (call
+        function:
+          [(variable) (atom)] @keyword.directive)
+    ])
+ (#eq? @keyword "define"))
+
+(attribute
+  name: (atom) @keyword
+  module: (atom) @module
+ (#eq? @keyword "spec"))
+
+; Functions
+(function name: (atom) @function)
+(call module: (atom) @module)
+(call function: (atom) @function)
+(stab_clause name: (atom) @function)
+(function_capture module: (atom) @module)
+(function_capture function: (atom) @function)
+
+; Records
+(record_content
+  (binary_operator
+    left: (atom) @variable.other.member
+    operator: "="))
+
+(record field: (atom) @variable.other.member)
+(record name: (atom) @type)
+
+; Keywords
+((attribute name: (atom) @keyword)
+ (#match?
+  @keyword
+  "^(define|export|export_type|include|include_lib|ifdef|ifndef|if|elif|else|endif|vsn|on_load|behaviour|record|file|type|opaque|spec)$"))
+
+["case" "fun" "if" "of" "when" "end" "receive" "try" "catch" "after"] @keyword
+
+; Operators
+(binary_operator
+  left: (atom) @function
+  operator: "/"
+  right: (integer) @constant.numeric.integer)
+
+(binary_operator operator: _ @operator)
+(unary_operator operator: _ @operator)
+["/" ":" "#" "->"] @operator
+
+; Comments
+((variable) @comment.discard
+ (#match? @comment.discard "^_"))
+
+(tripledot) @comment.discard
+
+(comment) @comment
+
+; Macros
+(macro
+  "?"+ @keyword.directive
+  name: (_) @keyword.directive)
+
+; Basic types
+(variable) @variable
+[
+  (atom)
+  (quoted_atom)
+] @string.special.symbol
+(string) @string
+(character) @constant.character
+
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+; Punctuation
+["," "." "-" ";"] @punctuation.delimiter
+["(" ")" "{" "}" "[" "]" "<<" ">>"] @punctuation.bracket
+
+; (ERROR) @error

--- a/runtime/queries/erlang/injections.scm
+++ b/runtime/queries/erlang/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
I was touching up a fork of [AbstractMachinesLab/tree-sitter-erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang/) for a while but I ended up writing from scratch to fix some composability problems with the rules. That also gave me an opportunity to structure the rules a bit more "tree-like", so this grammar responds well to the `A-j/k/h/l` motions:

https://user-images.githubusercontent.com/21230295/153741374-a2754163-c9db-4011-8dae-6512343106d0.mp4

playground: https://the-mikedavis.github.io/tree-sitter-erlang/

I know that there's an Erlang LSP but I haven't tried it out yet. I'll make a follow-up PR if my tests go well.