### PR TITLE
Add shell insert commands to typable and config

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -64,7 +64,7 @@
 | `:config-reload` | Refreshes helix's config. |
 | `:config-open` | Open the helix config.toml file. |
 | `:log-open` | Open the helix log file. |
-| `:insert-output` | Run shell command, inserting output after each selection |
-| `:append-output` | Run shell command, appending output after each selection |
+| `:insert-output` | Run shell command, inserting output after each selection. |
+| `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -64,5 +64,7 @@
 | `:config-reload` | Refreshes helix's config. |
 | `:config-open` | Open the helix config.toml file. |
 | `:log-open` | Open the helix log file. |
+| `:insert-output` | Run shell command, inserting output after each selection |
+| `:append-output` | Run shell command, appending output after each selection |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1167,6 +1167,26 @@ fn refresh_config(
     Ok(())
 }
 
+fn append_output(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    ensure!(!args.is_empty(), "Shell command required");
+    shell(cx, &args.join(" "), &ShellBehavior::Append);
+    Ok(())
+}
+
+fn insert_output(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    ensure!(!args.is_empty(), "Shell command required");
+    shell(cx, &args.join(" "), &ShellBehavior::Insert);
+    Ok(())
+}
+
 fn pipe(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -1664,6 +1684,20 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Open the helix log file.",
             fun: open_log,
+            completer: None,
+        },
+        TypableCommand {
+            name: "insert-output",
+            aliases: &[],
+            doc: "Run shell command, inserting output after each selection.",
+            fun: insert_output,
+            completer: None,
+        },
+        TypableCommand {
+            name: "append-output",
+            aliases: &[],
+            doc: "Run shell command, appending output after each selection.",
+            fun: append_output,
             completer: None,
         },
         TypableCommand {


### PR DESCRIPTION
- Add `insert-output` and `append-output` to allow for usage within command list as-well-as config files

This will allow for the example below where I am trying to create a syntax-highlighted git diff command

```
G = [ 
  ":open ~/.config/helix/temp.diff",
  "select_all",
  "delete_selection",
  ":append-output git diff"
]
```