### PR TITLE
adds missing tree-sitter-comment injection for js/ts

### DIFF
--- a/runtime/queries/javascript/injections.scm
+++ b/runtime/queries/javascript/injections.scm
@@ -22,12 +22,15 @@
 ((regex_pattern) @injection.content
  (#set! injection.language "regex"))
 
-; Parse JSDoc annotations in comments
+; Parse JSDoc annotations in multiline comments
 
 ((comment) @injection.content
- (#set! injection.language "jsdoc"))
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
 
-; Parse comment tags (TODO, FIXME, ...)
+; Parse general tags in single line comments
 
-([(comment)] @injection.content
- (#set! injection.language "comment"))
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))
+

--- a/runtime/queries/javascript/injections.scm
+++ b/runtime/queries/javascript/injections.scm
@@ -22,7 +22,12 @@
 ((regex_pattern) @injection.content
  (#set! injection.language "regex"))
 
- ; Parse JSDoc annotations in comments
+; Parse JSDoc annotations in comments
 
 ((comment) @injection.content
  (#set! injection.language "jsdoc"))
+
+; Parse comment tags (TODO, FIXME, ...)
+
+([(comment)] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/jsdoc/injections.scm
+++ b/runtime/queries/jsdoc/injections.scm
@@ -1,0 +1,5 @@
+; Parse general comment tags
+
+((document) @injection.content
+ (#set! injection.include-children)
+ (#set! injection.language "comment"))


### PR DESCRIPTION
this adds the injection for tree-sitter-comment to javascript. i am not sure if there is a reason for this missing. maybe it was supposed to interfere with the injection for "jsdoc" comments?

anyhow, it does seem to work to with both injections on "comment".
![Screenshot 2022-06-14 at 06 46 27](https://user-images.githubusercontent.com/1705805/173495419-8cfbd7a7-12e7-419e-ab93-b936df4e52e2.png)

