### PR TITLE
Show infobox to hint textobjects with `mi` and `ma`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5353,6 +5353,7 @@ fn select_textobject_inner(cx: &mut Context) {
 
 fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     let count = cx.count();
+
     cx.on_next_key(move |cx, event| {
         if let Some(ch) = event.char() {
             let textobject = move |editor: &mut Editor| {
@@ -5400,9 +5401,33 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 doc.set_selection(view.id, selection);
             };
             textobject(cx.editor);
+            cx.editor.autoinfo = None;
             cx.editor.last_motion = Some(Motion(Box::new(textobject)));
         }
-    })
+    });
+
+    if let Some(title) = match objtype {
+        textobject::TextObject::Inside => Some("Match inside"),
+        textobject::TextObject::Around => Some("Match around"),
+        textobject::TextObject::Movement => None,
+    } {
+        let help_text = vec![
+            ("w", "Word"),
+            ("W", "WORD"),
+            ("c", "Class (tree-sitter)"),
+            ("f", "Function (tree-sitter)"),
+            ("p", "Parameter (tree-sitter)"),
+            ("m", "Matching delimiter under cursor"),
+        ];
+
+        cx.editor.autoinfo = Some(Info::new(
+            title,
+            help_text
+                .into_iter()
+                .map(|(col1, col2)| (col1.to_string(), col2.to_string()))
+                .collect(),
+        ));
+    };
 }
 
 fn surround_add(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5411,7 +5411,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         textobject::TextObject::Around => Some("Match around"),
         textobject::TextObject::Movement => None,
     } {
-        let help_text = vec![
+        let help_text = [
             ("w", "Word"),
             ("W", "WORD"),
             ("c", "Class (tree-sitter)"),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5418,7 +5418,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("f", "Function (tree-sitter)"),
             ("p", "Parameter (tree-sitter)"),
             ("m", "Matching delimiter under cursor"),
-            (" ", "Any opening or closing pair character"),
+            (" ", "... or any ascii character acting as a pair"),
         ];
 
         cx.editor.autoinfo = Some(Info::new(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5356,6 +5356,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
 
     cx.on_next_key(move |cx, event| {
         cx.editor.autoinfo = None;
+        cx.editor.pseudo_pending = None;
         if let Some(ch) = event.char() {
             let textobject = move |editor: &mut Editor| {
                 let (view, doc) = current!(editor);
@@ -5406,9 +5407,9 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         }
     });
 
-    if let Some(title) = match objtype {
-        textobject::TextObject::Inside => Some("Match inside"),
-        textobject::TextObject::Around => Some("Match around"),
+    if let Some((title, abbrev)) = match objtype {
+        textobject::TextObject::Inside => Some(("Match inside", "mi")),
+        textobject::TextObject::Around => Some(("Match around", "ma")),
         textobject::TextObject::Movement => None,
     } {
         let help_text = [
@@ -5428,6 +5429,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 .map(|(col1, col2)| (col1.to_string(), col2.to_string()))
                 .collect(),
         ));
+        cx.editor.pseudo_pending = Some(abbrev.to_string());
     };
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5418,6 +5418,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("f", "Function (tree-sitter)"),
             ("p", "Parameter (tree-sitter)"),
             ("m", "Matching delimiter under cursor"),
+            (" ", "Any opening or closing pair character"),
         ];
 
         cx.editor.autoinfo = Some(Info::new(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5410,7 +5410,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     if let Some((title, abbrev)) = match objtype {
         textobject::TextObject::Inside => Some(("Match inside", "mi")),
         textobject::TextObject::Around => Some(("Match around", "ma")),
-        textobject::TextObject::Movement => None,
+        _ => return,
     } {
         let help_text = [
             ("w", "Word"),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5419,7 +5419,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("f", "Function (tree-sitter)"),
             ("p", "Parameter (tree-sitter)"),
             ("m", "Matching delimiter under cursor"),
-            (" ", "... or any ascii character acting as a pair"),
+            (" ", "... or any character acting as a pair"),
         ];
 
         cx.editor.autoinfo = Some(Info::new(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5355,6 +5355,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     let count = cx.count();
 
     cx.on_next_key(move |cx, event| {
+        cx.editor.autoinfo = None;
         if let Some(ch) = event.char() {
             let textobject = move |editor: &mut Editor| {
                 let (view, doc) = current!(editor);
@@ -5401,7 +5402,6 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 doc.set_selection(view.id, selection);
             };
             textobject(cx.editor);
-            cx.editor.autoinfo = None;
             cx.editor.last_motion = Some(Motion(Box::new(textobject)));
         }
     });

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1211,6 +1211,9 @@ impl Component for EditorView {
                     disp.push_str(&s);
                 }
             }
+            if let Some(pseudo_pending) = &cx.editor.pseudo_pending {
+                disp.push_str(&*pseudo_pending)
+            }
             let style = cx.editor.theme.get("ui.text");
             let macro_width = if cx.editor.macro_recording.is_some() {
                 3

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1212,7 +1212,7 @@ impl Component for EditorView {
                 }
             }
             if let Some(pseudo_pending) = &cx.editor.pseudo_pending {
-                disp.push_str(&*pseudo_pending)
+                disp.push_str(pseudo_pending.as_str())
             }
             let style = cx.editor.theme.get("ui.text");
             let macro_width = if cx.editor.macro_recording.is_some() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -299,6 +299,7 @@ pub struct Editor {
 
     pub idle_timer: Pin<Box<Sleep>>,
     pub last_motion: Option<Motion>,
+    pub pseudo_pending: Option<String>,
 
     pub exit_code: i32,
 }
@@ -346,6 +347,7 @@ impl Editor {
             autoinfo: None,
             idle_timer: Box::pin(sleep(config.idle_timeout)),
             last_motion: None,
+            pseudo_pending: None,
             config,
             auto_pairs,
             exit_code: 0,


### PR DESCRIPTION
We should probably add to the status area as well, but this is a significant improvement in discoverability for textobject surround selection.