### PR TITLE
Support opening symbol definition in a separate view.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -272,7 +272,7 @@ impl MappableCommand {
         normal_mode, "Enter normal mode",
         select_mode, "Enter selection extend mode",
         exit_select_mode, "Exit selection mode",
-        goto_definition, "Goto definition",
+        goto_definition_replace, "Goto definition",
         add_newline_above, "Add newline above",
         add_newline_below, "Add newline below",
         goto_type_definition, "Goto type definition",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1202,6 +1202,20 @@ fn pipe(
     Ok(())
 }
 
+fn goto_definition(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    _event: PromptEvent,
+) -> anyhow::Result<()> {
+    let action = match args[0].as_ref() {
+        "vsplit" => Action::VerticalSplit,
+        "hsplit" => Action::HorizontalSplit,
+        &_ => Action::Replace,
+    };
+    lsp::goto_definition(cx, action);
+    Ok(())
+}
+
 fn run_shell_command(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -1717,6 +1731,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &["sh"],
             doc: "Run a shell command",
             fun: run_shell_command,
+            completer: Some(completers::directory),
+        },
+         TypableCommand {
+            name: "goto_definition",
+            aliases: &[],
+            doc: "Go to definition",
+            fun: goto_definition,
             completer: Some(completers::directory),
         },
     ];

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -36,14 +36,14 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "v" => select_mode,
         "G" => goto_line,
-        "g" => { "Goto"
+       "g" => { "Goto"
             "g" => goto_file_start,
             "e" => goto_last_line,
             "f" => goto_file,
             "h" => goto_line_start,
             "l" => goto_line_end,
             "s" => goto_first_nonwhitespace,
-            "d" => goto_definition,
+            "d" => goto_definition_replace,
             "y" => goto_type_definition,
             "r" => goto_reference,
             "i" => goto_implementation,


### PR DESCRIPTION
I would like to be able to open a symbol definition in a split view rather than replacing the current one. I have not found support for this in helix. This PR is a request for navigating me to the right direction rather than a final implementation (it does not fix all possible code branches and there is some code duplication). I suspect there might be already some more general idea/design about passing a view as a destination for a command.
Much appreciate any suggestions.