### PR TITLE
Fix building without typescript / ocaml submodules

### DIFF
--- a/helix-syntax/build.rs
+++ b/helix-syntax/build.rs
@@ -199,8 +199,15 @@ fn main() {
     // drop(tx);
     assert_eq!(rx.try_iter().sum::<usize>(), n_jobs);
 
-    build_dir("tree-sitter-typescript/tsx", "tsx");
-    build_dir("tree-sitter-typescript/typescript", "typescript");
-    build_dir("tree-sitter-ocaml/ocaml", "ocaml");
-    build_dir("tree-sitter-ocaml/interface", "ocaml-interface")
+    for (dir, lang) in [
+        ("tree-sitter-typescript/tsx", "tsx"),
+        ("tree-sitter-typescript/typescript", "typescript"),
+        ("tree-sitter-ocaml/ocaml", "ocaml"),
+        ("tree-sitter-ocaml/interface", "ocaml-interface"),
+    ]
+    .iter()
+    .filter(|(dir, _)| Path::new(dir).exists())
+    {
+        build_dir(dir, lang);
+    }
 }


### PR DESCRIPTION
The `typescript` and `ocaml` submodules are hardcoded in the build script `helix-syntax/build.rs` which means the build script has to be modified when trying to build helix without these languages.

With this change they are ignored when the folder doesn't exist, making the behavior more consistent with the other language submodules.

I'm not sure how useful this change is to others. Feel free to close if it's too specific.