### PR TITLE
Python highlights to incl. types, parameters, etc.

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -1,10 +1,15 @@
-; Identifier naming conventions
+; Types
 
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
+(type (identifier) @type)
+(type (subscript (identifier) @type)) ; only one deep...
+(class_definition name: (identifier) @type)
+(class_definition superclasses: (argument_list (identifier) @type))
 
-((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_]*$"))
+; Decorators
+
+(decorator) @function
+(decorator (identifier) @function)
+(decorator (call function: (identifier) @function))
 
 ; Builtin functions
 
@@ -16,8 +21,9 @@
 
 ; Function calls
 
-(decorator) @function
-
+((call
+  function: (identifier) @constructor)
+ (#match? @constructor "^[A-Z]"))
 (call
   function: (attribute attribute: (identifier) @function.method))
 (call
@@ -28,9 +34,33 @@
 (function_definition
   name: (identifier) @function)
 
-(identifier) @variable
+; First parameter of a classmethod
+((class_definition
+  body: (block
+          (decorated_definition
+            (decorator (identifier) @_decorator)
+            definition: (function_definition
+              parameters: (parameters . (identifier) @variable.builtin)))))
+ (#eq? @variable.builtin "cls")
+ (#eq? @_decorator "classmethod"))
+
+((identifier) @variable.builtin
+ (#eq? @variable.builtin "self"))
+
+(parameters
+  (identifier) @variable.parameter)
+(parameters (typed_parameter (identifier) @variable.parameter))
 (attribute attribute: (identifier) @variable.other.member)
-(type (identifier) @type)
+
+; Identifier naming conventions
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z_]*$"))
+
+((identifier) @type
+ (#match? @type "^[A-Z].*[a-z]$"))
+
+(identifier) @variable
 
 ; Literals
 

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -1,7 +1,12 @@
 ; Types
 
 (type (identifier) @type)
-(type (subscript (identifier) @type)) ; only one deep...
+; Handle subscript and | binary operator nesting 4 levels deep
+(type
+  (_ (identifier)? @type
+    (_ (identifier)? @type
+      (_ (identifier)? @type
+        (_ (identifier)? @type)))))
 (class_definition name: (identifier) @type)
 (class_definition superclasses: (argument_list (identifier) @type))
 


### PR DESCRIPTION
* Better handling of `@type` highlighting
* Parameters highlighted with `@variable.parameter`
* Made `@constructor` more specific to highlight on call
* Decorator identifier highlighted as part of `@function`
* `cls` and `self` treated as `@variable.builtin`

Re-ordering of some statements to give a better priority.

This takes some ideas from the neovim implementation.

Looks like it might be relevant to #2427 and is probably an alternative to #2451.

Converted to draft to work on a combined effort on type highlighting with the above PR.