### PR TITLE
Add a version selection component to the documentation

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -9,3 +9,4 @@ edit-url-template = "https://github.com/helix-editor/helix/tree/master/book/{pat
 cname = "docs.helix-editor.com"
 default-theme = "colibri"
 preferred-dark-theme = "colibri"
+additional-css = ["theme/css/version-select.css"]

--- a/book/theme/book.js
+++ b/book/theme/book.js
@@ -1,5 +1,17 @@
 "use strict";
 
+// Navigate to the selected version documentation when the version-select
+// form changes
+(function versionSelect() {
+    document.getElementById("version-select")
+        .addEventListener("change", event => {
+            var target = event.target.value;
+            var oldPath = window.location.pathname.split("/").pop() + window.location.hash;
+            var nextLocation = "".concat(target, "/").concat(oldPath);
+            window.location.href = nextLocation;
+        });
+})();
+
 // Fix back button cache problem
 window.onunload = function () { };
 

--- a/book/theme/css/version-select.css
+++ b/book/theme/css/version-select.css
@@ -1,0 +1,26 @@
+form#version-select {
+  float: right;
+  margin: 0.25rem 0;
+}
+
+form#version-select select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  border: 0;
+  box-sizing: content-box;
+  background-color: transparent;
+  color: var(--sidebar-fg);
+  padding: 1rem 1.5rem;
+  font-size: 0.875em;
+}
+
+/* downwards arrow on left-hand-side of select */
+form#version-select::before {
+  position: relative;
+  left: 1.75rem;
+  content: "\25BC";
+  font-size: 8px;
+  color: var(--sidebar-fg);
+}

--- a/book/theme/index.hbs
+++ b/book/theme/index.hbs
@@ -105,6 +105,12 @@
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
             <div class="sidebar-scrollbox">
+                <form id="version-select" autocomplete="off">
+                    <select>
+                        <option value="https://docs.helix-editor.com">22.03</option>
+                        <option value="https://docs.helix-editor.com/master" selected>master</option>
+                    </select>
+                </form>
                 {{#toc}}{{/toc}}
             </div>
             <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>


### PR DESCRIPTION
closes #2064

This adds a small `select` element that can be used to navigate
between the release and master docs. The select appears in the
navigation pane to the right of the "Helix" header. Your path is
preserved while navigating, so if you are on the keybindings page
on master and set the select to 22.03, you jump to the keybindings
page on 22.03.

![version-select](https://user-images.githubusercontent.com/21230295/163688962-fdbbe0fc-a459-4dba-ba25-34c62ae9cf1f.png)

![version-select-master](https://user-images.githubusercontent.com/21230295/163688969-72007e6c-1837-453a-b599-ac9c9f72a748.png)