### PR TITLE
Use a minimal binary to fetch grammar sources in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,9 @@ jobs:
 
       - name: Fetch tree-sitter grammars
         uses: actions-rs/cargo@v1
-        env:
-          HELIX_DISABLE_AUTO_GRAMMAR_BUILD: yes
         with:
           command: run
-          args: -- --grammar fetch
+          args: --package=helix-loader --bin=hx-loader
 
       - name: Bundle grammars
         run: tar cJf grammars.tar.xz -C runtime/grammars/sources .

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -9,6 +9,10 @@ categories = ["editor"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 
+[[bin]]
+name = "hx-loader"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
@@ -27,4 +31,3 @@ threadpool = { version = "1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.7"
-

--- a/helix-loader/src/main.rs
+++ b/helix-loader/src/main.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use helix_loader::grammar::fetch_grammars;
+
+// This binary is used in the Release CI as an optimization to cut down on
+// compilation time. This is not meant to be run manually.
+
+fn main() -> Result<()> {
+    fetch_grammars()
+}


### PR DESCRIPTION
This is an optimization for the release CI. The release CI can take
a while since it compiles release builds for all operating systems.
We cut down on duplicate work and overall time by fetching
tree-sitter grammar repositories and then using those repositories
in all later steps. Previously we built all of helix just to run

    helix_loader::grammar::fetch_grammars()

which is wasteful on time. With this change we only build the
helix-loader crate.