### PR TITLE
check MSRV in CI, lower MSRV to 1.57.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check:
-    name: Check
+    name: Check Stable
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -47,6 +47,53 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+
+  check-msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-v2-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-v2-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-v2-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-v2-cargo-index-
+
+      - name: Cache cargo target dir
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-v2-cargo-build-target-
+
+      - name: Install cargo-msrv
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-msrv
+
+      - name: Check MSRV compatibility
+        uses: actions-rs/cargo@v1
+        with:
+          command: msrv
+          args: --verify --path=helix-term
 
   test:
     name: Test Suite

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 default-run = "hx"
-metadata.msrv = "1.60.0"
+metadata.msrv = "1.57.0"
 
 [package.metadata.nix]
 build = true

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 default-run = "hx"
+metadata.msrv = "1.60.0"
 
 [package.metadata.nix]
 build = true

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -302,7 +302,9 @@ impl Editor {
                                     .arg(arguments.args.join(" "))
                                     .spawn()
                                     .unwrap(),
-                                e => panic!("Error to start debug console: {}", e),
+                                // TODO replace pretty-print with standard format when MSRV
+                                // is raised to 1.60.0
+                                e => panic!("Error to start debug console: {:?}", e),
                             })
                     } else {
                         std::process::Command::new("tmux")


### PR DESCRIPTION
It's very easy to use new rust features without realizing it since
the CI and local development workflows may use the latest rust version.
We try to keep some backwards compatibility with rust versions to make
packaging easier for some OS-level package-managers like Void Linux's.
See #1881.

This change adds a new CI check which uses the cargo-msrv crate to
verify an MSRV version recorded in helix-term's Cargo.toml. When
changing MSRV, we can then edit `helix-term/Cargo.toml`'s
`package.metadata.msrv` key.

The MSRV is set at 1.60.0 for the sake of checkmarks on builds but
ideally we want to support 1.57.0. The PR that fixes the MSRV in #2460
should set this MSRV metadata key back to 1.57.0.

Closes #2482.