### PR TITLE
Change default Hare tab width to 8

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1284,7 +1284,7 @@ injection-regex = "hare"
 file-types = ["ha"]
 roots = []
 comment-token = "//"
-indent = { tab-width = 4, unit = "\t" }
+indent = { tab-width = 8, unit = "\t" }
 
 [[grammar]]
 name = "hare"


### PR DESCRIPTION
According to the [official Hare style guide](https://harelang.org/style/#a-general-conventions), "The tab size SHOULD be 8 columns."

I have made the corresponding change.