### PR TITLE
ensure :quit and :quit! take no arguments

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -15,9 +15,11 @@ pub struct TypableCommand {
 
 fn quit(
     cx: &mut compositor::Context,
-    _args: &[Cow<str>],
+    args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
+    ensure!(args.is_empty(), ":quit takes no arguments");
+
     // last view and we have unsaved changes
     if cx.editor.tree.views().count() == 1 {
         buffers_remaining_impl(cx.editor)?
@@ -30,9 +32,11 @@ fn quit(
 
 fn force_quit(
     cx: &mut compositor::Context,
-    _args: &[Cow<str>],
+    args: &[Cow<str>],
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
+    ensure!(args.is_empty(), ":quit! takes no arguments");
+
     cx.editor.close(view!(cx.editor).id);
 
     Ok(())


### PR DESCRIPTION
I lost my train of thought and accidentally typed `:q! :w` 😄

Since quitting is a little destructive, I think it makes sense to fail the quit if it's not a well-formed 0-arg `:quit(!)`.

What do you think?