### PR TITLE
chore(theme): fix "ui.selection" for rose_pine themes

### DIFF
--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -6,7 +6,7 @@
 "ui.menu.selected" = { fg = "iris", bg = "surface" }
 "ui.linenr" = {fg = "subtle" }
 "ui.liner.selected" = "highlightOverlay"
-"ui.selection" = "highlight"
+"ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
 "ui.statusline" = {fg = "foam", bg = "surface" }
 "ui.statusline.inactive" = { fg = "iris", bg = "surface" }

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -6,7 +6,7 @@
 "ui.menu.selected" = { fg = "iris", bg = "surface" }
 "ui.linenr" = {fg = "subtle" }
 "ui.liner.selected" = "highlightOverlay"
-"ui.selection" = "highlight"
+"ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
 "ui.statusline" = {fg = "foam", bg = "surface" }
 "ui.statusline.inactive" = { fg = "iris", bg = "surface" }


### PR DESCRIPTION
Fix "ui.selection" of rose_pine themes as

before
<img width="476" alt="Screen Shot 2022-02-27 at 10 24 44 AM" src="https://user-images.githubusercontent.com/24458075/155891037-de4fa2fb-523b-4da2-b586-4e87d4782507.png">

after
<img width="672" alt="Screen Shot 2022-02-27 at 10 25 58 AM" src="https://user-images.githubusercontent.com/24458075/155891054-76dfcdc0-80cf-4873-b98d-c4fb346f9470.png">
