### PR TITLE
Fix Rescript hightlights query

### DIFF
--- a/runtime/queries/rescript/highlights.scm
+++ b/runtime/queries/rescript/highlights.scm
@@ -62,7 +62,6 @@
 
 [
  (formal_parameters (value_identifier))
- (positional_parameter (value_identifier))
  (labeled_parameter (value_identifier))
 ] @variable.parameter
 


### PR DESCRIPTION
Hey there,

With the latest update of `tree-sitter-rescript`, there's a slight change to the query. This PR removes a node highlight query for a node that no longer exists.