### PR TITLE
Add make file-type "mk" to languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -676,7 +676,7 @@ source = { git = "https://github.com/uyha/tree-sitter-cmake", rev = "f6616f1e417
 [[language]]
 name = "make"
 scope = "source.make"
-file-types = ["Makefile", "makefile", "justfile", ".justfile"]
+file-types = ["Makefile", "makefile", "mk", "justfile", ".justfile"]
 roots =[]
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
.mk is more or less standard for make files that aren't named "Makefile".