### PR TITLE
Fix base16_terminal theme using incorrect ansi-color

### DIFF
--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -12,7 +12,7 @@
 "ui.statusline.inactive" = { fg = "gray", bg = "black" }
 "ui.help" = { fg = "white", bg = "black" }
 "ui.cursor" = { fg = "light-gray", modifiers = ["reversed"] }
-"ui.cursor.primary" = { fg = "light-white", modifiers = ["reversed"] }
+"ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual" = "light-gray"
 "variable" = "light-red"
 "constant.numeric" = "yellow"


### PR DESCRIPTION
The usage of light-white doesn't exist and its causing the base16_terminal to have a non existing cursor, also yielding an error in the error log. 

Helix uses the notion of naming light-gray rather than light-white.

No visible cursor in theme
<img width="896" alt="Screenshot 2022-04-26 at 08 40 40_no_cursor_visible" src="https://user-images.githubusercontent.com/1064547/165237914-7031505c-4541-478a-8f9b-a4ade23d612a.png">

Visible cursor after using the correct color
<img width="893" alt="Screenshot 2022-04-26 at 08 40 23_visible_cursor_again" src="https://user-images.githubusercontent.com/1064547/165237920-52725c41-7f5a-405b-b366-f28774237c17.png">



