### PR TITLE
feat(line-numbers): add total line numbers to position content

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -834,7 +834,12 @@ impl EditorView {
                 .cursor(doc.text().slice(..)),
         );
         right_side_text.0.push(Span::styled(
-            format!(" {}:{} ", pos.row + 1, pos.col + 1), // Convert to 1-indexing.
+            format!(
+                " {}:{}:{} ",
+                pos.row + 1,
+                pos.col + 1,
+                doc.text().len_lines()
+            ), // Convert to 1-indexing.
             base_style,
         ));
 


### PR DESCRIPTION
I have been using helix as my main power house for work recently, however there are a couple things that would really like to integrate. The first of which is having a total line number indicator in the editor. 

Some may disagree but I like having it there. 