### PR TITLE
fix: format ErrorKind to avoid compilation error

### DIFF
--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -302,7 +302,7 @@ impl Editor {
                                     .arg(arguments.args.join(" "))
                                     .spawn()
                                     .unwrap(),
-                                e => panic!("Error to start debug console: {}", e),
+                                e => panic!("Error to start debug console: {:#?}", e),
                             })
                     } else {
                         std::process::Command::new("tmux")


### PR DESCRIPTION
On one of my machines (just one :thinking:) compiling helix on 6801b28d
yields the following error

```
error[E0277]: `ErrorKind` doesn't implement `std::fmt::Display`
   --> helix-view/src/handlers/dap.rs:305:81
    |
305 | ...                   e => panic!("Error to start debug console: {}", e),
    |                                                                       ^ `ErrorKind` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `ErrorKind`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `helix-view` due to previous error
```

This commit takes the compiler's advice and uses the pretty-print
formatter.