### PR TITLE
update BEAM language tree-sitter grammars

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -17,6 +17,7 @@
 | git-config | ✓ |  |  |  |
 | git-diff | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
+| gleam | ✓ |  |  |  |
 | glsl | ✓ |  | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
 | graphql | ✓ |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -11,7 +11,7 @@
 | dockerfile | ✓ |  |  | `docker-langserver` |
 | elixir | ✓ |  |  | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |
-| erlang | ✓ |  |  |  |
+| erlang | ✓ |  |  | `erlang_ls` |
 | fish | ✓ | ✓ | ✓ |  |
 | git-commit | ✓ |  |  |  |
 | git-config | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -939,15 +939,16 @@ source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "
 [[language]]
 name = "erlang"
 scope = "source.erlang"
-injection-regex = "^erl$"
-file-types = ["erl", "hrl", "app", "rebar.config"]
+injection-regex = "erl(ang)?"
+file-types = ["erl", "hrl", "app", "rebar.config", "rebar.lock"]
 roots = ["rebar.config"]
 comment-token = "%%"
 indent = { tab-width = 4, unit = "    " }
+language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "86985bde399c5f40b00bc75f7ab70a6c69a5f9c3" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "1e81393b8f0a81b35ff1679a9420fafbd2cf3511" }
 
 [[language]]
 name = "kotlin"

--- a/languages.toml
+++ b/languages.toml
@@ -1003,3 +1003,16 @@ language-server = { command = "solc", args = ["--lsp"] }
 [[grammar]]
 name = "solidity"
 source = { git = "https://github.com/slinlee/tree-sitter-solidity", rev = "f3a002274744e859bf64cf3524985f8c31ea84fd" }
+
+[[language]]
+name = "gleam"
+scope = "source.gleam"
+injection-regex = "gleam"
+file-types = ["gleam"]
+roots = ["gleam.toml"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "gleam"
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "7159ce961592192b0e7cdf88782cda0fdf41a4cb" }

--- a/languages.toml
+++ b/languages.toml
@@ -78,8 +78,8 @@ source = { git = "https://github.com/yusdacra/tree-sitter-protobuf", rev = "19c2
 [[language]]
 name = "elixir"
 scope = "source.elixir"
-injection-regex = "elixir"
-file-types = ["ex", "exs"]
+injection-regex = "(elixir|ex)"
+file-types = ["ex", "exs", "mix.lock"]
 shebangs = ["elixir"]
 roots = []
 comment-token = "#"
@@ -88,7 +88,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "elixir"
-source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "f5d7bda543da788bd507b05bd722627dde66c9ec"  }
+source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "60863fc6e27d60cf4b1917499ed2259f92c7800e"  }
 
 [[language]]
 name = "fish"

--- a/runtime/queries/elixir/highlights.scm
+++ b/runtime/queries/elixir/highlights.scm
@@ -82,11 +82,11 @@
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float
 
-(alias) @type
+(alias) @namespace
 
 (call
   target: (dot
-    left: (atom) @type))
+    left: (atom) @namespace))
 
 (char) @constant.character
 

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -22,7 +22,7 @@
       (tuple
         (binary_operator
           left: (atom) @variable.other.member
-          operator: "="))
+          operator: ["=" "::"]))
       (tuple
         (binary_operator
           left:
@@ -74,7 +74,7 @@
   @keyword
   "^(define|export|export_type|include|include_lib|ifdef|ifndef|if|elif|else|endif|vsn|on_load|behaviour|record|file|type|opaque|spec)$"))
 
