### PR TITLE
Fix edge-case in tree-sitter expand_selection selection command

### DIFF
--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -2,12 +2,11 @@ use crate::{Range, RopeSlice, Selection, Syntax};
 use tree_sitter::Node;
 
 pub fn expand_selection(syntax: &Syntax, text: RopeSlice, selection: Selection) -> Selection {
-    select_node_impl(syntax, text, selection, |descendant, from, to| {
-        if descendant.start_byte() == from && descendant.end_byte() == to {
-            descendant.parent()
-        } else {
-            Some(descendant)
+    select_node_impl(syntax, text, selection, |mut node, from, to| {
+        while node.start_byte() == from && node.end_byte() == to {
+            node = node.parent()?;
         }
+        Some(node)
     })
 }
 


### PR DESCRIPTION
If a tree-sitter grammar outputs multiple nodes with the same range that contain each other (I noticed this with the LaTex grammar and the `text` and `word` nodes), the `expand_selection` command currently "gets stuck" at them. This happens because the `descendant_for_byte_range` function always returns the lowest of these nodes, so changing the selection to the range of its parent doesn't do anything.
I changed it, so that now it skips nodes with identical ranges.