### PR TITLE
Default to tabs instead of spaces for Odin files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1337,7 +1337,7 @@ scope = "source.odin"
 file-types = ["odin"]
 roots = []
 comment-token = "//"
-indent = { tab-width = 4, unit = "  " }
+indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "odin"


### PR DESCRIPTION
The Odin compiler+packages use tabs instead of spaces, so this PR sets tabs as default in `languages.toml`.