### PR TITLE
make mousedrag selection use character indexing instead of gap indexing

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1046,7 +1046,7 @@ impl EditorView {
 
                 let mut selection = doc.selection(view.id).clone();
                 let primary = selection.primary_mut();
-                *primary = Range::new(primary.anchor, pos);
+                *primary = primary.put_cursor(doc.text().slice(..), pos, true);
                 doc.set_selection(view.id, selection);
                 EventResult::Consumed(None)
             }


### PR DESCRIPTION
fixes #2722

The selection when dragging the mouse was using the `Range` gap indexing, so it was stopping 1 character to the left, whether going right or left of the anchor.