### PR TITLE
Improve documentation on Language Server installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ that sets the variable to the install dir.
 > NOTE: running via cargo also doesn't require setting explicit `HELIX_RUNTIME` path, it will automatically
 > detect the `runtime` directory in the project root.
 
+In order to use LSP features like auto-complete, you will need to
+[install the appropriate Language Server](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
+for a language.
+
 [![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
 
 ## MacOS

--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -16,6 +16,7 @@ injection-regex = "^mylang$"
 file-types = ["mylang", "myl"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
+language-server = { command = "mylang-lsp", args = ["--stdio"] }
 ```
 
 These are the available keys and descriptions for the file.
@@ -32,8 +33,13 @@ These are the available keys and descriptions for the file.
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
 | `comment-token`       | The token to use as a comment-token                           |
 | `indent`              | The indent to use. Has sub keys `tab-width` and `unit`        |
-| `config`              | Language server configuration                                 |
+| `language-server`     | The Language Server to run. Has sub keys `command` and `args` |
+| `config`              | Language Server configuration                                 |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
+
+When adding a Language Server configuration, be sure to update the
+[Language Server Wiki](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
+with installation notes.
 
 ## Grammar configuration
 


### PR DESCRIPTION
Following up on https://github.com/helix-editor/helix/pull/2031#issuecomment-1093330411

It also seems to be a pretty common case that a new user will not know off the bat that they need to install the language server. I think VSCode/nvim plugins might install these themselves which makes it unexpected to have to install it when using helix. So I added a note to the bottom of the installation instructions pointing to the new lsp wiki.

Also, thanks @David-Else (and subsequent contributors) for setting up that wiki :)