### PR TITLE
Add default language server for HTML

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -27,7 +27,7 @@
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |
-| json | ✓ |  | ✓ | `vscode-json-language-server` |
+| json | ✓ |  | ✓ |  |
 | jsx | ✓ |  | ✓ | `typescript-language-server` |
 | julia | ✓ |  |  | `julia` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -27,7 +27,7 @@
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |
-| json | ✓ |  | ✓ |  |
+| json | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsx | ✓ |  | ✓ | `typescript-language-server` |
 | julia | ✓ |  |  | `julia` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -23,7 +23,7 @@
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | hcl | ✓ |  | ✓ | `terraform-ls` |
-| html | ✓ |  |  |  |
+| html | ✓ |  |  | `vscode-html-language-server` |
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -121,6 +121,9 @@ scope = "source.json"
 injection-regex = "json"
 file-types = ["json"]
 roots = []
+language-server = { command = "vscode-json-language-server", args = ["--stdio"] }
+auto-format = true
+config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -121,9 +121,6 @@ scope = "source.json"
 injection-regex = "json"
 file-types = ["json"]
 roots = []
-language-server = { command = "vscode-json-language-server", args = ["--stdio"] }
-auto-format = true
-config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -348,6 +348,9 @@ scope = "text.html.basic"
 injection-regex = "html"
 file-types = ["html"]
 roots = []
+language-server = { command = "vscode-html-language-server", args = ["--stdio"] }
+auto-format = true
+config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Formatting now works after much experimentation.

Neovim provides these additional settings:
```
    init_options = {
      embeddedLanguages = { css = true, javascript = true },
      configurationSection = { 'html', 'css', 'javascript' },
    },
```
But I don't think they are doing anything extra in Helix. Without them it still seems to be accepting and formatting JS, I think it is best to leave them out for now unless someone else knows more about them.

I will add to the WIKI when this is merged.