### PR TITLE
fix(docs): cleanup obsolete indents.toml mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It's a terminal-based editor first, but I'd like to explore a custom renderer
 (similar to emacs) in wgpu or skulpin.
 
 Note: Only certain languages have indentation definitions at the moment. Check
-`runtime/queries/<lang>/` for `indents.toml`.
+`runtime/queries/<lang>/` for `indents.scm`.
 
 # Installation
 

--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -91,8 +91,6 @@ the last matching query supersedes the ones before it. See
 
 - If a parser is segfaulting or you want to remove the parser, make sure to remove the compiled parser in `runtime/grammar/<name>.so`
 
-- The indents query is `indents.toml`, *not* `indents.scm`. See [this](https://github.com/helix-editor/helix/issues/114) issue for more information.
-
 [treesitter-language-injection]: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection
 [languages.toml]: https://github.com/helix-editor/helix/blob/master/languages.toml
 [neovim-query-precedence]: https://github.com/helix-editor/helix/pull/1170#issuecomment-997294090


### PR DESCRIPTION
#114 was solved so the docs should reflect that.