### PR TITLE
Configurable status line location

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -145,10 +145,15 @@ impl EditorView {
 
         self.render_diagnostics(doc, view, inner, surface, theme);
 
-        let statusline_area = view
-            .area
-            .clip_top(view.area.height.saturating_sub(1))
-            .clip_bottom(1); // -1 from bottom to remove commandline
+        let statusline_area = if true {
+            view.area
+        } else {
+            // -1 from bottom to remove commandline
+            view.area
+                .clip_top(view.area.height.saturating_sub(1))
+                .clip_bottom(1)
+        };
+
         self.render_statusline(doc, view, statusline_area, surface, theme, is_focused);
     }
 
@@ -477,11 +482,16 @@ impl EditorView {
             text.reserve(*width); // ensure there's enough space for the gutter
             for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
                 let selected = cursors.contains(&line);
+                let y_offset = if true {
+                    viewport.y + i as u16 + 1
+                } else {
+                    viewport.y + i as u16
+                };
 
                 if let Some(style) = gutter(line, selected, &mut text) {
                     surface.set_stringn(
                         viewport.x + offset,
-                        viewport.y + i as u16,
+                        y_offset,
                         &text,
                         *width,
                         gutter_style.patch(style),

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -14,9 +14,17 @@ impl Component for Info {
         // which evaluate to the most bottom right coordinate.
         let width = self.width + 2 + 2; // +2 for border, +2 for margin
         let height = self.height + 2; // +2 for border
+
+        // Adjust y position based on statusline
+        let y_offset = if true {
+            viewport.y + 1
+        } else {
+            viewport.height.saturating_sub(height + 2)
+        };
+
         let area = viewport.intersection(Rect::new(
             viewport.width.saturating_sub(width),
-            viewport.height.saturating_sub(height + 2), // +2 for statusline
+            y_offset,
             width,
             height,
         ));

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -113,7 +113,13 @@ impl View {
             .map(|(_, width)| *width as u16)
             .sum::<u16>()
             + 1; // +1 for some space between gutters and line
-        self.area.clip_left(offset).clip_bottom(1) // -1 for statusline
+
+        // Adjust for statusline too
+        if true {
+            self.area.clip_left(offset).clip_top(1)
+        } else {
+            self.area.clip_left(offset).clip_bottom(1)
+        }
     }
 
     //


### PR DESCRIPTION
I've gotten a bare-bones version of this working, but need help to get it the rest of the way. 

## Configuration

The places where the calculation differs currently have a mock conditional `if true` as a placeholder for taking into account a configuration item. Real code will use an enum for the options and have match arms. Almost all edits have context.editor available to them, and therefore I can query the config in them. However, the calculation of `inner_area` in the View struct does not have the context available in any form, and many places that call it don't either. It's essential to correctly set the inner area, as that is the view - gutter - statusline => where the code lives. I'm not sure how to get information on whether to clip top or bottom from the config at this point. I thought about moving the statusline outside of the view, but the statusline really is part of the view, as a distinct one appears for each view with the relevant information displayed. We could theoretically ditch that for a unified statusline and change out its content depending on the focused view, but that robs us of easy visibility of which views correspond to which buffers. Trying to add that info back in puts us right back where we started trying to figure out how to adjust the view's inner_area depending on where the filename should display.

## Autoinfo

Autoinfo looked a little out of place in the bottom corner, so I opted to move it to the top along with the status line, so that they are always together. I could change it back, but it would still need code to handle the statusline not being present to place it up against the command area at the bottom.

## Command area

Currently, although I figured out how to move the command/status msg areas to the top as well, it feels somehow uglier having the gap at the top than at the bottom. I decided to leave that off as I would rather have a refactor to render the command area on top of the status line instead. That is a much more involved change though so I'd rather that be a follow-up PR.