### PR TITLE
visible whitespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "once_cell",
  "pulldown-cmark",
  "retain_mut",
+ "ropey",
  "serde",
  "serde_json",
  "signal-hook",

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -137,3 +137,29 @@ Search specific options.
 |--|--|---------|
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
 | `wrap-around`| Whether the search should wrap after depleting the matches | `true` |
+
+### `[editor.whitespace]` Section
+
+Options for rendering whitespace with visible characters. Use `:set whitespace.render all` to temporarily enable visible whitespace.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `tab`, and `newline`. | `"none"` |
+| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space` or `newline` | See example below |
+
+Example
+
+```toml
+[editor.whitespace]
+render = "all"
+# or control each character
+[editor.whitespace.render]
+space = "all"
+tab = "all"
+newline = "none"
+
+[editor.whitespace.characters]
+space = "·"
+tab = "→"
+newline = "⏎"
+```

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -224,6 +224,7 @@ These scopes are used for theming the editor interface.
 | `ui.text`                | Command prompts, popup text, etc.              |
 | `ui.text.focus`          |                                                |
 | `ui.text.info`           | The key: command text in `ui.popup.info` boxes |
+| `ui.virtual.whitespace`  | Visible white-space characters                 |
 | `ui.menu`                | Code and command completion menus              |
 | `ui.menu.selected`       | Selected autocomplete item                     |
 | `ui.selection`           | For selections in the editing area             |
@@ -233,4 +234,3 @@ These scopes are used for theming the editor interface.
 | `info`                   | Diagnostics info (gutter)                      |
 | `hint`                   | Diagnostics hint (gutter)                      |
 | `diagnostic`             | For text in editing area                       |
-

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1"
 once_cell = "1.10"
 
 which = "4.2"
+ropey = { version = "1.4", default-features = false }
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 num_cpus = "1"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -283,7 +283,7 @@ impl Application {
             // the Application can apply it.
             ConfigEvent::Update(editor_config) => {
                 let mut app_config = (*self.config.load().clone()).clone();
-                app_config.editor = editor_config;
+                app_config.editor = *editor_config;
                 self.config.store(Arc::new(app_config));
             }
         }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -240,6 +240,7 @@ impl<T: 'static> Component for FilePicker<T> {
                 surface,
                 &cx.editor.theme,
                 highlights,
+                &cx.editor.config().whitespace,
             );
 
             // highlight the line

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -148,6 +148,8 @@ pub struct Config {
     pub lsp: LspConfig,
     /// Column numbers at which to draw the rulers. Default to `[]`, meaning no rulers.
     pub rulers: Vec<u16>,
+    #[serde(default)]
+    pub whitespace: WhitespaceConfig,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -263,6 +265,88 @@ impl std::str::FromStr for GutterType {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WhitespaceConfig {
+    pub render: WhitespaceRender,
+    pub characters: WhitespaceCharacters,
+}
+
+impl Default for WhitespaceConfig {
+    fn default() -> Self {
+        Self {
+            render: WhitespaceRender::Basic(WhitespaceRenderValue::None),
+            characters: WhitespaceCharacters::default(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged, rename_all = "kebab-case")]
+pub enum WhitespaceRender {
+    Basic(WhitespaceRenderValue),
+    Specific {
+        default: Option<WhitespaceRenderValue>,
+        space: Option<WhitespaceRenderValue>,
+        tab: Option<WhitespaceRenderValue>,
+        newline: Option<WhitespaceRenderValue>,
+    },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WhitespaceRenderValue {
+    None,
+    // TODO
+    // Selection,
+    All,
+}
+
+impl WhitespaceRender {
+    pub fn space(&self) -> WhitespaceRenderValue {
+        match *self {
+            Self::Basic(val) => val,
+            Self::Specific { default, space, .. } => {
+                space.or(default).unwrap_or(WhitespaceRenderValue::None)
+            }
+        }
+    }
+    pub fn tab(&self) -> WhitespaceRenderValue {
+        match *self {
+            Self::Basic(val) => val,
+            Self::Specific { default, tab, .. } => {
+                tab.or(default).unwrap_or(WhitespaceRenderValue::None)
+            }
+        }
+    }
+    pub fn newline(&self) -> WhitespaceRenderValue {
+        match *self {
+            Self::Basic(val) => val,
+            Self::Specific {
+                default, newline, ..
+            } => newline.or(default).unwrap_or(WhitespaceRenderValue::None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WhitespaceCharacters {
+    pub space: char,
+    pub tab: char,
+    pub newline: char,
+}
+
+impl Default for WhitespaceCharacters {
+    fn default() -> Self {
+        Self {
+            space: '·',    // U+00B7
+            tab: '→',     // U+2192
+            newline: '⏎', // U+23CE
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -288,6 +372,7 @@ impl Default for Config {
             search: SearchConfig::default(),
             lsp: LspConfig::default(),
             rulers: Vec::new(),
+            whitespace: WhitespaceConfig::default(),
         }
     }
 }
@@ -366,7 +451,7 @@ pub struct Editor {
 #[derive(Debug, Clone)]
 pub enum ConfigEvent {
     Refresh,
-    Update(Config),
+    Update(Box<Config>),
 }
 
 #[derive(Debug, Clone)]

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -1,6 +1,7 @@
 # Author: RayGervais <raygervais@hotmail.ca>
 
 "ui.background" = { bg = "base00" }
+"ui.virtual" = "base03"
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base01", bg = "base04" }
 "ui.linenr" = { fg = "base03", bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -13,6 +13,7 @@
 "ui.help" = { fg = "base04", bg = "base01" }
 "ui.cursor" = { fg = "base04", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }
+"ui.virtual" = "base03"
 "ui.text" = "base05"
 "operator" = "base05"
 "ui.text.focus" = "base05"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -13,6 +13,7 @@
 "ui.help" = { fg = "white", bg = "black" }
 "ui.cursor" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "light-white", modifiers = ["reversed"] }
+"ui.virtual" = "light-gray"
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -53,6 +53,7 @@
 
 "ui.text" = { fg = "#e5ded6" }
 "ui.text.focus" = { fg = "#e5ded6", modifiers= ["bold"] }
+"ui.virtual" = "#627d9d"
 
 "ui.selection" = { bg = "#313f4e" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -44,6 +44,7 @@
 "ui.menu" = { fg = "lilac", bg = "berry_saturated" }
 "ui.menu.selected" = { fg = "mint", bg = "berry_saturated" }
 "ui.selection" = { bg = "berry_saturated" }
+"ui.virtual" = { fg = "berry_desaturated" }
 
 "diff.plus" = { fg = "mint" }
 "diff.delta" = { fg = "gold" }

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -78,6 +78,8 @@
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "white" }
 
+"ui.virtual" = { fg = "dark_green" }
+
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }
 "info" = { fg = "light_blue" }

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -36,6 +36,7 @@
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
+"ui.virtual" = { fg = "comment" }
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -70,6 +70,7 @@
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.selection" = { bg = "bg3" }
+"ui.virtual" = "grey0"
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -70,6 +70,7 @@
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.selection" = { bg = "bg3" }
+"ui.virtual" = "grey0"
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -53,6 +53,7 @@
 "ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
+"ui.virtual" = "bg2"
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -54,6 +54,7 @@
 "ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
+"ui.virtual" = "bg2"
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -53,6 +53,7 @@
 
 "ui.text" = { fg = "#7B91B3" }
 "ui.text.focus" = { fg = "#250E07", modifiers= ["bold"] }
+"ui.virtual" = "#A6B6CE"
 
 "ui.selection" = { bg = "#540099" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -32,6 +32,7 @@
 "attribute" = { fg = "fn_declaration" }
 
 "comment" = { fg = "#88846F" }
+"ui.virtual" = "#88846F"
 
 "string" = { fg = "#e6db74" }
 "constant.character" = { fg = "#e6db74" }

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -5,6 +5,7 @@
 "ui.linenr.selected" = { bg = "base3" }
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual" = "base5"
 
 "info" = "base8"
 "hint" = "base8"

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -5,6 +5,7 @@
 "ui.linenr.selected" = { bg = "base3" }
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual" = "base5"
 
 "info" = "base8"
 "hint" = "base8"

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -5,6 +5,7 @@
 "ui.linenr.selected" = { bg = "base3" }
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual" = "base5"
 
 "info" = "base8"
 "hint" = "base8"

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -5,6 +5,7 @@
 "ui.linenr.selected" = { bg = "base3" }
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual" = "base5"
 
 "info" = "base8"
 "hint" = "base8"

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -5,6 +5,7 @@
 "ui.linenr.selected" = { bg = "base3" }
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
+"ui.virtual" = "base5"
 
 "info" = "base8"
 "hint" = "base8"

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -3,6 +3,7 @@
 "ui.linenr.selected" = { fg = "nord4" }
 "ui.text.focus" = { fg = "nord8", modifiers= ["bold"] }
 "ui.menu.selected" = { fg = "nord8", bg = "nord2" }
+"ui.virtual" = "gray"
 
 "info" = "nord8"
 "hint" = "nord8"

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -47,6 +47,7 @@ diagnostic = { modifiers = ["underlined"] }
 "error" = { fg = "red", modifiers = ["bold"] }
 
 "ui.background" = { bg = "black" }
+"ui.virtual" = { fg = "light-gray" }
 
 "ui.cursor" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -15,6 +15,7 @@
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "foam", modifiers = ["bold"]}
 "ui.text.info" = {fg = "pine", modifiers = ["bold"]}
+"ui.virtual" = "highlight"
 "operator" = "rose"
 "variable" = "text"
 "constant.numeric" = "iris"

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -15,6 +15,7 @@
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "foam", modifiers = ["bold"]}
 "ui.text.info" = {fg = "pine", modifiers = ["bold"]}
+"ui.virtual" = "highlight"
 "operator" = "rose"
 "variable" = "text"
 "number" = "iris"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -50,6 +50,7 @@
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
 "ui.selection" = { bg = "bg3" }
+"ui.virtual" = "grey2"
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -50,6 +50,7 @@
 "ui.menu" = { fg = "bg0", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
 "ui.selection" = { fg = "bg0", bg = "bg3" }
+"ui.virtual" = { fg = "bg2" }
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -39,6 +39,8 @@
 # 背景
 "ui.background" = { bg = "base03" }
 
+"ui.virtual" = { fg = "base01" }
+
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }
 # 当前行号栏

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -39,6 +39,8 @@
 # 背景
 "ui.background" = { bg = "base03" }
 
+"ui.virtual" = { fg = "base01" }
+
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }
 # 当前行号栏

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -64,6 +64,7 @@
 "ui.cursor.match" = { bg = "bg3" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "#655370", bg = "#d1dcdf", modifiers = ["bold"] }
+"ui.virtual" = "bg2"
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -39,6 +39,7 @@
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "black" }
+"ui.virtual" = { fg = "comment" }
 
 "error" = { fg = "red" }
 "warning" = { fg = "yellow" }

--- a/theme.toml
+++ b/theme.toml
@@ -53,6 +53,7 @@ label = "honey"
 
 "ui.text" = { fg = "lavender" }
 "ui.text.focus" = { fg = "white" }
+"ui.virtual" = { fg = "comet" }
 
 "ui.selection" = { bg = "#540099" }
 "ui.selection.primary" = { bg = "#540099" }


### PR DESCRIPTION
Example with this rebased on top of #1796:

![whitespace-with-indent-guides](https://user-images.githubusercontent.com/21230295/158038150-b313692c-6614-447f-81e4-cd1ea88a814d.png)

Adds some configuration options to `config.toml`:

```toml
# render whitespace characters (\t, \n, ' ')
[editor.whitespace]
render = "all"
# render = "none"    to disable visible whitespace

# or control whether each character is shown:
[editor.whitespace.render]
space = "all"
tab = "all"
newline = "none"

# control the grapheme used to represent the whitespace
[editor.whitespace.characters]
space = "·"
tab = "→"
newline = "⏎"
```

And a new scope for themes `ui.virtual.whitespace`, which should be set to something slightly off-background.

This makes way for a future `"editor.whitespace.render" = "selection"` as well, which could enable showing whitespace only in a selection rather than always.

TODOs:

- [ ] non breaking space character? (U+00A0F, default: `⍽`)
- [x] update existing themes to include `ui.virtual`
- [x] add new config documentation to the book
- [x] decide whether this should be off by default
- [x] squash down commits 🔨

connects #1068 
closes #1218
closes #688