### PR TITLE
Replace line endings using `set_line_ending` command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -13,7 +13,7 @@
 | `:new`, `:n` | Create a new scratch buffer. |
 | `:format`, `:fmt` | Format the file using the LSP formatter. |
 | `:indent-style` | Set the indentation style for editing. ('t' for tabs or 1-8 for number of spaces.) |
-| `:line-ending` | Set the document's default line ending. Options: crlf, lf, cr, ff, nel. |
+| `:line-ending` | Set the document's default line ending. Options: crlf, lf. |
 | `:earlier`, `:ear` | Jump back to an earlier point in edit history. Accepts a number of steps or a time span. |
 | `:later`, `:lat` | Jump to a later point in edit history. Accepts a number of steps or a time span. |
 | `:write-quit`, `:wq`, `:x` | Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt) |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -280,7 +280,6 @@ fn set_line_ending(
     args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
-    use helix_core::line_ending;
     use LineEnding::*;
 
     // If no argument, report current line ending setting.
@@ -329,11 +328,10 @@ fn set_line_ending(
     let transaction = Transaction::change(
         doc.text(),
         doc.text().lines().filter_map(|line| {
-            let current_pos = pos;
             pos += line.len_chars();
-            match line_ending::get_line_ending(&line) {
+            match helix_core::line_ending::get_line_ending(&line) {
                 Some(ending) if ending != line_ending => {
-                    let start = current_pos + line_ending::rope_end_without_line_ending(&line);
+                    let start = pos - ending.len_chars();
                     let end = pos;
                     Some((start, end, Some(line_ending.as_str().into())))
                 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -339,7 +339,6 @@ fn set_line_ending(
             }
         }),
     );
-
     doc.apply(&transaction, view.id);
 
     Ok(())
@@ -1132,6 +1131,9 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "line-ending",
             aliases: &[],
+            #[cfg(not(feature = "unicode-lines"))]
+            doc: "Set the document's default line ending. Options: crlf, lf.",
+            #[cfg(feature = "unicode-lines")]
             doc: "Set the document's default line ending. Options: crlf, lf, cr, ff, nel.",
             fun: set_line_ending,
             completer: None,


### PR DESCRIPTION
A `Transaction` is generated to replace all line endings (other than the one your changing it to) in a file. I opted to not create a method for `Document` since I'm not sure it would ever be used elsewhere, and it would be easy to pull out of the command function if needed.