### PR TITLE
Deploy docs for master separately

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run: mdbook build book
       
-      - name: Set ouput directory
+      - name: Set output directory
         run: |
           OUTDIR=$(basename ${{ github.ref }})
           echo "OUTDIR=$OUTDIR" >> $GITHUB_ENV

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-  release:
-    types: [published]
+    tags:
+      - '*'
 
 jobs:
   deploy:
@@ -20,18 +20,22 @@ jobs:
           # mdbook-version: '0.4.8'
 
       - run: mdbook build book
+      
+      - name: Set ouput directory
+        run: |
+          OUTDIR=$(basename ${{ github.ref }})
+          echo "OUTDIR=$OUTDIR" >> $GITHUB_ENV
 
-      - name: Deploy master
+      - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
-          destination_dir: ./master
+          destination_dir: ./${{ env.OUTDIR }}
 
-      - name: Deploy tagged release
+      - name: Deploy stable
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'release'
+        if: startswith(github.ref, 'refs/tags/')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -19,9 +21,17 @@ jobs:
 
       - run: mdbook build book
 
-      - name: Deploy
+      - name: Deploy master
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book
+          destination_dir: ./master
+
+      - name: Deploy tagged release
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'release'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,5 +1,7 @@
 # Summary
 
+[Helix](./title-page.md)
+
 - [Installation](./install.md)
 - [Usage](./usage.md)
   - [Keymap](./keymap.md)

--- a/book/src/title-page.md
+++ b/book/src/title-page.md
@@ -1,0 +1,15 @@
+# Helix
+
+Docs for bleeding edge master can be found at
+[https://docs.helix-editor.com/master](https://docs.helix-editor.com/master).
+
+See the [usage] section for a quick overview of the editor, [keymap]
+section for all available keybindings and the [configuration] section
+for defining custom keybindings, setting themes, etc.
+
+Refer the [FAQ] for common questions.
+
+[FAQ]: https://github.com/helix-editor/helix/wiki/FAQ
+[usage]: ./usage.md
+[keymap]: ./keymap.md
+[configuration]: ./configuration.md


### PR DESCRIPTION
Fixes #1607. Docs for master is now deployed at https://docs.helix-editor.com/master. The docs for 0.6 will have to be pushed to the `gh-pages` branch manually, since the main docs are now updated only on releases.

I'm _think_ this should work, though I've not tested it.