### PR TITLE
Fix linker errors on M1 native build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,8 @@
           env = prev.env ++ [
             { name = "HELIX_RUNTIME"; eval = "$PWD/runtime"; }
             { name = "RUST_BACKTRACE"; value = "1"; }
-            { name = "RUSTFLAGS"; value = "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"; }
+            { name = "RUSTFLAGS"; value = "-C link-arg=-fuse-ld=lld -C target-cpu=native"; }
+            { name = "CFLAGS"; value = "-mno-outline-atomics"; }
           ];
         };
       };


### PR DESCRIPTION
Firstly when I build I got this:

```
  = note: ld: unknown option: --no-rosegment
          collect2: error: ld returned 1 exit status
```

Which I fixed by simply removing the linker flag. Afterwards I had to add the `CFLAGS` from [here](https://github.com/rust-lang/git2-rs/issues/706) take care of the following error message:

```
  = note: Undefined symbols for architecture arm64:
            "___aarch64_ldadd4_acq_rel", referenced from:
                _atomic_inc in libtree_sitter-fd0ec8c590e94094.rlib(lib.o)
                _atomic_dec in libtree_sitter-fd0ec8c590e94094.rlib(lib.o)
          ld: symbol(s) not found for architecture arm64
          collect2: error: ld returned 1 exit status
```