### PR TITLE
TOML highlight: `use variable.other.member` instead of `string` for quoted keys

### DIFF
--- a/runtime/queries/toml/highlights.scm
+++ b/runtime/queries/toml/highlights.scm
@@ -1,8 +1,10 @@
 ; Properties
 ;-----------
 
-(bare_key) @variable.other.member
-(quoted_key) @string
+[
+  (bare_key)
+  (quoted_key)
+] @variable.other.member
 
 ; Literals
 ;---------


### PR DESCRIPTION
Makes the keys visually distinct from actual string values and is also consistent with the highlighting in the TOML docs https://toml.io/en/v1.0.0#keys

before:
![image](https://user-images.githubusercontent.com/17070041/166644554-7556daa4-8531-48a4-9dd5-7057f72cdbd4.png)

after:
![image](https://user-images.githubusercontent.com/17070041/166644565-07e06a05-afeb-4b84-82b1-2a3f897e92d9.png)
