### PR TITLE
Temporary code to run the debug console on windows

### DIFF
--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -285,10 +285,8 @@ impl Editor {
                     let arguments: dap::requests::RunInTerminalArguments =
                         serde_json::from_value(request.arguments.unwrap_or_default()).unwrap();
                     // TODO: no unwrap
-                    let process;
-                    if cfg!(windows) {
-                        // run windows terminal if it exists on the system
-                        process = std::process::Command::new("wt")
+                    let process = if cfg!(windows) {
+                        std::process::Command::new("wt")
                             .arg("new-tab")
                             .arg("--title")
                             .arg("DEBUG")
@@ -297,7 +295,6 @@ impl Editor {
                             .arg(arguments.args.join(" "))
                             .spawn()
                             .unwrap_or_else(|error| match error.kind() {
-                                // in case wt does not exist, run with conhost (default in windows)
                                 ErrorKind::NotFound => std::process::Command::new("conhost")
                                     .arg("cmd")
                                     .arg("/C")
@@ -305,14 +302,14 @@ impl Editor {
                                     .spawn()
                                     .unwrap(),
                                 e => panic!("Error to start debug console: {}", e),
-                            });
+                            })
                     } else {
-                        process = std::process::Command::new("tmux")
+                        std::process::Command::new("tmux")
                             .arg("split-window")
                             .arg(arguments.args.join(" "))
                             .spawn()
-                            .unwrap();
-                    }
+                            .unwrap()
+                    };
 
                     let _ = debugger
                         .reply(


### PR DESCRIPTION
When wanting to execute the debug, in windows, it generated an error in the dap handler.
I saw that it only runs in tmux, a program that does not exist in windows.
Therefore, add a temporary code to be able to execute the debug console either in Windows Terminal, or if it does not exist, execute consolehost (it exists by default in windows).

This error appears in case helix is ​​not running as administrator.
![image](https://user-images.githubusercontent.com/55039048/165372359-359d4012-d902-4e4e-9c72-9ccd44720107.png)


When running in administrator, it runs without problems, in my case, Windows Terminal usually has problems finding the path to wt.exe, so I run with conhost.exe

![image](https://user-images.githubusercontent.com/55039048/165373607-dd265ffe-e089-424b-9e23-bb3bb33c34ac.png)

![image](https://user-images.githubusercontent.com/55039048/165373705-4e678ca6-a8fb-4c55-8e29-37dd2599dbbc.png)


My knowledge in rust is still limited, but in this way I solved the error
