### PR TITLE
Adding the global gitignore to the default

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -973,7 +973,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 name = "git-ignore"
 scope = "source.gitignore"
 roots = []
-file-types = [".gitignore"]
+file-types = [".gitignore", ".gitignore_global"]
 injection-regex = "git-ignore"
 comment-token = "#"
 grammar = "gitignore"


### PR DESCRIPTION
Noticed the new grammar doesn't match the global gitignore by default, so I've added it here.