### PR TITLE
Fix indentation fallback

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -398,6 +398,9 @@ impl LanguageConfiguration {
             .get_or_init(|| {
                 let lang_name = self.language_id.to_ascii_lowercase();
                 let query_text = read_query(&lang_name, "indents.scm");
+                if query_text.is_empty() {
+                    return None;
+                }
                 let lang = self.highlight_config.get()?.as_ref()?.language;
                 Query::new(lang, &query_text).ok()
             })


### PR DESCRIPTION
If there exists no `indents.scm` for some language, we want to use the fallback (always copy the indentation from the current line). This didn't happen because we returned an empty query instead.