### PR TITLE
Add csharp lsp support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -206,9 +206,10 @@ name = "c-sharp"
 scope = "source.csharp"
 injection-regex = "c-?sharp"
 file-types = ["cs"]
-roots = []
+roots = ["sln", "csproj"]
 comment-token = "//"
 indent = { tab-width = 4, unit = "\t" }
+language-server = { command = "OmniSharp", args = [ "--languageserver", "--stdio", "--hostPID" ] }
 
 [[grammar]]
 name = "c-sharp"


### PR DESCRIPTION
 OmniSharp is the defacto LSP for C#, so this just adds it as the default. Tested on Windows/Linux