### PR TITLE
Format keys identically in statusline and command palette

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2233,9 +2233,8 @@ pub fn command_palette(cx: &mut Context) {
                     .iter()
                     .map(|bind| {
                         bind.iter()
-                            .map(|key| key.to_string())
-                            .collect::<Vec<String>>()
-                            .join("+")
+                            .map(|key| key.key_sequence_format())
+                            .collect::<String>()
                     })
                     .collect::<Vec<String>>()
                     .join(", ")

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -13,7 +13,6 @@ use helix_core::{
     },
     movement::Direction,
     syntax::{self, HighlightEvent},
-    unicode::segmentation::UnicodeSegmentation,
     unicode::width::UnicodeWidthStr,
     LineEnding, Position, Range, Selection, Transaction,
 };
@@ -1353,12 +1352,7 @@ impl Component for EditorView {
                 disp.push_str(&count.to_string())
             }
             for key in self.keymaps.pending() {
-                let s = key.to_string();
-                if s.graphemes(true).count() > 1 {
-                    disp.push_str(&format!("<{}>", s));
-                } else {
-                    disp.push_str(&s);
-                }
+                disp.push_str(&key.key_sequence_format());
             }
             if let Some(pseudo_pending) = &cx.editor.pseudo_pending {
                 disp.push_str(pseudo_pending.as_str())

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -1,6 +1,6 @@
 //! Input event handling, currently backed by crossterm.
 use anyhow::{anyhow, Error};
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidthStr};
 use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 
@@ -20,6 +20,31 @@ impl KeyEvent {
         match self.code {
             KeyCode::Char(ch) => Some(ch),
             _ => None,
+        }
+    }
+
+    /// Format the key in such a way that a concatenated sequence
+    /// of keys can be read easily.
+    ///
+    /// ```
+    /// # use std::str::FromStr;
+    /// # use helix_view::input::KeyEvent;
+    ///
+    /// let k = KeyEvent::from_str("w").unwrap().key_sequence_format();
+    /// assert_eq!(k, "w");
+    ///
+    /// let k = KeyEvent::from_str("C-w").unwrap().key_sequence_format();
+    /// assert_eq!(k, "<C-w>");
+    ///
+    /// let k = KeyEvent::from_str(" ").unwrap().key_sequence_format();
+    /// assert_eq!(k, "<space>");
+    /// ```
+    pub fn key_sequence_format(&self) -> String {
+        let s = self.to_string();
+        if s.graphemes(true).count() > 1 {
+            format!("<{}>", s)
+        } else {
+            s
         }
     }
 }


### PR DESCRIPTION
The command palette previously used `+` as a delimiter for denoting a single key in a key sequence, (like `C+w`). This was at odds with how the statusline displayed them with pending keys (like `<C-w>`). This patch uses the `<C-w>` formatting everywhere.