### PR TITLE
Remove retain_mut from helix-term after 1.61.0 rust release

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -66,9 +66,6 @@ serde = { version = "1.0", features = ["derive"] }
 grep-regex = "0.1.9"
 grep-searcher = "0.1.8"
 
-# Remove once retain_mut lands in stable rust
-retain_mut = "0.1.7"
-
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -365,10 +365,6 @@ impl<T> Picker<T> {
                     .map(|(index, _option)| (index, 0)),
             );
         } else if pattern.starts_with(&self.previous_pattern) {
-            // TODO: remove when retain_mut is in stable rust
-            #[allow(unused_imports)]
-            use retain_mut::RetainMut;
-
             // optimization: if the pattern is a more specific version of the previous one
             // then we can score the filtered set.
             #[allow(unstable_name_collisions)]


### PR DESCRIPTION
Built fresh from master today and got these warnings.

```
warning: use of deprecated trait `retain_mut::RetainMut`: Rust 1.61 has included retain_mut directly
   --> helix-term/src/ui/picker.rs:370:29
    |
370 |             use retain_mut::RetainMut;
    |                             ^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `retain_mut::RetainMut::retain_mut`: Rust 1.61 has included retain_mut directly
   --> helix-term/src/ui/picker.rs:375:26
    |
375 |             self.matches.retain_mut(|(index, score)| {
    |                          ^^^^^^^^^^

warning: `helix-term` (lib) generated 2 warnings
```

[Rust 1.61.0 was released yesterday](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html) so I removed `retain_mut` and successfully built a new version locally.