### PR TITLE
Allow EditorView access to config, plus add file modification indicator configuration option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -45,6 +45,7 @@ hidden = false
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
+| `file-modification-indicator` | The string to be displayed in the statusbar when the file has been modified. | `"[+]"` |
 
 ### `[editor.lsp]` Section
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -130,7 +130,7 @@ impl Application {
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
             &config.keys
         }));
-        let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
+        let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys), Arc::clone(&config)));
         compositor.push(editor_view);
 
         if args.load_tutor {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -7,7 +7,7 @@ use crate::{
     ui::{Completion, ProgressSpinners},
 };
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapAny};
 use helix_core::{
     coords_at_pos, encoding,
     graphemes::{
@@ -38,7 +38,7 @@ pub struct EditorView {
     last_insert: (commands::MappableCommand, Vec<InsertEvent>),
     pub(crate) completion: Option<Completion>,
     spinners: ProgressSpinners,
-    editor_config: Arc<arc_swap::ArcSwapAny<std::sync::Arc<Config>>>,
+    editor_config: Arc<ArcSwapAny<Arc<Config>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -58,10 +58,7 @@ impl Default for EditorView {
 }
 
 impl EditorView {
-    pub fn new(
-        keymaps: Keymaps,
-        editor_config: Arc<arc_swap::ArcSwapAny<std::sync::Arc<Config>>>,
-    ) -> Self {
+    pub fn new(keymaps: Keymaps, editor_config: Arc<ArcSwapAny<Arc<Config>>>) -> Self {
         Self {
             keymaps,
             on_next_key: None,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -44,6 +44,8 @@ use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer}
 
 use arc_swap::access::{DynAccess, DynGuard};
 
+pub const DEFAULT_FILE_MODIFICATION_INDICATOR: &str = "[+]";
+
 fn deserialize_duration_millis<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -156,6 +158,8 @@ pub struct Config {
     pub rulers: Vec<u16>,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
+    /// string for file modification indicator
+    pub file_modification_indicator: String,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -391,6 +395,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
+            file_modification_indicator: DEFAULT_FILE_MODIFICATION_INDICATOR.to_string(),
         }
     }
 }


### PR DESCRIPTION
- provides visibility of the configuration to EditorView (closes #2828)
- adds a `file-modification-indicator` config option to change the string displayed
when file is modified.