### PR TITLE
Add more context to the symbol picker

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -105,7 +105,10 @@ fn get_symbol_string(symbol: &lsp::SymbolInformation) -> String {
         lsp::SymbolKind::EVENT => "event     ",
         lsp::SymbolKind::OPERATOR => "operator  ",
         lsp::SymbolKind::TYPE_PARAMETER => "type param",
-        _ => "",
+        _ => {
+            log::warn!("Unknown symbol kind: {:?}", symbol.kind);
+            ""
+        }
     };
 
     // TODO: we currently only show the symbol directly containing the current symbol; however,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -108,6 +108,8 @@ fn get_symbol_string(symbol: &lsp::SymbolInformation) -> String {
         _ => "",
     };
 
+    // TODO: we currently only show the symbol directly containing the current symbol; however,
+    // it'd be really useful to have the ability to show all the ancestor symbols as well.
     let prefix = symbol
         .clone()
         .container_name


### PR DESCRIPTION
The symbol picker functionality is really useful; however, it can be annoying when you want to do something like only see the `function` symbols, or maybe only `struct` or `enum` kinds. It'd also be convenient to be able to filter by the containing symbol name.

This adds the symbol kind along with its direct parent symbol. So:
```rust
mod foo {
    fn bar() {}
}
```
will show symbols like
```
module    : foo
function  : foo → bar
```

This lets you quickly filter by the symbol kind, containing symbol or
symbol name.

Here is how this looks before (top) and after (bottom):
![compare](https://user-images.githubusercontent.com/665342/167559921-d334081a-f84e-4218-9cd3-e9233a54f6ee.png)

The nice thing about this is that you can search by the symbol type (like function) to more quickly narrow in on what you want.
![compare-search](https://user-images.githubusercontent.com/665342/167559929-d533e934-6f48-4237-a0be-20c605ce5d59.png)

By showing the containing symbol (if it exists) it becomes easy to search only symbols in the `test` module as well.

---

This also addresses a TODO and a bit of minor formatting cleanup.