### PR TITLE
Fix nix shell by hardcoding the flakecompat library

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,9 @@
 # Flake's devShell for non-flake-enabled nix instances
 let
-  src = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flakeCompat.locked;
-  compat = fetchTarball { url = "https://github.com/edolstra/flake-compat/archive/${src.rev}.tar.gz"; sha256 = src.narHash; };
+  compat =
+    builtins.fetchGit {
+        url = "https://github.com/edolstra/flake-compat.git";
+        rev = "b4a34015c698c7793d592d66adbab377907a2be8";
+    };
 in
 (import compat { src = ./.; }).shellNix.default


### PR DESCRIPTION
Since it wasn't available in the lockfile, I just hardcoded it
in the shell.nix file.

This is a possible solution for
https://github.com/helix-editor/helix/issues/2195