### PR TITLE
Add confirmation message on write

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2130,6 +2130,7 @@ pub mod cmd {
             let id = doc.id();
             let _ = cx.editor.refresh_language_server(id);
         }
+        cx.editor.set_status("File written.");
         Ok(())
     }
 


### PR DESCRIPTION
This simple commit adds a confirmation message when you write (`:w`)

Resolves #1672 