-["case" "fun" "if" "of" "when" "end" "receive" "try" "catch" "after"] @keyword
+["case" "fun" "if" "of" "when" "end" "receive" "try" "catch" "after" "begin" "maybe"] @keyword
 
 ; Operators
 (binary_operator

--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -1,0 +1,101 @@
+; Comments
+(module_comment) @comment
+(statement_comment) @comment
+(comment) @comment
+
+; Constants
+(constant
+  name: (identifier) @constant)
+
+; Modules
+(module) @namespace
+(import alias: (identifier) @namespace)
+(remote_type_identifier
+  module: (identifier) @namespace)
+((field_access
+  record: (identifier) @namespace
+  field: (label) @function)
+ (#is-not? local))
+
+; Functions
+(unqualified_import (identifier) @function)
+(function
+  name: (identifier) @function)
+(external_function
+  name: (identifier) @function)
+(function_parameter
+  name: (identifier) @variable.parameter)
+((function_call
+   function: (identifier) @function)
+ (#is-not? local))
+((binary_expression
+   operator: "|>"
+   right: (identifier) @function)
+ (#is-not? local))
+
+; "Properties"
+; Assumed to be intended to refer to a name for a field; something that comes
+; before ":" or after "."
+; e.g. record field names, tuple indices, names for named arguments, etc
+(label) @variable.other.member
+(tuple_access
+  index: (integer) @variable.other.member)
+
+; Type names
+(remote_type_identifier) @type
+(type_identifier) @type
+
+; Literals
+(string) @string
+(bit_string_segment_option) @function.builtin
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+; Variables
+(identifier) @variable
+(discard) @comment.unused
+
+; Operators
+(binary_expression
+  operator: _ @operator)
+
+; Keywords
+[
+  (visibility_modifier) ; "pub"
+  (opacity_modifier) ; "opaque"
+  "as"
+  "assert"
+  "case"
+  "const"
+  "external"
+  "fn"
+  "if"
+  "import"
+  "let"
+  "todo"
+  "try"
+  "type"
+] @keyword
+
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<<"
+  ">>"
+] @punctuation.bracket
+[
+  "."
+  ","
+  ;; Controversial -- maybe some are operators?
+  ":"
+  "#"
+  "="
+  "->"
+  ".."
+  "-"
+] @punctuation.delimiter

--- a/runtime/queries/gleam/locals.scm
+++ b/runtime/queries/gleam/locals.scm
@@ -1,0 +1,15 @@
+; Scopes
+(function_body) @local.scope
+
+(case_clause) @local.scope
+
+; Definitions
+(let pattern: (identifier) @local.definition)
+(function_parameter name: (identifier) @local.definition)
+(list_pattern (identifier) @local.definition)
+(list_pattern assign: (identifier) @local.definition)
+(tuple_pattern (identifier) @local.definition)
+(record_pattern_argument pattern: (identifier) @local.definition)
+
+; References
+(identifier) @local.reference


### PR DESCRIPTION
There are some updates to bring tree-sitter-erlang and tree-sitter-elixir up to date including some fixes plus I've added tree-sitter-gleam!

highlights:

**Erlang**

- fixes for syntax highlighting
	- `begin`
	- `after`
	- record fields without defaults but with typing
- [EEP49 `maybe`](https://www.erlang.org/eeps/eep-0049#specification) is now parsed (new syntax in OTP25)

**Elixir**

- fix for mistakenly highlighting keywords in some odd stab clause scenarios
    - iirc it was some very rare syntax like
      ```elixir
      fn
        index ->
          IO.inspect(index)      # some other line(s) and then the last line is an identifier
          index
          # <- keyword           ('in' is highlighted as a keyword)
        _index ->
          0
      end
      ```
- switch to `@namespace` for modules (upstream switched to `@module` and `@namespace` seems closest of the available highlights)
- nullary ranges are now parsed: `Enum.to_list(..) == []` (new syntax in 1.14)

**Gleam**

`tree-sitter-gleam` is added. Gleam is a cool newer statically typed, rust-like language that compiles to BEAM. The highlights are interesting because whether an identifier is a module or a variable depends on whether it's in scope. Like so:

```gleam
fn record_with_fun_field() {
  let foo = Bar(baz: fn(x) { x + 1 })
  foo.baz(41)
  // <- variable
  //  ^ property
  string.replace("hello", "l", "o")
  // ^ module
  //     ^ function
}
```

(GitHub doesn't use tree-sitter-gleam yet but it's on their roadmap.)