### PR TITLE
Add mode specific styles

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -45,6 +45,7 @@ hidden = false
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
+| `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 
 ### `[editor.lsp]` Section
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -219,6 +219,9 @@ These scopes are used for theming the editor interface.
 | `ui.linenr.selected`      | Line number for the line the cursor is on      |
 | `ui.statusline`           | Statusline                                     |
 | `ui.statusline.inactive`  | Statusline (unfocused document)                |
+| `ui.statusline.normal`    | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.insert`    | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.select`    | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
 | `ui.popup`                | Documentation popups (e.g space-k)             |
 | `ui.popup.info`           | Prompt for multiple key options                |
 | `ui.window`               | Border lines separating splits                 |
@@ -226,7 +229,7 @@ These scopes are used for theming the editor interface.
 | `ui.text`                 | Command prompts, popup text, etc.              |
 | `ui.text.focus`           |                                                |
 | `ui.text.info`            | The key: command text in `ui.popup.info` boxes |
-| `ui.virtual.ruler`        | Ruler columns (see the [`editor.rulers` config][rulers-config])|
+| `ui.virtual.ruler`        | Ruler columns (see the [`editor.rulers` config][editor-section])|
 | `ui.virtual.whitespace`   | Visible white-space characters                 |
 | `ui.virtual.indent-guide` | Vertical indent width guides                   |
 | `ui.menu`                 | Code and command completion menus              |
@@ -243,4 +246,4 @@ These scopes are used for theming the editor interface.
 | `diagnostic.warning`      | Diagnostics warning (editing area)             |
 | `diagnostic.error`        | Diagnostics error (editing area)               |
 
-[rulers-config]: ./configuration.md#editor-section
+[editor-section]: ./configuration.md#editor-section

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -701,10 +701,10 @@ impl EditorView {
         // Left side of the status line.
         //-------------------------------
 
-        let mode = match doc.mode() {
-            Mode::Insert => "INS",
-            Mode::Select => "SEL",
-            Mode::Normal => "NOR",
+        let (mode, mode_style) = match doc.mode() {
+            Mode::Insert => (" INS ", theme.get("ui.statusline.insert")),
+            Mode::Select => (" SEL ", theme.get("ui.statusline.select")),
+            Mode::Normal => (" NOR ", theme.get("ui.statusline.normal")),
         };
         let progress = doc
             .language_server()
@@ -723,7 +723,7 @@ impl EditorView {
         // statusline
         surface.set_style(viewport.with_height(1), base_style);
         if is_focused {
-            surface.set_string(viewport.x + 1, viewport.y, mode, base_style);
+            surface.set_string(viewport.x, viewport.y, mode, mode_style);
         }
         surface.set_string(viewport.x + 5, viewport.y, progress, base_style);
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -157,7 +157,7 @@ impl EditorView {
             .area
             .clip_top(view.area.height.saturating_sub(1))
             .clip_bottom(1); // -1 from bottom to remove commandline
-        self.render_statusline(doc, view, statusline_area, surface, theme, is_focused);
+        self.render_statusline(editor, doc, view, statusline_area, surface, is_focused);
     }
 
     pub fn render_rulers(
@@ -688,11 +688,11 @@ impl EditorView {
 
     pub fn render_statusline(
         &self,
+        editor: &Editor,
         doc: &Document,
         view: &View,
         viewport: Rect,
         surface: &mut Surface,
-        theme: &Theme,
         is_focused: bool,
     ) {
         use tui::text::{Span, Spans};
@@ -701,6 +701,7 @@ impl EditorView {
         // Left side of the status line.
         //-------------------------------
 
+        let theme = &editor.theme;
         let (mode, mode_style) = match doc.mode() {
             Mode::Insert => (" INS ", theme.get("ui.statusline.insert")),
             Mode::Select => (" SEL ", theme.get("ui.statusline.select")),
@@ -723,7 +724,13 @@ impl EditorView {
         // statusline
         surface.set_style(viewport.with_height(1), base_style);
         if is_focused {
-            surface.set_string(viewport.x, viewport.y, mode, mode_style);
+            let color_modes = editor.config().color_modes;
+            surface.set_string(
+                viewport.x,
+                viewport.y,
+                mode,
+                if color_modes { mode_style } else { base_style },
+            );
         }
         surface.set_string(viewport.x + 5, viewport.y, progress, base_style);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -158,6 +158,8 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,
+    /// Whether to color modes with different colors. Defaults to `false`.
+    pub color_modes: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -410,6 +412,7 @@ impl Default for Config {
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
+            color_modes: false,
         }
     }
 }

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -9,6 +9,9 @@
 "ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
 "ui.statusline" = {fg = "foam", bg = "surface" }
+"ui.statusline.insert" = {fg = "base", bg = "foam", modifiers = ["bold"]}
+"ui.statusline.normal" = {fg = "base", bg = "rose", modifiers = ["bold"]}
+"ui.statusline.select" = {fg = "base", bg = "iris", modifiers = ["bold"]}
 "ui.statusline.inactive" = { fg = "iris", bg = "surface" }
 "ui.cursor" = { fg = "rose", modifiers = ["reversed"] }
 "ui.text" = { fg = "text" }


### PR DESCRIPTION
In similar vein to neovim's `lualine` and similar statusline packages this allows helix users to style their mode based on which mode it is thus making each mode more visually distinct at a glance

Screenshots of how it looks attached below
<img width="747" alt="cropped-nor" src="https://user-images.githubusercontent.com/5855663/172017539-7684043e-94b2-4f0a-8179-57bf830b4e49.png">
<img width="746" alt="cropped-ins" src="https://user-images.githubusercontent.com/5855663/172017546-53ebb4b4-c7ca-4e6a-ac8e-d2cef20e7f10.png">
<img width="746" alt="cropped-sel" src="https://user-images.githubusercontent.com/5855663/172017549-d2848b56-4beb-4755-a730-acca104bbcd1.png">

