### PR TITLE
Fix Golang textobject queries

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -413,7 +413,9 @@ impl LanguageConfiguration {
                 let lang_name = self.language_id.to_ascii_lowercase();
                 let query_text = read_query(&lang_name, "textobjects.scm");
                 let lang = self.highlight_config.get()?.as_ref()?.language;
-                let query = Query::new(lang, &query_text).ok()?;
+                let query = Query::new(lang, &query_text)
+                    .map_err(|e| log::error!("Failed to parse textobjects.scm queries: {}", e))
+                    .ok()?;
                 Some(TextObjectQuery { query })
             })
             .as_ref()

--- a/runtime/queries/go/textobjects.scm
+++ b/runtime/queries/go/textobjects.scm
@@ -12,7 +12,7 @@
   (type_spec (type_identifier) (struct_type (field_declaration_list (_)?) @class.inside))) @class.around
 
 (type_declaration
-  (type_spec (type_identifier) (interface_type (method_spec_list (_)?) @class.inside))) @class.around
+  (type_spec (type_identifier) (interface_type (method_spec)+ @class.inside))) @class.around
 
 (parameter_list
   (_) @parameter.inside)


### PR DESCRIPTION
df57914 has the details on the fix itself: it was a node that was removed when we updated for generics support.

Also included is an error log for failures to parse textobjects queries (see [here](https://github.com/helix-editor/helix/issues/1920#issuecomment-1089736393)) which makes it easier to debug this in the future.

closes #1920 