### PR TITLE
Adjust colors in tokyonight themes

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -4,8 +4,12 @@
 "constant" = { fg = "orange" }
 "constant.character.escape" = { fg = "magenta" }
 "function" = { fg = "blue", modifiers = ["italic"] }
-"keyword" = { fg = "magenta" }
+"function.macro" = { fg = "cyan" }
+"keyword" = { fg = "cyan", modifiers = ["italic"] }
+"keyword.control" = { fg = "magenta" }
 "keyword.control.import" = { fg = "cyan" }
+"keyword.operator" = { fg = "turquoise" }
+"keyword.function" = { fg = "magenta", modifiers = ["italic"] }
 "operator" = { fg = "turquoise" }
 "punctuation" = { fg = "turquoise" }
 "string" = { fg = "light-green" }
@@ -14,8 +18,8 @@
 "type" = { fg = "teal" }
 "namespace" = { fg = "blue" }
 "variable" = { fg = "white" }
-"variable.builtin" = { fg = "red", modifiers = ["italic"] }
-"variable.other.member" = { fg = "magenta" }
+"variable.builtin" = { fg = "red" }
+"variable.other.member" = { fg = "green" }
 "variable.parameter" = { fg = "yellow", modifiers = ["italic"] }
 
 "diff.plus" = { fg = "green" }
@@ -38,7 +42,8 @@
 "ui.statusline.inactive" = { fg = "foreground_gutter", bg = "background_menu" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
-"ui.virtual" = { fg = "foreground_gutter" }
+"ui.virtual.ruler" = { bg = "foreground_gutter" }
+"ui.virtual.whitespace" = { fg = "foreground_gutter" }
 "ui.window" = { fg = "black" }
 
 "error" = { fg = "red" }

--- a/runtime/themes/tokyonight_storm.toml
+++ b/runtime/themes/tokyonight_storm.toml
@@ -4,8 +4,12 @@
 "constant" = { fg = "orange" }
 "constant.character.escape" = { fg = "magenta" }
 "function" = { fg = "blue", modifiers = ["italic"] }
-"keyword" = { fg = "magenta" }
+"function.macro" = { fg = "cyan" }
+"keyword" = { fg = "cyan", modifiers = ["italic"] }
+"keyword.control" = { fg = "magenta" }
 "keyword.control.import" = { fg = "cyan" }
+"keyword.operator" = { fg = "turquoise" }
+"keyword.function" = { fg = "magenta", modifiers = ["italic"] }
 "operator" = { fg = "turquoise" }
 "punctuation" = { fg = "turquoise" }
 "string" = { fg = "light-green" }
@@ -14,8 +18,8 @@
 "type" = { fg = "teal" }
 "namespace" = { fg = "blue" }
 "variable" = { fg = "white" }
-"variable.builtin" = { fg = "red", modifiers = ["italic"] }
-"variable.other.member" = { fg = "magenta" }
+"variable.builtin" = { fg = "red" }
+"variable.other.member" = { fg = "green" }
 "variable.parameter" = { fg = "yellow", modifiers = ["italic"] }
 
 "diff.plus" = { fg = "green" }
@@ -38,7 +42,8 @@
 "ui.statusline.inactive" = { fg = "foreground_gutter", bg = "background_menu" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
-"ui.virtual" = { fg = "foreground_gutter" }
+"ui.virtual.ruler" = { bg = "foreground_gutter" }
+"ui.virtual.whitespace" = { fg = "foreground_gutter" }
 "ui.window" = { fg = "black" }
 
 "error" = { fg = "red" }


### PR DESCRIPTION
Change `ui.virtual.ruler` color to `bg` instead of `fg`, correct syntax highlighting to more closely resemble the neovim theme.