### PR TITLE
Rename paragraph motion commands from move to goto

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -277,8 +277,8 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `[a`     | Go to previous argument/parameter (**TS**)   | `goto_prev_parameter` |
 | `]o`     | Go to next comment (**TS**)                  | `goto_next_comment`   |
 | `[o`     | Go to previous comment (**TS**)              | `goto_prev_comment`   |
-| `]p`     | Go to next paragraph                         | `move_next_paragraph` |
-| `[p`     | Go to previous paragraph                     | `move_prev_paragraph` |
+| `]p`     | Go to next paragraph                         | `goto_next_paragraph` |
+| `[p`     | Go to previous paragraph                     | `goto_prev_paragraph` |
 | `[space` | Add newline above                            | `add_newline_above`   |
 | `]space` | Add newline below                            | `add_newline_below`   |
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -277,8 +277,8 @@ Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaire
 | `[a`     | Go to previous argument/parameter (**TS**)   | `goto_prev_parameter` |
 | `]o`     | Go to next comment (**TS**)                  | `goto_next_comment`   |
 | `[o`     | Go to previous comment (**TS**)              | `goto_prev_comment`   |
-| `]p`     | Go to next paragraph                         | `goto_next_paragraph` |
-| `[p`     | Go to previous paragraph                     | `goto_prev_paragraph` |
+| `]p`     | Go to next paragraph                         | `move_next_paragraph` |
+| `[p`     | Go to previous paragraph                     | `move_prev_paragraph` |
 | `[space` | Add newline above                            | `add_newline_above`   |
 | `]space` | Add newline below                            | `add_newline_below`   |
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -209,8 +209,6 @@ impl MappableCommand {
         move_next_long_word_start, "Move to beginning of next long word",
         move_prev_long_word_start, "Move to beginning of previous long word",
         move_next_long_word_end, "Move to end of next long word",
-        move_prev_paragraph, "Move to previous paragraph",
-        move_next_paragraph, "Move to next paragraph",
         extend_next_word_start, "Extend to beginning of next word",
         extend_prev_word_start, "Extend to beginning of previous word",
         extend_next_long_word_start, "Extend to beginning of next long word",
@@ -390,6 +388,8 @@ impl MappableCommand {
         goto_prev_parameter, "Goto previous parameter",
         goto_next_comment, "Goto next comment",
         goto_prev_comment, "Goto previous comment",
+        goto_next_paragraph, "Goto next paragraph",
+        goto_prev_paragraph, "Goto previous paragraph",
         dap_launch, "Launch debug target",
         dap_toggle_breakpoint, "Toggle breakpoint",
         dap_continue, "Continue program execution",
@@ -905,7 +905,7 @@ fn move_next_long_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_long_word_end)
 }
 
-fn move_para_impl<F>(cx: &mut Context, move_fn: F)
+fn goto_para_impl<F>(cx: &mut Context, move_fn: F)
 where
     F: Fn(RopeSlice, Range, usize, Movement) -> Range + 'static,
 {
@@ -929,12 +929,12 @@ where
     cx.editor.last_motion = Some(Motion(Box::new(motion)));
 }
 
-fn move_prev_paragraph(cx: &mut Context) {
-    move_para_impl(cx, movement::move_prev_paragraph)
+fn goto_prev_paragraph(cx: &mut Context) {
+    goto_para_impl(cx, movement::move_prev_paragraph)
 }
 
-fn move_next_paragraph(cx: &mut Context) {
-    move_para_impl(cx, movement::move_next_paragraph)
+fn goto_next_paragraph(cx: &mut Context) {
+    goto_para_impl(cx, movement::move_next_paragraph)
 }
 
 fn goto_file_start(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -104,7 +104,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_prev_class,
             "a" => goto_prev_parameter,
             "o" => goto_prev_comment,
-            "p" => move_prev_paragraph,
+            "p" => goto_prev_paragraph,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -114,7 +114,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "c" => goto_next_class,
             "a" => goto_next_parameter,
             "o" => goto_next_comment,
-            "p" => move_next_paragraph,
+            "p" => goto_next_paragraph,
             "space" => add_newline_below,
         },
 


### PR DESCRIPTION
As mentioned on the matrix. What do you think @pickfire, should the commands be renamed so it's `goto_next_paragraph` instead? That would line up with the other commands in this section in the docs