### PR TITLE
Ignore SendErrors when handling grammars

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -133,7 +133,9 @@ where
         let tx = tx.clone();
 
         pool.execute(move || {
-            tx.send(job(grammar)).unwrap();
+            // Ignore any SendErrors, if any job in another thread has encountered an
+            // error the Receiver will be closed causing this send to fail.
+            let _ = tx.send(job(grammar));
         });
     }
 


### PR DESCRIPTION
When handling grammars, fetching and building is done in a thread pool.  Results are communicated over channels and the receiving channel is closed on first error. This causes subsequent sends to fail causing a mess in stderr. This ignores all SendErrors causing only the first error to be printed.

Solves #2642