### PR TITLE
C# highlighting improvements

### DIFF
--- a/runtime/queries/c-sharp/highlights.scm
+++ b/runtime/queries/c-sharp/highlights.scm
@@ -1,5 +1,35 @@
 ;; Methods
-(method_declaration (identifier) @type (identifier) @function)
+(method_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  type: [(identifier) (qualified_name)] @type)
+
+(invocation_expression
+  (member_access_expression
+    name: (identifier) @function))
+
+(invocation_expression
+  (member_access_expression
+    expression: (identifier) @variable))
+
+(invocation_expression
+  function: (conditional_access_expression
+    (member_binding_expression
+      name: (identifier) @function)))
+
+(invocation_expression
+      [(identifier) (qualified_name)] @function)
+
+; Generic Method invocation with generic type
+(invocation_expression
+  function: (generic_name
+              . (identifier) @function))
+
+;; Namespaces
+
+(namespace_declaration
+  name: [(identifier) (qualified_name)] @namespace)
 
 ;; Types
 (interface_declaration name: (identifier) @type)
@@ -8,8 +38,10 @@
 (struct_declaration (identifier) @type)
 (record_declaration (identifier) @type)
 (namespace_declaration name: (identifier) @type)
-
+(using_directive (_) @namespace)
 (constructor_declaration name: (identifier) @type)
+(object_creation_expression [(identifier) (qualified_name)] @type)
+(type_parameter_list (type_parameter) @type)
 
 [
   (implicit_type)
@@ -18,6 +50,31 @@
   (function_pointer_type)
   (predefined_type)
 ] @type.builtin
+
+;; Generic Types
+(type_of_expression
+  (generic_name
+    (identifier) @type))
+
+(base_list
+  (generic_name
+    (identifier) @type))
+
+(type_constraint
+  (generic_name
+    (identifier) @type))
+
+(object_creation_expression
+  (generic_name
+   (identifier) @type))
+
+(property_declaration
+  (generic_name
+    (identifier) @type))
+
+(_
+  type: (generic_name
+   (identifier) @type))
 
 ;; Enum
 (enum_member_declaration (identifier) @variable.other.member)
@@ -66,24 +123,37 @@
   "++"
   "+="
   "<"
+  "<="
   "<<"
+  "<<="
   "="
   "=="
   "!"
   "!="
   "=>"
   ">"
+  ">="
   ">>"
+  ">>="
   "|"
   "||"
+  "|="
   "?"
   "??"
   "^"
+  "^="
   "~"
   "*"
+  "*="
   "/"
+  "/="
   "%"
+  "%="
   ":"
+  ".."
+  "&="
+  "->"
+  "??="
 ] @operator
 
 [
@@ -131,6 +201,7 @@
   "return"
   "sizeof"
   "stackalloc"
+  "static"
   "struct"
   "switch"
   "throw"
@@ -157,6 +228,8 @@
   "let"
 ] @keyword
 
+(preprocessor_call) @keyword.directive
+(preprocessor_call (_) @keyword.directive)
 
 ;; Linq
 (from_clause (identifier) @variable)
@@ -172,13 +245,13 @@
       (identifier) @variable)))
 
 ;; Exprs
-(binary_expression (identifier) @variable (identifier) @variable)
-(binary_expression (identifier)* @variable)
-(conditional_expression (identifier) @variable)
-(prefix_unary_expression (identifier) @variable)
-(postfix_unary_expression (identifier)* @variable)
-(assignment_expression (identifier) @variable)
-(cast_expression (identifier) @type (identifier) @variable)
+(binary_expression [(identifier) (qualified_name)] @variable [(identifier) (qualified_name)] @variable)
+(binary_expression [(identifier) (qualified_name)]* @variable)
+(conditional_expression [(identifier) (qualified_name)] @variable)
+(prefix_unary_expression [(identifier) (qualified_name)] @variable)
+(postfix_unary_expression [(identifier) (qualified_name)]* @variable)
+(assignment_expression [(identifier) (qualified_name)] @variable)
+(cast_expression [(identifier) (qualified_name)] @type [(identifier) (qualified_name)] @variable)
 
 ;; Class
 (base_list (identifier) @type)
@@ -192,6 +265,10 @@
 (property_declaration
   type: (identifier) @type
   name: (identifier) @variable)
+  
+;; Delegate
+
+(delegate_declaration (identifier) @type)
 
 ;; Lambda
 (lambda_expression) @variable
@@ -206,12 +283,20 @@
 (parameter (identifier) @variable.parameter)
 (parameter_modifier) @keyword
 
+(parameter_list
+  (parameter
+   name: (identifier) @parameter))
+
+(parameter_list
+  (parameter
+   type: [(identifier) (qualified_name)] @type))
+
 ;; Typeof
-(type_of_expression (identifier) @type)
+(type_of_expression [(identifier) (qualified_name)] @type)
 
 ;; Variable
-(variable_declaration (identifier) @type)
-(variable_declarator (identifier) @variable)
+(variable_declaration [(identifier) (qualified_name)] @type)
+(variable_declarator [(identifier) (qualified_name)] @variable)
 
 ;; Return
 (return_statement (identifier) @variable)
@@ -219,8 +304,8 @@
 
 ;; Type
 (generic_name (identifier) @type)
-(type_parameter (identifier) @variable.parameter)
-(type_argument_list (identifier) @type)
+(type_parameter [(identifier) (qualified_name)] @variable.parameter)
+(type_argument_list [(identifier) (qualified_name)] @type)
 
 ;; Type constraints
 (type_parameter_constraints_clause (identifier) @variable.parameter)
@@ -236,3 +321,16 @@
 
 ;; Lock statement
 (lock_statement (identifier) @variable)
+
+;; Rest
+(member_access_expression) @variable
+(element_access_expression (identifier) @variable)
+(argument (identifier) @variable)
+(for_statement (identifier) @variable)
+(for_each_statement (identifier) @variable)
+(expression_statement (identifier) @variable)
+(member_access_expression expression: (identifier) @variable)
+(member_access_expression name: (identifier) @variable)
+(conditional_access_expression [(identifier) (qualified_name)] @variable)
+((identifier) @comment.unused
+ (#eq? @comment.unused "_"))


### PR DESCRIPTION
Adds more queries for better highlighting:

before:
![helix-csharp-highlight-before](https://user-images.githubusercontent.com/9267430/157936336-df31eddb-b079-44c4-a9a4-325733def085.png)

after:
![helix-csharp-highlight-improvement](https://user-images.githubusercontent.com/9267430/157936356-d443107a-674a-4838-ab4a-a3d1be157a43.png)

