### PR TITLE
Allow syntax highlighting to be disabled

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -6,8 +6,9 @@ use helix_core::{
     pos_at_coords, syntax, Selection,
 };
 use helix_lsp::{lsp, util::lsp_pos_to_pos, LspProgressMap};
-use helix_view::document::DocumentEvent;
-use helix_view::{align_view, editor::ConfigEvent, document::DocumentEvent, editor::ConfigEvent, theme, Align, Editor};
+use helix_view::{
+    align_view, document::DocumentEvent, editor::ConfigEvent, theme, tree::Layout, Align, Editor,
+};
 use serde_json::json;
 
 use crate::{

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -799,14 +799,13 @@ impl Application {
                 &self.editor,
                 "File is big. Do you want to enable syntax highlighting anyway (it will slow down the editor) ? ".into(),
                 ui::YesNoAnswer::No,
-                move |cx: &mut crate::compositor::Context, answer: ui::YesNoAnswer| match answer {
-                    ui::YesNoAnswer::Yes => {
+                move |cx: &mut crate::compositor::Context, answer: ui::YesNoAnswer| {
+                    if let ui::YesNoAnswer::Yes = answer {
                         let view = cx.editor.tree.get(cx.editor.tree.focus);
                         let document_in_focus = cx.editor.documents.get_mut(&view.doc).unwrap();
                         document_in_focus.enable_syntax = true;
                         document_in_focus.detect_language(cx.editor.syn_loader.clone());
                     }
-                    _ => {}
                 },
             )),
         };

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -803,7 +803,7 @@ impl Application {
                     ui::YesNoAnswer::Yes => {
                         let view = cx.editor.tree.get(cx.editor.tree.focus);
                         let document_in_focus = cx.editor.documents.get_mut(&view.doc).unwrap();
-                        document_in_focus.enable_syntax_parser = true;
+                        document_in_focus.enable_syntax = true;
                         document_in_focus.detect_language(cx.editor.syn_loader.clone());
                     }
                     _ => {}

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -432,7 +432,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command pallete",
-        toggle_syntax_highlighting, "Toggle syntax highlighting for current document",
+        toggle_syntax_parser, "Toggle (on/off) syntax parser for current document",
     );
 }
 
@@ -4857,9 +4857,9 @@ fn replay_macro(cx: &mut Context) {
     }));
 }
 
-fn toggle_syntax_highlighting(cx: &mut Context) {
+fn toggle_syntax_parser(cx: &mut Context) {
     let (_, doc) = current!(cx.editor);
-    doc.highlight_syntax = !doc.highlight_syntax;
+    doc.enable_syntax_parser = !doc.enable_syntax_parser;
     // Force reload syntax
     doc.detect_language(cx.editor.syn_loader.clone());
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -431,7 +431,8 @@ impl MappableCommand {
         decrement, "Decrement item under cursor",
         record_macro, "Record macro",
         replay_macro, "Replay macro",
-        command_palette, "Open command palette",
+        command_palette, "Open command pallete",
+        toggle_syntax_highlighting, "Toggle syntax highlighting for current document",
     );
 }
 
@@ -4854,4 +4855,11 @@ fn replay_macro(cx: &mut Context) {
         // replaying recursively.
         cx.editor.macro_replaying.pop();
     }));
+}
+
+fn toggle_syntax_highlighting(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    doc.highlight_syntax = !doc.highlight_syntax;
+    // Force reload syntax
+    doc.detect_language(cx.editor.syn_loader.clone());
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -432,7 +432,6 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command pallete",
-        toggle_syntax, "Toggle (on/off) syntax for current document",
     );
 }
 
@@ -4855,11 +4854,4 @@ fn replay_macro(cx: &mut Context) {
         // replaying recursively.
         cx.editor.macro_replaying.pop();
     }));
-}
-
-fn toggle_syntax(cx: &mut Context) {
-    let (_, doc) = current!(cx.editor);
-    doc.enable_syntax = !doc.enable_syntax;
-    // Force reload syntax
-    doc.detect_language(cx.editor.syn_loader.clone());
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -432,7 +432,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command pallete",
-        toggle_syntax_parser, "Toggle (on/off) syntax parser for current document",
+        toggle_syntax, "Toggle (on/off) syntax for current document",
     );
 }
 
