### PR TITLE
feat: added line-wise select mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -573,7 +573,7 @@ fn extend_full_line_vertically(cx: &mut Context, direction: Direction) {
         let (view, doc) = current!(cx.editor);
         let text = doc.text().slice(..);
         let primary_range = doc.selection(view.id).primary();
-        let current_line = text.char_to_line(primary_range.clone().head);
+        let current_line = text.char_to_line(primary_range.head);
         let anchor_line = text.char_to_line(primary_range.anchor);
 
         // If not already extended to the end in forward mode, only extend to the end, not to the next line
@@ -584,11 +584,10 @@ fn extend_full_line_vertically(cx: &mut Context, direction: Direction) {
 
         // If going against the range direction
         extend_to_line_bounds(cx);
-        if primary_range.direction() != direction {
-            if current_line == anchor_line {
-                flip_selections(cx);
-            }
+        if primary_range.direction() != direction && current_line == anchor_line {
+            flip_selections(cx);
         }
+
         move_impl(cx, move_vertically, direction, Movement::Extend);
         extend_to_line_bounds(cx);
     }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -35,6 +35,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "E" => move_next_long_word_end,
 
         "v" => select_mode,
+        "V" => line_select_mode,
         "G" => goto_line,
         "g" => { "Goto"
             "g" => goto_file_start,
@@ -323,6 +324,34 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "v" => normal_mode,
     }));
+    let mut line_select = normal.clone();
+    line_select.merge_nodes(keymap!({ "Line-select mode"
+        "j" | "down" => extend_full_line_down,
+        "k" | "up" => extend_full_line_up,
+
+        "g" => { "Goto"
+            "g" => extend_full_line_to_file_start,
+            "e" => extend_full_line_to_file_end,
+            "f" => no_op,
+            "h" => no_op,
+            "l" => no_op,
+            "s" => no_op,
+            "d" => no_op,
+            "y" => no_op,
+            "r" => no_op,
+            "i" => no_op,
+            "t" => no_op,
+            "c" => no_op,
+            "b" => no_op,
+            "a" => no_op,
+            "m" => no_op,
+            "n" => no_op,
+            "p" => no_op,
+            "." => no_op,
+        },
+
+        "v" | "esc" => exit_line_select_mode,
+    }));
     let insert = keymap!({ "Insert mode"
         "esc" => normal_mode,
 
@@ -369,5 +398,6 @@ pub fn default() -> HashMap<Mode, Keymap> {
         Mode::Normal => Keymap::new(normal),
         Mode::Select => Keymap::new(select),
         Mode::Insert => Keymap::new(insert),
+        Mode::LineSelect => Keymap::new(line_select),
     )
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -310,6 +310,7 @@ impl EditorView {
         let cursor_scope = match mode {
             Mode::Insert => theme.find_scope_index("ui.cursor.insert"),
             Mode::Select => theme.find_scope_index("ui.cursor.select"),
+            Mode::LineSelect => theme.find_scope_index("ui.cursor.select"),
             Mode::Normal => Some(base_cursor_scope),
         }
         .unwrap_or(base_cursor_scope);
@@ -669,6 +670,7 @@ impl EditorView {
         let mode = match doc.mode() {
             Mode::Insert => "INS",
             Mode::Select => "SEL",
+            Mode::LineSelect => "LIN",
             Mode::Normal => "NOR",
         };
         let progress = doc

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -35,6 +35,7 @@ pub enum Mode {
     Normal = 0,
     Select = 1,
     Insert = 2,
+    LineSelect = 3,
 }
 
 impl Display for Mode {
@@ -43,6 +44,7 @@ impl Display for Mode {
             Mode::Normal => f.write_str("normal"),
             Mode::Select => f.write_str("select"),
             Mode::Insert => f.write_str("insert"),
+            Mode::LineSelect => f.write_str("line-select"),
         }
     }
 }
@@ -55,6 +57,7 @@ impl FromStr for Mode {
             "normal" => Ok(Mode::Normal),
             "select" => Ok(Mode::Select),
             "insert" => Ok(Mode::Insert),
+            "line-select" => Ok(Mode::LineSelect),
             _ => bail!("Invalid mode '{}'", s),
         }
     }


### PR DESCRIPTION
Hello there !

This PR adds an equivalent to vim's V-LINE mode, here called line-select mode, that I've always been missing in Helix. 

It allows the user to select lines up and down while automatically flipping the selections when the range head crosses the anchor. It also handles count and goto start/end of file.

The commands are usable from any other mode.
![line_select_demo](https://user-images.githubusercontent.com/43273245/171401250-e29b234b-98b7-4227-9a4a-3c9be1fb53b5.gif)
(_the keymap in this GIF demo is old code, don't mind it !_)

Thanks and have a good day !
