### PR TITLE
Add texlab language server for latex

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -30,7 +30,7 @@
 | json | ✓ |  | ✓ |  |
 | julia | ✓ |  |  | `julia` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
-| latex | ✓ |  |  |  |
+| latex | ✓ |  |  | `texlab` |
 | lean | ✓ |  |  | `lean` |
 | ledger | ✓ |  |  |  |
 | llvm | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -436,6 +436,7 @@ injection-regex = "tex"
 file-types = ["tex"]
 roots = []
 comment-token = "%"
+language-server = { command = "texlab" }
 indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]


### PR DESCRIPTION
Hi. I think [texlab](https://github.com/latex-lsp/texlab) should be a default langage server for latex. Let me know if this PR needs more work/consideration, docs for example?