### PR TITLE
File watcher implementation & LSP DidChangeWatchedFiles notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +266,15 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -491,11 +522,13 @@ dependencies = [
  "clipboard-win",
  "crossterm",
  "futures-util",
+ "globset",
  "helix-core",
  "helix-dap",
  "helix-lsp",
  "helix-tui",
  "log",
+ "notify",
  "once_cell",
  "serde",
  "serde_json",
@@ -546,6 +579,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +615,26 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6112e8f37b59803ac47a42d14f1f3a59bbf72fc6857ffc5be455e28a691f8e"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -649,6 +722,24 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -291,6 +291,9 @@ impl Client {
                     did_change_configuration: Some(lsp::DynamicRegistrationClientCapabilities {
                         dynamic_registration: Some(false),
                     }),
+                    did_change_watched_files: Some(lsp::DidChangeWatchedFilesClientCapabilities {
+                        dynamic_registration: Some(true),
+                    }),
                     workspace_folders: Some(true),
                     ..Default::default()
                 }),
@@ -395,6 +398,15 @@ impl Client {
         self.notify::<lsp::notification::DidChangeConfiguration>(
             lsp::DidChangeConfigurationParams { settings },
         )
+    }
+
+    pub fn did_change_watched_files(
+        &self,
+        changes: Vec<lsp::FileEvent>,
+    ) -> impl Future<Output = Result<()>> {
+        self.notify::<lsp::notification::DidChangeWatchedFiles>(lsp::DidChangeWatchedFilesParams {
+            changes,
+        })
     }
 
     // -------------------------------------------------------------------------------------------

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -229,6 +229,8 @@ pub enum MethodCall {
     ApplyWorkspaceEdit(lsp::ApplyWorkspaceEditParams),
     WorkspaceFolders,
     WorkspaceConfiguration(lsp::ConfigurationParams),
+    RegisterCapability(lsp::RegistrationParams),
+    UnregisterCapability(lsp::UnregistrationParams),
 }
 
 impl MethodCall {
@@ -247,6 +249,14 @@ impl MethodCall {
             lsp::request::WorkspaceConfiguration::METHOD => {
                 let params: lsp::ConfigurationParams = params.parse()?;
                 Self::WorkspaceConfiguration(params)
+            }
+            lsp::request::RegisterCapability::METHOD => {
+                let params: lsp::RegistrationParams = params.parse()?;
+                Self::RegisterCapability(params)
+            }
+            lsp::request::UnregisterCapability::METHOD => {
+                let params: lsp::UnregistrationParams = params.parse()?;
+                Self::UnregisterCapability(params)
             }
             _ => {
                 return Err(Error::Unhandled);

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -42,6 +42,9 @@ log = "~0.4"
 
 which = "4.2"
 
+notify = "5.0.0-pre.15"
+globset = "0.4.8"
+
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "4.4", features = ["std"] }
 

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -16,6 +16,7 @@ pub mod keyboard;
 pub mod theme;
 pub mod tree;
 pub mod view;
+pub mod watcher;
 
 use std::num::NonZeroUsize;
 

--- a/helix-view/src/watcher.rs
+++ b/helix-view/src/watcher.rs
@@ -153,7 +153,7 @@ impl FileWatcher {
         };
         let ev = WatcherEvent::Register(watch, tx);
         if let Err(e) = self.tx.send(ev) {
-            anyhow::bail!("file watcher channel error: {e}");
+            anyhow::bail!("file watcher channel error: {}", e);
         }
 
         Ok(rx.await?)

--- a/helix-view/src/watcher.rs
+++ b/helix-view/src/watcher.rs
@@ -1,0 +1,336 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use globset::{GlobBuilder, GlobMatcher};
+use notify::{
+    event::{CreateKind, ModifyKind, RemoveKind, RenameMode},
+    EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use slotmap::SlotMap;
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
+use tokio::task::JoinHandle;
+
+pub use notify::{event as notify_event, Event};
+
+// A list of directory names to ignore when found in the root of
+// a workspace. These are directories that would otherwise generate
+// a very large amount of events which could cause stuttering.
+// i.e. `rust-analyzer` calls `cargo check` on every write
+// which generates a large amount of fingerprint file changes in the
+// `target` directory.
+const IGNORE: &[&str] = &["target"];
+
+/// Handle used to interact with the file watcher task.
+pub struct FileWatcher {
+    tx: UnboundedSender<WatcherEvent>,
+    task: JoinHandle<()>,
+}
+
+enum WatcherEvent {
+    Notify(notify::Event),
+    Register(Watch, oneshot::Sender<WatchId>),
+    Unregister(WatchId),
+    AddWorkspace(PathBuf),
+    RemoveWorkspace(PathBuf),
+    Shutdown,
+}
+
+slotmap::new_key_type! {
+    /// Token obtained from watch registration, needed for deregistration.
+    pub struct WatchId;
+}
+
+/// A watch registered with a `FileWatcher`: `callback` is called with any
+/// events from the workspace `workspace` that match the given filter.
+struct Watch {
+    callback: Box<Callback>,
+    workspace: PathBuf,
+    filter: Filter,
+}
+
+type Callback = dyn FnMut(&Event) + Send + 'static;
+
+impl Watch {
+    fn wants(&self, workspace: &Path, path: &Path) -> bool {
+        workspace == self.workspace
+            && match &self.filter {
+                Filter::Glob(glob) => glob.is_match(path),
+                Filter::Custom(f) => f(path),
+                Filter::None => true,
+            }
+    }
+}
+
+// TODO: This could be replaced with just the filter closure, moving glob logic
+// to the LSP side. Not sure what's preferable. Conversely, currently filtering
+// which event kinds are actually wanted is done on the LSP side, which is a bit
+// weird.
+enum Filter {
+    Glob(GlobMatcher),
+    Custom(Box<CustomFilter>),
+    None,
+}
+
+type CustomFilter = dyn Fn(&Path) -> bool + Send + 'static;
+
+impl FileWatcher {
+    /// Start the file watcher task, which allows registering a callback to
+    /// filesystem events concerning paths matching a given filter.
+    pub fn new() -> anyhow::Result<Self> {
+        let (tx, state) = Dispatcher::new()?;
+        let task = tokio::spawn(state.run());
+
+        Ok(Self { task, tx })
+    }
+
+    /// Register a callback that is called on any filesystem event in the
+    /// monitored directory.
+    pub async fn register<F>(&self, workspace: PathBuf, callback: F) -> anyhow::Result<WatchId>
+    where
+        F: FnMut(&Event) + Send + 'static,
+    {
+        self.register_filtered(workspace, Filter::None, Box::new(callback))
+            .await
+    }
+
+    /// Register a callback that is called on filesystem events concerning paths
+    /// matching the given glob string.
+    pub async fn register_glob<F>(
+        &self,
+        workspace: PathBuf,
+        glob: &str,
+        callback: F,
+    ) -> anyhow::Result<WatchId>
+    where
+        F: FnMut(&Event) + Send + 'static,
+    {
+        let filter = Filter::Glob(
+            GlobBuilder::new(glob)
+                .literal_separator(true)
+                .build()?
+                .compile_matcher(),
+        );
+        self.register_filtered(workspace, filter, Box::new(callback))
+            .await
+    }
+
+    /// Register a callback that is called on filesystem events concerning paths
+    /// matching a provided filter closure that returns true for desired paths.
+    pub async fn register_custom<F, FF>(
+        &self,
+        workspace: PathBuf,
+        filter: FF,
+        callback: F,
+    ) -> anyhow::Result<WatchId>
+    where
+        F: FnMut(&Event) + Send + 'static,
+        FF: Fn(&Path) -> bool + Send + 'static,
+    {
+        self.register_filtered(
+            workspace,
+            Filter::Custom(Box::new(filter)),
+            Box::new(callback),
+        )
+        .await
+    }
+
+    async fn register_filtered(
+        &self,
+        workspace: PathBuf,
+        filter: Filter,
+        callback: Box<Callback>,
+    ) -> anyhow::Result<WatchId> {
+        let (tx, rx) = oneshot::channel();
+
+        let watch = Watch {
+            filter,
+            workspace,
+            callback,
+        };
+        let ev = WatcherEvent::Register(watch, tx);
+        if let Err(e) = self.tx.send(ev) {
+            anyhow::bail!("file watcher channel error: {e}");
+        }
+
+        Ok(rx.await?)
+    }
+
+    /// Unregister a callback given a `WatchId` obtained from its registration.
+    pub fn unregister(&self, id: WatchId) {
+        let _ = self.tx.send(WatcherEvent::Unregister(id));
+    }
+
+    // TODO: Currently `add_workspace` and `remove_workspace` fail silently
+    // if given invalid workspace names.
+
+    /// Add a workspace to the list of watched workspaces. Events are only emitted
+    /// for watched workspaces.
+    pub fn add_workspace(&self, workspace_root: PathBuf) {
+        let _ = self.tx.send(WatcherEvent::AddWorkspace(workspace_root));
+    }
+
+    /// Remove a workspace from the list of watched workspaces.
+    pub fn remove_workspace(&self, workspace_root: PathBuf) {
+        let _ = self.tx.send(WatcherEvent::RemoveWorkspace(workspace_root));
+    }
+
+    // TODO: should this be in a drop function using tokio::spawn instead?
+    pub async fn shutdown(self) -> anyhow::Result<()> {
+        let _ = self.tx.send(WatcherEvent::Shutdown);
+        Ok(self.task.await?)
+    }
+}
+
+/// Contains the `notify` watcher and state used in the file watching async task.
+struct Dispatcher {
+    inner: RecommendedWatcher,
+    rx: UnboundedReceiver<WatcherEvent>,
+
+    workspaces: HashMap<PathBuf, HashSet<PathBuf>>,
+    watches: SlotMap<WatchId, Watch>,
+}
+
+impl Dispatcher {
+    fn new() -> anyhow::Result<(UnboundedSender<WatcherEvent>, Self)> {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let inner = {
+            let tx = tx.clone();
+            RecommendedWatcher::new(move |res: notify::Result<_>| {
+                let _ = tx.send(WatcherEvent::Notify(res.unwrap()));
+            })?
+        };
+
+        let res = Self {
+            inner,
+            rx,
+            workspaces: HashMap::default(),
+            watches: SlotMap::default(),
+        };
+
+        Ok((tx, res))
+    }
+
+    /// Future to run the file watcher task.
+    async fn run(mut self) {
+        while let Some(event) = self.rx.recv().await {
+            match event {
+                WatcherEvent::Notify(event) => {
+                    self.handle_raw_event(event);
+                }
+                WatcherEvent::Register(watch, tx) => {
+                    let _ = tx.send(self.watches.insert(watch));
+                }
+                WatcherEvent::Unregister(id) => {
+                    self.watches.remove(id);
+                }
+                WatcherEvent::AddWorkspace(path) => {
+                    self.watch_workspace(path);
+                }
+                WatcherEvent::RemoveWorkspace(path) => {
+                    if let Some(dirs) = self.workspaces.remove(&path) {
+                        for dir in &dirs {
+                            self.inner.unwatch(dir).unwrap();
+                        }
+                    }
+                }
+                WatcherEvent::Shutdown => break,
+            }
+        }
+    }
+
+    fn handle_raw_event(&mut self, event: notify::Event) {
+        // Not interested in any events that don't have an associated path.
+        let path = match event.paths.get(0) {
+            Some(p) => p,
+            None => return,
+        };
+
+        // Monitor events in root directory to ensure we set watches on new or
+        // renamed directories. Note that `notify` seems to already "unwatch"
+        // directories when they are removed or renamed.
+        // TODO: what to do if a workspace root changes names?
+        if let Some(parent) = path.parent() {
+            // Must keep the list of watched directories per workspace up to date,
+            // as well.
+            if let Some(dirs) = self.workspaces.get_mut(parent) {
+                match event.kind {
+                    EventKind::Create(CreateKind::Folder) => {
+                        self.inner.watch(path, RecursiveMode::Recursive).unwrap();
+                        dirs.insert(path.to_owned());
+                    }
+                    EventKind::Remove(RemoveKind::Folder) => {
+                        dirs.remove(path);
+                    }
+                    EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
+                        // This event kind always involves two paths.
+                        let new_path = event.paths.get(1).unwrap();
+                        self.inner
+                            .watch(new_path, RecursiveMode::Recursive)
+                            .unwrap();
+                        dirs.insert(new_path.to_owned());
+                        dirs.remove(path);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Find the root of the workspace that the event's primary path is located in.
+        let workspace = match self.workspaces.keys().find(|ws| path.starts_with(ws)) {
+            Some(root) => root,
+            None => return,
+        };
+
+        // Dispatch event to registered callbacks.
+        for watch in self
+            .watches
+            .values_mut()
+            .filter(|w| w.wants(workspace, path))
+        {
+            (watch.callback)(&event);
+        }
+    }
+
+    fn watch_workspace(&mut self, root: PathBuf) {
+        // The set of individual directory watches issued, necessary for unwatching
+        // the workspace.
+        let mut watches = HashSet::new();
+
+        // Watch root for directories and file changes. This is non-recursive
+        // to allow for ignoring specific directories in the root directory.
+        // Note that if directories are created or deleted after calling
+        // `add_directory`, they must have watches set/unset on them in response
+        // to events from this watch call.
+        self.inner
+            .watch(&root, RecursiveMode::NonRecursive)
+            .unwrap();
+        watches.insert(root.clone());
+
+        // Watch the root's children directories recursively, ignoring those in
+        // the ignore list.
+        for entry in fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            // If we can't get the file type, just ignore it.
+            .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|s| !IGNORE.contains(&s))
+                    .unwrap_or(true) // Allow non-utf8 paths.
+            })
+        {
+            self.inner
+                .watch(&entry.path(), RecursiveMode::Recursive)
+                .unwrap();
+            watches.insert(entry.path());
+        }
+
+        self.workspaces.insert(root, watches);
+    }
+}


### PR DESCRIPTION
Closes #2479 and is a prerequisite for #1125. Also probably supersedes #588.

I don't think this is quite ready to merge but it's definitely due for some reviewing. Functionality works fine for closing the intended issue but I've got concerns when it comes to other issues that depend on file watching.

`notify` is the main dependency added. I've reused `globset` as a dependency to parse the LSP spec's glob patterns, it's already included through `ignore`.

There are a couple different choices with regard to what directories to set `notify` watching: 

1. Recursively watch the current working directory.
2. Set watches only on the specific files that are of interest.
3. Same as (1) but mix in non-recursive watching to allow for ignoring certain directories. 

The issue with (1) is that there's no way to outright ignore directories: it seems likely that the amount of file changes `rust-analyzer` generates in the `target` directory on every write through `cargo check` could cause stuttering on lower-specced machines. The issue with (2) is that it can't detect new files as it's not watching for them, and the LSP may be interested in events from files that aren't open in the editor. So I've gone with (3) here: non-recursively watching the root directory, ignoring those matching some default list of build/cache directories ala Rust's `target` directory, and recursively watching the rest. This approach is taken from [emacs-lsp](https://github.com/emacs-lsp/lsp-mode/blob/master/docs/page/file-watchers.md), which has a seemingly pretty comprehensive list of ignored directories. The downside is that this adds some complexity with keeping track of directory creations/deletions/renames in the root directory, but it's not bad.

File watching works as follows: Watcher sets up `notify` watches on open LSP workspaces. Interested parties register a callback to be called when the watcher receives events matching a path filter in a specific workspace.

Some considerations:
- `DidChangeWatchedFiles` can only be registered dynamically, so supporting it requires handling `RegisterCapability` and `UnregisterCapability`. I haven't yet added support for unregistering the `DidChangeWatchedFiles` capability as I'm not sure where to store the required state: it seems to belong with the LSP client, but mutating the client seems to require interior mutability right now which gives me pause.
- Helix supports having multiple LSPs in use which all may have their own root workspace folders, so I've attempted to handle the case of multiple workspaces in the file watcher. I'm not really sure if that was the right move.
- Something weird here is that you might expect the watcher to default to watching everything from the current working directory down, but right now it just works with LSP workspaces. The current model also might cause issues with something like #1125 where any file could be open in the editor, even outside any workspace or the working directory, so seems like that would require mixing in some functionality to facilitate choice (2) above. Any thoughts would be welcome.
- I haven't wired up LSP clients to add/remove their workspaces to/from the watcher's list of workspaces when they're created or dropped yet, mostly because I'm not really sure if I'm taking the right approach with how workspaces are handled right now.
- The only build directory I have ignored right now is `target`. Happy to add others from `emacs-lsp`'s list in if maintainers are fine with this approach. Something nagging me is that since these directories are per-language it would also make sense to me if these were configured per-language, rather than one big list.
- I've used the pre-release version of `notify` which has been around for a while and seems pretty stable. It doesn't support debouncing yet but it seems like it's not too far off either. I haven't added debouncing to this PR yet either, it's possible it's best to just leave it as is and wait until `notify`'s debounce support hits if the lack of debouncing isn't causing any issues.

That's all for now off the top of my head, but there's probably other stuff lurking around in the PR.