### PR TITLE
Fix ctrl-u on insert behavior

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -682,14 +682,18 @@ fn kill_to_line_start(cx: &mut Context) {
         let first_char = text.line_to_char(line);
         let anchor = range.cursor(text);
         let head = if anchor == first_char && line != 0 {
+            // select until previous line
             line_end_char_index(&text, line - 1)
         } else if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
             if first_char + pos < anchor {
+                // select until first non-blank in line if cursor is after it
                 first_char + pos
             } else {
+                // select until start of line
                 first_char
             }
         } else {
+            // select until start of line
             first_char
         };
         Range::new(head, anchor)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -679,7 +679,20 @@ fn kill_to_line_start(cx: &mut Context) {
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         let line = range.cursor_line(text);
-        range.put_cursor(text, text.line_to_char(line), true)
+        let first_char = text.line_to_char(line);
+        let anchor = range.cursor(text);
+        let head = if anchor == first_char && line != 0 {
+            line_end_char_index(&text, line - 1)
+        } else if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
+            if first_char + pos < anchor {
+                first_char + pos
+            } else {
+                first_char
+            }
+        } else {
+            first_char
+        };
+        Range::new(head, anchor)
     });
     delete_selection_insert_mode(doc, view, &selection);
 }


### PR DESCRIPTION
Now should follow vim behavior more
- no longer remove text on cursor
- no longer remove selected text while inserting
- first kill to start non-whitespace, start, previous new line