### PR TITLE
Customizable/configurable status line

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -48,13 +48,43 @@ hidden = false
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 
+### `[editor.statusline]` Section
+
+Allows configuring the statusline at the bottom of the editor.
+
+The configuration distinguishes between three areas of the status line:
+
+`[ ... ... LEFT ... ... | ... ... ... ... CENTER ... ... ... ... | ... ... RIGHT ... ... ]`
+
+Statusline elements can be defined as follows:
+
+```toml
+[editor.status-line]
+left = ["mode", "spinner"]
+center = ["file-name"]
+right = ["diagnostics", "selections", "position", "file-encoding", "file-type"]
+```
+
+The following elements can be configured:
+
+| Key    | Description |
+| ------ | ----------- |
+| `mode` | The current editor mode (`NOR`/`INS`/`SEL`) |
+| `spinner` | A progress spinner indicating LSP activity |
+| `file-name` | The path/name of the opened file |
+| `file-encoding` | The encoding of the opened file |
+| `file-type` | The type of the opened file |
+| `diagnostics` | The number of warnings and/or errors |
+| `selections` | The number of active selections |
+| `position` | The cursor position |
+
 ### `[editor.lsp]` Section
 
 | Key                | Description                                 | Default |
 | ---                | -----------                                 | ------- |
 | `display-messages` | Display LSP progress messages below statusline[^1] | `false` |
 
