### PR TITLE
Match in visual use head not anchor

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3702,7 +3702,7 @@ fn match_brackets(cx: &mut Context) {
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id).clone().transform(|range| {
             if let Some(pos) =
-                match_brackets::find_matching_bracket_fuzzy(syntax, doc.text(), range.anchor)
+                match_brackets::find_matching_bracket_fuzzy(syntax, doc.text(), range.cursor(text))
             {
                 range.put_cursor(text, pos, doc.mode == Mode::Select)
             } else {


### PR DESCRIPTION
Currently match is finding the match based on the anchor rather than the
head (cursor) so this behavior is rather unexpected when user is doing
a match but a different item was matched instead when the selection is
more than one character.

Example

```
#(let hello = {|)#
};
```

When `mm`

Before (it will match more than just the cursor matching char)

```
#(let hello = {
};|)#
```

After (it finds matching character based on the cursor)

```
#(let hello = {
}|)#;
```

There is one change I would like to do here but did not since it brings in more change, which is that `mm` will select everything within by default, rather than needing to do `v`. Maybe need to confirm with @sudormrfbin for that.