### PR TITLE
Implement LSP `workspace/configuration` and `workspace/didChangeConfiguration`

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -110,6 +110,10 @@ impl Client {
         self.offset_encoding
     }
 
+    pub fn config(&self) -> &Option<Value> {
+        &self.config
+    }
+
     /// Execute a RPC request on the language server.
     async fn request<R: lsp::request::Request>(&self, params: R::Params) -> Result<R::Result>
     where

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -110,8 +110,8 @@ impl Client {
         self.offset_encoding
     }
 
-    pub fn config(&self) -> &Option<Value> {
-        &self.config
+    pub fn config(&self) -> Option<&Value> {
+        self.config.as_ref()
     }
 
     /// Execute a RPC request on the language server.

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -245,6 +245,9 @@ impl Client {
             capabilities: lsp::ClientCapabilities {
                 workspace: Some(lsp::WorkspaceClientCapabilities {
                     configuration: Some(true),
+                    did_change_configuration: Some(lsp::DynamicRegistrationClientCapabilities {
+                        dynamic_registration: Some(false),
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {
@@ -329,6 +332,16 @@ impl Client {
             log::warn!("language server failed to terminate gracefully - {}", e);
         }
         self.exit().await
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Workspace
+    // -------------------------------------------------------------------------------------------
+
+    pub fn did_change_configuration(&self, settings: Value) -> impl Future<Output = Result<()>> {
+        self.notify::<lsp::notification::DidChangeConfiguration>(
+            lsp::DidChangeConfigurationParams { settings },
+        )
     }
 
     // -------------------------------------------------------------------------------------------

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -243,6 +243,10 @@ impl Client {
             root_uri: root,
             initialization_options: self.config.clone(),
             capabilities: lsp::ClientCapabilities {
+                workspace: Some(lsp::WorkspaceClientCapabilities {
+                    configuration: Some(true),
+                    ..Default::default()
+                }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {
                     completion: Some(lsp::CompletionClientCapabilities {
                         completion_item: Some(lsp::CompletionItemCapability {

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -191,6 +191,7 @@ pub mod util {
 pub enum MethodCall {
     WorkDoneProgressCreate(lsp::WorkDoneProgressCreateParams),
     ApplyWorkspaceEdit(lsp::ApplyWorkspaceEditParams),
+    WorkspaceConfiguration(lsp::ConfigurationParams),
 }
 
 impl MethodCall {
@@ -208,6 +209,12 @@ impl MethodCall {
                     .parse()
                     .expect("Failed to parse ApplyWorkspaceEdit params");
                 Self::ApplyWorkspaceEdit(params)
+            }
+            lsp::request::WorkspaceConfiguration::METHOD => {
+                let params: lsp::ConfigurationParams = params
+                    .parse()
+                    .expect("Failed to parse WorkspaceConfiguration params");
+                Self::WorkspaceConfiguration(params)
             }
             _ => {
                 log::warn!("unhandled lsp request: {}", method);


### PR DESCRIPTION
This partially fixes #1268, LSP configuration should now work with all servers (tested with texlab). Even though we don't yet allow for changing settings on the fly, providing the `workspace/didChangeConfiguration` capability has some advantages:

- Some servers might continuously request the configuration if the capability isn't defined, in case any settings change.
- The client receives the configuration even if it doesn't request it by itself, because we send a notification immediately after initialization. This is (probably) not required by the spec but Neovim does it as well.