### PR TITLE
Document values for editor.cursor-shape

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -55,6 +55,7 @@ hidden = false
 
 Defines the shape of cursor in each mode. Note that due to limitations
 of the terminal environment, only the primary cursor can change shape.
+Valid values for these options are `block`, `bar`, `underline`, or `none`.
 
 | Key      | Description                                | Default |
 | ---      | -----------                                | ------- |


### PR DESCRIPTION
These are hinted at in the example config at the top (except `none`), but really should be listed explicitly near the option itself for clarity.