### PR TITLE
add workflow for pushing nix flake artifacts to Cachix

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,28 @@
+# Publish the Nix flake outputs to Cachix
+name: Cachix
+on:
+  push: master
+
+jobs:
+  publish:
+    name: Publish Flake
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v16
+
+    - name: Authenticate with Cachix
+      uses: cachix/cachix-action@v10
+      with:
+        name: helix
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+    - name: Build nix flake
+      run: |
+        nix build
+        nix flake check

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -21,6 +21,4 @@ jobs:
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - name: Build nix flake
-      run: |
-        nix build
-        nix flake check
+      run: nix build

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-      with:
-        submodules: true
 
     - name: Install nix
       uses: cachix/install-nix-action@v16

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -19,7 +19,12 @@ brew install helix
 
 A [flake](https://nixos.wiki/wiki/Flakes) containing the package is available in
 the project root. The flake can also be used to spin up a reproducible development
-shell for working on Helix.
+shell for working on Helix with `nix develop`.
+
+Flake outputs are cached for each push to master using
+[Cachix](https://www.cachix.org/). With Cachix
+[installed](https://docs.cachix.org/installation), `cachix use helix` will
+configure Nix to use cached outputs when possible.
 
 ### Arch Linux
 


### PR DESCRIPTION
closes #1717 

based on https://github.com/cachix/install-nix-action/tree/b2b9fc6cf9ad2446d49c06143ad34b98bf73be99#usage-with-flakes

I grabbed the `helix` cache on Cachix. I'll need to coordinate with @archseer to get the auth token secret set up in actions.