### PR TITLE
Continue loading the config on error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "pulldown-cmark",
  "retain_mut",
  "serde",
+ "serde_ignored",
  "serde_json",
  "signal-hook",
  "signal-hook-tokio",
@@ -911,6 +912,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -179,7 +179,7 @@ pub struct IndentationConfiguration {
 
 /// Configuration for auto pairs
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields, untagged)]
+#[serde(rename_all = "kebab-case", untagged)]
 pub enum AutoPairConfig {
     /// Enables or disables auto pairing. False means disabled. True means to use the default pairs.
     Enable(bool),

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -61,6 +61,7 @@ toml = "0.5"
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_ignored = "0.1.2"
 
 # ripgrep for global search
 grep-regex = "0.1.9"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -19,6 +19,7 @@ use crate::{
 
 use log::{error, warn};
 use std::{
+    collections::BTreeSet,
     io::{stdin, stdout, Write},
     sync::Arc,
     time::{Duration, Instant},
@@ -271,10 +272,11 @@ impl Application {
     }
 
     fn refresh_config(&mut self) {
-        let config = Config::load(helix_loader::config_file()).unwrap_or_else(|err| {
-            self.editor.set_error(err.to_string());
-            Config::default()
-        });
+        let config = Config::load(helix_loader::config_file(), &mut BTreeSet::new())
+            .unwrap_or_else(|err| {
+                self.editor.set_error(err.to_string());
+                Config::default()
+            });
 
         // Refresh theme
         if let Some(theme) = config.theme.clone() {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,19 +1,23 @@
 use crate::keymap::{default::default, merge_keys, Keymap};
 use helix_view::document::Mode;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 use std::io::Error as IOError;
 use std::path::PathBuf;
 use toml::de::Error as TomlError;
 
+use helix_view::editor::ok_or_default;
+
+// NOTE: The fields in this struct use the deserializer ok_or_default to continue parsing when
+// there is an error. In that case, it will use the default value.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(default, deserialize_with = "ok_or_default")]
     pub theme: Option<String>,
-    #[serde(default = "default")]
+    #[serde(default = "default", deserialize_with = "ok_or_default")]
     pub keys: HashMap<Mode, Keymap>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ok_or_default")]
     pub editor: helix_view::editor::Config,
 }
 
@@ -43,17 +47,24 @@ impl Display for ConfigLoadError {
 }
 
 impl Config {
-    pub fn load(config_path: PathBuf) -> Result<Config, ConfigLoadError> {
+    pub fn load(
+        config_path: PathBuf,
+        ignored_keys: &mut BTreeSet<String>,
+    ) -> Result<Config, ConfigLoadError> {
         match std::fs::read_to_string(config_path) {
-            Ok(config) => toml::from_str(&config)
+            Ok(config) => {
+                serde_ignored::deserialize(&mut toml::Deserializer::new(&config), |path| {
+                    ignored_keys.insert(path.to_string());
+                })
                 .map(merge_keys)
-                .map_err(ConfigLoadError::BadConfig),
+                .map_err(ConfigLoadError::BadConfig)
+            }
             Err(err) => Err(ConfigLoadError::Error(err)),
         }
     }
 
-    pub fn load_default() -> Result<Config, ConfigLoadError> {
-        Config::load(helix_loader::config_file())
+    pub fn load_default(ignored_keys: &mut BTreeSet<String>) -> Result<Config, ConfigLoadError> {
+        Config::load(helix_loader::config_file(), ignored_keys)
     }
 }
 
@@ -103,5 +114,52 @@ mod tests {
         // From the Default trait
         let default_keys = Config::default().keys;
         assert_eq!(default_keys, default());
+    }
+
+    #[test]
+    fn partial_config_parsing() {
+        use crate::keymap;
+        use crate::keymap::Keymap;
+        use helix_core::hashmap;
+        use helix_view::document::Mode;
+
+        let sample_keymaps = r#"
+            theme = false
+
+            [editor]
+            line-number = false
+            mous = "false"
+            scrolloff = 7
+
+            [editor.search]
+            smart-case = false
+
+            [keys.insert]
+            y = "move_line_down"
+            SC-a = "delete_selection"
+
+            [keys.normal]
+            A-F12 = "move_next_word_end"
+        "#;
+
+        let mut editor = helix_view::editor::Config::default();
+        editor.search.smart_case = false;
+        editor.scrolloff = 7;
+
+        assert_eq!(
+            toml::from_str::<Config>(sample_keymaps).unwrap(),
+            Config {
+                keys: hashmap! {
+                    Mode::Insert => Keymap::new(keymap!({ "Insert mode"
+                        "y" => move_line_down,
+                    })),
+                    Mode::Normal => Keymap::new(keymap!({ "Normal mode"
+                        "A-F12" => move_next_word_end,
+                    })),
+                },
+                editor,
+                ..Default::default()
+            }
+        );
     }
 }

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -34,6 +34,18 @@ impl<'de> Deserialize<'de> for KeyTrieNode {
         D: serde::Deserializer<'de>,
     {
         let map = HashMap::<KeyEvent, KeyTrie>::deserialize(deserializer)?;
+        let map: HashMap<_, _> = map
+            .into_iter()
+            .filter_map(|(key, value)| {
+                // Filter the KeyEvents that has an invalid value because those come from a
+                // parsing error and we should just ignore them.
+                if key == KeyEvent::invalid() {
+                    None
+                } else {
+                    Some((key, value))
+                }
+            })
+            .collect();
         let order = map.keys().copied().collect::<Vec<_>>(); // NOTE: map.keys() has arbitrary order
         Ok(Self {
             map,


### PR DESCRIPTION
Fix #1732

There are cases where this improve the error that is shown to the user, but in some cases, the error message gets worse, i.e. it loses its context (key name) and/or position.
I'll try to find a way to improve this, but I'm not sure how, so suggestions are welcomed! (I tried serde-path-to-error, but it does not seem like it works when called from `ok_or_default`.)

I'm submitting this PR now to gather early reviews.