@@ -4857,9 +4857,9 @@ fn replay_macro(cx: &mut Context) {
     }));
 }
 
-fn toggle_syntax_parser(cx: &mut Context) {
+fn toggle_syntax(cx: &mut Context) {
     let (_, doc) = current!(cx.editor);
-    doc.enable_syntax_parser = !doc.enable_syntax_parser;
+    doc.enable_syntax = !doc.enable_syntax;
     // Force reload syntax
     doc.detect_language(cx.editor.syn_loader.clone());
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1515,6 +1515,31 @@ fn run_shell_command(
     Ok(())
 }
 
+fn toggle_syntax(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    if args.len() != 1 {
+        return Ok(());
+    }
+
+    let (_, doc) = current!(cx.editor);
+    let arg = args.get(0).unwrap().as_ref();
+    match arg {
+        "on" => {
+            doc.enable_syntax = true;
+            doc.detect_language(cx.editor.syn_loader.clone());
+        }
+        "off" => {
+            doc.enable_syntax = false;
+            doc.detect_language(cx.editor.syn_loader.clone());
+        }
+        _ => {}
+    };
+    Ok(())
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -1995,6 +2020,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             fun: run_shell_command,
             completer: Some(completers::directory),
         },
+        TypableCommand {
+            name: "toggle-syntax",
+            aliases: &[],
+            doc: "Enable/Disable syntax for current document",
+            fun: toggle_syntax,
+            completer: Some(completers::onoff)
+        }
     ];
 
 pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableCommand>> =

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -417,6 +417,10 @@ pub mod completers {
         })
     }
 
