### PR TITLE
update helix-syntax revision in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,9 @@
                 pkgs = common.pkgs;
                 helix = pkgs.fetchgit {
                   url = "https://github.com/helix-editor/helix.git";
-                  rev = "a8fd33ac012a79069ef1409503a2edcf3a585153";
+                  rev = "d62ad8b595a4f901b9c5dba1bb6e8f70ece395bf";
                   fetchSubmodules = true;
-                  sha256 = "sha256-5AtOC55ttWT+7RYMboaFxpGZML51ix93wAkYJTt+8JI=";
+                  sha256 = "sha256-X0N2clg2DQQ2bwyBrZVeaXLoSKaQ7NALydnd2eJzECg=";
                 };
               in
               pkgs.runCommand prev.src.name { } ''


### PR DESCRIPTION
closes #1746

The queries for Go were updated in ddbf03613d5a3dd64f3f5ba13795e70c29297837.
The old ref was before this commit, so running helix from the flake

    nix flake run github:helix-editor/helix/d62ad8b595a4f901b9c5dba1bb6e8f70ece395bf -- path/to/file.go

will crash because the old grammar's query analysis will fail (because `iota`
was not yet a named node).

This commit updates the version of the grammars that we pull down when building
the flake so that the queries match the grammars. We'll have to do an update like
this whenever a grammar is bumped in a breaking way (which happens fairly often
in tree-sitter) until #1659 comes along and the version of the grammar becomes
tied to the version declared in source.