### PR TITLE
Adding an entry in the g menu for G (goto line)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -289,7 +289,7 @@ impl MappableCommand {
         goto_last_accessed_file, "Goto last accessed file",
         goto_last_modified_file, "Goto last modified file",
         goto_last_modification, "Goto last modification",
-        goto_line, "Goto line",
+        goto_line, "Goto line <n> (must enter <n> first)",
         goto_last_line, "Goto last line",
         goto_first_diag, "Goto first diagnostic",
         goto_last_diag, "Goto last diagnostic",

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -38,6 +38,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "G" => goto_line,
         "g" => { "Goto"
             "g" => goto_file_start,
+            "G" => goto_line,
             "e" => goto_last_line,
             "f" => goto_file,
             "h" => goto_line_start,


### PR DESCRIPTION
The current `g` menu is a little confusing for the `goto_line` functionality (#2078). This is an attempt to clarify. 
![2022-04-11 at 13 50 41 - Alacritty - CleanShot@2x](https://user-images.githubusercontent.com/70898/162799567-fb1237fc-28fa-465d-be20-ad14f4d505f8.png)

