### PR TITLE
Release nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     - '[0-9]+.[0-9]+'
     - '[0-9]+.[0-9]+.[0-9]+'
   schedule:
-  - cron: "0 3 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   fetch-grammars:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags:
     - '[0-9]+.[0-9]+'
     - '[0-9]+.[0-9]+.[0-9]+'
+  schedule:
+  - cron: "0 3 * * *"
 
 jobs:
   fetch-grammars:
@@ -201,6 +203,8 @@ jobs:
           name=dev
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             name=${GITHUB_REF:10}
+          else
+            name="$(date --iso-8601)"-nightly
           fi
           echo ::set-output name=val::$name
           echo TAG=$name >> $GITHUB_ENV
@@ -249,10 +253,8 @@ jobs:
           mv dist $source/
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*
-          file_glob: true
-          tag: ${{ steps.tagname.outputs.val }}
-          overwrite: true
+          files: dist/*
+          tag_name: ${{ steps.tagname.outputs.val }}
+          prerelease: ${{ endsWith(steps.tagname.outputs.val, 'nightly') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,9 +133,10 @@ jobs:
         run: |
           mkdir dist
 
-          name=dev
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             name=${GITHUB_REF:10}
+          else
+            name="$(date --iso-8601)"-nightly
           fi
 
           export VERSION="$name"


### PR DESCRIPTION
This was simpler than I was expecting. Most of the work is being done by this action: https://github.com/softprops/action-gh-release which can create the tag and release if they are not already made as well as upload artifacts and control whether a release is a pre-release or regular.

Example output: https://github.com/the-mikedavis/helix/releases/tag/2022-04-21-nightly (the AppImage version has been fixed)

closes #358