### PR TITLE
Add rust-analyzer to shell environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
           packages =
             prev.packages
             ++ (
-              with common.pkgs; [lld_13 lldb cargo-tarpaulin cargo-flamegraph]
+              with common.pkgs; [lld_13 lldb cargo-tarpaulin cargo-flamegraph rust-analyzer]
             );
           env =
             prev.env


### PR DESCRIPTION
## Problem
`rust-analyzer` is needed for development but not included in the shell environment.
## Solution
Add it.