### PR TITLE
Rewrite Language Support docs

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -37,9 +37,11 @@ These are the available keys and descriptions for the file.
 | `config`              | Language Server configuration                                 |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 
+When adding a new language or Language Server configuration for an existing
+language, run `cargo xtask docgen` to add the new configuration to the
+[Language Support][lang-support] docs before creating a pull request.
 When adding a Language Server configuration, be sure to update the
-[Language Server Wiki](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
-with installation notes.
+[Language Server Wiki][install-lsp-wiki] with installation notes.
 
 ## Grammar configuration
 
@@ -94,3 +96,5 @@ the last matching query supersedes the ones before it. See
 [treesitter-language-injection]: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection
 [languages.toml]: https://github.com/helix-editor/helix/blob/master/languages.toml
 [neovim-query-precedence]: https://github.com/helix-editor/helix/pull/1170#issuecomment-997294090
+[install-lsp-wiki]: https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers
+[lang-support]: ../lang-support.md

--- a/book/src/lang-support.md
+++ b/book/src/lang-support.md
@@ -1,10 +1,16 @@
 # Language Support
 
-For more information like arguments passed to default LSP server,
-extensions assosciated with a filetype, custom LSP settings, filetype
-specific indent settings, etc see the default
-[`languages.toml`][languages.toml] file.
+The following languages and Language Servers are supported. In order to use
+Language Server features, you must first [install][lsp-install-wiki] the
+appropriate Language Server.
+
+Check the language support in your installed helix version with `hx --health`.
+
+Also see the [Language Configuration][lang-config] docs and the [Adding
+Languages][adding-languages] guide for more language configuration information.
 
 {{#include ./generated/lang-support.md}}
 
-[languages.toml]: https://github.com/helix-editor/helix/blob/master/languages.toml
+[lsp-install-wiki]: https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers
+[lang-config]: ./languages.md
+[adding-languages]: ./guides/adding_languages.md

--- a/languages.toml
+++ b/languages.toml
@@ -1,3 +1,6 @@
+# Language support configuration.
+# See the languages documentation: https://docs.helix-editor.com/master/languages.html
+
 [[language]]
 name = "rust"
 scope = "source.rust"


### PR DESCRIPTION
Adding you here sudormrfbin as I see you were the original author.

Related to https://github.com/helix-editor/helix/issues/2058#issuecomment-1094276181

I wanted to stress

* you need a language server installed to support LSP-driven features (a somewhat common question)
* `hx --health` can show you the language support you have for the version installed

Plus I think linking to the `languages.toml` is unnecessary, I think we can just link to the other language docs. The `languages.toml` is probably confusing per the linked issue. I also added a pointer in the languages.toml to the lang docs. Seems a little excessive but meh, it's a low-cost thing that might help ¯\\\_(ツ)_/¯