### PR TITLE
add textobject queries for beam languages, capture rust closures as functions

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -15,7 +15,7 @@
 | edoc | ✓ |  |  |  |
 | eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |
-| elixir | ✓ |  |  | `elixir-ls` |
+| elixir | ✓ | ✓ |  | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |
 | erb | ✓ |  |  |  |
 | erlang | ✓ | ✓ |  | `erlang_ls` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -27,7 +27,7 @@
 | git-diff | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
-| gleam | ✓ |  |  |  |
+| gleam | ✓ | ✓ |  |  |
 | glsl | ✓ |  | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
 | gomod | ✓ |  |  | `gopls` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -18,7 +18,7 @@
 | elixir | ✓ |  |  | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |
 | erb | ✓ |  |  |  |
-| erlang | ✓ |  |  | `erlang_ls` |
+| erlang | ✓ | ✓ |  | `erlang_ls` |
 | fish | ✓ | ✓ | ✓ |  |
 | gdscript | ✓ |  | ✓ |  |
 | git-attributes | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1049,7 +1049,7 @@ language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "481e7f8ddf27f07a47d1531b6e2b154b89ece31d" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "c0ebc82600caaf4339f2b00691f958e9df97c065" }
 
 [[language]]
 name = "kotlin"

--- a/runtime/queries/elixir/textobjects.scm
+++ b/runtime/queries/elixir/textobjects.scm
@@ -1,0 +1,27 @@
+; Function heads and guards have no body at all, so `keywords` and `do_block` nodes are both optional
+((call
+   target: (identifier) @_keyword
+   (arguments
+     [
+       (call
+         (arguments (_)? @parameter.inside))
+       ; function has a guard
+       (binary_operator
+         left:
+           (call
+             (arguments (_)? @parameter.inside)))
+     ]
+     ; body is "do: body" instead of a do-block
+     (keywords
+       (pair
+         value: (_) @function.inside))?)?
+   (do_block (_)* @function.inside)?)
+ (#match? @_keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp|test|describe|setup)$")) @function.around
+
+(anonymous_function
+  (stab_clause right: (body) @function.inside)) @function.around
+
+((call
+   target: (identifier) @_keyword
+   (do_block (_)* @class.inside))
+ (#match? @_keyword "^(defmodule|defprotocol|defimpl)$")) @class.around

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -58,7 +58,7 @@
  (#eq? @keyword "(spec|callback)"))
 
 ; Functions
-(function name: (atom) @function)
+(function_clause name: (atom) @function)
 (call module: (atom) @module)
 (call function: (atom) @function)
 (stab_clause name: (atom) @function)

--- a/runtime/queries/erlang/textobjects.scm
+++ b/runtime/queries/erlang/textobjects.scm
@@ -1,0 +1,8 @@
+(function_clause
+  pattern: (arguments (_)? @parameter.inside)
+  body: (_) @function.inside) @function.around
+
+(anonymous_function
+  (stab_clause body: (_) @function.inside)) @function.around
+
+(comment (comment_content) @comment.inside) @comment.around

--- a/runtime/queries/gleam/textobjects.scm
+++ b/runtime/queries/gleam/textobjects.scm
@@ -1,0 +1,6 @@
+(function
+  parameters: (function_parameters (function_parameter)? @parameter.inside)
+  body: (function_body) @function.inside) @function.around
+
+(anonymous_function
+  body: (function_body) @function.inside) @function.around

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -7,6 +7,8 @@
   (function_item
     body: (_) @function.inside)) @function.around
 
+(closure_expression body: (_) @function.inside) @function.around
+
 (
   [
     (attribute_item)+


### PR DESCRIPTION
Adds [textobject](https://docs.helix-editor.com/usage.html#textobjects) queries for Erlang, Elixir & Gleam

Also includes an update for tree-sitter-erlang that makes `function_clause` a named node.

Erlang and Elixir may have multiple function clauses for one function:

```erl
fib(0) -> 0;                                %% one textobj, ]f selects this line
fib(1) -> 1;                                %% this line is another
fib(N) when N > 0 -> fib(N-1) + fib(N-2).   %% and this line is another
```

In these queries I'm capturing function clauses as `function.around` but I'm curious if others think it should be around the entire function definition.