### PR TITLE
update tree-sitter queries and grammars for Erlang and Gleam

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1125,7 +1125,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "7159ce961592192b0e7cdf88782cda0fdf41a4cb" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "d7861b2a4b4d594c58bb4f1be5f1f4ee4c67e5c3" }
 
 [[language]]
 name = "ron"

--- a/languages.toml
+++ b/languages.toml
@@ -1047,7 +1047,7 @@ language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "3f611cfdc790214c3f9f9cf1658b3ae8039c54b8" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "6cd8f956ada445b277de1581b5328ae8e8be9aac" }
 
 [[language]]
 name = "kotlin"

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -85,6 +85,11 @@
   operator: "/"
   right: (integer) @constant.numeric.integer)
 
+((binary_operator operator: _ @keyword.operator)
+ (#match? @keyword.operator "^\\w+$"))
+((unary_operator operator: _ @keyword.operator)
+ (#match? @keyword.operator "^\\w+$"))
+
 (binary_operator operator: _ @operator)
 (unary_operator operator: _ @operator)
 ["/" ":" "#" "->"] @operator

--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -12,6 +12,8 @@
 (import alias: (identifier) @namespace)
 (remote_type_identifier
   module: (identifier) @namespace)
+(remote_constructor_name
+  module: (identifier) @namespace)
 ((field_access
   record: (identifier) @namespace
   field: (label) @function)
@@ -44,6 +46,9 @@
 ; Type names
 (remote_type_identifier) @type
 (type_identifier) @type
+
+; Data constructors
+(constructor_name) @constructor
 
 ; Literals
 (string) @string

--- a/runtime/queries/gleam/locals.scm
+++ b/runtime/queries/gleam/locals.scm
@@ -1,5 +1,5 @@
 ; Scopes
-(function_body) @local.scope
+(function) @local.scope
 
 (case_clause) @local.scope
 


### PR DESCRIPTION
The commits have the nitty-gritty details: these are some small corner-case fixes that improve the highlights for Erlang and Gleam.