### PR TITLE
helix-term build: check git command's exit code

### DIFF
--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -6,6 +6,7 @@ fn main() {
         .args(&["rev-parse", "HEAD"])
         .output()
         .ok()
+        .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok());
 
     let version: Cow<_> = match git_hash {


### PR DESCRIPTION
Noticed this when building with a derivation very similar to the one in nixpkgs (https://github.com/the-mikedavis/dotfiles/blob/4767713774fb87b369725585719c75c334ca92a0/overlays/helix.nix): the git hash comes out to the empty string :thinking:. The next line takes a `[..8]` slice of the string so it ends up panicing.

In this case I think it makes sense to leave the revision out of the version string.