### PR TITLE
Separate colors for different diagnostics types

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -234,6 +234,10 @@ These scopes are used for theming the editor interface.
 | `error`                  | Diagnostics error (gutter)                     |
 | `info`                   | Diagnostics info (gutter)                      |
 | `hint`                   | Diagnostics hint (gutter)                      |
-| `diagnostic`             | For text in editing area                       |
+| `diagnostic`             | Diagnostics fallback style (editing area)      |
+| `diagnostic.hint`        | Diagnostics hint (editing area)                |
+| `diagnostic.info`        | Diagnostics info (editing area)                |
+| `diagnostic.warning`     | Diagnostics warning (editing area)             |
+| `diagnostic.error`       | Diagnostics error (editing area)               |
 
 [rulers-config]: ./configuration.md#editor-section

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -248,16 +248,11 @@ impl EditorView {
         theme: &Theme,
     ) -> Vec<(usize, std::ops::Range<usize>)> {
         use helix_core::diagnostic::Severity;
-        let get_diagnostic_subscope_colors = |maybe_severity: Option<Severity>| {
-            let full_scope = match maybe_severity {
-                Some(Severity::Hint) => "diagnostic.hint",
-                Some(Severity::Info) => "diagnostic.info",
-                Some(Severity::Warning) => "diagnostic.warning",
-                Some(Severity::Error) => "diagnostic.error",
-                None => "diagnostic",
-            };
+        let get_scope_of = |scope| {
             theme
-            .find_scope_index(full_scope)
+            .find_scope_index(scope)
+            // get one of the themes below as fallback values
+            .or_else(|| theme.find_scope_index("diagnostic"))
             .or_else(|| theme.find_scope_index("ui.cursor"))
             .or_else(|| theme.find_scope_index("ui.selection"))
             .expect(
@@ -265,10 +260,23 @@ impl EditorView {
             )
         };
 
+        // basically just queries the theme color defined in the config
+        let hint = get_scope_of("diagnostic.hint");
+        let info = get_scope_of("diagnostic.info");
+        let warning = get_scope_of("diagnostic.warning");
+        let error = get_scope_of("diagnostic.error");
+        let r#default = get_scope_of("diagnostic"); // this is a bit redundant but should be fine
+
         doc.diagnostics()
             .iter()
             .map(|diagnostic| {
-                let diagnostic_scope = get_diagnostic_subscope_colors(diagnostic.severity);
+                let diagnostic_scope = match diagnostic.severity {
+                    Some(Severity::Info) => info,
+                    Some(Severity::Hint) => hint,
+                    Some(Severity::Warning) => warning,
+                    Some(Severity::Error) => error,
+                    _ => r#default,
+                };
                 (
                     diagnostic_scope,
                     diagnostic.range.start..diagnostic.range.end,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -247,17 +247,28 @@ impl EditorView {
         doc: &Document,
         theme: &Theme,
     ) -> Vec<(usize, std::ops::Range<usize>)> {
-        let diagnostic_scope = theme
-            .find_scope_index("diagnostic")
+        use helix_core::diagnostic::Severity;
+        let get_diagnostic_subscope_colors = |maybe_severity: Option<Severity>| {
+            let full_scope = match maybe_severity {
+                Some(Severity::Hint) => "diagnostic.hint",
+                Some(Severity::Info) => "diagnostic.info",
+                Some(Severity::Warning) => "diagnostic.warning",
+                Some(Severity::Error) => "diagnostic.error",
+                None => "diagnostic",
+            };
+            theme
+            .find_scope_index(full_scope)
             .or_else(|| theme.find_scope_index("ui.cursor"))
             .or_else(|| theme.find_scope_index("ui.selection"))
             .expect(
                 "at least one of the following scopes must be defined in the theme: `diagnostic`, `ui.cursor`, or `ui.selection`",
-            );
+            )
+        };
 
         doc.diagnostics()
             .iter()
             .map(|diagnostic| {
+                let diagnostic_scope = get_diagnostic_subscope_colors(diagnostic.severity);
                 (
                     diagnostic_scope,
                     diagnostic.range.start..diagnostic.range.end,

--- a/theme.toml
+++ b/theme.toml
@@ -67,10 +67,10 @@ label = "honey"
 "ui.menu.selected" = { fg = "revolver", bg = "white" }
 
 diagnostic = { modifiers = ["underlined"] }
-"diagnostic.hint" = { fg = "revolver", bg = "lilac" }
-"diagnostic.info" = { fg = "revolver", bg = "lavender" }
-"diagnostic.warning" = { fg = "revolver", bg = "honey" }
-"diagnostic.error" = { fg = "revolver", bg = "apricot" }
+# "diagnostic.hint" = { fg = "revolver", bg = "lilac" }
+# "diagnostic.info" = { fg = "revolver", bg = "lavender" }
+# "diagnostic.warning" = { fg = "revolver", bg = "honey" }
+# "diagnostic.error" = { fg = "revolver", bg = "apricot" }
 
 warning = "lightning"
 error = "apricot"

--- a/theme.toml
+++ b/theme.toml
@@ -67,6 +67,10 @@ label = "honey"
 "ui.menu.selected" = { fg = "revolver", bg = "white" }
 
 diagnostic = { modifiers = ["underlined"] }
+"diagnostic.hint" = { fg = "revolver", bg = "lilac" }
+"diagnostic.info" = { fg = "revolver", bg = "lavender" }
+"diagnostic.warning" = { fg = "revolver", bg = "honey" }
+"diagnostic.error" = { fg = "revolver", bg = "apricot" }
 
 warning = "lightning"
 error = "apricot"


### PR DESCRIPTION
This commit adds separate diagnostic highlight colors for the different
types of LSP severities. If the severity type doesn't exist or is
unknown, we use some fallback coloring which was in use before this
commit.

Some initial color options were also added in the theme.toml

Resolves issue #2157