### PR TITLE
Avoid modifying jumplist until jumping to ref

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -485,8 +485,6 @@ fn goto_impl(
     locations: Vec<lsp::Location>,
     offset_encoding: OffsetEncoding,
 ) {
-    push_jump(editor);
-
     let cwdir = std::env::current_dir().expect("couldn't determine current directory");
 
     match locations.as_slice() {
@@ -520,6 +518,7 @@ fn goto_impl(
                     format!("{}:{}", file, line).into()
                 },
                 move |cx, location, action| {
+                    push_jump(cx.editor);
                     jump_to_location(cx.editor, location, offset_encoding, action)
                 },
                 move |_editor, location| Some(location_to_file_location(location)),


### PR DESCRIPTION
When a goto command is cancelled, the jumplist should remain unchanged.

This commit delays saving the current selection to the jumplist until jumping to a reference.

Fixes #2663