### PR TITLE
Add `unbind-default-keys` config option

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -75,5 +75,23 @@ Ctrl, Shift and Alt modifiers are encoded respectively with the prefixes
 
 Keys can be disabled by binding them to the `no_op` command.
 
+To remove all default bindings, `unbind-default-keys = true` can be added to the top level configuration.
+
+```toml
+unbind-default-keys = true
+
+# Only these normal mode bindings will be used
+[keys.normal]
+n = "normal_mode"
+t = "goto_definition"
+
+# remember to add bindings to return to normal mode
+[keys.select]
+esc = "normal_mode"
+
+[keys.insert]
+esc = "normal_mode"
+```
+
 A list of commands is available in the [Keymap](https://docs.helix-editor.com/keymap.html) documentation
  and in the source code at [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs) at the invocation of `static_commands!` macro and the `TypableCommandList`.

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -360,7 +360,10 @@ impl Keymaps {
     pub fn get(&mut self, mode: Mode, key: KeyEvent) -> KeymapResult {
         // TODO: remove the sticky part and look up manually
         let keymaps = &*self.map();
-        let keymap = &keymaps[&mode];
+        let keymap = match keymaps.get(&mode) {
+            Some(keymap) => keymap,
+            None => return KeymapResult::NotFound,
+        };
 
         if key!(Esc) == key {
             if !self.state.is_empty() {
@@ -415,10 +418,10 @@ impl Default for Keymaps {
     }
 }
 
-/// Merge default config keys with user overwritten keys for custom user config.
+/// Merge existing config keys with user overwritten keys.
 pub fn merge_keys(dst: &mut HashMap<Mode, Keymap>, mut delta: HashMap<Mode, Keymap>) {
-    for (mode, keys) in dst {
-        keys.merge(delta.remove(mode).unwrap_or_default())
+    for (mode, keys) in delta.drain() {
+        dst.entry(mode).or_default().merge(keys);
     }
 }
 


### PR DESCRIPTION
Closes #2720.

There were a few changes I made to reduce confusion with some function/method locations and naming:

- `helix_term::keymap::merge_keys` was moved to `helix_term::config::Config::merge_keys` as a method because it only operates on and changes `Config`, and was modified to take a set of bindings to merge with itself. New functions were also added to handle the new optional behavior.
- `Config::load` now is the single source of truth for loading and merging configs, which was previously also handled in `helix_term::application::new` in a slightly different but mostly redundant manner.
- `Default` is removed from `Config` and replaced with `Config::new` and `Config::with_default_keys`. `new` returns a Config with no bindings while `with_default_keys` returns a Config with the default bindings (which is the same behavior as the old `default`). This to prevent confusion between a default rust `struct` and helix's default keybindings as these terms were previously conflated.
- `Config::keys` no longer loads default bindings through serde when no keys are found as this was always redundant.
- `helix_term::keymap::Keymaps::get` no longer crashes when a mode isn't found. This will also help with future mode additions (likely through plugins down the line).

Let me know if any of these changes should be handled differently

EDIT: After updating to a much newer version of helix, this PR only adds the new option `unbind_default_keys` which does not populate the initial keymap at all. This also includes the fix where Helix would crash if a keybind for a non-existent mode is triggered