### PR TITLE
Prevent panic when receiving malformed LSP PublishDiagnostic

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -276,7 +276,13 @@ impl Notification {
             lsp::notification::PublishDiagnostics::METHOD => {
                 let params: lsp::PublishDiagnosticsParams = params
                     .parse()
-                    .expect("Failed to parse PublishDiagnostics params");
+                    .map_err(|err| {
+                        log::error!(
+                            "received malformed PublishDiagnostic from Language Server: {}",
+                            err
+                        )
+                    })
+                    .ok()?;
 
                 // TODO: need to loop over diagnostics and distinguish them by URI
                 Self::PublishDiagnostics(params)


### PR DESCRIPTION
Instead of panicing we can discard the malformed diagnostic. This
`.parse()` fails commonly when a non-conformant language server gives
a diagnostic with a location that breaks the spec:

    { "character": 0, "line": -1 }

can currently be returned by ElixirLS and the python LS. Other
messages in this block are discarded but this one feels special enough
to log. Maybe we should refactor all parses to log errors in cases of
malformed messages?

closes #1204