### PR TITLE
languages: Fix ruby rakefile and gemfile file type

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -446,7 +446,7 @@ source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "Rakefile", "irb", "Gemfile", "gemspec"]
+file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"

--- a/languages.toml
+++ b/languages.toml
@@ -446,7 +446,7 @@ source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec"]
+file-types = ["rb", "rake", "Rakefile", "irb", "Gemfile", "gemspec"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
I found default listed ruby file type (`rakefile` and `gemfile`) does not match Rakefile and Gemfile, so fix them.