### PR TITLE
Add run_shell_command for Commands

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -49,3 +49,4 @@
 | `:sort` | Sort ranges in selection. |
 | `:rsort` | Sort ranges in selection in reverse order. |
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
+| `:run_shell_command`, `:sh` | Run a shell command |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2934,6 +2934,27 @@ pub mod cmd {
         Ok(())
     }
 
+    fn run_shell_command(
+        cx: &mut compositor::Context,
+        args: &[Cow<str>],
+        _event: PromptEvent,
+    ) -> anyhow::Result<()> {
+        let shell = &cx.editor.config.shell;
+        let (output, _success) = match shell_impl(shell, &args.join(" "), None) {
+            Ok(result) => result,
+            Err(err) => {
+                cx.editor.set_error(err.to_string());
+                return Ok(());
+            }
+        };
+
+        if !output.is_empty() {
+            cx.editor.autoinfo = Some(Info::from_string("Run shell command", output.to_string()));
+        }
+
+        Ok(())
+    }
+
     pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -3277,6 +3298,13 @@ pub mod cmd {
             doc: "Display tree sitter subtree under cursor, primarily for debugging queries.",
             fun: tree_sitter_subtree,
             completer: None,
+        },
+        TypableCommand {
+            name: "run_shell_command",
+            aliases: &["sh"],
+            doc: "Run a shell command",
+            fun: run_shell_command,
+            completer: Some(completers::directory),
         },
     ];
 

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -41,6 +41,24 @@ impl Info {
         }
     }
 
+    pub fn from_string(title: &str, body: String) -> Self {
+        if body.is_empty() {
+            return Self {
+                title: title.to_string(),
+                height: 1,
+                width: title.len() as u16,
+                text: "".to_string(),
+            };
+        }
+
+        Self {
+            title: title.to_string(),
+            width: body.lines().map(|l| l.width()).max().unwrap() as u16,
+            height: body.lines().count() as u16,
+            text: body,
+        }
+    }
+
     pub fn from_keymap(title: &str, body: Vec<(&str, BTreeSet<KeyEvent>)>) -> Self {
         let body = body
             .into_iter()


### PR DESCRIPTION
I added a command to run a shell command as discussed in #1541.
Just running, no piping, no inserting/appending

Output is displayed in the info area.

https://user-images.githubusercontent.com/5352478/154830334-dd34ad11-3b3f-4688-8202-8b20b776a2dd.mp4

