### PR TITLE
Do not add extra line breaks in markdown lists

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -171,6 +171,8 @@ impl Markdown {
                 Event::Start(Tag::List(list)) => list_stack.push(list),
                 Event::End(Tag::List(_)) => {
                     list_stack.pop();
+                    // whenever list closes, new line
+                    lines.push(Spans::default());
                 }
                 Event::Start(Tag::Item) => {
                     tags.push(Tag::Item);
@@ -186,11 +188,19 @@ impl Markdown {
                         | Tag::Paragraph
                         | Tag::CodeBlock(CodeBlockKind::Fenced(_))
                         | Tag::Item => {
-                            // whenever code block or paragraph closes, new line
                             let spans = std::mem::take(&mut spans);
                             if !spans.is_empty() {
                                 lines.push(Spans::from(spans));
                             }
+                        }
+                        _ => (),
+                    }
+
+                    // whenever heading, code block or paragraph closes, new line
+                    match tag {
+                        Tag::Heading(_, _, _)
+                        | Tag::Paragraph
+                        | Tag::CodeBlock(CodeBlockKind::Fenced(_)) => {
                             lines.push(Spans::default());
                         }
                         _ => (),


### PR DESCRIPTION
Before:
![list-newlines](https://user-images.githubusercontent.com/3251566/172251724-f730e74f-1bf5-49d5-9b66-ab44041228a6.png)


After:
![list-newlines-fixed](https://user-images.githubusercontent.com/3251566/172252198-60fbbb0a-3b32-4d32-9322-774db8080e40.png)
