### PR TITLE
fixes background reset

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -669,12 +669,14 @@ impl EditorView {
 
         let mut lines = Vec::new();
         for diagnostic in diagnostics {
-            let style = Style::reset().patch(match diagnostic.severity {
-                Some(Severity::Error) => error,
-                Some(Severity::Warning) | None => warning,
-                Some(Severity::Info) => info,
-                Some(Severity::Hint) => hint,
-            });
+            let style = Style::default().remove_modifier(Modifier::all()).patch(
+                match diagnostic.severity {
+                    Some(Severity::Error) => error,
+                    Some(Severity::Warning) | None => warning,
+                    Some(Severity::Info) => info,
+                    Some(Severity::Hint) => hint,
+                },
+            );
             let text = Text::styled(&diagnostic.message, style);
             lines.extend(text.lines);
         }


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/2856#issuecomment-1166656545. Another set of eyes on this would be good, but here's how it looks (before / after; backgrounds deliberately garish):

Before:
![IMG_0606](https://user-images.githubusercontent.com/941359/176052384-2de85a12-667c-4947-be8b-93aa40f525e6.png)

After:
![IMG_0605](https://user-images.githubusercontent.com/941359/176052494-d7da8ac4-0991-4edf-ac3d-6e5bc5797a70.png)


