### PR TITLE
Fix open on multiline selection

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2292,8 +2292,10 @@ fn open(cx: &mut Context, open: Open) {
     let mut offs = 0;
 
     let mut transaction = Transaction::change_by_selection(contents, selection, |range| {
-        let cursor_line = range.cursor_line(text);
-
+        let cursor_line = text.char_to_line(match open {
+            Open::Below => graphemes::prev_grapheme_boundary(text, range.to()),
+            Open::Above => range.from(),
+        });
         let new_line = match open {
             // adjust position to the end of the line (next line - 1)
             Open::Below => cursor_line + 1,


### PR DESCRIPTION
Select multiple line and open should be based on the whole selection
and not just the line of the cursor, which causes weird behavior like
opening in the middle of the selection which user might not expect.

[![asciicast](https://asciinema.org/a/W7ykJFBFJDoHUpQbcvXijQiq6.svg)](https://asciinema.org/a/W7ykJFBFJDoHUpQbcvXijQiq6)