### PR TITLE
docs: simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ We provide packaging for various distributions, but here's a quick method to
 build from source.
 
 ```
-cargo install helix-term --git https://github.com/helix-editor/helix
-hx --grammar fetch
-hx --grammar build
+git clone https://github.com/helix-editor/helix
+cd helix
+cargo install --path helix-term
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ We provide packaging for various distributions, but here's a quick method to
 build from source.
 
 ```
-git clone https://github.com/helix-editor/helix
-cd helix
-cargo install --path helix-term
+cargo install helix-term --git https://github.com/helix-editor/helix
 hx --grammar fetch
 hx --grammar build
 ```

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -44,7 +44,9 @@ sudo dnf install helix
 ## Build from source
 
 ```
-cargo install helix-term --git https://github.com/helix-editor/helix
+git clone https://github.com/helix-editor/helix
+cd helix
+cargo install --path helix-term
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin`.
@@ -52,9 +54,3 @@ This will install the `hx` binary to `$HOME/.cargo/bin`.
 Helix also needs it's runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overriden
 via the `HELIX_RUNTIME` environment variable.
-
-## Building tree-sitter grammars
-
-Tree-sitter grammars must be fetched and compiled if not pre-packaged.
-Fetch grammars with `hx --grammar fetch` (requires `git`) and compile them
-with `hx --grammar build` (requires a C compiler).

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -44,9 +44,7 @@ sudo dnf install helix
 ## Build from source
 
 ```
-git clone https://github.com/helix-editor/helix
-cd helix
-cargo install --path helix-term
+cargo install helix-term --git https://github.com/helix-editor/helix
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin`.


### PR DESCRIPTION
Updates the installation instructions to ~~make use of cargo-install's git option~~ remove the step of building the grammar because that's done by the build script automatically.