### PR TITLE
Add support for digraphs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Key Remapping](./remapping.md)
   - [Hooks](./hooks.md)
   - [Languages](./languages.md)
+  - [Digraphs](./digraphs.md)
 - [Guides](./guides/README.md)
   - [Adding Languages](./guides/adding_languages.md)
   - [Adding Textobject Queries](./guides/textobject.md)

--- a/book/src/digraphs.md
+++ b/book/src/digraphs.md
@@ -1,0 +1,14 @@
+# Digraphs
+
+By default, special characters can be input using the `insert_digraphs` (or `C-K`) command while in insert mode. Custom digraphs can be added to the `editor.digraphs` section of the config:
+
+```toml
+[editor.digraphs]
+ka = "か"
+ku = { symbols = "く", description = "The japanese character Ku" }
+shrug = "¯\_(ツ)_/¯"
+```
+
+## Defaults
+
+TBD

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -9,38 +9,38 @@
 
 > NOTE: Unlike vim, `f`, `F`, `t` and `T` are not confined to the current line.
 
-| Key                   | Description                                        | Command                     |
-| -----                 | -----------                                        | -------                     |
-| `h`, `Left`           | Move left                                          | `move_char_left`            |
-| `j`, `Down`           | Move down                                          | `move_line_down`            |
-| `k`, `Up`             | Move up                                            | `move_line_up`              |
-| `l`, `Right`          | Move right                                         | `move_char_right`           |
-| `w`                   | Move next word start                               | `move_next_word_start`      |
-| `b`                   | Move previous word start                           | `move_prev_word_start`      |
-| `e`                   | Move next word end                                 | `move_next_word_end`        |
-| `W`                   | Move next WORD start                               | `move_next_long_word_start` |
-| `B`                   | Move previous WORD start                           | `move_prev_long_word_start` |
-| `E`                   | Move next WORD end                                 | `move_next_long_word_end`   |
-| `t`                   | Find 'till next char                               | `find_till_char`            |
-| `f`                   | Find next char                                     | `find_next_char`            |
-| `T`                   | Find 'till previous char                           | `till_prev_char`            |
-| `F`                   | Find previous char                                 | `find_prev_char`            |
-| `G`                   | Go to line number `<n>`                            | `goto_line`                 |
-| `Alt-.`               | Repeat last motion (`f`, `t` or `m`)               | `repeat_last_motion`        |
-| `Home`                | Move to the start of the line                      | `goto_line_start`           |
-| `End`                 | Move to the end of the line                        | `goto_line_end`             |
-| `Ctrl-b`, `PageUp`    | Move page up                                       | `page_up`                   |
-| `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                 |
-| `Ctrl-u`              | Move half page up                                  | `half_page_up`              |
-| `Ctrl-d`              | Move half page down                                | `half_page_down`            |
-| `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`              |
-| `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`             |
-| `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`            |
+| Key                  | Description                                | Command                     |
+| -------------------- | ------------------------------------------ | --------------------------- |
+| `h`, `Left`          | Move left                                  | `move_char_left`            |
+| `j`, `Down`          | Move down                                  | `move_line_down`            |
+| `k`, `Up`            | Move up                                    | `move_line_up`              |
+| `l`, `Right`         | Move right                                 | `move_char_right`           |
+| `w`                  | Move next word start                       | `move_next_word_start`      |
+| `b`                  | Move previous word start                   | `move_prev_word_start`      |
+| `e`                  | Move next word end                         | `move_next_word_end`        |
+| `W`                  | Move next WORD start                       | `move_next_long_word_start` |
+| `B`                  | Move previous WORD start                   | `move_prev_long_word_start` |
+| `E`                  | Move next WORD end                         | `move_next_long_word_end`   |
+| `t`                  | Find 'till next char                       | `find_till_char`            |
+| `f`                  | Find next char                             | `find_next_char`            |
+| `T`                  | Find 'till previous char                   | `till_prev_char`            |
+| `F`                  | Find previous char                         | `find_prev_char`            |
+| `G`                  | Go to line number `<n>`                    | `goto_line`                 |
+| `Alt-.`              | Repeat last motion (`f`, `t` or `m`)       | `repeat_last_motion`        |
+| `Home`               | Move to the start of the line              | `goto_line_start`           |
+| `End`                | Move to the end of the line                | `goto_line_end`             |
+| `Ctrl-b`, `PageUp`   | Move page up                               | `page_up`                   |
+| `Ctrl-f`, `PageDown` | Move page down                             | `page_down`                 |
+| `Ctrl-u`             | Move half page up                          | `half_page_up`              |
+| `Ctrl-d`             | Move half page down                        | `half_page_down`            |
+| `Ctrl-i`             | Jump forward on the jumplist               | `jump_forward`              |
+| `Ctrl-o`             | Jump backward on the jumplist              | `jump_backward`             |
+| `Ctrl-s`             | Save the current selection to the jumplist | `save_selection`            |
 
 ### Changes
 
 | Key         | Description                                                          | Command                   |
-| -----       | -----------                                                          | -------                   |
+| ----------- | -------------------------------------------------------------------- | ------------------------- |
 | `r`         | Replace with a character                                             | `replace`                 |
 | `R`         | Replace with yanked text                                             | `replace_with_yanked`     |
 | `~`         | Switch case of the selected text                                     | `switch_case`             |
@@ -75,66 +75,65 @@
 
 #### Shell
 
-| Key     | Description                                                                      | Command               |
-| ------  | -----------                                                                      | -------               |
+| Key                     | Description                                                                      | Command               |
+| ----------------------- | -------------------------------------------------------------------------------- | --------------------- |
 | <code>&#124;</code>     | Pipe each selection through shell command, replacing with output                 | `shell_pipe`          |
 | <code>Alt-&#124;</code> | Pipe each selection into shell command, ignoring output                          | `shell_pipe_to`       |
-| `!`     | Run shell command, inserting output before each selection                        | `shell_insert_output` |
-| `Alt-!` | Run shell command, appending output after each selection                         | `shell_append_output` |
-| `$`     | Pipe each selection into shell command, keep selections where command returned 0 | `shell_keep_pipe`     |
-
+| `!`                     | Run shell command, inserting output before each selection                        | `shell_insert_output` |
+| `Alt-!`                 | Run shell command, appending output after each selection                         | `shell_append_output` |
+| `$`                     | Pipe each selection into shell command, keep selections where command returned 0 | `shell_keep_pipe`     |
 
 ### Selection manipulation
 
-| Key                   | Description                                                       | Command                              |
-| -----                 | -----------                                                       | -------                              |
-| `s`                   | Select all regex matches inside selections                        | `select_regex`                       |
-| `S`                   | Split selection into subselections on regex matches               | `split_selection`                    |
-| `Alt-s`               | Split selection on newlines                                       | `split_selection_on_newline`         |
-| `&`                   | Align selection in columns                                        | `align_selections`                   |
-| `_`                   | Trim whitespace from the selection                                | `trim_selections`                    |
-| `;`                   | Collapse selection onto a single cursor                           | `collapse_selection`                 |
-| `Alt-;`               | Flip selection cursor and anchor                                  | `flip_selections`                    |
-| `Alt-:`               | Ensures the selection is in forward direction                     | `ensure_selections_forward`          |
-| `,`                   | Keep only the primary selection                                   | `keep_primary_selection`             |
-| `Alt-,`               | Remove the primary selection                                      | `remove_primary_selection`           |
-| `C`                   | Copy selection onto the next line (Add cursor below)              | `copy_selection_on_next_line`        |
-| `Alt-C`               | Copy selection onto the previous line (Add cursor above)          | `copy_selection_on_prev_line`        |
-| `(`                   | Rotate main selection backward                                    | `rotate_selections_backward`         |
-| `)`                   | Rotate main selection forward                                     | `rotate_selections_forward`          |
-| `Alt-(`               | Rotate selection contents backward                                | `rotate_selection_contents_backward` |
-| `Alt-)`               | Rotate selection contents forward                                 | `rotate_selection_contents_forward`  |
-| `%`                   | Select entire file                                                | `select_all`                         |
-| `x`                   | Select current line, if already selected, extend to next line     | `extend_line`                        |
-| `X`                   | Extend selection to line bounds (line-wise selection)             | `extend_to_line_bounds`              |
-| `Alt-x`               | Shrink selection to line bounds (line-wise selection)             | `shrink_to_line_bounds`              |
-| `J`                   | Join lines inside selection                                       | `join_selections`                    |
-| `K`                   | Keep selections matching the regex                                | `keep_selections`                    |
-| `Alt-K`               | Remove selections matching the regex                              | `remove_selections`                  |
-| `Ctrl-c`              | Comment/uncomment the selections                                  | `toggle_comments`                    |
-| `Alt-o`, `Alt-up`     | Expand selection to parent syntax node (**TS**)                   | `expand_selection`                   |
-| `Alt-i`, `Alt-down`   | Shrink syntax tree object selection (**TS**)                      | `shrink_selection`                   |
-| `Alt-p`, `Alt-left`   | Select previous sibling node in syntax tree (**TS**)              | `select_prev_sibling`                |
-| `Alt-n`, `Alt-right`  | Select next sibling node in syntax tree (**TS**)                  | `select_next_sibling`                |
+| Key                  | Description                                                   | Command                              |
+| -------------------- | ------------------------------------------------------------- | ------------------------------------ |
+| `s`                  | Select all regex matches inside selections                    | `select_regex`                       |
+| `S`                  | Split selection into subselections on regex matches           | `split_selection`                    |
+| `Alt-s`              | Split selection on newlines                                   | `split_selection_on_newline`         |
+| `&`                  | Align selection in columns                                    | `align_selections`                   |
+| `_`                  | Trim whitespace from the selection                            | `trim_selections`                    |
+| `;`                  | Collapse selection onto a single cursor                       | `collapse_selection`                 |
+| `Alt-;`              | Flip selection cursor and anchor                              | `flip_selections`                    |
+| `Alt-:`              | Ensures the selection is in forward direction                 | `ensure_selections_forward`          |
+| `,`                  | Keep only the primary selection                               | `keep_primary_selection`             |
+| `Alt-,`              | Remove the primary selection                                  | `remove_primary_selection`           |
+| `C`                  | Copy selection onto the next line (Add cursor below)          | `copy_selection_on_next_line`        |
+| `Alt-C`              | Copy selection onto the previous line (Add cursor above)      | `copy_selection_on_prev_line`        |
+| `(`                  | Rotate main selection backward                                | `rotate_selections_backward`         |
+| `)`                  | Rotate main selection forward                                 | `rotate_selections_forward`          |
+| `Alt-(`              | Rotate selection contents backward                            | `rotate_selection_contents_backward` |
+| `Alt-)`              | Rotate selection contents forward                             | `rotate_selection_contents_forward`  |
+| `%`                  | Select entire file                                            | `select_all`                         |
+| `x`                  | Select current line, if already selected, extend to next line | `extend_line`                        |
+| `X`                  | Extend selection to line bounds (line-wise selection)         | `extend_to_line_bounds`              |
+| `Alt-x`              | Shrink selection to line bounds (line-wise selection)         | `shrink_to_line_bounds`              |
+| `J`                  | Join lines inside selection                                   | `join_selections`                    |
+| `K`                  | Keep selections matching the regex                            | `keep_selections`                    |
+| `Alt-K`              | Remove selections matching the regex                          | `remove_selections`                  |
+| `Ctrl-c`             | Comment/uncomment the selections                              | `toggle_comments`                    |
+| `Alt-o`, `Alt-up`    | Expand selection to parent syntax node (**TS**)               | `expand_selection`                   |
+| `Alt-i`, `Alt-down`  | Shrink syntax tree object selection (**TS**)                  | `shrink_selection`                   |
+| `Alt-p`, `Alt-left`  | Select previous sibling node in syntax tree (**TS**)          | `select_prev_sibling`                |
+| `Alt-n`, `Alt-right` | Select next sibling node in syntax tree (**TS**)              | `select_next_sibling`                |
 
 ### Search
 
 Search commands all operate on the `/` register by default. Use `"<char>` to operate on a different one.
 
