### PR TITLE
Appen\Paste-After\Shell-Pile-After EOL special case

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -83,6 +83,18 @@ impl Range {
         std::cmp::max(self.anchor, self.head)
     }
 
+    /// End of the range taking into account end of line.
+    #[inline]
+    #[must_use]
+    pub fn to_without_eol(&self, text: &RopeSlice) -> usize {
+        let to = self.to();
+        if text.char(to - 1) == '\n' {
+            to - 1
+        } else {
+            to
+        }
+    }
+
     /// Total length of the range.
     #[inline]
     #[must_use]


### PR DESCRIPTION
In normal mode when cursor on the new line symbol (\n) actions like append or paste after inserts data after new line to the next line. But it is annoying, you have to remember to get cursor back by 1 char and then paste. The PR fixes that behavior by checking if there is '\n' on the end of the range, if it is just subtract 1.