### PR TITLE
Update night_owl

### DIFF
--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -1,11 +1,11 @@
 # Author : Joe Mckay joemckay3006@gmail.com
 # Palette from https://github.com/haishanh/night-owl.vim
 
-'warning' = { fg = 'peach' }
-'error' = { fg = 'red' }
-'info' = { fg = 'blue' }
-'hint' = { fg = 'paleblue' }
-'diagnostic' = { fg = 'background', bg = 'red' }
+'warning' = { fg = 'peach', modifiers = ['dim'] }
+'error' = { fg = 'red', modifiers = ['dim'] }
+'info' = { fg = 'blue', modifiers = ['dim'] }
+'hint' = { fg = 'paleblue', modifiers = ['dim'] }
+'diagnostic' = { modifiers = ['underlined'] }
 
 # UI
 'ui.background' = { fg = 'foreground', bg = 'background' }
@@ -22,18 +22,22 @@
 'ui.linenr.selected' = { fg = 'greyE', bg = 'background2'  }
 'ui.statusline' = { fg = 'greyE', bg = 'background2' }
 'ui.statusline.inactive' = { fg = 'grey7', bg = 'background2' }
+'ui.statusline.normal' = { bg = 'slate' }
+'ui.statusline.insert' = { bg = 'peach' }
+'ui.statusline.select' = { bg = 'green' }
 'ui.menu' = { fg = 'foreground', bg = 'selection' }
 'ui.menu.selected' = { fg = 'foreground', bg = 'pink' }
 'ui.popup' = { fg = 'foreground', bg = 'background2' }
 'ui.popup.info' = { fg = 'gold', bg = 'background2'}
 'ui.help' = { fg = 'gold', bg = 'background2'}
 'ui.virtual.ruler' = { bg = 'grey4' }
-'ui.virtual.whitespace' = { fg = 'slate' }
+'ui.virtual.whitespace' = { fg = 'grey4' }
 
 # SYNTAX
 'type' = { fg = 'green' }
 'constructor' = { fg = 'blue' }
 'constant' = { fg = 'foreground' }
+'constant.builtin' = { fg = 'paleblue' }
 'constant.character.escape' = { fg = 'peach' }
 'string' = { fg = 'gold' }
 'string.regexp' = { fg = 'green' }
@@ -63,8 +67,8 @@
 # MARKUP
 'markup.heading' = { fg = 'blue', modifiers = ['bold'] }
 'markup.heading.marker' = { fg = 'grey4', modifiers = ['dim'] }
-'markup.heading.1' = { fg = 'blue', modifers = ['bold'] }
-'markup.heading.2' = { fg = 'paleblue', modifers = ['bold']  }
+'markup.heading.1' = { fg = 'blue', modifiers = ['bold'] }
+'markup.heading.2' = { fg = 'paleblue', modifiers = ['bold']  }
 'markup.heading.3' = { fg = 'green', modifiers = ['bold'] }
 'markup.heading.4' = { fg = 'pink', modifiers = ['bold'] }
 'markup.heading.5' = { fg = 'peach', modifiers = ['bold'] }


### PR DESCRIPTION
Updated for #2676 , but I took the opportunity to do some other changes.

- Misspelling of 'modifiers' for markdown.heading.1 and 2.
- Errors are now just underlined instead of in red.
- Diagnostics are dimmed, as well as whitespace.
- Add constant.builtin.