### PR TITLE
Auto pair-removal

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2999,7 +2999,7 @@ pub mod insert {
                         auto_pairs,
                     ) {
                         (Some(_x), Some(_y), Some(ap))
-                            if range.len() == 1
+                            if range.is_single_grapheme(text)
                                 && ap.get(_x).is_some()
                                 && ap.get(_x).unwrap().close == _y =>
                         // delete both autopaired characters

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2999,7 +2999,9 @@ pub mod insert {
                         auto_pairs,
                     ) {
                         (Some(_x), Some(_y), Some(ap))
-                            if ap.get(_x).is_some() && (ap.get(_x).unwrap().close == _y) =>
+                            if range.len() == 1
+                                && ap.get(_x).is_some()
+                                && ap.get(_x).unwrap().close == _y =>
                         // delete both autopaired characters
                         {
                             (

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2992,12 +2992,26 @@ pub mod insert {
                         (start, pos, None) // delete!
                     }
                 } else {
-                    // delete char
-                    (
-                        graphemes::nth_prev_grapheme_boundary(text, pos, count),
-                        pos,
-                        None,
-                    )
+                    match (text.get_char(pos.saturating_sub(1)), text.get_char(pos)) {
+                        (Some(_x), Some(_y)) if auto_pairs::DEFAULT_PAIRS.contains(&(_x, _y)) =>
+                        // delete both
+                        {
+                            (
+                                graphemes::nth_prev_grapheme_boundary(text, pos, count),
+                                graphemes::nth_next_grapheme_boundary(text, pos, count),
+                                None,
+                            )
+                        }
+                        _ =>
+                        // delete 1 char
+                        {
+                            (
+                                graphemes::nth_prev_grapheme_boundary(text, pos, count),
+                                pos,
+                                None,
+                            )
+                        }
+                    }
                 }
             });
         doc.apply(&transaction, view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2946,6 +2946,9 @@ pub mod insert {
         let transaction =
             Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
                 let pos = range.cursor(text);
+                if pos == 0 {
+                    return (pos, pos, None);
+                }
                 let line_start_pos = text.line_to_char(range.cursor_line(text));
                 // consider to delete by indent level if all characters before `pos` are indent units.
                 let fragment = Cow::from(text.slice(line_start_pos..pos));


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/1673
Supersedes https://github.com/helix-editor/helix/pull/1379
No problems with multiple selections observed.
Putting match inside tuple would hurt readabilty - these tuples already take a while to comprehend.

Simple logic inspired by Godot 3.x stable branch:
https://github.com/godotengine/godot/blob/14f69acaa4ef80b235ef78f9caac1072daf8008b/scene/gui/text_edit.cpp#L2101
https://github.com/godotengine/godot/blob/14f69acaa4ef80b235ef78f9caac1072daf8008b/scene/gui/text_edit.cpp#L2054