### PR TITLE
PHP roots and languageserver improvements

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -46,7 +46,7 @@
 | ocaml-interface | ✓ |  |  |  |
 | org | ✓ |  |  |  |
 | perl | ✓ | ✓ | ✓ |  |
-| php | ✓ | ✓ | ✓ |  |
+| php | ✓ | ✓ | ✓ | `intelephense` |
 | prolog |  |  |  | `swipl` |
 | protobuf | ✓ |  | ✓ |  |
 | python | ✓ | ✓ | ✓ | `pylsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -428,7 +428,8 @@ scope = "source.php"
 injection-regex = "php"
 file-types = ["php"]
 shebangs = ["php"]
-roots = []
+roots = ["composer.json", "index.php"]
+language-server = { command = "intelephense", args = ["--stdio"] }
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]


### PR DESCRIPTION
Hello, 

this pull request adds two things to the default languages.toml:

# Setting the default lsp to intelephense
After a lot of testing of different lsp implementations for php I found intelephense to be the best one for my projects (laravel, TYPO3, Wordpress). The free version offers a lot of value and the professional version is very affordable (15€). I understand that it can be controversial depending on a paid product for full functionality as an open source project, but as a developer I also value tools that save my time. 

# Defining roots
I added `composer.json` (composer is the de facto standard package manager for PHP) and `index.php` (still the default entry point for all modern projects) as workspace roots.