### PR TITLE
Elixir: inject Markdown into docs, remove h sigil HEEx injection

### DIFF
--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -11,6 +11,15 @@
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
- (#match? @_sigil_name "^(h|H)$")
+ (#eq? @_sigil_name "H")
  (#set! injection.language "heex")
  (#set! injection.combined))
+
+(unary_operator
+  operator: "@"
+  operand: (call
+  target: ((identifier) @_identifier (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))
+    (arguments [
+      (string (quoted_content) @injection.content)
+      (sigil (quoted_content) @injection.content)
+  ])) (#set! injection.language "markdown"))

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -18,7 +18,7 @@
 (unary_operator
   operator: "@"
   operand: (call
-  target: ((identifier) @_identifier (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))
+  target: ((identifier) @_identifier (#match? @_identifier "^(module|type|short)?doc$"))
     (arguments [
       (string (quoted_content) @injection.content)
       (sigil (quoted_content) @injection.content)


### PR DESCRIPTION
@the-mikedavis I figured I'd checkout Helix and see how it compares to Neovim. Consider me a convert 😆  

This PR contains two changes:
- injects Markdown, the [official documentation format](https://hexdocs.pm/elixir/writing-documentation.html#markdown), into Elixir
- Removes the non-existent `h` sigil from Elixir language injections. Phoenix Live View only supports the uppercase `H` sigil for HEEx.

Please let me know if there are any tests or documentation that need to be updated. Thanks!