### PR TITLE
Prevent rendering visible whitespace on trailing cursor

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -388,6 +388,8 @@ impl EditorView {
                     spans.pop();
                 }
                 HighlightEvent::Source { start, end } => {
+                    let is_trailing_cursor = text.len_chars() < end;
+
                     // `unwrap_or_else` part is for off-the-end indices of
                     // the rope, to allow cursor highlighting at the end
                     // of the rope.
@@ -397,7 +399,7 @@ impl EditorView {
                         .fold(text_style, |acc, span| acc.patch(theme.highlight(span.0)));
 
                     let space = if whitespace.render.space() == WhitespaceRenderValue::All
-                        && text.len_chars() < end
+                        && !is_trailing_cursor
                     {
                         &space
                     } else {


### PR DESCRIPTION
closes #2328 

I must've mixed this up: there was https://github.com/helix-editor/helix/commit/45fd800925c7a9e2c9fa56c7259a6548689e67c8 but I must have dropped it out in a merge conflict or rebase, whoops! 😅