### PR TITLE
Rewrite auto-pairs docs

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -90,16 +90,18 @@ available, which is not defined by default.
 
 ### `[editor.auto-pairs]` Section
 
-Enable automatic insertion of pairs to parentheses, brackets, etc. Can be
-a simple boolean value, or a specific mapping of pairs of single characters.
+Enables automatic insertion of pairs to parentheses, brackets, etc. Can be a
+simple boolean value, or a specific mapping of pairs of single characters.
 
-| Key | Description |
-| --- | ----------- |
-| `false` | Completely disable auto pairing, regardless of language-specific settings
-| `true` | Use the default pairs: <code>(){}[]''""``</code>
-| Mapping of pairs | e.g. `{ "(" =  ")", "{" = "}", ... }`
+To disable auto-pairs altogether, set `auto-pairs` to `false`:
 
-Example
+```toml
+[editor]
+auto-pairs = false # defaults to `true`
+```
+
+The default pairs are <code>(){}[]''""``</code>, but these can be customized by
+setting `auto-pairs` to a TOML table:
 
 ```toml
 [editor.auto-pairs]


### PR DESCRIPTION
The current docs are a bit confusing in my opinion because of the table: `true`/`false` aren't really keys per se. I think this clears up the usage for a common case of wanting to disable auto-pairs altogether (with `false`). See also https://github.com/helix-editor/helix/discussions/2383