### PR TITLE
ignore Enter keypress when menu has no selection

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -231,8 +231,10 @@ impl<T: Item + 'static> Component for Menu<T> {
             key!(Enter) => {
                 if let Some(selection) = self.selection() {
                     (self.callback_fn)(cx.editor, Some(selection), MenuEvent::Validate);
+                    return close_fn;
+                } else {
+                    return EventResult::Ignored(None);
                 }
-                return close_fn;
             }
             // KeyEvent {
             //     code: KeyCode::Char(c),


### PR DESCRIPTION
supersedes #1622

Uses the new `EventResult` member introduced in #1285. I want to allow
Enter to create a newline when there is no selection in the autocomplete menu.

This occurs somewhat often when using LSP autocomplete in Elixir which
uses `do/end` blocks (and I set the autocomplete menu delay to 0 which
exacerbates the problem):

```elixir
defmodule MyModule do
  def do_foo(x) do
    x
  end
  def other_function(y) do|
end
```

Here the cursor is `|` in insert mode. The LSP suggests `do_foo` but I
want to create a newline. Hitting Enter currently closes the menu,
so I end up having to hit Enter twice when the module contains any
local with a `do` prefix, which can be inconsistent. With this change,
we ignore the Enter keypress to end up creating the newline in this case.