### PR TITLE
nix: specify C compiler in Cargo metadata

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -14,6 +14,7 @@ default-run = "hx"
 [package.metadata.nix]
 build = true
 app = true
+cCompiler = "clang"
 
 [features]
 unicode-lines = ["helix-core/unicode-lines"]


### PR DESCRIPTION
For me this fixes the `aarch64-darwin` build (I finally have one to test on 😀) via the Nix flake ❄️

I'm not totally sure why this was necessary. We have https://github.com/helix-editor/helix/blob/07e7a13a9e6b0a6c0bb456504b62572ec6be9eb2/flake.nix#L32-L36

that should say which compiler to use, but on master we end up using GCC to compile the tree-sitter dependency which fails. I poked around a little with a bisect but I haven't found a good build without this change yet.

This comes from https://github.com/yusdacra/nix-cargo-integration/issues/65#issuecomment-1077292510