### PR TITLE
Implement `log-open` command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -63,5 +63,6 @@
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
 | `:config-reload` | Refreshes helix's config. |
 | `:config-open` | Open the helix config.toml file. |
+| `:log-open` | Open the helix log file. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1146,6 +1146,15 @@ fn open_config(
     Ok(())
 }
 
+fn open_log(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    cx.editor.open(helix_loader::log_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn refresh_config(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -1645,6 +1654,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Open the helix config.toml file.",
             fun: open_config,
+            completer: None,
+        },
+        TypableCommand {
+            name: "log-open",
+            aliases: &[],
+            doc: "Open the helix log file.",
+            fun: open_log,
             completer: None,
         },
         TypableCommand {


### PR DESCRIPTION
This commit adds a simple command called "log-open" similar to the
"config-open" command

Resolves issue #2418

@review: Maybe we want to change the action to "SplitVertical" but for now I chose to replicate the form of `open_config`.