### PR TITLE
Soft wrap

### DIFF
--- a/helix-core/src/wrap.rs
+++ b/helix-core/src/wrap.rs
@@ -1,7 +1,12 @@
+use ropey::RopeSlice;
 use smartstring::{LazyCompact, SmartString};
 
 /// Given a slice of text, return the text re-wrapped to fit it
 /// within the given width.
 pub fn reflow_hard_wrap(text: &str, max_line_len: usize) -> SmartString<LazyCompact> {
     textwrap::refill(text, max_line_len).into()
+}
+
+pub struct RopeSoftWrap<'a> {
+    text: RopeSlice<'a>,
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -437,6 +437,64 @@ impl EditorView {
                     use helix_core::graphemes::{grapheme_width, RopeGraphemes};
 
                     for grapheme in RopeGraphemes::new(text) {
+                        let out_of_bounds = visual_x < offset.col as u16;
+                        let skip = visual_x >= viewport.width as u16;
+
+                        if skip {
+                            visual_x = 0;
+                            line += 1;
+                            surface.set_string(
+                                viewport.x + visual_x - offset.col as u16,
+                                viewport.y + line,
+                                " ",
+                                style,
+                            );
+                        } else if LineEnding::from_rope_slice(&grapheme).is_some() {
+                            if !out_of_bounds {
+                                surface.set_string(
+                                    viewport.x + visual_x - offset.col as u16,
+                                    viewport.y + line,
+                                    " ",
+                                    style,
+                                );
+                            }
+
+                            visual_x = 0;
+                            line += 1;
+
+                            // TODO: with proper iter this shouldn't be necessary
+                            if line >= viewport.height {
+                                break 'outer;
+                            }
+                        } else {
+                            let grapheme = Cow::from(grapheme);
+
+                            let (grapheme, width) = if grapheme == "\t" {
+                                // make sure we display tab as appropriate amount of spaces
+                                let visual_tab_width = tab_width - (visual_x as usize % tab_width);
+                                (&tab[..visual_tab_width], visual_tab_width)
+                            } else {
+                                // Cow will prevent allocations if span contained in a single slice
+                                // which should really be the majority case
+                                let width = grapheme_width(&grapheme);
+                                (grapheme.as_ref(), width)
+                            };
+
+                            if !out_of_bounds {
+                                // if we're offscreen just keep going until we hit a new line
+                                surface.set_string(
+                                    viewport.x + visual_x - offset.col as u16,
+                                    viewport.y + line,
+                                    grapheme,
+                                    style,
+                                );
+                            }
+
+                            visual_x = visual_x.saturating_add(width as u16);
+                        }
+                    }
+
+                    for grapheme in RopeGraphemes::new(text) {
                         let out_of_bounds = visual_x < offset.col as u16
                             || visual_x >= viewport.width + offset.col as u16;
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -436,51 +436,45 @@ impl EditorView {
 
                     use helix_core::graphemes::{grapheme_width, RopeGraphemes};
 
-                    for grapheme in RopeGraphemes::new(text) {
+                    let mut iter = RopeGraphemes::new(text);
+                    let mut next_grapheme = iter.next();
+                    while let Some(grapheme) = next_grapheme {
+                        let grapheme = Cow::from(grapheme);
+                        let (grapheme, width) = if grapheme == "\t" {
+                            // make sure we display tab as appropriate amount of spaces
+                            let visual_tab_width = tab_width - (visual_x as usize % tab_width);
+                            (&tab[..visual_tab_width], visual_tab_width)
+                        } else {
+                            // Cow will prevent allocations if span contained in a single slice
+                            // which should really be the majority case
+                            let width = grapheme_width(&grapheme);
+                            (grapheme.as_ref(), width)
+                        };
+
+                        visual_x = visual_x.saturating_add(width as u16);
+
                         let out_of_bounds = visual_x < offset.col as u16;
-                        let skip = visual_x >= viewport.width as u16;
+                        let skip = visual_x >= viewport.width + offset.col as u16;
 
                         if skip {
                             visual_x = 0;
                             line += 1;
-                            surface.set_string(
-                                viewport.x + visual_x - offset.col as u16,
-                                viewport.y + line,
-                                " ",
-                                style,
-                            );
-                        } else if LineEnding::from_rope_slice(&grapheme).is_some() {
-                            if !out_of_bounds {
-                                surface.set_string(
-                                    viewport.x + visual_x - offset.col as u16,
-                                    viewport.y + line,
-                                    " ",
-                                    style,
-                                );
-                            }
-
-                            visual_x = 0;
-                            line += 1;
-
-                            // TODO: with proper iter this shouldn't be necessary
-                            if line >= viewport.height {
-                                break 'outer;
-                            }
                         } else {
-                            let grapheme = Cow::from(grapheme);
+                            next_grapheme = iter.next();
 
-                            let (grapheme, width) = if grapheme == "\t" {
-                                // make sure we display tab as appropriate amount of spaces
-                                let visual_tab_width = tab_width - (visual_x as usize % tab_width);
-                                (&tab[..visual_tab_width], visual_tab_width)
-                            } else {
-                                // Cow will prevent allocations if span contained in a single slice
-                                // which should really be the majority case
-                                let width = grapheme_width(&grapheme);
-                                (grapheme.as_ref(), width)
-                            };
-
-                            if !out_of_bounds {
+                            if LineEnding::from_str(&grapheme).is_some() {
+                                if !out_of_bounds {
+                                    // we still want to render an empty cell with the style
+                                    surface.set_string(
+                                        viewport.x + visual_x - offset.col as u16,
+                                        viewport.y + line,
+                                        " ",
+                                        style,
+                                    );
+                                }
+                                visual_x = 0;
+                                line += 1;
+                            } else if !out_of_bounds {
                                 // if we're offscreen just keep going until we hit a new line
                                 surface.set_string(
                                     viewport.x + visual_x - offset.col as u16,
@@ -489,10 +483,7 @@ impl EditorView {
                                     style,
                                 );
                             }
-
-                            visual_x = visual_x.saturating_add(width as u16);
                         }
-                    }
 
                     for grapheme in RopeGraphemes::new(text) {
                         let out_of_bounds = visual_x < offset.col as u16


### PR DESCRIPTION
## Objective

This PR will resolve #136. On Matrix, @cessen suggested splitting the overall soft-wrapping feature into two PRs for each of the two techniques he proposed. This PR will only implement [the first,](https://github.com/helix-editor/helix/issues/136#issuecomment-860005371) which should be enough for the majority of cases.

## Status

The `View` position is not yet represented by a `char` offset into the text, and so editing is not yet feasible. Rendering is also partial, as it will not correctly calculate the lines, won't wrap on a word break, nor will the cursor wrap to the next line once it goes past the screen. While I am reasonably confident about how to approach implementing this, it's being delayed by a lack of time on my part.

Will depend upon #3268