### PR TITLE
feat(term): uniformize word-wise movement and deletion

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -298,30 +298,30 @@ convenience. These can be helpful for making simple modifications
 without escaping to normal mode, but beware that you will not have an
 undo-able "save point" until you return to normal mode.
 
-| Key                       | Description                 | Command                 |
-| -----                     | -----------                 | -------                 |
-| `Escape`                  | Switch to normal mode       | `normal_mode`           |
-| `Ctrl-x`                  | Autocomplete                | `completion`            |
-| `Ctrl-r`                  | Insert a register content   | `insert_register`       |
-| `Ctrl-w`, `Alt-Backspace` | Delete previous word        | `delete_word_backward`  |
-| `Alt-d`                   | Delete next word            | `delete_word_forward`   |
-| `Alt-b`, `Ctrl-Left`      | Backward a word             | `move_prev_word_end`    |
-| `Ctrl-b`, `Left`          | Backward a char             | `move_char_left`        |
-| `Alt-f`, `Ctrl-Right`     | Forward a word              | `move_next_word_start`  |
-| `Ctrl-f`, `Right`         | Forward a char              | `move_char_right`       |
-| `Ctrl-e`, `End`           | Move to line end            | `goto_line_end_newline` |
-| `Ctrl-a`, `Home`          | Move to line start          | `goto_line_start`       |
-| `Ctrl-u`                  | Delete to start of line     | `kill_to_line_start`    |
-| `Ctrl-k`                  | Delete to end of line       | `kill_to_line_end`      |
-| `Ctrl-j`, `Enter`         | Insert new line             | `insert_newline`        |
-| `Backspace`, `Ctrl-h`     | Delete previous char        | `delete_char_backward`  |
-| `Delete`, `Ctrl-d`        | Delete next char            | `delete_char_forward`   |
-| `Ctrl-p`, `Up`            | Move to previous line       | `move_line_up`          |
-| `Ctrl-n`, `Down`          | Move to next line           | `move_line_down`        |
-| `PageUp`                  | Move one page up            | `page_up`               |
-| `PageDown`                | Move one page down          | `page_down`             |
-| `Alt->`                   | Go to end of buffer         | `goto_file_end`         |
-| `Alt-<`                   | Go to start of buffer       | `goto_file_start`       |
+| Key                                         | Description                 | Command                 |
+| -----                                       | -----------                 | -------                 |
+| `Escape`                                    | Switch to normal mode       | `normal_mode`           |
+| `Ctrl-x`                                    | Autocomplete                | `completion`            |
+| `Ctrl-r`                                    | Insert a register content   | `insert_register`       |
+| `Ctrl-w`, `Alt-Backspace`, `Ctrl-Backspace` | Delete previous word        | `delete_word_backward`  |
+| `Alt-d`, `Alt-Delete`, `Ctrl-Delete`        | Delete next word            | `delete_word_forward`   |
+| `Alt-b`, `Ctrl-Left`                        | Backward a word             | `move_prev_word_end`    |
+| `Ctrl-b`, `Left`                            | Backward a char             | `move_char_left`        |
+| `Alt-f`, `Ctrl-Right`                       | Forward a word              | `move_next_word_start`  |
+| `Ctrl-f`, `Right`                           | Forward a char              | `move_char_right`       |
+| `Ctrl-e`, `End`                             | Move to line end            | `goto_line_end_newline` |
+| `Ctrl-a`, `Home`                            | Move to line start          | `goto_line_start`       |
+| `Ctrl-u`                                    | Delete to start of line     | `kill_to_line_start`    |
+| `Ctrl-k`                                    | Delete to end of line       | `kill_to_line_end`      |
+| `Ctrl-j`, `Enter`                           | Insert new line             | `insert_newline`        |
+| `Backspace`, `Ctrl-h`                       | Delete previous char        | `delete_char_backward`  |
+| `Delete`, `Ctrl-d`                          | Delete next char            | `delete_char_forward`   |
+| `Ctrl-p`, `Up`                              | Move to previous line       | `move_line_up`          |
+| `Ctrl-n`, `Down`                            | Move to next line           | `move_line_down`        |
+| `PageUp`                                    | Move one page up            | `page_up`               |
+| `PageDown`                                  | Move one page down          | `page_down`             |
+| `Alt->`                                     | Go to end of buffer         | `goto_file_end`         |
+| `Alt-<`                                     | Go to start of buffer       | `goto_file_start`       |
 
 ## Select / extend mode
 
@@ -358,26 +358,25 @@ Keys to use within picker. Remapping currently not supported.
 
 Keys to use within prompt, Remapping currently not supported.
 
