### PR TITLE
feat(lsp): add vala language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -79,6 +79,7 @@
 | tsx | ✓ |  |  | `typescript-language-server` |
 | twig | ✓ |  |  |  |
 | typescript | ✓ |  | ✓ | `typescript-language-server` |
+| vala | ✓ |  |  | `vala-language-server` |
 | vue | ✓ |  |  | `vls` |
 | wgsl | ✓ |  |  |  |
 | yaml | ✓ |  | ✓ | `yaml-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -1240,8 +1240,8 @@ source = { git = "https://github.com/LhKipp/tree-sitter-nu", rev = "db4e990b7882
 name = "vala"
 scope = "source.vala"
 injection-regex = "vala"
-file-types = ["vala", "vapi", "genie"]
-roots = [".git", "meson.build"]
+file-types = ["vala", "vapi"]
+roots = ["meson.build"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "vala-language-server" }

--- a/languages.toml
+++ b/languages.toml
@@ -1235,3 +1235,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "nu"
 source = { git = "https://github.com/LhKipp/tree-sitter-nu", rev = "db4e990b78824c8abef3618e0f93b7fe1e8f4c0d" }
+
+[[language]]
+name = "vala"
+scope = "source.vala"
+injection-regex = "vala"
+file-types = ["vala", "vapi", "genie"]
+roots = [".git", "meson.build"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "vala-language-server" }
+
+[[grammar]]
+name = "vala"
+source = { git = "https://github.com/vala-lang/tree-sitter-vala", rev = "c9eea93ba2ec4ec1485392db11945819779745b3" }

--- a/languages.toml
+++ b/languages.toml
@@ -1241,7 +1241,7 @@ name = "vala"
 scope = "source.vala"
 injection-regex = "vala"
 file-types = ["vala", "vapi"]
-roots = ["meson.build"]
+roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "vala-language-server" }

--- a/runtime/queries/vala/highlights.scm
+++ b/runtime/queries/vala/highlights.scm
@@ -1,0 +1,217 @@
+; highlights.scm
+
+; highlight constants
+(
+  (member_access_expression (identifier) @constant)
+  (#match? @constant "^[A-Z][A-Z_0-9]*$")
+)
+
+(
+  (member_access_expression (member_access_expression) @include (identifier) @constant)
+  (#match? @constant "^[A-Z][A-Z_0-9]*$")
+)
+
+(comment) @comment
+
+(type (symbol (_)? @include (identifier) @type))
+
+; highlight creation methods in object creation expressions
+(
+  (object_creation_expression (type (symbol (symbol (symbol)? @include (identifier) @type) (identifier) @constructor)))
+  (#match? @constructor "^[a-z][a-z_0-9]*$")
+)
+
+(unqualified_type (symbol . (identifier) @type))
+(unqualified_type (symbol (symbol) @include (identifier) @type))
+
+(attribute) @attribute
+(method_declaration (symbol (symbol) @type (identifier) @function))
+(method_declaration (symbol (identifier) @function))
+(local_function_declaration (identifier) @function)
+(destructor_declaration (identifier) @function)
+(creation_method_declaration (symbol (symbol) @type (identifier) @constructor))
+(creation_method_declaration (symbol (identifier) @constructor))
+(enum_declaration (symbol) @type)
+(enum_value (identifier) @constant)
+(errordomain_declaration (symbol) @type)
+(errorcode (identifier) @constant)
+(constant_declaration (identifier) @constant)
+(method_call_expression (member_access_expression (identifier) @function))
+(lambda_expression (identifier) @parameter)
+(parameter (identifier) @parameter)
+(property_declaration (symbol (identifier) @property))
+(field_declaration (identifier) @field)
+[
+ (this_access)
+ (base_access)
+ (value_access)
+] @variable.builtin
+(boolean) @boolean
+(character) @character
+(integer) @number
+(null) @constant.builtin
+(real) @float
+(regex) @constant
+(string) @string
+[
+ (escape_sequence)
+ (string_formatter)
+] @string.special
+(template_string) @string
+(template_string_expression) @string.special
+(verbatim_string) @string
+[
+ "var"
+ "void"
+] @type.builtin
+
+[
+ "abstract"
+ "async"
+ "break"
+ "case"
+ "catch"
+ "class"
+ "const"
+ "construct"
+ "continue"
+ "default"
+ "delegate"
+ "do"
+ "dynamic"
+ "else"
+ "enum"
+ "errordomain"
+ "extern"
+ "finally"
+ "for"
+ "foreach"
+ "get"
+ "if"
+ "inline"
+ "interface"
+ "internal"
+ "lock"
+ "namespace"
+ "new"
+ "out"
+ "override"
+ "owned"
+ "partial"
+ "private"
+ "protected"
+ "public"
+ "ref"
+ "set"
+ "signal"
+ "static"
+ "struct"
+ "switch"
+ "throw"
+ "throws"
+ "try"
+ "unowned"
+ "virtual"
+ "weak"
+ "while"
+ "with"
+] @keyword
+
+[
+  "and"
+  "as"
+  "delete"
+  "in"
+  "is"
+  "not"
+  "or"
+  "sizeof"
+  "typeof"
+] @keyword.operator
+
+"using" @include
+
+(symbol "global::" @include)
+
+(array_creation_expression "new" @keyword.operator)
+(object_creation_expression "new" @keyword.operator)
+(argument "out" @keyword.operator)
+(argument "ref" @keyword.operator)
+
+[
+  "continue"
+  "do"
+  "for"
+  "foreach"
+  "while"
+] @repeat
+
+[
+  "catch"
+  "finally"
+  "throw"
+  "throws"
+  "try"
+] @exception
+
+[
+  "return"
+  "yield"
+] @keyword.return
+
+[
+ "="
+ "=="
+ "+"
+ "+="
+ "-"
+ "-="
+ "++"
+ "--"
+ "|"
+ "|="
+ "&"
+ "&="
+ "^"
+ "^="
+ "/"
+ "/="
+ "*"
+ "*="
+ "%"
+ "%="
+ "<<"
+ "<<="
+ ">>"
+ ">>="
+ "."
+ "?."
+ "->"
+ "!"
+ "!="
+ "~"
+ "??"
+ "?"
+ ":"
+ "<"
+ "<="
+ ">"
+ ">="
+ "||"
+ "&&"
+ "=>"
+] @operator
+
+[
+ ","
+ ";"
+] @punctuation.delimiter
+
+[
+ "("
+ ")"
+ "{"
+ "}"
+ "["
+ "]"
+] @punctuation.bracket

--- a/runtime/queries/vala/highlights.scm
+++ b/runtime/queries/vala/highlights.scm
@@ -24,7 +24,7 @@
 (unqualified_type (symbol . (identifier) @type))
 (unqualified_type (symbol (symbol) @include (identifier) @type))
 
-(attribute) @attribute
+(attribute) @variable.other.member
 (method_declaration (symbol (symbol) @type (identifier) @function))
 (method_declaration (symbol (identifier) @function))
 (local_function_declaration (identifier) @function)
@@ -37,10 +37,10 @@
 (errorcode (identifier) @constant)
 (constant_declaration (identifier) @constant)
 (method_call_expression (member_access_expression (identifier) @function))
-(lambda_expression (identifier) @parameter)
-(parameter (identifier) @parameter)
-(property_declaration (symbol (identifier) @property))
-(field_declaration (identifier) @field)
+(lambda_expression (identifier) @variable.parameter)
+(parameter (identifier) @variable.parameter)
+(property_declaration (symbol (identifier) @variable.other.member))
+(field_declaration (identifier) @variable.other.member)
 [
  (this_access)
  (base_access)
@@ -50,7 +50,7 @@
 (character) @character
 (integer) @number
 (null) @constant.builtin
-(real) @float
+(real) @constant.numeric.float
 (regex) @constant
 (string) @string
 [
@@ -144,7 +144,7 @@
   "for"
   "foreach"
   "while"
-] @repeat
+] @keyword.control.repeat
 
 [
   "catch"
@@ -152,12 +152,12 @@
   "throw"
   "throws"
   "try"
-] @exception
+] @keyword.control.exception
 
 [
   "return"
   "yield"
-] @keyword.return
+] @keyword.control.return
 
 [
  "="

--- a/runtime/queries/vala/highlights.scm
+++ b/runtime/queries/vala/highlights.scm
@@ -46,12 +46,12 @@
  (base_access)
  (value_access)
 ] @variable.builtin
-(boolean) @boolean
-(character) @character
-(integer) @number
+(boolean) @constant.builtin.boolean
+(character) @constant.character
+(integer) @constant.numeric.integer
 (null) @constant.builtin
 (real) @constant.numeric.float
-(regex) @constant
+(regex) @string.regexp
 (string) @string
 [
  (escape_sequence)

--- a/runtime/queries/vala/highlights.scm
+++ b/runtime/queries/vala/highlights.scm
@@ -7,22 +7,22 @@
 )
 
 (
-  (member_access_expression (member_access_expression) @include (identifier) @constant)
+  (member_access_expression (member_access_expression) @namespace (identifier) @constant)
   (#match? @constant "^[A-Z][A-Z_0-9]*$")
 )
 
 (comment) @comment
 
-(type (symbol (_)? @include (identifier) @type))
+(type (symbol (_)? @namespace (identifier) @type))
 
 ; highlight creation methods in object creation expressions
 (
-  (object_creation_expression (type (symbol (symbol (symbol)? @include (identifier) @type) (identifier) @constructor)))
+  (object_creation_expression (type (symbol (symbol (symbol)? @namespace (identifier) @type) (identifier) @constructor)))
   (#match? @constructor "^[a-z][a-z_0-9]*$")
 )
 
 (unqualified_type (symbol . (identifier) @type))
-(unqualified_type (symbol (symbol) @include (identifier) @type))
+(unqualified_type (symbol (symbol) @namespace (identifier) @type))
 
 (attribute) @variable.other.member
 (method_declaration (symbol (symbol) @type (identifier) @function))
@@ -129,9 +129,9 @@
   "typeof"
 ] @keyword.operator
 
-"using" @include
+"using" @namespace
 
-(symbol "global::" @include)
+(symbol "global::" @namespace)
 
 (array_creation_expression "new" @keyword.operator)
 (object_creation_expression "new" @keyword.operator)

--- a/runtime/queries/vala/highlights.scm
+++ b/runtime/queries/vala/highlights.scm
@@ -29,7 +29,7 @@
 (method_declaration (symbol (identifier) @function))
 (local_function_declaration (identifier) @function)
 (destructor_declaration (identifier) @function)
-(creation_method_declaration (symbol (symbol) @type (identifier) @constructor))
+(creation_method_declaration (symbol (symbol (identifier) @type) (identifier) @constructor))
 (creation_method_declaration (symbol (identifier) @constructor))
 (enum_declaration (symbol) @type)
 (enum_value (identifier) @constant)
@@ -40,7 +40,8 @@
 (lambda_expression (identifier) @variable.parameter)
 (parameter (identifier) @variable.parameter)
 (property_declaration (symbol (identifier) @variable.other.member))
-(field_declaration (identifier) @variable.other.member)
+(field_declaration (identifier) @variable)
+(identifier) @variable
 [
  (this_access)
  (base_access)


### PR DESCRIPTION
fix https://github.com/helix-editor/helix/issues/2224

![image](https://user-images.githubusercontent.com/41882455/164933866-4a28098b-571d-49fc-a8ac-799b2e58e21f.png)

![image](https://user-images.githubusercontent.com/41882455/164917062-2ba7fe64-77e4-4709-a64f-4977e2bfba0b.png)

![image](https://user-images.githubusercontent.com/41882455/164933703-f3056437-5070-44b9-b2a4-8281bdcb9048.png)

one question: Vala allows comments to be recorded in code in different ways. but in `languages.toml` we can only config a single `comment-token = "//"`,  how can we to block comment toggle action ?

```vala
// Comment continues until end of line

/* Comment lasts between delimiters */

/**
 * Documentation comment
 */
```

refs:

lang server: https://github.com/vala-lang/vala-language-server

ts: https://github.com/vala-lang/tree-sitter-vala

https://wiki.gnome.org/Projects/Vala/StringSample

https://learnxinyminutes.com/docs/vala/

https://naaando.gitbooks.io/the-vala-tutorial/content/en/3-basics/comments.html

-------------

demo vala code to test:

```vala
// Single line comment

/* Multiline
Comment */

/**
* Documentation comment
*/

char character = 'a';
unichar unicode_character = 'u'; // 32-bit unicode character

int i = 2; // ints can also have guaranteed sizes (e.g. int64, uint64)
uint j = -6; // Won't compile; unsigned ints can only be positive

class HelloWorld: Object {
    private uint year = 0;

    public HelloWorld () {
    }

    public HelloWorld.with_year (int year) {
        if (year>0)
            this.year = year;
    }

    public void greeting () {
        if (year == 0)
            print ("Hello World\n");
        else
            /* Strings prefixed with '@' are string templates. */
            print (@"Hello World, $(this.year)\n");
    }
}

void main (string[] args) {
    var helloworld = new HelloWorld.with_year (2022);
    helloworld.greeting ();
}

```