### PR TITLE
feat: make `move_vertically` aware of tabs and wide characters

### DIFF
--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -109,10 +109,12 @@ pub fn visual_coords_at_pos(text: RopeSlice, pos: usize, tab_width: usize) -> Po
 /// with left-side block-cursor positions, as this prevents the the block cursor
 /// from jumping to the next line.  Otherwise you typically want it to be `false`,
 /// such as when dealing with raw anchor/head positions.
-///
-/// TODO: this should be changed to work in terms of visual row/column, not
-/// graphemes.
-pub fn pos_at_coords(text: RopeSlice, coords: Position, limit_before_line_ending: bool) -> usize {
+pub fn pos_at_coords(
+    text: RopeSlice,
+    coords: Position,
+    tab_width: usize,
+    limit_before_line_ending: bool,
+) -> usize {
     let Position { mut row, col } = coords;
     if limit_before_line_ending {
         row = row.min(text.len_lines() - 1);
@@ -125,11 +127,20 @@ pub fn pos_at_coords(text: RopeSlice, coords: Position, limit_before_line_ending
     };
 
     let mut col_char_offset = 0;
-    for (i, g) in RopeGraphemes::new(text.slice(line_start..line_end)).enumerate() {
-        if i == col {
+    let mut cols_remaining = col;
+    for grapheme in RopeGraphemes::new(text.slice(line_start..line_end)) {
+        let grapheme_width = if grapheme == "\t" {
+            tab_width
+        } else {
+            let grapheme = Cow::from(grapheme);
+            grapheme_width(&grapheme)
+        };
+        if let Some(new_cols_remaining) = cols_remaining.checked_sub(grapheme_width) {
+            cols_remaining = new_cols_remaining;
+        } else {
             break;
         }
-        col_char_offset += g.chars().count();
+        col_char_offset += grapheme.chars().count();
     }
 
     line_start + col_char_offset
@@ -245,64 +256,68 @@ mod test {
     fn test_pos_at_coords() {
         let text = Rope::from("ḧëḷḷö\nẅöṛḷḋ");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
-        assert_eq!(pos_at_coords(slice, (0, 5).into(), false), 5); // position on \n
-        assert_eq!(pos_at_coords(slice, (0, 6).into(), false), 6); // position after \n
-        assert_eq!(pos_at_coords(slice, (0, 6).into(), true), 5); // position after \n
-        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 6); // position on w
-        assert_eq!(pos_at_coords(slice, (1, 1).into(), false), 7); // position on o
-        assert_eq!(pos_at_coords(slice, (1, 4).into(), false), 10); // position on d
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 5).into(), 4, false), 5); // position on \n
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), 4, false), 6); // position after \n
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), 4, true), 5); // position after \n
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), 4, false), 6); // position on w
+        assert_eq!(pos_at_coords(slice, (1, 1).into(), 4, false), 7); // position on o
+        assert_eq!(pos_at_coords(slice, (1, 4).into(), 4, false), 10); // position on d
 
         // Test with wide characters.
-        // TODO: account for character width.
         let text = Rope::from("今日はいい\n");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 1);
-        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 2);
-        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 3);
-        assert_eq!(pos_at_coords(slice, (0, 4).into(), false), 4);
-        assert_eq!(pos_at_coords(slice, (0, 5).into(), false), 5);
-        assert_eq!(pos_at_coords(slice, (0, 6).into(), false), 6);
-        assert_eq!(pos_at_coords(slice, (0, 6).into(), true), 5);
-        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 6);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), 4, false), 1);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), 4, false), 1);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), 4, false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 5).into(), 4, false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 6).into(), 4, false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 7).into(), 4, false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 8).into(), 4, false), 4);
+        assert_eq!(pos_at_coords(slice, (0, 9).into(), 4, false), 4);
+        assert_eq!(pos_at_coords(slice, (0, 10).into(), 4, false), 5);
+        assert_eq!(pos_at_coords(slice, (0, 10).into(), 4, true), 5);
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), 4, false), 6);
 
         // Test with grapheme clusters.
         let text = Rope::from("a̐éö̲\r\n");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 2);
-        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 4);
-        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 7); // \r\n is one char here
-        assert_eq!(pos_at_coords(slice, (0, 4).into(), false), 9);
-        assert_eq!(pos_at_coords(slice, (0, 4).into(), true), 7);
-        assert_eq!(pos_at_coords(slice, (1, 0).into(), false), 9);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), 4, false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), 4, false), 4);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), 4, false), 7); // \r\n is one char here
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), 4, false), 9);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), 4, true), 7);
+        assert_eq!(pos_at_coords(slice, (1, 0).into(), 4, false), 9);
 
         // Test with wide-character grapheme clusters.
-        // TODO: account for character width.
         let text = Rope::from("किमपि");
         // 2 - 1 - 2 codepoints
         // TODO: delete handling as per https://news.ycombinator.com/item?id=20058454
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 2);
-        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 3);
-        assert_eq!(pos_at_coords(slice, (0, 3).into(), false), 5);
-        assert_eq!(pos_at_coords(slice, (0, 3).into(), true), 5);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), 4, false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), 4, false), 3);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), 4, true), 3);
 
         // Test with tabs.
