### PR TITLE
Update theme base16_default (`ui.menu`)

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -1,6 +1,6 @@
 # Author: NNB <nnbnh@protonmail.com>
 
-"ui.menu" = "black"
+"ui.menu" = { fg = "black", bg = "white" }
 "ui.menu.selected" = { modifiers = ["reversed"] }
 "ui.linenr" = { fg = "gray", bg = "black" }
 "ui.popup" = { modifiers = ["reversed"] }


### PR DESCRIPTION
The built-in base16_default theme was not updated with changes from 82fb217, which would look as below.
This reverts it to how it was before the change (ie. `ui.statusline`).

![sc](https://user-images.githubusercontent.com/43825779/174234018-6d2e9223-891e-4b73-b726-403feb30f895.png)
