### PR TITLE
Replace shell_pipe_to with shell_pipe_popup

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -78,7 +78,7 @@
 | Key     | Description                                                                      | Command               |
 | ------  | -----------                                                                      | -------               |
 | <code>&#124;</code>     | Pipe each selection through shell command, replacing with output                 | `shell_pipe`          |
-| <code>Alt-&#124;</code> | Pipe each selection into shell command, ignoring output                          | `shell_pipe_to`       |
+| <code>Alt-&#124;</code> | Pipe each selection into shell command and show outputs in a popup               | `shell_pipe_popup`    |
 | `!`     | Run shell command, inserting output before each selection                        | `shell_insert_output` |
 | `Alt-!` | Run shell command, appending output after each selection                         | `shell_append_output` |
 | `$`     | Pipe each selection into shell command, keep selections where command returned 0 | `shell_keep_pipe`     |

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -275,7 +275,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "\"" => select_register,
         "|" => shell_pipe,
-        "A-|" => shell_pipe_to,
+        "A-|" => shell_pipe_popup,
         "!" => shell_insert_output,
         "A-!" => shell_append_output,
         "$" => shell_keep_pipe,


### PR DESCRIPTION
The new shell_pipe_popup performs a similar function but also allows the user to see the output in an automatically closing popup.

I know this #1682 is similar, but I want selection piping and quick output feedback for running word counts.