### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+target
+.direnv
+helix-term/rustfmt.toml
+helix-syntax/languages/
+result
+runtime/grammars/**
+.github
+.vscode
+*.png
+*.md
+flake.*
+docs
+book
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM       rust:1.61-slim as build
+WORKDIR    /app
+COPY       . .
+ENV        HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
+RUN        cargo build
+
+FROM       ubuntu:latest as release
+RUN        groupadd helixuser && useradd -ms /bin/bash -g helixuser helixuser
+USER       helixuser
+WORKDIR    /home/helixuser/.config/helix/runtime
+COPY       --from=build --chown=helixuser:helixuser /app/runtime .
+WORKDIR    /home/helixuser/helix
+COPY       --from=build --chown=helixuser:helixuser /app/target/debug .
+RUN        echo "export TERM=xterm-256color" >> ~/.bashrc && \
+             echo "export COLORTERM=truecolor" >> ~/.bashrc && \
+             echo "export HELIX_RUNTIME=$HOME/.config/helix/runtime" >> ~/.bashrc && \
+             echo "export PATH=$HOME/.bin:$PATH" >> ~/.bashrc && \
+             chmod 700 hx && \
+             mkdir -p ~/.bin && \
+             ln -s "$HOME/helix/hx" "$HOME/.bin/hx"
+WORKDIR    /home/helixuser/workspace
+ENV        PATH=/home/helixuser/.bin:$PATH
+ENV        COLORTERM=truecolor
+ENTRYPOINT [ "hx", "." ]


### PR DESCRIPTION
This PR adds a Dockerfile for creating a helix image that is ready-to-use for editing through volume mounts.

## Usage

### Building the image

```sh
docker build -t helix .
```

### Running `hx` on your pwd

```sh
docker run --rm -it -v ${pwd}:/home/helixuser/workspace helix
```

> Note: You may wish to clear your `target` dir before mounting the volume

## Considerations

- `--release` flag isn't currently set on `cargo build`; didn't seem wise to strip debug info for now
- If this were to be pushed to a container registry, it would probably make sense to create a `dev` build that is similar in setup to the `release` stage, but is `FROM build` so that rust tooling is included. That would enable development from within the container for helix, within helix
- I ran into https://github.com/helix-editor/helix/issues/2415 while building, so I set `HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1`. If this isn't affecting others it can be removed.
- The exports in the `~/.bashrc` exist in case you want to run the image with `--entrypoint /bin/bash`. The `ENV`s that do the same thing are needed for the `ENTRYPOINT`.

---

inspired by https://github.com/helix-editor/helix/pull/2601#issuecomment-1140465540