-        // Todo: account for tab stops.
         let text = Rope::from("\tHello\n");
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (0, 0).into(), false), 0);
-        assert_eq!(pos_at_coords(slice, (0, 1).into(), false), 1);
-        assert_eq!(pos_at_coords(slice, (0, 2).into(), false), 2);
+        assert_eq!(pos_at_coords(slice, (0, 0).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 1).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 2).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 3).into(), 4, false), 0);
+        assert_eq!(pos_at_coords(slice, (0, 4).into(), 4, false), 1);
+        assert_eq!(pos_at_coords(slice, (0, 5).into(), 4, false), 2);
 
         // Test out of bounds.
         let text = Rope::new();
         let slice = text.slice(..);
-        assert_eq!(pos_at_coords(slice, (10, 0).into(), true), 0);
-        assert_eq!(pos_at_coords(slice, (0, 10).into(), true), 0);
-        assert_eq!(pos_at_coords(slice, (10, 10).into(), true), 0);
+        assert_eq!(pos_at_coords(slice, (10, 0).into(), 4, true), 0);
+        assert_eq!(pos_at_coords(slice, (0, 10).into(), 4, true), 0);
+        assert_eq!(pos_at_coords(slice, (10, 10).into(), 4, true), 0);
     }
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -158,7 +158,12 @@ impl Application {
                         // with Action::Load all documents have the same view
                         let view_id = editor.tree.focus;
                         let doc = editor.document_mut(doc_id).unwrap();
-                        let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
+                        let pos = Selection::point(pos_at_coords(
+                            doc.text().slice(..),
+                            pos,
+                            doc.tab_width(),
+                            true,
+                        ));
                         doc.set_selection(view_id, pos);
                     }
                 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -509,7 +509,7 @@ fn no_op(_cx: &mut Context) {}
 
 fn move_impl<F>(cx: &mut Context, move_fn: F, dir: Direction, behaviour: Movement)
 where
-    F: Fn(RopeSlice, Range, Direction, usize, Movement) -> Range,
+    F: Fn(RopeSlice, Range, Direction, usize, Movement, usize) -> Range,
 {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
@@ -518,7 +518,7 @@ where
     let selection = doc
         .selection(view.id)
         .clone()
-        .transform(|range| move_fn(text, range, dir, count, behaviour));
+        .transform(|range| move_fn(text, range, dir, count, behaviour, doc.tab_width()));
     doc.set_selection(view.id, selection);
 }
 
@@ -1351,7 +1351,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
 
     // If cursor needs moving, replace primary selection
     if line != cursor.row {
-        let head = pos_at_coords(text, Position::new(line, cursor.col), true); // this func will properly truncate to line end
+        let head = pos_at_coords(text, Position::new(line, cursor.col), doc.tab_width(), true); // this func will properly truncate to line end
 
         let anchor = if doc.mode == Mode::Select {
             range.anchor
@@ -1442,8 +1442,18 @@ fn copy_selection_on_line(cx: &mut Context, direction: Direction) {
                 break;
             }
 
-            let anchor = pos_at_coords(text, Position::new(anchor_row, anchor_pos.col), true);
-            let head = pos_at_coords(text, Position::new(head_row, head_pos.col), true);
+            let anchor = pos_at_coords(
+                text,
+                Position::new(anchor_row, anchor_pos.col),
+                doc.tab_width(),
+                true,
+            );
+            let head = pos_at_coords(
+                text,
+                Position::new(head_row, head_pos.col),
+                doc.tab_width(),
+                true,
+            );
 
             // skip lines that are too short
             if coords_at_pos(text, anchor).col == anchor_pos.col

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -48,7 +48,12 @@ fn open(
         let (path, pos) = args::parse_file(arg);
         let _ = cx.editor.open(path, Action::Replace)?;
         let (view, doc) = current!(cx.editor);
-        let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
+        let pos = Selection::point(pos_at_coords(
+            doc.text().slice(..),
+            pos,
+            doc.tab_width(),
+            true,
+        ));
         doc.set_selection(view.id, pos);
         // does not affect opening a buffer without pos
         align_view(doc, view, Align::Center);


### PR DESCRIPTION
As the `TODO` in `move_vertically` previously noted, the current behaviour leads to jerky vertical movement on lines with wide characters and tabs. This pull request refactors a few of the related functions (and resolves some of their `TODO`s in the process) so that vertical movement is always smooth.

Since the parameters to `pos_at_coords` had to be modified to accept `tab_width`, quite a few tests had to be updated. Some of these tests also needed their expected values changed since `pos_at_coords` now operates based on visual row/column instead of graphemes, as the `TODO` called for. I'm not 100% sure if I updated a few of the tests correctly though, in particular, [this assertion](https://github.com/mtoohey31/helix/blob/966a17f29fbb5d975c9c3752605d1932273f4e06/helix-core/src/position.rs#L280), and [this block](https://github.com/mtoohey31/helix/blob/966a17f29fbb5d975c9c3752605d1932273f4e06/helix-core/src/position.rs#L300-L304). If someone could offer a second opinion on those, I'd appreciate it!