### PR TITLE
Fix reflow for CRLF line ending (wip)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,8 +1033,7 @@ dependencies = [
 [[package]]
 name = "textwrap"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+source = "git+https://github.com/mgeisler/textwrap?rev=9c648da#9c648da603fd99f4b37aeafbe5c617c3e1b64a1f"
 dependencies = [
  "smawk",
  "unicode-linebreak",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -41,7 +41,7 @@ encoding_rs = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 
 etcetera = "0.4"
-textwrap = "0.15.0"
+textwrap = { git = "https://github.com/mgeisler/textwrap", rev = "9c648da" }
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }

--- a/helix-core/src/wrap.rs
+++ b/helix-core/src/wrap.rs
@@ -1,7 +1,24 @@
 use smartstring::{LazyCompact, SmartString};
 
+use crate::LineEnding;
+
 /// Given a slice of text, return the text re-wrapped to fit it
 /// within the given width.
-pub fn reflow_hard_wrap(text: &str, max_line_len: usize) -> SmartString<LazyCompact> {
-    textwrap::refill(text, max_line_len).into()
+pub fn reflow_hard_wrap(
+    text: &str,
+    max_line_len: usize,
+    line_ending: LineEnding,
+) -> SmartString<LazyCompact> {
+    let options = textwrap::Options::new(max_line_len).line_ending(line_ending.into());
+    textwrap::refill(text, options).into()
+}
+
+impl Into<textwrap::LineEnding> for LineEnding {
+    fn into(self) -> textwrap::LineEnding {
+        match self {
+            LineEnding::Crlf => textwrap::LineEnding::CRLF,
+            // Best effort, match what's supported by textwrap
+            _ => textwrap::LineEnding::LF,
+        }
+    }
 }

--- a/helix-core/src/wrap.rs
+++ b/helix-core/src/wrap.rs
@@ -13,9 +13,9 @@ pub fn reflow_hard_wrap(
     textwrap::refill(text, options).into()
 }
 
-impl Into<textwrap::LineEnding> for LineEnding {
-    fn into(self) -> textwrap::LineEnding {
-        match self {
+impl From<LineEnding> for textwrap::LineEnding {
+    fn from(le: LineEnding) -> Self {
+        match le {
             LineEnding::Crlf => textwrap::LineEnding::CRLF,
             // Best effort, match what's supported by textwrap
             _ => textwrap::LineEnding::LF,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1093,7 +1093,8 @@ fn reflow(
     let selection = doc.selection(view.id);
     let transaction = Transaction::change_by_selection(rope, selection, |range| {
         let fragment = range.fragment(rope.slice(..));
-        let reflowed_text = helix_core::wrap::reflow_hard_wrap(&fragment, max_line_len);
+        let reflowed_text =
+            helix_core::wrap::reflow_hard_wrap(&fragment, max_line_len, doc.line_ending);
 
         (range.from(), range.to(), Some(reflowed_text))
     });


### PR DESCRIPTION
This is a fix for the #2645.

It assumes a fix for the _textwrap_ library, which is already in `master` but not yet released.

See details here https://github.com/mgeisler/textwrap/issues/453

Here's a quick demonstration of how it works
https://asciinema.org/a/KZNzsnuHYXppwzw6tvVHyfiSe
