### PR TITLE
add tree-sitter-jsdoc

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -41,6 +41,7 @@
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  | `jdtls` |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |
+| jsdoc | ✓ |  |  |  |
 | json | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsx | ✓ |  | ✓ | `typescript-language-server` |
 | julia | ✓ |  |  | `julia` |

--- a/languages.toml
+++ b/languages.toml
@@ -1421,3 +1421,15 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "edoc"
 source = { git = "https://github.com/the-mikedavis/tree-sitter-edoc", rev = "1691ec0aa7ad1ed9fa295590545f27e570d12d60" }
+
+[[language]]
+name = "jsdoc"
+scope = "source.jsdoc"
+injection-regex = "jsdoc"
+file-types = ["jsdoc"]
+roots = []
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "jsdoc"
+source = { git = "https://github.com/tree-sitter/tree-sitter-jsdoc", rev = "189a6a4829beb9cdbe837260653b4a3dfb0cc3db" }

--- a/runtime/queries/jsdoc/highlights.scm
+++ b/runtime/queries/jsdoc/highlights.scm
@@ -1,0 +1,2 @@
+(tag_name) @keyword
+(type) @type


### PR DESCRIPTION
connects #2648

This is a pretty small grammar. The injection for comments is already set up in `runtime/queries/javascript/injections.scm`. Github also uses this for their syntax highlighting, like in:

```js
/**
 * Extract the string matched by the regex and return both the resulting string
 * and the matched string
 *
 * @param {string} source
 * @param {RegExp} regExp
 * @returns
 */
export function extract(source, regExp) {
  const result = regExp.exec(source)
  return result ? {
    normalizedSource: source.replace(result[0], ''),
    extracted: result[1]
  } : { normalisedSource: source, extracted: '' }
}
```