### PR TITLE
Fix recursive macro crash and empty macro lockout

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4655,8 +4655,6 @@ fn replay_macro(cx: &mut Context) {
         return;
     }
 
-    cx.editor.macro_replaying.push(reg);
-
     let keys: Vec<KeyEvent> = if let Some([keys_str]) = cx.editor.registers.read(reg) {
         match helix_view::input::parse_macro(keys_str) {
             Ok(keys) => keys,
@@ -4670,6 +4668,10 @@ fn replay_macro(cx: &mut Context) {
         return;
     };
 
+    // Once the macro has been fully validated, it's marked as being under replay
+    // to ensure we don't fall into infinite recursion.
+    cx.editor.macro_replaying.push(reg);
+
     let count = cx.count();
     cx.callback = Some(Box::new(move |compositor, cx| {
         for _ in 0..count {
@@ -4677,7 +4679,9 @@ fn replay_macro(cx: &mut Context) {
                 compositor.handle_event(crossterm::event::Event::Key(key.into()), cx);
             }
         }
+        // The macro under replay is cleared at the end of the callback, not in the
+        // macro replay context, or it will not correctly protect the user from
+        // replaying recursively.
+        cx.editor.macro_replaying.pop();
     }));
-
-    cx.editor.macro_replaying.pop();
 }


### PR DESCRIPTION
Resolves #2845 
Resolves #2846 

Took me a bit to sit down and write the fix, but it seems quite straightforward (just shuffling two lines). I added a couple explicative comments, but to summarize:

The existing macro replay protection didn't work, because the guard (an entry in the `replaying_macro` vector) was cleared at the end of the `replay_macro` function, but all that function does is queue the keypresses to be executed in a separate context, so recursion could still happen. Now, the guard is cleared only after the entire queue of macro presses has resolved.

As for the lockdown, The problem is that we were marking the macro as being under replay before validating it, which left the register in an invalid unrecoverable state if the macro was invalid.