### PR TITLE
Remove usage of format ident feature from tests

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1293,7 +1293,7 @@ mod test {
             let selection =
                 selection.transform(|r| move_prev_paragraph(text.slice(..), r, 1, Movement::Move));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -1316,7 +1316,7 @@ mod test {
             let selection =
                 selection.transform(|r| move_prev_paragraph(text.slice(..), r, 2, Movement::Move));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -1339,7 +1339,7 @@ mod test {
             let selection = selection
                 .transform(|r| move_prev_paragraph(text.slice(..), r, 1, Movement::Extend));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -1381,7 +1381,7 @@ mod test {
             let selection =
                 selection.transform(|r| move_next_paragraph(text.slice(..), r, 1, Movement::Move));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -1404,7 +1404,7 @@ mod test {
             let selection =
                 selection.transform(|r| move_next_paragraph(text.slice(..), r, 2, Movement::Move));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -1427,7 +1427,7 @@ mod test {
             let selection = selection
                 .transform(|r| move_next_paragraph(text.slice(..), r, 1, Movement::Extend));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1996,7 +1996,9 @@ mod test {
             assert_eq!(
                 matches[0].byte_range(),
                 range,
-                "@{capture} expected {range:?}"
+                "@{} expected {:?}",
+                capture,
+                range
             )
         };
 

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -53,7 +53,7 @@ pub fn print(s: &str) -> (String, Selection) {
         };
 
         if is_primary && primary_idx.is_some() {
-            panic!("primary `#[` already appeared {left:?} {s:?}");
+            panic!("primary `#[` already appeared {:?} {:?}", left, s);
         }
 
         let head_at_beg = iter.next_if_eq(&'|').is_some();
@@ -85,15 +85,15 @@ pub fn print(s: &str) -> (String, Selection) {
         }
 
         if head_at_beg {
-            panic!("missing end `{close_pair}#` {left:?} {s:?}");
+            panic!("missing end `{}#` {:?} {:?}", close_pair, left, s);
         } else {
-            panic!("missing end `|{close_pair}#` {left:?} {s:?}");
+            panic!("missing end `|{}#` {:?} {:?}", close_pair, left, s);
         }
     }
 
     let primary = match primary_idx {
         Some(i) => i,
-        None => panic!("missing primary `#[|]#` {s:?}"),
+        None => panic!("missing primary `#[|]#` {:?}", s),
     };
     let selection = Selection::new(ranges, primary);
     (left, selection)

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -381,7 +381,7 @@ mod test {
             let selection = selection
                 .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Inside, 1));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -404,7 +404,7 @@ mod test {
             let selection = selection
                 .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Inside, 2));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 
@@ -435,7 +435,7 @@ mod test {
             let selection = selection
                 .transform(|r| textobject_paragraph(text.slice(..), r, TextObject::Around, 1));
             let actual = crate::test::plain(&s, selection);
-            assert_eq!(actual, expected, "\nbefore: `{before:?}`");
+            assert_eq!(actual, expected, "\nbefore: `{:?}`", before);
         }
     }
 


### PR DESCRIPTION
connects #2026 
see also #1881

So we can continue targetting 1.57 as MSRV.