### PR TITLE
Add support for path completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,6 +1427,8 @@ dependencies = [
  "bitflags 2.6.0",
  "dunce",
  "etcetera",
+ "once_cell",
+ "regex-automata",
  "regex-cursor",
  "ropey",
  "rustix",
@@ -2039,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2063,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ropey"

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -32,6 +32,7 @@
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
+| `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. | `250` |
 | `completion-timeout` | Time in milliseconds after typing a word character before completions are shown, set to 5 for instant.  | `250` |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -69,6 +69,7 @@ These configuration keys are available:
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `soft-wrap` | [editor.softwrap](./configuration.md#editorsoft-wrap-section)
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set, defaults to `editor.text-width`   |
+| `path-completion`     | Overrides the `editor.path-completion` config key for the language. |
 | `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. |
 | `persistent-diagnostic-sources` | An array of LSP diagnostic sources assumed unchanged when the language server resends the same set of diagnostics. Helix can track the position for these diagnostics internally instead. Useful for diagnostics that are recomputed on save.
 

--- a/helix-core/src/completion.rs
+++ b/helix-core/src/completion.rs
@@ -1,0 +1,9 @@
+use crate::Transaction;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CompletionItem {
+    pub transaction: Transaction,
+    pub label: String,
+    /// Containing Markdown
+    pub documentation: String,
+}

--- a/helix-core/src/completion.rs
+++ b/helix-core/src/completion.rs
@@ -1,9 +1,12 @@
+use std::borrow::Cow;
+
 use crate::Transaction;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CompletionItem {
     pub transaction: Transaction,
-    pub label: String,
+    pub label: Cow<'static, str>,
+    pub kind: Cow<'static, str>,
     /// Containing Markdown
     pub documentation: String,
 }

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -3,6 +3,7 @@ pub use encoding_rs as encoding;
 pub mod auto_pairs;
 pub mod chars;
 pub mod comment;
+pub mod completion;
 pub mod config;
 pub mod diagnostic;
 pub mod diff;
@@ -63,6 +64,7 @@ pub use selection::{Range, Selection};
 pub use smallvec::{smallvec, SmallVec};
 pub use syntax::Syntax;
 
+pub use completion::CompletionItem;
 pub use diagnostic::Diagnostic;
 
 pub use line_ending::{LineEnding, NATIVE_LINE_ENDING};

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -125,6 +125,9 @@ pub struct LanguageConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formatter: Option<FormatterConfiguration>,
 
+    /// If set, overrides `editor.path-completion`.
+    pub path_completion: Option<bool>,
+
     #[serde(default)]
     pub diagnostic_severity: Severity,
 

--- a/helix-event/src/cancel.rs
+++ b/helix-event/src/cancel.rs
@@ -1,19 +1,285 @@
+use std::borrow::Borrow;
 use std::future::Future;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
 
-pub use oneshot::channel as cancelation;
-use tokio::sync::oneshot;
+use tokio::sync::Notify;
 
-pub type CancelTx = oneshot::Sender<()>;
-pub type CancelRx = oneshot::Receiver<()>;
-
-pub async fn cancelable_future<T>(future: impl Future<Output = T>, cancel: CancelRx) -> Option<T> {
+pub async fn cancelable_future<T>(
+    future: impl Future<Output = T>,
+    cancel: impl Borrow<TaskHandle>,
+) -> Option<T> {
     tokio::select! {
         biased;
-        _ = cancel => {
+        _ = cancel.borrow().canceled() => {
             None
         }
         res = future => {
             Some(res)
         }
+    }
+}
+
+#[derive(Default, Debug)]
+struct Shared {
+    state: AtomicU64,
+    // notify has some features that we don't really need here because it
+    // supports waking single tasks (notify_one) and does it's own (more
+    // complicated) state tracking, we could reimplement the waiter linked list
+    // with modest effort and reduce memory consumption by one word/8 bytes and
+    // reduce code complexity/number of atomic operations.
+    //
+    // I don't think that's worth the complexity (unsafe code).
+    //
+    // if we only cared about async code then we could also only use a notify
+    // (without the generation count), this would be equivalent (or maybe more
+    // correct if we want to allow cloning the TX) but it would be extremly slow
+    // to frequently check for cancelation from sync code
+    notify: Notify,
+}
+
+impl Shared {
+    fn generation(&self) -> u32 {
+        self.state.load(Relaxed) as u32
+    }
+
+    fn num_running(&self) -> u32 {
+        (self.state.load(Relaxed) >> 32) as u32
+    }
+
+    /// increments the generation count and sets num_running
+    /// to the provided value, this operation is not with
+    /// regard to the generation counter (doesn't use fetch_add)
+    /// so the calling code must ensure it cannot execute concurrently
+    /// to maintain correctness (but not safety)
+    fn inc_generation(&self, num_running: u32) -> (u32, u32) {
+        let state = self.state.load(Relaxed);
+        let generation = state as u32;
+        let prev_running = (state >> 32) as u32;
+        // no need to create a new generation if the refcount is zero (fastaph)
+        if prev_running == 0 && num_running == 0 {
+            return (generation, 0);
+        }
+        let new_generation = generation.saturating_add(1);
+        self.state.store(
+            new_generation as u64 | ((num_running as u64) << 32),
+            Relaxed,
+        );
+        self.notify.notify_waiters();
+        (new_generation, prev_running)
+    }
+
+    fn inc_running(&self, generation: u32) {
+        let mut state = self.state.load(Relaxed);
+        loop {
+            let current_generation = state as u32;
+            if current_generation != generation {
+                break;
+            }
+            let off = 1 << 32;
+            let res = self.state.compare_exchange_weak(
+                state,
+                state.saturating_add(off),
+                Relaxed,
+                Relaxed,
+            );
+            match res {
+                Ok(_) => break,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+
+    fn dec_running(&self, generation: u32) {
+        let mut state = self.state.load(Relaxed);
+        loop {
+            let current_generation = state as u32;
+            if current_generation != generation {
+                break;
+            }
+            let num_running = (state >> 32) as u32;
+            // running can't be zero here, that would mean we misscounted somewhere
+            assert_ne!(num_running, 0);
+            let off = 1 << 32;
+            let res = self
+                .state
+                .compare_exchange_weak(state, state - off, Relaxed, Relaxed);
+            match res {
+                Ok(_) => break,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+}
+
+// this intentionally doesn't implement clone and requires amutable reference
+// for cancelation to avoid races (in inc_generation)
+
+/// A task controller allows managing a single subtask enabling the contorller
+/// to cancel the subtask and to check wether it is still running. For efficency
+/// reasons the controller can be reused/restarted, in that case the previous
+/// task is automatically cancelled.
+///
+/// If the controller is dropped the subtasks are automatically canceled.
+#[derive(Default, Debug)]
+pub struct TaskController {
+    shared: Arc<Shared>,
+}
+
+impl TaskController {
+    pub fn new() -> Self {
+        TaskController::default()
+    }
+    /// Cancels the active task (handle)
+    ///
+    /// returns wether any tasks were still running before the canellation
+    pub fn cancel(&mut self) -> bool {
+        self.shared.inc_generation(0).1 != 0
+    }
+
+    /// checks wether there are any task handles
+    /// that haven't been dropped (or canceled) yet
+    pub fn is_running(&self) -> bool {
+        self.shared.num_running() != 0
+    }
+
+    /// Starts a new task and cancels the previous task (handles)
+    pub fn restart(&mut self) -> TaskHandle {
+        TaskHandle {
+            generation: self.shared.inc_generation(1).0,
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl Drop for TaskController {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+/// A handle that is used to link a task with a task controller, it can be
+/// used to cancel async futures very efficently but can also be checked for
+/// cancaellation very quickly (single atomic read) in blocking code. The
+/// handle can be cheaply cloned (referenced counted).
+///
+/// The TaskController can check wether a task is "running" by inspecting the
+/// refcount of the (current) tasks handeles. Therefore, if that information
+/// is important ensure that the handle is not dropped until the task fully
+/// completes
+pub struct TaskHandle {
+    shared: Arc<Shared>,
+    generation: u32,
+}
+
+impl Clone for TaskHandle {
+    fn clone(&self) -> Self {
+        self.shared.inc_running(self.generation);
+        TaskHandle {
+            shared: self.shared.clone(),
+            generation: self.generation,
+        }
+    }
+}
+
+impl Drop for TaskHandle {
+    fn drop(&mut self) {
+        self.shared.dec_running(self.generation);
+    }
+}
+
+impl TaskHandle {
+    /// waits until [`TaskController::cancel`] is called for the corresponding
+    /// [`TaskController`]. Immidietly returns if `cancel` was already called since
+    pub async fn canceled(&self) {
+        let notified = self.shared.notify.notified();
+        if !self.is_canceled() {
+            notified.await
+        }
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        self.generation != self.shared.generation()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::poll_fn;
+
+    use futures_executor::block_on;
+    use tokio::task::yield_now;
+
+    use crate::{cancelable_future, TaskController};
+
+    #[test]
+    fn immidiate_cancel() {
+        let mut controller = TaskController::new();
+        let handle = controller.restart();
+        controller.cancel();
+        assert!(handle.is_canceled());
+        controller.restart();
+        assert!(handle.is_canceled());
+
+        let res = block_on(cancelable_future(
+            poll_fn(|_cx| std::task::Poll::Ready(())),
+            handle,
+        ));
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn running_count() {
+        let mut controller = TaskController::new();
+        let handle = controller.restart();
+        assert!(controller.is_running());
+        assert!(!handle.is_canceled());
+        drop(handle);
+        assert!(!controller.is_running());
+        assert!(!controller.cancel());
+        let handle = controller.restart();
+        assert!(!handle.is_canceled());
+        assert!(controller.is_running());
+        let handle2 = handle.clone();
+        assert!(!handle.is_canceled());
+        assert!(controller.is_running());
+        drop(handle2);
+        assert!(!handle.is_canceled());
+        assert!(controller.is_running());
+        assert!(controller.cancel());
+        assert!(handle.is_canceled());
+        assert!(!controller.is_running());
+    }
+
+    #[test]
+    fn no_cancel() {
+        let mut controller = TaskController::new();
+        let handle = controller.restart();
+        assert!(!handle.is_canceled());
+
+        let res = block_on(cancelable_future(
+            poll_fn(|_cx| std::task::Poll::Ready(())),
+            handle,
+        ));
+        assert!(res.is_some());
+    }
+
+    #[test]
+    fn delayed_cancel() {
+        let mut controller = TaskController::new();
+        let handle = controller.restart();
+
+        let mut hit = false;
+        let res = block_on(cancelable_future(
+            async {
+                controller.cancel();
+                hit = true;
+                yield_now().await;
+            },
+            handle,
+        ));
+        assert!(res.is_none());
+        assert!(hit);
     }
 }

--- a/helix-event/src/lib.rs
+++ b/helix-event/src/lib.rs
@@ -32,7 +32,7 @@
 //! to helix-view in the future if we manage to detach the compositor from its rendering backend.
 
 use anyhow::Result;
-pub use cancel::{cancelable_future, cancelation, CancelRx, CancelTx};
+pub use cancel::{cancelable_future, TaskController, TaskHandle};
 pub use debounce::{send_blocking, AsyncHook};
 pub use redraw::{
     lock_frame, redraw_requested, request_redraw, start_frame, RenderLockGuard, RequestRedrawOnDrop,

--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -18,6 +18,8 @@ ropey = { version = "1.6.1", default-features = false }
 which = "6.0"
 regex-cursor = "0.1.4"
 bitflags = "2.6"
+once_cell = "1.19"
+regex-automata = "0.4.8"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -1,8 +1,11 @@
 use std::{
-    ffi::OsStr,
+    borrow::Cow,
+    ffi::{OsStr, OsString},
     path::{Path, PathBuf},
     sync::RwLock,
 };
+
+use once_cell::sync::Lazy;
 
 static CWD: RwLock<Option<PathBuf>> = RwLock::new(None);
 
@@ -59,6 +62,93 @@ pub fn which<T: AsRef<OsStr>>(
     })
 }
 
+fn find_brace_end(src: &[u8]) -> Option<usize> {
+    use regex_automata::meta::Regex;
+
+    static REGEX: Lazy<Regex> = Lazy::new(|| Regex::builder().build("[{}]").unwrap());
+    let mut depth = 0;
+    for mat in REGEX.find_iter(src) {
+        let pos = mat.start();
+        match src[pos] {
+            b'{' => depth += 1,
+            b'}' if depth == 0 => return Some(pos),
+            b'}' => depth -= 1,
+            _ => unreachable!(),
+        }
+    }
+    None
+}
+
+fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>) -> Cow<OsStr> {
+    use regex_automata::meta::Regex;
+
+    static REGEX: Lazy<Regex> = Lazy::new(|| {
+        Regex::builder()
+            .build_many(&[
+                r"\$\{([^\}:]+):-",
+                r"\$\{([^\}:]+):=",
+                r"\$\{([^\}-]+)-",
+                r"\$\{([^\}=]+)=",
+                r"\$\{([^\}]+)",
+                r"\$(\w+)",
+            ])
+            .unwrap()
+    });
+
+    let bytes = src.as_encoded_bytes();
+    let mut res = Vec::with_capacity(bytes.len());
+    let mut pos = 0;
+    for captures in REGEX.captures_iter(bytes) {
+        let mat = captures.get_match().unwrap();
+        let pattern_id = mat.pattern().as_usize();
+        let mut range = mat.range();
+        let var = &bytes[captures.get_group(1).unwrap().range()];
+        let default = if pattern_id != 5 {
+            let Some(bracket_pos) = find_brace_end(&bytes[range.end..]) else {
+                break;
+            };
+            let default = &bytes[range.end..range.end + bracket_pos];
+            range.end += bracket_pos + 1;
+            default
+        } else {
+            &[]
+        };
+        // safety: this is a codepoint aligned substring of an osstr (always valid)
+        let var = unsafe { OsStr::from_encoded_bytes_unchecked(var) };
+        let expansion = resolve(var);
+        let expansion = match &expansion {
+            Some(val) => {
+                if val.is_empty() && pattern_id < 2 {
+                    default
+                } else {
+                    val.as_encoded_bytes()
+                }
+            }
+            None => default,
+        };
+        res.extend_from_slice(&bytes[pos..range.start]);
+        pos = range.end;
+        res.extend_from_slice(expansion);
+    }
+    if pos == 0 {
+        src.into()
+    } else {
+        res.extend_from_slice(&bytes[pos..]);
+        // safety: this is a composition of valid osstr (and codepoint aligned slices which are also valid)
+        unsafe { OsString::from_encoded_bytes_unchecked(res) }.into()
+    }
+}
+
+/// performs substitution of enviorment variables. Supports the following (POSIX) syntax:
+///
+/// * `$<var>`, `${<var>}`
+/// * `${<var>:-<default>}`, `${<var>-<default>}`
+/// * `${<var>:=<default>}`, `${<var>=default}`
+///
+pub fn expand<S: AsRef<OsStr> + ?Sized>(src: &S) -> Cow<OsStr> {
+    expand_impl(src.as_ref(), |var| std::env::var_os(var))
+}
+
 #[derive(Debug)]
 pub struct ExecutableNotFoundError {
     command: String,
@@ -75,7 +165,9 @@ impl std::error::Error for ExecutableNotFoundError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{current_working_dir, set_current_working_dir};
+    use std::ffi::{OsStr, OsString};
+
+    use super::{current_working_dir, expand_impl, set_current_working_dir};
 
     #[test]
     fn current_dir_is_set() {
@@ -87,5 +179,35 @@ mod tests {
 
         let cwd = current_working_dir();
         assert_eq!(cwd, new_path);
+    }
+
+    macro_rules! assert_env_expand {
+        ($env: expr, $lhs: expr, $rhs: expr) => {
+            assert_eq!(&*expand_impl($lhs.as_ref(), $env), OsStr::new($rhs));
+        };
+    }
+
+    /// paths that should work on all platforms
+    #[test]
+    fn test_env_expand() {
+        let env = |var: &OsStr| -> Option<OsString> {
+            match var.to_str().unwrap() {
+                "FOO" => Some("foo".into()),
+                "EMPTY" => Some("".into()),
+                _ => None,
+            }
+        };
+        assert_env_expand!(env, "pass_trough", "pass_trough");
+        assert_env_expand!(env, "$FOO", "foo");
+        assert_env_expand!(env, "bar/$FOO/baz", "bar/foo/baz");
+        assert_env_expand!(env, "bar/${FOO}/baz", "bar/foo/baz");
+        assert_env_expand!(env, "baz/${BAR:-bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${BAR:=bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${BAR-bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${BAR=bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${EMPTY:-bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${EMPTY:=bar}/foo", "baz/bar/foo");
+        assert_env_expand!(env, "baz/${EMPTY-bar}/foo", "baz//foo");
+        assert_env_expand!(env, "baz/${EMPTY=bar}/foo", "baz//foo");
     }
 }

--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -1,8 +1,12 @@
 pub use etcetera::home_dir;
+use once_cell::sync::Lazy;
+use regex_cursor::{engines::meta::Regex, Input};
+use ropey::RopeSlice;
 
 use std::{
     borrow::Cow,
     ffi::OsString,
+    ops::Range,
     path::{Component, Path, PathBuf, MAIN_SEPARATOR_STR},
 };
 
@@ -201,6 +205,97 @@ pub fn get_truncated_path(path: impl AsRef<Path>) -> PathBuf {
     ret
 }
 
+fn path_comonent_regex(windows: bool) -> String {
+    // TODO: support backslash path escape on windows (when using git bash for example)
+    let space_escape = if windows { r"[\^`]\s" } else { r"[\\]\s" };
+    // partially baesd on what's allowed in an url but with some care to avoid
+    // false positivies (like any kind of brackets or quotes)
+    r"[\w@.\-+#$%?!,;~&]|".to_owned() + space_escape
+}
+
+/// regex for delimeted enviorment captures like `${HOME}`
+fn braced_env_regex(windows: bool) -> String {
+    // use
+    r"\$\{(?:".to_owned() + &path_comonent_regex(windows) + r"|[/:=])+\}"
+}
+
+fn compile_path_regex(
+    prefix: &str,
+    postfix: &str,
+    match_single_file: bool,
+    windows: bool,
+) -> Regex {
+    let first_component = format!(
+        "(?:{}|(?:{}))",
+        braced_env_regex(windows),
+        path_comonent_regex(windows)
+    );
+    // for all components except the first we allow an equals so that `foo=/
+    // bar/baz` does not include foo this is primarily inteded for url queries
+    // (where an equals is never in the first component)
+    let component = format!("(?:{first_component}|=)");
+    let sep = if windows { r"[/\\]" } else { "/" };
+    let url_prefix = r"[\w+\-.]+://??";
+    let path_prefix = if windows {
+        // single slash handles most windows prefixes (like\\server\...) but `\
+        // \?\C:\..` (and C:\) needs a specical since we don't allow : in path
+        // components (so that colon seperted paths and <path>:<line> work)
+        r"\\\\\?\\\w:|\w:|\\|"
+    } else {
+        ""
+    };
+    let path_start = format!("(?:{first_component}+|~|{path_prefix}{url_prefix})");
+    let optional = if match_single_file {
+        format!("|{path_start}")
+    } else {
+        String::new()
+    };
+    let path_regex = format!(
+        "{prefix}(?:{path_start}?(?:(?:{sep}{component}+)+{sep}?|{sep}){optional}){postfix}"
+    );
+    Regex::new(&path_regex).unwrap()
+}
+
+/// if `src` ends with a path then this function returns the part of the slice
+pub fn get_path_suffix(src: RopeSlice<'_>, match_single_file: bool) -> Option<RopeSlice<'_>> {
+    let regex = if match_single_file {
+        static REGEX: Lazy<Regex> = Lazy::new(|| compile_path_regex("", "$", true, cfg!(windows)));
+        &*REGEX
+    } else {
+        static REGEX: Lazy<Regex> = Lazy::new(|| compile_path_regex("", "$", false, cfg!(windows)));
+        &*REGEX
+    };
+
+    regex
+        .find(Input::new(src))
+        .map(|mat| src.byte_slice(mat.range()))
+}
+
+/// returns an iterator of the **byte** ranges in src that contain a path
+pub fn find_paths(
+    src: RopeSlice<'_>,
+    match_single_file: bool,
+) -> impl Iterator<Item = Range<usize>> + '_ {
+    let regex = if match_single_file {
+        static REGEX: Lazy<Regex> = Lazy::new(|| compile_path_regex("", "", true, cfg!(windows)));
+        &*REGEX
+    } else {
+        static REGEX: Lazy<Regex> = Lazy::new(|| compile_path_regex("", "", false, cfg!(windows)));
+        &*REGEX
+    };
+    regex.find_iter(Input::new(src)).map(|mat| mat.range())
+}
+
+/// performs substitution of `~` and enviorment variables, see [`env::expand`](crate::env::expand) and [`expand_tilde`]
+pub fn expand<T: AsRef<Path> + ?Sized>(path: &T) -> Cow<'_, Path> {
+    let path = path.as_ref();
+    let path = expand_tilde(path);
+    match crate::env::expand(&*path) {
+        Cow::Borrowed(_) => path,
+        Cow::Owned(path) => PathBuf::from(path).into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -208,7 +303,10 @@ mod tests {
         path::{Component, Path},
     };
 
-    use crate::path;
+    use regex_cursor::Input;
+    use ropey::RopeSlice;
+
+    use crate::path::{self, compile_path_regex};
 
     #[test]
     fn expand_tilde() {
@@ -226,6 +324,129 @@ mod tests {
 
             // The path was at least expanded to something.
             assert_ne!(component_count, 0);
+        }
+    }
+
+    macro_rules! assert_match {
+        ($regex: expr, $haystack: expr) => {
+            let haystack = Input::new(RopeSlice::from($haystack));
+            assert!(
+                $regex.is_match(haystack),
+                "regex should match {}",
+                $haystack
+            );
+        };
+    }
+    macro_rules! assert_no_match {
+        ($regex: expr, $haystack: expr) => {
+            let haystack = Input::new(RopeSlice::from($haystack));
+            assert!(
+                !$regex.is_match(haystack),
+                "regex should not match {}",
+                $haystack
+            );
+        };
+    }
+
+    macro_rules! assert_matches {
+        ($regex: expr, $haystack: expr, [$($matches: expr),*]) => {
+            let src = $haystack;
+            let matches: Vec<_> = $regex
+                .find_iter(Input::new(RopeSlice::from(src)))
+                .map(|it| &src[it.range()])
+                .collect();
+            assert_eq!(matches, vec![$($matches),*]);
+        };
+    }
+
+    /// linux-only path
+    #[test]
+    fn path_regex_unix() {
+        // due to ambigueity with the \ path seperator we can't support space escapes `\ ` on windows
+        let regex = compile_path_regex("^", "$", false, false);
+        assert_match!(regex, "${FOO}/hello\\ world");
+        assert_match!(regex, "${FOO}/\\ ");
+    }
+
+    /// windows-only paths
+    #[test]
+    fn path_regex_windows() {
+        let regex = compile_path_regex("^", "$", false, true);
+        assert_match!(regex, "${FOO}/hello^ world");
+        assert_match!(regex, "${FOO}/hello` world");
+        assert_match!(regex, "${FOO}/^ ");
+        assert_match!(regex, "${FOO}/` ");
+        assert_match!(regex, r"foo\bar");
+        assert_match!(regex, r"foo\bar");
+        assert_match!(regex, r"..\bar");
+        assert_match!(regex, r"..\");
+        assert_match!(regex, r"C:\");
+        assert_match!(regex, r"\\?\C:\foo");
+        assert_match!(regex, r"\\server\foo");
+    }
+
+    /// paths that should work on all platforms
+    #[test]
+    fn path_regex() {
+        for windows in [false, true] {
+            let regex = compile_path_regex("^", "$", false, windows);
+            assert_no_match!(regex, "foo");
+            assert_no_match!(regex, "");
+            assert_match!(regex, "https://github.com/notifications/query=foo");
+            assert_match!(regex, "file:///foo/bar");
+            assert_match!(regex, "foo/bar");
+            assert_match!(regex, "$HOME/foo");
+            assert_match!(regex, "${FOO:-bar}/baz");
+            assert_match!(regex, "foo/bar_");
+            assert_match!(regex, "/home/bar");
+            assert_match!(regex, "foo/");
+            assert_match!(regex, "./");
+            assert_match!(regex, "../");
+            assert_match!(regex, "../..");
+            assert_match!(regex, "./foo");
+            assert_match!(regex, "./foo.rs");
+            assert_match!(regex, "/");
+            assert_match!(regex, "~/");
+            assert_match!(regex, "~/foo");
+            assert_match!(regex, "~/foo");
+            assert_match!(regex, "~/foo/../baz");
+            assert_match!(regex, "${HOME}/foo");
+            assert_match!(regex, "$HOME/foo");
+            assert_match!(regex, "/$FOO");
+            assert_match!(regex, "/${FOO}");
+            assert_match!(regex, "/${FOO}/${BAR}");
+            assert_match!(regex, "/${FOO}/${BAR}/foo");
+            assert_match!(regex, "/${FOO}/${BAR}");
+            assert_match!(regex, "${FOO}/hello_$WORLD");
+            assert_match!(regex, "${FOO}/hello_${WORLD}");
+            let regex = compile_path_regex("", "", false, windows);
+            assert_no_match!(regex, "");
+            assert_matches!(
+                regex,
+                r#"${FOO}/hello_${WORLD}  ${FOO}/hello_${WORLD} foo("./bar", "/home/foo")""#,
+                [
+                    "${FOO}/hello_${WORLD}",
+                    "${FOO}/hello_${WORLD}",
+                    "./bar",
+                    "/home/foo"
+                ]
+            );
+            assert_matches!(
+                regex,
+                r#"--> helix-stdx/src/path.rs:427:13"#,
+                ["helix-stdx/src/path.rs"]
+            );
+            assert_matches!(
+                regex,
+                r#"PATH=/foo/bar:/bar/baz:${foo:-/foo}/bar:${PATH}"#,
+                ["/foo/bar", "/bar/baz", "${foo:-/foo}/bar"]
+            );
+            let regex = compile_path_regex("^", "$", true, windows);
+            assert_no_match!(regex, "");
+            assert_match!(regex, "foo");
+            assert_match!(regex, "foo/");
+            assert_match!(regex, "$FOO");
+            assert_match!(regex, "${BAR}");
         }
     }
 }

--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -51,7 +51,7 @@ where
 
 /// Normalize a path without resolving symlinks.
 // Strategy: start from the first component and move up. Cannonicalize previous path,
-// join component, cannonicalize new path, strip prefix and join to the final result.
+// join component, canonicalize new path, strip prefix and join to the final result.
 pub fn normalize(path: impl AsRef<Path>) -> PathBuf {
     let mut components = path.as_ref().components().peekable();
     let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
-use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ::url::Url;
 use arc_swap::ArcSwap;
 use futures_util::future::BoxFuture;
 use futures_util::stream::FuturesUnordered;
@@ -16,12 +18,11 @@ use helix_event::{
 };
 use helix_lsp::lsp;
 use helix_lsp::util::pos_to_lsp_pos;
-use helix_stdx::path::{canonicalize, fold_home_dir};
-use helix_stdx::rope::{self, RopeSliceExt};
+use helix_stdx::path::{self, canonicalize, fold_home_dir, get_path_suffix};
+use helix_stdx::rope::RopeSliceExt;
 use helix_view::document::{Mode, SavePoint};
 use helix_view::handlers::lsp::CompletionEvent;
 use helix_view::{DocumentId, Editor, ViewId};
-use once_cell::sync::Lazy;
 use tokio::sync::mpsc::Sender;
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
@@ -311,75 +312,42 @@ fn path_completion(
         return None;
     }
 
-    // TODO find a good regex for most use cases (especially Windows, which is not yet covered...)
-    // currently only one path match per line is possible in unix
-    static PATH_REGEX: Lazy<rope::Regex> =
-        Lazy::new(|| rope::Regex::new(r"((?:~|\$HOME|\$\{HOME\})?(?:\.{0,2}/)+.*)$").unwrap());
-
     let cur_line = text.char_to_line(cursor);
     let start = text.line_to_char(cur_line).max(cursor.saturating_sub(1000));
-    let line_until_cursor = text.slice(start..cursor).regex_input_at(..);
+    let line_until_cursor = text.slice(start..cursor);
 
-    let (dir_path, typed_file_name) = PATH_REGEX.search(line_until_cursor).and_then(|m| {
-        let start_byte = text.char_to_byte(start);
-        let matched_path = &text
-            .byte_slice((start_byte + m.start())..(start_byte + m.end()))
-            .to_string();
-
-        // resolve home dir (~/, $HOME/, ${HOME}/) on unix
-        #[cfg(unix)]
-        let mut path = {
-            static HOME_DIR: Lazy<Option<OsString>> = Lazy::new(|| std::env::var_os("HOME"));
-
-            let home_resolved_path = if let Some(home) = &*HOME_DIR {
-                let first_separator_after_home = if matched_path.starts_with("~/") {
-                    Some(1)
-                } else if matched_path.starts_with("$HOME") {
-                    Some(5)
-                } else if matched_path.starts_with("${HOME}") {
-                    Some(7)
-                } else {
-                    None
-                };
-                if let Some(start_char) = first_separator_after_home {
-                    let mut path = home.to_owned();
-                    path.push(&matched_path[start_char..]);
-                    path
-                } else {
-                    matched_path.into()
-                }
+    let (dir_path, typed_file_name) =
+        get_path_suffix(line_until_cursor, false).and_then(|matched_path| {
+            let matched_path = Cow::from(matched_path);
+            let path: Cow<_> = if matched_path.starts_with("file://") {
+                Url::from_str(&matched_path)
+                    .ok()
+                    .and_then(|url| url.to_file_path().ok())?
+                    .into()
             } else {
-                matched_path.into()
+                Path::new(&*matched_path).into()
             };
-            PathBuf::from(home_resolved_path)
-        };
-        #[cfg(not(unix))]
-        let mut path = PathBuf::from(matched_path);
-
-        if path.is_relative() {
-            if let Some(doc_path) = doc.path().and_then(|dp| dp.parent()) {
-                path = doc_path.join(path);
-            } else if let Ok(work_dir) = std::env::current_dir() {
-                path = work_dir.join(path);
+            let path = path::expand(&path);
+            let parent_dir = doc.path().and_then(|dp| dp.parent());
+            let path = match parent_dir {
+                Some(parent_dir) if path.is_absolute() => parent_dir.join(&path),
+                _ => path.into_owned(),
+            };
+            let ends_with_slash = matches!(matched_path.as_bytes().last(), Some(b'/' | b'\\'));
+            // check if there are chars after the last slash, and if these chars represent a directory
+            match std::fs::metadata(path.clone()).ok() {
+                Some(m) if m.is_dir() && ends_with_slash => {
+                    Some((PathBuf::from(path.as_path()), None))
+                }
+                _ if !ends_with_slash => path.parent().map(|parent_path| {
+                    (
+                        PathBuf::from(parent_path),
+                        path.file_name().and_then(|f| f.to_str().map(String::from)),
+                    )
+                }),
+                _ => None,
             }
-        }
-        let ends_with_slash = match matched_path.chars().last() {
-            Some(std::path::MAIN_SEPARATOR) => true,
-            None => return None,
-            _ => false,
-        };
-        // check if there are chars after the last slash, and if these chars represent a directory
-        match std::fs::metadata(path.clone()).ok() {
-            Some(m) if m.is_dir() && ends_with_slash => Some((PathBuf::from(path.as_path()), None)),
-            _ if !ends_with_slash => path.parent().map(|parent_path| {
-                (
-                    PathBuf::from(parent_path),
-                    path.file_name().and_then(|f| f.to_str().map(String::from)),
-                )
-            }),
-            _ => None,
-        }
-    })?;
+        })?;
 
     // The async file accessor functions of tokio were considered, but they were a bit slower
     // and less ergonomic than just using the std functions in a separate "thread"

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -397,20 +396,7 @@ fn path_completion(
 
         read_dir
             .filter_map(Result::ok)
-            .filter_map(|dir_entry| {
-                let path = dir_entry.path();
-                // check if <chars> in <path>/<chars><cursor> matches the start of the filename
-                let filename_starts_with_prefix =
-                    match (path.file_name().and_then(OsStr::to_str), &typed_file_name) {
-                        (Some(re_stem), Some(t)) => re_stem.starts_with(t),
-                        _ => true,
-                    };
-                if filename_starts_with_prefix {
-                    dir_entry.metadata().ok().map(|md| (path, md))
-                } else {
-                    None
-                }
-            })
+            .filter_map(|dir_entry| dir_entry.metadata().ok().map(|md| (dir_entry.path(), md)))
             .map(|(path, md)| {
                 let file_name = path
                     .file_name()

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -493,7 +493,7 @@ fn path_completion(
                     #[cfg(not(unix))]
                     {
                         format!(
-                            "type: `{path_kind}`\n\
+                            "type: `{kind}`\n\
                              {resolved}full path: `{full_path_name}`",
                         )
                     }

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -1,31 +1,26 @@
-use std::borrow::Cow;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ::url::Url;
 use arc_swap::ArcSwap;
-use futures_util::future::BoxFuture;
 use futures_util::stream::FuturesUnordered;
 use futures_util::FutureExt;
 use helix_core::chars::char_is_word;
 use helix_core::syntax::LanguageServerFeature;
-use helix_core::Transaction;
 use helix_event::{
     cancelable_future, cancelation, register_hook, send_blocking, CancelRx, CancelTx,
 };
 use helix_lsp::lsp;
 use helix_lsp::util::pos_to_lsp_pos;
-use helix_stdx::path::{self, canonicalize, fold_home_dir, get_path_suffix};
 use helix_stdx::rope::RopeSliceExt;
 use helix_view::document::{Mode, SavePoint};
 use helix_view::handlers::lsp::CompletionEvent;
 use helix_view::{DocumentId, Editor, ViewId};
+use path::path_completion;
 use tokio::sync::mpsc::Sender;
 use tokio::time::Instant;
-use tokio_stream::StreamExt;
+use tokio_stream::StreamExt as _;
 
 use crate::commands;
 use crate::compositor::Compositor;
@@ -35,10 +30,13 @@ use crate::job::{dispatch, dispatch_blocking};
 use crate::keymap::MappableCommand;
 use crate::ui::editor::InsertEvent;
 use crate::ui::lsp::SignatureHelp;
-use crate::ui::{self, CompletionItem, LspCompletionItem, PathCompletionItem, PathKind, Popup};
+use crate::ui::{self, Popup};
 
 use super::Handlers;
+pub use item::{CompletionItem, LspCompletionItem};
 pub use resolve::ResolveHandler;
+mod item;
+mod path;
 mod resolve;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -204,6 +202,7 @@ fn request_completion(
     // necessary from our side too.
     trigger.pos = cursor;
     let trigger_text = text.slice(..cursor);
+    let cancel_completion = Arc::new(AtomicBool::new(false));
 
     let mut seen_language_servers = HashSet::new();
     let mut futures: FuturesUnordered<_> = doc
@@ -271,7 +270,12 @@ fn request_completion(
             }
             .boxed()
         })
-        .chain(path_completion(cursor, text.clone(), doc))
+        .chain(path_completion(
+            cursor,
+            text.clone(),
+            doc,
+            cancel_completion.clone(),
+        ))
         .collect();
 
     let future = async move {
@@ -292,7 +296,13 @@ fn request_completion(
     let ui = compositor.find::<ui::EditorView>().unwrap();
     ui.last_insert.1.push(InsertEvent::RequestCompletion);
     tokio::spawn(async move {
-        let items = cancelable_future(future, cancel).await.unwrap_or_default();
+        let items = match cancelable_future(future, cancel).await {
+            Some(v) => v,
+            None => {
+                cancel_completion.store(true, std::sync::atomic::Ordering::Relaxed);
+                Vec::new()
+            }
+        };
         if items.is_empty() {
             return;
         }
@@ -301,167 +311,6 @@ fn request_completion(
         })
         .await
     });
-}
-
-fn path_completion(
-    cursor: usize,
-    text: helix_core::Rope,
-    doc: &helix_view::Document,
-) -> Option<BoxFuture<'static, anyhow::Result<Vec<CompletionItem>>>> {
-    if !doc.supports_path_completion() {
-        return None;
-    }
-
-    let cur_line = text.char_to_line(cursor);
-    let start = text.line_to_char(cur_line).max(cursor.saturating_sub(1000));
-    let line_until_cursor = text.slice(start..cursor);
-
-    let (dir_path, typed_file_name) =
-        get_path_suffix(line_until_cursor, false).and_then(|matched_path| {
-            let matched_path = Cow::from(matched_path);
-            let path: Cow<_> = if matched_path.starts_with("file://") {
-                Url::from_str(&matched_path)
-                    .ok()
-                    .and_then(|url| url.to_file_path().ok())?
-                    .into()
-            } else {
-                Path::new(&*matched_path).into()
-            };
-            let path = path::expand(&path);
-            let parent_dir = doc.path().and_then(|dp| dp.parent());
-            let path = match parent_dir {
-                Some(parent_dir) if path.is_absolute() => parent_dir.join(&path),
-                _ => path.into_owned(),
-            };
-            let ends_with_slash = matches!(matched_path.as_bytes().last(), Some(b'/' | b'\\'));
-            // check if there are chars after the last slash, and if these chars represent a directory
-            match std::fs::metadata(path.clone()).ok() {
-                Some(m) if m.is_dir() && ends_with_slash => {
-                    Some((PathBuf::from(path.as_path()), None))
-                }
-                _ if !ends_with_slash => path.parent().map(|parent_path| {
-                    (
-                        PathBuf::from(parent_path),
-                        path.file_name().and_then(|f| f.to_str().map(String::from)),
-                    )
-                }),
-                _ => None,
-            }
-        })?;
-
-    // The async file accessor functions of tokio were considered, but they were a bit slower
-    // and less ergonomic than just using the std functions in a separate "thread"
-    let future = tokio::task::spawn_blocking(move || {
-        let Ok(read_dir) = std::fs::read_dir(&dir_path) else {
-            return Vec::new();
-        };
-
-        read_dir
-            .filter_map(Result::ok)
-            .filter_map(|dir_entry| dir_entry.metadata().ok().map(|md| (dir_entry.path(), md)))
-            .map(|(path, md)| {
-                let file_name = path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-
-                let full_path = fold_home_dir(canonicalize(path));
-                let full_path_name = full_path.to_string_lossy();
-
-                let kind = if md.is_symlink() {
-                    PathKind::Link
-                } else if md.is_dir() {
-                    PathKind::Folder
-                } else {
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::FileTypeExt;
-                        if md.file_type().is_block_device() {
-                            PathKind::Block
-                        } else if md.file_type().is_socket() {
-                            PathKind::Socket
-                        } else if md.file_type().is_char_device() {
-                            PathKind::CharacterDevice
-                        } else if md.file_type().is_fifo() {
-                            PathKind::Fifo
-                        } else {
-                            PathKind::File
-                        }
-                    }
-                    #[cfg(not(unix))]
-                    PathKind::File
-                };
-
-                let documentation = {
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::prelude::PermissionsExt;
-                        let mode = md.permissions().mode();
-
-                        let perms = [
-                            (libc::S_IRUSR, 'r'),
-                            (libc::S_IWUSR, 'w'),
-                            (libc::S_IXUSR, 'x'),
-                            (libc::S_IRGRP, 'r'),
-                            (libc::S_IWGRP, 'w'),
-                            (libc::S_IXGRP, 'x'),
-                            (libc::S_IROTH, 'r'),
-                            (libc::S_IWOTH, 'w'),
-                            (libc::S_IXOTH, 'x'),
-                        ]
-                        .into_iter()
-                        .fold(
-                            String::with_capacity(9),
-                            |mut acc, (p, s)| {
-                                // This cast is necessary on some platforms such as macos as `mode_t` is u16 there
-                                #[allow(clippy::unnecessary_cast)]
-                                acc.push(if mode & (p as u32) > 0 { s } else { '-' });
-                                acc
-                            },
-                        );
-
-                        // TODO it would be great to be able to individually color the documentation,
-                        // but this will likely require a custom doc implementation (i.e. not `lsp::Documentation`)
-                        // and/or different rendering in completion.rs
-                        format!(
-                            "type: `{kind}`\n\
-                             permissions: `[{perms}]`\n\
-                             full path: `{full_path_name}`",
-                        )
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        format!(
-                            "type: `{kind}`\n\
-                             full path: `{full_path_name}`",
-                        )
-                    }
-                };
-
-                let edit_diff = typed_file_name
-                    .as_ref()
-                    .map(|f| f.len())
-                    .unwrap_or_default();
-
-                let transaction = Transaction::change(
-                    &text,
-                    std::iter::once((cursor - edit_diff, cursor, Some(file_name.as_str().into()))),
-                );
-
-                CompletionItem::Path(PathCompletionItem {
-                    kind,
-                    item: helix_core::CompletionItem {
-                        transaction,
-                        label: file_name,
-                        documentation,
-                    },
-                })
-            })
-            .collect::<Vec<_>>()
-    });
-
-    Some(async move { Ok(future.await?) }.boxed())
 }
 
 fn show_completion(
@@ -520,8 +369,11 @@ pub fn trigger_auto_completion(
                     }) if triggers.iter().any(|trigger| text.ends_with(trigger)))
         });
 
-    let trigger_path_completion =
-        text.ends_with(std::path::MAIN_SEPARATOR_STR) && doc.supports_path_completion();
+    let trigger_path_completion = matches!(
+        text.get_bytes_at(text.len_bytes())
+            .and_then(|t| t.reversed().next()),
+        Some(b'/' | b'\\')
+    ) && doc.path_completion_enabled();
 
     if is_trigger_char || trigger_path_completion {
         send_blocking(

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -390,7 +390,7 @@ fn path_completion(
     // The async file accessor functions of tokio were considered, but they were a bit slower
     // and less ergonomic than just using the std functions in a separate "thread"
     let future = tokio::task::spawn_blocking(move || {
-        let Some(read_dir) = std::fs::read_dir(&dir_path).ok() else {
+        let Ok(read_dir) = std::fs::read_dir(&dir_path) else {
             return Vec::new();
         };
 
@@ -485,7 +485,7 @@ fn path_completion(
                     }
                 };
 
-                let edit_diff = typed_file_name.as_ref().map(|f| f.len()).unwrap_or(0);
+                let edit_diff = typed_file_name.as_ref().map(|f| f.len()).unwrap_or_default();
 
                 let transaction = Transaction::change(
                     &text,

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -468,7 +468,10 @@ fn path_completion(
                     }
                 };
 
-                let edit_diff = typed_file_name.as_ref().map(|f| f.len()).unwrap_or_default();
+                let edit_diff = typed_file_name
+                    .as_ref()
+                    .map(|f| f.len())
+                    .unwrap_or_default();
 
                 let transaction = Transaction::change(
                     &text,

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -321,7 +321,10 @@ fn path_completion(
     let line_until_cursor = text.slice(start..cursor).regex_input_at(..);
 
     let (dir_path, typed_file_name) = PATH_REGEX.search(line_until_cursor).and_then(|m| {
-        let matched_path = &text.byte_slice(m.start()..m.end()).to_string();
+        let start_byte = text.char_to_byte(start);
+        let matched_path = &text
+            .byte_slice((start_byte + m.start())..(start_byte + m.end()))
+            .to_string();
 
         // resolve home dir (~/, $HOME/, ${HOME}/) on unix
         #[cfg(unix)]

--- a/helix-term/src/handlers/completion/item.rs
+++ b/helix-term/src/handlers/completion/item.rs
@@ -39,5 +39,3 @@ impl CompletionItem {
         }
     }
 }
-
-

--- a/helix-term/src/handlers/completion/item.rs
+++ b/helix-term/src/handlers/completion/item.rs
@@ -1,0 +1,43 @@
+use helix_lsp::{lsp, LanguageServerId};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct LspCompletionItem {
+    pub item: lsp::CompletionItem,
+    pub provider: LanguageServerId,
+    pub resolved: bool,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum CompletionItem {
+    Lsp(LspCompletionItem),
+    Other(helix_core::CompletionItem),
+}
+
+impl PartialEq<CompletionItem> for LspCompletionItem {
+    fn eq(&self, other: &CompletionItem) -> bool {
+        match other {
+            CompletionItem::Lsp(other) => self == other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<CompletionItem> for helix_core::CompletionItem {
+    fn eq(&self, other: &CompletionItem) -> bool {
+        match other {
+            CompletionItem::Other(other) => self == other,
+            _ => false,
+        }
+    }
+}
+
+impl CompletionItem {
+    pub fn preselect(&self) -> bool {
+        match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => item.preselect.unwrap_or(false),
+            CompletionItem::Other(_) => false,
+        }
+    }
+}
+
+

--- a/helix-term/src/handlers/completion/path.rs
+++ b/helix-term/src/handlers/completion/path.rs
@@ -1,0 +1,186 @@
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+    str::FromStr as _,
+    sync::{atomic::AtomicBool, Arc},
+};
+
+use futures_util::{future::BoxFuture, FutureExt as _};
+use helix_core as core;
+use helix_core::Transaction;
+use helix_stdx::path::{self, canonicalize, fold_home_dir, get_path_suffix};
+use helix_view::Document;
+use url::Url;
+
+use super::item::CompletionItem;
+
+pub(crate) fn path_completion(
+    cursor: usize,
+    text: core::Rope,
+    doc: &Document,
+    cancel: Arc<AtomicBool>,
+) -> Option<BoxFuture<'static, anyhow::Result<Vec<CompletionItem>>>> {
+    if !doc.path_completion_enabled() {
+        return None;
+    }
+
+    let cur_line = text.char_to_line(cursor);
+    let start = text.line_to_char(cur_line).max(cursor.saturating_sub(1000));
+    let line_until_cursor = text.slice(start..cursor);
+
+    let (dir_path, typed_file_name) =
+        get_path_suffix(line_until_cursor, false).and_then(|matched_path| {
+            let matched_path = Cow::from(matched_path);
+            let path: Cow<_> = if matched_path.starts_with("file://") {
+                Url::from_str(&matched_path)
+                    .ok()
+                    .and_then(|url| url.to_file_path().ok())?
+                    .into()
+            } else {
+                Path::new(&*matched_path).into()
+            };
+            let path = path::expand(&path);
+            let parent_dir = doc.path().and_then(|dp| dp.parent());
+            let path = match parent_dir {
+                Some(parent_dir) if path.is_relative() => parent_dir.join(&path),
+                _ => path.into_owned(),
+            };
+            let ends_with_slash = matches!(matched_path.as_bytes().last(), Some(b'/' | b'\\'));
+            if ends_with_slash {
+                Some((PathBuf::from(path.as_path()), None))
+            } else {
+                path.parent().map(|parent_path| {
+                    (
+                        PathBuf::from(parent_path),
+                        path.file_name().and_then(|f| f.to_str().map(String::from)),
+                    )
+                })
+            }
+        })?;
+
+    if cancel.load(std::sync::atomic::Ordering::Relaxed) {
+        return None;
+    }
+
+    // The async file accessor functions of tokio were considered, but they were a bit slower
+    // and less ergonomic than just using the std functions in a separate "thread"
+    let future = tokio::task::spawn_blocking(move || {
+        let Ok(read_dir) = std::fs::read_dir(&dir_path) else {
+            return Vec::new();
+        };
+
+        if cancel.load(std::sync::atomic::Ordering::Relaxed) {
+            return Vec::new();
+        }
+
+        read_dir
+            .filter_map(Result::ok)
+            .filter_map(|dir_entry| {
+                dir_entry
+                    .metadata()
+                    .ok()
+                    .map(|md| (dir_entry.file_name(), md))
+            })
+            .map_while(|(file_name, md)| {
+                if cancel.load(std::sync::atomic::Ordering::Relaxed) {
+                    return None;
+                }
+
+                let file_name_str = file_name.to_string_lossy().to_string();
+
+                let full_path = fold_home_dir(canonicalize(dir_path.join(file_name)));
+                let full_path_name = full_path.to_string_lossy();
+
+                let kind = if md.is_symlink() {
+                    "link"
+                } else if md.is_dir() {
+                    "folder"
+                } else {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::FileTypeExt;
+                        if md.file_type().is_block_device() {
+                            "block"
+                        } else if md.file_type().is_socket() {
+                            "socket"
+                        } else if md.file_type().is_char_device() {
+                            "char_device"
+                        } else if md.file_type().is_fifo() {
+                            "fifo"
+                        } else {
+                            "file"
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    "file"
+                };
+                let kind = Cow::Borrowed(kind);
+
+                let documentation = {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::prelude::PermissionsExt;
+                        let mode = md.permissions().mode();
+
+                        let perms = [
+                            (libc::S_IRUSR, 'r'),
+                            (libc::S_IWUSR, 'w'),
+                            (libc::S_IXUSR, 'x'),
+                            (libc::S_IRGRP, 'r'),
+                            (libc::S_IWGRP, 'w'),
+                            (libc::S_IXGRP, 'x'),
+                            (libc::S_IROTH, 'r'),
+                            (libc::S_IWOTH, 'w'),
+                            (libc::S_IXOTH, 'x'),
+                        ]
+                        .into_iter()
+                        .fold(
+                            String::with_capacity(9),
+                            |mut acc, (p, s)| {
+                                // This cast is necessary on some platforms such as macos as `mode_t` is u16 there
+                                #[allow(clippy::unnecessary_cast)]
+                                acc.push(if mode & (p as u32) > 0 { s } else { '-' });
+                                acc
+                            },
+                        );
+
+                        // TODO it would be great to be able to individually color the documentation,
+                        // but this will likely require a custom doc implementation (i.e. not `lsp::Documentation`)
+                        // and/or different rendering in completion.rs
+                        format!(
+                            "type: `{kind}`\n\
+                             permissions: `[{perms}]`\n\
+                             full path: `{full_path_name}`",
+                        )
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        format!(
+                            "type: `{kind}`\n\
+                             full path: `{full_path_name}`",
+                        )
+                    }
+                };
+
+                let edit_diff = typed_file_name
+                    .as_ref()
+                    .map(|f| f.len())
+                    .unwrap_or_default();
+
+                let transaction = Transaction::change(
+                    &text,
+                    std::iter::once((cursor - edit_diff, cursor, Some((&file_name_str).into()))),
+                );
+
+                Some(CompletionItem::Other(core::CompletionItem {
+                    kind,
+                    transaction,
+                    label: file_name_str.into(),
+                    documentation,
+                }))
+            })
+            .collect::<Vec<_>>()
+    });
+
+    Some(async move { Ok(future.await?) }.boxed())
+}

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -4,7 +4,7 @@ use helix_lsp::lsp;
 use tokio::sync::mpsc::Sender;
 use tokio::time::{Duration, Instant};
 
-use helix_event::{send_blocking, AsyncHook, CancelRx};
+use helix_event::{send_blocking, AsyncHook, TaskController, TaskHandle};
 use helix_view::Editor;
 
 use super::LspCompletionItem;
@@ -31,11 +31,7 @@ impl ResolveHandler {
     pub fn new() -> ResolveHandler {
         ResolveHandler {
             last_request: None,
-            resolver: ResolveTimeout {
-                next_request: None,
-                in_flight: None,
-            }
-            .spawn(),
+            resolver: ResolveTimeout::default().spawn(),
         }
     }
 
@@ -101,7 +97,8 @@ struct ResolveRequest {
 #[derive(Default)]
 struct ResolveTimeout {
     next_request: Option<ResolveRequest>,
-    in_flight: Option<(helix_event::CancelTx, Arc<LspCompletionItem>)>,
+    in_flight: Option<Arc<LspCompletionItem>>,
+    task_controller: TaskController,
 }
 
 impl AsyncHook for ResolveTimeout {
@@ -121,7 +118,7 @@ impl AsyncHook for ResolveTimeout {
         } else if self
             .in_flight
             .as_ref()
-            .is_some_and(|(_, old_request)| old_request.item == request.item.item)
+            .is_some_and(|old_request| old_request.item == request.item.item)
         {
             self.next_request = None;
             None
@@ -135,14 +132,14 @@ impl AsyncHook for ResolveTimeout {
         let Some(request) = self.next_request.take() else {
             return;
         };
-        let (tx, rx) = helix_event::cancelation();
-        self.in_flight = Some((tx, request.item.clone()));
-        tokio::spawn(request.execute(rx));
+        let token = self.task_controller.restart();
+        self.in_flight = Some(request.item.clone());
+        tokio::spawn(request.execute(token));
     }
 }
 
 impl ResolveRequest {
-    async fn execute(self, cancel: CancelRx) {
+    async fn execute(self, cancel: TaskHandle) {
         let future = self.ls.resolve_completion_item(&self.item.item);
         let Some(resolved_item) = helix_event::cancelable_future(future, cancel).await else {
             return;

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -23,17 +23,8 @@ use crate::ui::LspCompletionItem;
 /// > 'completionItem/resolve' request is sent with the selected completion item as a parameter.
 /// > The returned completion item should have the documentation property filled in.
 pub struct ResolveHandler {
-    last_request: Option<Arc<CompletionItem>>,
+    last_request: Option<Arc<LspCompletionItem>>,
     resolver: Sender<ResolveRequest>,
-}
-
-macro_rules! lsp_variant {
-    ($item: expr) => {
-        match $item {
-            CompletionItem::Lsp(item) => item,
-            _ => unreachable!("This should always be an lsp completion item"),
-        }
-    };
 }
 
 impl ResolveHandler {
@@ -48,12 +39,8 @@ impl ResolveHandler {
         }
     }
 
-    /// # Panics
-    /// When the item is not a `CompletionItem::Lsp(_)`
-    pub fn ensure_item_resolved(&mut self, editor: &mut Editor, item: &mut CompletionItem) {
-        let lsp_item = lsp_variant!(item);
-
-        if lsp_item.resolved {
+    pub fn ensure_item_resolved(&mut self, editor: &mut Editor, item: &mut LspCompletionItem) {
+        if item.resolved {
             return;
         }
         // We consider an item to be fully resolved if it has non-empty, none-`None` details,
@@ -61,7 +48,7 @@ impl ResolveHandler {
         // check but some language servers send values like `Some([])` for additional text
         // edits although the items need to be resolved. This is probably a consequence of
         // how `null` works in the JavaScript world.
-        let is_resolved = lsp_item
+        let is_resolved = item
             .item
             .documentation
             .as_ref()
@@ -69,31 +56,25 @@ impl ResolveHandler {
                 lsp::Documentation::String(text) => !text.is_empty(),
                 lsp::Documentation::MarkupContent(markup) => !markup.value.is_empty(),
             })
-            && lsp_item
+            && item
                 .item
                 .detail
                 .as_ref()
                 .is_some_and(|detail| !detail.is_empty())
-            && lsp_item
+            && item
                 .item
                 .additional_text_edits
                 .as_ref()
                 .is_some_and(|edits| !edits.is_empty());
         if is_resolved {
-            lsp_item.resolved = true;
+            item.resolved = true;
             return;
         }
         if self.last_request.as_deref().is_some_and(|it| it == item) {
             return;
         }
-
-        let lsp_item = lsp_variant!(item);
-        let Some(ls) = editor
-            .language_servers
-            .get_by_id(lsp_item.provider)
-            .cloned()
-        else {
-            lsp_item.resolved = true;
+        let Some(ls) = editor.language_servers.get_by_id(item.provider).cloned() else {
+            item.resolved = true;
             return;
         };
         if matches!(
@@ -107,20 +88,20 @@ impl ResolveHandler {
             self.last_request = Some(item.clone());
             send_blocking(&self.resolver, ResolveRequest { item, ls })
         } else {
-            lsp_item.resolved = true;
+            item.resolved = true;
         }
     }
 }
 
 struct ResolveRequest {
-    item: Arc<CompletionItem>,
+    item: Arc<LspCompletionItem>,
     ls: Arc<helix_lsp::Client>,
 }
 
 #[derive(Default)]
 struct ResolveTimeout {
     next_request: Option<ResolveRequest>,
-    in_flight: Option<(helix_event::CancelTx, Arc<CompletionItem>)>,
+    in_flight: Option<(helix_event::CancelTx, Arc<LspCompletionItem>)>,
 }
 
 impl AsyncHook for ResolveTimeout {
@@ -140,7 +121,7 @@ impl AsyncHook for ResolveTimeout {
         } else if self
             .in_flight
             .as_ref()
-            .is_some_and(|(_, old_request)| *old_request == request.item)
+            .is_some_and(|(_, old_request)| old_request.item == request.item.item)
         {
             self.next_request = None;
             None
@@ -162,9 +143,7 @@ impl AsyncHook for ResolveTimeout {
 
 impl ResolveRequest {
     async fn execute(self, cancel: CancelRx) {
-        let lsp_item = &lsp_variant!(&*self.item).item;
-
-        let future = self.ls.resolve_completion_item(lsp_item);
+        let future = self.ls.resolve_completion_item(&self.item.item);
         let Some(resolved_item) = helix_event::cancelable_future(future, cancel).await else {
             return;
         };
@@ -174,22 +153,22 @@ impl ResolveRequest {
                 .unwrap()
                 .completion
             {
-                let resolved_item = match resolved_item {
-                    Ok(item) => CompletionItem::Lsp(LspCompletionItem {
+                let resolved_item = CompletionItem::Lsp(match resolved_item {
+                    Ok(item) => LspCompletionItem {
                         item,
-                        provider: lsp_variant!(&*self.item).provider,
                         resolved: true,
-                    }),
+                        ..*self.item
+                    },
                     Err(err) => {
                         log::error!("completion resolve request failed: {err}");
                         // set item to resolved so we don't request it again
                         // we could also remove it but that oculd be odd ui
                         let mut item = (*self.item).clone();
-                        lsp_variant!(&mut item).resolved = true;
+                        item.resolved = true;
                         item
                     }
-                };
-                completion.replace_item(&self.item, resolved_item);
+                });
+                completion.replace_item(&*self.item, resolved_item);
             };
         })
         .await

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -7,9 +7,9 @@ use tokio::time::{Duration, Instant};
 use helix_event::{send_blocking, AsyncHook, CancelRx};
 use helix_view::Editor;
 
+use super::LspCompletionItem;
 use crate::handlers::completion::CompletionItem;
 use crate::job;
-use super::LspCompletionItem;
 
 /// A hook for resolving incomplete completion items.
 ///

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -9,7 +9,7 @@ use helix_view::Editor;
 
 use crate::handlers::completion::CompletionItem;
 use crate::job;
-use crate::ui::LspCompletionItem;
+use super::LspCompletionItem;
 
 /// A hook for resolving incomplete completion items.
 ///

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -9,6 +9,7 @@ use helix_view::Editor;
 
 use crate::handlers::completion::CompletionItem;
 use crate::job;
+use crate::ui::LspCompletionItem;
 
 /// A hook for resolving incomplete completion items.
 ///
@@ -22,7 +23,7 @@ use crate::job;
 /// > 'completionItem/resolve' request is sent with the selected completion item as a parameter.
 /// > The returned completion item should have the documentation property filled in.
 pub struct ResolveHandler {
-    last_request: Option<Arc<CompletionItem>>,
+    last_request: Option<Arc<LspCompletionItem>>,
     resolver: Sender<ResolveRequest>,
 }
 
@@ -38,7 +39,7 @@ impl ResolveHandler {
         }
     }
 
-    pub fn ensure_item_resolved(&mut self, editor: &mut Editor, item: &mut CompletionItem) {
+    pub fn ensure_item_resolved(&mut self, editor: &mut Editor, item: &mut LspCompletionItem) {
         if item.resolved {
             return;
         }
@@ -93,14 +94,14 @@ impl ResolveHandler {
 }
 
 struct ResolveRequest {
-    item: Arc<CompletionItem>,
+    item: Arc<LspCompletionItem>,
     ls: Arc<helix_lsp::Client>,
 }
 
 #[derive(Default)]
 struct ResolveTimeout {
     next_request: Option<ResolveRequest>,
-    in_flight: Option<(helix_event::CancelTx, Arc<CompletionItem>)>,
+    in_flight: Option<(helix_event::CancelTx, Arc<LspCompletionItem>)>,
 }
 
 impl AsyncHook for ResolveTimeout {
@@ -152,8 +153,8 @@ impl ResolveRequest {
                 .unwrap()
                 .completion
             {
-                let resolved_item = match resolved_item {
-                    Ok(item) => CompletionItem {
+                let resolved_item = CompletionItem::Lsp(match resolved_item {
+                    Ok(item) => LspCompletionItem {
                         item,
                         resolved: true,
                         ..*self.item
@@ -166,8 +167,9 @@ impl ResolveRequest {
                         item.resolved = true;
                         item
                     }
-                };
-                completion.replace_item(&self.item, resolved_item);
+                });
+                let old_item = CompletionItem::Lsp((*self.item).clone());
+                completion.replace_item(&old_item, resolved_item);
             };
         })
         .await

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -155,6 +155,24 @@ pub enum CompletionItem {
     Path(PathCompletionItem),
 }
 
+impl PartialEq<CompletionItem> for LspCompletionItem {
+    fn eq(&self, other: &CompletionItem) -> bool {
+        match other {
+            CompletionItem::Lsp(other) => self == other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<CompletionItem> for PathCompletionItem {
+    fn eq(&self, other: &CompletionItem) -> bool {
+        match other {
+            CompletionItem::Path(other) => self == other,
+            _ => false,
+        }
+    }
+}
+
 impl CompletionItem {
     pub fn preselect(&self) -> bool {
         match self {
@@ -505,7 +523,11 @@ impl Completion {
         self.popup.contents().is_empty()
     }
 
-    pub fn replace_item(&mut self, old_item: &CompletionItem, new_item: CompletionItem) {
+    pub fn replace_item(
+        &mut self,
+        old_item: &impl PartialEq<CompletionItem>,
+        new_item: CompletionItem,
+    ) {
         self.popup.contents_mut().replace_option(old_item, new_item);
     }
 
@@ -531,7 +553,7 @@ impl Component for Completion {
             Some(option) => option,
             None => return,
         };
-        if let CompletionItem::Lsp(_) = option {
+        if let CompletionItem::Lsp(option) = option {
             self.resolve_handler.ensure_item_resolved(cx.editor, option);
         }
         // need to render:

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -91,7 +91,7 @@ impl menu::Item for CompletionItem {
             CompletionItem::Path(PathCompletionItem { kind, .. }) => kind.as_str(),
         };
 
-        menu::Row::new(vec![
+        menu::Row::new([
             menu::Cell::from(Span::styled(
                 label,
                 if deprecated {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -28,30 +28,35 @@ impl menu::Item for CompletionItem {
 
     #[inline]
     fn filter_text(&self, _data: &Self::Data) -> Cow<str> {
-        self.item
-            .filter_text
-            .as_ref()
-            .unwrap_or(&self.item.label)
-            .as_str()
-            .into()
+        match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => item
+                .filter_text
+                .as_ref()
+                .unwrap_or(&item.label)
+                .as_str()
+                .into(),
+            CompletionItem::Path(PathCompletionItem { item, .. }) => Cow::from(&item.label),
+        }
     }
 
     fn format(&self, _data: &Self::Data) -> menu::Row {
-        let deprecated = self.item.deprecated.unwrap_or_default()
-            || self.item.tags.as_ref().map_or(false, |tags| {
-                tags.contains(&lsp::CompletionItemTag::DEPRECATED)
-            });
+        let deprecated = match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => {
+                item.deprecated.unwrap_or_default()
+                    || item.tags.as_ref().map_or(false, |tags| {
+                        tags.contains(&lsp::CompletionItemTag::DEPRECATED)
+                    })
+            }
+            CompletionItem::Path(_) => false,
+        };
 
-        menu::Row::new(vec![
-            menu::Cell::from(Span::styled(
-                self.item.label.as_str(),
-                if deprecated {
-                    Style::default().add_modifier(Modifier::CROSSED_OUT)
-                } else {
-                    Style::default()
-                },
-            )),
-            menu::Cell::from(match self.item.kind {
+        let label = match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => &item.label,
+            CompletionItem::Path(PathCompletionItem { item, .. }) => &item.label,
+        };
+
+        let kind = match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => match item.kind {
                 Some(lsp::CompletionItemKind::TEXT) => "text",
                 Some(lsp::CompletionItemKind::METHOD) => "method",
                 Some(lsp::CompletionItemKind::FUNCTION) => "function",
@@ -82,16 +87,81 @@ impl menu::Item for CompletionItem {
                     ""
                 }
                 None => "",
-            }),
+            },
+            CompletionItem::Path(PathCompletionItem { kind, .. }) => kind.as_str(),
+        };
+
+        menu::Row::new(vec![
+            menu::Cell::from(Span::styled(
+                label,
+                if deprecated {
+                    Style::default().add_modifier(Modifier::CROSSED_OUT)
+                } else {
+                    Style::default()
+                },
+            )),
+            menu::Cell::from(kind),
         ])
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone)]
-pub struct CompletionItem {
+#[derive(Debug, PartialEq, Clone)]
+pub enum PathKind {
+    Folder,
+    File,
+    Link,
+    Block,
+    Socket,
+    CharacterDevice,
+    Fifo,
+}
+
+impl PathKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            PathKind::Folder => "folder",
+            PathKind::File => "file",
+            PathKind::Link => "link",
+            PathKind::Block => "block",
+            PathKind::Socket => "socket",
+            PathKind::CharacterDevice => "char_device",
+            PathKind::Fifo => "fifo",
+        }
+    }
+}
+
+impl std::fmt::Display for PathKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct LspCompletionItem {
     pub item: lsp::CompletionItem,
     pub provider: LanguageServerId,
     pub resolved: bool,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct PathCompletionItem {
+    pub kind: PathKind,
+    pub item: helix_core::CompletionItem,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum CompletionItem {
+    Lsp(LspCompletionItem),
+    Path(PathCompletionItem),
+}
+
+impl CompletionItem {
+    pub fn preselect(&self) -> bool {
+        match self {
+            CompletionItem::Lsp(LspCompletionItem { item, .. }) => item.preselect.unwrap_or(false),
+            CompletionItem::Path(_) => false,
+        }
+    }
 }
 
 /// Wraps a Menu.
@@ -115,11 +185,11 @@ impl Completion {
         let preview_completion_insert = editor.config().preview_completion_insert;
         let replace_mode = editor.config().completion_replace;
         // Sort completion items according to their preselect status (given by the LSP server)
-        items.sort_by_key(|item| !item.item.preselect.unwrap_or(false));
+        items.sort_by_key(|item| !item.preselect());
 
         // Then create the menu
         let menu = Menu::new(items, (), move |editor: &mut Editor, item, event| {
-            fn item_to_transaction(
+            fn lsp_item_to_transaction(
                 doc: &Document,
                 view_id: ViewId,
                 item: &lsp::CompletionItem,
@@ -257,16 +327,23 @@ impl Completion {
                     // always present here
                     let item = item.unwrap();
 
-                    let transaction = item_to_transaction(
-                        doc,
-                        view.id,
-                        &item.item,
-                        language_server!(item).offset_encoding(),
-                        trigger_offset,
-                        true,
-                        replace_mode,
-                    );
-                    doc.apply_temporary(&transaction, view.id);
+                    match item {
+                        CompletionItem::Lsp(item) => doc.apply_temporary(
+                            &lsp_item_to_transaction(
+                                doc,
+                                view.id,
+                                &item.item,
+                                language_server!(item).offset_encoding(),
+                                trigger_offset,
+                                true,
+                                replace_mode,
+                            ),
+                            view.id,
+                        ),
+                        CompletionItem::Path(PathCompletionItem { item, .. }) => {
+                            doc.apply_temporary(&item.transaction, view.id)
+                        }
+                    };
                 }
                 PromptEvent::Update => {}
                 PromptEvent::Validate => {
@@ -275,32 +352,62 @@ impl Completion {
                     {
                         doc.restore(view, &savepoint, false);
                     }
-                    // always present here
-                    let mut item = item.unwrap().clone();
 
-                    let language_server = language_server!(item);
-                    let offset_encoding = language_server.offset_encoding();
-
-                    if !item.resolved {
-                        if let Some(resolved) =
-                            Self::resolve_completion_item(language_server, item.item.clone())
-                        {
-                            item.item = resolved;
-                        }
-                    };
                     // if more text was entered, remove it
                     doc.restore(view, &savepoint, true);
                     // save an undo checkpoint before the completion
                     doc.append_changes_to_history(view);
-                    let transaction = item_to_transaction(
-                        doc,
-                        view.id,
-                        &item.item,
-                        offset_encoding,
-                        trigger_offset,
-                        false,
-                        replace_mode,
-                    );
+
+                    // item always present here
+                    let (mut transaction, additional_edits) = match item.unwrap().clone() {
+                        CompletionItem::Lsp(mut item) => {
+                            let language_server = language_server!(item);
+
+                            // resolve item if not yet resolved
+                            if !item.resolved {
+                                if let Some(resolved_item) = Self::resolve_completion_item(
+                                    language_server,
+                                    item.item.clone(),
+                                ) {
+                                    item.item = resolved_item;
+                                }
+                            };
+
+                            let encoding = language_server.offset_encoding();
+                            (
+                                lsp_item_to_transaction(
+                                    doc,
+                                    view.id,
+                                    &item.item,
+                                    encoding,
+                                    trigger_offset,
+                                    false,
+                                    replace_mode,
+                                ),
+                                item.item.additional_text_edits.map(|e| (e, encoding)),
+                            )
+                        }
+                        CompletionItem::Path(PathCompletionItem { item, .. }) => {
+                            (item.transaction, None)
+                        }
+                    };
+
+                    if let Some((additional_edits, offset_encoding)) = additional_edits {
+                        if !additional_edits.is_empty() {
+                            // use the selection of the completion, instead of the (empty) one from the additional text edits
+                            let selection = transaction.selection().cloned();
+                            transaction =
+                                transaction.compose(util::generate_transaction_from_edits(
+                                    doc.text(),
+                                    additional_edits,
+                                    offset_encoding, // TODO: should probably transcode in Client
+                                ));
+                            if let Some(selection) = selection {
+                                transaction = transaction.with_selection(selection);
+                            }
+                        }
+                    }
+
                     doc.apply(&transaction, view.id);
 
                     editor.last_completion = Some(CompleteAction::Applied {
@@ -308,17 +415,6 @@ impl Completion {
                         changes: completion_changes(&transaction, trigger_offset),
                     });
 
-                    // TODO: add additional _edits to completion_changes?
-                    if let Some(additional_edits) = item.item.additional_text_edits {
-                        if !additional_edits.is_empty() {
-                            let transaction = util::generate_transaction_from_edits(
-                                doc.text(),
-                                additional_edits,
-                                offset_encoding, // TODO: should probably transcode in Client
-                            );
-                            doc.apply(&transaction, view.id);
-                        }
-                    }
                     // we could have just inserted a trigger char (like a `crate::` completion for rust
                     // so we want to retrigger immediately when accepting a completion.
                     trigger_auto_completion(&editor.handlers.completions, editor, true);
@@ -440,7 +536,7 @@ impl Component for Completion {
             Some(option) => option,
             None => return,
         };
-        if !option.resolved {
+        if let CompletionItem::Lsp(option) = option {
             self.resolve_handler.ensure_item_resolved(cx.editor, option);
         }
         // need to render:
@@ -465,27 +561,32 @@ impl Component for Completion {
             Markdown::new(md, cx.editor.syn_loader.clone())
         };
 
-        let mut markdown_doc = match &option.item.documentation {
-            Some(lsp::Documentation::String(contents))
-            | Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
-                kind: lsp::MarkupKind::PlainText,
-                value: contents,
-            })) => {
-                // TODO: convert to wrapped text
-                markdowned(language, option.item.detail.as_deref(), Some(contents))
+        let mut markdown_doc = match option {
+            CompletionItem::Lsp(option) => match &option.item.documentation {
+                Some(lsp::Documentation::String(contents))
+                | Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
+                    kind: lsp::MarkupKind::PlainText,
+                    value: contents,
+                })) => {
+                    // TODO: convert to wrapped text
+                    markdowned(language, option.item.detail.as_deref(), Some(contents))
+                }
+                Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
+                    kind: lsp::MarkupKind::Markdown,
+                    value: contents,
+                })) => {
+                    // TODO: set language based on doc scope
+                    markdowned(language, option.item.detail.as_deref(), Some(contents))
+                }
+                None if option.item.detail.is_some() => {
+                    // TODO: set language based on doc scope
+                    markdowned(language, option.item.detail.as_deref(), None)
+                }
+                None => return,
+            },
+            CompletionItem::Path(option) => {
+                markdowned(language, None, Some(&option.item.documentation))
             }
-            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
-                kind: lsp::MarkupKind::Markdown,
-                value: contents,
-            })) => {
-                // TODO: set language based on doc scope
-                markdowned(language, option.item.detail.as_deref(), Some(contents))
-            }
-            None if option.item.detail.is_some() => {
-                // TODO: set language based on doc scope
-                markdowned(language, option.item.detail.as_deref(), None)
-            }
-            None => return,
         };
 
         let popup_area = self.popup.area(area, cx.editor);

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -55,7 +55,7 @@ impl menu::Item for CompletionItem {
 
         let label = match self {
             CompletionItem::Lsp(LspCompletionItem { item, .. }) => item.label.as_str(),
-            CompletionItem::Other(core::CompletionItem { label, .. }) => &label,
+            CompletionItem::Other(core::CompletionItem { label, .. }) => label,
         };
 
         let kind = match self {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -2,13 +2,14 @@ use crate::{
     commands::{self, OnKeyCallback},
     compositor::{Component, Context, Event, EventResult},
     events::{OnModeSwitch, PostCommand},
+    handlers::completion::CompletionItem,
     key,
     keymap::{KeymapResult, Keymaps},
     ui::{
         document::{render_document, LinePos, TextRenderer},
         statusline,
         text_decorations::{self, Decoration, DecorationManager, InlineDiagnostics},
-        Completion, CompletionItem, ProgressSpinners,
+        Completion, ProgressSpinners,
     },
 };
 

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -228,7 +228,7 @@ impl<T: Item> Menu<T> {
 }
 
 impl<T: Item + PartialEq> Menu<T> {
-    pub fn replace_option(&mut self, old_option: &T, new_option: T) {
+    pub fn replace_option(&mut self, old_option: &impl PartialEq<T>, new_option: T) {
         for option in &mut self.options {
             if old_option == option {
                 *option = new_option;

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -17,7 +17,7 @@ mod text_decorations;
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
-pub use completion::{Completion, CompletionItem};
+pub use completion::{Completion, CompletionItem, LspCompletionItem, PathCompletionItem, PathKind};
 pub use editor::EditorView;
 use helix_stdx::rope;
 pub use markdown::Markdown;

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -17,7 +17,7 @@ mod text_decorations;
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
-pub use completion::{Completion, CompletionItem, LspCompletionItem, PathCompletionItem, PathKind};
+pub use completion::Completion;
 pub use editor::EditorView;
 use helix_stdx::rope;
 pub use markdown::Markdown;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1713,6 +1713,12 @@ impl Document {
         self.version
     }
 
+    pub fn supports_path_completion(&self) -> bool {
+        self.language_config()
+            .and_then(|lang_config| lang_config.path_completion)
+            .unwrap_or_else(|| self.config.load().path_completion)
+    }
+
     /// maintains the order as configured in the language_servers TOML array
     pub fn language_servers(&self) -> impl Iterator<Item = &helix_lsp::Client> {
         self.language_config().into_iter().flat_map(move |config| {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1713,7 +1713,7 @@ impl Document {
         self.version
     }
 
-    pub fn supports_path_completion(&self) -> bool {
+    pub fn path_completion_enabled(&self) -> bool {
         self.language_config()
             .and_then(|lang_config| lang_config.path_completion)
             .unwrap_or_else(|| self.config.load().path_completion)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -267,6 +267,11 @@ pub struct Config {
     pub auto_pairs: AutoPairConfig,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
     pub auto_completion: bool,
+    /// Enable filepath completion.
+    /// Show files and directories if an existing path at the cursor was recognized,
+    /// either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved).
+    /// Defaults to true.
+    pub path_completion: bool,
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
     /// Automatic save on focus lost and/or after delay.
@@ -944,6 +949,7 @@ impl Default for Config {
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
+            path_completion: true,
             auto_format: true,
             auto_save: AutoSave::default(),
             idle_timeout: Duration::from_millis(250),


### PR DESCRIPTION
This PR adds support for path completion.

It supports the following:

* Autocompletion is triggered with `/`.
* Documentation preview (file permissions, canonicalized path).
* shell expansion (e.g. `~/path`, `$HOME/path`, `${HOME}/path`)
* Async (via `spawn_blocking` instead of tokios file accessor functions, as they IMHO make the code less readable and are quite a bit slower than just spawning a "thread")
* Configurable with `editor.path-completion` (default `true`), per-language overrideable path-completion support
* Refactors `goto_file` with a new more robust path-detection/resolution mechanism and also adds shell-expansion.

A baby-step towards #1015