### PR TITLE
Ignore non-number suffix or prefix when in(/de)crementing

### DIFF
--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -58,33 +58,32 @@ impl<'a> NumberIncrementor<'a> {
         let number = if prefixed {
             word[2..].replace('_', "")
         } else {
-            if !word_range.contains_range(&range) {
+            if !word_range.contains(range.head) {
                 return None;
             }
 
             let len = word_range.len();
 
             // Offsets of selection within word
-            let start_offset = range.from() - word_range.from();
-            let end_offset = range.to() - word_range.from();
+            let offset = range.head - word_range.from();
 
             // Find end of number
             let end = word
                 .chars()
                 .enumerate()
-                .skip(end_offset)
+                .skip(offset)
                 .find(|(_, c)| !(c.is_ascii_digit() || *c == '_'))
                 .map(|(i, _)| i)
                 .unwrap_or(len);
 
-            let (start_byte, _) = word.char_indices().nth(start_offset)?;
+            let (start_byte, _) = word.char_indices().nth(offset)?;
             // Find start of nubmer
             let start = word[..start_byte]
                 .chars()
                 .rev()
                 .enumerate()
                 .find(|(_, c)| !(c.is_ascii_digit() || *c == '-' || *c == '_'))
-                .map(|(i, _)| start_offset - i)
+                .map(|(i, _)| offset - i)
                 .unwrap_or(0);
 
             if end < start {

--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -373,6 +373,125 @@ mod test {
     }
 
     #[test]
+    fn test_number_on_prefix() {
+        let rope = Rope::from_str("num1");
+        let range = Range::point(1);
+        assert_eq!(NumberIncrementor::from_range(rope.slice(..), range), None);
+    }
+
+    #[test]
+    fn test_number_on_suffix() {
+        let rope = Rope::from_str("1px");
+        let range = Range::point(2);
+        assert_eq!(NumberIncrementor::from_range(rope.slice(..), range), None);
+    }
+
+    #[test]
+    fn test_number_with_suffix() {
+        let rope = Rope::from_str("1px");
+        let range = Range::point(0);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(0, 1),
+                value: 1,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_number_with_prefix() {
+        let rope = Rope::from_str("num1");
+        let range = Range::point(3);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(3, 4),
+                value: 1,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_number_with_prefix_and_suffix() {
+        let rope = Rope::from_str("num1hundred");
+        let range = Range::point(3);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(3, 4),
+                value: 1,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_word_with_two_numbers_first() {
+        let rope = Rope::from_str("num1of5things");
+        let range = Range::point(3);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(3, 4),
+                value: 1,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_word_with_two_numbers_second() {
+        let rope = Rope::from_str("num1of5things");
+        let range = Range::point(6);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(6, 7),
+                value: 5,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_negative_number_with_suffix() {
+        let rope = Rope::from_str("-5px");
+        let range = Range::point(1);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(0, 2),
+                value: -5,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
+    fn test_negative_number_with_suffix_on_minus() {
+        let rope = Rope::from_str("-5px");
+        let range = Range::point(0);
+        assert_eq!(
+            NumberIncrementor::from_range(rope.slice(..), range),
+            Some(NumberIncrementor {
+                range: Range::new(0, 2),
+                value: -5,
+                radix: 10,
+                text: rope.slice(..),
+            })
+        );
+    }
+
+    #[test]
     fn test_number_too_large_at_point() {
         let rope = Rope::from_str("Test text 0xFFFFFFFFFFFFFFFFF more text.");
         let range = Range::point(12);

--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -41,20 +41,25 @@ impl<'a> NumberIncrementor<'a> {
             range
         };
 
-        let word: String = text
+        let full_word: String = text
             .slice(range.from()..range.to())
             .chars()
             .filter(|&c| c != '_')
             .collect();
-        let (radix, prefixed) = if word.starts_with("0x") {
+        let (radix, prefixed) = if full_word.starts_with("0x") {
             (16, true)
-        } else if word.starts_with("0o") {
+        } else if full_word.starts_with("0o") {
             (8, true)
-        } else if word.starts_with("0b") {
+        } else if full_word.starts_with("0b") {
             (2, true)
         } else {
             (10, false)
         };
+
+        // Ignore non-number suffix at end of word, for example '1px'
+        let word = full_word.trim_end_matches(|c: char| !c.is_digit(radix));
+        let chars_removed = full_word.chars().count() - word.chars().count();
+        let range = Range::new(range.from(), range.to() - chars_removed);
 
         let number = if prefixed { &word[2..] } else { &word };
 

--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -61,7 +61,7 @@ impl<'a> NumberIncrementor<'a> {
         let chars_removed = full_word.chars().count() - word.chars().count();
         let range = Range::new(range.from(), range.to() - chars_removed);
 
-        let number = if prefixed { &word[2..] } else { &word };
+        let number = if prefixed { &word[2..] } else { word };
 
         let value = i128::from_str_radix(number, radix).ok()?;
         if (value.is_positive() && value.leading_zeros() < 64)

--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -35,35 +35,42 @@ impl<'a> NumberIncrementor<'a> {
         let range = textobject_word(text, range, TextObject::Inside, 1, false);
 
         // If there is a minus sign to the left of the word object, we want to include it in the range.
-        let range = if range.from() > 0 && text.char(range.from() - 1) == '-' {
+        let mut range = if range.from() > 0 && text.char(range.from() - 1) == '-' {
             range.extend(range.from() - 1, range.from())
         } else {
             range
         };
 
-        let full_word: String = text
-            .slice(range.from()..range.to())
-            .chars()
-            .filter(|&c| c != '_')
-            .collect();
-        let (radix, prefixed) = if full_word.starts_with("0x") {
+        let word: String = text.slice(range.from()..range.to()).chars().collect();
+        let (radix, prefixed) = if word.starts_with("0x") {
             (16, true)
-        } else if full_word.starts_with("0o") {
+        } else if word.starts_with("0o") {
             (8, true)
-        } else if full_word.starts_with("0b") {
+        } else if word.starts_with("0b") {
             (2, true)
         } else {
             (10, false)
         };
 
-        // Ignore non-number suffix at end of word, for example '1px'
-        let word = full_word.trim_end_matches(|c: char| !c.is_digit(radix));
-        let chars_removed = full_word.chars().count() - word.chars().count();
-        let range = Range::new(range.from(), range.to() - chars_removed);
+        let number = if prefixed {
+            word[2..].replace('_', "")
+        } else {
+            // remove prefix such as num in "num1"
+            let trimmed_start =
+                word.trim_start_matches(|c: char| !(c.is_ascii_digit() || c == '-'));
 
-        let number = if prefixed { &word[2..] } else { word };
+            // remove suffix such as px in "1px"
+            let trimmed = trimmed_start.trim_end_matches(|c: char| !c.is_ascii_digit());
+            let chars_removed_start = word.len() - trimmed_start.len();
+            let chars_removed_end = trimmed_start.len() - trimmed.len();
+            range = Range::new(
+                range.from() + chars_removed_start,
+                range.to() - chars_removed_end,
+            );
+            trimmed.replace('_', "")
+        };
 
-        let value = i128::from_str_radix(number, radix).ok()?;
+        let value = i128::from_str_radix(&number, radix).ok()?;
         if (value.is_positive() && value.leading_zeros() < 64)
             || (value.is_negative() && value.leading_ones() < 64)
         {

--- a/helix-core/src/increment/number.rs
+++ b/helix-core/src/increment/number.rs
@@ -77,7 +77,7 @@ impl<'a> NumberIncrementor<'a> {
                 .map(|(i, _)| i)
                 .unwrap_or(len);
 
-            let (start_byte, _) = word.char_indices().nth(start_offset).unwrap();
+            let (start_byte, _) = word.char_indices().nth(start_offset)?;
             // Find start of nubmer
             let start = word[..start_byte]
                 .chars()


### PR DESCRIPTION
Ignores suffixes to numbers such as "px" when incrementing a word like "1px".
Fixes #2815 