### PR TITLE
feat: highlight / select symbol under cursor using LSP textDocument/documentHighlight

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -759,6 +759,26 @@ impl Client {
         Ok(response.unwrap_or_default())
     }
 
+    pub fn text_document_document_highlight(
+        &self,
+        text_document: lsp::TextDocumentIdentifier,
+        position: lsp::Position,
+        work_done_token: Option<lsp::ProgressToken>,
+    ) -> impl Future<Output = Result<Value>> {
+        let params = lsp::DocumentHighlightParams {
+            text_document_position_params: lsp::TextDocumentPositionParams {
+                text_document,
+                position,
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams { work_done_token },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+        };
+
+        self.call::<lsp::request::DocumentHighlightRequest>(params)
+    }
+
     fn goto_request<
         T: lsp::request::Request<
             Params = lsp::GotoDefinitionParams,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -263,7 +263,7 @@ impl MappableCommand {
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         symbol_picker, "Open symbol picker",
-        select_references_to_symbol_under_cursor, "Select references to symbol under cursor",
+        select_references_to_symbol_under_cursor, "Select symbol references",
         workspace_symbol_picker, "Open workspace symbol picker",
         last_picker, "Open last picker",
         prepend_to_line, "Insert at start of line",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -263,6 +263,7 @@ impl MappableCommand {
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         symbol_picker, "Open symbol picker",
+        select_references_to_symbol_under_cursor, "Select references to symbol under cursor",
         workspace_symbol_picker, "Open workspace symbol picker",
         last_picker, "Open last picker",
         prepend_to_line, "Insert at start of line",

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -749,7 +749,7 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
                     let mut i = 0;
 
                     for document_highlight in document_highlights {
-                        let lsp_range: lsp::Range = document_highlight.range.into();
+                        let lsp_range: lsp::Range = document_highlight.range;
                         let range =
                             helix_lsp::util::lsp_range_to_range(text, lsp_range, offset_encoding);
                         if let Some(range) = range {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -6,7 +6,7 @@ use helix_lsp::{
 
 use super::{align_view, push_jump, Align, Context, Editor};
 
-use helix_core::{Selection, SmallVec};
+use helix_core::Selection;
 use helix_view::editor::Action;
 
 use crate::{
@@ -734,37 +734,31 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
     cx.callback(
         future,
         move |editor, _compositor, response: Option<Vec<lsp::DocumentHighlight>>| {
-            if let Some(document_highlights) = response {
-                if !document_highlights.is_empty() {
-                    let (view, doc) = current!(editor);
-                    let language_server = language_server!(editor, doc);
-                    let offset_encoding = language_server.offset_encoding();
-                    let text = doc.text();
-                    let pos = doc.selection(view.id).primary().head;
+            let document_highlights = match response {
+                Some(highlights) if !highlights.is_empty() => highlights,
+                _ => return,
+            };
+            let (view, doc) = current!(editor);
+            let language_server = language_server!(editor, doc);
+            let offset_encoding = language_server.offset_encoding();
+            let text = doc.text();
+            let pos = doc.selection(view.id).primary().head;
 
-                    let mut ranges = SmallVec::with_capacity(document_highlights.len());
-
-                    // We must find the range that contains our primary cursor to prevent our primary cursor to move
-                    let mut primary_index = 0;
-                    let mut i = 0;
-
-                    for document_highlight in document_highlights {
-                        let lsp_range: lsp::Range = document_highlight.range;
-                        let range =
-                            helix_lsp::util::lsp_range_to_range(text, lsp_range, offset_encoding);
-                        if let Some(range) = range {
-                            if range.contains(pos) || range.head == pos {
-                                primary_index = i;
-                            }
-                            ranges.push(range);
-                            i += 1;
-                        }
+            // We must find the range that contains our primary cursor to prevent our primary cursor to move
+            let mut primary_index = 0;
+            let ranges = document_highlights
+                .iter()
+                .filter_map(|highlight| lsp_range_to_range(text, highlight.range, offset_encoding))
+                .enumerate()
+                .map(|(i, range)| {
+                    if range.contains(pos) {
+                        primary_index = i;
                     }
-
-                    let selection = Selection::new(ranges, primary_index);
-                    doc.set_selection(view.id, selection);
-                }
-            }
+                    range
+                })
+                .collect();
+            let selection = Selection::new(ranges, primary_index);
+            doc.set_selection(view.id, selection);
         },
     );
 }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -257,6 +257,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "/" => global_search,
             "k" => hover,
             "r" => rename_symbol,
+            "h" => select_references_to_symbol_under_cursor,
             "?" => command_palette,
         },
         "z" => { "View"


### PR DESCRIPTION
Hi !

This PR implements the LSP [textDocument/documentHighlight](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight) request. The command asks the LSP server for the ranges of references to current symbol, and select them (using multiple cursors).

I initially just wanted to have these symbols highlighted (like in nvim or vscode), but using multi-cursors is more convenient because the user can navigate between the references using `(` and `)`, and also because it reuses already existing components : 

![Peek 2022-06-10 14-15](https://user-images.githubusercontent.com/43273245/173063456-1ffdec2b-5c91-405a-90c4-0a3da5aeccdd.gif)

I have set the `Space + h` (for highlight) mapping to use this.

Have a good day !
