### PR TITLE
Update tree-sitters Erlang and HEEx

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -974,7 +974,7 @@ language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "1e81393b8f0a81b35ff1679a9420fafbd2cf3511" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "3f611cfdc790214c3f9f9cf1658b3ae8039c54b8" }
 
 [[language]]
 name = "kotlin"

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -48,8 +48,14 @@
 
 (attribute
   name: (atom) @keyword
+  (arguments
+    (_) @keyword.directive)
+ (#match? @keyword "ifn?def"))
+
+(attribute
+  name: (atom) @keyword
   module: (atom) @module
- (#eq? @keyword "spec"))
+ (#eq? @keyword "(spec|callback)"))
 
 ; Functions
 (function name: (atom) @function)
@@ -69,10 +75,7 @@
 (record name: (atom) @type)
 
 ; Keywords
-((attribute name: (atom) @keyword)
- (#match?
-  @keyword
-  "^(define|export|export_type|include|include_lib|ifdef|ifndef|if|elif|else|endif|vsn|on_load|behaviour|record|file|type|opaque|spec)$"))
+(attribute name: (atom) @keyword)
 
 ["case" "fun" "if" "of" "when" "end" "receive" "try" "catch" "after" "begin" "maybe"] @keyword
 
@@ -86,10 +89,6 @@
 (unary_operator operator: _ @operator)
 ["/" ":" "#" "->"] @operator
 
-; Comments
-((variable) @comment.discard
- (#match? @comment.discard "^_"))
-
 (tripledot) @comment.discard
 
 (comment) @comment
@@ -99,12 +98,13 @@
   "?"+ @keyword.directive
   name: (_) @keyword.directive)
 
+; Comments
+((variable) @comment.discard
+ (#match? @comment.discard "^_"))
+
 ; Basic types
 (variable) @variable
-[
-  (atom)
-  (quoted_atom)
-] @string.special.symbol
+(atom) @string.special.symbol
 (string) @string
 (character) @constant.character
 

--- a/runtime/queries/heex/highlights.scm
+++ b/runtime/queries/heex/highlights.scm
@@ -11,8 +11,6 @@
   "--%>"
   "-->"
   "/>"
-  "{"
-  "}"
   ; These could be `@keyword`s but the closing `>` wouldn't be highlighted
   ; as `@keyword`
   "<:"
@@ -21,6 +19,8 @@
 
 ; Non-comment or tag delimiters
 [
+  "{"
+  "}"
   "<%"
   "<%="
   "<%%="


### PR DESCRIPTION
HEEx has a small fix for the highlights: `{`/`}` should be `@keyword`s like the rest of the templating tokens.

Erlang has a few fixes

* macros with names that start with underscore like `?_assertEqual/2` are highlighted as macros rather than `comment.unused`
* quoted and unquoted atoms are now one node `(atom)` which simplifies some highlight scenarios
* all attributes are highlighted as keywords
    * I was trying to be selective before and only cover the built-ins but meh, it's a good-looking highlight for all atttributes ¯\\\_(ツ)_/¯