### PR TITLE
Avoid unnecessary clone when formatting error

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1644,11 +1644,8 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
                 wrap_around,
             );
         } else {
-            // get around warning `mutable_borrow_reservation_conflict`
-            // which will be a hard error in the future
-            // see: https://github.com/rust-lang/rust/issues/59159
-            let query = query.clone();
-            cx.editor.set_error(format!("Invalid regex: {}", query));
+            let error = format!("Invalid regex: {}", query);
+            cx.editor.set_error(error);
         }
     }
 }


### PR DESCRIPTION
Instead of first cloning the query and then allocating again to format
the error, format the error using a reference to the query.

Comment about borrow-checker warning is removed,
documenting simple borrow-checker constructions gets noisy pretty quickly, imho.