### PR TITLE
Move top level lsp config to editor.lsp

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -43,6 +43,14 @@ hidden = false
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 
+### `[editor.lsp]` Section
+
+| Key                | Description                                 | Default |
+| ---                | -----------                                 | ------- |
+| `display-messages` | Display LSP progress messages below statusline[^1] | `false` |
+
+[^1]: A progress spinner is always shown in the statusline beside the file path.
+
 ### `[editor.cursor-shape]` Section
 
 Defines the shape of cursor in each mode. Note that due to limitations
@@ -126,13 +134,3 @@ Search specific options.
 |--|--|---------|
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
 | `wrap-around`| Whether the search should wrap after depleting the matches | `true` |
-
-
-## LSP
-
-To display all language server messages in the status line add the following to your `config.toml`:
-
-```toml
-[lsp]
-display-messages = true
-```

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -760,7 +760,7 @@ impl Application {
                             self.lsp_progress.update(server_id, token, work);
                         }
 
-                        if self.config.load().lsp.display_messages {
+                        if self.config.load().editor.lsp.display_messages {
                             self.editor.set_status(status);
                         }
                     }

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -12,8 +12,6 @@ use toml::de::Error as TomlError;
 pub struct Config {
     pub theme: Option<String>,
     #[serde(default)]
-    pub lsp: LspConfig,
-    #[serde(default = "default")]
     pub keys: HashMap<Mode, Keymap>,
     #[serde(default)]
     pub editor: helix_view::editor::Config,
@@ -23,7 +21,6 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             theme: None,
-            lsp: LspConfig::default(),
             keys: default(),
             editor: helix_view::editor::Config::default(),
         }
@@ -43,12 +40,6 @@ impl Display for ConfigLoadError {
             ConfigLoadError::Error(err) => err.fmt(f),
         }
     }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct LspConfig {
-    pub display_messages: bool,
 }
 
 impl Config {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -11,7 +11,7 @@ use toml::de::Error as TomlError;
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub theme: Option<String>,
-    #[serde(default)]
+    #[serde(default = "default")]
     pub keys: HashMap<Mode, Keymap>,
     #[serde(default)]
     pub editor: helix_view::editor::Config,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -143,6 +143,13 @@ pub struct Config {
     /// Search configuration.
     #[serde(default)]
     pub search: SearchConfig,
+    pub lsp: LspConfig,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LspConfig {
+    pub display_messages: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -253,6 +260,7 @@ impl Default for Config {
             cursor_shape: CursorShapeConfig::default(),
             true_color: false,
             search: SearchConfig::default(),
+            lsp: LspConfig::default(),
         }
     }
 }


### PR DESCRIPTION
This is mainly done to accomodate the new lsp.signature-help config option that will be introduced in https://github.com/helix-editor/helix/pull/1755 which will have to be accessed by commands. The top level config struct is split and moved to different places, making the relocation necessary.
