### PR TITLE
Fix bug with auto replacing components in compositor

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2922,7 +2922,7 @@ pub mod cmd {
                         Box::new(move |editor: &mut Editor, compositor: &mut Compositor| {
                             let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                             let popup = Popup::new("hover", contents).auto_close(true);
-                            compositor.replace_or_push("hover", Box::new(popup));
+                            compositor.replace_or_push("hover", popup);
                         });
                     Ok(call)
                 };

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -254,7 +254,7 @@ pub fn code_action(cx: &mut Context) {
                 vertical: 1,
                 horizontal: 1,
             });
-            compositor.replace_or_push("code-action", Box::new(popup));
+            compositor.replace_or_push("code-action", popup);
         },
     )
 }
@@ -637,7 +637,7 @@ pub fn hover(cx: &mut Context) {
 
                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                 let popup = Popup::new("hover", contents).auto_close(true);
-                compositor.replace_or_push("hover", Box::new(popup));
+                compositor.replace_or_push("hover", popup);
             }
         },
     );

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -221,10 +221,9 @@ impl Compositor {
     }
 
     pub fn find_id<T: 'static>(&mut self, id: &'static str) -> Option<&mut T> {
-        let type_name = std::any::type_name::<T>();
         self.layers
             .iter_mut()
-            .find(|component| component.type_name() == type_name && component.id() == Some(id))
+            .find(|component| component.id() == Some(id))
             .and_then(|component| component.as_any_mut().downcast_mut())
     }
 }

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -128,11 +128,11 @@ impl Compositor {
 
     /// Replace a component that has the given `id` with the new layer and if
     /// no component is found, push the layer normally.
-    pub fn replace_or_push(&mut self, id: &'static str, layer: Box<dyn Component>) {
+    pub fn replace_or_push<T: Component>(&mut self, id: &'static str, layer: T) {
         if let Some(component) = self.find_id(id) {
             *component = layer;
         } else {
-            self.push(layer)
+            self.push(Box::new(layer))
         }
     }
 


### PR DESCRIPTION
This was last known to be working with 5995568c at the time of commit, but now doesn't work with latest rust stable.

The issue probably stems from using `std::any::type_name()` for finding a component in the compositor, for which the docs explicitly warn against considering it as a unique identifier for types. `replace_or_push()` takes a boxed `Component` and passes it to `find_id()` which compares this with a bare Component. `type_name()` returns `Box<T>` for the former and `T` for latter and we have a false negative. This has been solved by using a generics instead of trait objects to pass in a `T: Component` and then use it for comparison.

I'm not exactly sure how this worked fine at the time of commit of 5995568c; maybe the internal implementation of `type_name()` changed to properly indicate indirection with Box. Ideally we can use some other mechanism which doesn't depend on `type_name()`.

