### PR TITLE
Fix suspend when running hx within git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "helix-view",
  "ignore",
  "log",
+ "nix",
  "num_cpus",
  "once_cell",
  "pulldown-cmark",
@@ -635,6 +636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +678,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -67,6 +67,7 @@ grep-searcher = "0.1.8"
 
 # Remove once retain_mut lands in stable rust
 retain_mut = "0.1.7"
+nix = "0.23"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }


### PR DESCRIPTION
When editing git commit message using helix, when ctrl-z is pressed
the terminal will get stuck since helix does not suspend correctly,
as helix is currently using tokio with multi-threads, with signal-hook
default low_level::emulate_default_handler it only send the SIGSTOP to
the current process but tokio uses multi-process so not everything gets
suspended and the terminal also gets stuck.

Now switched to use libc kill function and send it to pid 0 so that all
processes gets suspended correctly.

Maybe I need to create an issue in signal-hook for this to check why they didn't kill all processes.