-| Key   | Description                                 | Command              |
-| ----- | -----------                                 | -------              |
-| `/`   | Search for regex pattern                    | `search`             |
-| `?`   | Search for previous pattern                 | `rsearch`            |
-| `n`   | Select next search match                    | `search_next`        |
-| `N`   | Select previous search match                | `search_prev`        |
-| `*`   | Use current selection as the search pattern | `search_selection`   |
+| Key | Description                                 | Command            |
+| --- | ------------------------------------------- | ------------------ |
+| `/` | Search for regex pattern                    | `search`           |
+| `?` | Search for previous pattern                 | `rsearch`          |
+| `n` | Select next search match                    | `search_next`      |
+| `N` | Select previous search match                | `search_prev`      |
+| `*` | Use current selection as the search pattern | `search_selection` |
 
 ### Minor modes
 
 These sub-modes are accessible from normal mode and typically switch back to normal mode after a command.
 
 | Key      | Description                                        | Command        |
-| -----    | -----------                                        | -------        |
+| -------- | -------------------------------------------------- | -------------- |
 | `v`      | Enter [select (extend) mode](#select--extend-mode) | `select_mode`  |
 | `g`      | Enter [goto mode](#goto-mode)                      | N/A            |
 | `m`      | Enter [match mode](#match-mode)                    | N/A            |
@@ -151,9 +150,8 @@ the selection. The "sticky" variant of this mode is persistent; use the Escape
 key to return to normal mode after usage (useful when you're simply looking
 over text and not actively editing it).
 
-
 | Key                  | Description                                               | Command             |
-| -----                | -----------                                               | -------             |
+| -------------------- | --------------------------------------------------------- | ------------------- |
 | `z`, `c`             | Vertically center the line                                | `align_view_center` |
 | `t`                  | Align the line to the top of the screen                   | `align_view_top`    |
 | `b`                  | Align the line to the bottom of the screen                | `align_view_bottom` |
@@ -169,26 +167,26 @@ over text and not actively editing it).
 
 Jumps to various locations.
 
-| Key   | Description                                      | Command                    |
-| ----- | -----------                                      | -------                    |
-| `g`   | Go to line number `<n>` else start of file       | `goto_file_start`          |
-| `e`   | Go to the end of the file                        | `goto_last_line`           |
-| `f`   | Go to files in the selection                     | `goto_file`                |
-| `h`   | Go to the start of the line                      | `goto_line_start`          |
-| `l`   | Go to the end of the line                        | `goto_line_end`            |
-| `s`   | Go to first non-whitespace character of the line | `goto_first_nonwhitespace` |
-| `t`   | Go to the top of the screen                      | `goto_window_top`          |
-| `c`   | Go to the middle of the screen                   | `goto_window_center`       |
-| `b`   | Go to the bottom of the screen                   | `goto_window_bottom`       |
-| `d`   | Go to definition (**LSP**)                       | `goto_definition`          |
-| `y`   | Go to type definition (**LSP**)                  | `goto_type_definition`     |
-| `r`   | Go to references (**LSP**)                       | `goto_reference`           |
-| `i`   | Go to implementation (**LSP**)                   | `goto_implementation`      |
-| `a`   | Go to the last accessed/alternate file           | `goto_last_accessed_file`  |
-| `m`   | Go to the last modified/alternate file           | `goto_last_modified_file`  |
-| `n`   | Go to next buffer                                | `goto_next_buffer`         |
-| `p`   | Go to previous buffer                            | `goto_previous_buffer`     |
-| `.`   | Go to last modification in current file          | `goto_last_modification`   |
+| Key | Description                                      | Command                    |
+| --- | ------------------------------------------------ | -------------------------- |
+| `g` | Go to line number `<n>` else start of file       | `goto_file_start`          |
+| `e` | Go to the end of the file                        | `goto_last_line`           |
+| `f` | Go to files in the selection                     | `goto_file`                |
+| `h` | Go to the start of the line                      | `goto_line_start`          |
+| `l` | Go to the end of the line                        | `goto_line_end`            |
+| `s` | Go to first non-whitespace character of the line | `goto_first_nonwhitespace` |
+| `t` | Go to the top of the screen                      | `goto_window_top`          |
+| `c` | Go to the middle of the screen                   | `goto_window_center`       |
+| `b` | Go to the bottom of the screen                   | `goto_window_bottom`       |
+| `d` | Go to definition (**LSP**)                       | `goto_definition`          |
+| `y` | Go to type definition (**LSP**)                  | `goto_type_definition`     |
+| `r` | Go to references (**LSP**)                       | `goto_reference`           |
+| `i` | Go to implementation (**LSP**)                   | `goto_implementation`      |
+| `a` | Go to the last accessed/alternate file           | `goto_last_accessed_file`  |
+| `m` | Go to the last modified/alternate file           | `goto_last_modified_file`  |
+| `n` | Go to next buffer                                | `goto_next_buffer`         |
+| `p` | Go to previous buffer                            | `goto_previous_buffer`     |
+| `.` | Go to last modification in current file          | `goto_last_modification`   |
 
 #### Match mode
 
@@ -197,7 +195,7 @@ in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
 and [textobject](./usage.md#textobject) usage.
 
 | Key              | Description                                     | Command                    |
-| -----            | -----------                                     | -------                    |
+| ---------------- | ----------------------------------------------- | -------------------------- |
 | `m`              | Goto matching bracket (**TS**)                  | `match_brackets`           |
 | `s` `<char>`     | Surround current selection with `<char>`        | `surround_add`             |
 | `r` `<from><to>` | Replace surround character `<from>` with `<to>` | `surround_replace`         |
@@ -212,7 +210,7 @@ TODO: Mappings for selecting syntax nodes (a superset of `[`).
 This layer is similar to vim keybindings as kakoune does not support window.
 
 | Key                    | Description                                          | Command           |
-| -----                  | -------------                                        | -------           |
+| ---------------------- | ---------------------------------------------------- | ----------------- |
 | `w`, `Ctrl-w`          | Switch to next window                                | `rotate_view`     |
 | `v`, `Ctrl-v`          | Vertical right split                                 | `vsplit`          |
 | `s`, `Ctrl-s`          | Horizontal bottom split                              | `hsplit`          |
@@ -233,25 +231,24 @@ This layer is similar to vim keybindings as kakoune does not support window.
 
 This layer is a kludge of mappings, mostly pickers.
 
-
-| Key     | Description                                                             | Command                             |
-| -----   | -----------                                                             | -------                             |
-| `f`     | Open file picker                                                        | `file_picker`                       |
-| `b`     | Open buffer picker                                                      | `buffer_picker`                     |
-| `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                             |
-| `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                     |
-| `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`           |
-| `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                     |
-| `a`     | Apply code action  (**LSP**)                                            | `code_action`                       |
-| `'`     | Open last fuzzy picker                                                  | `last_picker`                       |
-| `w`     | Enter [window mode](#window-mode)                                       | N/A                                 |
-| `p`     | Paste system clipboard after selections                                 | `paste_clipboard_after`             |
-| `P`     | Paste system clipboard before selections                                | `paste_clipboard_before`            |
-| `y`     | Join and yank selections to clipboard                                   | `yank_joined_to_clipboard`          |
-| `Y`     | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`  |
-| `R`     | Replace selections by clipboard contents                                | `replace_selections_with_clipboard` |
-| `/`     | Global search in workspace folder                                       | `global_search`                     |
-| `?`     | Open command palette                                                    | `command_palette`                   |
+| Key | Description                                                             | Command                             |
+| --- | ----------------------------------------------------------------------- | ----------------------------------- |
+| `f` | Open file picker                                                        | `file_picker`                       |
+| `b` | Open buffer picker                                                      | `buffer_picker`                     |
+| `k` | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                             |
+| `s` | Open document symbol picker (**LSP**)                                   | `symbol_picker`                     |
+| `S` | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`           |
+| `r` | Rename symbol (**LSP**)                                                 | `rename_symbol`                     |
+| `a` | Apply code action (**LSP**)                                             | `code_action`                       |
+| `'` | Open last fuzzy picker                                                  | `last_picker`                       |
+| `w` | Enter [window mode](#window-mode)                                       | N/A                                 |
+| `p` | Paste system clipboard after selections                                 | `paste_clipboard_after`             |
+| `P` | Paste system clipboard before selections                                | `paste_clipboard_before`            |
+| `y` | Join and yank selections to clipboard                                   | `yank_joined_to_clipboard`          |
+| `Y` | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`  |
+| `R` | Replace selections by clipboard contents                                | `replace_selections_with_clipboard` |
+| `/` | Global search in workspace folder                                       | `global_search`                     |
+| `?` | Open command palette                                                    | `command_palette`                   |
 
 > TIP: Global search displays results in a fuzzy picker, use `space + '` to bring it back up after opening a file.
 
@@ -260,16 +257,16 @@ This layer is a kludge of mappings, mostly pickers.
 Displays documentation for item under cursor.
 
 | Key      | Description |
-| ----     | ----------- |
+| -------- | ----------- |
 | `Ctrl-u` | Scroll up   |
 | `Ctrl-d` | Scroll down |
- 
+
 #### Unimpaired
 
 Mappings in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaired).
 
 | Key      | Description                                  | Command               |
-| -----    | -----------                                  | -------               |
+| -------- | -------------------------------------------- | --------------------- |
 | `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`      |
 | `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`      |
 | `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`     |
@@ -296,30 +293,31 @@ convenience. These can be helpful for making simple modifications
 without escaping to normal mode, but beware that you will not have an
 undo-able "save point" until you return to normal mode.
 
-| Key                       | Description                 | Command                 |
-| -----                     | -----------                 | -------                 |
-| `Escape`                  | Switch to normal mode       | `normal_mode`           |
-| `Ctrl-x`                  | Autocomplete                | `completion`            |
-| `Ctrl-r`                  | Insert a register content   | `insert_register`       |
-| `Ctrl-w`, `Alt-Backspace` | Delete previous word        | `delete_word_backward`  |
-| `Alt-d`                   | Delete next word            | `delete_word_forward`   |
-| `Alt-b`, `Ctrl-Left`      | Backward a word             | `move_prev_word_end`    |
-| `Ctrl-b`, `Left`          | Backward a char             | `move_char_left`        |
-| `Alt-f`, `Ctrl-Right`     | Forward a word              | `move_next_word_start`  |
-| `Ctrl-f`, `Right`         | Forward a char              | `move_char_right`       |
-| `Ctrl-e`, `End`           | Move to line end            | `goto_line_end_newline` |
-| `Ctrl-a`, `Home`          | Move to line start          | `goto_line_start`       |
-| `Ctrl-u`                  | Delete to start of line     | `kill_to_line_start`    |
-| `Ctrl-k`                  | Delete to end of line       | `kill_to_line_end`      |
-| `Ctrl-j`, `Enter`         | Insert new line             | `insert_newline`        |
-| `Backspace`, `Ctrl-h`     | Delete previous char        | `delete_char_backward`  |
-| `Delete`, `Ctrl-d`        | Delete next char            | `delete_char_forward`   |
-| `Ctrl-p`, `Up`            | Move to previous line       | `move_line_up`          |
-| `Ctrl-n`, `Down`          | Move to next line           | `move_line_down`        |
-| `PageUp`                  | Move one page up            | `page_up`               |
-| `PageDown`                | Move one page down          | `page_down`             |
-| `Alt->`                   | Go to end of buffer         | `goto_file_end`         |
-| `Alt-<`                   | Go to start of buffer       | `goto_file_start`       |
+| Key                       | Description               | Command                 |
+| ------------------------- | ------------------------- | ----------------------- |
+| `Escape`                  | Switch to normal mode     | `normal_mode`           |
+| `Ctrl-x`                  | Autocomplete              | `completion`            |
+| `Ctrl-r`                  | Insert a register content | `insert_register`       |
+| `Ctrl-w`, `Alt-Backspace` | Delete previous word      | `delete_word_backward`  |
+| `Alt-d`                   | Delete next word          | `delete_word_forward`   |
+| `Alt-b`, `Ctrl-Left`      | Backward a word           | `move_prev_word_end`    |
+| `Ctrl-b`, `Left`          | Backward a char           | `move_char_left`        |
+| `Alt-f`, `Ctrl-Right`     | Forward a word            | `move_next_word_start`  |
+| `Ctrl-f`, `Right`         | Forward a char            | `move_char_right`       |
+| `Ctrl-e`, `End`           | Move to line end          | `goto_line_end_newline` |
+| `Ctrl-a`, `Home`          | Move to line start        | `goto_line_start`       |
+| `Ctrl-u`                  | Delete to start of line   | `kill_to_line_start`    |
+| `Ctrl-k`                  | Delete to end of line     | `kill_to_line_end`      |
+| `Ctrl-j`, `Enter`         | Insert new line           | `insert_newline`        |
+| `Backspace`, `Ctrl-h`     | Delete previous char      | `delete_char_backward`  |
+| `Delete`, `Ctrl-d`        | Delete next char          | `delete_char_forward`   |
+| `Ctrl-p`, `Up`            | Move to previous line     | `move_line_up`          |
+| `Ctrl-n`, `Down`          | Move to next line         | `move_line_down`        |
+| `PageUp`                  | Move one page up          | `page_up`               |
+| `PageDown`                | Move one page down        | `page_down`             |
+| `Alt->`                   | Go to end of buffer       | `goto_file_end`         |
+| `Alt-<`                   | Go to start of buffer     | `goto_file_start`       |
+| `Ctrl-K`                  | Insert digraph            | `insert_digraph`        |
 
 ## Select / extend mode
 
@@ -338,44 +336,43 @@ you to selectively add search terms to your selections.
 
 Keys to use within picker. Remapping currently not supported.
 
-| Key                          | Description       |
-| -----                        | -------------     |
-| `Up`, `Ctrl-p`               | Previous entry    |
-| `PageUp`, `Ctrl-u`           | Page up           |
-| `Down`, `Ctrl-n`             | Next entry        |
-| `PageDown`, `Ctrl-d`         | Page down         |
-| `Home`                       | Go to first entry |
-| `End`                        | Go to last entry  |
-| `Ctrl-space`                 | Filter options    |
-| `Enter`                      | Open selected     |
-| `Ctrl-s`                     | Open horizontally |
-| `Ctrl-v`                     | Open vertically   |
-| `Escape`, `Ctrl-c`           | Close picker      |
+| Key                  | Description       |
+| -------------------- | ----------------- |
+| `Up`, `Ctrl-p`       | Previous entry    |
+| `PageUp`, `Ctrl-u`   | Page up           |
+| `Down`, `Ctrl-n`     | Next entry        |
+| `PageDown`, `Ctrl-d` | Page down         |
+| `Home`               | Go to first entry |
+| `End`                | Go to last entry  |
+| `Ctrl-space`         | Filter options    |
+| `Enter`              | Open selected     |
+| `Ctrl-s`             | Open horizontally |
+| `Ctrl-v`             | Open vertically   |
+| `Escape`, `Ctrl-c`   | Close picker      |
 
 # Prompt
 
 Keys to use within prompt, Remapping currently not supported.
 
-| Key                     | Description                                                             |
-| -----                   | -------------                                                           |
-| `Escape`, `Ctrl-c`      | Close prompt                                                            |
-| `Alt-b`, `Alt-Left`     | Backward a word                                                         |
-| `Ctrl-b`, `Left`        | Backward a char                                                         |
-| `Alt-f`, `Alt-Right`    | Forward a word                                                          |
-| `Ctrl-f`, `Right`       | Forward a char                                                          |
-| `Ctrl-e`, `End`         | Move prompt end                                                         |
-| `Ctrl-a`, `Home`        | Move prompt start                                                       |
-| `Ctrl-w`                | Delete previous word                                                    |
-| `Alt-d`                 | Delete next word                                                        |
-| `Ctrl-u`                | Delete to start of line                                                 |
-| `Ctrl-k`                | Delete to end of line                                                   |
-| `backspace`, `Ctrl-h`   | Delete previous char                                                    |
-| `delete`, `Ctrl-d`      | Delete next char                                                        |
-| `Ctrl-s`                | Insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later   |
-| `Ctrl-p`, `Up`          | Select previous history                                                 |
-| `Ctrl-n`, `Down`        | Select next history                                                     |
-| `Ctrl-r`                | Insert the content of the register selected by following input char     |
-| `Tab`                   | Select next completion item                                             |
-| `BackTab`               | Select previous completion item                                         |
-| `Enter`                 | Open selected                                                           |
-
+| Key                   | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `Escape`, `Ctrl-c`    | Close prompt                                                          |
+| `Alt-b`, `Alt-Left`   | Backward a word                                                       |
+| `Ctrl-b`, `Left`      | Backward a char                                                       |
+| `Alt-f`, `Alt-Right`  | Forward a word                                                        |
+| `Ctrl-f`, `Right`     | Forward a char                                                        |
+| `Ctrl-e`, `End`       | Move prompt end                                                       |
+| `Ctrl-a`, `Home`      | Move prompt start                                                     |
+| `Ctrl-w`              | Delete previous word                                                  |
+| `Alt-d`               | Delete next word                                                      |
+| `Ctrl-u`              | Delete to start of line                                               |
+| `Ctrl-k`              | Delete to end of line                                                 |
+| `backspace`, `Ctrl-h` | Delete previous char                                                  |
+| `delete`, `Ctrl-d`    | Delete next char                                                      |
+| `Ctrl-s`              | Insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later |
+| `Ctrl-p`, `Up`        | Select previous history                                               |
+| `Ctrl-n`, `Down`      | Select next history                                                   |
+| `Ctrl-r`              | Insert the content of the register selected by following input char   |
+| `Tab`                 | Select next completion item                                           |
+| `BackTab`             | Select previous completion item                                       |
+| `Enter`               | Open selected                                                         |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4696,6 +4696,7 @@ fn insert_digraphs(cx: &mut Context) {
                     // todo: Prompt does not currently allow additional text as part
                     // of it's suggestions. Show the user the symbol and description
                     // once prompt has been made more robust
+                    #[allow(clippy::useless_format)]
                     ((0..), Cow::from(format!("{}", entry.sequence)))
                 })
                 .collect()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -426,7 +426,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command palette",
-        insert_digraphs, "Insert unicode character with prompt",
+        insert_digraphs, "Insert unicode characters with prompt",
     );
 }
 
@@ -4682,5 +4682,47 @@ fn replay_macro(cx: &mut Context) {
 }
 
 fn insert_digraphs(cx: &mut Context) {
-    todo!() //cx.
+    ui::prompt(
+        cx,
+        "digraph:".into(),
+        Some('K'), //todo: decide on register to use
+        move |editor, input| {
+            editor
+                .config()
+                .digraphs
+                .search(input)
+                .take(10)
+                .map(|entry| {
+                    // todo: Prompt does not currently allow additional text as part
+                    // of it's suggestions. Show the user the symbol and description
+                    // once prompt has been made more robust
+                    ((0..), Cow::from(format!("{}", entry.sequence)))
+                })
+                .collect()
+        },
+        move |cx, input, event| {
+            match event {
+                PromptEvent::Validate => (),
+                _ => return,
+            }
+            let config = cx.editor.config();
+            let symbols = if let Some(entry) = config.digraphs.get(input) {
+                &entry.symbols
+            } else {
+                cx.editor.set_error("Digraph not found");
+                return;
+            };
+
+            let (view, doc) = current!(cx.editor);
+            let selection = doc.selection(view.id);
+            let mut changes = Vec::with_capacity(selection.len());
+
+            for range in selection.ranges() {
+                changes.push((range.from(), range.from(), Some(symbols.clone().into())));
+            }
+            let trans = Transaction::change(doc.text(), changes.into_iter());
+            doc.apply(&trans, view.id);
+            doc.append_changes_to_history(view.id);
+        },
+    )
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -426,7 +426,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command palette",
-        insert_digraphs, "Insert unicode characters with prompt",
+        insert_digraph, "Insert unicode characters with prompt",
     );
 }
 
