### PR TITLE
address rust 1.61.0 clippy lints

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1224,11 +1224,11 @@ fn replace(cx: &mut Context) {
     // need to wait for next key
     cx.on_next_key(move |cx, event| {
         let (view, doc) = current!(cx.editor);
-        let ch = match event {
+        let ch: Option<&str> = match event {
             KeyEvent {
                 code: KeyCode::Char(ch),
                 ..
-            } => Some(&ch.encode_utf8(&mut buf[..])[..]),
+            } => Some(ch.encode_utf8(&mut buf[..])),
             KeyEvent {
                 code: KeyCode::Enter,
                 ..

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -366,6 +366,7 @@ impl<T> Picker<T> {
             );
         } else if pattern.starts_with(&self.previous_pattern) {
             // TODO: remove when retain_mut is in stable rust
+            #[allow(unused_imports)]
             use retain_mut::RetainMut;
 
             // optimization: if the pattern is a more specific version of the previous one


### PR DESCRIPTION
Rust 1.61 was released a few hours ago and some of the new clippy lints break the CI. These should fix the Lint CI.