### PR TITLE
feat(commands): make it possible to disable format-on-save via the 'auto-format' option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -39,6 +39,7 @@ hidden = false
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers`, note that `diagnostics` also includes other features like breakpoints | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
+| `auto-format` | Enable automatic formatting on save. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -127,6 +127,8 @@ pub struct Config {
     pub auto_pairs: AutoPairConfig,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
     pub auto_completion: bool,
+    /// Automatic formatting on save. Defaults to true.
+    pub auto_format: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
     /// Used for autocompletion, set to 0 for instant. Defaults to 400ms.
     #[serde(
@@ -363,6 +365,7 @@ impl Default for Config {
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
+            auto_format: true,
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,


### PR DESCRIPTION
Believe it or not, not all projects have jumped onto the auto-formatting hype train :D and sometimes it is desirable to be able to quickly `:set-option auto-format false` when working on something where rustfmt would introduce too much undesirable changes in git diff.