### PR TITLE
Monokai pro spectrum theme shows error in yellow on red background

### DIFF
--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -62,7 +62,7 @@
 "variable.parameter" = "#f59762"
 
 # error
-"error" = "red"
+"error" = { bg = "red", fg = "yellow" }
 
 # annotations, decorators
 "special" = "#f59762"


### PR DESCRIPTION
current theme shows keyword and error in the same way - red on black

see: #2421 

before:
![image](https://user-images.githubusercontent.com/4949019/167309327-7468e1aa-a9ba-4960-ad34-9ac78ef61378.png)

after:
![image](https://user-images.githubusercontent.com/4949019/167309332-4065c26b-5deb-438f-9312-58d039ec3169.png)
