### PR TITLE
prefer Document::set_selection to inserting selections directly

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -700,7 +700,7 @@ impl Editor {
                 let view_id = view!(self).id;
                 let doc = self.documents.get_mut(&id).unwrap();
                 if doc.selections().is_empty() {
-                    doc.selections.insert(view_id, Selection::point(0));
+                    doc.set_selection(view_id, Selection::point(0));
                 }
                 return;
             }
@@ -716,7 +716,7 @@ impl Editor {
                 );
                 // initialize selection for view
                 let doc = self.documents.get_mut(&id).unwrap();
-                doc.selections.insert(view_id, Selection::point(0));
+                doc.set_selection(view_id, Selection::point(0));
             }
         }
 
@@ -851,7 +851,7 @@ impl Editor {
             let view = View::new(doc_id, self.config().gutters.clone());
             let view_id = self.tree.insert(view);
             let doc = self.documents.get_mut(&doc_id).unwrap();
-            doc.selections.insert(view_id, Selection::point(0));
+            doc.set_selection(view_id, Selection::point(0));
         }
 
         self._refresh();


### PR DESCRIPTION
Inserting these with the `HashMap::insert` method evades the call
to `Selection::ensure_invariants`. The effect is that the scratch
buffer (or other buffers opened through these code-paths) can start
with a selection at (0, 0), when a file with equivalent contents ("\n")
would start with (0, 1).

I.e.:

    hx

and

    touch f
    hx f

start with different selections even though they have an equivalent
Rope. With this change they both start with (0, 1).