### PR TITLE
simplify some keymap key names follow up tests

### DIFF
--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -323,7 +323,39 @@ mod test {
                 code: KeyCode::Char('%'),
                 modifiers: KeyModifiers::NONE
             }
-        )
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>(";").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char(';'),
+                modifiers: KeyModifiers::NONE
+            }
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>(">").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('>'),
+                modifiers: KeyModifiers::NONE
+            }
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>("<").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('<'),
+                modifiers: KeyModifiers::NONE
+            }
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>("+").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('+'),
+                modifiers: KeyModifiers::NONE
+            }
+        );
     }
 
     #[test]
@@ -349,6 +381,14 @@ mod test {
             KeyEvent {
                 code: KeyCode::Char('2'),
                 modifiers: KeyModifiers::SHIFT | KeyModifiers::CONTROL
+            }
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>("A-C-+").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('+'),
+                modifiers: KeyModifiers::ALT | KeyModifiers::CONTROL
             }
         );
     }


### PR DESCRIPTION
## Summary

> Rather than just testing these keys are now unsupported, shouldn't we also test that they get parsed correctly by the new syntax?

Adding more happy path tests to make sure the removed key names are parsed correctly by the new syntax. This is a follow up to this [comment](https://github.com/helix-editor/helix/pull/2677#discussion_r889790263) in the previous PR #2677 





