### PR TITLE
Assistance on transition to termwiz

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -28,8 +28,8 @@ use anyhow::Error;
 use crossterm::{
     event::{DisableMouseCapture, Event, EventStream},
     execute, terminal,
-    tty::IsTty,
 };
+use termwiz::istty::IsTty;
 #[cfg(not(windows))]
 use {
     signal_hook::{consts::signal, low_level},


### PR DESCRIPTION
This is intended as a working branch to share work towards replacing crossterm with termwiz.

I began with replacing the terminal claiming and restoring with termwiz' equivalent logic. Since termwiz keeps those mehtods on the terminal instance, I had to move the logic into the Compositor to get access. However, the panic handler is a bit tricky as I can't reach inside the compositor from within there, and since Termwiz puts the methods on the struct, I'm not really sure how to acheive the same result.