### PR TITLE
[FEAT] Create a cursor on jumplist entry

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3900,8 +3900,13 @@ fn copy_cursor_backward(cx: &mut Context) {
 
     if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
         view.doc = *id;
-        for range in selection.ranges() {
-            this_selection = this_selection.push(*range);
+        if cx.editor.documents.get(&view.doc).is_some() {
+            for range in selection.ranges() {
+                this_selection = this_selection.push(*range);
+            }
+        } else {
+            // if jumplist is in other buffer, just jump
+            this_selection = selection.clone();
         }
         let (view, doc) = current!(cx.editor); // refetch doc
         doc.set_selection(view.id, this_selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -357,6 +357,7 @@ impl MappableCommand {
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save the current selection to the jumplist",
+        copy_cursor_backward, "Place a new cursor on backward selection of the jumplist",
         jump_view_right, "Jump to the split to the right",
         jump_view_left, "Jump to the split to the left",
         jump_view_up, "Jump to the split above",
@@ -3890,6 +3891,23 @@ fn save_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     push_jump(view, doc);
     cx.editor.set_status("Selection saved to jumplist");
+}
+
+fn copy_cursor_backward(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let mut this_selection = doc.selection(view.id).clone();
+
+    if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
+        view.doc = *id;
+        for range in selection.ranges() {
+            this_selection = this_selection.push(*range);
+        }
+        let (view, doc) = current!(cx.editor); // refetch doc
+        doc.set_selection(view.id, this_selection);
+
+        align_view(doc, view, Align::Center);
+    };
 }
 
 fn rotate_view(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -197,7 +197,6 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "tab" => jump_forward, // tab == <C-i>
         "C-o" => jump_backward,
-        "C-q" => copy_cursor_backward,
         "C-s" => save_selection,
 
         "space" => { "Space"

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -197,6 +197,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "tab" => jump_forward, // tab == <C-i>
         "C-o" => jump_backward,
+        "C-q" => copy_cursor_backward,
         "C-s" => save_selection,
 
         "space" => { "Space"


### PR DESCRIPTION
Related to https://github.com/helix-editor/helix/discussions/2784#discussioncomment-2967254

This PR adds a command `copy_cursor_backward` that creates a new cursor by jumping backward in the jumplist, preserving the previous selection. This adds a flexible way of editing text with multiple cursors, especially when combined with textobjects motions. 

### Demo

Save selection to jumplist `C-s`, jump to function `]f`, copy cursor backward `C-q`:
![copy_back](https://user-images.githubusercontent.com/46683255/174477387-9e37009f-02c3-45c2-948f-bafaf8e35e85.gif)

### TODO

- [ ] Keymap, I have assigned `C-q` for no particular reason.
- [ ] Docs.
- [ ] Copy cursor forward comand? The implementation is trivial but I don't see a lot of purpose in that.
