### PR TITLE
feat(ui): treat slashes as word separators in prompt

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -56,6 +56,10 @@ pub enum Movement {
     None,
 }
 
+fn is_word_sep(c: char) -> bool {
+    c == std::path::MAIN_SEPARATOR || c.is_whitespace()
+}
+
 impl Prompt {
     pub fn new(
         prompt: Cow<'static, str>,
@@ -118,7 +122,7 @@ impl Prompt {
 
                     let mut found = None;
                     for prev in (0..char_position - 1).rev() {
-                        if char_indices[prev].1.is_whitespace() {
+                        if is_word_sep(char_indices[prev].1) {
                             found = Some(prev + 1);
                             break;
                         }
@@ -141,14 +145,14 @@ impl Prompt {
                 for _ in 0..rep {
                     // Skip any non-whitespace characters
                     while char_position < char_indices.len()
-                        && !char_indices[char_position].1.is_whitespace()
+                        && !is_word_sep(char_indices[char_position].1)
                     {
                         char_position += 1;
                     }
 
                     // Skip any whitespace characters
                     while char_position < char_indices.len()
-                        && char_indices[char_position].1.is_whitespace()
+                        && is_word_sep(char_indices[char_position].1)
                     {
                         char_position += 1;
                     }


### PR DESCRIPTION
When fiddling with paths in a :o prompt, one usually would want Ctrl-W to erase a path segment rather than the whole path. This is how Ctrl-W works in e.g. (neo)vim out of the box.

---

Maybe eventually there should be a customizable list of word characters… but this really should be the default behavior.