### PR TITLE
Use XDG dirs per spec

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+HELIX_CONFIG = { value = "./runtime/config.toml", force = true, relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +172,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -402,7 +422,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "cc",
- "etcetera",
+ "directories",
  "libloading",
  "once_cell",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,15 +156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,17 +163,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -235,6 +215,17 @@ name = "etcetera"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "016b04fd1e94fb833d432634245c9bb61cf1c7409668a0e7d4c3ab00c5172dec"
+dependencies = [
+ "cfg-if",
+ "dirs-next",
+ "thiserror",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d017fce18e4e9bfa75e1db51f49f4487bd3f8a7df509b24a46474a956ee962fd"
 dependencies = [
  "cfg-if",
  "dirs-next",
@@ -381,7 +372,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "encoding_rs",
- "etcetera",
+ "etcetera 0.3.2",
  "helix-loader",
  "log",
  "once_cell",
@@ -422,7 +413,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "cc",
- "directories",
+ "etcetera 0.4.0",
  "libloading",
  "once_cell",
  "serde",

--- a/README.md
+++ b/README.md
@@ -46,14 +46,13 @@ hx --grammar build
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars.
 
 Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
-config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%AppData%/helix/runtime` on Windows).
-This location can be overridden via the `HELIX_RUNTIME` environment variable.
+data directory (default `$XDG_DATA_HOME/helix` on Linux/macOS, or `%AppData%/helix/` on Windows).
+This location can be overridden via appropriate entries in helix config file.
 
 Packages already solve this for you by wrapping the `hx` binary with a wrapper
 that sets the variable to the install dir.
 
-> NOTE: running via cargo also doesn't require setting explicit `HELIX_RUNTIME` path, it will automatically
-> detect the `runtime` directory in the project root.
+> NOTE: running via cargo also doesn't require setting explicit `HELIX_CONFIG` path, it is set for you automatically by cargo.
 
 In order to use LSP features like auto-complete, you will need to
 [install the appropriate Language Server](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
@@ -69,7 +68,7 @@ Helix can be installed on MacOS through homebrew via:
 brew tap helix-editor/helix
 brew install helix
 ```
- 
+
 # Contributing
 
 Contributing guidelines can be found [here](./docs/CONTRIBUTING.md).

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -153,7 +153,7 @@ to add/edit this section since Helix will use sensible defaults for given system
 | `language-file` | [language.toml](./languages.md) location | `$XDG_CONFIG_HOME/helix/languages.toml` |
 | `log-file`	  | Log file location | `$XDG_STATE_HOME/helix/helix.log` |
 | `query-dir` 	  | Queries location | `$XDG_DATA_HOME/helix/queries` |
-| `theme-dir` 	  | Themes location | `$XDG_CONFIG_HOME/helix/themes` |
+| `theme-dir` 	  | Themes location | `$XDG_DATA_HOME/helix/themes` |
 
 #### Windows
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -161,6 +161,6 @@ to add/edit this section since Helix will use sensible defaults for given system
 |--|--|---------|
 | `grammar-dir`	  | Grammars location | `%AppData%/helix/grammars` |
 | `language-file` | [language.toml](./languages.md) location | `%AppData%/helix/languages.toml` |
-| `log-file`	  | Log file location | `%LocalAppData%/helix/helix.log` |
+| `log-file`	  | Log file location | `%AppData%/helix/helix.log` |
 | `query-dir` 	  | Queries location | `%AppData%/helix/queries` |
 | `theme-dir` 	  | Themes location | `%AppData%/helix/themes` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -2,7 +2,7 @@
 
 To override global configuration parameters, create a `config.toml` file located in your config directory:
 
-* Linux and Mac: `~/.config/helix/config.toml`
+* Linux and Mac: `$XDG_CONFIG_HOME/helix/config.toml`
 * Windows: `%AppData%\helix\config.toml`
 
 > Hint: You can easily open the config file by typing `:config-open` within Helix normal mode.
@@ -23,6 +23,9 @@ select = "underline"
 
 [editor.file-picker]
 hidden = false
+
+[paths]
+log-file = "/home/user/logs/helix.log"
 ```
 
 ## Editor
@@ -136,3 +139,28 @@ Search specific options.
 |--|--|---------|
 | `smart-case` | Enable smart case regex searching (case insensitive unless pattern contains upper case characters) | `true` |
 | `wrap-around`| Whether the search should wrap after depleting the matches | `true` |
+
+### `[paths]` Section
+
+Make Helix use specific files and directories. Generally there's no need
+to add/edit this section since Helix will use sensible defaults for given system.
+
+#### Linux
+
+| Key | Description | Default |
+|--|--|---------|
+| `grammar-dir`	  | Grammars location | `$XDG_DATA_HOME/helix/grammars` |
+| `language-file` | [language.toml](./languages.md) location | `$XDG_CONFIG_HOME/helix/languages.toml` |
+| `log-file`	  | Log file location | `$XDG_STATE_HOME/helix/helix.log` |
+| `query-dir` 	  | Queries location | `$XDG_DATA_HOME/helix/queries` |
+| `theme-dir` 	  | Themes location | `$XDG_CONFIG_HOME/helix/themes` |
+
+#### Windows
+
+| Key | Description | Default |
+|--|--|---------|
+| `grammar-dir`	  | Grammars location | `%AppData%/helix/grammars` |
+| `language-file` | [language.toml](./languages.md) location | `%AppData%/helix/languages.toml` |
+| `log-file`	  | Log file location | `%LocalAppData%/helix/helix.log` |
+| `query-dir` 	  | Queries location | `%AppData%/helix/queries` |
+| `theme-dir` 	  | Themes location | `%AppData%/helix/themes` |

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -58,8 +58,8 @@ cargo install --path helix-term
 This will install the `hx` binary to `$HOME/.cargo/bin`.
 
 Helix also needs it's runtime files so make sure to copy/symlink the `runtime/` directory into the
-config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overriden
-via the `HELIX_RUNTIME` environment variable.
+data directory (for example `$XDG_DATA_HOME/helix` on Linux/macOS). This location can be overriden
+via appropriate entries in helix config file.
 
 ## Building tree-sitter grammars
 

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://helix-editor.com"
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
-etcetera = "0.3"
+directories = "4"
 tree-sitter = "0.20"
 libloading = "0.7"
 once_cell = "1.9"

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://helix-editor.com"
 
 [dependencies]
 anyhow = "1"
+etcetera = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
-directories = "4"
 tree-sitter = "0.20"
 libloading = "0.7"
 once_cell = "1.9"

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -59,7 +59,7 @@ const REMOTE_NAME: &str = "origin";
 
 pub fn get_language(name: &str) -> Result<Language> {
     let name = name.to_ascii_lowercase();
-    let mut library_path = crate::runtime_dir().join("grammars").join(&name);
+    let mut library_path = crate::grammar_dir().join(&name);
     library_path.set_extension(DYLIB_EXTENSION);
 
     let library = unsafe { Library::new(&library_path) }
@@ -142,8 +142,7 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<()> {
         remote, revision, ..
     } = grammar.source
     {
-        let grammar_dir = crate::runtime_dir()
-            .join("grammars")
+        let grammar_dir = crate::grammar_dir()
             .join("sources")
             .join(&grammar.grammar_id);
 
@@ -233,8 +232,7 @@ fn build_grammar(grammar: GrammarConfiguration) -> Result<()> {
     let grammar_dir = if let GrammarSource::Local { path } = &grammar.source {
         PathBuf::from(&path)
     } else {
-        crate::runtime_dir()
-            .join("grammars")
+        crate::grammar_dir()
             .join("sources")
             .join(&grammar.grammar_id)
     };
@@ -280,7 +278,7 @@ fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> 
             None
         }
     };
-    let parser_lib_path = crate::runtime_dir().join("grammars");
+    let parser_lib_path = crate::grammar_dir();
     let mut library_path = parser_lib_path.join(&grammar.grammar_id);
     library_path.set_extension(DYLIB_EXTENSION);
 
@@ -385,9 +383,6 @@ fn mtime(path: &Path) -> Result<SystemTime> {
 /// Gives the contents of a file from a language's `runtime/queries/<lang>`
 /// directory
 pub fn load_runtime_file(language: &str, filename: &str) -> Result<String, std::io::Error> {
-    let path = crate::RUNTIME_DIR
-        .join("queries")
-        .join(language)
-        .join(filename);
+    let path = crate::query_dir().join(language).join(filename);
     std::fs::read_to_string(&path)
 }

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod grammar;
 
 use anyhow::{bail, Result};
+use etcetera::app_strategy::{choose_app_strategy, AppStrategy, AppStrategyArgs};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -121,9 +122,13 @@ fn create_dir(dir: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-fn project_dirs() -> directories::ProjectDirs {
-    directories::ProjectDirs::from("com", "helix-editor", "helix")
-        .expect("Unable to continue. User has no home.")
+fn project_dirs() -> impl AppStrategy {
+    let args = AppStrategyArgs {
+        top_level_domain: "com".to_string(),
+        author: "helix-editor".to_string(),
+        app_name: "helix".to_string(),
+    };
+    choose_app_strategy(args).expect("Unable to continue. User environment not sane.")
 }
 
 pub fn config_file() -> PathBuf {
@@ -159,9 +164,9 @@ pub fn query_dir() -> &'static std::path::Path {
 
 fn state_dir() -> PathBuf {
     match project_dirs().state_dir() {
-        Some(dir) => dir.to_path_buf(),
-        // state_dir is Linux-specific, fallback to data_local
-        None => project_dirs().data_local_dir().to_path_buf(),
+        Some(dir) => dir,
+        // state_dir is Linux-specific, fallback to data
+        None => project_dirs().data_dir(),
     }
 }
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -40,6 +40,9 @@ fn cache_dir() -> std::path::PathBuf {
 }
 
 pub fn config_file() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("HELIX_CONFIG") {
+        return std::path::PathBuf::from(dir);
+    }
     config_dir().join("config.toml")
 }
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -1,9 +1,12 @@
 pub mod grammar;
 
-use etcetera::base_strategy::{choose_base_strategy, BaseStrategy};
-
 pub static RUNTIME_DIR: once_cell::sync::Lazy<std::path::PathBuf> =
     once_cell::sync::Lazy::new(runtime_dir);
+
+fn project_dirs() -> directories::ProjectDirs {
+    directories::ProjectDirs::from("com", "helix-editor", "helix")
+        .expect("Unable to continue. User has no home")
+}
 
 pub fn runtime_dir() -> std::path::PathBuf {
     if let Ok(dir) = std::env::var("HELIX_RUNTIME") {
@@ -29,19 +32,11 @@ pub fn runtime_dir() -> std::path::PathBuf {
 }
 
 fn config_dir() -> std::path::PathBuf {
-    // TODO: allow env var override
-    let strategy = choose_base_strategy().expect("Unable to find the config directory!");
-    let mut path = strategy.config_dir();
-    path.push("helix");
-    path
+    project_dirs().config_dir().to_path_buf()
 }
 
 fn cache_dir() -> std::path::PathBuf {
-    // TODO: allow env var override
-    let strategy = choose_base_strategy().expect("Unable to find the config directory!");
-    let mut path = strategy.cache_dir();
-    path.push("helix");
-    path
+    project_dirs().cache_dir().to_path_buf()
 }
 
 pub fn config_file() -> std::path::PathBuf {

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -28,7 +28,7 @@ pub fn runtime_dir() -> std::path::PathBuf {
         .unwrap()
 }
 
-pub fn config_dir() -> std::path::PathBuf {
+fn config_dir() -> std::path::PathBuf {
     // TODO: allow env var override
     let strategy = choose_base_strategy().expect("Unable to find the config directory!");
     let mut path = strategy.config_dir();
@@ -36,7 +36,7 @@ pub fn config_dir() -> std::path::PathBuf {
     path
 }
 
-pub fn cache_dir() -> std::path::PathBuf {
+fn cache_dir() -> std::path::PathBuf {
     // TODO: allow env var override
     let strategy = choose_base_strategy().expect("Unable to find the config directory!");
     let mut path = strategy.cache_dir();
@@ -48,12 +48,28 @@ pub fn config_file() -> std::path::PathBuf {
     config_dir().join("config.toml")
 }
 
+pub fn grammar_dir() -> std::path::PathBuf {
+    config_dir().join("grammars")
+}
+
 pub fn lang_config_file() -> std::path::PathBuf {
     config_dir().join("languages.toml")
 }
 
 pub fn log_file() -> std::path::PathBuf {
     cache_dir().join("helix.log")
+}
+
+pub fn theme_dir() -> std::path::PathBuf {
+    config_dir().join("themes")
+}
+
+pub fn tutor_file() -> std::path::PathBuf {
+    config_dir().join("tutor.txt")
+}
+
+pub fn query_dir() -> std::path::PathBuf {
+    config_dir().join("queries")
 }
 
 /// Default bultin-in languages.toml.
@@ -65,7 +81,7 @@ pub fn default_lang_config() -> toml::Value {
 /// User configured languages.toml file, merged with the default config.
 pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
     let def_lang_conf = default_lang_config();
-    let data = std::fs::read(crate::config_dir().join("languages.toml"));
+    let data = std::fs::read(lang_config_file());
     let user_lang_conf = match data {
         Ok(raw) => {
             let value = toml::from_slice(&raw)?;

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -74,3 +74,5 @@ signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 
 [build-dependencies]
 helix-loader = { version = "0.6", path = "../helix-loader" }
+serde = { version = "1", default-features = false, features = ["derive"] }
+toml = "0.5"

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -4,6 +4,14 @@ use std::process::Command;
 
 const VERSION: &str = include_str!("../VERSION");
 
+// mirror struct for helix_term::Config
+// original can't be used because it's not built yet
+use serde::Deserialize;
+#[derive(Deserialize)]
+struct BuildConfig {
+    paths: helix_loader::Paths,
+}
+
 fn main() {
     let git_hash = Command::new("git")
         .args(&["rev-parse", "HEAD"])
@@ -17,12 +25,20 @@ fn main() {
         None => VERSION.into(),
     };
 
+    std::env::set_current_dir("..").unwrap();
+    let config = std::env::var("HELIX_CONFIG").unwrap();
+    let config = std::fs::read_to_string(config).unwrap();
+    let paths = toml::from_str::<BuildConfig>(&config).unwrap().paths;
+    helix_loader::init_paths(paths).unwrap();
+    std::env::set_current_dir("./helix-term").unwrap();
+
+    let grammar_dir = helix_loader::grammar_dir();
     if std::env::var("HELIX_DISABLE_AUTO_GRAMMAR_BUILD").is_err() {
         fetch_grammars().expect("Failed to fetch tree-sitter grammars");
         build_grammars().expect("Failed to compile tree-sitter grammars");
     }
 
-    println!("cargo:rerun-if-changed=../runtime/grammars/");
+    println!("cargo:rerun-if-changed={}", grammar_dir.display());
     println!("cargo:rerun-if-changed=../VERSION");
 
     println!("cargo:rustc-env=VERSION_AND_GIT_HASH={}", version);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -61,10 +61,10 @@ impl Application {
         let mut compositor = Compositor::new()?;
         let size = compositor.size();
 
-        let conf_dir = helix_loader::config_dir();
-
-        let theme_loader =
-            std::sync::Arc::new(theme::Loader::new(&conf_dir, &helix_loader::runtime_dir()));
+        let theme_loader = std::sync::Arc::new(theme::Loader::new(
+            &helix_loader::theme_dir(),
+            &helix_loader::runtime_dir(),
+        ));
 
         let true_color = config.editor.true_color || crate::true_color();
         let theme = config
@@ -115,7 +115,7 @@ impl Application {
         compositor.push(editor_view);
 
         if args.load_tutor {
-            let path = helix_loader::runtime_dir().join("tutor.txt");
+            let path = helix_loader::tutor_file();
             editor.open(path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None)?;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -62,7 +62,7 @@ impl Application {
         let size = compositor.size();
 
         let theme_loader = std::sync::Arc::new(theme::Loader::new(
-            &helix_loader::theme_dir(),
+            helix_loader::theme_dir(),
             &helix_loader::runtime_dir(),
         ));
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -63,7 +63,8 @@ impl Application {
 
         let theme_loader = std::sync::Arc::new(theme::Loader::new(
             helix_loader::theme_dir(),
-            &helix_loader::runtime_dir(),
+            // temporarily identical, until system dirs are supported
+            helix_loader::theme_dir(),
         ));
 
         let true_color = config.editor.true_color || crate::true_color();

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -886,7 +886,7 @@ fn tutor(
     _args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
-    let path = helix_loader::runtime_dir().join("tutor.txt");
+    let path = helix_loader::tutor_file();
     cx.editor.open(path, Action::Replace)?;
     // Unset path to prevent accidentally saving to the original tutor file.
     doc_mut!(cx.editor).set_path(None)?;

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -48,7 +48,7 @@ pub fn general() -> std::io::Result<()> {
     let config_file = helix_loader::config_file();
     let lang_file = helix_loader::lang_config_file();
     let log_file = helix_loader::log_file();
-    let rt_dir = helix_loader::runtime_dir();
+    let grammar_dir = helix_loader::grammar_dir();
 
     if config_file.exists() {
         writeln!(stdout, "Config file: {}", config_file.display())?;
@@ -61,17 +61,17 @@ pub fn general() -> std::io::Result<()> {
         writeln!(stdout, "Language file: default")?;
     }
     writeln!(stdout, "Log file: {}", log_file.display())?;
-    writeln!(stdout, "Runtime directory: {}", rt_dir.display())?;
+    writeln!(stdout, "Grammar directory: {}", grammar_dir.display())?;
 
-    if let Ok(path) = std::fs::read_link(&rt_dir) {
-        let msg = format!("Runtime directory is symlinked to {}", path.display());
+    if let Ok(path) = std::fs::read_link(&grammar_dir) {
+        let msg = format!("Grammar directory is symlinked to {}", path.display());
         writeln!(stdout, "{}", msg.yellow())?;
     }
-    if !rt_dir.exists() {
-        writeln!(stdout, "{}", "Runtime directory does not exist.".red())?;
+    if !grammar_dir.exists() {
+        writeln!(stdout, "{}", "Grammar directory does not exist.".red())?;
     }
-    if rt_dir.read_dir().ok().map(|it| it.count()) == Some(0) {
-        writeln!(stdout, "{}", "Runtime directory is empty.".red())?;
+    if grammar_dir.read_dir().ok().map(|it| it.count()) == Some(0) {
+        writeln!(stdout, "{}", "Grammar directory is empty.".red())?;
     }
 
     Ok(())

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -109,9 +109,10 @@ FLAGS:
         return Ok(0);
     }
 
-    let conf_dir = helix_loader::config_dir();
-    if !conf_dir.exists() {
-        std::fs::create_dir_all(&conf_dir).ok();
+    if let Some(conf_dir) = helix_loader::config_file().parent() {
+        if !conf_dir.exists() {
+            std::fs::create_dir_all(&conf_dir).ok();
+        }
     }
 
     let config = match Config::load_default() {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -234,8 +234,7 @@ pub mod completers {
     }
 
     pub fn theme(_editor: &Editor, input: &str) -> Vec<Completion> {
-        let mut names = theme::Loader::read_names(&helix_loader::theme_dir());
-        names.extend(theme::Loader::read_names(&helix_loader::theme_dir()));
+        let mut names = theme::Loader::read_names(helix_loader::theme_dir());
         names.push("default".into());
         names.push("base16_default".into());
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -234,10 +234,8 @@ pub mod completers {
     }
 
     pub fn theme(_editor: &Editor, input: &str) -> Vec<Completion> {
-        let mut names = theme::Loader::read_names(&helix_loader::runtime_dir().join("themes"));
-        names.extend(theme::Loader::read_names(
-            &helix_loader::config_dir().join("themes"),
-        ));
+        let mut names = theme::Loader::read_names(&helix_loader::theme_dir());
+        names.extend(theme::Loader::read_names(&helix_loader::theme_dir()));
         names.push("default".into());
         names.push("base16_default".into());
 

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -29,8 +29,8 @@ impl Loader {
     /// Creates a new loader that can load themes from two directories.
     pub fn new<P: AsRef<Path>>(user_dir: P, default_dir: P) -> Self {
         Self {
-            user_dir: user_dir.as_ref().join("themes"),
-            default_dir: default_dir.as_ref().join("themes"),
+            user_dir: PathBuf::from(user_dir.as_ref()),
+            default_dir: PathBuf::from(default_dir.as_ref()),
         }
     }
 

--- a/runtime/config.toml
+++ b/runtime/config.toml
@@ -1,0 +1,6 @@
+[paths]
+grammar-dir = "./runtime/grammars"
+log-file = "./runtime/helix.log"
+language-file = "./languages.toml"
+query-dir = "./runtime/queries"
+theme-dir = "./runtime/themes"


### PR DESCRIPTION
OK, so this ended up a bit bigger than expected. I'm not exactly happy about the static but that was what HELIX_RUNTIME did and the rest of the code relied on that. Passing the paths from config struct could be another PR.

Locations implemented as outlined in https://github.com/helix-editor/helix/issues/584#issuecomment-1086768512. 

Getting paths from loader will panic if they're not loaded properly via `init_paths`. It could silently fallback to some default, but not calling init_paths is a programmer mistake and it's good feedback when dealing with tests and build.rs that would otherwise silently write outside of their intended sandbox to regular user directories.
