### PR TITLE
fix Markdown list highlighting

### DIFF
--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -35,9 +35,12 @@
   (list_marker_plus)
   (list_marker_minus)
   (list_marker_star)
+] @markup.list.numbered
+
+[
   (list_marker_dot)
   (list_marker_parenthesis)
-] @punctuation.special
+] @markup.list.unnumbered
 
 [
   (backslash_escape)


### PR DESCRIPTION
This should fix https://github.com/helix-editor/helix/issues/1597

I did it according to the current docs. Question is, should we

1. keep the 2 different styles for ordered/unordered
2. add markup for list text itself
