### PR TITLE
feat(languages): detect cjs as javascript

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -303,7 +303,7 @@ source = { git = "https://github.com/omertuc/tree-sitter-go-work", rev = "6dd9dd
 name = "javascript"
 scope = "source.js"
 injection-regex = "^(js|javascript)$"
-file-types = ["js", "jsx", "mjs"]
+file-types = ["js", "jsx", "mjs", "cjs"]
 shebangs = ["node"]
 roots = []
 comment-token = "//"


### PR DESCRIPTION
Just a small tweak: `.cjs` files should also be detected as Javascript. The Typescript language server [supports this file extension](https://github.com/microsoft/TypeScript/issues/38784), and afaik there is no difference in syntax so the same grammar can also be used.