### PR TITLE
Fix backwards character deletion on other whitespaces

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2981,7 +2981,7 @@ pub mod insert {
                         for _ in 0..drop {
                             // delete up to `drop` spaces
                             match chars.next() {
-                                Some(' ') => start -= 1,
+                                Some(c) if c.is_whitespace() => start -= 1,
                                 _ => break,
                             }
                         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2944,7 +2944,7 @@ pub mod insert {
                 let line_start_pos = text.line_to_char(range.cursor_line(text));
                 // consider to delete by indent level if all characters before `pos` are indent units.
                 let fragment = Cow::from(text.slice(line_start_pos..pos));
-                if !fragment.is_empty() && fragment.chars().all(|ch| ch.is_ascii_whitespace()) {
+                if !fragment.is_empty() && fragment.chars().all(|ch| ch == ' ' || ch == '\t') {
                     if text.get_char(pos.saturating_sub(1)) == Some('\t') {
                         // fast path, delete one char
                         (

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2981,7 +2981,7 @@ pub mod insert {
                         for _ in 0..drop {
                             // delete up to `drop` spaces
                             match chars.next() {
-                                Some(c) if c.is_ascii_whitespace() => start -= 1,
+                                Some(' ') => start -= 1,
                                 _ => break,
                             }
                         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2944,7 +2944,7 @@ pub mod insert {
                 let line_start_pos = text.line_to_char(range.cursor_line(text));
                 // consider to delete by indent level if all characters before `pos` are indent units.
                 let fragment = Cow::from(text.slice(line_start_pos..pos));
-                if !fragment.is_empty() && fragment.chars().all(|ch| ch.is_whitespace()) {
+                if !fragment.is_empty() && fragment.chars().all(|ch| ch.is_ascii_whitespace()) {
                     if text.get_char(pos.saturating_sub(1)) == Some('\t') {
                         // fast path, delete one char
                         (
@@ -2981,7 +2981,7 @@ pub mod insert {
                         for _ in 0..drop {
                             // delete up to `drop` spaces
                             match chars.next() {
-                                Some(c) if c.is_whitespace() => start -= 1,
+                                Some(c) if c.is_ascii_whitespace() => start -= 1,
                                 _ => break,
                             }
                         }


### PR DESCRIPTION
This issue closes #2842

In summary:
`delete_char_backward` ignored any other whitespace other than ' ', which resulted in you not being able to backspace or `C-h` on insert mode when there's only whitespace with the character next to the cursor being a lexiographic whitespace.