### PR TITLE
Fix panic on close last buffer (#2367)

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -814,8 +814,7 @@ impl Editor {
             .tree
             .views_mut()
             .filter_map(|(view, _focus)| {
-                // remove the document from jump list of all views
-                view.jumps.remove(&doc_id);
+                view.remove_document(&doc_id);
 
                 if view.doc == doc_id {
                     // something was previously open in the view, switch to previous doc
@@ -826,9 +825,6 @@ impl Editor {
                         Some(Action::Close(view.id))
                     }
                 } else {
-                    // documents also need be removed from the view "document access history"
-                    // so we don't accidentally try to jump back to them after they have been deleted
-                    view.docs_access_history.retain(|doc| doc != &doc_id);
                     None
                 }
             })

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -826,6 +826,9 @@ impl Editor {
                         Some(Action::Close(view.id))
                     }
                 } else {
+                    // documents also need be removed from the view "document access history"
+                    // so we don't accidentally try to jump back to them after they have been deleted
+                    view.docs_access_history.retain(|doc| doc != &doc_id);
                     None
                 }
             })

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -681,7 +681,7 @@ impl Editor {
 
                     // Remove the scratch buffer from any jumplists
                     for (view, _) in self.tree.views_mut() {
-                        view.jumps.remove(&id)
+                        view.remove_document(&id);
                     }
                 } else {
                     let jump = (view.doc, doc.selection(view.id).clone());

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -316,6 +316,11 @@ impl View {
         ))
     }
 
+    pub fn remove_document(&mut self, doc_id: &DocumentId) {
+        self.jumps.remove(doc_id);
+        self.docs_access_history.retain(|doc| doc != doc_id);
+    }
+
     // pub fn traverse<F>(&self, text: RopeSlice, start: usize, end: usize, fun: F)
     // where
     //     F: Fn(usize, usize),


### PR DESCRIPTION
In certain circumstances it was possible to cause a panic when closing
buffers due to some mishandling of view document history.

A change has been made to delete removed documents from the history of
accessed documents for each view. The ensures we don't attempt to jump
to a deleted document by mistake.