### PR TITLE
Add shell completion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
               pkgname=helix-$TAG-$platform
               mkdir $pkgname
               cp $source/LICENSE $source/README.md $pkgname
+              mkdir $pkgname/contrib
+              cp -r $source/contrib/completion $pkgname/contrib
               mv bins-$platform/runtime $pkgname/
               mv bins-$platform/hx$exe $pkgname
               chmod +x $pkgname/hx$exe

--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Bash completion script for Helix editor
+
+_hx() {
+	# $1 command name
+	# $2 word being completed
+	# $3 word preceding
+	COMPREPLY=()
+
+	case "$3" in
+	-g | --grammar)
+		COMPREPLY=($(compgen -W "fetch build" -- $2))
+		;;
+	--health)
+		local languages=$(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g')
+		COMPREPLY=($(compgen -W "$languages" -- $2))
+		;;
+	*)
+		COMPREPLY=($(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar" -- $2))
+		;;
+	esac
+} && complete -F _hx hx
+

--- a/contrib/completion/hx.fish
+++ b/contrib/completion/hx.fish
@@ -1,0 +1,12 @@
+#!/usr/bin/env fish
+# Fish completion script for Helix editor
+
+set -l langs (hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g')
+
+complete -c hx -s h -l help -d "Prints help information"
+complete -c hx -l tutor -d "Loads the tutorial"
+complete -c hx -l health -x -a "$langs" -d "Checks for errors in editor setup"
+complete -c hx -s g -l grammar -x -a "fetch build" -d "Fetches or builds tree-sitter grammars"
+complete -c hx -s v -o vv -o vvv -d "Increases logging verbosity"
+complete -c hx -s V -l version -d "Prints version information"
+

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -1,0 +1,29 @@
+#compdef _hx hx
+# Zsh completion script for Helix editor
+
+_hx() {
+	_arguments -C \
+		"-h[Prints help information]" \
+		"--help[Prints help information]" \
+		"-v[Increase logging verbosity]" \
+		"-vv[Increase logging verbosity]" \
+		"-vvv[Increase logging verbosity]" \
+		"-V[Prints version information]" \
+		"--version[Prints version information]" \
+		"--tutor[Loads the tutorial]" \
+		"--health[Checks for errors in editor setup]:language:->health" \
+		"-g[Fetches or builds tree-sitter grammars]:action:->grammar" \
+		"--grammar[Fetches or builds tree-sitter grammars]:action:->grammar" \
+		"*:file:_files"
+
+	case "$state" in
+	health)
+		local languages=($(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g'))
+		_values 'language' $languages
+		;;
+	grammar)
+		_values 'action' fetch build
+		;;
+	esac
+}
+


### PR DESCRIPTION
Ref #1975. I opted for `contrib/`, this of course is for debate. Installed automatically by brew via [homebrew-helix#6](https://github.com/helix-editor/homebrew-helix/pull/6), no idea about any other distribution methods.

The GH workflow is untested, as I simply don't know how …