### PR TITLE
Remove double-width characters for infobox

### DIFF
--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -1,4 +1,5 @@
 use crate::compositor::{Component, Context};
+use helix_core::unicode::width::UnicodeWidthStr;
 use helix_view::graphics::{Margin, Rect};
 use helix_view::info::Info;
 use tui::buffer::Buffer as Surface;
@@ -8,6 +9,7 @@ impl Component for Info {
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
         let text_style = cx.editor.theme.get("ui.text.info");
         let popup_style = cx.editor.theme.get("ui.popup.info");
+        let background_style = cx.editor.theme.get("ui.background");
 
         // Calculate the area of the terminal to modify. Because we want to
         // render at the bottom right, we use the viewport's width and height
@@ -21,6 +23,27 @@ impl Component for Info {
             height,
         ));
         surface.clear_with(area, popup_style);
+
+        // Render margin to prevent double-width characters (CJK) from flowing
+        // into border, but we also do not want to overwrite existing
+        // cells so we only overwrite those that are troublesome
+        // (double-width).
+        let left_margin_area = viewport.intersection(Rect::new(
+            viewport.width.saturating_sub(width + 1),   // +1 for margin
+            viewport.height.saturating_sub(height + 2), // +2 for status
+            1,
+            height + 1,
+        ));
+        // surface.clear_with(left_margin_area, background_style);
+        for x in left_margin_area.left()..left_margin_area.right() {
+            for y in left_margin_area.top()..left_margin_area.bottom() {
+                let cell = &mut surface[(x, y)];
+                if cell.symbol().width() > 1 {
+                    cell.reset();
+                    cell.set_style(background_style);
+                }
+            }
+        }
 
         let block = Block::default()
             .title(self.title.as_str())

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -15,6 +15,10 @@ pub struct Cell {
 }
 
 impl Cell {
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
         self.symbol.clear();
         self.symbol.push_str(symbol);


### PR DESCRIPTION
Fix #2442

![Screenshot_20220514_084908](https://user-images.githubusercontent.com/4687791/168404568-cc181690-0538-4a0b-817b-d1c5dc29af3e.png)

The character removed was `に`.

I also tried an alternative method to put margin over all characters, I think that would be faster since it does not need to calculate character width.

But I think a better solution is to add border handling methods to surface to automatically remove double-width characters.