### PR TITLE
Fix panic in min_width_1/grapheme_aligned when Range extends past bounds

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -542,11 +542,12 @@ impl Selection {
     }
 
     // Ensures the selection adheres to the following invariants:
-    // 1. All ranges are grapheme aligned.
-    // 2. All ranges are at least 1 character wide, unless at the
+    // 1. All ranges are within the bounds of the text.
+    // 2. All ranges are grapheme aligned.
+    // 3. All ranges are at least 1 character wide, unless at the
     //    very end of the document.
-    // 3. Ranges are non-overlapping.
-    // 4. Ranges are sorted by their position in the text.
+    // 4. Ranges are non-overlapping.
+    // 5. Ranges are sorted by their position in the text.
     pub fn ensure_invariants(self, text: RopeSlice) -> Self {
         self.transform(|r| r.clamp_range(text).min_width_1(text).grapheme_aligned(text))
             .normalize()


### PR DESCRIPTION
This change addresses a bug when using `jump_forward` / `jump_backwards`, when the saved selection in the jumplist contains a range that extends past the end of the document.

The easiest way to reproduce this bug is to write "hi", save the space after "hi" to the jumplist via ctrl+s, delete everything, use ctrl+o to jump and you receive
```
thread 'main' panicked at 'assertion failed: char_idx <= slice.len_chars()', helix-core/src/graphemes.rs:37:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
because the range extends past the slice length.

I am _very_ unfamiliar with this codebase, and I did add some tests and can confirm that after my changes, the use case I described now no longer panics, but if this is not the correct place to implement this bounds checking, please let me know.

