### PR TITLE
Add typed commands buffer-next and buffer-previous

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -9,6 +9,8 @@
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Close all buffers but the currently focused one. |
 | `:buffer-close-all`, `:bca`, `:bcloseall` | Close all buffers, without quiting. |
 | `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Close all buffers forcefully (ignoring unsaved changes), without quiting. |
+| `:buffer-next`, `:bn`, `:bnext` | Go to next buffer. |
+| `:buffer-previous`, `:bp`, `:bprev` | Go to previous buffer. |
 | `:write`, `:w` | Write changes to disk. Accepts an optional path (:write some/path.txt) |
 | `:new`, `:n` | Create a new scratch buffer. |
 | `:format`, `:fmt` | Format the file using the LSP formatter. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -637,36 +637,35 @@ fn goto_line_start(cx: &mut Context) {
 }
 
 fn goto_next_buffer(cx: &mut Context) {
-    goto_buffer(cx, Direction::Forward);
+    goto_buffer(cx.editor, Direction::Forward);
 }
 
 fn goto_previous_buffer(cx: &mut Context) {
-    goto_buffer(cx, Direction::Backward);
+    goto_buffer(cx.editor, Direction::Backward);
 }
 
-fn goto_buffer(cx: &mut Context, direction: Direction) {
-    let current = view!(cx.editor).doc;
+fn goto_buffer(editor: &mut Editor, direction: Direction) {
+    let current = view!(editor).doc;
 
     let id = match direction {
         Direction::Forward => {
-            let iter = cx.editor.documents.keys();
+            let iter = editor.documents.keys();
             let mut iter = iter.skip_while(|id| *id != &current);
             iter.next(); // skip current item
-            iter.next().or_else(|| cx.editor.documents.keys().next())
+            iter.next().or_else(|| editor.documents.keys().next())
         }
         Direction::Backward => {
-            let iter = cx.editor.documents.keys();
+            let iter = editor.documents.keys();
             let mut iter = iter.rev().skip_while(|id| *id != &current);
             iter.next(); // skip current item
-            iter.next()
-                .or_else(|| cx.editor.documents.keys().rev().next())
+            iter.next().or_else(|| editor.documents.keys().rev().next())
         }
     }
     .unwrap();
 
     let id = *id;
 
-    cx.editor.switch(id, Action::Replace);
+    editor.switch(id, Action::Replace);
 }
 
 fn extend_to_line_start(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -105,29 +105,6 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<Docum
     document_ids
 }
 
-fn buffer_next_or_previous_impl(editor: &mut Editor, direction: Direction) -> anyhow::Result<()> {
-    let current = view!(editor).doc;
-
-    let id = match direction {
-        Direction::Forward => {
-            let iter = editor.documents.keys();
-            let mut iter = iter.skip_while(|id| *id != &current);
-            iter.next(); // skip current item
-            iter.next().or_else(|| editor.documents.keys().next())
-        }
-        Direction::Backward => {
-            let iter = editor.documents.keys();
-            let mut iter = iter.rev().skip_while(|id| *id != &current);
-            iter.next(); // skip current item
-            iter.next().or_else(|| editor.documents.keys().rev().next())
-        }
-    }
-    .unwrap();
-    let id = *id;
-    editor.switch(id, Action::Replace);
-    Ok(())
-}
-
 fn buffer_close(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -200,7 +177,8 @@ fn buffer_next(
     _args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
-    buffer_next_or_previous_impl(cx.editor, Direction::Forward)
+    goto_buffer(cx.editor, Direction::Forward);
+    Ok(())
 }
 
 fn buffer_previous(
@@ -208,7 +186,8 @@ fn buffer_previous(
     _args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
-    buffer_next_or_previous_impl(cx.editor, Direction::Backward)
+    goto_buffer(cx.editor, Direction::Backward);
+    Ok(())
 }
 
 fn write_impl(cx: &mut compositor::Context, path: Option<&Cow<str>>) -> anyhow::Result<()> {


### PR DESCRIPTION
Hi Helix maintainers 👋 ,

This is the implementation for issue https://github.com/helix-editor/helix/issues/1926 to add the typed commands `buffer-next` and `buffer-previous`.

Best regards,
David
