### PR TITLE
Highlight whole row in picker menus

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -607,7 +607,16 @@ impl<T: 'static> Component for Picker<T> {
         for (i, (_index, option)) in files.take(rows as usize).enumerate() {
             let is_active = i == (self.cursor - offset);
             if is_active {
-                surface.set_string(inner.x.saturating_sub(2), inner.y + i as u16, ">", selected);
+                surface.set_string(
+                    inner.x.saturating_sub(3),
+                    inner.y + i as u16,
+                    " > ",
+                    selected,
+                );
+                surface.set_style(
+                    Rect::new(inner.x, inner.y + i as u16, inner.width, 1),
+                    selected,
+                );
             }
 
             let spans = (self.format_fn)(option);


### PR DESCRIPTION
This is for themes that use `bg` to highlight the selection in picker menus. 
Makes it easier to navigate, looks cleaner, and is in line with the style of the autocomplete menu.

before:
![image](https://user-images.githubusercontent.com/17070041/176959201-da05abf6-3f5e-484c-a19c-56323e1c382c.png)

after:
![image](https://user-images.githubusercontent.com/17070041/176964170-cfbb9d6e-a8c6-447b-85f0-28b0d3294df7.png)

Not 100% sure if this is still needed:
https://github.com/helix-editor/helix/blob/fbb200b7ddd3f70bdc8f76b6c53f030d3990dc62/helix-term/src/ui/picker.rs#L638-L639