### PR TITLE
[Proposal] Add language server picker

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -519,6 +519,13 @@ impl Loader {
             .cloned()
     }
 
+    pub fn language_configs(&self) -> Vec<Arc<LanguageConfiguration>> {
+        self.language_configs
+            .iter()
+            .map(|config| config.clone())
+            .collect()
+    }
+
     pub fn language_configuration_for_injection_string(
         &self,
         string: &str,

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -362,6 +362,10 @@ impl Registry {
     pub fn iter_clients(&self) -> impl Iterator<Item = &Arc<Client>> {
         self.inner.values().map(|(_, client)| client)
     }
+
+    pub fn language_ids(&self) -> Vec<LanguageId> {
+        self.inner.keys().cloned().collect()
+    }
 }
 
 #[derive(Debug)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -431,6 +431,7 @@ impl MappableCommand {
         decrement, "Decrement",
         record_macro, "Record macro",
         replay_macro, "Replay macro",
+        language_server_picker, "Set language server",
         command_palette, "Open command pallete",
     );
 }
@@ -2092,6 +2093,30 @@ fn buffer_picker(cx: &mut Context) {
         },
     );
     cx.push_layer(Box::new(overlayed(picker)));
+}
+
+
+pub fn language_server_picker(cx: &mut Context) {
+    cx.callback = Some(Box::new(
+        move |compositor: &mut Compositor, cx: &mut compositor::Context| {
+            let mut opts = cx.editor.syn_loader.clone().language_configs();
+            opts.sort_by(|a, b| {
+                a.language_id.cmp(&b.language_id)
+            });
+            let picker = Picker::new(
+                opts,
+                move |c| {
+                    Cow::Borrowed(c.language_id.as_str())
+                },
+                |cx, config, _action| {
+                    let doc = doc!(cx.editor).id();
+                    cx.editor.set_language_server(doc, config.scope());
+                },
+            );
+            compositor.push(Box::new(picker));
+        } 
+    ));
+
 }
 
 pub fn command_palette(cx: &mut Context) {

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -741,6 +741,7 @@ impl Default for Keymaps {
                 "/" => global_search,
                 "k" => hover,
                 "r" => rename_symbol,
+                "l" => language_server_picker,
                 "?" => command_palette,
             },
             "z" => { "View"

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -412,6 +412,12 @@ impl Editor {
         Self::launch_language_server(&mut self.language_servers, doc)
     }
 
+    pub fn set_language_server(&mut self, doc_id: DocumentId, scope: &str) -> Option<()> {
+        let doc = self.documents.get_mut(&doc_id)?;
+        doc.set_language2(scope, self.syn_loader.clone());
+        Self::launch_language_server(&mut self.language_servers, doc)
+    }
+
     /// Launch a language server for a given document
     fn launch_language_server(ls: &mut helix_lsp::Registry, doc: &mut Document) -> Option<()> {
         // try to find a language server based on the language name


### PR DESCRIPTION
A common debugging workflow for me involves yanking some bits of data from a database, tossing them into a scratchpad of sorts, formatting it, inspecting it, and perhaps changing parts of it before it is put back. It is generally JSON or CSS. Being able to quickly enable highlighting or more for a scratch buffer is desirable.

This is not entirely complete, so I'm marking it as a draft. I won't have the time to fully look into it tonight, but I'm getting a panic when trying to enable languages that I have actual language servers for, such as `rust` or `javascript`:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', helix-view\src\editor.rs:446:31
```

Apart from that though, it's looking pretty nifty!

![image](https://user-images.githubusercontent.com/19535809/157816952-6b1e6458-fb3c-425b-96ce-567fdf1bc18b.png)

![image](https://user-images.githubusercontent.com/19535809/157817048-a67d6ba7-8baa-42fd-9771-c5afad4fa301.png)

I think this would be more preferrable as a TypableCommand, as I don't imagine this is a common workflow. I tossed it in the keymap though for now to quickly play around with it.

---

edit: I will admit, the choice of using a Picker for this was entirely inspired by VSCode:

![image](https://user-images.githubusercontent.com/19535809/157900991-b43493ac-3934-4dc0-9d96-07a5fa98e87d.png)
