### PR TITLE
'insert_register' doesn't handle register name correctly

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3038,6 +3038,7 @@ fn yank_main_selection_to_primary_clipboard(cx: &mut Context) {
 enum Paste {
     Before,
     After,
+    Cursor,
 }
 
 fn paste_impl(
@@ -3084,6 +3085,8 @@ fn paste_impl(
             (Paste::Before, false) => range.from(),
             // paste append
             (Paste::After, false) => range.to(),
+            // paste at cursor
+            (Paste::Cursor, _) => range.cursor(text.slice(..)),
         };
         (pos, pos, values.next())
     });
@@ -3829,10 +3832,12 @@ fn select_register(cx: &mut Context) {
 }
 
 fn insert_register(cx: &mut Context) {
+    cx.editor.autoinfo = Some(Info::from_registers(&cx.editor.registers));
     cx.on_next_key(move |cx, event| {
         if let Some(ch) = event.char() {
-            cx.editor.selected_register = Some(ch);
-            paste_before(cx);
+            cx.editor.autoinfo = None;
+            cx.register = Some(ch);
+            paste(cx, Paste::Cursor);
         }
     })
 }


### PR DESCRIPTION
### Problem

`insert_register` ignores register name and always pastes the last yanked text.

- version: 0.6(nixpkg) and f1e90ac2e3040dd09b3652d1bcabb4aee834aedd on the main branch

### Proposal

- Set register name to `cx.register` instead of `cx.editor.selected_register`.

plus:

- Update `cx.editor.autoinfo` to display register contents, like `select_register`.
- Call `paste_after` instead of `paste_before`; the position of the pasted text matches other editors.

Now it seems to work well.
