### PR TITLE
Continue comments when opening a new line

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -101,6 +101,7 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
 /// Return token if the current line is commented.
 /// Otherwise, return None.
 pub fn continue_comment<'a>(doc: &Rope, line: usize, tokens: &'a [String]) -> Option<&'a str> {
+    // TODO: don't continue shebangs.
     if tokens.is_empty() {
         return None;
     }

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -170,6 +170,7 @@ pub fn continue_block_comment<'a>(
         // token and check that it starts and ends with the correct block comment tokens.
         // FIXME: this doesn't take into account that a line comment followed by a block comment
         // counts as only one comment object.
+        // TODO: Maybe that's caused by the + in the query?
         if !found_block_comments {
             let nodes = lang_config.textobject_query().and_then(|query| {
                 query.capture_nodes_any(&["comment.around"], slice_tree, slice, &mut cursor)

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -55,6 +55,13 @@ pub struct Configuration {
     pub language: Vec<LanguageConfiguration>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlockCommentTokens {
+    pub start: String,
+    pub middle: String,
+    pub end: String,
+}
+
 // largely based on tree-sitter/cli/src/loader.rs
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -69,6 +76,7 @@ pub struct LanguageConfiguration {
     pub comment_token: Option<String>, // TODO: remove.
     #[serde(default)]
     pub comment_tokens: Vec<String>,
+    pub block_comment_tokens: Option<BlockCommentTokens>,
 
     #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]
     pub config: Option<serde_json::Value>,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -66,7 +66,9 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub shebangs: Vec<String>, // interpreter(s) associated with language
     pub roots: Vec<String>,      // these indicate project roots <.git, Cargo.toml>
-    pub comment_token: Option<String>,
+    pub comment_token: Option<String>, // TODO: remove.
+    #[serde(default)]
+    pub comment_tokens: Vec<String>,
 
     #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]
     pub config: Option<serde_json::Value>,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2295,7 +2295,7 @@ fn open(cx: &mut Context, open: Open) {
         text.push_str(doc.line_ending.as_str());
         text.push_str(&indent);
 
-        handle_comment_continue(&doc, range, &mut text, cursor_line, open == Open::Below);
+        handle_comment_continue(doc, range, &mut text, cursor_line, open == Open::Below);
 
         let text = text.repeat(count);
 
@@ -2321,22 +2321,40 @@ fn open(cx: &mut Context, open: Open) {
     goto_line_end_newline(cx);
 }
 
-fn handle_comment_continue(doc: &Document, range: &Range, text: &mut String, cursor_line: usize, open_below: bool) {
+fn handle_comment_continue(
+    doc: &Document,
+    range: &Range,
+    text: &mut String,
+    cursor_line: usize,
+    open_below: bool,
+) {
     if let Some(lang_config) = doc.language_config() {
         let line_comment_tokens = &lang_config.comment_tokens;
-        if let Some(token) = comment::continue_block_comment(doc.text(), doc.syntax(), lang_config, range, open_below) {
+        if let Some(token) = comment::continue_block_comment(
+            doc.text(),
+            doc.syntax(),
+            lang_config,
+            range,
+            open_below,
+        ) {
             text.push(' ');
             text.push_str(token);
             text.push(' ');
-        }
-        else if let Some(token) = comment::continue_comment(doc.text(), cursor_line, line_comment_tokens) {
+        } else if let Some(token) =
+            comment::continue_comment(doc.text(), cursor_line, line_comment_tokens)
+        {
             text.push_str(token);
             text.push(' ');
-        }
-        else if let Some(ref block_comment_tokens) = lang_config.block_comment_tokens {
+        } else if let Some(ref block_comment_tokens) = lang_config.block_comment_tokens {
             // FIXME: this doesn't work for the following lines of a comment start.
             // FIXME: this is too indented in some cases.
-            if comment::continue_comment(doc.text(), cursor_line, &[block_comment_tokens.start.clone()]).is_some() {
+            if comment::continue_comment(
+                doc.text(),
+                cursor_line,
+                &[block_comment_tokens.start.clone()],
+            )
+            .is_some()
+            {
                 text.push(' ');
                 text.push_str(&block_comment_tokens.middle);
                 text.push(' ');
@@ -2806,7 +2824,7 @@ pub mod insert {
                 text.push_str(doc.line_ending.as_str());
                 text.push_str(&indent);
 
-                handle_comment_continue(&doc, range, &mut text, current_line, false);
+                handle_comment_continue(doc, range, &mut text, current_line, false);
 
                 pos + offs + text.chars().count()
             };

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2241,6 +2241,7 @@ async fn make_format_callback(
     Ok(call)
 }
 
+#[derive(PartialEq)]
 enum Open {
     Below,
     Above,
@@ -2294,14 +2295,7 @@ fn open(cx: &mut Context, open: Open) {
         text.push_str(doc.line_ending.as_str());
         text.push_str(&indent);
 
-        let tokens = doc
-            .language_config()
-            .map(|lc| lc.comment_tokens.as_ref())
-            .unwrap_or_default();
-        if let Some(token) = comment::continue_comment(doc.text(), cursor_line, tokens) {
-            text.push_str(token);
-            text.push(' ');
-        }
+        handle_comment_continue(&doc, range, &mut text, cursor_line, open == Open::Below);
 
         let text = text.repeat(count);
 
@@ -2325,6 +2319,30 @@ fn open(cx: &mut Context, open: Open) {
 
     // Since we might have added a comment token, move to the end of the line.
     goto_line_end_newline(cx);
+}
+
+fn handle_comment_continue(doc: &Document, range: &Range, text: &mut String, cursor_line: usize, open_below: bool) {
+    if let Some(lang_config) = doc.language_config() {
+        let line_comment_tokens = &lang_config.comment_tokens;
+        if let Some(token) = comment::continue_block_comment(doc.text(), doc.syntax(), lang_config, range, open_below) {
+            text.push(' ');
+            text.push_str(token);
+            text.push(' ');
+        }
+        else if let Some(token) = comment::continue_comment(doc.text(), cursor_line, line_comment_tokens) {
+            text.push_str(token);
+            text.push(' ');
+        }
+        else if let Some(ref block_comment_tokens) = lang_config.block_comment_tokens {
+            // FIXME: this doesn't work for the following lines of a comment start.
+            // FIXME: this is too indented in some cases.
+            if comment::continue_comment(doc.text(), cursor_line, &[block_comment_tokens.start.clone()]).is_some() {
+                text.push(' ');
+                text.push_str(&block_comment_tokens.middle);
+                text.push(' ');
+            }
+        }
+    }
 }
 
 // o inserts a new line after each line with a selection
@@ -2788,14 +2806,7 @@ pub mod insert {
                 text.push_str(doc.line_ending.as_str());
                 text.push_str(&indent);
 
-                let tokens = doc
-                    .language_config()
-                    .map(|lc| lc.comment_tokens.as_ref())
-                    .unwrap_or_default();
-                if let Some(token) = comment::continue_comment(doc.text(), current_line, tokens) {
-                    text.push_str(token);
-                    text.push(' ');
-                }
+                handle_comment_continue(&doc, range, &mut text, current_line, false);
 
                 pos + offs + text.chars().count()
             };

--- a/languages.toml
+++ b/languages.toml
@@ -173,6 +173,8 @@ injection-regex = "cpp"
 file-types = ["cc", "hh", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "clangd" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -364,6 +366,7 @@ file-types = ["py"]
 shebangs = ["python"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 language-server = { command = "pylsp" }
 # TODO: pyls needs utf-8 offsets
 indent = { tab-width = 4, unit = "    " }
@@ -523,6 +526,8 @@ file-types = ["ml"]
 shebangs = []
 roots = []
 comment-token = "(**)"
+comment-tokens = ["(**)"]
+block-comment-tokens = { start = "(*", middle = "*", end = "*)" }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -600,6 +605,8 @@ injection-regex = "haskell"
 file-types = ["hs"]
 roots = []
 comment-token = "--"
+comment-tokens = ["--"]
+block-comment-tokens = { start = "{-", middle = "-", end = "-}" }
 language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
 indent = { tab-width = 2, unit = "  " }
 

--- a/languages.toml
+++ b/languages.toml
@@ -7,6 +7,7 @@ roots = ["Cargo.toml", "Cargo.lock"]
 auto-format = true
 comment-token = "//"
 comment-tokens = ["//", "///"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
 

--- a/languages.toml
+++ b/languages.toml
@@ -58,6 +58,7 @@ injection-regex = "toml"
 file-types = ["toml"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -71,6 +72,8 @@ injection-regex = "protobuf"
 file-types = ["proto"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -85,6 +88,7 @@ file-types = ["ex", "exs", "mix.lock"]
 shebangs = ["elixir"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 language-server = { command = "elixir-ls" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -100,6 +104,7 @@ file-types = ["fish"]
 shebangs = ["fish"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -114,6 +119,8 @@ file-types = ["mint"]
 shebangs = []
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "mint", args = ["ls"] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -136,6 +143,8 @@ injection-regex = "c"
 file-types = ["c"] # TODO: ["h"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "clangd" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -212,6 +221,8 @@ injection-regex = "c-?sharp"
 file-types = ["cs"]
 roots = ["sln", "csproj"]
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "\t" }
 language-server = { command = "OmniSharp", args = [ "--languageserver", "--stdio" ] }
 
@@ -227,6 +238,8 @@ file-types = ["go"]
 roots = ["Gopkg.toml", "go.mod"]
 auto-format = true
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "gopls" }
 # TODO: gopls needs utf-8 offsets?
 indent = { tab-width = 4, unit = "\t" }
@@ -274,6 +287,8 @@ file-types = ["js", "jsx", "mjs"]
 shebangs = ["node"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 # TODO: highlights-params
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "javascript" }
 indent = { tab-width = 2, unit = "  " }
@@ -301,6 +316,8 @@ injection-regex = "jsx"
 file-types = ["jsx"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "javascript" }
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
@@ -312,6 +329,8 @@ injection-regex = "^(ts|typescript)$"
 file-types = ["ts"]
 shebangs = []
 roots = []
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 # TODO: highlights-params
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "typescript"}
 indent = { tab-width = 2, unit = "  " }
@@ -326,6 +345,8 @@ scope = "source.tsx"
 injection-regex = "^(tsx)$" # |typescript
 file-types = ["tsx"]
 roots = []
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 # TODO: highlights-params
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "typescriptreact" }
 indent = { tab-width = 2, unit = "  " }
@@ -340,6 +361,7 @@ scope = "source.css"
 injection-regex = "css"
 file-types = ["css", "scss"]
 roots = []
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -383,6 +405,8 @@ file-types = ["nix"]
 shebangs = []
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "rnix-lsp" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -398,6 +422,7 @@ file-types = ["rb"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 language-server = { command = "solargraph", args = ["stdio"] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -413,6 +438,8 @@ file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile
 shebangs = ["sh", "bash", "dash"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "bash-language-server", args = ["start"] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -427,6 +454,8 @@ injection-regex = "php"
 file-types = ["php"]
 shebangs = ["php"]
 roots = []
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -439,6 +468,8 @@ scope = "source.twig"
 injection-regex = "twig"
 file-types = ["twig"]
 roots = []
+comment-tokens = ["{##}"]
+block-comment-tokens = { start = "{#", middle = "#", end = "#}" }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -452,6 +483,7 @@ injection-regex = "tex"
 file-types = ["tex"]
 roots = []
 comment-token = "%"
+comment-tokens = ["%"]
 language-server = { command = "texlab" }
 indent = { tab-width = 4, unit = "\t" }
 
@@ -466,6 +498,7 @@ injection-regex = "lean"
 file-types = ["lean"]
 roots = [ "lakefile.lean" ]
 comment-token = "--"
+comment-tokens = ["--"]
 language-server = { command = "lean", args = [ "--server" ] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -480,6 +513,8 @@ injection-regex = "julia"
 file-types = ["jl"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
+block-comment-tokens = { start = "#=", middle = "=", end = "=#" }
 language-server = { command = "julia", args = [
     "--startup-file=no",
     "--history-file=no",
@@ -499,6 +534,8 @@ scope = "source.java"
 injection-regex = "java"
 file-types = ["java"]
 roots = ["pom.xml"]
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -512,6 +549,7 @@ injection-regex = "ledger"
 file-types = ["ldg", "ledger", "journal"]
 roots = []
 comment-token = ";"
+comment-tokens = [";"]
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -554,6 +592,7 @@ file-types = ["lua"]
 shebangs = ["lua"]
 roots = []
 comment-token = "--"
+comment-tokens = ["--"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -591,6 +630,7 @@ scope = "source.yaml"
 file-types = ["yml", "yaml"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 injection-regex = "yml|yaml"
 
@@ -622,6 +662,7 @@ file-types = ["zig"]
 roots = ["build.zig"]
 auto-format = true
 comment-token = "//"
+comment-tokens = ["//", "///"]
 language-server = { command = "zls" }
 indent = { tab-width = 4, unit = "    " }
 
@@ -636,6 +677,8 @@ roots = []
 file-types = ["pl", "prolog"]
 shebangs = ["swipl"]
 comment-token = "%"
+comment-tokens = ["%"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "swipl", args = [
     "-g", "use_module(library(lsp_server))",
     "-g", "lsp_server:main",
@@ -647,6 +690,7 @@ scope = "source.tsq"
 file-types = ["scm"]
 roots = []
 comment-token = ";"
+comment-tokens = [";"]
 injection-regex = "tsq"
 indent = { tab-width = 2, unit = "  " }
 
@@ -660,6 +704,7 @@ scope = "source.cmake"
 file-types = ["cmake", "CMakeLists.txt"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "cmake-language-server" }
 injection-regex = "cmake"
@@ -674,6 +719,7 @@ scope = "source.make"
 file-types = ["Makefile", "makefile", "justfile", ".justfile"]
 roots =[]
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
@@ -686,6 +732,8 @@ scope = "source.glsl"
 file-types = ["glsl", "vert", "tesc", "tese", "geom", "frag", "comp" ]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
 injection-regex = "glsl"
 
@@ -700,6 +748,7 @@ file-types = ["pl", "pm"]
 shebangs = ["perl"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -713,6 +762,7 @@ roots = []
 file-types = ["rkt"]
 shebangs = ["racket"]
 comment-token = ";"
+comment-tokens = [";"]
 language-server = { command = "racket", args = ["-l", "racket-langserver"] }
 
 [[language]]
@@ -732,6 +782,8 @@ scope = "source.wgsl"
 file-types = ["wgsl"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -744,6 +796,7 @@ scope = "source.llvm"
 roots = []
 file-types = ["ll"]
 comment-token = ";"
+comment-tokens = [";"]
 indent = { tab-width = 2, unit = "  " }
 injection-regex = "llvm"
 
@@ -757,6 +810,7 @@ scope = "source.llvm_mir"
 roots = []
 file-types = []
 comment-token = ";"
+comment-tokens = [";"]
 indent = { tab-width = 2, unit = "  " }
 injection-regex = "mir"
 
@@ -773,6 +827,7 @@ scope = "source.yaml"
 roots = []
 file-types = ["mir"]
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 
 [[language]]
@@ -781,6 +836,7 @@ scope = "source.tablegen"
 roots = []
 file-types = ["td"]
 comment-token = "//"
+comment-tokens = ["//"]
 indent = { tab-width = 2, unit = "  " }
 injection-regex = "tablegen"
 
@@ -807,6 +863,8 @@ file-types = ["dart"]
 roots = ["pubspec.yaml"]
 auto-format = true
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "dart", args = ["language-server", "--client-id=helix"] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -820,6 +878,8 @@ scope = "source.scala"
 roots = ["build.sbt", "pom.xml"]
 file-types = ["scala", "sbt"]
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "metals" }
 
@@ -834,6 +894,7 @@ injection-regex = "docker|dockerfile"
 roots = ["Dockerfile"]
 file-types = ["Dockerfile", "dockerfile"]
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "docker-langserver", args = ["--stdio"] }
 
@@ -847,6 +908,7 @@ scope = "git.commitmsg"
 roots = []
 file-types = ["COMMIT_EDITMSG"]
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -860,6 +922,7 @@ roots = []
 file-types = ["diff"]
 injection-regex = "diff"
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -873,6 +936,7 @@ roots = []
 file-types = ["git-rebase-todo"]
 injection-regex = "git-rebase"
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 2, unit = " " }
 
 [[grammar]]
@@ -898,6 +962,7 @@ roots = []
 file-types = [".gitmodules", ".gitconfig"]
 injection-regex = "git-config"
 comment-token = "#"
+comment-tokens = ["#"]
 indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
@@ -924,6 +989,8 @@ file-types = ["elm"]
 roots = ["elm.json"]
 auto-format = true
 comment-token = "--"
+comment-tokens = ["--"]
+block-comment-tokens = { start = "{-", middle = "-", end = "-}" }
 language-server = { command = "elm-language-server" }
 indent = { tab-width = 4, unit = "    " }
 
@@ -950,6 +1017,8 @@ file-types = ["res"]
 roots = ["bsconfig.json"]
 auto-format = true
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "rescript-language-server", args = ["--stdio"] }
 indent = { tab-width = 2, unit = "  " }
 
@@ -964,6 +1033,7 @@ injection-regex = "erl(ang)?"
 file-types = ["erl", "hrl", "app", "rebar.config", "rebar.lock"]
 roots = ["rebar.config"]
 comment-token = "%%"
+comment-tokens = ["%"]
 indent = { tab-width = 4, unit = "    " }
 language-server = { command = "erlang_ls" }
 
@@ -977,8 +1047,10 @@ scope = "source.kotlin"
 file-types = ["kt", "kts"]
 roots = ["settings.gradle", "settings.gradle.kts"]
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
-language-server = { command = "kotlin-language-server" } 
+language-server = { command = "kotlin-language-server" }
 
 [[grammar]]
 name = "kotlin"
@@ -991,6 +1063,8 @@ injection-regex = "(hcl|tf)"
 file-types = ["hcl", "tf", "tfvars"]
 roots = []
 comment-token = "#"
+comment-tokens = ["#", "//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "terraform-ls", args = ["serve"] }
 auto-format = true
@@ -1018,6 +1092,8 @@ injection-regex = "^(sol|solidity)$"
 file-types = ["sol"]
 roots = []
 comment-token = "//"
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 indent = { tab-width = 4, unit = "    " }
 language-server = { command = "solc", args = ["--lsp"] }
 
@@ -1032,6 +1108,7 @@ injection-regex = "gleam"
 file-types = ["gleam"]
 roots = ["gleam.toml"]
 comment-token = "//"
+comment-tokens = ["//", "///"]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -863,7 +863,7 @@ file-types = ["dart"]
 roots = ["pubspec.yaml"]
 auto-format = true
 comment-token = "//"
-comment-tokens = ["//"]
+comment-tokens = ["//", "///"]
 block-comment-tokens = { start = "/*", middle = "*", end = "*/" }
 language-server = { command = "dart", args = ["language-server", "--client-id=helix"] }
 indent = { tab-width = 2, unit = "  " }

--- a/languages.toml
+++ b/languages.toml
@@ -6,6 +6,7 @@ file-types = ["rs"]
 roots = ["Cargo.toml", "Cargo.lock"]
 auto-format = true
 comment-token = "//"
+comment-tokens = ["//", "///"]
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
 

--- a/runtime/queries/dart/textobjects.scm
+++ b/runtime/queries/dart/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/elm/textobjects.scm
+++ b/runtime/queries/elm/textobjects.scm
@@ -1,0 +1,1 @@
+(block_comment) @comment.block.around

--- a/runtime/queries/glsl/textobjects.scm
+++ b/runtime/queries/glsl/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/haskell/textobjects.scm
+++ b/runtime/queries/haskell/textobjects.scm
@@ -1,0 +1,1 @@
+(comment)+ @comment.around

--- a/runtime/queries/hcl/textobjects.scm
+++ b/runtime/queries/hcl/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/java/textobjects.scm
+++ b/runtime/queries/java/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/julia/textobjects.scm
+++ b/runtime/queries/julia/textobjects.scm
@@ -1,0 +1,1 @@
+(block_comment) @comment.block.around

--- a/runtime/queries/kotlin/textobjects.scm
+++ b/runtime/queries/kotlin/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/ocaml/textobjects.scm
+++ b/runtime/queries/ocaml/textobjects.scm
@@ -1,0 +1,1 @@
+(comment)+ @comment.around

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -33,3 +33,5 @@
 (line_comment)+ @comment.around
 
 (block_comment) @comment.around
+
+(block_comment) @comment.block.around

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -32,6 +32,4 @@
 
 (line_comment)+ @comment.around
 
-(block_comment) @comment.around
-
-(block_comment) @comment.block.around
+(block_comment) @comment.around @comment.block.around

--- a/runtime/queries/scala/textobjects.scm
+++ b/runtime/queries/scala/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around


### PR DESCRIPTION
Fix #1730.

We probably want to be able to configure whether we want this or not. If so, what option name do you propose?

This does not support continuing block comment, i.e. adding a `*` when a comment starts with `/*`. I propose we do this in a future PR since this would require some more thought regarding the block comment token (i.e. do we want to add it to `languages.toml`?).