### PR TITLE
Add default language server for Vue

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -68,7 +68,7 @@
 | tsx | ✓ |  |  | `typescript-language-server` |
 | twig | ✓ |  |  |  |
 | typescript | ✓ |  | ✓ | `typescript-language-server` |
-| vue | ✓ |  |  |  |
+| vue | ✓ |  |  | `vls` |
 | wgsl | ✓ |  |  |  |
 | yaml | ✓ |  | ✓ |  |
 | zig | ✓ |  | ✓ | `zls` |

--- a/languages.toml
+++ b/languages.toml
@@ -581,8 +581,9 @@ name = "vue"
 scope = "source.vue"
 injection-regex = "vue"
 file-types = ["vue"]
-roots = []
+roots = ["package.json", "vue.config.js"]
 indent = { tab-width = 2, unit = "  " }
+language-server = { command = "vls" }
 
 [[grammar]]
 name = "vue"


### PR DESCRIPTION
Should resolve #2010. Sadly can't config [volar](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-language-server) to it,only vetur works fine.