### PR TITLE
Update tree-sitter-git-commit with performance fix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -830,7 +830,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "git-commit"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "066e395e1107df17183cf3ae4230f1a1406cc972" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "7ae23de633de41f8f5b802f6f05b6596df6d00c1" }
 
 [[language]]
 name = "git-diff"

--- a/runtime/queries/git-commit/injections.scm
+++ b/runtime/queries/git-commit/injections.scm
@@ -1,5 +1,5 @@
-((comment (scissors))
- (message) @injection.content
+(((scissors)
+  (message) @injection.content)
  (#set! injection.include-children)
  (#set! injection.language "diff"))
 


### PR DESCRIPTION
Any text following a `scissors` node is now contained in one `message` node. This is a huge speed boost for verbose commits which inject tree-sitter-git-diff after the scissors. The old behavior was that each line was its own injection, which is slow when there are thousands of injections.

cherry-picked out of #1728
closes #1836
see also https://github.com/the-mikedavis/tree-sitter-git-commit/commit/d04666995496e6ebb014b7de05514afe8b18c33c