### PR TITLE
README note about Truecolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Helix can be installed on MacOS through homebrew via:
 brew tap helix-editor/helix
 brew install helix
 ```
+
+# Truecolor
+
+Avoid terminals without [Truecolor](https://github.com/termstandard/colors#not-supporting-truecolor) support. The default theme requires Truecolor. You may also select a theme that is prefixed with `base_16_` to avoid the need for Truecolor support.
  
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ brew install helix
 
 # Truecolor
 
-The default theme requires a terminal with [Truecolor](https://github.com/termstandard/colors#not-supporting-truecolor) support. Alternatively, you can select a theme prefixed with `base_16_` to avoid this requirement.
+The default theme requires a terminal with [Truecolor](https://github.com/termstandard/colors#not-supporting-truecolor) support. Alternatively, you can select a theme prefixed with `base16_` to avoid this requirement.
  
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ brew install helix
 
 # Truecolor
 
-Avoid terminals without [Truecolor](https://github.com/termstandard/colors#not-supporting-truecolor) support. The default theme requires Truecolor. You may also select a theme that is prefixed with `base_16_` to avoid the need for Truecolor support.
+The default theme requires a terminal with [Truecolor](https://github.com/termstandard/colors#not-supporting-truecolor) support. Alternatively, you can select a theme prefixed with `base_16_` to avoid this requirement.
  
 # Contributing
 


### PR DESCRIPTION
This adds a section to the readme that provides guidance to users to select a terminal that supports Truecolor, optionally using a theme that has wider support (based on [this comment](https://github.com/helix-editor/helix/issues/2256#issuecomment-1107932648))