### PR TITLE
Change default formatter for any language

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -40,6 +40,7 @@ file-types = ["mylang", "myl"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "mylang-lsp", args = ["--stdio"] }
+formatter = { command = "mylang-formatter" , args = ["--stdin"] }
 ```
 
 These configuration keys are available:
@@ -59,6 +60,7 @@ These configuration keys are available:
 | `language-server`     | The Language Server to run. See the Language Server configuration section below. |
 | `config`              | Language Server configuration                                 |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
+| `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 
 ### Language Server configuration
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -136,7 +136,8 @@ pub struct FormatterConfiguration {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
-    pub r#type: FormatterType,
+    #[serde(rename = "type")]
+    pub type_: FormatterType,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -138,13 +138,6 @@ pub struct FormatterConfiguration {
     pub args: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum FormatterType {
-    Stdio,
-    File,
-}
-
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct AdvancedCompletion {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -136,8 +136,6 @@ pub struct FormatterConfiguration {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
-    #[serde(rename = "type")]
-    pub type_: FormatterType,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -141,6 +141,7 @@ pub struct FormatterConfiguration {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum FormatterType {
     Stdio,
     File,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -136,7 +136,7 @@ pub struct FormatterConfiguration {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
-    pub formatter_type: FormatterType,
+    pub r#type: FormatterType,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -129,7 +129,7 @@ pub struct LanguageServerConfiguration {
     pub language_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct FormatterConfiguration {
     pub command: String,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -79,6 +79,9 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub auto_format: bool,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formatter: Option<FormatterConfiguration>,
+
     #[serde(default)]
     pub diagnostic_severity: Severity,
 
@@ -124,6 +127,22 @@ pub struct LanguageServerConfiguration {
     #[serde(default = "default_timeout")]
     pub timeout: u64,
     pub language_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct FormatterConfiguration {
+    pub command: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    pub formatter_type: FormatterType,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+pub enum FormatterType {
+    Stdio,
+    File,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -205,22 +205,6 @@ pub mod util {
             }),
         )
     }
-
-    /// The result of asking the language server to format the document. This can be turned into a
-    /// `Transaction`, but the advantage of not doing that straight away is that this one is
-    /// `Send` and `Sync`.
-    #[derive(Clone, Debug)]
-    pub struct LspFormatting {
-        pub doc: Rope,
-        pub edits: Vec<lsp::TextEdit>,
-        pub offset_encoding: OffsetEncoding,
-    }
-
-    impl From<LspFormatting> for Transaction {
-        fn from(fmt: LspFormatting) -> Transaction {
-            generate_transaction_from_edits(&fmt.doc, fmt.edits, fmt.offset_encoding)
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2372,7 +2372,7 @@ async fn make_format_callback(
     doc_id: DocumentId,
     doc_version: i32,
     modified: Modified,
-    format: impl Future<Output = helix_lsp::util::LspFormatting> + Send + 'static,
+    format: impl Future<Output = Transaction> + Send + 'static,
 ) -> anyhow::Result<job::Callback> {
     let format = format.await;
     let call: job::Callback = Box::new(move |editor, _compositor| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -28,7 +28,7 @@ use helix_core::{
 };
 use helix_view::{
     clipboard::ClipboardType,
-    document::{Mode, SCRATCH_BUFFER_NAME},
+    document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
     editor::{Action, Motion},
     info::Info,
     input::KeyEvent,
@@ -2372,9 +2372,9 @@ async fn make_format_callback(
     doc_id: DocumentId,
     doc_version: i32,
     modified: Modified,
-    format: impl Future<Output = Transaction> + Send + 'static,
+    format: impl Future<Output = Result<Transaction, FormatterError>> + Send + 'static,
 ) -> anyhow::Result<job::Callback> {
-    let format = format.await;
+    let format = format.await?;
     let call: job::Callback = Box::new(move |editor, _compositor| {
         let view_id = view!(editor).id;
         if let Some(doc) = editor.document_mut(doc_id) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2379,7 +2379,7 @@ async fn make_format_callback(
         let view_id = view!(editor).id;
         if let Some(doc) = editor.document_mut(doc_id) {
             if doc.version() == doc_version {
-                doc.apply(&Transaction::from(format), view_id);
+                doc.apply(&format, view_id);
                 doc.append_changes_to_history(view_id);
                 doc.detect_indent_and_line_ending();
                 if let Modified::SetUnmodified = modified {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -268,8 +268,11 @@ fn new_file(
 fn format(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
-    _event: PromptEvent,
+    event: PromptEvent,
 ) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
     let (view, doc) = current!(cx.editor);
     if let Some(format) = doc.format(view.id) {
         let callback =

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -551,7 +551,6 @@ fn write_all_impl(
     let auto_format = cx.editor.config().auto_format;
     let jobs = &mut cx.jobs;
     // save all documents
-    // Saves only visible buffers? How do we reload the not visible ones?
     for doc in &mut cx.editor.documents.values_mut() {
         if doc.path().is_none() {
             errors.push_str("cannot write a buffer without a filename\n");

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -213,7 +213,7 @@ fn write_impl(
         bail!("cannot write a buffer without a filename");
     }
     let fmt = if auto_format {
-        doc.auto_format(view.id).map(|fmt| {
+        doc.auto_format(view.id)?.map(|fmt| {
             let shared = fmt.shared();
             let callback = make_format_callback(
                 doc.id(),
@@ -271,7 +271,7 @@ fn format(
     _event: PromptEvent,
 ) -> anyhow::Result<()> {
     let (view, doc) = current!(cx.editor);
-    if let Some(format) = doc.format(view.id) {
+    if let Some(format) = doc.format(view.id)? {
         let callback =
             make_format_callback(doc.id(), doc.version(), Modified::LeaveModified, format);
         cx.jobs.callback(callback);
@@ -486,7 +486,7 @@ fn write_all_impl(
         }
 
         let fmt = if auto_format {
-            doc.auto_format(view.id).map(|fmt| {
+            doc.auto_format(view.id)?.map(|fmt| {
                 let shared = fmt.shared();
                 let callback = make_format_callback(
                     doc.id(),

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -436,10 +436,11 @@ impl Document {
                         })?;
 
                     {
-                        let mut stdin = process.stdin.take().unwrap();
-                        stdin
-                            .write_all(&self.text().bytes().collect::<Vec<u8>>())
-                            .unwrap();
+                        let mut stdin = process
+                            .stdin
+                            .take()
+                            .ok_or(anyhow!("Failed to take stdin"))?;
+                        stdin.write_all(&self.text().bytes().collect::<Vec<u8>>())?;
                     }
 
                     let output = process.wait_with_output()?;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -431,8 +431,7 @@ impl Document {
                     })?;
                 {
                     let mut stdin = process.stdin.take().ok_or(FormatterError::BrokenStdin)?;
-                    stdin
-                        .write_all(&text.bytes().collect::<Vec<u8>>())
+                    to_writer(&mut stdin, encoding::UTF_8, &text)
                         .await
                         .map_err(|_| FormatterError::BrokenStdin)?;
                 }
@@ -1105,18 +1104,17 @@ impl std::error::Error for FormatterError {}
 
 impl Display for FormatterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
+        match self {
             Self::SpawningFailed { command, error } => {
-                format!("Failed to spawn formatter {}: {:?}", command, error)
+                write!(f, "Failed to spawn formatter {}: {:?}", command, error)
             }
-            Self::BrokenStdin => "Could not write to formatter stdin".to_string(),
-            Self::WaitForOutputFailed => "Waiting for formatter output failed".to_string(),
-            Self::Stderr(output) => format!("Formatter error: {}", output),
-            Self::InvalidUtf8Output => "Invalid UTF-8 formatter output".to_string(),
-            Self::DiskReloadError(error) => format!("Error reloading file from disk: {}", error),
-            Self::NonZeroExitStatus => "Formatter exited with non zero exit status:".to_string(),
-        };
-        f.write_str(&s)
+            Self::BrokenStdin => write!(f, "Could not write to formatter stdin"),
+            Self::WaitForOutputFailed => write!(f, "Waiting for formatter output failed"),
+            Self::Stderr(output) => write!(f, "Formatter error: {}", output),
+            Self::InvalidUtf8Output => write!(f, "Invalid UTF-8 formatter output"),
+            Self::DiskReloadError(error) => write!(f, "Error reloading file from disk: {}", error),
+            Self::NonZeroExitStatus => write!(f, "Formatter exited with non zero exit status:"),
+        }
     }
 }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -448,6 +448,10 @@ impl Document {
                     ));
                 }
 
+                if !output.status.success() {
+                    return Err(FormatterError::NonZeroExitStatus);
+                }
+
                 let str = String::from_utf8(output.stdout)
                     .map_err(|_| FormatterError::InvalidUtf8Output)?;
 
@@ -1094,6 +1098,7 @@ pub enum FormatterError {
     Stderr(String),
     InvalidUtf8Output,
     DiskReloadError(String),
+    NonZeroExitStatus,
 }
 
 impl std::error::Error for FormatterError {}
@@ -1109,6 +1114,7 @@ impl Display for FormatterError {
             Self::Stderr(output) => format!("Formatter error: {}", output),
             Self::InvalidUtf8Output => "Invalid UTF-8 formatter output".to_string(),
             Self::DiskReloadError(error) => format!("Error reloading file from disk: {}", error),
+            Self::NonZeroExitStatus => "Formatter exited with non zero exit status:".to_string(),
         };
         f.write_str(&s)
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -449,7 +449,7 @@ impl Document {
                             .map_err(|_| anyhow!("Process did not output valid UTF-8"))
                             .ok()?;
                         self.apply(
-                            &helix_core::diff::compare_ropes(&self.text(), &Rope::from_str(str)),
+                            &helix_core::diff::compare_ropes(self.text(), &Rope::from_str(str)),
                             view_id,
                         );
                     }
@@ -479,10 +479,8 @@ impl Document {
                                     "Formatter {}",
                                     String::from_utf8_lossy(&output.stderr)
                                 );
-                            } else {
-                                if let Err(e) = self.reload(view_id) {
-                                    log::error!("Error reloading after formatting {}", e);
-                                }
+                            } else if let Err(e) = self.reload(view_id) {
+                                log::error!("Error reloading after formatting {}", e);
                             }
                         } else {
                             log::error!("Cannot format file without filepath");

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1153,7 +1153,7 @@ impl Display for FormatterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::SpawningFailed { command, error } => {
-                format!("Failed to spawn formatter {}: {}", command, error)
+                format!("Failed to spawn formatter {}: {:?}", command, error)
             }
             Self::BrokenStdin => "Could not write to formatter stdin".to_string(),
             Self::WaitForOutputFailed => "Waiting for formatter output failed".to_string(),

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -435,10 +435,15 @@ impl Document {
                             }
                         };
 
-                        let mut stdin = process.stdin.take().unwrap();
-                        stdin
-                            .write_all(&self.text().bytes().collect::<Vec<u8>>())
-                            .unwrap();
+                        {
+                            let mut stdin = process.stdin.take().unwrap();
+                            // let mut text = self.text().bytes().collect::<Vec<u8>>();
+                            // text.push(0);
+                            stdin
+                                .write_all(&self.text().bytes().collect::<Vec<u8>>())
+                                .unwrap();
+                        }
+
                         let output = process.wait_with_output().ok()?;
 
                         if !output.stderr.is_empty() {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -12,7 +12,6 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::io::AsyncWriteExt;
 
 use helix_core::{
     encoding,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -521,7 +521,6 @@ impl Editor {
         syn_loader: Arc<syntax::Loader>,
         config: Box<dyn DynAccess<Config>>,
     ) -> Self {
-        let language_servers = helix_lsp::Registry::new();
         let conf = config.load();
         let auto_pairs = (&conf.auto_pairs).into();
 
@@ -537,7 +536,7 @@ impl Editor {
             macro_recording: None,
             macro_replaying: Vec::new(),
             theme: theme_loader.default(),
-            language_servers,
+            language_servers: helix_lsp::Registry::new(),
             diagnostics: BTreeMap::new(),
             debugger: None,
             debugger_events: SelectAll::new(),

--- a/languages.toml
+++ b/languages.toml
@@ -679,6 +679,8 @@ auto-format = true
 comment-token = "//"
 language-server = { command = "zls" }
 indent = { tab-width = 4, unit = "    " }
+formatter = { command = "zig" , args = ["fmt", "--stdin"] }
+
 
 [[grammar]]
 name = "zig"


### PR DESCRIPTION
I have never worked on a big project in rust, so I don't know if the `Result`/`Option` handling is ok.

This PR aims to allow the user to choose which formatter to use instead of always relying on lsp. Discussion about this in issue  #2362.

Currently the only problem is that write_all_impl saves only the viewed buffers, this is because the formatter needs to reload or apply the transaction to the document. How do we get around this?