### PR TITLE
feat(ui): add nbsp (non-breaking space) to rendered whitespace

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -145,7 +145,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 | Key | Description | Default |
 |-----|-------------|---------|
 | `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `tab`, and `newline`. | `"none"` |
-| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space` or `newline` | See example below |
+| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp` or `newline` | See example below |
 
 Example
 
@@ -160,6 +160,7 @@ newline = "none"
 
 [editor.whitespace.characters]
 space = "·"
+nbsp = "⍽"
 tab = "→"
 newline = "⏎"
 ```

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -370,6 +370,7 @@ impl EditorView {
             " ".repeat(tab_width)
         };
         let space = whitespace.characters.space.to_string();
+        let nbsp = whitespace.characters.nbsp.to_string();
         let newline = if whitespace.render.newline() == WhitespaceRenderValue::All {
             whitespace.characters.newline.to_string()
         } else {
@@ -400,6 +401,14 @@ impl EditorView {
                         && text.len_chars() < end
                     {
                         &space
+                    } else {
+                        " "
+                    };
+
+                    let nbsp = if whitespace.render.nbsp() == WhitespaceRenderValue::All
+                        && text.len_chars() < end
+                    {
+                        &nbsp
                     } else {
                         " "
                     };
@@ -443,6 +452,9 @@ impl EditorView {
                             } else if grapheme == " " {
                                 is_whitespace = true;
                                 (space, 1)
+                            } else if grapheme == "\u{00A0}" {
+                                is_whitespace = true;
+                                (nbsp, 1)
                             } else {
                                 is_whitespace = false;
                                 // Cow will prevent allocations if span contained in a single slice

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -288,6 +288,7 @@ pub enum WhitespaceRender {
     Specific {
         default: Option<WhitespaceRenderValue>,
         space: Option<WhitespaceRenderValue>,
+        nbsp: Option<WhitespaceRenderValue>,
         tab: Option<WhitespaceRenderValue>,
         newline: Option<WhitespaceRenderValue>,
     },
@@ -308,6 +309,14 @@ impl WhitespaceRender {
             Self::Basic(val) => val,
             Self::Specific { default, space, .. } => {
                 space.or(default).unwrap_or(WhitespaceRenderValue::None)
+            }
+        }
+    }
+    pub fn nbsp(&self) -> WhitespaceRenderValue {
+        match *self {
+            Self::Basic(val) => val,
+            Self::Specific { default, nbsp, .. } => {
+                nbsp.or(default).unwrap_or(WhitespaceRenderValue::None)
             }
         }
     }
@@ -333,6 +342,7 @@ impl WhitespaceRender {
 #[serde(default)]
 pub struct WhitespaceCharacters {
     pub space: char,
+    pub nbsp: char,
     pub tab: char,
     pub newline: char,
 }
@@ -341,6 +351,7 @@ impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
             space: '·',    // U+00B7
+            nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE
         }


### PR DESCRIPTION
[`&nbsp;`](https://en.wikipedia.org/wiki/Non-breaking_space) maybe not the most common thing to see in files but e.g. Kakoune does support highlighting these.