### PR TITLE
Implement cursorline

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,6 +37,7 @@ hidden = false
 | `scroll-lines` | Number of lines to scroll per scroll wheel step. | `3` |
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
+| `cursorline` | Highlight all lines with a cursor. | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers`, note that `diagnostics` also includes other features like breakpoints | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -686,7 +686,7 @@ impl EditorView {
             );
             if primary_line == line {
                 surface.set_style(area, primary_style);
-            } else if secondary_lines.contains(&line) {
+            } else if secondary_lines.binary_search(&line).is_ok() {
                 surface.set_style(area, secondary_style);
             }
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -121,6 +121,8 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
+    /// Highlight the lines cursors are currently on. Defaults to false.
+    pub cursorline: bool,
     /// Gutters. Default ["diagnostics", "line-numbers"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
@@ -376,6 +378,7 @@ impl Default for Config {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },
             line_number: LineNumber::Absolute,
+            cursorline: false,
             gutters: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),


### PR DESCRIPTION
Highlight all lines where cursers are on, imitating vim's `cursorline` option.

See #1761.

### Todo:
 - [x] implement it
 - [x] config option
 - [x] documentation
 - [ ] update (a few) themes

### Improvements:
- [x] Use `ui.cursorline[.primary | .secondary]`
- [x] Discuss whether to highlight secondary cursors.
- [ ] TBD: Option to disable on inactive window
- [ ] TBD: Syncing?
 