### PR TITLE
Add shrink equivalent of extend_to_line_bounds

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -107,6 +107,7 @@
 | `%`                   | Select entire file                                                | `select_all`                         |
 | `x`                   | Select current line, if already selected, extend to next line     | `extend_line`                        |
 | `X`                   | Extend selection to line bounds (line-wise selection)             | `extend_to_line_bounds`              |
+| `Alt-x`               | Shrink selection to line bounds (line-wise selection)             | `shrink_to_line_bounds`              |
 | `J`                   | Join lines inside selection                                       | `join_selections`                    |
 | `K`                   | Keep selections matching the regex                                | `keep_selections`                    |
 | `Alt-K`               | Remove selections matching the regex                              | `remove_selections`                  |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1958,8 +1958,8 @@ fn shrink_to_line_bounds(cx: &mut Context) {
 
             // line_to_char gives us the start position of the line, so
             // we need to get the start position of the next line, then
-            // backtrack to get the end position of the last line.
-            let mut end = text.line_to_char(end_line + 1) - 1;
+            // backtrack to get the end position + 1 of the last line.
+            let mut end = text.line_to_char((end_line + 1).min(text.len_lines())) - 1;
 
             if start != range.from() {
                 start = text.line_to_char((start_line + 1).min(text.len_lines()));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1957,16 +1957,17 @@ fn shrink_to_line_bounds(cx: &mut Context) {
             let mut start = text.line_to_char(start_line);
 
             // line_to_char gives us the start position of the line, so
-            // we need to get the start position of the next line, then
-            // backtrack to get the end position + 1 of the last line.
-            let mut end = text.line_to_char((end_line + 1).min(text.len_lines())) - 1;
+            // we need to get the start position of the next line. In
+            // the editor, this will correspond to the cursor being on
+            // the EOL whitespace charactor, which is what we want.
+            let mut end = text.line_to_char((end_line + 1).min(text.len_lines()));
 
             if start != range.from() {
                 start = text.line_to_char((start_line + 1).min(text.len_lines()));
             }
 
             if end != range.to() {
-                end = text.line_to_char(end_line).saturating_sub(1);
+                end = text.line_to_char(end_line);
             }
 
             if range.anchor <= range.head {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -87,7 +87,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "%" => select_all,
         "x" => extend_line,
         "X" => extend_to_line_bounds,
-        // crop_to_whole_line
+        "A-x" => shrink_to_line_bounds,
 
         "m" => { "Match"
             "m" => match_brackets,


### PR DESCRIPTION
Implements #2002, with a difference in that using the command when the selection spans only a single line will not result in conditional logic.

I believe there's some holes in the logic that could open to a panic so marking as draft until I can address.