### PR TITLE
theme: Use distinct colors for match pair and cursor for gruvbox

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -50,7 +50,7 @@
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
-"ui.cursor.match" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -51,7 +51,7 @@
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
-"ui.cursor.match" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 


### PR DESCRIPTION
With `gruvbox` themes, `{ modifiers = ["reversed"] }` makes it
impossible to identify which pair the cursor is on. `ui.cursor.primary`
is set to be the same as `ui.cursor.match`.

Using `{ bg = "bg2" }` for `ui.cursor.match` instead makes sure that
it is possible to find out the current cursor position.
![gruvbox-matching-pair-highlight](https://user-images.githubusercontent.com/343499/157845401-18335d2f-6318-4695-a6ae-6dbaecb7047b.png)