-[^1]: A progress spinner is always shown in the statusline beside the file path.
+[^1]: By default, a progress spinner is shown in the statusline beside the file path.
 
 ### `[editor.cursor-shape]` Section
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -72,7 +72,7 @@ The following elements can be configured:
 | `mode` | The current editor mode (`NOR`/`INS`/`SEL`) |
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
-| `file-encoding` | The encoding of the opened file |
+| `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-type` | The type of the opened file |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -59,7 +59,7 @@ The configuration distinguishes between three areas of the status line:
 Statusline elements can be defined as follows:
 
 ```toml
-[editor.status-line]
+[editor.statusline]
 left = ["mode", "spinner"]
 center = ["file-name"]
 right = ["diagnostics", "selections", "position", "file-encoding", "file-type"]

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -164,7 +164,7 @@ impl EditorView {
             .clip_bottom(1); // -1 from bottom to remove commandline
 
         let mut context =
-            statusline::RenderContext::new(doc, view, theme, is_focused, &self.spinners);
+            statusline::RenderContext::new(doc, view, &editor.theme, is_focused, &self.spinners);
 
         StatusLine::render(editor, &mut context, statusline_area, surface);
     }
@@ -733,26 +733,6 @@ impl EditorView {
                 surface.set_style(area, secondary_style);
             }
         }
-    }
-
-    pub fn render_statusline(
-        &self,
-        editor: &Editor,
-        doc: &Document,
-        view: &View,
-        viewport: Rect,
-        surface: &mut Surface,
-        is_focused: bool,
-    ) {
-        let context = statusline::RenderContext {
-            doc,
-            view,
-            theme: &editor.theme,
-            focused: is_focused,
-            spinners: &self.spinners,
-        };
-
-        StatusLine::render(editor, &context, viewport, surface);
     }
 
     /// Handle events by looking them up in `self.keymaps`. Returns None

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -3,7 +3,7 @@ use crate::{
     compositor::{Component, Context, EventResult},
     key,
     keymap::{KeymapResult, Keymaps},
-    ui::{Completion, ProgressSpinners, StatusLine},
+    ui::{Completion, ProgressSpinners},
 };
 
 use helix_core::{
@@ -166,7 +166,7 @@ impl EditorView {
         let mut context =
             statusline::RenderContext::new(doc, view, &editor.theme, is_focused, &self.spinners);
 
-        StatusLine::render(editor, &mut context, statusline_area, surface);
+        statusline::render(editor, &mut context, statusline_area, surface);
     }
 
     pub fn render_rulers(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -164,9 +164,9 @@ impl EditorView {
             .clip_bottom(1); // -1 from bottom to remove commandline
 
         let mut context =
-            statusline::RenderContext::new(doc, view, &editor.theme, is_focused, &self.spinners);
+            statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
 
-        statusline::render(editor, &mut context, statusline_area, surface);
+        statusline::render(&mut context, statusline_area, surface);
     }
 
     pub fn render_rulers(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -163,15 +163,10 @@ impl EditorView {
             .clip_top(view.area.height.saturating_sub(1))
             .clip_bottom(1); // -1 from bottom to remove commandline
 
-        let context = statusline::RenderContext {
-            doc,
-            view,
-            theme,
-            focused: is_focused,
-            spinners: &self.spinners,
-        };
+        let mut context =
+            statusline::RenderContext::new(doc, view, theme, is_focused, &self.spinners);
 
-        StatusLine::render(editor, &context, statusline_area, surface);
+        StatusLine::render(editor, &mut context, statusline_area, surface);
     }
 
     pub fn render_rulers(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -838,12 +838,19 @@ impl EditorView {
             base_style,
         ));
 
+        // Encoding
         let enc = doc.encoding();
         if enc != encoding::UTF_8 {
             right_side_text
                 .0
                 .push(Span::styled(format!(" {} ", enc.name()), base_style));
         }
+
+        // File type
+        let file_type = doc.language_id().unwrap_or("text");
+        right_side_text
+            .0
+            .push(Span::styled(format!(" {} ", file_type), base_style));
 
         // Render to the statusline.
         surface.set_spans(

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -8,6 +8,7 @@ mod picker;
 mod popup;
 mod prompt;
 mod spinner;
+mod statusline;
 mod text;
 
 pub use completion::Completion;
@@ -18,6 +19,7 @@ pub use picker::{FileLocation, FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
+pub use statusline::StatusLine;
 pub use text::Text;
 
 use helix_core::regex::Regex;

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -19,7 +19,6 @@ pub use picker::{FileLocation, FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
-pub use statusline::StatusLine;
 pub use text::Text;
 
 use helix_core::regex::Regex;

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -18,7 +18,7 @@ pub struct RenderContext<'a> {
     pub theme: &'a Theme,
     pub focused: bool,
     pub spinners: &'a ProgressSpinners,
-    pub buffer: RenderBuffer<'a>,
+    pub parts: RenderBuffer<'a>,
 }
 
 impl<'a> RenderContext<'a> {
@@ -35,7 +35,7 @@ impl<'a> RenderContext<'a> {
             theme,
             focused,
             spinners,
-            buffer: RenderBuffer::default(),
+            parts: RenderBuffer::default(),
         }
     }
 }
@@ -65,13 +65,13 @@ impl StatusLine {
         surface.set_style(viewport.with_height(1), base_style);
 
         let write_left = |context: &mut RenderContext, text, style| {
-            Self::append(&mut context.buffer.left, text, &base_style, style)
+            Self::append(&mut context.parts.left, text, &base_style, style)
         };
         let write_center = |context: &mut RenderContext, text, style| {
-            Self::append(&mut context.buffer.center, text, &base_style, style)
+            Self::append(&mut context.parts.center, text, &base_style, style)
         };
         let write_right = |context: &mut RenderContext, text, style| {
-            Self::append(&mut context.buffer.right, text, &base_style, style)
+            Self::append(&mut context.parts.right, text, &base_style, style)
         };
 
         // Left side of the status line.
@@ -85,8 +85,8 @@ impl StatusLine {
         surface.set_spans(
             viewport.x,
             viewport.y,
-            &context.buffer.left,
-            context.buffer.left.width() as u16,
+            &context.parts.left,
+            context.parts.left.width() as u16,
         );
 
         // Right side of the status line.
@@ -101,10 +101,10 @@ impl StatusLine {
             viewport.x
                 + viewport
                     .width
-                    .saturating_sub(context.buffer.right.width() as u16),
+                    .saturating_sub(context.parts.right.width() as u16),
             viewport.y,
-            &context.buffer.right,
-            context.buffer.right.width() as u16,
+            &context.parts.right,
+            context.parts.right.width() as u16,
         );
 
         // Center of the status line.
@@ -118,18 +118,14 @@ impl StatusLine {
         // Width of the empty space between the left and center area and between the center and right area.
         let spacing = 1u16;
 
-        let edge_width = context
-            .buffer
-            .left
-            .width()
-            .max(context.buffer.right.width()) as u16;
+        let edge_width = context.parts.left.width().max(context.parts.right.width()) as u16;
         let center_max_width = viewport.width - (2 * edge_width + 2 * spacing);
-        let center_width = center_max_width.min(context.buffer.center.width() as u16);
+        let center_width = center_max_width.min(context.parts.center.width() as u16);
 
         surface.set_spans(
             viewport.x + viewport.width / 2 - center_width / 2,
             viewport.y,
-            &context.buffer.center,
+            &context.parts.center,
             center_width,
         );
     }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -85,11 +85,6 @@ impl StatusLine {
 
         // Left side of the status line.
 
-        let config = &editor.config().status_line.left;
-        for render in config.into_iter().map(|id| Self::get_render_function(*id)) {
-            render(context, write_left);
-        }
-
         let element_ids = &editor.config().status_line.left;
         element_ids
             .into_iter()

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -35,25 +35,16 @@ impl<'a> RenderContext<'a> {
             theme,
             focused,
             spinners,
-            buffer: RenderBuffer::new(),
+            buffer: RenderBuffer::default(),
         }
     }
 }
 
+#[derive(Default)]
 pub struct RenderBuffer<'a> {
     pub left: Spans<'a>,
     pub center: Spans<'a>,
     pub right: Spans<'a>,
-}
-
-impl<'a> RenderBuffer<'a> {
-    pub fn new() -> Self {
-        Self {
-            left: Spans::default(),
-            center: Spans::default(),
-            right: Spans::default(),
-        }
-    }
 }
 
 pub struct StatusLine;
@@ -87,7 +78,7 @@ impl StatusLine {
 
         let element_ids = &editor.config().status_line.left;
         element_ids
-            .into_iter()
+            .iter()
             .map(|element_id| Self::get_render_function(*element_id))
             .for_each(|render| render(context, write_left));
 
@@ -102,7 +93,7 @@ impl StatusLine {
 
         let element_ids = &editor.config().status_line.right;
         element_ids
-            .into_iter()
+            .iter()
             .map(|element_id| Self::get_render_function(*element_id))
             .for_each(|render| render(context, write_right));
 
@@ -120,7 +111,7 @@ impl StatusLine {
 
         let element_ids = &editor.config().status_line.center;
         element_ids
-            .into_iter()
+            .iter()
             .map(|element_id| Self::get_render_function(*element_id))
             .for_each(|render| render(context, write_center));
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -184,18 +184,18 @@ where
 {
     write(
         context,
-        format!(
-            "{}",
-            context
-                .doc
-                .language_server()
-                .and_then(|srv| context
+        context
+            .doc
+            .language_server()
+            .and_then(|srv| {
+                context
                     .spinners
                     .get(srv.id())
-                    .and_then(|spinner| spinner.frame()))
-                // Even if there's no spinner; reserve its space to avoid elements frequently shifting.
-                .unwrap_or(" ")
-        ),
+                    .and_then(|spinner| spinner.frame())
+            })
+            // Even if there's no spinner; reserve its space to avoid elements frequently shifting.
+            .unwrap_or(" ")
+            .to_string(),
         None,
     );
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -174,7 +174,15 @@ impl StatusLine {
                     "   "
                 }
             ),
-            None,
+            if visible {
+                match context.doc.mode() {
+                    Mode::Insert => Some(context.theme.get("ui.statusline.insert")),
+                    Mode::Select => Some(context.theme.get("ui.statusline.select")),
+                    Mode::Normal => Some(context.theme.get("ui.statusline.normal")),
+                }
+            } else {
+                None
+            },
         );
     }
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -185,7 +185,7 @@ where
     write(
         context,
         format!(
-            " {} ",
+            "{}",
             context
                 .doc
                 .language_server()

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,13 +1,28 @@
-use helix_core::{coords_at_pos, encoding};
+use helix_core::{
+    coords_at_pos,
+    encoding::{self, Encoding},
+    Position,
+};
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::Rect,
-    Document, Editor, View,
+    theme::Style,
+    Document, Editor, Theme, View,
 };
 
 use crate::ui::ProgressSpinners;
 
 use tui::buffer::Buffer as Surface;
+use tui::text::{Span, Spans};
+
+struct StatusLineElement {
+    /// The element
+    pub text: String,
+
+    /// The style to be used to render the element (this style will be merged with the base style).
+    /// If not set, a default base style will be used.
+    pub style: Option<Style>,
+}
 
 pub struct StatusLine;
 
@@ -21,33 +36,38 @@ impl StatusLine {
         is_focused: bool,
         spinners: &ProgressSpinners,
     ) {
-        use tui::text::{Span, Spans};
-
         //-------------------------------
         // Left side of the status line.
         //-------------------------------
-
-        let mode = match doc.mode() {
-            Mode::Insert => "INS",
-            Mode::Select => "SEL",
-            Mode::Normal => "NOR",
-        };
-        let progress = doc
-            .language_server()
-            .and_then(|srv| spinners.get(srv.id()).and_then(|spinner| spinner.frame()))
-            .unwrap_or("");
 
         let base_style = if is_focused {
             editor.theme.get("ui.statusline")
         } else {
             editor.theme.get("ui.statusline.inactive")
         };
-        // statusline
+
         surface.set_style(viewport.with_height(1), base_style);
+
         if is_focused {
-            surface.set_string(viewport.x + 1, viewport.y, mode, base_style);
+            let mode = Self::render_mode(doc);
+            surface.set_string(
+                viewport.x + 1,
+                viewport.y,
+                mode.text,
+                mode.style
+                    .map_or(base_style, |s| base_style.clone().patch(s)),
+            );
         }
-        surface.set_string(viewport.x + 5, viewport.y, progress, base_style);
+
+        let spinner = Self::render_lsp_spinner(doc, spinners);
+        surface.set_string(
+            viewport.x + 5,
+            viewport.y,
+            spinner.text,
+            spinner
+                .style
+                .map_or(base_style, |s| base_style.clone().patch(s)),
+        );
 
         //-------------------------------
         // Right side of the status line.
@@ -68,33 +88,47 @@ impl StatusLine {
             counts
         });
         let (warnings, errors) = diags;
-        let warning_style = editor.theme.get("warning");
-        let error_style = editor.theme.get("error");
+
         for i in 0..2 {
-            let (count, style) = match i {
-                0 => (warnings, warning_style),
-                1 => (errors, error_style),
+            let (count, state_element, count_element) = match i {
+                0 => (
+                    warnings,
+                    Self::render_diagnostics_warning_state(&editor.theme),
+                    Self::render_diagnostics_warning_count(warnings),
+                ),
+                1 => (
+                    errors,
+                    Self::render_diagnostics_error_state(&editor.theme),
+                    Self::render_diagnostics_error_count(errors),
+                ),
                 _ => unreachable!(),
             };
-            if count == 0 {
-                continue;
+
+            if count > 0 {
+                right_side_text.0.push(Span::styled(
+                    state_element.text,
+                    state_element
+                        .style
+                        .map_or(base_style, |s| base_style.clone().patch(s)),
+                ));
+
+                right_side_text.0.push(Span::styled(
+                    count_element.text,
+                    count_element
+                        .style
+                        .map_or(base_style, |s| base_style.clone().patch(s)),
+                ));
             }
-            let style = base_style.patch(style);
-            right_side_text.0.push(Span::styled("●", style));
-            right_side_text
-                .0
-                .push(Span::styled(format!(" {} ", count), base_style));
         }
 
         // Selections
         let sels_count = doc.selection(view.id).len();
+        let selections_element = Self::render_selections(sels_count);
         right_side_text.0.push(Span::styled(
-            format!(
-                " {} sel{} ",
-                sels_count,
-                if sels_count == 1 { "" } else { "s" }
-            ),
-            base_style,
+            selections_element.text,
+            selections_element
+                .style
+                .map_or(base_style, |s| base_style.clone().patch(s)),
         ));
 
         // Position
@@ -104,24 +138,35 @@ impl StatusLine {
                 .primary()
                 .cursor(doc.text().slice(..)),
         );
+        let position_element = Self::render_position(&pos);
         right_side_text.0.push(Span::styled(
-            format!(" {}:{} ", pos.row + 1, pos.col + 1), // Convert to 1-indexing.
-            base_style,
+            position_element.text,
+            position_element
+                .style
+                .map_or(base_style, |s| base_style.clone().patch(s)),
         ));
 
         // Encoding
         let enc = doc.encoding();
         if enc != encoding::UTF_8 {
-            right_side_text
-                .0
-                .push(Span::styled(format!(" {} ", enc.name()), base_style));
+            let encoding_element = Self::render_encoding(enc);
+            right_side_text.0.push(Span::styled(
+                encoding_element.text,
+                encoding_element
+                    .style
+                    .map_or(base_style, |s| base_style.clone().patch(s)),
+            ));
         }
 
         // File type
         let file_type = doc.language_id().unwrap_or("text");
-        right_side_text
-            .0
-            .push(Span::styled(format!(" {} ", file_type), base_style));
+        let file_type_element = Self::render_file_type(file_type);
+        right_side_text.0.push(Span::styled(
+            file_type_element.text,
+            file_type_element
+                .style
+                .map_or(base_style, |s| base_style.clone().patch(s)),
+        ));
 
         // Render to the statusline.
         surface.set_spans(
@@ -137,6 +182,113 @@ impl StatusLine {
         //-------------------------------
         // Middle / File path / Title
         //-------------------------------
+        let title_element = Self::render_file_name(doc);
+
+        surface.set_string_truncated(
+            viewport.x + 8, // 8: 1 space + 3 char mode string + 1 space + 1 spinner + 1 space
+            viewport.y,
+            title_element.text.as_str(),
+            viewport
+                .width
+                .saturating_sub(6)
+                .saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
+            |_| {
+                title_element
+                    .style
+                    .map_or(base_style, |s| base_style.clone().patch(s))
+            },
+            true,
+            true,
+        );
+    }
+
+    fn render_mode(doc: &Document) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(
+                "{}",
+                match doc.mode() {
+                    Mode::Insert => "INS",
+                    Mode::Select => "SEL",
+                    Mode::Normal => "NOR",
+                }
+            ),
+            style: None,
+        };
+    }
+
+    fn render_lsp_spinner(doc: &Document, spinners: &ProgressSpinners) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(
+                "{}",
+                doc.language_server()
+                    .and_then(|srv| spinners.get(srv.id()).and_then(|spinner| spinner.frame()))
+                    .unwrap_or("")
+            ),
+            style: None,
+        };
+    }
+
+    fn render_diagnostics_warning_state(theme: &Theme) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!("●"),
+            style: Some(theme.get("warning")),
+        };
+    }
+
+    fn render_diagnostics_warning_count(warnings: usize) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(" {} ", warnings),
+            style: None,
+        };
+    }
+
+    fn render_diagnostics_error_state(theme: &Theme) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!("●"),
+            style: Some(theme.get("error")),
+        };
+    }
+
+    fn render_diagnostics_error_count(errors: usize) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(" {} ", errors),
+            style: None,
+        };
+    }
+
+    fn render_selections(selections: usize) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(
+                " {} sel{} ",
+                &selections,
+                if selections == 1 { "" } else { "s" }
+            ),
+            style: None,
+        };
+    }
+
+    fn render_position(position: &Position) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(" {}:{} ", position.row + 1, position.col + 1),
+            style: None,
+        };
+    }
+
+    fn render_encoding(encoding: &'static Encoding) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(" {} ", encoding.name()),
+            style: None,
+        };
+    }
+
+    fn render_file_type(file_type: &str) -> StatusLineElement {
+        return StatusLineElement {
+            text: format!(" {} ", file_type),
+            style: None,
+        };
+    }
+
+    fn render_file_name(doc: &Document) -> StatusLineElement {
         let title = {
             let rel_path = doc.relative_path();
             let path = rel_path
@@ -146,17 +298,9 @@ impl StatusLine {
             format!("{}{}", path, if doc.is_modified() { "[+]" } else { "" })
         };
 
-        surface.set_string_truncated(
-            viewport.x + 8, // 8: 1 space + 3 char mode string + 1 space + 1 spinner + 1 space
-            viewport.y,
-            &title,
-            viewport
-                .width
-                .saturating_sub(6)
-                .saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
-            |_| base_style,
-            true,
-            true,
-        );
+        return StatusLineElement {
+            text: title,
+            style: None,
+        };
     }
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,0 +1,162 @@
+use helix_core::{coords_at_pos, encoding};
+use helix_view::{
+    document::{Mode, SCRATCH_BUFFER_NAME},
+    graphics::Rect,
+    Document, Editor, View,
+};
+
+use crate::ui::ProgressSpinners;
+
+use tui::buffer::Buffer as Surface;
+
+pub struct StatusLine;
+
+impl StatusLine {
+    pub fn render(
+        editor: &Editor,
+        doc: &Document,
+        view: &View,
+        viewport: Rect,
+        surface: &mut Surface,
+        is_focused: bool,
+        spinners: &ProgressSpinners,
+    ) {
+        use tui::text::{Span, Spans};
+
+        //-------------------------------
+        // Left side of the status line.
+        //-------------------------------
+
+        let mode = match doc.mode() {
+            Mode::Insert => "INS",
+            Mode::Select => "SEL",
+            Mode::Normal => "NOR",
+        };
+        let progress = doc
+            .language_server()
+            .and_then(|srv| spinners.get(srv.id()).and_then(|spinner| spinner.frame()))
+            .unwrap_or("");
+
+        let base_style = if is_focused {
+            editor.theme.get("ui.statusline")
+        } else {
+            editor.theme.get("ui.statusline.inactive")
+        };
+        // statusline
+        surface.set_style(viewport.with_height(1), base_style);
+        if is_focused {
+            surface.set_string(viewport.x + 1, viewport.y, mode, base_style);
+        }
+        surface.set_string(viewport.x + 5, viewport.y, progress, base_style);
+
+        //-------------------------------
+        // Right side of the status line.
+        //-------------------------------
+
+        let mut right_side_text = Spans::default();
+
+        // Compute the individual info strings and add them to `right_side_text`.
+
+        // Diagnostics
+        let diags = doc.diagnostics().iter().fold((0, 0), |mut counts, diag| {
+            use helix_core::diagnostic::Severity;
+            match diag.severity {
+                Some(Severity::Warning) => counts.0 += 1,
+                Some(Severity::Error) | None => counts.1 += 1,
+                _ => {}
+            }
+            counts
+        });
+        let (warnings, errors) = diags;
+        let warning_style = editor.theme.get("warning");
+        let error_style = editor.theme.get("error");
+        for i in 0..2 {
+            let (count, style) = match i {
+                0 => (warnings, warning_style),
+                1 => (errors, error_style),
+                _ => unreachable!(),
+            };
+            if count == 0 {
+                continue;
+            }
+            let style = base_style.patch(style);
+            right_side_text.0.push(Span::styled("●", style));
+            right_side_text
+                .0
+                .push(Span::styled(format!(" {} ", count), base_style));
+        }
+
+        // Selections
+        let sels_count = doc.selection(view.id).len();
+        right_side_text.0.push(Span::styled(
+            format!(
+                " {} sel{} ",
+                sels_count,
+                if sels_count == 1 { "" } else { "s" }
+            ),
+            base_style,
+        ));
+
+        // Position
+        let pos = coords_at_pos(
+            doc.text().slice(..),
+            doc.selection(view.id)
+                .primary()
+                .cursor(doc.text().slice(..)),
+        );
+        right_side_text.0.push(Span::styled(
+            format!(" {}:{} ", pos.row + 1, pos.col + 1), // Convert to 1-indexing.
+            base_style,
+        ));
+
+        // Encoding
+        let enc = doc.encoding();
+        if enc != encoding::UTF_8 {
+            right_side_text
+                .0
+                .push(Span::styled(format!(" {} ", enc.name()), base_style));
+        }
+
+        // File type
+        let file_type = doc.language_id().unwrap_or("text");
+        right_side_text
+            .0
+            .push(Span::styled(format!(" {} ", file_type), base_style));
+
+        // Render to the statusline.
+        surface.set_spans(
+            viewport.x
+                + viewport
+                    .width
+                    .saturating_sub(right_side_text.width() as u16),
+            viewport.y,
+            &right_side_text,
+            right_side_text.width() as u16,
+        );
+
+        //-------------------------------
+        // Middle / File path / Title
+        //-------------------------------
+        let title = {
+            let rel_path = doc.relative_path();
+            let path = rel_path
+                .as_ref()
+                .map(|p| p.to_string_lossy())
+                .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+            format!("{}{}", path, if doc.is_modified() { "[+]" } else { "" })
+        };
+
+        surface.set_string_truncated(
+            viewport.x + 8, // 8: 1 space + 3 char mode string + 1 space + 1 spinner + 1 space
+            viewport.y,
+            &title,
+            viewport
+                .width
+                .saturating_sub(6)
+                .saturating_sub(right_side_text.width() as u16 + 1) as usize, // "+ 1": a space between the title and the selection info
+            |_| base_style,
+            true,
+            true,
+        );
+    }
+}

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -163,12 +163,15 @@ impl StatusLine {
             context,
             format!(
                 " {} ",
-                match context.doc.mode() {
-                    Mode::Insert if visible => "INS",
-                    Mode::Select if visible => "SEL",
-                    Mode::Normal if visible => "NOR",
+                if visible {
+                    match context.doc.mode() {
+                        Mode::Insert => "INS",
+                        Mode::Select => "SEL",
+                        Mode::Normal => "NOR",
+                    }
+                } else {
                     // If not focused, explicitly leave an empty space instead of returning None.
-                    _ => "   ",
+                    "   "
                 }
             ),
             None,

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -119,7 +119,7 @@ impl StatusLine {
         let spacing = 1u16;
 
         let edge_width = context.parts.left.width().max(context.parts.right.width()) as u16;
-        let center_max_width = viewport.width - (2 * edge_width + 2 * spacing);
+        let center_max_width = viewport.width.saturating_sub(2 * edge_width + 2 * spacing);
         let center_width = center_max_width.min(context.parts.center.width() as u16);
 
         surface.set_spans(

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -62,7 +62,7 @@ impl StatusLine {
             context.theme.get("ui.statusline.inactive")
         };
 
-        surface.set_style(viewport.with_height(1), base_style);
+        surface.set_style(viewport, base_style);
 
         let write_left = |context: &mut RenderContext, text, style| {
             Self::append(&mut context.parts.left, text, &base_style, style)
@@ -76,7 +76,7 @@ impl StatusLine {
 
         // Left side of the status line.
 
-        let element_ids = &editor.config().status_line.left;
+        let element_ids = &editor.config().statusline.left;
         element_ids
             .iter()
             .map(|element_id| Self::get_render_function(*element_id))
@@ -91,7 +91,7 @@ impl StatusLine {
 
         // Right side of the status line.
 
-        let element_ids = &editor.config().status_line.right;
+        let element_ids = &editor.config().statusline.right;
         element_ids
             .iter()
             .map(|element_id| Self::get_render_function(*element_id))
@@ -109,7 +109,7 @@ impl StatusLine {
 
         // Center of the status line.
 
-        let element_ids = &editor.config().status_line.center;
+        let element_ids = &editor.config().statusline.center;
         element_ids
             .iter()
             .map(|element_id| Self::get_render_function(*element_id))
@@ -220,45 +220,14 @@ impl StatusLine {
                 });
 
         if warnings > 0 {
-            Self::render_diagnostics_warning_state(context, write);
-            Self::render_diagnostics_warning_count(context, warnings, write);
+            write(context, "●".to_string(), Some(context.theme.get("warning")));
+            write(context, format!(" {} ", warnings), None);
         }
 
         if errors > 0 {
-            Self::render_diagnostics_error_state(context, write);
-            Self::render_diagnostics_error_count(context, errors, write);
+            write(context, "●".to_string(), Some(context.theme.get("error")));
+            write(context, format!(" {} ", errors), None);
         }
-    }
-
-    fn render_diagnostics_warning_state<F>(context: &mut RenderContext, write: F)
-    where
-        F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-    {
-        write(context, "●".to_string(), Some(context.theme.get("warning")));
-    }
-
-    fn render_diagnostics_warning_count<F>(
-        context: &mut RenderContext,
-        warning_count: usize,
-        write: F,
-    ) where
-        F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-    {
-        write(context, format!(" {} ", warning_count), None);
-    }
-
-    fn render_diagnostics_error_state<F>(context: &mut RenderContext, write: F)
-    where
-        F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-    {
-        write(context, "●".to_string(), Some(context.theme.get("error")));
-    }
-
-    fn render_diagnostics_error_count<F>(context: &mut RenderContext, error_count: usize, write: F)
-    where
-        F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-    {
-        write(context, format!(" {} ", error_count), None);
     }
 
     fn render_selections<F>(context: &mut RenderContext, write: F)

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -62,7 +62,7 @@ impl StatusLine {
             context.theme.get("ui.statusline.inactive")
         };
 
-        surface.set_style(viewport, base_style);
+        surface.set_style(viewport.with_height(1), base_style);
 
         let write_left = |context: &mut RenderContext, text, style| {
             Self::append(&mut context.parts.left, text, &base_style, style)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -148,6 +148,7 @@ pub struct Config {
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
     /// Shape for cursor in each mode
+    pub status_line: StatusLineConfig,
     pub cursor_shape: CursorShapeConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
@@ -178,6 +179,54 @@ pub struct SearchConfig {
     pub smart_case: bool,
     /// Whether the search should wrap after depleting the matches. Default to true.
     pub wrap_around: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct StatusLineConfig {
+    pub left: Vec<StatusLineElement>,
+    pub center: Vec<StatusLineElement>,
+    pub right: Vec<StatusLineElement>,
+}
+
+impl Default for StatusLineConfig {
+    fn default() -> Self {
+        use StatusLineElement as E;
+
+        return Self {
+            left: vec![E::Mode, E::Spinner, E::FileName],
+            center: vec![],
+            right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
+        };
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StatusLineElement {
+    /// The editor mode (Normal, Insert, Visual/Selection)
+    Mode,
+
+    /// The LSP activity spinner
+    Spinner,
+
+    /// The file nane/path, including a dirty flag if it's unsaved
+    FileName,
+
+    /// The file encoding
+    FileEncoding,
+
+    /// The file type (language ID or "text")
+    FileType,
+
+    /// A summary of the number of errors and warnings
+    Diagnostics,
+
+    /// The number of selections (cursors)
+    Selections,
+
+    /// The cursor position
+    Position,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs
@@ -409,6 +458,7 @@ impl Default for Config {
             completion_trigger_len: 2,
             auto_info: true,
             file_picker: FilePickerConfig::default(),
+            status_line: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),
             true_color: false,
             search: SearchConfig::default(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -193,11 +193,11 @@ impl Default for StatusLineConfig {
     fn default() -> Self {
         use StatusLineElement as E;
 
-        return Self {
+        Self {
             left: vec![E::Mode, E::Spinner, E::FileName],
             center: vec![],
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
-        };
+        }
     }
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -147,8 +147,9 @@ pub struct Config {
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
-    /// Shape for cursor in each mode
+    /// Configuration of the statusline elements
     pub status_line: StatusLineConfig,
+    /// Shape for cursor in each mode
     pub cursor_shape: CursorShapeConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -148,7 +148,7 @@ pub struct Config {
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
     /// Configuration of the statusline elements
-    pub status_line: StatusLineConfig,
+    pub statusline: StatusLineConfig,
     /// Shape for cursor in each mode
     pub cursor_shape: CursorShapeConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
@@ -459,7 +459,7 @@ impl Default for Config {
             completion_trigger_len: 2,
             auto_info: true,
             file_picker: FilePickerConfig::default(),
-            status_line: StatusLineConfig::default(),
+            statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),
             true_color: false,
             search: SearchConfig::default(),


### PR DESCRIPTION
### Summary

Building upon the feedback of #2420 and the discussion in #708, I refactored the status line implementation and made it configurable.

The configuration happens in the user's configuration file and distinguishes between three areas of the status line: **left**, **center** and **right**.

```
[ ... ... LEFT ... ... | ... ... ... ... CENTER ... ... ... ... | ... ... RIGHT ... ... ]
```

Within each area, status line elements can be defined. There are no particular restrictions regarding the order, and elements can occur multiple times or be removed completely.

The following elements can currently be configured (see `helix_view::editor::StatusLineElement`):

```
mode
spinner
file-name
file-encoding
file-type
diagnostics
selections
position
```

### Example

This would move the file name to the center, and add a file type indicated to the far right):

```toml
[editor.status-line]
left = ["mode", "spinner"]
center = ["file-name"]
right = ["diagnostics", "selections", "position", "file-encoding", "file-type"]
```

![image](https://user-images.githubusercontent.com/2804556/167313157-a5ad08b8-285b-4054-b11a-60c662322fe9.png)

### Additional info

The default configuration keeps the same status line layout with the same elements as before. While I do see room for improvement here, I assume it'd better be done in another PR.

On top of the elements which were already present, I added the implementation for one additional element: the file type (disabled by default).