### PR TITLE
Cleanup for runtime/tutor.txt

### DIFF
--- a/runtime/tutor.txt
+++ b/runtime/tutor.txt
@@ -20,6 +20,7 @@ _________________________________________________________________
  the first lesson.
 
 
+
 =================================================================
 =                  1.1 BASIC CURSOR MOVEMENT                    =
 =================================================================
@@ -35,10 +36,6 @@ _________________________________________________________________
  to use the hjkl keys as they are closer to the other keys you
  will be using. Try moving around to get a feel for hjkl.
  Once you're ready, hold j to continue to the next lesson.
-
-
-
-
 
 
 
@@ -60,10 +57,6 @@ _________________________________________________________________
 
 
 
-
-
-
-
 =================================================================
 =                         1.3 DELETION                          =
 =================================================================
@@ -77,12 +70,6 @@ _________________________________________________________________
  --> Thhiss senttencee haass exxtra charracterss.
 
  Once the sentence is correct, move on to the next lesson.
-
-
-
-
-
-
 
 
 
@@ -108,6 +95,8 @@ _________________________________________________________________
  Note: The status bar will display your current mode.
        Notice that when you type i, 'NOR' changes to 'INS'.
 
+
+
 =================================================================
 =                   1.5 MORE ON INSERT MODE                     =
 =================================================================
@@ -129,6 +118,8 @@ _________________________________________________________________
 
  --> This sentence is miss
      This sentence is missing some text.
+
+
 
 =================================================================
 =                      1.6 SAVING A FILE                        =
@@ -172,8 +163,6 @@ _________________________________________________________________
 
 
 
-
-
 =================================================================
 =                  2.1 MOTIONS AND SELECTIONS                   =
 =================================================================
@@ -191,8 +180,6 @@ _________________________________________________________________
  5. Repeat for all extra words in the line.
 
  --> This sentence pencil has vacuum extra words in the it.
-
-
 
 
 
@@ -239,7 +226,6 @@ _________________________________________________________________
 
 
 
-
 =================================================================
 =                   2.4 COUNTS WITH MOTIONS                     =
 =================================================================
@@ -247,18 +233,12 @@ _________________________________________________________________
  Type a number before a motion to repeat it that many times.
 
  1. Move the cursor to the line below marked -->.
-
  2. Type 2w to move 2 words forward.
-
  3. Type 3e to move to the end of the third word forward.
-
  4. Type 2b to move 2 words backwards
-
  5. Try the above with different numbers.
 
  --> This is just a line with words you can move around in.
-
-
 
 
 
@@ -283,7 +263,6 @@ _________________________________________________________________
 
 
 
-
 =================================================================
 =                         2.6 UNDOING                           =
 =================================================================
@@ -298,11 +277,6 @@ _________________________________________________________________
  6. Type U (<SHIFT> + u) several times to redo your fixes.
 
  --> Fiix the errors on thhis line and reeplace them witth undo.
-
-
-
-
-
 
 
 
@@ -326,6 +300,7 @@ _________________________________________________________________
    select the next line.
 
  * Type u to undo. Type U to redo.
+
 
 
 =================================================================
@@ -369,9 +344,6 @@ _________________________________________________________________
 
 
 
-
-
-
 =================================================================
 =                    3.3 SELECTING VIA REGEX                    =
 =================================================================
@@ -393,7 +365,6 @@ _________________________________________________________________
 
 
 
-
 =================================================================
 =                   3.4 COLLAPSING SELECTIONS                   =
 =================================================================
@@ -409,10 +380,6 @@ _________________________________________________________________
     by the motions.
 
  --> This is an error-free line with words to move around in.
-
-
-
-
 
 
 
@@ -438,6 +405,8 @@ _________________________________________________________________
  Note: Unlike Vim, Helix doesn't limit these commands to the 
        current line. It searches for the character in the file.
 
+
+
 =================================================================
 =                        CHAPTER 3 RECAP                        =
 =================================================================
@@ -453,10 +422,6 @@ _________________________________________________________________
  * Type f / F to extend selection up to & including a character.
 
  * Type t / T to extend selection until a character.
-
-
-
-
 
 
 
@@ -482,6 +447,8 @@ _________________________________________________________________
  Note: Helix doesn't share the system clipboard by default. Type
        space-y/p to yank/paste on your computer's main clipboard.
 
+
+
 =================================================================
 =                     4.2 CHANGING CASE                         =
 =================================================================
@@ -503,6 +470,8 @@ _________________________________________________________________
  --> thIs sENtencE hAs MIS-cApitalIsed leTTerS.
  --> this SENTENCE SHOULD all be in LOWERCASE.
  --> THIS sentence should ALL BE IN uppercase!
+
+
 
 =================================================================
 =                          4.3 MACROS                           =
@@ -526,6 +495,8 @@ _________________________________________________________________
  --> ... sentence doesn't have it's first and last ... .
      This sentence doesn't have it's first and last word.
 
+
+
 =================================================================
 =                        CHAPTER 4 RECAP                        =
 =================================================================
@@ -540,11 +511,6 @@ _________________________________________________________________
 
  * Type Q to record and stop recording a macro.
    * Type q to repeat the recorded macro.
-
-
-
-
-
 
 
 
@@ -565,8 +531,6 @@ _________________________________________________________________
  1. Type C-s somewhere.
  2. Move far away in the file.
  3. Type C-o (just once!) to come back to where you saved.
-
-
 
 
 
@@ -591,7 +555,6 @@ _________________________________________________________________
 
 
 
-
 =================================================================
 =                        CHAPTER 5 RECAP                        =
 =================================================================
@@ -601,16 +564,6 @@ _________________________________________________________________
 
  * Type / to search forward in file, and ? to search backwards.
    * Use n and N to cycle through search matches.
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -630,9 +583,6 @@ lines.
 
  Note: J works on all lines in selection, so typing xxx or 3x to
        select the lines and then a single J will work the same.
-
-
-
 
 
 
@@ -656,8 +606,6 @@ lines.
 
 
 
-
-
 =================================================================
 =                      6.3 OPENING LINES                        =
 =================================================================
@@ -669,14 +617,6 @@ lines.
  2. Type o to open a line below and type your answer.
 
  --> What is the best editor?
-
-
-
-
-
-
-
-
 
 
 
@@ -695,16 +635,6 @@ lines.
 
 
 
-
-
-
-
-
-
-
 =================================================================
  This tutorial is still a work-in-progress.
  More sections are planned.
-
-
-


### PR DESCRIPTION
I have noticed some inconsistencies in the [tutor.txt](../blob/master/runtime/tutor.txt) file.

For example, there are no fixed amount of lines between each section (I opted for 3).

Also, in every numbered list, each element is never separated by a new line, except for the *COUNTS WITH MOTIONS* section:
https://github.com/helix-editor/helix/blob/efae76160d19ebba2bba31ecd5c104374c7b4483/runtime/tutor.txt#L243-L259