### PR TITLE
Fix unwrap error when undo after `shell_append_output`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4430,6 +4430,7 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     if behavior != &ShellBehavior::Ignore {
         let transaction = Transaction::change(doc.text(), changes.into_iter());
         doc.apply(&transaction, view.id);
+        doc.append_changes_to_history(view.id);
     }
 
     // after replace cursor may be out of bounds, do this to


### PR DESCRIPTION
Steps to reproduce:
1. press  `Shift+|` 
2. enter `ls` in prompt
3. press `u` for undo 
4. ether nothing happened or helix closed with error