### PR TITLE
LSP Completion preselect and preview doc

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -54,7 +54,6 @@ hidden = false
 | Key                | Description                                         | Default |
 | ---                | -----------                                         | ------- |
 | `display-messages` | Display LSP progress messages below statusline[^1]  | `false` |
-| `preselect`        | Show the LSP server's preselected suggestions first | `true`  |
 
 [^1]: A progress spinner is always shown in the statusline beside the file path.
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -43,6 +43,7 @@ hidden = false
 | `auto-format` | Enable automatic formatting on save. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
+| `completion-doc-preview` | Show the documentation of the first item in the completion menu | `false` |
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
@@ -50,9 +51,10 @@ hidden = false
 
 ### `[editor.lsp]` Section
 
-| Key                | Description                                 | Default |
-| ---                | -----------                                 | ------- |
-| `display-messages` | Display LSP progress messages below statusline[^1] | `false` |
+| Key                | Description                                         | Default |
+| ---                | -----------                                         | ------- |
+| `display-messages` | Display LSP progress messages below statusline[^1]  | `false` |
+| `preselect`        | Show the LSP server's preselected suggestions first | `true`  |
 
 [^1]: A progress spinner is always shown in the statusline beside the file path.
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -686,7 +686,14 @@ impl Application {
                             self.lsp_progress.update(server_id, token, work);
                         }
 
-                        if self.config.load().editor.lsp.display_messages {
+                        if self
+                            .config
+                            .load()
+                            .editor
+                            .lsp
+                            .display_messages
+                            .unwrap_or(false)
+                        {
                             self.editor.set_status(status);
                         }
                     }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -686,14 +686,7 @@ impl Application {
                             self.lsp_progress.update(server_id, token, work);
                         }
 
