### PR TITLE
feat(languages): add odin language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -57,6 +57,7 @@
 | nu | ✓ |  |  |  |
 | ocaml | ✓ |  | ✓ | `ocamllsp` |
 | ocaml-interface | ✓ |  |  | `ocamllsp` |
+| odin | ✓ |  |  |  |
 | org | ✓ |  |  |  |
 | perl | ✓ | ✓ | ✓ |  |
 | php | ✓ | ✓ | ✓ | `intelephense` |

--- a/languages.toml
+++ b/languages.toml
@@ -1303,3 +1303,16 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "cpon"
 source = { git = "https://github.com/fvacek/tree-sitter-cpon", rev = "11ba46a4de3eb86934003133099c9963a60f9687" }
+
+[[language]]
+name = "odin"
+auto-format = false
+scope = "source.odin"
+file-types = ["odin"]
+roots = []
+comment-token = "//"
+indent = { tab-width = 4, unit = "  " }
+
+[[grammar]]
+name = "odin"
+source = { git = "https://github.com/MineBill/tree-sitter-odin", rev = "da885f4a387f169b9b69fe0968259ee257a8f69a" }

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -1,0 +1,140 @@
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function))
+
+
+; ; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(proc_group
+  (identifier) @function)
+
+; ; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+(const_declaration
+  (identifier) @constant)
+(const_declaration_with_type
+  (identifier) @constant)
+
+"any" @type
+
+(directive_identifier) @constant
+
+; ; Operators
+
+[
+  "?"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "*"
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "+"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+  ".."
+  "..<"
+  "..="
+  "::"
+] @operator
+
+; ; Keywords
+
+[
+  ; "asm"
+  "auto_cast"
+  ; "bit_set"
+  "cast"
+  ; "context"
+  ; "or_else"
+  ; "or_return"
+  "in"
+  ; "not_in"
+  "distinct"
+  "foreign"
+  "transmute"
+  ; "typeid"
+
+  "break"
+  "case"
+  "continue"
+  "defer"
+  "else"
+  "using"
+  "when"
+  "where"
+  "fallthrough"
+  "for"
+  "proc"
+  "if"
+  "import"
+  "map"
+  "package"
+  "return"
+  "struct"
+  "union"
+  "enum"
+  "switch"
+  "dynamic"
+] @keyword
+
+; ; Literals
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @string
+
+(escape_sequence) @escape
+
+[
+  (int_literal)
+  (float_literal)
+  (imaginary_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (nil)
+  (undefined)
+] @constant
+
+(comment) @comment

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -19,7 +19,7 @@
 ; ; Identifiers
 
 (type_identifier) @type
-(field_identifier) @property
+(field_identifier) @variable.other.member
 (identifier) @variable
 
 (const_declaration
@@ -122,19 +122,20 @@
   (rune_literal)
 ] @string
 
-(escape_sequence) @escape
+(escape_sequence) @constant.character.escape
 
-[
-  (int_literal)
-  (float_literal)
-  (imaginary_literal)
-] @number
+(int_literal) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+(imaginary_literal) @constant.numeric
 
 [
   (true)
   (false)
+] @constant.builtin.boolean
+
+[
   (nil)
   (undefined)
-] @constant
+] @constant.builtin
 
-(comment) @comment
+(comment) @comment.line


### PR DESCRIPTION
This commit adds the odin language by using the grammar and highlighting
queries written by [MineBills repo](https://github.com/MineBill/tree-sitter-odin).

This commit resolves #2340 by just applying all the changes already
discussed in the issue.