### PR TITLE
Making the 'set-option' command help more descriptive.

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -55,7 +55,7 @@
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
 | `:set-language`, `:lang` | Set the language of current buffer. |
-| `:set-option`, `:set` | Set a config option at runtime. For example to disable smart case search, use `:set search.smart-case false`. |
+| `:set-option`, `:set` | Set a config option at runtime.<br>For example to disable smart case search, use `:set search.smart-case false`. |
 | `:get-option`, `:get` | Get the current value of a config option. |
 | `:sort` | Sort ranges in selection. |
 | `:rsort` | Sort ranges in selection in reverse order. |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -55,7 +55,7 @@
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Go to line number. |
 | `:set-language`, `:lang` | Set the language of current buffer. |
-| `:set-option`, `:set` | Set a config option at runtime. |
+| `:set-option`, `:set` | Set a config option at runtime. For example to disable smart case search, use `:set search.smart-case false`. |
 | `:get-option`, `:get` | Get the current value of a config option. |
 | `:sort` | Sort ranges in selection. |
 | `:rsort` | Sort ranges in selection in reverse order. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1508,7 +1508,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "set-option",
             aliases: &["set"],
-            doc: "Set a config option at runtime. For example to disable smart case search, use `:set search.smart-case false`.",
+            doc: "Set a config option at runtime.<br>For example to disable smart case search, use `:set search.smart-case false`.",
             fun: set_option,
             completer: Some(completers::setting),
         },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1508,7 +1508,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "set-option",
             aliases: &["set"],
-            doc: "Set a config option at runtime.<br>For example to disable smart case search, use `:set search.smart-case false`.",
+            doc: "Set a config option at runtime.\nFor example to disable smart case search, use `:set search.smart-case false`.",
             fun: set_option,
             completer: Some(completers::setting),
         },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1508,7 +1508,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "set-option",
             aliases: &["set"],
-            doc: "Set a config option at runtime.",
+            doc: "Set a config option at runtime. For example to disable smart case search, use `:set search.smart-case false`.",
             fun: set_option,
             completer: Some(completers::setting),
         },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,7 +106,9 @@ pub mod md_gen {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            md.push_str(&md_table_row(&[names.to_owned(), cmd.doc.to_owned()]));
+            let doc = cmd.doc.replace("\n", "<br>");
+
+            md.push_str(&md_table_row(&[names.to_owned(), doc.to_owned()]));
         }
 
         Ok(md)


### PR DESCRIPTION
The syntax for the new `set-option` command is not obvious, and I had to check the code to see what it was (code comment is what is included in this PR).