### PR TITLE
pin exact rust version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install 1.60.0 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.60.0
           override: true
 
       - name: Cache cargo registry
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install 1.60.0 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
+        rust: [1.60.0]
 
   lints:
     name: Lints
@@ -111,11 +111,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install 1.60.0 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 
@@ -159,11 +159,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install 1.60.0 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.60.0
           override: true
 
       - name: Cache cargo registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install 1.60.0 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.60.0
           override: true
 
       - name: Cache cargo registry
@@ -68,35 +68,35 @@ jobs:
         include:
         - build: x86_64-linux
           os: ubuntu-20.04
-          rust: stable
+          rust: 1.60.0
           target: x86_64-unknown-linux-gnu
           cross: false
         # - build: aarch64-linux
         #   os: ubuntu-20.04
-        #   rust: stable
+        #   rust: 1.60.0
         #   target: aarch64-unknown-linux-gnu
         #   cross: true
         - build: x86_64-macos
           os: macos-latest
-          rust: stable
+          rust: 1.60.0
           target: x86_64-apple-darwin
           cross: false
         - build: x86_64-windows
           os: windows-2019
-          rust: stable
+          rust: 1.60.0
           target: x86_64-pc-windows-msvc
           cross: false
         # - build: aarch64-macos
         #   os: macos-latest
-        #   rust: stable
+        #   rust: 1.60.0
         #   target: aarch64-apple-darwin
         # - build: x86_64-win-gnu
         #   os: windows-2019
-        #   rust: stable-x86_64-gnu
+        #   rust: 1.60.0-x86_64-gnu
         #   target: x86_64-pc-windows-gnu
         # - build: win32-msvc
         #   os: windows-2019
-        #   rust: stable
+        #   rust: 1.60.0
         #   target: i686-pc-windows-msvc
 
     steps:


### PR DESCRIPTION
`stable` can change very quickly: `stable` upgraded from 1.60.0 to
1.61.0 in a handful of hours after release. The new additions to
clippy fail the lints in CI. It would be nice to choose the upgrade
time for new rust versions so we're not forced to fix new clippy lints
right as new rust versions are published.

On the other hand, it feels a bit icky to pin the exact versions.
Ideally it'd be nice to have a dependabot-like PR that would upgrade
these. Maybe we can hack something together with an Actions workflow.