### PR TITLE
Make gutters configurable

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `diagnostics` (which also includes other features like breakpoints) and `line-numbers` | `["diagnostics", "line-numbers"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers`, note that `diagnostics` also includes other features like breakpoints | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `breakpoints` and `diagnostics` (combined, left has precedence over right) as well as `line-numbers` | `["breakpoints", "diagnostics", "line-numbers"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` (which also includes other features like breakpoints) and `line-numbers` | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. `none` doesn't show line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (which are combined in one column) as well as `line-numbers` | `['diagnostics', 'breakpoints', 'line-numbers']` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (which are combined) as well as `line-numbers` | `['diagnostics', 'breakpoints', 'line-numbers']` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (combined, left has precedence over right) as well as `line-numbers` | `['breakpoints', 'diagnostics', 'line-numbers']` |
+| `gutters` | Gutters to display: Available are `breakpoints` and `diagnostics` (combined, left has precedence over right) as well as `line-numbers` | `['breakpoints', 'diagnostics', 'line-numbers']` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -36,7 +36,7 @@ hidden = false
 | `middle-click-paste` | Middle click paste support. | `true` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
-| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. `none` doesn't show line numbers. | `absolute` |
+| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (which are combined) as well as `line-numbers` | `['diagnostics', 'breakpoints', 'line-numbers']` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,6 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. `none` doesn't show line numbers. | `absolute` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (which are combined in one column) as well as `line-numbers` | `['diagnostics', 'breakpoints', 'line-numbers']` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (which are combined) as well as `line-numbers` | `['diagnostics', 'breakpoints', 'line-numbers']` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `breakpoints` (combined, left has precedence over right) as well as `line-numbers` | `['breakpoints', 'diagnostics', 'line-numbers']` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -36,7 +36,7 @@ hidden = false
 | `middle-click-paste` | Middle click paste support. | `true` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
-| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
+| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. `none` doesn't show line numbers. | `absolute` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,7 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
-| `gutters` | Gutters to display: Available are `breakpoints` and `diagnostics` (combined, left has precedence over right) as well as `line-numbers` | `['breakpoints', 'diagnostics', 'line-numbers']` |
+| `gutters` | Gutters to display: Available are `breakpoints` and `diagnostics` (combined, left has precedence over right) as well as `line-numbers` | `["breakpoints", "diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -472,8 +472,8 @@ impl EditorView {
         let mut text = String::with_capacity(8);
 
         for (constructor, width) in view.gutters() {
-            let gutter = constructor(editor, doc, view, theme, is_focused, *width);
-            text.reserve(*width); // ensure there's enough space for the gutter
+            let gutter = constructor(editor, doc, view, theme, is_focused, width);
+            text.reserve(width); // ensure there's enough space for the gutter
             for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
                 let selected = cursors.contains(&line);
 
@@ -482,14 +482,14 @@ impl EditorView {
                         viewport.x + offset,
                         viewport.y + i as u16,
                         &text,
-                        *width,
+                        width,
                         gutter_style.patch(style),
                     );
                 }
                 text.clear();
             }
 
-            offset += *width as u16;
+            offset += width as u16;
         }
     }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -471,9 +471,9 @@ impl EditorView {
         // avoid lots of small allocations by reusing a text buffer for each line
         let mut text = String::with_capacity(8);
 
-        for (constructor, width) in view.gutters() {
-            let gutter = constructor(editor, doc, view, theme, is_focused, width);
-            text.reserve(width); // ensure there's enough space for the gutter
+        for (constructor, width) in &view.gutters {
+            let gutter = constructor(editor, doc, view, theme, is_focused, *width);
+            text.reserve(*width); // ensure there's enough space for the gutter
             for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
                 let selected = cursors.contains(&line);
 
@@ -482,14 +482,14 @@ impl EditorView {
                         viewport.x + offset,
                         viewport.y + i as u16,
                         &text,
-                        width,
+                        *width,
                         gutter_style.patch(style),
                     );
                 }
                 text.clear();
             }
 
-            offset += width as u16;
+            offset += *width as u16;
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -117,7 +117,7 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
-    /// Gutters. Default ["breakpoints", "diagnostics", "line-numbers"]
+    /// Gutters. Default ["diagnostics", "line-numbers"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
@@ -243,8 +243,6 @@ impl std::str::FromStr for LineNumber {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum GutterType {
-    /// Show breakpoints
-    Breakpoints,
     /// Show diagnostics
     Diagnostics,
     /// Show line numbers
@@ -256,11 +254,10 @@ impl std::str::FromStr for GutterType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "breakpoints" | "bp" => Ok(Self::Breakpoints),
             "diagnostics" | "diag" => Ok(Self::Diagnostics),
             "line-numbers" | "ln" => Ok(Self::LineNumbers),
             _ => anyhow::bail!(
-                "Gutter type can only be `breakpoints`, `diagnostics` or `line-numbers`."
+                "Gutter type can only be `diagnostics` or `line-numbers`."
             ),
         }
     }
@@ -279,7 +276,6 @@ impl Default for Config {
             },
             line_number: LineNumber::Absolute,
             gutters: vec![
-                GutterType::Breakpoints,
                 GutterType::Diagnostics,
                 GutterType::LineNumbers,
             ],

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -256,9 +256,7 @@ impl std::str::FromStr for GutterType {
         match s.to_lowercase().as_str() {
             "diagnostics" | "diag" => Ok(Self::Diagnostics),
             "line-numbers" | "ln" => Ok(Self::LineNumbers),
-            _ => anyhow::bail!(
-                "Gutter type can only be `diagnostics` or `line-numbers`."
-            ),
+            _ => anyhow::bail!("Gutter type can only be `diagnostics` or `line-numbers`."),
         }
     }
 }
@@ -275,10 +273,7 @@ impl Default for Config {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },
             line_number: LineNumber::Absolute,
-            gutters: vec![
-                GutterType::Diagnostics,
-                GutterType::LineNumbers,
-            ],
+            gutters: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -243,7 +243,7 @@ impl std::str::FromStr for LineNumber {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum GutterType {
-    /// Show diagnostics
+    /// Show diagnostics and other features like breakpoints
     Diagnostics,
     /// Show line numbers
     LineNumbers,
@@ -254,8 +254,8 @@ impl std::str::FromStr for GutterType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "diagnostics" | "diag" => Ok(Self::Diagnostics),
-            "line-numbers" | "ln" => Ok(Self::LineNumbers),
+            "diagnostics" => Ok(Self::Diagnostics),
+            "line-numbers" => Ok(Self::LineNumbers),
             _ => anyhow::bail!("Gutter type can only be `diagnostics` or `line-numbers`."),
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -243,10 +243,10 @@ impl std::str::FromStr for LineNumber {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum GutterType {
-    /// Show breakpoints
-    Breakpoints,
     /// Show diagnostics
     Diagnostics,
+    /// Show breakpoints
+    Breakpoints,
     /// Show line numbers
     LineNumbers,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -224,6 +224,9 @@ pub enum LineNumber {
     /// If focused and in normal/select mode, show relative line number to the primary cursor.
     /// If unfocused or in insert mode, show absolute line number.
     Relative,
+
+    /// Don't show line number
+    None,
 }
 
 impl std::str::FromStr for LineNumber {
@@ -577,7 +580,9 @@ impl Editor {
                 return;
             }
             Action::HorizontalSplit | Action::VerticalSplit => {
-                let view = View::new(id);
+                let omit_line_number_gutter =
+                    self.config().line_number == crate::editor::LineNumber::None;
+                let view = View::new(id, omit_line_number_gutter);
                 let view_id = self.tree.split(
                     view,
                     match action {
@@ -699,7 +704,9 @@ impl Editor {
                 .map(|(&doc_id, _)| doc_id)
                 .next()
                 .unwrap_or_else(|| self.new_document(Document::default()));
-            let view = View::new(doc_id);
+            let omit_line_number_gutter =
+                self.config().line_number == crate::editor::LineNumber::None;
+            let view = View::new(doc_id, omit_line_number_gutter);
             let view_id = self.tree.insert(view);
             let doc = self.documents.get_mut(&doc_id).unwrap();
             doc.selections.insert(view_id, Selection::point(0));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -117,7 +117,7 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
-    /// Gutters. Default ["diagnostics", "breakpoints", "line-numbers"]
+    /// Gutters. Default ["breakpoints", "diagnostics", "line-numbers"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
@@ -243,10 +243,10 @@ impl std::str::FromStr for LineNumber {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum GutterType {
-    /// Show diagnostics
-    Diagnostics,
     /// Show breakpoints
     Breakpoints,
+    /// Show diagnostics
+    Diagnostics,
     /// Show line numbers
     LineNumbers,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -117,7 +117,7 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
-    /// Gutters. Default ["breakpoints", "diagnostics", "line-numbers"]
+    /// Gutters. Default ["diagnostics", "breakpoints", "line-numbers"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -163,36 +163,8 @@ pub fn diagnostics_or_breakpoints<'doc>(
 ) -> GutterFn<'doc> {
     let diagnostics = diagnostic(editor, doc, view, theme, is_focused, width);
     let breakpoints = breakpoints(editor, doc, view, theme, is_focused, width);
-    let gutters = &editor.config().gutters;
-
-    let mut need_diagnostics = false;
-    let mut need_breakpoints = false;
-    let mut breakpoints_before_diagnostics = true;
-
-    for gutter in gutters.iter() {
-        match gutter {
-            crate::editor::GutterType::Breakpoints => {
-                if need_diagnostics {
-                    breakpoints_before_diagnostics = false;
-                }
-                need_breakpoints = true;
-            }
-            crate::editor::GutterType::Diagnostics => {
-                need_diagnostics = true;
-            }
-            _ => {}
-        }
-    }
 
     Box::new(move |line, selected, out| {
-        if need_diagnostics && need_breakpoints && breakpoints_before_diagnostics {
-            breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
-        } else if need_diagnostics && need_breakpoints {
-            diagnostics(line, selected, out).or_else(|| breakpoints(line, selected, out))
-        } else if need_diagnostics {
-            diagnostics(line, selected, out)
-        } else {
-            breakpoints(line, selected, out)
-        }
+        breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
     })
 }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -187,7 +187,7 @@ pub fn diagnostics_or_breakpoints<'doc>(
     Box::new(move |line, selected, out| {
         if need_diagnostics && need_breakpoints && breakpoints_before_diagnostics {
             breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
-        } else if need_diagnostics && need_breakpoints && !breakpoints_before_diagnostics {
+        } else if need_diagnostics && need_breakpoints {
             diagnostics(line, selected, out).or_else(|| breakpoints(line, selected, out))
         } else if need_diagnostics {
             diagnostics(line, selected, out)

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -39,7 +39,7 @@ pub fn diagnostic<'doc>(
     })
 }
 
-pub fn line_number<'doc>(
+pub fn line_numbers<'doc>(
     editor: &'doc Editor,
     doc: &'doc Document,
     view: &View,
@@ -163,8 +163,17 @@ pub fn diagnostics_or_breakpoints<'doc>(
 ) -> GutterFn<'doc> {
     let diagnostics = diagnostic(editor, doc, view, theme, is_focused, width);
     let breakpoints = breakpoints(editor, doc, view, theme, is_focused, width);
+    let gutters = &editor.config().gutters;
+    let need_diagnostics = gutters.contains(&crate::editor::GutterType::Diagnostics);
+    let need_breakpoints = gutters.contains(&crate::editor::GutterType::Breakpoints);
 
     Box::new(move |line, selected, out| {
-        breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
+        if need_diagnostics && need_breakpoints {
+            breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
+        } else if need_diagnostics {
+            diagnostics(line, selected, out)
+        } else {
+            breakpoints(line, selected, out)
+        }
     })
 }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -171,13 +171,13 @@ pub fn diagnostics_or_breakpoints<'doc>(
 
     for gutter in gutters.iter() {
         match gutter {
-            &crate::editor::GutterType::Breakpoints => {
+            crate::editor::GutterType::Breakpoints => {
                 if need_diagnostics {
                     breakpoints_before_diagnostics = false;
                 }
                 need_breakpoints = true;
             }
-            &crate::editor::GutterType::Diagnostics => {
+            crate::editor::GutterType::Diagnostics => {
                 need_diagnostics = true;
             }
             _ => {}

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -164,12 +164,31 @@ pub fn diagnostics_or_breakpoints<'doc>(
     let diagnostics = diagnostic(editor, doc, view, theme, is_focused, width);
     let breakpoints = breakpoints(editor, doc, view, theme, is_focused, width);
     let gutters = &editor.config().gutters;
-    let need_diagnostics = gutters.contains(&crate::editor::GutterType::Diagnostics);
-    let need_breakpoints = gutters.contains(&crate::editor::GutterType::Breakpoints);
+
+    let mut need_diagnostics = false;
+    let mut need_breakpoints = false;
+    let mut breakpoints_before_diagnostics = true;
+
+    for gutter in gutters.iter() {
+        match gutter {
+            &crate::editor::GutterType::Breakpoints => {
+                if need_diagnostics {
+                    breakpoints_before_diagnostics = false;
+                }
+                need_breakpoints = true;
+            }
+            &crate::editor::GutterType::Diagnostics => {
+                need_diagnostics = true;
+            }
+            _ => {}
+        }
+    }
 
     Box::new(move |line, selected, out| {
-        if need_diagnostics && need_breakpoints {
+        if need_diagnostics && need_breakpoints && breakpoints_before_diagnostics {
             breakpoints(line, selected, out).or_else(|| diagnostics(line, selected, out))
+        } else if need_diagnostics && need_breakpoints && !breakpoints_before_diagnostics {
+            diagnostics(line, selected, out).or_else(|| breakpoints(line, selected, out))
         } else if need_diagnostics {
             diagnostics(line, selected, out)
         } else {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -581,7 +581,7 @@ mod test {
         });
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
@@ -589,7 +589,7 @@ mod test {
         let l0 = tree.focus;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
@@ -597,7 +597,7 @@ mod test {
         tree.focus = l0;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
@@ -605,7 +605,7 @@ mod test {
         tree.focus = l0;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -578,22 +578,22 @@ mod test {
             width: 180,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default());
+        let mut view = View::new(DocumentId::default(), false);
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
-        let view = View::new(DocumentId::default());
+        let view = View::new(DocumentId::default(), false);
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default());
+        let view = View::new(DocumentId::default(), false);
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default());
+        let view = View::new(DocumentId::default(), false);
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -568,6 +568,7 @@ impl<'a> Iterator for Traverse<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::editor::GutterType;
     use crate::DocumentId;
 
     #[test]
@@ -578,22 +579,34 @@ mod test {
             width: 180,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default(), false);
+        let mut view = View::new(
+            DocumentId::default(),
+            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+        );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
-        let view = View::new(DocumentId::default(), false);
+        let view = View::new(
+            DocumentId::default(),
+            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+        );
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), false);
+        let view = View::new(
+            DocumentId::default(),
+            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+        );
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), false);
+        let view = View::new(
+            DocumentId::default(),
+            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+        );
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -581,7 +581,7 @@ mod test {
         });
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
@@ -589,7 +589,7 @@ mod test {
         let l0 = tree.focus;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
@@ -597,7 +597,7 @@ mod test {
         tree.focus = l0;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
@@ -605,7 +605,7 @@ mod test {
         tree.focus = l0;
         let view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords() {
-        let mut view = View::new(DocumentId::default());
+        let mut view = View::new(DocumentId::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
         let text = rope.slice(..);
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_cjk() {
-        let mut view = View::new(DocumentId::default());
+        let mut view = View::new(DocumentId::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
         let text = rope.slice(..);
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_graphemes() {
-        let mut view = View::new(DocumentId::default());
+        let mut view = View::new(DocumentId::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");
         let text = rope.slice(..);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -66,7 +66,7 @@ impl JumpList {
 
 const GUTTERS: &[(Gutter, usize)] = &[
     (gutter::diagnostics_or_breakpoints, 1),
-    (gutter::line_number, 5),
+    (gutter::line_number, 5), // must be at the end since it's optional
 ];
 
 #[derive(Debug)]
@@ -85,10 +85,11 @@ pub struct View {
     pub last_modified_docs: [Option<DocumentId>; 2],
     /// used to store previous selections of tree-sitter objecs
     pub object_selections: Vec<Selection>,
+    pub omit_line_number_gutter: bool,
 }
 
 impl View {
-    pub fn new(doc: DocumentId) -> Self {
+    pub fn new(doc: DocumentId, omit_line_number_gutter: bool) -> Self {
         Self {
             id: ViewId::default(),
             doc,
@@ -98,11 +99,16 @@ impl View {
             last_accessed_doc: None,
             last_modified_docs: [None, None],
             object_selections: Vec::new(),
+            omit_line_number_gutter,
         }
     }
 
     pub fn gutters(&self) -> &[(Gutter, usize)] {
-        GUTTERS
+        if self.omit_line_number_gutter {
+            &GUTTERS[0..GUTTERS.len() - 1]
+        } else {
+            GUTTERS
+        }
     }
 
     pub fn inner_area(&self) -> Rect {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -344,7 +344,7 @@ mod tests {
     fn test_text_pos_at_screen_coords() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
@@ -409,7 +409,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_cjk() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
@@ -449,7 +449,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_graphemes() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::LineNumbers, GutterType::Breakpoints],
+            vec![GutterType::Breakpoints, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -330,7 +330,8 @@ mod tests {
     use super::*;
     use helix_core::Rope;
     const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
-                           // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
+    const OFFSET_OMIT_LINE_NUMBER_GUTTER: u16 = 2; // 1 diagnostic + 5 linenr + 1 gutter
+                                                   // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
 
     #[test]
     fn test_text_pos_at_screen_coords() {
@@ -376,6 +377,22 @@ mod tests {
         );
 
         assert_eq!(view.text_pos_at_screen_coords(&text, 41, 80, 4), Some(8));
+    }
+
+    #[test]
+    fn test_text_pos_at_screen_coords_with_omit_line_number_gutter() {
+        let mut view = View::new(DocumentId::default(), true);
+        view.area = Rect::new(40, 40, 40, 40);
+        let rope = Rope::from_str("abc\n\tdef");
+        let text = rope.slice(..);
+        assert_eq!(
+            view.text_pos_at_screen_coords(&text, 41, 40 + OFFSET + 1, 4),
+            Some(7)
+        );
+        assert_eq!(
+            view.text_pos_at_screen_coords(&text, 41, 40 + OFFSET_OMIT_LINE_NUMBER_GUTTER + 1, 4),
+            Some(4)
+        );
     }
 
     #[test]

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -100,16 +100,10 @@ impl View {
 
     pub fn gutters(&self) -> Vec<(Gutter, usize)> {
         let mut gutters: Vec<(Gutter, usize)> = vec![];
-        let mut diagnostics_or_breakpoints_inserted = false;
         use crate::editor::GutterType;
         for gutter in &self.gutter_types {
             match gutter {
-                GutterType::Diagnostics | GutterType::Breakpoints => {
-                    if !diagnostics_or_breakpoints_inserted {
-                        gutters.push((gutter::diagnostics_or_breakpoints, 1));
-                        diagnostics_or_breakpoints_inserted = true;
-                    }
-                }
+                GutterType::Diagnostics => gutters.push((gutter::diagnostics_or_breakpoints, 1)),
                 GutterType::LineNumbers => gutters.push((gutter::line_numbers, 5)),
             }
         }
@@ -343,7 +337,7 @@ mod tests {
     fn test_text_pos_at_screen_coords() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
@@ -390,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_with_omit_line_number_gutter() {
-        let mut view = View::new(DocumentId::default(), vec![GutterType::Breakpoints]);
+        let mut view = View::new(DocumentId::default(), vec![GutterType::Diagnostics]);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
         let text = rope.slice(..);
@@ -408,7 +402,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_cjk() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
@@ -448,7 +442,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_graphemes() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![GutterType::Breakpoints, GutterType::LineNumbers],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -330,7 +330,7 @@ mod tests {
     use super::*;
     use helix_core::Rope;
     const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
-    const OFFSET_OMIT_LINE_NUMBER_GUTTER: u16 = 2; // 1 diagnostic + 5 linenr + 1 gutter
+    const OFFSET_OMIT_LINE_NUMBER_GUTTER: u16 = 2; // 1 diagnostic + 1 gutter
                                                    // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
 
     #[test]

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -329,7 +329,7 @@ mod tests {
     use super::*;
     use helix_core::Rope;
     const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
-    const OFFSET_OMIT_LINE_NUMBER_GUTTER: u16 = 2; // 1 diagnostic + 1 gutter
+    const OFFSET_WITHOUT_LINE_NUMBERS: u16 = 2; // 1 diagnostic + 1 gutter
                                                    // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
     use crate::editor::GutterType;
 
@@ -383,17 +383,25 @@ mod tests {
     }
 
     #[test]
-    fn test_text_pos_at_screen_coords_with_omit_line_number_gutter() {
+    fn test_text_pos_at_screen_coords_without_line_numbers_gutter() {
         let mut view = View::new(DocumentId::default(), vec![GutterType::Diagnostics]);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
         let text = rope.slice(..);
         assert_eq!(
-            view.text_pos_at_screen_coords(&text, 41, 40 + OFFSET + 1, 4),
-            Some(7)
+            view.text_pos_at_screen_coords(&text, 41, 40 + OFFSET_WITHOUT_LINE_NUMBERS + 1, 4),
+            Some(4)
         );
+    }
+
+    #[test]
+    fn test_text_pos_at_screen_coords_without_any_gutters() {
+        let mut view = View::new(DocumentId::default(), vec![]);
+        view.area = Rect::new(40, 40, 40, 40);
+        let rope = Rope::from_str("abc\n\tdef");
+        let text = rope.slice(..);
         assert_eq!(
-            view.text_pos_at_screen_coords(&text, 41, 40 + OFFSET_OMIT_LINE_NUMBER_GUTTER + 1, 4),
+            view.text_pos_at_screen_coords(&text, 41, 40 + 1, 4),
             Some(4)
         );
     }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -330,7 +330,7 @@ mod tests {
     use helix_core::Rope;
     const OFFSET: u16 = 7; // 1 diagnostic + 5 linenr + 1 gutter
     const OFFSET_WITHOUT_LINE_NUMBERS: u16 = 2; // 1 diagnostic + 1 gutter
-                                                   // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
+                                                // const OFFSET: u16 = GUTTERS.iter().map(|(_, width)| *width as u16).sum();
     use crate::editor::GutterType;
 
     #[test]

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -98,8 +98,8 @@ impl View {
     pub fn new(doc: DocumentId, gutter_types: Vec<crate::editor::GutterType>) -> Self {
         let mut gutters: Vec<(Gutter, usize)> = vec![];
         use crate::editor::GutterType;
-        for gutter in &gutter_types {
-            match gutter {
+        for gutter_type in &gutter_types {
+            match gutter_type {
                 GutterType::Diagnostics => gutters.push((gutter::diagnostics_or_breakpoints, 1)),
                 GutterType::LineNumbers => gutters.push((gutter::line_numbers, 5)),
             }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -103,7 +103,6 @@ impl View {
         let mut diagnostics_or_breakpoints_inserted = false;
         use crate::editor::GutterType;
         for gutter in &self.gutter_types {
-            // TODO: diagnostics and breakpoints only once
             match gutter {
                 GutterType::Diagnostics | GutterType::Breakpoints => {
                     if !diagnostics_or_breakpoints_inserted {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -95,10 +95,10 @@ impl fmt::Debug for View {
 }
 
 impl View {
-    pub fn new(doc: DocumentId, gutters_types: Vec<crate::editor::GutterType>) -> Self {
+    pub fn new(doc: DocumentId, gutter_types: Vec<crate::editor::GutterType>) -> Self {
         let mut gutters: Vec<(Gutter, usize)> = vec![];
         use crate::editor::GutterType;
-        for gutter in &gutters_types {
+        for gutter in &gutter_types {
             match gutter {
                 GutterType::Diagnostics => gutters.push((gutter::diagnostics_or_breakpoints, 1)),
                 GutterType::LineNumbers => gutters.push((gutter::line_numbers, 5)),


### PR DESCRIPTION
This implements the feature request of issue https://github.com/helix-editor/helix/issues/1960 (slightly adapted based on feedback from @archseer).

Now one can configure the displayed gutters with
```toml
[editor]
gutters = ["diagnostics", "line-numbers"]
```
(default)

Here a picture with
```toml
[editor]
gutters = ["diagnostics"]
```
<img width="1647" alt="without-line-numbers" src="https://user-images.githubusercontent.com/1009936/161850097-4163fe6f-e655-4672-bcec-302476e8333b.png">


