### PR TITLE
fixes showing the last prompt on empty input

### DIFF
--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -73,6 +73,10 @@ impl Registers {
         self.read(name).and_then(|entries| entries.first())
     }
 
+    pub fn last(&self, name: char) -> Option<&String> {
+        self.read(name).and_then(|entries| entries.last())
+    }
+
     pub fn inner(&self) -> &HashMap<char, Register> {
         &self.inner
     }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -443,7 +443,7 @@ impl Prompt {
         let input: Cow<str> = if self.line.is_empty() {
             // latest value in the register list
             self.history_register
-                .and_then(|reg| cx.editor.registers.first(reg))
+                .and_then(|reg| cx.editor.registers.last(reg))
                 .map(|entry| entry.into())
                 .unwrap_or_else(|| Cow::from(""))
         } else {
@@ -522,7 +522,7 @@ impl Component for Prompt {
                     let input: Cow<str> = if self.line.is_empty() {
                         // latest value in the register list
                         self.history_register
-                            .and_then(|reg| cx.editor.registers.first(reg).cloned())
+                            .and_then(|reg| cx.editor.registers.last(reg).cloned())
                             .map(|entry| entry.into())
                             .unwrap_or_else(|| Cow::from(""))
                     } else {


### PR DESCRIPTION
This PR fixes the intended usage of last prompt on empty input but always shows wrongly the first prompt which is useless in b14c258a2c447b892c89d3e68ef4c9a74effca85 commit.