### PR TITLE
replace constant.number with constant.numeric

### DIFF
--- a/runtime/queries/hcl/highlights.scm
+++ b/runtime/queries/hcl/highlights.scm
@@ -21,7 +21,7 @@
 (identifier) @variable
 (comment) @comment
 (null_lit) @constant.builtin
-(numeric_lit) @constant.number
+(numeric_lit) @constant.numeric
 (bool_lit) @constant.builtin.boolean
 
 [

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -55,9 +55,6 @@ namespace = { fg = 'orangeL' }
 'constant.character' = { fg = 'greenS' }
 'constant.character.escape' = { fg = 'blueL' }
 'constant.numeric' = { fg = 'redH' }
-'constant.number' = { bg = 'blueH' }
-'constant.number.integer' = { fg = 'orangeS' }
-'constant.number.float' = { fg = 'orangeS' }
 'string' = { fg = 'greenN' }
 'string.regexp' = { fg = 'blueL' }
 'string.special' = { fg = 'orangeW' }


### PR DESCRIPTION
There were 2 instances of `constant.number` in the codebase. Should be `constant.numeric` instead.