### PR TITLE
Theme colors for diagnostic by severity

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -235,5 +235,9 @@ These scopes are used for theming the editor interface.
 | `info`                   | Diagnostics info (gutter)                      |
 | `hint`                   | Diagnostics hint (gutter)                      |
 | `diagnostic`             | For text in editing area                       |
+| `diagnostic.hint`        | For text in editing area (hint)                |
+| `diagnostic.info`        | For text in editing area (info)                |
+| `diagnostic.warning`     | For text in editing area (warning)             |
+| `diagnostic.error`       | For text in editing area (error)               |
 
 [rulers-config]: ./configuration.md#editor-section

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -258,8 +258,26 @@ impl EditorView {
         doc.diagnostics()
             .iter()
             .map(|diagnostic| {
+                use helix_core::diagnostic::Severity;
+
                 (
-                    diagnostic_scope,
+                    match diagnostic.severity {
+                        None => diagnostic_scope,
+                        Some(severity) => match severity {
+                            Severity::Hint => theme
+                                .find_scope_index("diagnostic.hint")
+                                .unwrap_or(diagnostic_scope),
+                            Severity::Info => theme
+                                .find_scope_index("diagnostic.info")
+                                .unwrap_or(diagnostic_scope),
+                            Severity::Warning => theme
+                                .find_scope_index("diagnostic.warning")
+                                .unwrap_or(diagnostic_scope),
+                            Severity::Error => theme
+                                .find_scope_index("diagnostic.error")
+                                .unwrap_or(diagnostic_scope),
+                        },
+                    },
                     diagnostic.range.start..diagnostic.range.end,
                 )
             })


### PR DESCRIPTION
Add `diagnostic.hint`, `diagnostic.info`, `diagnostic.warning`, `diagnostic.error` options for theme coloring