### PR TITLE
Display highest severity diagnostic in gutter

### DIFF
--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -26,19 +26,15 @@ pub fn diagnostic<'doc>(
     Box::new(move |line: usize, _selected: bool, out: &mut String| {
         use helix_core::diagnostic::Severity;
         if let Ok(index) = diagnostics.binary_search_by_key(&line, |d| d.line) {
-            let count_after = diagnostics[index + 1..]
-                .iter()
-                .take_while(|d| d.line == line)
-                .count();
+            let after = diagnostics[index..].iter().take_while(|d| d.line == line);
 
-            let count_before = diagnostics[..index]
+            let before = diagnostics[..index]
                 .iter()
                 .rev()
-                .take_while(|d| d.line == line)
-                .count();
+                .take_while(|d| d.line == line);
 
-            let line_diagnostics = &diagnostics[index - count_before..index + count_after + 1];
-            let diagnostic = line_diagnostics.iter().max_by_key(|d| d.severity).unwrap();
+            let diagnostics_on_line = after.chain(before);
+            let diagnostic = diagnostics_on_line.max_by_key(|d| d.severity).unwrap();
 
             write!(out, "●").unwrap();
             return Some(match diagnostic.severity {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -34,6 +34,8 @@ pub fn diagnostic<'doc>(
                 .take_while(|d| d.line == line);
 
             let diagnostics_on_line = after.chain(before);
+
+            // This unwrap is safe because the iterator cannot be empty as it contains at least the item found by the binary search.
             let diagnostic = diagnostics_on_line.max_by_key(|d| d.severity).unwrap();
 
             write!(out, "●").unwrap();


### PR DESCRIPTION
Fixes: #2827.
Gets sub-slice of diagnostics for all diagnostics on a line (still using binary search), and finds the max within the diagnostics of the line.