### PR TITLE
chore(filetype): bash and hcl file type add more common used extensions or files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -429,7 +429,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-ruby", rev = "dfff6
 name = "bash"
 scope = "source.bash"
 injection-regex = "bash"
-file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc"]
+file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild"]
 shebangs = ["sh", "bash", "dash"]
 roots = []
 comment-token = "#"
@@ -1007,8 +1007,8 @@ source = { git = "https://github.com/fwcd/tree-sitter-kotlin", rev = "a4f71eb9b8
 [[language]]
 name = "hcl"
 scope = "source.hcl"
-injection-regex = "(hcl|tf)"
-file-types = ["hcl", "tf", "tfvars"]
+injection-regex = "(hcl|tf|nomad)"
+file-types = ["hcl", "tf", "tfvars", "nomad"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
1.  Gentoo ebuilds, Arch Linux PKGBUILDs and Alpine Linux APKBUILDs are actually bash scripts.

set set `*.ebuild,*.eclass,PKGBUILD,APKBUILD`  to `bash`

ref: 

https://wiki.gentoo.org/wiki/Eclass
https://wiki.gentoo.org/wiki/Ebuild

https://wiki.alpinelinux.org/wiki/APKBUILD_Reference

https://wiki.archlinux.org/title/PKGBUILD

2. a `*.nomad` file is actually `hcl` file

demo: https://github.com/hashicorp/nomad/blob/main/demo/csi/hostpath/redis.nomad

---------------------------------------

screenshots:

![image](https://user-images.githubusercontent.com/41882455/164273194-cfc6c967-15ed-4ebb-8f85-b0fc41c4d8bb.png)

![image](https://user-images.githubusercontent.com/41882455/164273359-faf9005e-2ad6-4ade-9e65-5af5c4888481.png)
