### PR TITLE
Implement bulk buffer closing commands

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -5,6 +5,10 @@
 | `:open`, `:o` | Open a file from disk into the current view. |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully (ignoring unsaved changes). |
+| `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |
+| `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Close all buffers but the currently focused one. |
+| `:buffer-close-all`, `:bca`, `:bcloseall` | Close all buffers, without quiting. |
+| `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Close all buffers forcefully (ignoring unsaved changes), without quiting. |
 | `:write`, `:w` | Write changes to disk. Accepts an optional path (:write some/path.txt) |
 | `:new`, `:n` | Create a new scratch buffer. |
 | `:format`, `:fmt` | Format the file using the LSP formatter. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2118,7 +2118,7 @@ pub mod cmd {
 
         if !nonexistent_buffers.is_empty() {
             editor.set_error(format!(
-                "couldn't close the following buffer because they do not exist: {}",
+                "cannot close non-existent buffers: {}",
                 nonexistent_buffers.join(", ")
             ));
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2116,7 +2116,7 @@ pub mod cmd {
             }
         }
 
-        if nonexistent_buffers.len() != 0 {
+        if !nonexistent_buffers.is_empty() {
             editor.set_error(format!(
                 "couldn't close the following buffer because they do not exist: {}",
                 nonexistent_buffers.join(", ")

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2135,6 +2135,34 @@ pub mod cmd {
         buffer_close_impl(cx.editor, args, true)
     }
 
+    fn buffer_close_all(
+        cx: &mut compositor::Context,
+        _args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let all_documents: Vec<_> = cx.editor.documents().map(|doc| doc.id()).collect();
+
+        for doc_id in all_documents {
+            cx.editor.close_document(doc_id, false)?;
+        }
+
+        Ok(())
+    }
+
+    fn force_buffer_close_all(
+        cx: &mut compositor::Context,
+        _args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let all_documents: Vec<_> = cx.editor.documents().map(|doc| doc.id()).collect();
+
+        for doc_id in all_documents {
+            cx.editor.close_document(doc_id, true)?;
+        }
+
+        Ok(())
+    }
+
     fn write_impl(cx: &mut compositor::Context, path: Option<&Cow<str>>) -> anyhow::Result<()> {
         let jobs = &mut cx.jobs;
         let doc = doc_mut!(cx.editor);
@@ -2969,6 +2997,20 @@ pub mod cmd {
             doc: "Close the current buffer forcefully (ignoring unsaved changes).",
             fun: force_buffer_close,
           completer: Some(completers::buffer),
+        },
+        TypableCommand {
+            name: "buffer-close-all",
+            aliases: &["bca", "bcloseall"],
+            doc: "Close all buffers, without quiting.",
+            fun: buffer_close_all,
+            completer: None,
+        },
+        TypableCommand {
+            name: "buffer-close-all!",
+            aliases: &["bca!", "bcloseall!"],
+            doc: "Close all buffers forcefully (ignoring unsaved changes), without quiting.",
+            fun: force_buffer_close_all,
+            completer: None,
         },
         TypableCommand {
             name: "write",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2135,6 +2135,42 @@ pub mod cmd {
         buffer_close_impl(cx.editor, args, true)
     }
 
+    fn buffer_close_others(
+        cx: &mut compositor::Context,
+        _args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let all_documents: Vec<_> = cx.editor.documents().map(|doc| doc.id()).collect();
+        let current_document = &doc!(cx.editor).id();
+
+        for doc_id in all_documents
+            .into_iter()
+            .filter(|doc_id| doc_id != current_document)
+        {
+            cx.editor.close_document(doc_id, false)?;
+        }
+
+        Ok(())
+    }
+
+    fn force_buffer_close_others(
+        cx: &mut compositor::Context,
+        _args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let all_documents: Vec<_> = cx.editor.documents().map(|doc| doc.id()).collect();
+        let current_document = &doc!(cx.editor).id();
+
+        for doc_id in all_documents
+            .into_iter()
+            .filter(|doc_id| doc_id != current_document)
+        {
+            cx.editor.close_document(doc_id, true)?;
+        }
+
+        Ok(())
+    }
+
     fn buffer_close_all(
         cx: &mut compositor::Context,
         _args: &[Cow<str>],
@@ -2997,6 +3033,20 @@ pub mod cmd {
             doc: "Close the current buffer forcefully (ignoring unsaved changes).",
             fun: force_buffer_close,
           completer: Some(completers::buffer),
+        },
+        TypableCommand {
+            name: "buffer-close-others",
+            aliases: &["bco", "bcloseother"],
+            doc: "Close all buffers but the currently focused one.",
+            fun: buffer_close_others,
+            completer: None,
+        },
+        TypableCommand {
+            name: "buffer-close-others!",
+            aliases: &["bco!", "bcloseother!"],
+            doc: "Close all buffers but the currently focused one.",
+            fun: force_buffer_close_others,
+            completer: None,
         },
         TypableCommand {
             name: "buffer-close-all",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2144,9 +2144,9 @@ pub mod cmd {
         buffer_close_by_ids_impl(cx.editor, document_ids, true)
     }
 
-    fn buffer_gather_others_impl(cx: &mut compositor::Context) -> Vec<DocumentId> {
-        let current_document = &doc!(cx.editor).id();
-        cx.editor
+    fn buffer_gather_others_impl(editor: &mut Editor) -> Vec<DocumentId> {
+        let current_document = &doc!(editor).id();
+        editor
             .documents()
             .map(|doc| doc.id())
             .filter(|doc_id| doc_id != current_document)
@@ -2158,7 +2158,7 @@ pub mod cmd {
         _args: &[Cow<str>],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        let document_ids = buffer_gather_others_impl(cx);
+        let document_ids = buffer_gather_others_impl(cx.editor);
         buffer_close_by_ids_impl(cx.editor, document_ids, false)
     }
 
@@ -2167,12 +2167,12 @@ pub mod cmd {
         _args: &[Cow<str>],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        let document_ids = buffer_gather_others_impl(cx);
+        let document_ids = buffer_gather_others_impl(cx.editor);
         buffer_close_by_ids_impl(cx.editor, document_ids, true)
     }
 
-    fn buffer_gather_all_impl(cx: &mut compositor::Context) -> Vec<DocumentId> {
-        cx.editor.documents().map(|doc| doc.id()).collect()
+    fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
+        editor.documents().map(|doc| doc.id()).collect()
     }
 
     fn buffer_close_all(
@@ -2180,7 +2180,7 @@ pub mod cmd {
         _args: &[Cow<str>],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        let document_ids = buffer_gather_all_impl(cx);
+        let document_ids = buffer_gather_all_impl(cx.editor);
         buffer_close_by_ids_impl(cx.editor, document_ids, false)
     }
 
@@ -2189,7 +2189,7 @@ pub mod cmd {
         _args: &[Cow<str>],
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
-        let document_ids = buffer_gather_all_impl(cx);
+        let document_ids = buffer_gather_all_impl(cx.editor);
         buffer_close_by_ids_impl(cx.editor, document_ids, true)
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2079,10 +2079,10 @@ pub mod cmd {
 
     fn buffer_close_by_ids_impl(
         editor: &mut Editor,
-        doc_ids: impl IntoIterator<Item = DocumentId>,
+        doc_ids: &[DocumentId],
         force: bool,
     ) -> anyhow::Result<()> {
-        for doc_id in doc_ids {
+        for &doc_id in doc_ids {
             editor.close_document(doc_id, force)?;
         }
 
@@ -2132,7 +2132,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_paths_impl(cx.editor, args);
-        buffer_close_by_ids_impl(cx.editor, document_ids, false)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, false)
     }
 
     fn force_buffer_close(
@@ -2141,7 +2141,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_paths_impl(cx.editor, args);
-        buffer_close_by_ids_impl(cx.editor, document_ids, true)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, true)
     }
 
     fn buffer_gather_others_impl(editor: &mut Editor) -> Vec<DocumentId> {
@@ -2159,7 +2159,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_others_impl(cx.editor);
-        buffer_close_by_ids_impl(cx.editor, document_ids, false)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, false)
     }
 
     fn force_buffer_close_others(
@@ -2168,7 +2168,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_others_impl(cx.editor);
-        buffer_close_by_ids_impl(cx.editor, document_ids, true)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, true)
     }
 
     fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
@@ -2181,7 +2181,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_all_impl(cx.editor);
-        buffer_close_by_ids_impl(cx.editor, document_ids, false)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, false)
     }
 
     fn force_buffer_close_all(
@@ -2190,7 +2190,7 @@ pub mod cmd {
         _event: PromptEvent,
     ) -> anyhow::Result<()> {
         let document_ids = buffer_gather_all_impl(cx.editor);
-        buffer_close_by_ids_impl(cx.editor, document_ids, true)
+        buffer_close_by_ids_impl(cx.editor, &document_ids, true)
     }
 
     fn write_impl(cx: &mut compositor::Context, path: Option<&Cow<str>>) -> anyhow::Result<()> {


### PR DESCRIPTION
These are convenience methods for cleaning up accumulated buffers as described in #1637.

This could probably be further cleaned up to unify the buffer_close_impl in a way that works for all of the various buffer closing commands, but for now this is effective in my testing. Also I ran out of time, and wanted to get something up. Feel free to rip apart and I'll address later.