### PR TITLE
simplify Julia config

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -467,7 +467,7 @@ language-server = { command = "julia", args = [
     "--startup-file=no",
     "--history-file=no",
     "--quiet",
-    "-e", 
+    "-e",
     "using LanguageServer; runserver()",
     ] }
 indent = { tab-width = 4, unit = "    " }

--- a/languages.toml
+++ b/languages.toml
@@ -464,21 +464,13 @@ file-types = ["jl"]
 roots = []
 comment-token = "#"
 language-server = { command = "julia", args = [
-        "--startup-file=no",
-        "--history-file=no",
-        "--quiet",
-        "-e",
-        """
-                using LanguageServer;
-                using Pkg;
-                import StaticLint;
-                env_path = dirname(Pkg.Types.Context().env.project_file);
-                server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, "");
-                server.runlinter = true;
-                run(server);
-        """,
-        ] }
-indent = { tab-width = 2, unit = "  " }
+    "--startup-file=no",
+    "--history-file=no",
+    "--quiet",
+    "-e", 
+    "using LanguageServer; runserver()",
+    ] }
+indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "julia"


### PR DESCRIPTION
This simplifies the setup for the Julia language server. 
Also changes the standard indent to 4 spaces, which is recommended in the style guide. 
https://docs.julialang.org/en/v1/manual/style-guide/#Indentation