### PR TITLE
Update install instructions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ build from source.
 git clone https://github.com/helix-editor/helix
 cd helix
 cargo install --path helix-term
-hx --grammar fetch
-hx --grammar build
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars.


### PR DESCRIPTION
It's no longer necessary to fetch and build grammars separately. 