@@ -4681,7 +4681,7 @@ fn replay_macro(cx: &mut Context) {
     cx.editor.macro_replaying.pop();
 }
 
-fn insert_digraphs(cx: &mut Context) {
+fn insert_digraph(cx: &mut Context) {
     ui::prompt(
         cx,
         "digraph:".into(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -426,6 +426,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command palette",
+        insert_digraphs, "Insert unicode character with prompt",
     );
 }
 
@@ -4678,4 +4679,8 @@ fn replay_macro(cx: &mut Context) {
     }));
 
     cx.editor.macro_replaying.pop();
+}
+
+fn insert_digraphs(cx: &mut Context) {
+    todo!() //cx.
 }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -366,6 +366,8 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "C-x" => completion,
         "C-r" => insert_register,
+
+        "C-K" => insert_digraph,
     });
     hashmap!(
         Mode::Normal => Keymap::new(normal),

--- a/helix-view/src/digraph.rs
+++ b/helix-view/src/digraph.rs
@@ -1,0 +1,339 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Trie implementation for storing and searching input
+/// strings -> unicode characters defined by the user.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct DigraphStore {
+    head: DigraphNode,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum Error {
+    EmptyInput,
+    DuplicateEntry { current: String, existing: String },
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+struct DigraphNode {
+    output: Option<UnicodeOutput>,
+    children: Option<HashMap<char, DigraphNode>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct UnicodeOutput {
+    pub output: String,
+    pub description: Option<String>,
+}
+
+impl DigraphStore {
+    /// Inserts a new unicode string into the store
+    pub fn insert(&mut self, input_seq: &str, unicode: UnicodeOutput) -> Result<(), Error> {
+        if input_seq.len() <= 0 {
+            return Err(Error::EmptyInput);
+        }
+
+        self.head.insert(&input_seq, unicode)
+    }
+
+    /// Attempts to retrieve a stored unicode string if it exists
+    pub fn get(&self, exact_seq: &str) -> Option<&UnicodeOutput> {
+        self.head
+            .get(exact_seq)
+            .map(|n| n.output.as_ref())
+            .flatten()
+    }
+
+    /// Returns an iterator of closest matches to the input string
+    pub fn search(&self, input_seq: &str) -> impl Iterator<Item = &UnicodeOutput> {
+        self.head
+            .get(input_seq)
+            .into_iter()
+            .map(|x| x.iter())
+            .flatten()
+    }
+}
+
+impl DigraphNode {
+    fn insert(&mut self, input_seq: &str, unicode: UnicodeOutput) -> Result<(), Error> {
+        // see if we found the spot to insert our unicode
+        if input_seq.len() == 0 {
+            if let Some(existing) = &self.output {
+                return Err(Error::DuplicateEntry {
+                    existing: existing.output.clone(),
+                    current: unicode.output.clone(),
+                });
+            } else {
+                self.output = Some(unicode);
+                return Ok(());
+            }
+        }
+
+        // continue searching
+        let node = self
+            .children
+            .get_or_insert(Default::default())
+            .entry(input_seq.chars().next().unwrap())
+            .or_default();
+
+        node.insert(&input_seq[1..], unicode)
+    }
+
+    fn get(&self, exact_seq: &str) -> Option<&Self> {
+        if exact_seq.len() == 0 {
+            return Some(&self);
+        }
+
+        self.children
+            .as_ref()
+            .and_then(|cm| cm.get(&exact_seq.chars().next().unwrap()))
+            .and_then(|node| node.get(&exact_seq[1..]))
+    }
+
+    fn iter<'a>(&'a self) -> impl Iterator<Item = &UnicodeOutput> + 'a {
+        DigraphIter::new(&self)
+    }
+}
+
+pub struct DigraphIter<'a, 'b>
+where
+    'a: 'b,
+{
+    element_iter: Box<dyn Iterator<Item = &'a UnicodeOutput> + 'b>,
+    node_iter: Box<dyn Iterator<Item = &'a DigraphNode> + 'b>,
+}
+
+impl<'a, 'b> DigraphIter<'a, 'b>
+where
+    'a: 'b,
+{
+    fn new(node: &'a DigraphNode) -> Self {
+        // do a lazy breadth-first search by keeping track of the next 'rung' of
+        // elements to produce, and the next 'rung' of nodes to refill the element
+        // iterator when empty
+        Self {
+            element_iter: Box::new(node.output.iter().chain(Self::get_child_elements(&node))),
+            node_iter: Box::new(Self::get_child_nodes(&node)),
+        }
+    }
+
+    fn get_child_elements(node: &'a DigraphNode) -> impl Iterator<Item = &'a UnicodeOutput> + 'b {
+        node.children
+            .iter()
+            .flat_map(|hm| hm.iter())
+            .map(|(_, node)| node.output.as_ref())
+            .filter_map(|b| b)
+    }
+
+    fn get_child_nodes(node: &'a DigraphNode) -> impl Iterator<Item = &'a DigraphNode> + 'b {
+        node.children
+            .iter()
+            .map(|x| x.iter().map(|(_, node)| node))
+            .flatten()
+    }
+}
+impl<'a, 'b> Iterator for DigraphIter<'a, 'b>
+where
+    'a: 'b,
+{
+    type Item = &'a UnicodeOutput;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(e) = self.element_iter.next() {
+                return Some(e);
+            }
+
+            // We ran out of elements, fetch more by traversing the next rung of nodes
+            match self.node_iter.next() {
+                Some(node) => {
+                    // todo: figure out a better way to update self's nodes
+                    let mut new_nodes: Box<dyn Iterator<Item = &DigraphNode>> =
+                        Box::new(std::iter::empty());
+                    std::mem::swap(&mut new_nodes, &mut self.node_iter);
+                    let mut new_nodes: Box<dyn Iterator<Item = &DigraphNode>> =
+                        Box::new(new_nodes.chain(Self::get_child_nodes(&node)));
+                    std::mem::swap(&mut new_nodes, &mut self.node_iter);
+
+                    self.element_iter = Box::new(Self::get_child_elements(&node));
+                }
+                None => return None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digraph_insert() {
+        let mut dg = DigraphStore::default();
+        dg.insert(
+            "abc",
+            UnicodeOutput {
+                output: "testbug".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        dg.insert(
+            "abd",
+            UnicodeOutput {
+                output: "deadbeef".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            dg.head
+                .children
+                .as_ref()
+                .unwrap()
+                .get(&'a')
+                .unwrap()
+                .children
+                .as_ref()
+                .unwrap()
+                .get(&'b')
+                .unwrap()
+                .children
+                .as_ref()
+                .unwrap()
+                .get(&'c')
+                .unwrap()
+                .output
+                .clone()
+                .unwrap()
+                .output
+                .clone(),
+            "testbug".to_string()
+        );
+    }
+
+    #[test]
+    fn digraph_insert_and_get() {
+        let mut dg = DigraphStore::default();
+        dg.insert(
+            "abc",
+            UnicodeOutput {
+                output: "testbug".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        dg.insert(
+            "abd",
+            UnicodeOutput {
+                output: "deadbeef".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            dg.get("abc").map(|x| x.output.clone()),
+            Some("testbug".to_string())
+        );
+        assert_eq!(
+            dg.get("abd").map(|x| x.output.clone()),
+            Some("deadbeef".to_string())
+        );
+        assert_eq!(dg.get("abe").map(|x| x.output.clone()), None);
+    }
+
+    #[test]
+    fn digraph_node_iter() {
+        let mut dg = DigraphStore::default();
+        dg.insert(
+            "abc",
+            UnicodeOutput {
+                output: "testbug".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        dg.insert(
+            "abd",
+            UnicodeOutput {
+                output: "deadbeef".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(dg.head.iter().count(), 2);
+    }
+
+    #[test]
+    fn digraph_search() {
+        let mut dg = DigraphStore::default();
+        dg.insert(
+            "abc",
+            UnicodeOutput {
+                output: "testbug".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        dg.insert(
+            "abd",
+            UnicodeOutput {
+                output: "deadbeef".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        dg.insert(
+            "azz",
+            UnicodeOutput {
+                output: "qwerty".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(dg.search("ab").count(), 2);
+        assert_eq!(dg.search("az").next().unwrap().output, "qwerty");
+    }
+
+    #[test]
+    fn digraph_search_breadth() {
+        let mut dg = DigraphStore::default();
+        dg.insert(
+            "abccccc",
+            UnicodeOutput {
+                output: "testbug".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        dg.insert(
+            "abd",
+            UnicodeOutput {
+                output: "deadbeef".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        dg.insert(
+            "abee",
+            UnicodeOutput {
+                output: "qwerty".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(dg.search("ab").count(), 3);
+        assert_eq!(dg.search("ab").next().unwrap().output, "deadbeef");
+    }
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,5 +1,6 @@
 use crate::{
     clipboard::{get_clipboard_provider, ClipboardProvider},
+    digraph::DigraphStore,
     document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::{CursorKind, Rect},
     info::Info,
@@ -158,6 +159,8 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,
+    /// User supplied digraphs for use with the `insert_diagraphs` command
+    pub digraphs: DigraphStore,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -410,6 +413,7 @@ impl Default for Config {
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
+            digraphs: Default::default(),
         }
     }
 }

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -10,6 +10,7 @@ pub mod handlers {
     pub mod dap;
     pub mod lsp;
 }
+pub mod digraph;
 pub mod info;
 pub mod input;
 pub mod keyboard;


### PR DESCRIPTION
Closes #1438

The backend is implemented as a trie and finds suggestions using a simple breadth first search starting at the node given by the user's input. I chose the default keybind of `Ctrl-K` because while vim uses `Ctrl-k`, in helix that's currently bound to `kill_to_line_end`. This implementation is to set up initial, usable support for digraphs and can later be improved with:

- Better suggestions (currently `Prompt` doesn't allow for extra text in suggestions, so that would need to exist first)
- Fuzzy find on both input sequences and descriptions
- An sane, agreed upon default set of digraphs (currently only user configured symbols are supported)
- Configurable auto-input once a digraph is matched, and there are no more options the input could represent
- `replace`, `append`, and `insert` variants for binding to other keys in other modes as needed

https://user-images.githubusercontent.com/2438655/174872719-630eaa61-118e-41e1-a27c-a336c87a8514.mp4
