### PR TITLE
Add new key binding to view mode

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -268,8 +268,13 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" => half_page_up,
-            "C-d" => half_page_down,
+            "C-u" | "K" | "backspace" => half_page_up,
+            "C-d" | "J" | "space" => half_page_down,
+
+            "/" => search,
+            "?" => rsearch,
+            "n" => search_next,
+            "N" => search_prev,
         },
         "Z" => { "View" sticky=true
             "z" | "c" => align_view_center,
@@ -280,8 +285,13 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" => half_page_up,
-            "C-d" => half_page_down,
+            "C-u" | "K" | "backspace" => half_page_up,
+            "C-d" | "J" | "space" => half_page_down,
+
+            "/" => search,
+            "?" => rsearch,
+            "n" => search_next,
+            "N" => search_prev,
         },
 
         "\"" => select_register,


### PR DESCRIPTION
The idea is to make view mode more pager-like, and to make (half-)page-wise scrolling easier.

In particular, I suggest `space` to scroll down, like most pagers. Unfortunately, `shift-space` cannot be used to scroll up due to terminal limitations, so I suggest `backspace` as an alternative. I also suggest `J` and `K` for downwards and upwards scrolling, respectively. I also added search commands to view mode.

Addresses #2721