### PR TITLE
Sort themes, language & files by score & then name

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -255,7 +255,9 @@ pub mod completers {
             })
             .collect();
 
-        matches.sort_unstable_by_key(|(name, score)| (Reverse(*score), name.to_lowercase()));
+        matches.sort_unstable_by(|(name1, score1), (name2, score2)| {
+            (Reverse(*score1), name1).cmp(&(Reverse(*score2), name2))
+        });
         names = matches.into_iter().map(|(name, _)| ((0..), name)).collect();
 
         names
@@ -311,7 +313,9 @@ pub mod completers {
             })
             .collect();
 
-        matches.sort_unstable_by_key(|(_language, score)| Reverse(*score));
+        matches.sort_unstable_by(|(language1, score1), (language2, score2)| {
+            (Reverse(*score1), language1).cmp(&(Reverse(*score2), language2))
+        });
 
         matches
             .into_iter()
@@ -426,13 +430,18 @@ pub mod completers {
 
             let range = (input.len().saturating_sub(file_name.len()))..;
 
-            matches.sort_unstable_by_key(|(_file, score)| Reverse(*score));
+            matches.sort_unstable_by(|(file1, score1), (file2, score2)| {
+                (Reverse(*score1), file1).cmp(&(Reverse(*score2), file2))
+            });
+
             files = matches
                 .into_iter()
                 .map(|(file, _)| (range.clone(), file))
                 .collect();
 
             // TODO: complete to longest common match
+        } else {
+            files.sort_unstable_by(|(_, path1), (_, path2)| path1.cmp(&path2));
         }
 
         files

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -255,7 +255,7 @@ pub mod completers {
             })
             .collect();
 
-        matches.sort_unstable_by_key(|(_file, score)| Reverse(*score));
+        matches.sort_unstable_by_key(|(name, score)| (Reverse(*score), name.to_lowercase()));
         names = matches.into_iter().map(|(name, _)| ((0..), name)).collect();
 
         names

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -441,7 +441,7 @@ pub mod completers {
 
             // TODO: complete to longest common match
         } else {
-            files.sort_unstable_by(|(_, path1), (_, path2)| path1.cmp(&path2));
+            files.sort_unstable_by(|(_, path1), (_, path2)| path1.cmp(path2));
         }
 
         files


### PR DESCRIPTION
*I haven't contributed before. I'm not attached to this change. I realise it might not be considered worth while. Just excited by the project and noticed this minor thing.*

Previously the themes were appearing unordered after typing `:theme `.
This sorts them first by fuzzy score and then by name so that they
generally appear in a more ordered fashion in the initial list.

The sort by name does not really pay off when there is a score so an
alternative approach would be to sort by score if there is string to
fuzzy match against and otherwise sort by name.

I've lowercased the names as that avoids lower case & upper case letters
being sorted into separate groups. There might be a preferable approach
to that though.