### PR TITLE
support Bazel languages

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -85,6 +85,7 @@
 | solidity | ✓ |  |  | `solc` |
 | sql | ✓ |  |  |  |
 | sshclientconfig | ✓ |  |  |  |
+| starlark | ✓ | ✓ |  |  |
 | svelte | ✓ |  | ✓ | `svelteserver` |
 | swift | ✓ |  |  | `sourcekit-lsp` |
 | tablegen | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -461,7 +461,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-ruby", rev = "dfff6
 name = "bash"
 scope = "source.bash"
 injection-regex = "bash"
-file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild"]
+file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild", "bazelrc"]
 shebangs = ["sh", "bash", "dash"]
 roots = []
 comment-token = "#"
@@ -1478,3 +1478,13 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "clojure"
 source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569ae332ca365da623712ae1f50f84daeae2" }
+
+[[language]]
+name = "starlark"
+scope = "source.starlark"
+injection-regex = "(starlark|bzl|bazel)"
+file-types = ["bzl", "bazel", "BUILD"]
+roots = []
+comment-token = "#"
+indent = { tab-width = 4, unit = "    " }
+grammar = "python"

--- a/runtime/queries/starlark/highlights.scm
+++ b/runtime/queries/starlark/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/runtime/queries/starlark/injections.scm
+++ b/runtime/queries/starlark/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/starlark/textobjects.scm
+++ b/runtime/queries/starlark/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: python


### PR DESCRIPTION
The Bazel build system uses Starlark as a DSL. Starlark is syntax-wise equivalent to python so we can just reuse the python grammar for simplicity :)

Also included is bash highlighting for [`bazelrc`](https://bazel.build/docs/bazelrc) files.