### PR TITLE
Update selection style of Night Owl

### DIFF
--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -17,7 +17,7 @@
 'ui.cursor' = { fg = 'background', bg = 'blue' }
 'ui.cursor.primary' = { fg = 'background', bg = 'gold' }
 'ui.cursor.match' = { bg = 'selection', modifiers = ['underlined'] }
-'ui.selection' = { fg = 'foreground', bg = 'selection' }
+'ui.selection' = { bg = 'selection', modifiers = ['dim'] }
 'ui.linenr' = { fg = 'grey4', bg = 'background2' }
 'ui.linenr.selected' = { fg = 'greyE', bg = 'background2'  }
 'ui.statusline' = { fg = 'greyE', bg = 'background2' }


### PR DESCRIPTION
This lets you still see syntax highlighting instead of having a set fg for selected text. I also set it to `dim` to make it more recognizable.