### PR TITLE
Fix bug in LSP when creating a file in a folder that does not exist

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -286,6 +286,13 @@ pub fn apply_document_resource_op(op: &lsp::ResourceOp) -> std::io::Result<()> {
             if ignore_if_exists && path.exists() {
                 Ok(())
             } else {
+                // Create directory if it does not exist
+                if let Some(dir) = path.parent() {
+                    if !dir.is_dir() {
+                        fs::create_dir_all(&dir)?;
+                    }
+                }
+
                 fs::write(&path, [])
             }
         }


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/1773