### PR TITLE
Fix start-position of next search

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1486,11 +1486,11 @@ fn search_impl(
     // Get the right side of the primary block cursor for forward search, or the
     // grapheme before the start of the selection for reverse search.
     let start = match direction {
-        Direction::Forward => text.char_to_byte(graphemes::next_grapheme_boundary(
+        Direction::Forward => text.char_to_byte(graphemes::ensure_grapheme_boundary_next(
             text,
             selection.primary().to(),
         )),
-        Direction::Backward => text.char_to_byte(graphemes::prev_grapheme_boundary(
+        Direction::Backward => text.char_to_byte(graphemes::ensure_grapheme_boundary_prev(
             text,
             selection.primary().from(),
         )),


### PR DESCRIPTION
The search implementation would start searching at the next grapheme
boundary after the previous selection. In case the next occurence of the
needle is immediately after the current selection, this occurence would
not be found (without wraparound) because the first grapheme is skipped.

The correct approach is to use the ensure_grapheme_boundary functions instead
of using the functions that skip unconditionally to the next grapheme.


Example case:
> hellohellohello

When searching for "hello", the first and third occurrence will be found.
(Second will be found once depending on starting-position of the cursor)