### PR TITLE
Add `parameter.around` text object query

### DIFF
--- a/runtime/queries/c/textobjects.scm
+++ b/runtime/queries/c/textobjects.scm
@@ -10,7 +10,11 @@
 (union_specifier
   body: (_) @class.inside) @class.around
 
-(parameter_declaration) @parameter.inside
+(parameter_list 
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(argument_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (comment) @comment.inside
 

--- a/runtime/queries/go/textobjects.scm
+++ b/runtime/queries/go/textobjects.scm
@@ -14,11 +14,14 @@
 (type_declaration
   (type_spec (type_identifier) (interface_type (method_spec)+ @class.inside))) @class.around
 
+(type_parameter_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (parameter_list
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (argument_list
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (comment) @comment.inside
 

--- a/runtime/queries/php/textobjects.scm
+++ b/runtime/queries/php/textobjects.scm
@@ -21,13 +21,19 @@
   
 (anonymous_function_creation_expression
   body: (_) @function.inside) @function.around
-  
+
+(anonymous_function_use_clause
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (formal_parameters
-  [
+  ([
     (simple_parameter)
     (variadic_parameter)
     (property_promotion_parameter)
-  ] @parameter.inside)
+  ] @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (comment) @comment.inside
 

--- a/runtime/queries/python/textobjects.scm
+++ b/runtime/queries/python/textobjects.scm
@@ -5,13 +5,13 @@
   body: (block)? @class.inside) @class.around
 
 (parameters
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
   
 (lambda_parameters
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (argument_list
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (comment) @comment.inside
 

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -52,17 +52,20 @@
   (impl_item
     body: (_) @class.inside)) @class.around
 
-(parameters
-  (_) @parameter.inside)
-  
+(parameters 
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (type_parameters
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(type_arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (closure_parameters
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (arguments
-  (_) @parameter.inside)
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 [
   (line_comment)


### PR DESCRIPTION
It allows `maa` to select `parameter`, `argument`, `type_parameter`, `type_argument`, `closure_parameter` with following comma
And also `next_argument` and `prev_argument` matches argument with comma

updated also for `C`, `PHP`, `Go`, `Python` languages