### PR TITLE
Unimplemented repeat multiple commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -256,9 +256,7 @@ impl MappableCommand {
         flip_selections, "Flip selection cursor and anchor",
         ensure_selections_forward, "Ensure the selection is in forward direction",
         insert_mode, "Insert before selection",
-        insert_mode_collapse, "Insert before selection without extending",
         append_mode, "Insert after selection (append)",
-        append_mode_collapse, "Insert after selection (append) without extending",
         command_mode, "Enter command mode",
         file_picker, "Open file picker",
         file_picker_in_current_directory, "Open file picker at current working directory",
@@ -2103,12 +2101,6 @@ fn insert_mode(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
-// inserts at the start of each selection, without extending
-fn insert_mode_collapse(cx: &mut Context) {
-    insert_mode(cx);
-    collapse_selection(cx);
-}
-
 // inserts at the end of each selection
 fn append_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
@@ -2135,12 +2127,6 @@ fn append_mode(cx: &mut Context) {
         )
     });
     doc.set_selection(view.id, selection);
-}
-
-// inserts at the end of each selection, without extending
-fn append_mode_collapse(cx: &mut Context) {
-    append_mode(cx);
-    collapse_selection(cx);
 }
 
 fn file_picker(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -256,7 +256,9 @@ impl MappableCommand {
         flip_selections, "Flip selection cursor and anchor",
         ensure_selections_forward, "Ensure the selection is in forward direction",
         insert_mode, "Insert before selection",
+        insert_mode_collapse, "Insert before selection without extending",
         append_mode, "Insert after selection (append)",
+        append_mode_collapse, "Insert after selection (append) without extending",
         command_mode, "Enter command mode",
         file_picker, "Open file picker",
         file_picker_in_current_directory, "Open file picker at current working directory",
@@ -2101,6 +2103,12 @@ fn insert_mode(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
+// inserts at the start of each selection, without extending
+fn insert_mode_collapse(cx: &mut Context) {
+    insert_mode(cx);
+    collapse_selection(cx);
+}
+
 // inserts at the end of each selection
 fn append_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
@@ -2127,6 +2135,12 @@ fn append_mode(cx: &mut Context) {
         )
     });
     doc.set_selection(view.id, selection);
+}
+
+// inserts at the end of each selection, without extending
+fn append_mode_collapse(cx: &mut Context) {
+    append_mode(cx);
+    collapse_selection(cx);
 }
 
 fn file_picker(cx: &mut Context) {


### PR DESCRIPTION
Hi !
This PR _partially_ resolves a `FIXME`. It allows the editor to enter insert mode through a sequence of commands without panicking, making possible the use of user mappings such as:

```toml
a = ["append_mode", "collapse_selection"]
C = ["extend_to_line_end", "change_selection"]
# ...
```

And of course the sequence is repeatable with "."

There are still the cases of pending, not found and cancelled keys to handle though.