### PR TITLE
Avoid using the format ident Rust feature

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -63,12 +63,12 @@ pub fn get_language(name: &str) -> Result<Language> {
     library_path.set_extension(DYLIB_EXTENSION);
 
     let library = unsafe { Library::new(&library_path) }
-        .with_context(|| format!("Error opening dynamic library {library_path:?}"))?;
+        .with_context(|| format!("Error opening dynamic library {:?}", library_path))?;
     let language_fn_name = format!("tree_sitter_{}", name.replace('-', "_"));
     let language = unsafe {
         let language_fn: Symbol<unsafe extern "C" fn() -> Language> = library
             .get(language_fn_name.as_bytes())
-            .with_context(|| format!("Failed to load symbol {language_fn_name}"))?;
+            .with_context(|| format!("Failed to load symbol {}", language_fn_name))?;
         language_fn()
     };
     std::mem::forget(library);
@@ -133,7 +133,7 @@ where
     // TODO: print all failures instead of the first one found.
     rx.iter()
         .find(|result| result.is_err())
-        .map(|err| err.with_context(|| format!("Failed to {action} some grammar(s)")))
+        .map(|err| err.with_context(|| format!("Failed to {} some grammar(s)", action)))
         .unwrap_or(Ok(()))
 }
 
@@ -238,12 +238,16 @@ fn build_grammar(grammar: GrammarConfiguration) -> Result<()> {
     };
 
     let grammar_dir_entries = grammar_dir.read_dir().with_context(|| {
-        format!("Failed to read directory {grammar_dir:?}. Did you use 'hx --grammar fetch'?")
+        format!(
+            "Failed to read directory {:?}. Did you use 'hx --grammar fetch'?",
+            grammar_dir
+        )
     })?;
 
     if grammar_dir_entries.count() == 0 {
         return Err(anyhow!(
-            "Directory {grammar_dir:?} is empty. Did you use 'hx --grammar fetch'?"
+            "Directory {:?} is empty. Did you use 'hx --grammar fetch'?",
+            grammar_dir
         ));
     };
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -891,8 +891,8 @@ fn setting(
     }
     let (key, arg) = (&args[0].to_lowercase(), &args[1]);
 
-    let key_error = || anyhow::anyhow!("Unknown key `{key}`");
-    let field_error = |_| anyhow::anyhow!("Could not parse field `{arg}`");
+    let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
+    let field_error = |_| anyhow::anyhow!("Could not parse field `{}`", arg);
 
     let mut config = serde_json::to_value(&cx.editor.config().clone()).unwrap();
     let pointer = format!("/{}", key.replace('.', "/"));

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -89,10 +89,11 @@ pub fn languages_all() {
 
     let column = |item: &str, color: Color| {
         let data = format!(
-            "{:column_width$}",
+            "{:width$}",
             item.get(..column_width - 2)
-                .map(|s| format!("{s}…"))
-                .unwrap_or_else(|| item.to_string())
+                .map(|s| format!("{}…", s))
+                .unwrap_or_else(|| item.to_string()),
+            width = column_width,
         )
         .stylize()
         .with(color);
@@ -158,7 +159,7 @@ pub fn language(lang_str: String) {
     {
         Some(l) => l,
         None => {
-            let msg = format!("Language '{lang_str}' not found");
+            let msg = format!("Language '{}' not found", lang_str);
             println!("{}", msg.red());
             let suggestions: Vec<&str> = syn_loader_conf
                 .language


### PR DESCRIPTION
While this feature is undeniably ergonomic, it mostly inflates the MSRV, which is a problem over at Void Linux where bumping Rust version is a lengthy process.

Checked with `cargo-msrv` that with these changes the MSRV drops to 1.57