### PR TITLE
register publish_diagnostics client capability

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -341,6 +341,9 @@ impl Client {
                         }),
                         ..Default::default()
                     }),
+                    publish_diagnostics: Some(lsp::PublishDiagnosticsClientCapabilities {
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
                 window: Some(lsp::WindowClientCapabilities {


### PR DESCRIPTION
the lsp i've been working on checks client capabilities, testing with helix showed that it doesn't register the publish_diagnostics capability, though it appears to be supported (and looks nice!).  From what I could tell none of the sub-options are used so I left it at `..Default::default()`.