### PR TITLE
Add support for HCL language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -234,3 +234,7 @@
 	path = helix-syntax/languages/tree-sitter-kotlin
 	url = https://github.com/fwcd/tree-sitter-kotlin.git
 	shallow = true
+[submodule "helix-syntax/languages/tree-sitter-hcl"]
+	path = helix-syntax/languages/tree-sitter-hcl
+	url = https://github.com/MichaHoffmann/tree-sitter-hcl.git
+	shallow = true

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,6 +21,7 @@
 | go | ✓ | ✓ | ✓ | `gopls` |
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
+| hcl | ✓ |  | ✓ |  |
 | html | ✓ |  |  |  |
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -750,3 +750,12 @@ roots = ["settings.gradle", "settings.gradle.kts"]
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 language-server = { command = "kotlin-language-server" } 
+
+[[language]]
+name = "hcl"
+scope = "source.hcl"
+injection-regex = "(hcl|tf)"
+file-types = ["hcl", "tf"]
+roots = []
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }

--- a/runtime/queries/hcl/folds.scm
+++ b/runtime/queries/hcl/folds.scm
@@ -1,0 +1,6 @@
+[
+ (comment)
+ (block)
+ (heredoc_template)
+ (object)
+] @fold

--- a/runtime/queries/hcl/highlights.scm
+++ b/runtime/queries/hcl/highlights.scm
@@ -1,0 +1,100 @@
+(ERROR) @error
+
+; { key: val }
+
+(object_elem val: (expression
+  (variable_expr
+      (identifier) @type.builtin (#match? @type.builtin "^(bool|string|number|object|tuple|list|map|set|any)$"))))
+
+(get_attr (identifier) @variable.builtin (#match? @variable.builtin  "^(root|cwd|module)$"))
+(variable_expr (identifier) @variable.builtin (#match? @variable.builtin "^(var|local|path)$"))
+((identifier) @type.builtin (#match? @type.builtin "^(bool|string|number|object|tuple|list|map|set|any)$"))
+((identifier) @keyword (#match? @keyword "^(module|root|cwd|resource|variable|data|locals|terraform|provider|output)$"))
+
+; highlight identifier keys as though they were block attributes
+(object_elem key: (expression (variable_expr (identifier) @variable.other.member)))
+
+(attribute (identifier) @variable.other.member)
+(function_call (identifier) @function.method)
+(block (identifier) @type.builtin)
+
+(identifier) @variable
+(comment) @comment
+(null_lit) @constant.builtin
+(numeric_lit) @constant.number
+(bool_lit) @constant.builtin.boolean
+
+[
+  (template_interpolation_start) ; ${
+  (template_interpolation_end) ; }
+  (template_directive_start) ; %{
+  (template_directive_end) ; }
+  (strip_marker) ; ~
+] @punctuation.special
+
+[
+  (heredoc_identifier) ; <<END
+  (heredoc_start) ; END
+] @punctuation.delimiter
+
+[
+  (quoted_template_start) ; "
+  (quoted_template_end); "
+  (template_literal) ; non-interpolation/directive content
+] @string
+
+[ 
+  "if"
+  "else"
+  "endif"
+] @keyword.control.conditional
+
+[
+  "for"
+  "endfor"
+  "in"
+] @keyword.control.repeat
+
+[
+  ":"
+  "="
+] @none
+
+[
+  (ellipsis)
+  "\?"
+  "=>"
+] @punctuation.special
+
+[
+  "."
+  ".*"
+  ","
+  "[*]"
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  "("
+  ")"
+] @punctuation.bracket
+
+[
+  "!"
+  "\*"
+  "/"
+  "%"
+  "\+"
+  "-"
+  ">"
+  ">="
+  "<"
+  "<="
+  "=="
+  "!="
+  "&&"
+  "||"
+] @operator

--- a/runtime/queries/hcl/indents.toml
+++ b/runtime/queries/hcl/indents.toml
@@ -1,0 +1,13 @@
+indent = [
+  "object",
+  "block",
+  "tuple",
+  "for_tuple_expr",
+  "for_object_expr"
+]
+
+outdent = [
+  "object_end",
+  "block_end",
+  "tuple_end"
+]

--- a/runtime/queries/hcl/injections.scm
+++ b/runtime/queries/hcl/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+	(#set! injection.language "comment"))


### PR DESCRIPTION
Queries based on the neovims ones: https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries/hcl and modified for helix support.

I am making use of a couple of scopes that are used by other queries but not listed in the themes page. `@none` and `@punctuation.special` not sure if these are not valid or just missing from the docs.