### PR TITLE
catpuccin ui.popup should be a different color from ui.background

### DIFF
--- a/runtime/themes/catpuccin.toml
+++ b/runtime/themes/catpuccin.toml
@@ -42,7 +42,7 @@ label = "peach"
 "ui.linenr.selected" = { fg = "mauve" }
 "ui.statusline" = { fg = "black_2", bg = "blue" }
 "ui.statusline.inactive" = { fg = "pink", bg = "gray_1" }
-"ui.popup" = { bg = "black_2" }
+"ui.popup" = { bg = "black_1" }
 "ui.window" = { fg = "maroon" }
 "ui.help" = { bg = "#7958DC", fg = "#171452" }
 


### PR DESCRIPTION
Looks like black_1 was defined but never used.  This was likely meant to be ui.popup all along?