### PR TITLE
feat: enable keymaps for buffer_close and buffer_close_all

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3,7 +3,6 @@ pub(crate) mod lsp;
 pub(crate) mod typed;
 
 pub use dap::*;
-use log::warn;
 pub use lsp::*;
 pub use typed::*;
 
@@ -44,7 +43,7 @@ use movement::Movement;
 
 use crate::{
     args,
-    compositor::{self, Component, Compositor, Context as CompositorContext},
+    compositor::{self, Component, Compositor},
     ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
 };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3,6 +3,7 @@ pub(crate) mod lsp;
 pub(crate) mod typed;
 
 pub use dap::*;
+use log::warn;
 pub use lsp::*;
 pub use typed::*;
 
@@ -43,7 +44,7 @@ use movement::Movement;
 
 use crate::{
     args,
-    compositor::{self, Component, Compositor},
+    compositor::{self, Component, Compositor, Context as CompositorContext},
     ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
 };
 
@@ -365,6 +366,7 @@ impl MappableCommand {
         vsplit, "Vertical right split",
         vsplit_new, "Vertical right split scratch buffer",
         wclose, "Close window",
+        buffer_close, "Close current buffer",
         wonly, "Current window only",
         select_register, "Select register",
         insert_register, "Insert register",
@@ -3875,6 +3877,13 @@ fn wclose(cx: &mut Context) {
     let view_id = view!(cx.editor).id;
     // close current split
     cx.editor.close(view_id);
+}
+
+fn buffer_close(cx: &mut Context) {
+    let document_ids = typed::buffer_gather_paths_impl(cx.editor, &[]);
+    if let Err(err) = buffer_close_by_ids_impl(cx.editor, &document_ids, false) {
+        warn!("could not close buffer: {}", err);
+    }
 }
 
 fn wonly(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -56,7 +56,7 @@ fn open(
     Ok(())
 }
 
-fn buffer_close_by_ids_impl(
+pub(super) fn buffer_close_by_ids_impl(
     editor: &mut Editor,
     doc_ids: &[DocumentId],
     force: bool,
@@ -68,7 +68,7 @@ fn buffer_close_by_ids_impl(
     Ok(())
 }
 
-fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<DocumentId> {
+pub(super) fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<DocumentId> {
     // No arguments implies current document
     if args.is_empty() {
         let doc_id = view!(editor).doc;
@@ -105,7 +105,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<Docum
     document_ids
 }
 
-fn buffer_close(
+pub(super) fn buffer_close(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
     _event: PromptEvent,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -105,7 +105,7 @@ pub(super) fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -
     document_ids
 }
 
-pub(super) fn buffer_close(
+fn buffer_close(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
     _event: PromptEvent,


### PR DESCRIPTION
Hi everyone,
I discovered `helix` yesterday and I really like it.
I was migrating some of my `neovim` setup and wanted to add a key mapping for closing buffers but it seems that command is not accessible for mappings.

I'm quite new to rust but I noticed that for the current implementation of typed commands, making `buffer_close` was not straight forward as it needs the `compositor:Context`.
I could create that context from the `commands:Context` object but doesn't seem right.
Exposing the inner functions like `buffer_close_by_ids_impl` seems good but not sure how to handle the possible error.

Any other alternative.
Note: I want to implement the keymappings for buffer_close and buffer_close_all but I need early feedback.