+    pub fn onoff(_editor: &Editor, _input: &str) -> Vec<Completion> {
+        vec![(0.., Cow::from("on")), (0.., Cow::from("off"))]
+    }
+
     pub fn yesno(_editor: &Editor, _input: &str) -> Vec<Completion> {
         vec![(0.., Cow::from("yes")), (0.., Cow::from("no"))]
     }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -145,8 +145,8 @@ pub fn yesno_prompt(
         prompt,
         None,
         completers::yesno,
-        move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| match event {
-            PromptEvent::Validate => {
+        move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
+            if let PromptEvent::Validate = event {
                 let answer = match input {
                     "yes" => YesNoAnswer::Yes,
                     "no" => YesNoAnswer::No,
@@ -155,7 +155,6 @@ pub fn yesno_prompt(
 
                 callback_fn(cx, answer);
             }
-            _ => {}
         },
     );
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -30,6 +30,10 @@ const BUF_SIZE: usize = 8192;
 
 const DEFAULT_INDENT: IndentStyle = IndentStyle::Tabs;
 
+/// Threshold for file to be treated as "big".
+/// Big files have their syntax disabled.
+const BIG_FILE_THRESHOLD: u64 = 128 * 1024 * 1024; // 128 Megabytes
+
 pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -103,6 +107,8 @@ pub struct Document {
     syntax: Option<Syntax>,
     /// Corresponding language scope name. Usually `source.<lang>`.
     pub(crate) language: Option<Arc<LanguageConfiguration>>,
+    /// Sets if syntax highlighting should be used or not
+    pub highlight_syntax: bool,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,
@@ -353,6 +359,7 @@ impl Document {
             restore_cursor: false,
             syntax: None,
             language: None,
+            highlight_syntax: true,
             changes,
             old_state,
             diagnostics: Vec::new(),
@@ -565,6 +572,28 @@ impl Document {
         }
     }
 
+    /// Get size (in bytes) of currently opened file.
+    /// If no file is opened, or there is some issue with the file,
+    /// then size will be assumed as 0.
+    pub fn get_file_size(&self) -> u64 {
+        match &self.path {
+            Some(path) => {
+                let file = std::fs::File::open(path);
+                if file.is_err() {
+                    return 0;
+                }
+
+                let metadata = file.unwrap().metadata();
+                if metadata.is_err() {
+                    return 0;
+                }
+
+                metadata.unwrap().len()
+            }
+            None => 0,
+        }
+    }
+
     /// Detect the programming language based on the file type.
     pub fn detect_language(&mut self, config_loader: Arc<syntax::Loader>) {
         if let Some(path) = &self.path {
@@ -634,6 +663,10 @@ impl Document {
         // and error out when document is saved
         self.path = path;
 
+        if self.get_file_size() > BIG_FILE_THRESHOLD {
+            self.highlight_syntax = false;
+        }
+
         Ok(())
     }
 
@@ -645,9 +678,14 @@ impl Document {
         loader: Option<Arc<helix_core::syntax::Loader>>,
     ) {
         if let (Some(language_config), Some(loader)) = (language_config, loader) {
-            if let Some(highlight_config) = language_config.highlight_config(&loader.scopes()) {
-                let syntax = Syntax::new(&self.text, highlight_config, loader);
-                self.syntax = Some(syntax);
+            if self.highlight_syntax {
+                if let Some(highlight_config) = language_config.highlight_config(&loader.scopes()) {
+                    let syntax = Syntax::new(&self.text, highlight_config, loader);
+                    self.syntax = Some(syntax);
+                }
+            } else {
+                // If there is some syntax and it should be disabled, disable it.
+                self.syntax = None;
             }
 
             self.language = Some(language_config);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -115,7 +115,7 @@ pub struct Document {
     /// Corresponding language scope name. Usually `source.<lang>`.
     pub(crate) language: Option<Arc<LanguageConfiguration>>,
     /// Sets if syntax parser should be used or not
-    pub enable_syntax_parser: bool,
+    pub enable_syntax: bool,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,
@@ -371,7 +371,7 @@ impl Document {
             restore_cursor: false,
             syntax: None,
             language: None,
-            enable_syntax_parser: true,
+            enable_syntax: true,
             changes,
             old_state,
             diagnostics: Vec::new(),
@@ -655,7 +655,7 @@ impl Document {
         self.path = path;
 
         if self.text.len_bytes() > BIG_FILE_THRESHOLD {
-            self.enable_syntax_parser = false;
+            self.enable_syntax = false;
         }
 
         Ok(())
@@ -669,7 +669,7 @@ impl Document {
         loader: Option<Arc<helix_core::syntax::Loader>>,
     ) {
         if let (Some(language_config), Some(loader)) = (language_config, loader) {
-            if self.enable_syntax_parser {
+            if self.enable_syntax {
                 if let Some(highlight_config) = language_config.highlight_config(&loader.scopes()) {
                     let syntax = Syntax::new(&self.text, highlight_config, loader);
                     self.syntax = Some(syntax);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -656,6 +656,11 @@ impl Document {
 
         if self.text.len_bytes() > BIG_FILE_THRESHOLD {
             self.enable_syntax = false;
+            // Notify that syntax has been disabled
+            self.document_events
+                .0
+                .send(DocumentEvent::DisabledSyntax)
+                .unwrap();
         }
 
         Ok(())
@@ -677,11 +682,6 @@ impl Document {
             } else {
                 // If there is some syntax and it should be disabled, disable it.
                 self.syntax = None;
-                // Notify that syntax has been disabled
-                self.document_events
-                    .0
-                    .send(DocumentEvent::DisabledSyntax)
-                    .unwrap();
             }
 
             self.language = Some(language_config);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,6 +1,6 @@
 use crate::{
     clipboard::{get_clipboard_provider, ClipboardProvider},
-    document::{Mode, SCRATCH_BUFFER_NAME},
+    document::{DocumentEvent, Mode, SCRATCH_BUFFER_NAME},
     graphics::{CursorKind, Rect},
     info::Info,
     input::KeyEvent,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,6 +1,6 @@
 use crate::{
     clipboard::{get_clipboard_provider, ClipboardProvider},
-    document::{DocumentEvent, Mode, SCRATCH_BUFFER_NAME},
+    document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::{CursorKind, Rect},
     info::Info,
     input::KeyEvent,


### PR DESCRIPTION
This PR resolves issue #338.

It adds a possibility for syntax highlighting to be disabled for some document.
Such occurrence happens automatically for "big" files and can also be triggered artificially by a command from command palette.
Running the command toggles the syntax highlighting on/off, so it can be easily re-enabled if needed.

I have assumed that "big" file is more than or equal to 128 Megabytes in size. After this size, documents tend to lag, but this number if up for debate.