-| Key                     | Description                                                             |
-| -----                   | -------------                                                           |
-| `Escape`, `Ctrl-c`      | Close prompt                                                            |
-| `Alt-b`, `Alt-Left`     | Backward a word                                                         |
-| `Ctrl-b`, `Left`        | Backward a char                                                         |
-| `Alt-f`, `Alt-Right`    | Forward a word                                                          |
-| `Ctrl-f`, `Right`       | Forward a char                                                          |
-| `Ctrl-e`, `End`         | Move prompt end                                                         |
-| `Ctrl-a`, `Home`        | Move prompt start                                                       |
-| `Ctrl-w`                | Delete previous word                                                    |
-| `Alt-d`                 | Delete next word                                                        |
-| `Ctrl-u`                | Delete to start of line                                                 |
-| `Ctrl-k`                | Delete to end of line                                                   |
-| `backspace`, `Ctrl-h`   | Delete previous char                                                    |
-| `delete`, `Ctrl-d`      | Delete next char                                                        |
-| `Ctrl-s`                | Insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later   |
-| `Ctrl-p`, `Up`          | Select previous history                                                 |
-| `Ctrl-n`, `Down`        | Select next history                                                     |
-| `Ctrl-r`                | Insert the content of the register selected by following input char     |
-| `Tab`                   | Select next completion item                                             |
-| `BackTab`               | Select previous completion item                                         |
-| `Enter`                 | Open selected                                                           |
-
+| Key                                         | Description                                                             |
+| -----                                       | -------------                                                           |
+| `Escape`, `Ctrl-c`                          | Close prompt                                                            |
+| `Alt-b`, `Ctrl-Left`                        | Backward a word                                                         |
+| `Ctrl-b`, `Left`                            | Backward a char                                                         |
+| `Alt-f`, `Ctrl-Right`                       | Forward a word                                                          |
+| `Ctrl-f`, `Right`                           | Forward a char                                                          |
+| `Ctrl-e`, `End`                             | Move prompt end                                                         |
+| `Ctrl-a`, `Home`                            | Move prompt start                                                       |
+| `Ctrl-w`, `Alt-Backspace`, `Ctrl-Backspace` | Delete previous word                                                    |
+| `Alt-d`, `Alt-Delete`, `Ctrl-Delete`        | Delete next word                                                        |
+| `Ctrl-u`                                    | Delete to start of line                                                 |
+| `Ctrl-k`                                    | Delete to end of line                                                   |
+| `backspace`, `Ctrl-h`                       | Delete previous char                                                    |
+| `delete`, `Ctrl-d`                          | Delete next char                                                        |
+| `Ctrl-s`                                    | Insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later   |
+| `Ctrl-p`, `Up`                              | Select previous history                                                 |
+| `Ctrl-n`, `Down`                            | Select next history                                                     |
+| `Ctrl-r`                                    | Insert the content of the register selected by following input char     |
+| `Tab`                                       | Select next completion item                                             |
+| `BackTab`                                   | Select previous completion item                                         |
+| `Enter`                                     | Open selected                                                           |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -350,7 +350,7 @@ impl Application {
     }
 
     fn refresh_config(&mut self) {
-        let config = Config::load(helix_loader::config_file()).unwrap_or_else(|err| {
+        let config = Config::load_default().unwrap_or_else(|err| {
             self.editor.set_error(err.to_string());
             Config::default()
         });

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -351,6 +351,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "C-w" => delete_word_backward,
         "A-backspace" => delete_word_backward,
         "A-d" => delete_word_forward,
+        "A-del" => delete_word_forward,
         "C-s" => commit_undo_checkpoint,
 
         "left" => move_char_left,

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -477,14 +477,14 @@ impl Component for Prompt {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
                 return close_fn;
             }
-            alt!('b') | alt!(Left) => self.move_cursor(Movement::BackwardWord(1)),
-            alt!('f') | alt!(Right) => self.move_cursor(Movement::ForwardWord(1)),
+            alt!('b') | ctrl!(Left) => self.move_cursor(Movement::BackwardWord(1)),
+            alt!('f') | ctrl!(Right) => self.move_cursor(Movement::ForwardWord(1)),
             ctrl!('b') | key!(Left) => self.move_cursor(Movement::BackwardChar(1)),
             ctrl!('f') | key!(Right) => self.move_cursor(Movement::ForwardChar(1)),
             ctrl!('e') | key!(End) => self.move_end(),
             ctrl!('a') | key!(Home) => self.move_start(),
-            ctrl!('w') => self.delete_word_backwards(cx),
-            alt!('d') => self.delete_word_forwards(cx),
+            ctrl!('w') | alt!(Backspace) | ctrl!(Backspace) => self.delete_word_backwards(cx),
+            alt!('d') | alt!(Delete) | ctrl!(Delete) => self.delete_word_forwards(cx),
             ctrl!('k') => self.kill_to_end_of_line(cx),
             ctrl!('u') => self.kill_to_start_of_line(cx),
             ctrl!('h') | key!(Backspace) => {


### PR DESCRIPTION
Ctrl-Left and Ctrl-Right are common shortcuts in numerous applications.

This change is just adding a new key binding for the existing word-wise movement:
- Ctrl-Left is equivalent to Alt-b and Alt-Left, and
- Ctrl-Right is equivalent to Alt-f and Alt-Right.

**EDIT: after reviews, changed to the following:**

- Adds Ctrl+{Left/Right/Backspace/Delete} for word-wise movement/deletion in prompt, picker, …
- Removes Alt-Left and Alt-Right in prompt, picker, …
- Adds Alt-Delete in insert mode for forward word deletion

In some terminals, Alt-Backspace might not work because it is ambigous.
See: https://github.com/helix-editor/helix/pull/2193#issuecomment-1105042501
Hence, Alt alternative is not removed.