### PR TITLE
Add tokyonight theme

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -1,0 +1,81 @@
+# Author: Paul Graydon <p.y.graydon@gmail.com>
+
+"comment" = { fg = "comment", modifiers = ["italic"] }
+"constant" = { fg = "orange" }
+"constant.character.escape" = { fg = "magenta" }
+"function" = { fg = "blue", modifiers = ["italic"] }
+"keyword" = { fg = "magenta" }
+"keyword.control.import" = { fg = "cyan" }
+"operator" = { fg = "turquoise" }
+"punctuation" = { fg = "turquoise" }
+"string" = { fg = "light-green" }
+"string.regexp" = { fg = "light-blue" }
+"tag" = { fg = "red" }
+"type" = { fg = "teal" }
+"namespace" = { fg = "blue" }
+"variable" = { fg = "white" }
+"variable.builtin" = { fg = "red", modifiers = ["italic"] }
+"variable.other.member" = { fg = "magenta" }
+"variable.parameter" = { fg = "yellow", modifiers = ["italic"] }
+
+"diff.plus" = { fg = "green" }
+"diff.delta" = { fg = "orange" }
+"diff.minus" = { fg = "red" }
+
+"ui.background" = { fg = "foreground", bg = "background" }
+"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { fg = "orange", modifiers = ["bold"] }
+"ui.cursor.primary" = { modifiers = ["reversed"] }
+"ui.help" = { fg = "foreground", bg = "background_menu" }
+"ui.linenr" = { fg = "foreground_gutter" }
+"ui.linenr.selected" = { fg = "foreground" }
+"ui.menu" = { fg = "foreground", bg = "background_menu" }
+"ui.menu.selected" = { bg = "background_highlight" }
+"ui.popup" = { fg = "foreground", bg = "background_menu" }
+"ui.selection" = { bg = "background_highlight" }
+"ui.selection.primary" = { bg = "background_highlight" }
+"ui.statusline" = { fg = "foreground", bg = "background_menu" }
+"ui.statusline.inactive" = { fg = "foreground_gutter", bg = "background_menu" }
+"ui.text" = { fg = "foreground" }
+"ui.text.focus" = { fg = "cyan" }
+"ui.window" = { fg = "black" }
+
+"error" = { fg = "red" }
+"warning" = { fg = "yellow" }
+"info" = { fg = "blue" }
+"hint" = { fg = "teal" }
+"diagnostic" = { modifiers = ["underlined"] }
+"special" = { fg = "orange" }
+
+"markup.heading" = { fg = "cyan", modifiers = ["bold"] }
+"markup.list" = { fg = "cyan" }
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.url" = { fg = "green" }
+"markup.link.text" = { fg = "light-gray" }
+"markup.quote" = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw" = { fg = "cyan" }
+
+[palette]
+red = "#f7768e"
+orange = "#ff9e64"
+yellow = "#e0af68"
+light-green = "#9ece6a"
+green = "#73daca"
+turquoise = "#89ddff"
+light-cyan = "#b4f9f8"
+teal = "#2ac3de"
+cyan = "#7dcfff"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+white = "#c0caf5"
+light-gray = "#9aa5ce"
+parameters = "#cfc9c2"
+comment = "#565f89"
+black = "#414868"
+foreground = "#a9b1d6"
+foreground_highlight = "#c0caf5"
+foreground_gutter = "#3b4261"
+background = "#1a1b26"
+background_highlight = "#30374b"
+background_menu = "#16161e"


### PR DESCRIPTION
Hello there! I'd like to add support for the beautiful tokyonight theme, based on the original color scheme (https://github.com/enkia/tokyo-night-vscode-theme), and on the neovim theme (https://github.com/folke/tokyonight.nvim).
Note that this is for the Night variant only (darkest one), but the other variants can easily be made from this one by changing the palette! 