### PR TITLE
check selection's visible width when copying on mouse click

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1092,14 +1092,13 @@ impl EditorView {
                 }
 
                 let (view, doc) = current!(cxt.editor);
-                let range = doc.selection(view.id).primary();
 
                 if doc
-                    .text()
-                    .slice(range.from()..range.to())
-                    .as_str()
-                    .filter(|selection| selection.width() <= 1)
-                    .is_some()
+                    .selection(view.id)
+                    .primary()
+                    .fragment(doc.text().slice(..))
+                    .width()
+                    <= 1
                 {
                     return EventResult::Ignored(None);
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1094,7 +1094,13 @@ impl EditorView {
                 let (view, doc) = current!(cxt.editor);
                 let range = doc.selection(view.id).primary();
 
-                if range.to() - range.from() <= 1 {
+                if doc
+                    .text()
+                    .slice(range.from()..range.to())
+                    .as_str()
+                    .filter(|selection| selection.width() <= 1)
+                    .is_some()
+                {
                     return EventResult::Ignored(None);
                 }
 


### PR DESCRIPTION
Mouse-click-up copies the selection produced by dragging. The event
is ignored if the selection has a width of 1 though so you don't
copy when clicking rather than dragging. The current check copies
text when it has a visible width of 1 but is actually multiple
characters in the rope like a CRLF line-ending. With this change
we check the unicode width of the character(s) in the selection
rather than the range length, so clicking on a CRLF line-ending
does not copy.

Closes #2699