### PR TITLE
Add LSP for Markdown

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -44,7 +44,7 @@
 | llvm-mir-yaml | ✓ |  | ✓ |  |
 | lua | ✓ |  | ✓ |  |
 | make | ✓ |  |  |  |
-| markdown | ✓ |  |  |  |
+| markdown | ✓ |  |  | `remark-language-server` |
 | mint |  |  |  | `mint` |
 | nix | ✓ |  | ✓ | `rnix-lsp` |
 | ocaml | ✓ |  | ✓ | `ocamllsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -799,6 +799,7 @@ scope = "source.md"
 injection-regex = "md|markdown"
 file-types = ["md"]
 roots = []
+language-server = { command = "remark-language-server", args = ["--stdio"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Requires installing `remark-language-server`, adding a `.remarkrc.yaml` which defines the list of filters to enforce.

Example `.remarkrc.yaml`:

```yaml
plugins:
  - remark-preset-lint-consistent
  - remark-preset-lint-recommended

```

These plugins need to be installed separately too:

``` 
pnpm i remark-language-server remark-preset-lint-consistent remark-lint-recommended remark
```

![2022-04-19-120955_786x902_scrot](https://user-images.githubusercontent.com/1197406/164080336-8e63caac-a1dd-4a18-874d-6f1bdad16d80.png)

