### PR TITLE
Fixing (in two ways) a small typo

### DIFF
--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -1,7 +1,7 @@
-/// Default bultin-in languages.toml.
+/// Default built-in languages.toml.
 pub fn default_lang_config() -> toml::Value {
     toml::from_slice(include_bytes!("../../languages.toml"))
-        .expect("Could not parse bultin-in languages.toml to valid toml")
+        .expect("Could not parse built-in languages.toml to valid toml")
 }
 
 /// User configured languages.toml file, merged with the default config.

--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -101,7 +101,7 @@
             ]
 )
 
-; non-bultin command names
+; non-builtin command names
 (command name: (word) @function)
 
 ; derived from builtin -n (fish 3.2.2)


### PR DESCRIPTION
The code base treats "builtin" in two ways, so I tried to be consistent with the usage in those files, but wanted to fix the typo in any event.