### PR TITLE
Auto-complete directory members (#1801)

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -522,6 +522,11 @@ impl Component for Prompt {
             }
             key!(Tab) => {
                 self.change_completion_selection(CompletionDirection::Forward);
+                // if single completion candidate is a directory list content in completion
+                if self.completion.len() == 1 && self.line.ends_with(std::path::MAIN_SEPARATOR) {
+                    self.recalculate_completion(cx.editor);
+                    self.exit_selection();
+                }
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update)
             }
             shift!(Tab) => {


### PR DESCRIPTION
Allow tab-completion to continue when there is only a single, unambiguous
completion target which is a directory. This allows e.g. nested directories
to be quickly drilled down just by hitting tab instead of first selecting
the completion then hitting enter.

Close #1801 