### PR TITLE
Compute style only once per source highlight event

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -343,6 +343,9 @@ impl EditorView {
                     // the rope, to allow cursor highlighting at the end
                     // of the rope.
                     let text = text.get_slice(start..end).unwrap_or_else(|| " ".into());
+                    let style = spans
+                        .iter()
+                        .fold(text_style, |acc, span| acc.patch(theme.highlight(span.0)));
 
                     use helix_core::graphemes::{grapheme_width, RopeGraphemes};
 
@@ -352,10 +355,6 @@ impl EditorView {
 
                         if LineEnding::from_rope_slice(&grapheme).is_some() {
                             if !out_of_bounds {
-                                let style = spans.iter().fold(text_style, |acc, span| {
-                                    acc.patch(theme.highlight(span.0))
-                                });
-
                                 // we still want to render an empty cell with the style
                                 surface.set_string(
                                     viewport.x + visual_x - offset.col as u16,
@@ -387,10 +386,6 @@ impl EditorView {
                             };
 
                             if !out_of_bounds {
-                                let style = spans.iter().fold(text_style, |acc, span| {
-                                    acc.patch(theme.highlight(span.0))
-                                });
-
                                 // if we're offscreen just keep going until we hit a new line
                                 surface.set_string(
                                     viewport.x + visual_x - offset.col as u16,


### PR DESCRIPTION
During a single `HighlightEvent::Source`, the highlight spans do not change and we can merge them into a single style at the beginning of the event and use it instead of re-computing it for every grapheme.