-                        if self
-                            .config
-                            .load()
-                            .editor
-                            .lsp
-                            .display_messages
-                            .unwrap_or(false)
-                        {
+                        if self.config.load().editor.lsp.display_messages {
                             self.editor.set_status(status);
                         }
                     }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -453,7 +453,6 @@ pub fn code_action(cx: &mut Context) {
                 actions,
                 (),
                 ui::menu::SortStrategy::Text,
-                false,
                 move |editor, code_action, event| {
                     if event != PromptEvent::Validate {
                         return;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -449,34 +449,41 @@ pub fn code_action(cx: &mut Context) {
                 return;
             }
 
-            let mut picker = ui::Menu::new(actions, (), move |editor, code_action, event| {
-                if event != PromptEvent::Validate {
-                    return;
-                }
-
-                // always present here
-                let code_action = code_action.unwrap();
-
-                match code_action {
-                    lsp::CodeActionOrCommand::Command(command) => {
-                        log::debug!("code action command: {:?}", command);
-                        execute_lsp_command(editor, command.clone());
+            let mut picker = ui::Menu::new(
+                actions,
+                (),
+                ui::menu::SortStrategy::Text,
+                false,
+                move |editor, code_action, event| {
+                    if event != PromptEvent::Validate {
+                        return;
                     }
-                    lsp::CodeActionOrCommand::CodeAction(code_action) => {
-                        log::debug!("code action: {:?}", code_action);
-                        if let Some(ref workspace_edit) = code_action.edit {
-                            log::debug!("edit: {:?}", workspace_edit);
-                            apply_workspace_edit(editor, offset_encoding, workspace_edit);
-                        }
 
-                        // if code action provides both edit and command first the edit
-                        // should be applied and then the command
-                        if let Some(command) = &code_action.command {
+                    // always present here
+                    let code_action = code_action.unwrap();
+
+                    match code_action {
+                        lsp::CodeActionOrCommand::Command(command) => {
+                            log::debug!("code action command: {:?}", command);
                             execute_lsp_command(editor, command.clone());
                         }
+
+                        lsp::CodeActionOrCommand::CodeAction(code_action) => {
+                            log::debug!("code action: {:?}", code_action);
+                            if let Some(ref workspace_edit) = code_action.edit {
+                                log::debug!("edit: {:?}", workspace_edit);
+                                apply_workspace_edit(editor, offset_encoding, workspace_edit);
+                            }
+
+                            // if code action provides both edit and command first the edit
+                            // should be applied and then the command
+                            if let Some(command) = &code_action.command {
+                                execute_lsp_command(editor, command.clone());
+                            }
+                        }
                     }
-                }
-            });
+                },
+            );
             picker.move_down(); // pre-select the first item
 
             let popup =

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -100,7 +100,6 @@ impl Completion {
             items,
             (),
             menu::SortStrategy::Score,
-            editor.config().lsp.preselect.unwrap_or(false),
             move |editor: &mut Editor, item, event| {
                 fn item_to_transaction(
                     doc: &Document,

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -76,7 +76,6 @@ pub struct Menu<T: Item> {
     viewport: (u16, u16),
     recalculate: bool,
     sort_strategy: SortStrategy,
-    use_preselect: bool,
 }
 
 impl<T: Item> Menu<T> {
@@ -88,7 +87,6 @@ impl<T: Item> Menu<T> {
         options: Vec<T>,
         editor_data: <T as Item>::Data,
         sort_strategy: SortStrategy,
-        use_preselect: bool,
         callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
     ) -> Self {
         let mut menu = Self {
@@ -104,7 +102,6 @@ impl<T: Item> Menu<T> {
             viewport: (0, 0),
             recalculate: true,
             sort_strategy,
-            use_preselect,
         };
 
         // TODO: scoring on empty input should just use a fastpath
@@ -116,7 +113,6 @@ impl<T: Item> Menu<T> {
     pub fn score(&mut self, pattern: &str) {
         // dereference pointers here, not inside of the filter_map() loop
         let is_pattern_empty = pattern.is_empty();
-        let use_preselect = self.use_preselect;
 
         // reuse the matches allocation
         self.matches.clear();
@@ -129,7 +125,7 @@ impl<T: Item> Menu<T> {
                     // TODO: using fuzzy_indices could give us the char idx for match highlighting
 
                     // If prompt pattern is empty, show the preselected item as first option
-                    if use_preselect && is_pattern_empty {
+                    if is_pattern_empty {
                         if option.preselected() {
                             // The LSP server can preselect multiple items, however it doesn't give any preference
                             // for one over the other, so they all have the same score

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -15,6 +15,11 @@ use fuzzy_matcher::FuzzyMatcher;
 use helix_view::{graphics::Rect, Editor};
 use tui::layout::Constraint;
 
+pub enum SortStrategy {
+    Text,
+    Score,
+}
+
 pub trait Item {
     /// Additional editor state that is used for label calculation.
     type Data;
@@ -33,6 +38,10 @@ pub trait Item {
 
     fn row(&self, data: &Self::Data) -> Row {
         Row::new(vec![Cell::from(self.label(data))])
+    }
+
+    fn preselected(&self) -> bool {
+        false
     }
 }
 
@@ -66,6 +75,8 @@ pub struct Menu<T: Item> {
     size: (u16, u16),
     viewport: (u16, u16),
     recalculate: bool,
+    sort_strategy: SortStrategy,
+    use_preselect: bool,
 }
 
 impl<T: Item> Menu<T> {
@@ -76,6 +87,8 @@ impl<T: Item> Menu<T> {
     pub fn new(
         options: Vec<T>,
         editor_data: <T as Item>::Data,
+        sort_strategy: SortStrategy,
+        use_preselect: bool,
         callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
     ) -> Self {
         let mut menu = Self {
@@ -90,6 +103,8 @@ impl<T: Item> Menu<T> {
             size: (0, 0),
             viewport: (0, 0),
             recalculate: true,
+            sort_strategy,
+            use_preselect,
         };
 
         // TODO: scoring on empty input should just use a fastpath
@@ -99,6 +114,10 @@ impl<T: Item> Menu<T> {
     }
 
     pub fn score(&mut self, pattern: &str) {
+        // dereference pointers here, not inside of the filter_map() loop
+        let is_pattern_empty = pattern.is_empty();
+        let use_preselect = self.use_preselect;
+
         // reuse the matches allocation
         self.matches.clear();
         self.matches.extend(
@@ -108,15 +127,34 @@ impl<T: Item> Menu<T> {
                 .filter_map(|(index, option)| {
                     let text: String = option.filter_text(&self.editor_data).into();
                     // TODO: using fuzzy_indices could give us the char idx for match highlighting
-                    self.matcher
-                        .fuzzy_match(&text, pattern)
-                        .map(|score| (index, score))
+
+                    // If prompt pattern is empty, show the preselected item as first option
+                    if use_preselect && is_pattern_empty {
+                        if option.preselected() {
+                            // The LSP server can preselect multiple items, however it doesn't give any preference
+                            // for one over the other, so they all have the same score
+                            Some((index, 1))
+                        } else {
+                            Some((index, 0))
+                        }
+                    } else {
+                        self.matcher
+                            .fuzzy_match(&text, pattern)
+                            .map(|score| (index, score))
+                    }
                 }),
         );
-        // matches.sort_unstable_by_key(|(_, score)| -score);
-        self.matches.sort_unstable_by_key(|(index, _score)| {
-            self.options[*index].sort_text(&self.editor_data)
-        });
+
+        match self.sort_strategy {
+            SortStrategy::Text => {
+                self.matches.sort_unstable_by_key(|(index, _score)| {
+                    self.options[*index].sort_text(&self.editor_data)
+                });
+            }
+            SortStrategy::Score => {
+                self.matches.sort_unstable_by_key(|(_, score)| -score);
+            }
+        };
 
         // reset cursor position
         self.cursor = None;
@@ -206,12 +244,14 @@ impl<T: Item> Menu<T> {
         }
     }
 
+    pub fn get_match(&self, index: usize) -> Option<&T> {
+        self.matches
+            .get(index)
+            .map(|(index, _score)| &self.options[*index])
+    }
+
     pub fn selection(&self) -> Option<&T> {
-        self.cursor.and_then(|cursor| {
-            self.matches
-                .get(cursor)
-                .map(|(index, _score)| &self.options[*index])
-        })
+        self.cursor.and_then(|cursor| self.get_match(cursor))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -220,6 +260,14 @@ impl<T: Item> Menu<T> {
 
     pub fn len(&self) -> usize {
         self.matches.len()
+    }
+
+    pub fn options(&self) -> &[T] {
+        &self.options
+    }
+
+    pub fn matches(&self) -> &[(usize, i64)] {
+        self.matches.as_ref()
     }
 }
 
@@ -298,6 +346,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             .try_get("ui.menu")
             .unwrap_or_else(|| theme.get("ui.text"));
         let selected = theme.get("ui.menu.selected");
+        let highlighted = theme.get("ui.menu.highlighted");
         surface.clear_with(area, style);
 
         let scroll = self.scroll;
@@ -327,7 +376,8 @@ impl<T: Item + 'static> Component for Menu<T> {
         let rows = options.iter().map(|option| option.row(&self.editor_data));
         let table = Table::new(rows)
             .style(style)
-            .highlight_style(selected)
+            .selected_style(selected)
+            .highlighted_style(highlighted)
             .column_spacing(1)
             .widths(&self.widths);
 
@@ -339,6 +389,10 @@ impl<T: Item + 'static> Component for Menu<T> {
             &mut TableState {
                 offset: scroll,
                 selected: self.cursor,
+                highlighted: match cx.editor.config().completion_doc_preview {
+                    true => Some(0),
+                    false => None,
+                },
             },
         );
 

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -175,7 +175,9 @@ impl<'a> Row<'a> {
 /// // ...and they can be separated by a fixed spacing.
 /// .column_spacing(1)
 /// // If you wish to highlight a row in any specific way when it is selected...
-/// .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+/// .selected_style(Style::default().add_modifier(Modifier::BOLD))
+/// // If you wish to highlight a row in any specific way when it is preselected...
+/// .highlighted_style(Style::default().add_modifier(Modifier::BOLD))
 /// // ...and potentially show a symbol in front of the selection.
 /// .highlight_symbol(">>");
 /// ```

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -171,7 +171,7 @@ pub struct Config {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
     /// Whether to display LSP status messages below the statusline
-    pub display_messages: Option<bool>,
+    pub display_messages: bool,
     /// Whether to use show the LSP server preselected suggestion at the top of the menu. Defaults to true.
     pub preselect: Option<bool>,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -172,8 +172,6 @@ pub struct Config {
 pub struct LspConfig {
     /// Whether to display LSP status messages below the statusline
     pub display_messages: bool,
-    /// Whether to use show the LSP server preselected suggestion at the top of the menu. Defaults to true.
-    pub preselect: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -163,12 +163,17 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// Whether to show the documentation of the first item in the completion menu. Defaults to false.
+    pub completion_doc_preview: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
-    pub display_messages: bool,
+    /// Whether to display LSP status messages below the statusline
+    pub display_messages: Option<bool>,
+    /// Whether to use show the LSP server preselected suggestion at the top of the menu. Defaults to true.
+    pub preselect: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -417,6 +422,7 @@ impl Default for Config {
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            completion_doc_preview: false,
         }
     }
 }

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -10,6 +10,7 @@
 "ui.background" = { bg = "my_gray0" }
 "ui.menu" = { fg = "my_white", bg = "my_gray2" }
 "ui.menu.selected" = { fg = "my_gray2", bg = "my_gray5" }
+"ui.menu.highlighted" = { fg = "my_red", bg = "my_gray2" }
 "ui.linenr" = { fg = "my_gray4", bg = "my_gray2" }
 "ui.popup" = { bg = "my_gray2" }
 "ui.window" = { fg = "my_gray4", bg = "my_gray2" }

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -62,6 +62,7 @@
 
 "ui.menu" = { fg = "#e5ded6bg", bg = "#232d38" }
 "ui.menu.selected" = { bg = "#313f4e" }
+"ui.menu.highlighted" = { fg = "#dcb659" }
 
 "warning" = "#dc7759"
 "error" = "#dc597f"

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -29,6 +29,7 @@
 "ui.linenr.selected" = { fg = "foreground" }
 "ui.menu" = { fg = "foreground", bg = "background_dark" }
 "ui.menu.selected" = { fg = "cyan", bg = "background_dark" }
+"ui.menu.highlighted" = { fg = "cyan" }
 "ui.popup" = { fg = "foreground", bg = "background_dark" }
 "ui.selection" = { bg = "secondary_highlight" }
 "ui.selection.primary" = { bg = "primary_highlight" }

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -54,6 +54,7 @@
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
+"ui.menu.highlighted" = { fg = "green1" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -59,6 +59,7 @@
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
 "ui.menu" = { fg = "#7B91B3", bg = "#F3EAE9" }
 "ui.menu.selected" = { fg = "#D74E50", bg = "#F3EAE9" }
+"ui.menu.highlighted" = { fg = "#D74E50" }
 
 "warning" = "#D4A520"
 "error" = "#D74E50"

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -61,6 +61,7 @@
 "ui.help" = { bg = "widget" }
 "ui.menu" = { bg = "widget" }
 "ui.menu.selected" = { bg = "#414339" }
+"ui.menu.highlighted" = { fg = "#F92672" }
 
 "ui.cursor" = { fg = "cursor", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "cursor", modifiers = ["reversed"] }

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -6,6 +6,7 @@
 "ui.menu" = { fg = "nord6", bg = "#232d38" }
 "ui.menu.selected" = { fg = "nord8", bg = "nord2" }
 "ui.virtual.whitespace" = "gray"
+"ui.menu.highlighted" = { fg = "nord8" }
 
 "info" = "nord8"
 "hint" = "nord8"

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -75,6 +75,7 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.menu" = { fg = "white", bg = "gray" }
 "ui.menu.selected" = { fg = "black", bg = "blue" }
 "ui.menu.scroll" = { fg = "white", bg = "light-gray" }
+"ui.menu.highlighted" = { fg = "red" }
 
 [palette]
 

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -4,6 +4,7 @@
 "ui.background" = { bg = "base" }
 "ui.menu" = { fg = "text", bg = "overlay" }
 "ui.menu.selected" = { fg = "iris", bg = "surface" }
+"ui.menu.highlighted" = { fg = "iris"}
 "ui.linenr" = {fg = "subtle" }
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = { bg = "highlight" }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -30,6 +30,7 @@
 "ui.linenr.selected" = { fg = "foreground" }
 "ui.menu" = { fg = "foreground", bg = "background_dark" }
 "ui.menu.selected" = { fg = "cyan", bg = "background_dark" }
+"ui.menu.highlighted" = { fg = "cyan" }
 "ui.popup" = { fg = "foreground", bg = "background_dark" }
 "ui.selection" = { bg = "secondary_highlight" }
 "ui.selection.primary" = { bg = "primary_highlight" }

--- a/theme.toml
+++ b/theme.toml
@@ -71,6 +71,7 @@ label = "honey"
 "ui.menu" = { fg = "lavender", bg = "revolver" }
 "ui.menu.selected" = { fg = "revolver", bg = "white" }
 "ui.menu.scroll" = { fg = "lavender", bg = "comet" }
+"ui.menu.highlighted" = { fg = "almond"}
 
 diagnostic = { modifiers = ["underlined"] }
 # "diagnostic.hint" = { fg = "revolver", bg = "lilac" }


### PR DESCRIPTION
Hi !

This PR implements two completion features that are present in other LSP enabled editors, regarding preselection : 

## Support LSP preselect completion items

In addition to suggesting completion, some LSP servers can tell the client which suggestions would be the most probable fit. For instance, if you want to assign a value to a variable named `position`, RA will preselect a method that is also named `position()` if it is part of the suggested items. The LSP server can mark multiple completion items as preselect. This PR makes these preselected items appear at the top of the completion menu.

This behavior is configurable with the `editor.lsp.preselect` field, which defaults to `true`.

##  Preview the documentation of the first completion item without selecting it

When using preselect, having a live preview of the documentation can be nice to some users. This PR introduces an option to have the documentation of the first completion item show up while typing, without necessarily selecting it.

This behavior is configurable with the `editor.completion-doc-preview` field, which defaults to `false`.

The first item can also be highlighted, otherwise it can look confusing. The corresponding highlight is `ui.menu.highlighted`.

To implement this, I had to add a `highlighted` feature to the `Menu` component, distinct from the `selected` one, which could be useful for other stuff later.

Here is a little demo that shows both of the features enabled on top, and disabled below:

![Peek 2022-06-08 01-15](https://user-images.githubusercontent.com/43273245/172498504-433a041f-e338-4fcf-9ead-3fcde58b4100.gif)

I can add the highlight to the default themes if the PR goes through.

Thanks and have a good evening !