### PR TITLE
Wrap current directory picker with overlay widget

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2091,7 +2091,7 @@ fn file_picker(cx: &mut Context) {
 fn file_picker_in_current_directory(cx: &mut Context) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("./"));
     let picker = ui::file_picker(cwd, &cx.editor.config());
-    cx.push_layer(Box::new(picker));
+    cx.push_layer(Box::new(overlayed(picker)));
 }
 
 fn buffer_picker(cx: &mut Context) {


### PR DESCRIPTION
Before wrap:
![before_overlay](https://user-images.githubusercontent.com/20379044/165660972-973753c0-5884-4ebb-9607-14f6a8d46e2c.png)

After warp:
![after_overlay](https://user-images.githubusercontent.com/20379044/165661013-7efd1a2f-beeb-4658-87f6-7e06d53a16bc.png)

