### PR TITLE
lower LSP init error log to a `warn!`

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -457,7 +457,7 @@ impl Editor {
         let language_server = doc.language.as_ref().and_then(|language| {
             ls.get(language)
                 .map_err(|e| {
-                    log::error!(
+                    log::warn!(
                         "Failed to initialize the LSP for `{}` {{ {} }}",
                         language.scope(),
                         e


### PR DESCRIPTION
I think that this makes most sense since it's not user error in most cases, e.g. choosing not to install an LSP or not defining one.