### PR TITLE
CI: pin rust to 1.61.0 and check MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: helix-editor/rust-toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -37,10 +36,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: helix-editor/rust-toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -64,7 +62,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
 
   lints:
     name: Lints
@@ -74,10 +71,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: helix-editor/rust-toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
           components: rustfmt, clippy
 
@@ -103,10 +99,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: helix-editor/rust-toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,16 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, msrv]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Use MSRV rust toolchain
+        if: matrix.rust == 'msrv'
+        run: cp .github/workflows/msrv-rust-toolchain.toml rust-toolchain.toml
 
       - name: Install stable toolchain
         uses: helix-editor/rust-toolchain@v1
@@ -50,8 +57,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: runtime/grammars
-          key: ${{ runner.os }}-v2-tree-sitter-grammars-${{ hashFiles('languages.toml') }}
-          restore-keys: ${{ runner.os }}-v2-tree-sitter-grammars-
+          key: ${{ runner.os }}-stable-v${{ env.CACHE_VERSION }}-tree-sitter-grammars-${{ hashFiles('languages.toml') }}
+          restore-keys: ${{ runner.os }}-stable-v${{ env.CACHE_VERSION }}-tree-sitter-grammars-
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/msrv-rust-toolchain.toml
+++ b/.github/workflows/msrv-rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.60.0"
+components = ["rustfmt", "rust-src"]

--- a/.github/workflows/msrv-rust-toolchain.toml
+++ b/.github/workflows/msrv-rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.57.0"
 components = ["rustfmt", "rust-src"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -302,7 +302,9 @@ impl Editor {
                                     .arg(arguments.args.join(" "))
                                     .spawn()
                                     .unwrap(),
-                                e => panic!("Error to start debug console: {}", e),
+                                // TODO replace the pretty print {:?} with a regular format {}
+                                // when the MSRV is raised to 1.60.0
+                                e => panic!("Error to start debug console: {:?}", e),
                             })
                     } else {
                         std::process::Command::new("tmux")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.61.0"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
Pinning to a particular version brings some extra burden that we have to remember to update rust, but I think it's worth it to make CI more reproducible around new rust releases. The CI uses new rust versions almost immediately after release which means that CI may start failing faster than we can fix the lints, as in #2514. Ideally we update rust and fix clippy lints all in one go.

Connects #2528