### PR TITLE
grammars.nix: use github type for fetchTree where possible

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -10,16 +10,31 @@ let
   isGitGrammar = (grammar:
     builtins.hasAttr "source" grammar && builtins.hasAttr "git" grammar.source
     && builtins.hasAttr "rev" grammar.source);
+  isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
+  toGitHubFetcher = url: let
+    match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" url;
+  in {
+    owner = builtins.elemAt match 0;
+    repo = builtins.elemAt match 1;
+  };
   gitGrammars = builtins.filter isGitGrammar languagesConfig.grammar;
   buildGrammar = grammar:
     let
-      source = builtins.fetchTree {
+      gh = toGitHubFetcher grammar.source.git;
+      sourceGit = builtins.fetchTree {
         type = "git";
         url = grammar.source.git;
         rev = grammar.source.rev;
         ref = grammar.source.ref or "HEAD";
         shallow = true;
       };
+      sourceGitHub = builtins.fetchTree {
+        type = "github";
+        owner = gh.owner;
+        repo = gh.repo;
+        inherit (grammar.source) rev;
+      };
+      source = if isGitHubGrammar grammar then sourceGitHub else sourceGit;
     in stdenv.mkDerivation rec {
       # see https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix
 


### PR DESCRIPTION
fetchTree with git is slow even with shallow cloning. It might also be that shallow cloning simply [doesn't work](https://github.com/NixOS/nix/issues/5119). Either way, the github fetcher is much faster as it downloads a tarball using the GitHub API. All the current grammars are from GitHub so this should reduce fetch time a lot.