### PR TITLE
dark_plus: Add the borders color from the original theme

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -5,7 +5,7 @@
 
 "type" = { fg = "type" }
 "type.builtin" = { fg = "type" }
-"type.enum.variant" = { fg = "constant" } 
+"type.enum.variant" = { fg = "constant" }
 "constructor" = { fg = "constant" }
 "variable.other.member" = { fg = "variable" }
 
@@ -79,6 +79,7 @@
 "ui.text.focus" = { fg = "white" }
 
 "ui.virtual" = { fg = "dark_green" }
+"ui.virtual.ruler" = { bg = "borders" }
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }
@@ -117,3 +118,4 @@ background = "#1e1e1e"
 text = "#d4d4d4"
 cursor = "#a6a6a6"
 widget = "#252526"
+borders = "#323232"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -78,7 +78,7 @@
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "white" }
 
-"ui.virtual" = { fg = "dark_green" }
+"ui.virtual" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
 
 "warning" = { fg = "gold2" }


### PR DESCRIPTION
Hi, II added the border for the `rulers` based on the border color of the original theme.
Without this the `rulers` are not shown.