### PR TITLE
Update auto-pairs and idle-timeout when the config is reloaded

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -316,7 +316,12 @@ impl Application {
                     }),
             );
         }
+
         self.config.store(Arc::new(config));
+
+        // Update all the relevant members in the editor after replacing
+        // the configuration.
+        self.editor.refresh_config();
     }
 
     fn true_color(&self) -> bool {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -287,6 +287,10 @@ impl Application {
                 self.config.store(Arc::new(app_config));
             }
         }
+
+        // Update all the relevant members in the editor after updating
+        // the configuration.
+        self.editor.refresh_config();
     }
 
     fn refresh_config(&mut self) {
@@ -318,10 +322,6 @@ impl Application {
         }
 
         self.config.store(Arc::new(config));
-
-        // Update all the relevant members in the editor after replacing
-        // the configuration.
-        self.editor.refresh_config();
     }
 
     fn true_color(&self) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -531,6 +531,14 @@ impl Editor {
         self.config.load()
     }
 
+    /// Call if the config has changed to let the editor update all
+    /// relevant members.
+    pub fn refresh_config(&mut self) {
+        let config = self.config();
+        self.auto_pairs = (&config.auto_pairs).into();
+        self.reset_idle_timer();
+    }
+
     pub fn clear_idle_timer(&mut self) {
         // equivalent to internal Instant::far_future() (30 years)
         self.idle_timer


### PR DESCRIPTION
This fixes a problem where editor.auto-pairs is not reloaded with the rest of the configuration.

I also added idle-timeout, but that is likely not to matter due to it being reset between each key press.