### PR TITLE
Add true or false checkbox in health output table

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -134,8 +134,8 @@ pub fn languages_all() -> std::io::Result<()> {
 
     let check_binary = |cmd: Option<String>| match cmd {
         Some(cmd) => match which::which(&cmd) {
-            Ok(_) => column(&cmd, Color::Green),
-            Err(_) => column(&cmd, Color::Red),
+            Ok(_) => column(&format!("✔ {}", cmd), Color::Green),
+            Err(_) => column(&format!("✘ {}", cmd), Color::Red),
         },
         None => column("None", Color::Yellow),
     };


### PR DESCRIPTION
hx --health output table's second and third columns were not showing
symbols like ✔ or ✘ to indicate whether LSP or DAP binaries were found.
This change adds these symbols to improve accessibility.

Fixes #1894

Signed-off-by: Nirmal Patel <npate012@gmail.com>