### PR TITLE
Use `^` and `$` to match the beginning and end of a line when searching

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1642,6 +1642,7 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
         let wrap_around = search_config.wrap_around;
         if let Ok(regex) = RegexBuilder::new(query)
             .case_insensitive(case_insensitive)
+            .multi_line(true)
             .build()
         {
             search_impl(

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -73,6 +73,7 @@ pub fn regex_prompt(
 
                     match RegexBuilder::new(input)
                         .case_insensitive(case_insensitive)
+                        .multi_line(true)
                         .build()
                     {
                         Ok(regex) => {


### PR DESCRIPTION
Fixes #1737