### PR TITLE
Add swift language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -61,6 +61,7 @@
 | scala | ✓ |  | ✓ | `metals` |
 | solidity | ✓ |  |  | `solc` |
 | svelte | ✓ |  | ✓ | `svelteserver` |
+| swift | ✓ |  |  | `sourcekit-lsp` |
 | tablegen | ✓ | ✓ | ✓ |  |
 | toml | ✓ |  |  |  |
 | tsq | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1078,7 +1078,6 @@ injection-regex = "swift"
 file-types = ["swift"]
 roots = [ "Package.swift" ]
 comment-token = "//"
-indent = { tab-width = 2, unit = "  " }
 auto-format = true
 language-server = { command = "sourcekit-lsp" }
 

--- a/languages.toml
+++ b/languages.toml
@@ -1070,3 +1070,18 @@ roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "markdown"
 language-server = { command = "R", args = ["--slave", "-e", "languageserver::run()"] }
+
+[[language]]
+name = "swift"
+scope = "source.swift"
+injection-regex = "swift"
+file-types = ["swift"]
+roots = [ "Package.swift" ]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+auto-format = true
+language-server = { command = "sourcekit-lsp" }
+
+[[grammar]]
+name = "swift"
+source = { git = "https://github.com/Dispersia/tree-sitter-swift", rev = "e75240f89bb3bfd3396155859ae364e5c58d7377" }

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -1,0 +1,158 @@
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
+
+; Identifiers
+(attribute) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @function.method)
+(function_declaration ["init" @constructor])
+(throws) @keyword
+"async" @keyword
+(where_keyword) @keyword
+(parameter external_name: (simple_identifier) @variable.parameter)
+(parameter name: (simple_identifier) @variable.parameter)
+(type_parameter (type_identifier) @variable.parameter)
+(inheritance_constraint (identifier (simple_identifier) @variable.parameter))
+(equality_constraint (identifier (simple_identifier) @variable.parameter))
+(non_binding_pattern bound_identifier: (simple_identifier)) @variable
+
+[
+  "typealias"
+  "struct"
+  "class"
+  "enum"
+  "protocol"
+  "extension"
+  "indirect"
+  "some"
+] @keyword
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+] @keyword
+
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @keyword.control.repeat])
+(for_statement ["in" @keyword.control.repeat])
+(for_statement item: (simple_identifier) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @keyword.control.repeat
+
+["let" "var"] @keyword
+(non_binding_pattern (simple_identifier) @variable)
+
+(guard_statement ["guard" @keyword.control.conditional])
+(if_statement ["if" @keyword.control.conditional])
+(switch_statement ["switch" @keyword.control.conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.control.return
+(ternary_expression
+  ["?" ":"] @conditional)
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+(comment) @comment.line
+(multiline_comment) @comment.block
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @string.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @constant.numeric.float
+(boolean_literal) @constant.builtin.boolean
+"nil" @variable.builtin
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "=="
+ "==="
+ "??"
+
+ "->"
+
+ "..<"
+ "..."
+] @operator
+

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -46,10 +46,10 @@
   (modify_specifier)
 ] @keyword
 
-(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
-(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @variable.other.member))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @variable.other.member)))
 
-(import_declaration ["import" @include])
+(import_declaration ["import" @keyword.control.import])
 
 (enum_entry ["case" @keyword])
 
@@ -108,12 +108,12 @@
 (lambda_literal ["in" @keyword.operator])
 
 ; Basic literals
+(integer_literal) @constant.numeric.integer
 [
- (integer_literal)
  (hex_literal)
  (oct_literal)
  (bin_literal)
-] @number
+] @constant.numeric
 (real_literal) @constant.numeric.float
 (boolean_literal) @constant.builtin.boolean
 "nil" @variable.builtin

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -85,7 +85,7 @@
 (switch_entry (default_keyword) @keyword)
 "return" @keyword.control.return
 (ternary_expression
-  ["?" ":"] @conditional)
+  ["?" ":"] @keyword.control.conditional)
 
 ["do" (throw_keyword) (catch_keyword)] @keyword
 

--- a/runtime/queries/swift/locals.scm
+++ b/runtime/queries/swift/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @scope


### PR DESCRIPTION
 https://github.com/helix-editor/helix/issues/1964

 Was also planning on using this, so went ahead and implemented it. From that issue, I forked the current tree-sitter-swift and checked in the current build configs, until a better solution is implemented (if we just want to wait if they want to add a separate branch, that's fine too).

 There are a few keywords that are in the highlights.scm that I didn't see in https://docs.helix-editor.com/themes.html#syntax-highlighting, so I didn't know how to handle them and just left them as is.

 Finally, there is one issue in swift I can't seem to figure out.

![image](https://user-images.githubusercontent.com/7254623/162494012-c82f83e5-0f76-4cae-835e-0cd85994ec5d.png)

when tabbing through, it's auto appending the parenthesis, but puts the cursor outside so you have to backspace. Is there a way to prevent this I didn't see?