### PR TITLE
Reintroduce win32yank as a clipboard provider on Linux for WSL2 + Windows 10

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -88,6 +88,11 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
             primary_paste => "wl-paste", "-p", "--no-newline";
             primary_copy => "wl-copy", "-p", "--type", "text/plain";
         }
+    } else if exists("win32yank.exe") {
+        command_provider! {
+            paste => "win32yank.exe", "-o", "--lf";
+            copy => "win32yank.exe", "-i", "--crlf";
+        }
     } else if env_var_is_set("DISPLAY") && exists("xclip") {
         command_provider! {
             paste => "xclip", "-o", "-selection", "clipboard";

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -88,11 +88,6 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
             primary_paste => "wl-paste", "-p", "--no-newline";
             primary_copy => "wl-copy", "-p", "--type", "text/plain";
         }
-    } else if exists("win32yank.exe") {
-        command_provider! {
-            paste => "win32yank.exe", "-o", "--lf";
-            copy => "win32yank.exe", "-i", "--crlf";
-        }
     } else if env_var_is_set("DISPLAY") && exists("xclip") {
         command_provider! {
             paste => "xclip", "-o", "-selection", "clipboard";
@@ -108,6 +103,11 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
             copy => "xsel", "-i", "-b";
             primary_paste => "xsel", "-o";
             primary_copy => "xsel", "-i";
+        }
+    } else if exists("win32yank.exe") {
+        command_provider! {
+            paste => "win32yank.exe", "-o", "--lf";
+            copy => "win32yank.exe", "-i", "--crlf";
         }
     } else if exists("termux-clipboard-set") && exists("termux-clipboard-get") {
         command_provider! {


### PR DESCRIPTION
I'm not sure if there is any desire for this to be reintroduced as it was removed in https://github.com/helix-editor/helix/commit/adf97e088e38c12eb6c363f674aab5dca1962bbe. But here is a small PR on the off chance that it is until https://github.com/helix-editor/helix/pull/1827 is in a good state to merge.

If this PR isn't a desired addition to the repo at the moment, I am happy to continue to keep this branch on my fork up to date with the upstream so that Arch WSL2 users who come across this via Google or GitHub search can use `yay` to install an edited version of `helix-git` from the AUR:

```bash
yay -G helix-git
cd ~/.cache/yay/helix-git
rm -rf helix pkg src
# edit PKGBUILD to change the `_git` key to point to the fork and save changes
makepkg -si
```

Finally, a huge thanks to everyone that has dedicated their time and effort to creating such a wonderful text editor!