### PR TITLE
mention the C++ compiler in the grammar build failure message

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -355,7 +355,9 @@ fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> 
         }
     }
 
-    let output = command.output().context("Failed to execute C compiler")?;
+    let output = command
+        .output()
+        .context("Failed to execute C/C++ compiler")?;
     if !output.status.success() {
         return Err(anyhow!(
             "Parser compilation failed.\nStdout: {}\nStderr: {}",


### PR DESCRIPTION
Earlier in the builder we enable C++ (`.cpp(true)`) but only mention
the C compiler in the build failure message. Some grammars that have
C++ external scanners can provoke build failures in this step if a
C++ compiler isn't installed, so mentioning it in the error message
should help out debugging.

See also https://github.com/helix-editor/helix/issues/2596#issuecomment-1140328579