### PR TITLE
clear terminal after switching to alternate screen

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -683,6 +683,7 @@ impl Application {
         terminal::enable_raw_mode()?;
         let mut stdout = stdout();
         execute!(stdout, terminal::EnterAlternateScreen)?;
+        execute!(stdout, terminal::Clear(terminal::ClearType::All))?;
         if self.config.load().editor.mouse {
             execute!(stdout, EnableMouseCapture)?;
         }


### PR DESCRIPTION
when using helix over mosh, the screen doesn't get cleared and
characters get left all over the place until they are overwritten. with
this change, the screen gets properly cleared as soon as helix starts