### PR TITLE
remove stray 'println!' from grammar building function

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -229,7 +229,6 @@ where
 }
 
 fn build_grammar(grammar: GrammarConfiguration) -> Result<()> {
-    println!("{:#?}", grammar);
     let grammar_dir = if let GrammarSource::Local { path } = &grammar.source {
         PathBuf::from(&path)
     } else {


### PR DESCRIPTION
Whoops, I left a printf debug laying around. I think I must've accidentally rebased this in at some point when I was squashing down the commit history 😅