### PR TITLE
Add `m` textobject to select closest surround pair

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -66,6 +66,7 @@ Currently supported: `word`, `surround`, `function`, `class`, `parameter`.
 | `w`                    | Word                     |
 | `W`                    | WORD                     |
 | `(`, `[`, `'`, etc     | Specified surround pairs |
+| `m`                    | Closest surround pair    |
 | `f`                    | Function                 |
 | `c`                    | Class                    |
 | `a`                    | Argument/parameter       |

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -212,17 +212,22 @@ fn find_nth_close_pair(
 /// Find position of surround characters around every cursor. Returns None
 /// if any positions overlap. Note that the positions are in a flat Vec.
 /// Use get_surround_pos().chunks(2) to get matching pairs of surround positions.
-/// `ch` can be either closing or opening pair.
+/// `ch` can be either closing or opening pair. If `ch` is None, surround pairs
+/// are automatically detected around each cursor (note that this may result
+/// in them selecting different surround characters for each selection).
 pub fn get_surround_pos(
     text: RopeSlice,
     selection: &Selection,
-    ch: char,
+    ch: Option<char>,
     skip: usize,
 ) -> Result<Vec<usize>> {
     let mut change_pos = Vec::new();
 
     for &range in selection {
-        let (open_pos, close_pos) = find_nth_pairs_pos(text, ch, range, skip)?;
+        let (open_pos, close_pos) = match ch {
+            Some(ch) => find_nth_pairs_pos(text, ch, range, skip)?,
+            None => find_nth_closest_pairs_pos(text, range, skip)?,
+        };
         if change_pos.contains(&open_pos) || change_pos.contains(&close_pos) {
             return Err(Error::CursorOverlap);
         }

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -343,7 +343,7 @@ mod test {
 
         // cursor on s[o]me, c[h]ars, newl[i]ne
         assert_eq!(
-            get_surround_pos(slice, &selection, '(', 1)
+            get_surround_pos(slice, &selection, Some('('), 1)
                 .unwrap()
                 .as_slice(),
             &[0, 5, 7, 13, 15, 23]
@@ -359,7 +359,7 @@ mod test {
             Selection::new(SmallVec::from_slice(&[Range::point(2), Range::point(9)]), 0);
         // cursor on s[o]me, c[h]ars
         assert_eq!(
-            get_surround_pos(slice, &selection, '(', 1),
+            get_surround_pos(slice, &selection, Some('('), 1),
             Err(Error::PairNotFound) // different surround chars
         );
 
@@ -369,7 +369,7 @@ mod test {
         );
         // cursor on [x]x, newli[n]e
         assert_eq!(
-            get_surround_pos(slice, &selection, '(', 1),
+            get_surround_pos(slice, &selection, Some('('), 1),
             Err(Error::PairNotFound) // overlapping surround chars
         );
 
@@ -377,7 +377,7 @@ mod test {
             Selection::new(SmallVec::from_slice(&[Range::point(2), Range::point(3)]), 0);
         // cursor on s[o][m]e
         assert_eq!(
-            get_surround_pos(slice, &selection, '[', 1),
+            get_surround_pos(slice, &selection, Some('['), 1),
             Err(Error::CursorOverlap)
         );
     }

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -184,7 +184,31 @@ pub fn textobject_surround(
     ch: char,
     count: usize,
 ) -> Range {
-    surround::find_nth_pairs_pos(slice, ch, range, count)
+    textobject_surround_impl(slice, range, textobject, Some(ch), count)
+}
+
+pub fn textobject_surround_closest(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    count: usize,
+) -> Range {
+    textobject_surround_impl(slice, range, textobject, None, count)
+}
+
+fn textobject_surround_impl(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    ch: Option<char>,
+    count: usize,
+) -> Range {
+    let pair_pos = match ch {
+        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
+        // Automatically find the closest surround pairs
+        None => surround::find_nth_closest_pairs_pos(slice, range, count),
+    };
+    pair_pos
         .map(|(anchor, head)| match textobject {
             TextObject::Inside => Range::new(next_grapheme_boundary(slice, anchor), head),
             TextObject::Around => Range::new(anchor, next_grapheme_boundary(slice, head)),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3992,14 +3992,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'a' => textobject_treesitter("parameter", range),
                         'o' => textobject_treesitter("comment", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
-                        'm' => {
-                            let ch = text.char(range.cursor(text));
-                            if !ch.is_ascii_alphanumeric() {
-                                textobject::textobject_surround(text, range, objtype, ch, count)
-                            } else {
-                                range
-                            }
-                        }
+                        'm' => textobject::textobject_surround_closest(text, range, objtype, count),
                         // TODO: cancel new ranges if inconsistent surround matches across lines
                         ch if !ch.is_ascii_alphanumeric() => {
                             textobject::textobject_surround(text, range, objtype, ch, count)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4062,15 +4062,16 @@ fn surround_add(cx: &mut Context) {
 fn surround_replace(cx: &mut Context) {
     let count = cx.count();
     cx.on_next_key(move |cx, event| {
-        let from = match event.char() {
-            Some(from) => from,
+        let surround_ch = match event.char() {
+            Some('m') => None, // m selects the closest surround pair
+            Some(ch) => Some(ch),
             None => return,
         };
         let (view, doc) = current!(cx.editor);
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id);
 
-        let change_pos = match surround::get_surround_pos(text, selection, from, count) {
+        let change_pos = match surround::get_surround_pos(text, selection, surround_ch, count) {
             Ok(c) => c,
             Err(err) => {
                 cx.editor.set_error(err.to_string());
@@ -4101,15 +4102,16 @@ fn surround_replace(cx: &mut Context) {
 fn surround_delete(cx: &mut Context) {
     let count = cx.count();
     cx.on_next_key(move |cx, event| {
-        let ch = match event.char() {
-            Some(ch) => ch,
+        let surround_ch = match event.char() {
+            Some('m') => None, // m selects the closest surround pair
+            Some(ch) => Some(ch),
             None => return,
         };
         let (view, doc) = current!(cx.editor);
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id);
 
-        let change_pos = match surround::get_surround_pos(text, selection, ch, count) {
+        let change_pos = match surround::get_surround_pos(text, selection, surround_ch, count) {
             Ok(c) => c,
             Err(err) => {
                 cx.editor.set_error(err.to_string());


### PR DESCRIPTION
`m` now acts as a wildcard surround textobject, so for example with this text

```
[abc (def) ghi]
```
If the cursor is on `c`, `mim` will select everything inside `[]`, and if it's on `e` it will select inside `()`, without manually requiring either `mi(` or `mi[`.