### PR TITLE
add tree-sitter-edoc

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -12,6 +12,7 @@
 | dart | ✓ |  | ✓ | `dart` |
 | devicetree | ✓ |  | ✓ |  |
 | dockerfile | ✓ |  |  | `docker-langserver` |
+| edoc | ✓ |  |  |  |
 | eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |
 | elixir | ✓ |  |  | `elixir-ls` |

--- a/languages.toml
+++ b/languages.toml
@@ -1049,7 +1049,7 @@ language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "6cd8f956ada445b277de1581b5328ae8e8be9aac" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "481e7f8ddf27f07a47d1531b6e2b154b89ece31d" }
 
 [[language]]
 name = "kotlin"
@@ -1409,3 +1409,15 @@ injection-regex = "verilog"
 [[grammar]]
 name = "verilog"
 source = { git = "https://github.com/andreytkachenko/tree-sitter-verilog", rev = "514d8d70593d29ef3ef667fa6b0e504ae7c977e3" }
+
+[[language]]
+name = "edoc"
+scope = "source.edoc"
+file-types = ["edoc", "edoc.in"]
+injection-regex = "edoc"
+roots = []
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "edoc"
+source = { git = "https://github.com/the-mikedavis/tree-sitter-edoc", rev = "1691ec0aa7ad1ed9fa295590545f27e570d12d60" }

--- a/runtime/queries/edoc/highlights.scm
+++ b/runtime/queries/edoc/highlights.scm
@@ -1,0 +1,50 @@
+((section
+   (section_marker) @markup.heading.marker
+   (section_content) @markup.heading.1
+   (section_marker) @markup.heading.marker)
+ (#eq? @markup.heading.marker "=="))
+
+((section
+   (section_marker) @markup.heading.marker
+   (section_content) @markup.heading.2
+   (section_marker) @markup.heading.marker)
+ (#eq? @markup.heading.marker "==="))
+
+((section
+   (section_marker) @markup.heading.marker
+   (section_content) @markup.heading.3
+   (section_marker) @markup.heading.marker)
+ (#eq? @markup.heading.marker "===="))
+
+(macro (tag) @function.macro)
+(tag) @keyword
+(macro_escape) @constant.character.escape
+(inline_quote) @markup.raw.inline
+(email_address) @markup.link.url
+
+(em_xhtml_tag
+  (open_xhtml_tag) @tag
+  (xhtml_tag_content) @markup.italic
+  (close_xhtml_tag) @tag)
+
+(strong_xhtml_tag
+  (open_xhtml_tag) @tag
+  (xhtml_tag_content) @markup.bold
+  (close_xhtml_tag) @tag)
+
+(module) @namespace
+(function) @function
+(type) @type
+
+; could be @constant.numeric.integer but this looks similar to a capture
+(arity) @operator
+
+[":" "/"] @operator
+["(" ")"] @punctuation.delimiter
+["{" "}"] @function.macro
+
+[
+  (quote_marker)
+  (language_identifier)
+  (quote_content)
+] @markup.raw.block

--- a/runtime/queries/edoc/injections.scm
+++ b/runtime/queries/edoc/injections.scm
@@ -1,0 +1,20 @@
+((xhtml_tag) @injection.content
+ (#set! injection.combined)
+ (#set! injection.include-children)
+ (#set! injection.language "html"))
+
+((block_quote
+   !language
+   (quote_content) @injection.content)
+  (#set! injection.language "erlang"))
+
+(block_quote
+  language: (language_identifier) @injection.language
+  (quote_content) @injection.content)
+
+((macro
+   (tag) @_tag
+   (argument) @injection.content)
+ (#eq? @_tag "@type")
+ (#set injection.language "erlang")
+ (#set injection.include-children))

--- a/runtime/queries/erlang/injections.scm
+++ b/runtime/queries/erlang/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
- (#set! injection.language "comment"))
+((comment_content) @injection.content
+ (#set! injection.language "edoc"))

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -45,5 +45,5 @@
 [
   (backslash_escape)
   (hard_line_break)
-] @string.character.escape
+] @constant.character.escape
 

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -16,6 +16,7 @@
 ] @punctuation.bracket
 
 ":" @punctuation.delimiter
+"!" @operator
 
 [
   (one_or_more)


### PR DESCRIPTION
Syntax highlighting for the Erlang doc generator format: https://www.erlang.org/doc/apps/edoc/chapter.html. The XHTML part was actually quite easy to parse: it just looks for `<` and `>` and injects it as HTML.

Also included some fixes for markdown and tsq highlights.

Example:

![edoc-highlight](https://user-images.githubusercontent.com/21230295/171455914-ef998ded-be37-4f70-84be-99733ff9faa2.png)