### PR TITLE
fix(lsp): divide hcl into seperate languages

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -73,6 +73,7 @@
 | svelte | ✓ |  | ✓ | `svelteserver` |
 | swift | ✓ |  |  | `sourcekit-lsp` |
 | tablegen | ✓ | ✓ | ✓ |  |
+| tfvars |  |  |  | `terraform-ls` |
 | toml | ✓ |  |  |  |
 | tsq | ✓ |  |  |  |
 | tsx | ✓ |  |  | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -1058,10 +1058,7 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "terraform-ls", args = ["serve"], language-id = "terraform-vars" }
 auto-format = true
-
-[[grammar]]
-name = "tfvars"
-source = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "3cb7fc28247efbcb2973b97e71c78838ad98a583" }
+grammar = "hcl"
 
 [[language]]
 name = "org"

--- a/languages.toml
+++ b/languages.toml
@@ -1038,15 +1038,29 @@ source = { git = "https://github.com/fwcd/tree-sitter-kotlin", rev = "a4f71eb9b8
 name = "hcl"
 scope = "source.hcl"
 injection-regex = "(hcl|tf|nomad)"
-file-types = ["hcl", "tf", "tfvars", "nomad"]
+file-types = ["hcl", "tf", "nomad"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
-language-server = { command = "terraform-ls", args = ["serve"] }
+language-server = { command = "terraform-ls", args = ["serve"], language-id = "terraform" }
 auto-format = true
 
 [[grammar]]
 name = "hcl"
+source = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "3cb7fc28247efbcb2973b97e71c78838ad98a583" }
+
+[[language]]
+name = "tfvars"
+scope = "source.tfvars"
+file-types = ["tfvars"]
+roots = []
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "terraform-ls", args = ["serve"], language-id = "terraform-vars" }
+auto-format = true
+
+[[grammar]]
+name = "tfvars"
 source = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "3cb7fc28247efbcb2973b97e71c78838ad98a583" }
 
 [[language]]


### PR DESCRIPTION
Terraform-ls uses two seperate language-ids for terraform and terraform-vars files.

Read more about it [here](https://github.com/hashicorp/terraform-ls/blob/main/docs/language-clients.md#language-ids)