### PR TITLE
chore(lsp): check rename capabilities before send rename action

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -674,8 +674,10 @@ pub fn rename_symbol(cx: &mut Context) {
             let pos = doc.position(view.id, offset_encoding);
 
             let task = language_server.rename_symbol(doc.identifier(), pos, input.to_string());
-            let edits = block_on(task).unwrap_or_default();
-            apply_workspace_edit(cx.editor, offset_encoding, &edits);
+            match block_on(task) {
+                Ok(edits) => apply_workspace_edit(cx.editor, offset_encoding, &edits),
+                Err(err) => cx.editor.set_error(err.to_string()),
+            }
         },
     );
 }


### PR DESCRIPTION
check rename capabilities before send rename action

and logging a kindly warning message to the log file so that the user knows that it maybe a client config problem.

some lang server implementation (like intelephense) need a license key configured to do `rename` action.

in neovim, the config looks like:

```lua
lsp.intelephense.setup {
	settings = {
		intelephense = {
		        licenceKey = "the-actual-license-key",
		},
	},
}
```

in helix, one may miss configured like this:

in `languages.toml`

```toml
[[language]]
name = "php"
config = { "intelephense" = { "licenceKey" = "the-actual-license-key" }}
```

but the correct init config in helix should be like this:

```toml
[[language]]
name = "php"
config = { "licenceKey" = "the-actual-license-key" }
```
with the warning message in the log, people will easy to debug and confirm the config issues.
