### PR TITLE
Enable shellwords for Windows (with escaping disabled)

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1802,15 +1802,7 @@ pub fn command_mode(cx: &mut Context) {
 
             // Handle typable commands
             if let Some(cmd) = typed::TYPABLE_COMMAND_MAP.get(parts[0]) {
-                let args = if cfg!(unix) {
-                    shellwords::shellwords(input)
-                } else {
-                    // Windows doesn't support POSIX, so fallback for now
-                    parts
-                        .into_iter()
-                        .map(|part| part.into())
-                        .collect::<Vec<_>>()
-                };
+                let args = shellwords::shellwords(input);
 
                 if let Err(e) = (cmd.fun)(cx, &args[1..], event) {
                     cx.editor.set_error(format!("{}", e));


### PR DESCRIPTION
Shellwords was previously disabled for Windows because it uses backslash for path separators, while we use backslash for escaping.
This change enables shellwords without escaping for Windows users, enabling them to open files with spaces in file names (using quotes or doublequotes)