### PR TITLE
Resolve conflicts between prompt/picker bindings

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -311,10 +311,10 @@ Keys to use within picker. Remapping currently not supported.
 
 | Key                          | Description       |
 | -----                        | -------------     |
-| `Up`, `Ctrl-k`, `Ctrl-p`     | Previous entry    |
-| `PageUp`, `Ctrl-b`           | Page up           |
-| `Down`, `Ctrl-j`, `Ctrl-n`   | Next entry        |
-| `PageDown`, `Ctrl-f`         | Page down         |
+| `Up`, `Ctrl-p`               | Previous entry    |
+| `PageUp`, `Ctrl-u`           | Page up           |
+| `Down`, `Ctrl-n`             | Next entry        |
+| `PageDown`, `Ctrl-d`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |
 | `Ctrl-space`                 | Filter options    |

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -484,16 +484,16 @@ impl<T: 'static> Component for Picker<T> {
         })));
 
         match key_event.into() {
-            shift!(Tab) | key!(Up) | ctrl!('p') | ctrl!('k') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') => {
                 self.move_by(1, Direction::Backward);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') | ctrl!('j') => {
+            key!(Tab) | key!(Down) | ctrl!('n') => {
                 self.move_by(1, Direction::Forward);
             }
-            key!(PageDown) | ctrl!('f') => {
+            key!(PageDown) | ctrl!('d') => {
                 self.page_down();
             }
-            key!(PageUp) | ctrl!('b') => {
+            key!(PageUp) | ctrl!('u') => {
                 self.page_up();
             }
             key!(Home) => {


### PR DESCRIPTION
Currently, the picker's re-using a few bindings which are also present
in the prompt. This causes some editing behaviours to not function on
the picker.

**Ctrl + k** and **Ctrl + j**
This should kill till the end of the line on prompt, but is overridden
by the picker for scrolling. Since there are redundancies (`Ctrl + p`,
`Ctrl + n`), we can remove it from picker.

**Ctrl + f** and **Ctrl + b**
This are used by the prompt for back/forward movement. We could modify
it to be Ctrl + d and Ctrl + u, to match the `vim` behaviour.