### PR TITLE
Add tree-sitters EEx and HEEx

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -9,6 +9,7 @@
 | css | ✓ |  |  | `vscode-css-language-server` |
 | dart | ✓ |  | ✓ | `dart` |
 | dockerfile | ✓ |  |  | `docker-langserver` |
+| eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |
 | elixir | ✓ |  |  | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -26,6 +26,7 @@
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | hcl | ✓ |  | ✓ | `terraform-ls` |
+| heex | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server` |
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -91,7 +91,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "elixir"
-source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "60863fc6e27d60cf4b1917499ed2259f92c7800e"  }
+source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "1dabc1c790e07115175057863808085ea60dd08a"  }
 
 [[language]]
 name = "fish"

--- a/languages.toml
+++ b/languages.toml
@@ -1113,3 +1113,15 @@ grammar = "embedded-template"
 [[grammar]]
 name = "embedded-template"
 source = { git = "https://github.com/tree-sitter/tree-sitter-embedded-template", rev = "d21df11b0ecc6fd211dbe11278e92ef67bd17e97" }
+
+[[language]]
+name = "eex"
+scope = "source.eex"
+injection-regex = "eex"
+file-types = ["eex"]
+roots = []
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "eex"
+source = { git = "https://github.com/connorlay/tree-sitter-eex", rev = "f742f2fe327463335e8671a87c0b9b396905d1d1" }

--- a/languages.toml
+++ b/languages.toml
@@ -1125,3 +1125,15 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "eex"
 source = { git = "https://github.com/connorlay/tree-sitter-eex", rev = "f742f2fe327463335e8671a87c0b9b396905d1d1" }
+
+[[language]]
+name = "heex"
+scope = "source.heex"
+injection-regex = "heex"
+file-types = ["heex"]
+roots = []
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "heex"
+source = { git = "https://github.com/connorlay/tree-sitter-heex", rev = "592e22292a367312c35e13de7fdb888f029981d6" }

--- a/runtime/queries/eex/highlights.scm
+++ b/runtime/queries/eex/highlights.scm
@@ -1,0 +1,6 @@
+; https://github.com/connorlay/tree-sitter-eex/blob/f742f2fe327463335e8671a87c0b9b396905d1d1/queries/highlights.scm
+
+; wrapping in (directive .. ) prevents us from highlighting '%>' in a comment as a keyword
+(directive ["<%" "<%=" "<%%" "<%%=" "%>"] @keyword)
+
+(comment) @comment

--- a/runtime/queries/eex/injections.scm
+++ b/runtime/queries/eex/injections.scm
@@ -1,0 +1,9 @@
+; https://github.com/connorlay/tree-sitter-eex/blob/f742f2fe327463335e8671a87c0b9b396905d1d1/queries/injections.scm
+
+((directive (expression) @injection.content)
+ (#set! injection.language "elixir"))
+
+((partial_expression) @injection.content
+ (#set! injection.language "elixir")
+ (#set! injection.include-children)
+ (#set! injection.combined))

--- a/runtime/queries/elixir/highlights.scm
+++ b/runtime/queries/elixir/highlights.scm
@@ -217,5 +217,3 @@
   "<<"
   ">>"
 ] @punctuation.bracket
-
-(ERROR) @warning

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -7,3 +7,10 @@
  (#match? @_sigil_name "^(r|R)$")
  (#set! injection.language "regex")
  (#set! injection.combined))
+
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(h|H)$")
+ (#set! injection.language "heex")
+ (#set! injection.combined))

--- a/runtime/queries/heex/highlights.scm
+++ b/runtime/queries/heex/highlights.scm
@@ -1,0 +1,58 @@
+; https://github.com/connorlay/tree-sitter-heex/blob/592e22292a367312c35e13de7fdb888f029981d6/queries/highlights.scm
+; HEEx delimiters
+[
+  "<!"
+  "<!--"
+  "<"
+  "<%!--"
+  "<%#"
+  ">"
+  "</"
+  "--%>"
+  "-->"
+  "/>"
+  "{"
+  "}"
+  ; These could be `@keyword`s but the closing `>` wouldn't be highlighted
+  ; as `@keyword`
+  "<:"
+  "</:"
+] @punctuation.bracket
+
+; Non-comment or tag delimiters
+[
+  "<%"
+  "<%="
+  "<%%="
+  "%>"
+] @keyword
+
+; HEEx operators are highlighted as such
+"=" @operator
+
+; HEEx inherits the DOCTYPE tag from HTML
+(doctype) @constant
+
+; HEEx comments are highlighted as such
+(comment) @comment
+
+; HEEx tags are highlighted as HTML
+(tag_name) @tag
+
+; HEEx slots are highlighted as atoms (symbols)
+(slot_name) @string.special.symbol
+
+; HEEx attributes are highlighted as HTML attributes
+(attribute_name) @attribute
+[
+  (attribute_value)
+  (quoted_attribute_value)
+] @string
+
+; HEEx components are highlighted as Elixir modules and functions
+(component_name
+  [
+    (module) @module
+    (function) @function
+    "." @punctuation.delimiter
+  ])

--- a/runtime/queries/heex/injections.scm
+++ b/runtime/queries/heex/injections.scm
@@ -1,0 +1,21 @@
+; https://github.com/connorlay/tree-sitter-heex/blob/592e22292a367312c35e13de7fdb888f029981d6/queries/injections.scm
+; directives are standalone tags like '<%= @x %>'
+;
+; partial_expression_values are elixir code that is part of an expression that
+; spans multiple directive nodes, so they must be combined. For example:
+;     <%= if true do %>
+;       <p>hello, tree-sitter!</p>
+;     <% end %>
+((directive (partial_expression_value) @injection.content)
+ (#set! injection.language "elixir")
+ (#set! injection.include-children)
+ (#set! injection.combined))
+
+; Regular expression_values do not need to be combined
+((directive (expression_value) @injection.content)
+ (#set! injection.language "elixir"))
+
+; expressions live within HTML tags, and do not need to be combined
+;     <link href={ Routes.static_path(..) } />
+((expression (expression_value) @injection.content)
+ (#set! injection.language "elixir"))


### PR DESCRIPTION
EEx and HEEx are templating languages for Elixir.

I thought about pulling in HEEx before (#881) but it needed the incremental injections refactor in order to use combined injections (#1378).

The highlights are not perfect because of the whitespace sensitivity of tree-sitter-elixir. I've removed the error highlighting in tree-sitter-elixir queries to make it less noticeable. It may take a bit to fix that so I think we're better off adding heex with "good enough" syntax highlights for now (see also https://github.com/elixir-lang/tree-sitter-elixir/issues/2#issuecomment-1097377723). I could be persuaded to drop the commit that removes error highlighting though.

Also updates tree-sitter-elixir with a fix for a case that bugged me during editing (https://github.com/elixir-lang/tree-sitter-elixir/pull/33)