### PR TITLE
Add horizontal and vertical split scratch buffers

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -46,7 +46,9 @@
 | `:debug-remote`, `:dbg-tcp` | Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters. |
 | `:debug-eval` | Evaluate expression in current debug context. |
 | `:vsplit`, `:vs` | Open the file in a vertical split. |
+| `:vsplit-new`, `:vnew` | Open a scratch buffer in a vertical split. |
 | `:hsplit`, `:hs`, `:sp` | Open the file in a horizontal split. |
+| `:hsplit-new`, `:hnew` | Open a scratch buffer in a horizontal split. |
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
 | `:set-option`, `:set` | Set a config option at runtime |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -380,7 +380,9 @@ impl MappableCommand {
         jump_view_down, "Jump to the split below",
         rotate_view, "Goto next window",
         hsplit, "Horizontal bottom split",
+        hsplit_new, "Horizontal bottom split scratch buffer",
         vsplit, "Vertical right split",
+        vsplit_new, "Vertical right split scratch buffer",
         wclose, "Close window",
         wonly, "Current window only",
         select_register, "Select register",
@@ -3787,8 +3789,16 @@ fn hsplit(cx: &mut Context) {
     split(cx, Action::HorizontalSplit);
 }
 
+fn hsplit_new(cx: &mut Context) {
+    cx.editor.new_file(Action::HorizontalSplit);
+}
+
 fn vsplit(cx: &mut Context) {
     split(cx, Action::VerticalSplit);
+}
+
+fn vsplit_new(cx: &mut Context) {
+    cx.editor.new_file(Action::VerticalSplit);
 }
 
 fn wclose(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -771,6 +771,26 @@ fn hsplit(
     Ok(())
 }
 
+fn vsplit_new(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    cx.editor.new_file(Action::VerticalSplit);
+
+    Ok(())
+}
+
+fn hsplit_new(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    cx.editor.new_file(Action::HorizontalSplit);
+
+    Ok(())
+}
+
 fn debug_eval(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -1294,11 +1314,25 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             completer: Some(completers::filename),
         },
         TypableCommand {
+            name: "vsplit-new",
+            aliases: &["vnew"],
+            doc: "Open a scratch buffer in a vertical split.",
+            fun: vsplit_new,
+            completer: None,
+        },
+        TypableCommand {
             name: "hsplit",
             aliases: &["hs", "sp"],
             doc: "Open the file in a horizontal split.",
             fun: hsplit,
             completer: Some(completers::filename),
+        },
+        TypableCommand {
+            name: "hsplit-new",
+            aliases: &["hnew"],
+            doc: "Open a scratch buffer in a horizontal split.",
+            fun: hsplit_new,
+            completer: None,
         },
         TypableCommand {
             name: "tutor",

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -682,6 +682,10 @@ impl Default for Keymaps {
                 "C-j" | "j" | "down" => jump_view_down,
                 "C-k" | "k" | "up" => jump_view_up,
                 "C-l" | "l" | "right" => jump_view_right,
+                "n" => { "New split scratch buffer"
+                    "C-s" | "s" => hsplit_new,
+                    "C-v" | "v" => vsplit_new,
+                },
             },
 
             // move under <space>c
@@ -732,6 +736,10 @@ impl Default for Keymaps {
                     "C-j" | "j" | "down" => jump_view_down,
                     "C-k" | "k" | "up" => jump_view_up,
                     "C-l" | "l" | "right" => jump_view_right,
+                    "n" => { "New split scratch buffer"
+                        "C-s" | "s" => hsplit_new,
+                        "C-v" | "v" => vsplit_new,
+                    },
                 },
                 "y" => yank_joined_to_clipboard,
                 "Y" => yank_main_selection_to_clipboard,


### PR DESCRIPTION
# Add horizontal and vertical split scratch buffers

This change proposes the addition of two new commands to open scratch buffers in splits. It works out to be very similar to `:hsplit src/newfilename.rs` where `newfilename.rs` is a file that doesn't exist, but with the intention of not actually creating a file when you are done with it.