### PR TITLE
Added checkmarks to health.rs output, Resolves #1894

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -154,8 +154,8 @@ pub fn languages_all() -> std::io::Result<()> {
 
         for ts_feat in TsFeature::all() {
             match load_runtime_file(&lang.language_id, ts_feat.runtime_filename()).is_ok() {
-                true => column("Found", Color::Green),
-                false => column("Not Found", Color::Red),
+                true => column("Found ✓", Color::Green),
+                false => column("Not Found ✘", Color::Red),
             }
         }
 
@@ -263,8 +263,8 @@ fn probe_treesitter_feature(lang: &str, feature: TsFeature) -> std::io::Result<(
     let mut stdout = stdout.lock();
 
     let found = match load_runtime_file(lang, feature.runtime_filename()).is_ok() {
-        true => "Found".green(),
-        false => "Not found".red(),
+        true => "Found ✓".green(),
+        false => "Not found ✘".red(),
     };
     writeln!(stdout, "{} queries: {}", feature.short_title(), found)?;
 

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -154,8 +154,8 @@ pub fn languages_all() -> std::io::Result<()> {
 
         for ts_feat in TsFeature::all() {
             match load_runtime_file(&lang.language_id, ts_feat.runtime_filename()).is_ok() {
-                true => column("Found ✓", Color::Green),
-                false => column("Not Found ✘", Color::Red),
+                true => column("✔", Color::Green),
+                false => column("✘", Color::Red),
             }
         }
 
@@ -263,8 +263,8 @@ fn probe_treesitter_feature(lang: &str, feature: TsFeature) -> std::io::Result<(
     let mut stdout = stdout.lock();
 
     let found = match load_runtime_file(lang, feature.runtime_filename()).is_ok() {
-        true => "Found ✓".green(),
-        false => "Not found ✘".red(),
+        true => "✔".green(),
+        false => "✘".red(),
     };
     writeln!(stdout, "{} queries: {}", feature.short_title(), found)?;
 


### PR DESCRIPTION
For the Highlight, Textobject and Indent columns, health.rs now additionally prints either ✓ or ✘. This is in response to Issue #1894 