### PR TITLE
Add terraform lsp support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,7 +21,7 @@
 | go | ✓ | ✓ | ✓ | `gopls` |
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
-| hcl | ✓ |  | ✓ |  |
+| hcl | ✓ |  | ✓ | `terraform-ls` |
 | html | ✓ |  |  |  |
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -762,7 +762,9 @@ language-server = { command = "kotlin-language-server" }
 name = "hcl"
 scope = "source.hcl"
 injection-regex = "(hcl|tf)"
-file-types = ["hcl", "tf"]
+file-types = ["hcl", "tf", "tfvars"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
+language-server = { command = "terraform-ls", args = ["serve"] }
+auto-format = true


### PR DESCRIPTION
Using terraform-ls and enables auto-format support. Also adds tfvars as an extra filetype.