### PR TITLE
feat(languages): git-ignore and git-attributes

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -20,9 +20,11 @@
 | erlang | ✓ |  |  | `erlang_ls` |
 | fish | ✓ | ✓ | ✓ |  |
 | gdscript | ✓ |  | ✓ |  |
+| git-attributes | ✓ |  |  |  |
 | git-commit | ✓ |  |  |  |
 | git-config | ✓ |  |  |  |
 | git-diff | ✓ |  |  |  |
+| git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
 | gleam | ✓ |  |  |  |
 | glsl | ✓ |  | ✓ |  |

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -321,7 +321,7 @@ impl TextObjectQuery {
 
 fn read_query(language: &str, filename: &str) -> String {
     static INHERITS_REGEX: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r";+\s*inherits\s*:?\s*([a-z_,()]+)\s*").unwrap());
+        Lazy::new(|| Regex::new(r";+\s*inherits\s*:?\s*([a-z_,()-]+)\s*").unwrap());
 
     let query = load_runtime_file(language, filename).unwrap_or_default();
 

--- a/languages.toml
+++ b/languages.toml
@@ -967,7 +967,7 @@ grammar = "gitattributes"
 
 [[grammar]]
 name = "gitattributes"
-source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev = "ba4b39afcabf8a605f7a382f30be9450ac09ff08" }
+source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev = "3dd50808e3096f93dccd5e9dc7dc3dba2eb12dc4" }
 
 [[language]]
 name = "git-ignore"

--- a/languages.toml
+++ b/languages.toml
@@ -980,7 +980,7 @@ grammar = "gitignore"
 
 [[grammar]]
 name = "gitignore"
-source = { git = "https://github.com/shunsambongi/tree-sitter-gitignore", rev = "2e4cd389d2e187864569cf8fa8098a7e3d03bad6" }
+source = { git = "https://github.com/shunsambongi/tree-sitter-gitignore", rev = "f4685bf11ac466dd278449bcfe5fd014e94aa504" }
 
 [[language]]
 name = "graphql"

--- a/languages.toml
+++ b/languages.toml
@@ -957,6 +957,32 @@ name = "git-config"
 source = { git = "https://github.com/the-mikedavis/tree-sitter-git-config", rev = "0e4f0baf90b57e5aeb62dcdbf03062c6315d43ea" }
 
 [[language]]
+name = "git-attributes"
+scope = "source.gitattributes"
+roots = []
+file-types = [".gitattributes"]
+injection-regex = "git-attributes"
+comment-token = "#"
+grammar = "gitattributes"
+
+[[grammar]]
+name = "gitattributes"
+source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev = "ba4b39afcabf8a605f7a382f30be9450ac09ff08" }
+
+[[language]]
+name = "git-ignore"
+scope = "source.gitignore"
+roots = []
+file-types = [".gitignore"]
+injection-regex = "git-ignore"
+comment-token = "#"
+grammar = "gitignore"
+
+[[grammar]]
+name = "gitignore"
+source = { git = "https://github.com/shunsambongi/tree-sitter-gitignore", rev = "2e4cd389d2e187864569cf8fa8098a7e3d03bad6" }
+
+[[language]]
 name = "graphql"
 scope = "source.graphql"
 injection-regex = "graphql"

--- a/runtime/queries/git-attributes/highlights.scm
+++ b/runtime/queries/git-attributes/highlights.scm
@@ -1,0 +1,9 @@
+; inherits: git-ignore
+
+(attribute) @variable
+(value) @string
+
+(quoted_pattern ["\""] @string)
+
+(attribute_unset) @operator
+(attribute_set_to) @operator

--- a/runtime/queries/git-ignore/highlights.scm
+++ b/runtime/queries/git-ignore/highlights.scm
@@ -1,0 +1,25 @@
+(pattern_char) @string
+(pattern_char_escaped) @constant.character.escape
+
+(directory_separator) @string
+(directory_separator_escaped) @constant.character.escape
+
+(negation) @operator
+
+(wildcard_char_single) @operator
+(wildcard_chars) @operator
+(wildcard_chars_allow_slash) @operator
+
+(bracket_char) @string
+(bracket_char_escaped) @constant.character.escape
+
+(bracket_negation) @operator
+(bracket_range) @operator
+(bracket_char_class) @keyword
+
+[
+  "["
+  "]"
+] @punctuation.bracket
+
+(comment) @comment


### PR DESCRIPTION
This PR adds support for `.gitignore` and `.gitattributes` files. I was a little unsure of where to include dashes in the name/scope/injection regex, but I tried to be consistent with the other `git-*` filetypes. There's no indent values specified since these filetypes don't have indentation. I had to make one change to the core code to allow for hyphens in `; inherits: ...` comments, hope that's ok. Finally, using non-hyphenated grammar names seemed to be necessary, otherwise the grammars just don't work, but I'm not sure why...