### PR TITLE
Refactor Block with Default and bitflags

### DIFF
--- a/helix-tui/src/widgets/block.rs
+++ b/helix-tui/src/widgets/block.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use helix_view::graphics::{Rect, Style};
 
+/// Border render type. Defaults to [`BorderType::Plain`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BorderType {
     Plain,
@@ -25,6 +26,12 @@ impl BorderType {
     }
 }
 
+impl Default for BorderType {
+    fn default() -> BorderType {
+        BorderType::Plain
+    }
+}
+
 /// Base widget to be used with all upper level ones. It may be used to display a box border around
 /// the widget and/or add a title.
 ///
@@ -40,7 +47,7 @@ impl BorderType {
 ///     .border_type(BorderType::Rounded)
 ///     .style(Style::default().bg(Color::Black));
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Block<'a> {
     /// Optional title place on the upper left of the block
     title: Option<Spans<'a>>,
@@ -53,18 +60,6 @@ pub struct Block<'a> {
     border_type: BorderType,
     /// Widget style
     style: Style,
-}
-
-impl<'a> Default for Block<'a> {
-    fn default() -> Block<'a> {
-        Block {
-            title: None,
-            borders: Borders::NONE,
-            border_style: Default::default(),
-            border_type: BorderType::Plain,
-            style: Default::default(),
-        }
-    }
 }
 
 impl<'a> Block<'a> {

--- a/helix-tui/src/widgets/mod.rs
+++ b/helix-tui/src/widgets/mod.rs
@@ -27,17 +27,16 @@ use helix_view::graphics::Rect;
 
 bitflags! {
     /// Bitflags that can be composed to set the visible borders essentially on the block widget.
+    #[derive(Default)]
     pub struct Borders: u32 {
-        /// Show no border (default)
-        const NONE  = 0b0000_0001;
         /// Show the top border
-        const TOP   = 0b0000_0010;
+        const TOP = 0b0000_0001;
         /// Show the right border
-        const RIGHT = 0b0000_0100;
+        const RIGHT = 0b0000_0010;
         /// Show the bottom border
-        const BOTTOM = 0b000_1000;
+        const BOTTOM = 0b000_0100;
         /// Show the left border
-        const LEFT = 0b0001_0000;
+        const LEFT = 0b0000_1000;
         /// Show all borders
         const ALL = Self::TOP.bits | Self::RIGHT.bits | Self::BOTTOM.bits | Self::LEFT.bits;
     }

--- a/helix-tui/src/widgets/mod.rs
+++ b/helix-tui/src/widgets/mod.rs
@@ -28,7 +28,7 @@ use helix_view::graphics::Rect;
 bitflags! {
     /// Bitflags that can be composed to set the visible borders essentially on the block widget.
     #[derive(Default)]
-    pub struct Borders: u32 {
+    pub struct Borders: u8 {
         /// Show the top border
         const TOP = 0b0000_0001;
         /// Show the right border


### PR DESCRIPTION
Specifying empty for bitflags is not recommended, it is now removed and added
Default. For BorderType, it now defaults to plain.