### PR TITLE
Add --edit-config flag to directly open config.toml

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -5,6 +5,8 @@ To override global configuration parameters, create a `config.toml` file located
 * Linux and Mac: `~/.config/helix/config.toml`
 * Windows: `%AppData%\helix\config.toml`
 
+> Note: You may use `hx --edit-config` to create and edit the `config.toml` file.
+
 Example config:
 
 ```toml

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -113,6 +113,9 @@ impl Application {
             editor.open(path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None)?;
+        } else if args.config {
+            let path = conf_dir.join("config.toml");
+            editor.open(path, Action::VerticalSplit)?;
         } else if !args.files.is_empty() {
             let first = &args.files[0].0; // we know it's not empty
             if first.is_dir() {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -113,7 +113,7 @@ impl Application {
             editor.open(path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None)?;
-        } else if args.config {
+        } else if args.edit_config {
             let path = conf_dir.join("config.toml");
             editor.open(path, Action::VerticalSplit)?;
         } else if !args.files.is_empty() {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -11,6 +11,7 @@ pub struct Args {
     pub load_tutor: bool,
     pub verbosity: u64,
     pub files: Vec<(PathBuf, Position)>,
+    pub config: bool,
 }
 
 impl Args {
@@ -26,6 +27,7 @@ impl Args {
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,
                 "--tutor" => args.load_tutor = true,
+                "--edit-config" => args.config = true,
                 "--health" => {
                     args.health = true;
                     args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -11,7 +11,7 @@ pub struct Args {
     pub load_tutor: bool,
     pub verbosity: u64,
     pub files: Vec<(PathBuf, Position)>,
-    pub config: bool,
+    pub edit_config: bool,
 }
 
 impl Args {
@@ -27,7 +27,7 @@ impl Args {
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,
                 "--tutor" => args.load_tutor = true,
-                "--edit-config" => args.config = true,
+                "--edit-config" => args.edit_config = true,
                 "--health" => {
                     args.health = true;
                     args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -60,6 +60,7 @@ ARGS:
 
 FLAGS:
     -h, --help       Prints help information
+    --edit-config    Opens the helix config file
     --tutor          Loads the tutorial
     --health [LANG]  Checks for potential errors in editor setup
                      If given, checks for config errors in language LANG


### PR DESCRIPTION
Just a nice-to-have that makes editing the config feel a bit more first class.