### PR TITLE
Add single width left margin for completion popup

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -48,6 +48,8 @@ pub struct Menu<T: Item> {
 }
 
 impl<T: Item> Menu<T> {
+    const LEFT_PADDING: usize = 1;
+
     // TODO: it's like a slimmed down picker, share code? (picker = menu + prompt with different
     // rendering)
     pub fn new(
@@ -150,6 +152,7 @@ impl<T: Item> Menu<T> {
             len += 1; // +1: reserve some space for scrollbar
         }
 
+        len += Self::LEFT_PADDING;
         let width = len.min(viewport.0 as usize);
 
         self.widths = max_lens
@@ -306,13 +309,19 @@ impl<T: Item + 'static> Component for Menu<T> {
         use tui::widgets::TableState;
 
         table.render_table(
-            area,
+            area.clip_left(Self::LEFT_PADDING as u16),
             surface,
             &mut TableState {
                 offset: scroll,
                 selected: self.cursor,
             },
         );
+
+        if let Some(cursor) = self.cursor {
+            let offset_from_top = cursor - scroll;
+            let cell = &mut surface[(area.x, area.y + offset_from_top as u16)];
+            cell.set_style(selected);
+        }
 
         let fits = len <= win_height;
 

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -274,6 +274,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             .try_get("ui.menu")
             .unwrap_or_else(|| theme.get("ui.text"));
         let selected = theme.get("ui.menu.selected");
+        surface.clear_with(area, style);
 
         let scroll = self.scroll;
 


### PR DESCRIPTION
Adds a bit of padding to the left edge of the completion popup:

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/23398472/172911110-3e94c9aa-4b7b-4f9e-bfdc-7668bb696fb8.png) | ![after](https://user-images.githubusercontent.com/23398472/172911128-852324db-e18a-49d9-8a1a-1eec0e807258.png) |
