### PR TITLE
Improve goto_file

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1013,7 +1013,7 @@ fn goto_file_vsplit(cx: &mut Context) {
     goto_file_impl(cx, Action::VerticalSplit);
 }
 
-fn resolve_selected_path(
+fn trim_and_resolve_path(
     selection_text: String,
     doc_path_parent: Option<&Path>,
 ) -> Option<PathBuf> {
@@ -1052,7 +1052,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         let selection_text = text
             .slice(current_word.from()..current_word.to())
             .to_string();
-        if let Some(path) = resolve_selected_path(selection_text, doc_path_parent) {
+        if let Some(path) = trim_and_resolve_path(selection_text, doc_path_parent) {
             match path.metadata() {
                 Ok(metadata) => {
                     if metadata.is_dir() {
@@ -1073,7 +1073,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         let paths: Vec<_> = selections
             .iter()
             .map(|r| text.slice(r.from()..r.to()).to_string())
-            .filter_map(|selection_text| resolve_selected_path(selection_text, doc_path_parent))
+            .filter_map(|selection_text| trim_and_resolve_path(selection_text, doc_path_parent))
             .collect();
         for path in paths {
             if let Err(e) = cx.editor.open(path, action) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1023,14 +1023,10 @@ fn trim_and_resolve_path(
     }
 
     let selected_path = PathBuf::from(trimmed);
-    match (selected_path.is_relative(), doc_path_parent) {
-        (true, Some(parent_path)) => {
-            let mut result = PathBuf::new();
-            result.push(parent_path);
-            result.push(selected_path);
-            Some(result)
-        }
-        _ => Some(selected_path),
+    if let (true, Some(parent_path)) = (selected_path.is_relative(), doc_path_parent) {
+        Some(parent_path.join(selected_path))
+    } else {
+        Some(selected_path)
     }
 }
 


### PR DESCRIPTION
- Try to resolve relative paths relative to the documents
  parent path (its directory) in case there is a path for
  the document.

In case there is only one selection of a single character:

- Use `textobject_word(.., Inside, ..)` to determine the path.

  This way you can stand on the first or last character of
  the path and it will still use this path (and not
  the previous one, in case you stood on the first character
  of the path).

- If the path points to a directory, open the file picker for
  this directory. General improvements also apply, so if the
  selected path is relative, it will also be resolved relative
  to the documents directory if possible.

This might be considered a reason to close #1701