### PR TITLE
Passing extra formatting options to LSPs

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -23,7 +23,7 @@ Use `format` field to pass extra formatting options to [Document Formatting Requ
 name = "typescript"
 auto-format = true
 # pass format options according to https://github.com/typescript-language-server/typescript-language-server#workspacedidchangeconfiguration omitting the "[language].format." prefix.
-format = { "semicolons" = "insert", "insertSpaceBeforeFunctionParenthesis" = true }
+config = { format = { "semicolons" = "insert", "insertSpaceBeforeFunctionParenthesis" = true } }
 ```
 
 ## Tree-sitter grammars

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -14,6 +14,18 @@ name = "rust"
 auto-format = false
 ```
 
+## LSP formatting options
+
+Use `format` field to pass extra formatting options to [Document Formatting Requests](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#document-formatting-request--leftwards_arrow_with_hook).
+
+```toml
+[[language]]
+name = "typescript"
+auto-format = true
+# pass format options according to https://github.com/typescript-language-server/typescript-language-server#workspacedidchangeconfiguration omitting the "[language].format." prefix.
+format = { "semicolons" = "insert", "insertSpaceBeforeFunctionParenthesis" = true }
+```
+
 ## Tree-sitter grammars
 
 Tree-sitter grammars can also be configured in `languages.toml`:

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -78,6 +78,9 @@ pub struct LanguageConfiguration {
 
     #[serde(default)]
     pub auto_format: bool,
+    #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]
+    pub format: Option<serde_json::Value>,
+
     #[serde(default)]
     pub diagnostic_severity: Severity,
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -78,8 +78,6 @@ pub struct LanguageConfiguration {
 
     #[serde(default)]
     pub auto_format: bool,
-    #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]
-    pub format: Option<serde_json::Value>,
 
     #[serde(default)]
     pub diagnostic_severity: Severity,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -416,18 +416,10 @@ impl Document {
             .language_config()
             .and_then(|cfg| cfg.format.as_ref().and_then(|c| c.as_object()))
         {
-            for (key, value) in fmt {
-                let prop = if let Some(s) = value.as_str() {
-                    lsp::FormattingProperty::String(s.to_owned())
-                } else if let Some(b) = value.as_bool() {
-                    lsp::FormattingProperty::Bool(b)
-                } else if let Some(n) = value.as_i64() {
-                    lsp::FormattingProperty::Number(n as i32)
-                } else {
-                    log::warn!("invalid formatting property type {:?} for {}", value, key);
-                    continue;
-                };
-                properties.insert(key.to_owned(), prop);
+            for (key, value) in fmt.iter() {
+                if let Ok(prop) = serde_json::from_value(value.clone()) {
+                    properties.insert(key.to_owned(), prop);
+                }
             }
         }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -411,24 +411,11 @@ impl Document {
         let text = self.text.clone();
         let offset_encoding = language_server.offset_encoding();
 
-        let mut properties = HashMap::new();
-        if let Some(fmt) = self
-            .language_config()
-            .and_then(|cfg| cfg.format.as_ref().and_then(|c| c.as_object()))
-        {
-            for (key, value) in fmt.iter() {
-                if let Ok(prop) = serde_json::from_value(value.clone()) {
-                    properties.insert(key.to_owned(), prop);
-                }
-            }
-        }
-
         let request = language_server.text_document_formatting(
             self.identifier(),
             lsp::FormattingOptions {
                 tab_size: self.tab_width() as u32,
                 insert_spaces: matches!(self.indent_style, IndentStyle::Spaces(_)),
-                properties,
                 ..Default::default()
             },
             None,


### PR DESCRIPTION
- adds optional field _format_ to **[[language]]** sections in **languages.toml**

- passes specified options to the LSPs via [FormattingOptions](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#document-formatting-request--leftwards_arrow_with_hook)

- updated documentation accordingly

typescript example:

```toml
[[language]]
name = "typescript"
auto-format = true
# pass format options according to https://github.com/typescript-language-server/typescript-language-server#workspacedidchangeconfiguration omitting the "[language].format." prefix.
format = { "semicolons" = "insert", "insertSpaceBeforeFunctionParenthesis" = true }
```