### PR TITLE
remove redundant code

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -364,8 +364,6 @@ impl<T> Picker<T> {
                     .map(|(index, _option)| (index, 0)),
             );
         } else if pattern.starts_with(&self.previous_pattern) {
-            // TODO: remove when retain_mut is in stable rust
-            use retain_mut::RetainMut;
 
             // optimization: if the pattern is a more specific version of the previous one
             // then we can score the filtered set.


### PR DESCRIPTION
This cleans up some unused code, removing a warning that comes up during build of helix source:

### [helix-term/src/ui/picker.rs](https://github.com/helix-editor/helix/compare/master...thiagodebastos:remove-unused-code?expand=1#diff-b6c51d6e6645b52604abc7b9cd90c0200ab42d52be2f7e623929376971e784c6)

* `retain_mut::RetainMut` is no longer needed since `vec::vec::retain_mut` has been stabilised:
  * https://github.com/rust-lang/rust/pull/95491.
  * https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.retain_mut