### PR TITLE
Add the file type (language id) to the status line

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -733,12 +733,19 @@ impl EditorView {
             base_style,
         ));
 
+        // Encoding
         let enc = doc.encoding();
         if enc != encoding::UTF_8 {
             right_side_text
                 .0
                 .push(Span::styled(format!(" {} ", enc.name()), base_style));
         }
+
+        // File type
+        let file_type = doc.language_id().unwrap_or("text");
+        right_side_text
+            .0
+            .push(Span::styled(format!(" {} ", file_type), base_style));
 
         // Render to the statusline.
         surface.set_spans(


### PR DESCRIPTION
This is a tiny little change that adds the currently detected file type (i.e. the document's language id), and falls back to "text" if none is detected (e.g. when a scratch buffer is opened).

I didn't notice any localization around so I just hardcoded the text "text".

PS: I'm also playing with the idea of using an icon for each detected file type (à la [devicons](https://github.com/ryanoasis/vim-devicons)), let me know if that'd be a welcome change.