### PR TITLE
Handle panic on move within empty picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -415,6 +415,11 @@ impl<T> Picker<T> {
     pub fn move_by(&mut self, amount: usize, direction: Direction) {
         let len = self.matches.len();
 
+        if len == 0 {
+            // No results, can't move.
+            return;
+        }
+
         match direction {
             Direction::Forward => {
                 self.cursor = self.cursor.saturating_add(amount) % len;


### PR DESCRIPTION
When the picker results output is empty, movement actions result in a panic:
```
thread 'main' panicked at 'attempt to calculate the remainder with a divisor of zero', helix-term/src/ui/picker.rs:420:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This could be a no-op instead when the matches length is zero.

![scroll-panic](https://user-images.githubusercontent.com/343499/157815900-4f333623-c433-43d4-afef-10d78c5fc774.gif)
