### PR TITLE
feat(lang): add go.mod and go.work support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -24,6 +24,8 @@
 | gleam | ✓ |  |  |  |
 | glsl | ✓ |  | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
+| gomod | ✓ |  |  | `gopls` |
+| gowork | ✓ |  |  | `gopls` |
 | graphql | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | hcl | ✓ |  | ✓ | `terraform-ls` |

--- a/languages.toml
+++ b/languages.toml
@@ -269,6 +269,23 @@ name = "go"
 source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75" }
 
 [[language]]
+name = "gomod"
+scope = "source.gomod"
+injection-regex = "gomod"
+file-types = ["go.mod"]
+roots = []
+auto-format = true
+comment-token = "//"
+language-server = { command = "gopls" }
+# TODO: gopls needs utf-8 offsets?
+indent = { tab-width = 4, unit = "\t" }
+grammar = "gomod"
+
+[[grammar]]
+name = "gomod"
+source = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "e8f51f8e4363a3d9a427e8f63f4c1bbc5ef5d8d0" }
+
+[[language]]
 name = "javascript"
 scope = "source.js"
 injection-regex = "^(js|javascript)$"
@@ -998,7 +1015,7 @@ file-types = ["kt", "kts"]
 roots = ["settings.gradle", "settings.gradle.kts"]
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
-language-server = { command = "kotlin-language-server" } 
+language-server = { command = "kotlin-language-server" }
 
 [[grammar]]
 name = "kotlin"

--- a/languages.toml
+++ b/languages.toml
@@ -277,13 +277,26 @@ roots = []
 auto-format = true
 comment-token = "//"
 language-server = { command = "gopls" }
-# TODO: gopls needs utf-8 offsets?
 indent = { tab-width = 4, unit = "\t" }
-grammar = "gomod"
 
 [[grammar]]
 name = "gomod"
 source = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "e8f51f8e4363a3d9a427e8f63f4c1bbc5ef5d8d0" }
+
+[[language]]
+name = "gowork"
+scope = "source.gowork"
+injection-regex = "gowork"
+file-types = ["go.work"]
+roots = []
+auto-format = true
+comment-token = "//"
+language-server = { command = "gopls" }
+indent = { tab-width = 4, unit = "\t" }
+
+[[grammar]]
+name = "gowork"
+source = { git = "https://github.com/omertuc/tree-sitter-go-work", rev = "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2" }
 
 [[language]]
 name = "javascript"

--- a/runtime/queries/gomod/highlights.scm
+++ b/runtime/queries/gomod/highlights.scm
@@ -1,0 +1,17 @@
+[
+  "require"
+  "replace"
+  "go"
+  "exclude"
+  "retract"
+  "module"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/runtime/queries/gomod/injections.scm
+++ b/runtime/queries/gomod/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/runtime/queries/gomod/injections.scm
+++ b/runtime/queries/gomod/injections.scm
@@ -1,1 +1,3 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.langauge "comment"))
+

--- a/runtime/queries/gomod/injections.scm
+++ b/runtime/queries/gomod/injections.scm
@@ -1,3 +1,2 @@
 ((comment) @injection.content
- (#set! injection.langauge "comment"))
-
+ (#set! injection.language "comment"))

--- a/runtime/queries/gowork/highlights.scm
+++ b/runtime/queries/gowork/highlights.scm
@@ -1,0 +1,14 @@
+[
+  "replace"
+  "go"
+  "use"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/runtime/queries/gowork/injections.scm
+++ b/runtime/queries/gowork/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/runtime/queries/gowork/injections.scm
+++ b/runtime/queries/gowork/injections.scm
@@ -1,3 +1,2 @@
 ((comment) @injection.content
- (#set! injection.langauge "comment"))
- 
+ (#set! injection.language "comment"))

--- a/runtime/queries/gowork/injections.scm
+++ b/runtime/queries/gowork/injections.scm
@@ -1,1 +1,3 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.langauge "comment"))
+ 


### PR DESCRIPTION
add go.mod and go.work support

according to `tree-sitter/tree-sitter-go`  https://github.com/tree-sitter/tree-sitter-go/pull/42#issuecomment-827768030

> since go.mod and Go are two completely different languages, and some users may only care about Go, but not go.mod, I would prefer to just keep the go.mod grammar in its own repository. 

so tree-sitter-go will not add `go.mod` and `go.work` support. we need add this standalone.


```shell
❯ hx --health gomod   
Configured language server: gopls
Binary for language server: /home/ttys3/go/bin/gopls
Configured debug adapter: None
Highlight queries: ✔
Textobject queries: ✘
Indent queries: ✘
```

```shell
❯ hx --health gowork
Configured language server: gopls
Binary for language server: /home/ttys3/go/bin/gopls
Configured debug adapter: None
Highlight queries: ✔
Textobject queries: ✘
Indent queries: ✘
```


`go.mod` demo:
![image](https://user-images.githubusercontent.com/41882455/164257485-b70ea95a-477b-45a8-94ca-663f16662df8.png)

`go.mod` diagnostic demo:

![image](https://user-images.githubusercontent.com/41882455/164258656-82a97169-7512-47f1-bf19-0c3e68d3b03d.png)

--------------------------------

`go.work` demo:

![image](https://user-images.githubusercontent.com/41882455/164264350-e408a546-580a-4eff-9278-0db168d8539b.png)

`go.work` diagnostic demo:
![image](https://user-images.githubusercontent.com/41882455/164264554-e6772a91-55e1-4c2f-8147-7f14fb3d823f.png)
