### PR TITLE
Add theme key for picker separator

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -205,39 +205,40 @@ These scopes are used for theming the editor interface.
       - `hover` - for hover popup ui
 
 
-| Key                      | Notes                                          |
-| ---                      | ---                                            |
-| `ui.background`          |                                                |
-| `ui.cursor`              |                                                |
-| `ui.cursor.insert`       |                                                |
-| `ui.cursor.select`       |                                                |
-| `ui.cursor.match`        | Matching bracket etc.                          |
-| `ui.cursor.primary`      | Cursor with primary selection                  |
-| `ui.linenr`              | Line numbers                                   |
-| `ui.linenr.selected`     | Line number for the line the cursor is on      |
-| `ui.statusline`          | Statusline                                     |
-| `ui.statusline.inactive` | Statusline (unfocused document)                |
-| `ui.popup`               | Documentation popups (e.g space-k)             |
-| `ui.popup.info`          | Prompt for multiple key options                |
-| `ui.window`              | Border lines separating splits                 |
-| `ui.help`                | Description box for commands                   |
-| `ui.text`                | Command prompts, popup text, etc.              |
-| `ui.text.focus`          |                                                |
-| `ui.text.info`           | The key: command text in `ui.popup.info` boxes |
-| `ui.virtual.ruler`       | Ruler columns (see the [`editor.rulers` config][rulers-config])|
-| `ui.virtual.whitespace`  | Visible white-space characters                 |
-| `ui.menu`                | Code and command completion menus              |
-| `ui.menu.selected`       | Selected autocomplete item                     |
-| `ui.selection`           | For selections in the editing area             |
-| `ui.selection.primary`   |                                                |
-| `warning`                | Diagnostics warning (gutter)                   |
-| `error`                  | Diagnostics error (gutter)                     |
-| `info`                   | Diagnostics info (gutter)                      |
-| `hint`                   | Diagnostics hint (gutter)                      |
-| `diagnostic`             | Diagnostics fallback style (editing area)      |
-| `diagnostic.hint`        | Diagnostics hint (editing area)                |
-| `diagnostic.info`        | Diagnostics info (editing area)                |
-| `diagnostic.warning`     | Diagnostics warning (editing area)             |
-| `diagnostic.error`       | Diagnostics error (editing area)               |
+| Key                       | Notes                                          |
+| ---                       | ---                                            |
+| `ui.background`           |                                                |
+| `ui.background.separator` | Picker separator below input line              |
+| `ui.cursor`               |                                                |
+| `ui.cursor.insert`        |                                                |
+| `ui.cursor.select`        |                                                |
+| `ui.cursor.match`         | Matching bracket etc.                          |
+| `ui.cursor.primary`       | Cursor with primary selection                  |
+| `ui.linenr`               | Line numbers                                   |
+| `ui.linenr.selected`      | Line number for the line the cursor is on      |
+| `ui.statusline`           | Statusline                                     |
+| `ui.statusline.inactive`  | Statusline (unfocused document)                |
+| `ui.popup`                | Documentation popups (e.g space-k)             |
+| `ui.popup.info`           | Prompt for multiple key options                |
+| `ui.window`               | Border lines separating splits                 |
+| `ui.help`                 | Description box for commands                   |
+| `ui.text`                 | Command prompts, popup text, etc.              |
+| `ui.text.focus`           |                                                |
+| `ui.text.info`            | The key: command text in `ui.popup.info` boxes |
+| `ui.virtual.ruler`        | Ruler columns (see the [`editor.rulers` config][rulers-config])|
+| `ui.virtual.whitespace`   | Visible white-space characters                 |
+| `ui.menu`                 | Code and command completion menus              |
+| `ui.menu.selected`        | Selected autocomplete item                     |
+| `ui.selection`            | For selections in the editing area             |
+| `ui.selection.primary`    |                                                |
+| `warning`                 | Diagnostics warning (gutter)                   |
+| `error`                   | Diagnostics error (gutter)                     |
+| `info`                    | Diagnostics info (gutter)                      |
+| `hint`                    | Diagnostics hint (gutter)                      |
+| `diagnostic`              | Diagnostics fallback style (editing area)      |
+| `diagnostic.hint`         | Diagnostics hint (editing area)                |
+| `diagnostic.info`         | Diagnostics info (editing area)                |
+| `diagnostic.warning`      | Diagnostics warning (editing area)             |
+| `diagnostic.error`        | Diagnostics error (editing area)               |
 
 [rulers-config]: ./configuration.md#editor-section

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -26,7 +26,7 @@ use crate::ui::{Prompt, PromptEvent};
 use helix_core::{movement::Direction, Position};
 use helix_view::{
     editor::Action,
-    graphics::{Color, CursorKind, Margin, Modifier, Rect, Style},
+    graphics::{CursorKind, Margin, Modifier, Rect},
     Document, Editor,
 };
 
@@ -587,7 +587,7 @@ impl<T: 'static> Component for Picker<T> {
         self.prompt.render(area, surface, cx);
 
         // -- Separator
-        let sep_style = Style::default().fg(Color::Rgb(90, 89, 119));
+        let sep_style = cx.editor.theme.get("ui.background.separator");
         let borders = BorderType::line_symbols(BorderType::Plain);
         for x in inner.left()..inner.right() {
             if let Some(cell) = surface.get_mut(x, inner.y + 1) {

--- a/theme.toml
+++ b/theme.toml
@@ -43,6 +43,7 @@ label = "honey"
 # concat (ERROR) @error.syntax and "MISSING ;" selectors for errors
 
 "ui.background" = { bg = "midnight" }
+"ui.background.separator" = { fg = "comet" }
 "ui.linenr" = { fg = "comet" }
 "ui.linenr.selected" = { fg = "lilac" }
 "ui.statusline" = { fg = "lilac", bg = "revolver" }


### PR DESCRIPTION
Addresses #2522. 

I'm unsure what the most proper name/scope for the theme key is. I've chosen `ui.background.separator` as `ui.background` is the style used for widget borders so the scope should draw a reasonable default for all themes.