### PR TITLE
Add a config to decide how to find root of file pciker

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -75,6 +75,7 @@ available, which is not defined by default.
 |`git-global` | Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option. | true
 |`git-exclude` | Enables reading `.git/info/exclude` files. | true
 |`max-depth` | Set with an integer value for maximum depth to recurse. | Defaults to `None`.
+|`root` | Set the option decide how to find root dir, values: "pwd", "git", "file". | Defaults to `git`.
 
 ### `[editor.auto-pairs]` Section
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2026,8 +2026,17 @@ fn append_mode(cx: &mut Context) {
 }
 
 fn file_picker(cx: &mut Context) {
-    // We don't specify language markers, root will be the root of the current git repo
-    let root = find_root(None, &[]).unwrap_or_else(|| PathBuf::from("./"));
+    use helix_view::editor::FilePickerRoot;
+    let root = match cx.editor.config.file_picker.root {
+        FilePickerRoot::Git => find_root(None, &[]).unwrap_or_else(|| PathBuf::from("./")),
+        FilePickerRoot::Pwd => PathBuf::from("./"),
+        FilePickerRoot::File => doc!(cx.editor)
+            .path()
+            .and_then(|p| p.parent())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("./")),
+    };
+
     let picker = ui::file_picker(root, &cx.editor.config);
     cx.push_layer(Box::new(overlayed(picker)));
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -61,6 +61,14 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum FilePickerRoot {
+    Git,
+    Pwd,
+    File,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
     /// IgnoreOptions
@@ -84,6 +92,8 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
+    /// find root
+    pub root: FilePickerRoot,
 }
 
 impl Default for FilePickerConfig {
@@ -96,6 +106,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            root: FilePickerRoot::Git,
         }
     }
 }


### PR DESCRIPTION
Add a config for decide how to find root of file pciker
The value 'git' indicate to use git project
The value 'pwd' indicate to use pwd of helix process
The value 'file' indicate to use parent of current buffer.