### PR TITLE
elixirLS disable dialyzer by default

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -88,6 +88,7 @@ shebangs = ["elixir"]
 roots = []
 comment-token = "#"
 language-server = { command = "elixir-ls" }
+config = { elixirLS.dialyzerEnabled = false }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Not all Elixir projects use dialyzer and it can cause the editor to slow down quite a bit on large projects if the PLT is not built.

See https://github.com/elixir-lsp/elixir-ls#dialyzer-integration=