### PR TITLE
Revise the color for ui.cursor.match

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -56,6 +56,7 @@
 
 "ui.selection" = { bg = "#313f4e" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
+"ui.cursor.match" = { fg = "#313f4e", bg = "#dc7759" }
 "ui.cursor" = { fg = "#ABB2BF", modifiers = ["reversed"] }
 "ui.menu.selected" = { fg = "#e5ded6", bg = "#313f4e" }
 

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -81,7 +81,7 @@
 "ui.cursor" = {fg = "base02", bg = "cyan"}
 "ui.cursor.insert" = {fg = "base03", bg = "base3"}
 # 当前光标匹配的标点符号
-"ui.cursor.match" = {modifiers = ["reversed"]}
+"ui.cursor.match" = { fg = "base03", bg = "base00" }
 
 "warning" =  { fg = "orange", modifiers= ["bold", "underlined"] }
 "error" = { fg = "red", modifiers= ["bold", "underlined"] }

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -81,7 +81,7 @@
 "ui.cursor" = {fg = "base02", bg = "cyan"}
 "ui.cursor.insert" = {fg = "base03", bg = "base3"}
 # 当前光标匹配的标点符号
-"ui.cursor.match" = {modifiers = ["reversed"]}
+"ui.cursor.match" = { fg = "base02", bg = "light-gray" }
 
 "warning" =  { fg = "orange", modifiers= ["bold", "underlined"] }
 "error" = { fg = "red", modifiers= ["bold", "underlined"] }

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -61,7 +61,7 @@
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
-"ui.cursor.match" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { bg = "bg3" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "#655370", bg = "#d1dcdf", modifiers = ["bold"] }
 


### PR DESCRIPTION
In the following four provided themes, `ui.cursor.match` has the same look with `ui.cursor.primary`.
For better discrimination, I think we need different colors. How about the following assignments?

### bogster
- present
![bogster](https://user-images.githubusercontent.com/997855/159681851-076073e4-ea26-4ad2-80f3-44523c7943e8.png)
- PR
![bogster_2](https://user-images.githubusercontent.com/997855/159720796-1291a0d6-001a-4a14-a348-c613cfcd275a.png)

### solarized_light
- present
![solarized_light](https://user-images.githubusercontent.com/997855/159683937-f5bae932-51fc-4368-9896-e81b58efd506.png)
- PR
![solarized_light_1](https://user-images.githubusercontent.com/997855/159683215-a7458abc-ef6f-4f82-934c-c69ba06475ab.png)


### solarized_dark
- present
![solarized_dark](https://user-images.githubusercontent.com/997855/159681966-a4d5709b-4027-46d0-b2fd-7e988b915719.png)
- PR
![solarized_dark_1](https://user-images.githubusercontent.com/997855/159683450-ff66d0d1-e835-44a2-a0f6-bfe5cabfab9c.png)


### spacebones_light
- present
![spacebones_light](https://user-images.githubusercontent.com/997855/159681898-a79e36f6-fbcd-4560-9b3e-0dd3eea4312f.png)
- PR
![spacebones_light_1](https://user-images.githubusercontent.com/997855/159683617-4cefb98f-b0c1-4d03-a48d-69c43943c718.png)
