### PR TITLE
local language config

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -65,7 +65,22 @@ pub fn default_lang_config() -> toml::Value {
 /// User configured languages.toml file, merged with the default config.
 pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
     let def_lang_conf = default_lang_config();
-    let data = std::fs::read(crate::config_dir().join("languages.toml"));
+
+    // Checking if there is a language file where the executable is been run
+    // This allows to have language definitions in each project
+    let data = std::env::current_dir()
+        .ok()
+        .map(|path| path.join("languages.toml"))
+        .and_then(|path| {
+            if path.exists() {
+                let data = std::fs::read(path);
+                Some(data)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| std::fs::read(crate::config_dir().join("languages.toml")));
+
     let user_lang_conf = match data {
         Ok(raw) => {
             let value = toml::from_slice(&raw)?;

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -66,7 +66,7 @@ pub fn default_lang_config() -> toml::Value {
 pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
     let def_lang_conf = default_lang_config();
 
-    // Checking if there is a language file where the executable is been run
+    // Checking if there is a language file where the executable is being run
     // This allows to have language definitions in each project
     let data = std::env::current_dir()
         .ok()

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -71,14 +71,7 @@ pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
     let data = std::env::current_dir()
         .ok()
         .map(|path| path.join("languages.toml"))
-        .and_then(|path| {
-            if path.exists() {
-                let data = std::fs::read(path);
-                Some(data)
-            } else {
-                None
-            }
-        })
+        .and_then(|path| path.exists().then(|| std::fs::read(path)))
         .unwrap_or_else(|| std::fs::read(crate::config_dir().join("languages.toml")));
 
     let user_lang_conf = match data {


### PR DESCRIPTION
Adds the ability to search for a `languages.toml` file in the folder where helix is started. This is useful when working with multiple projects (specially rust) that require to have different features enabled. 