### PR TITLE
Add runtime `xcopy` command on powershell in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ tree-sitter grammars may be manually fetched and built with `hx --grammar fetch`
 Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%AppData%/helix/runtime` on Windows).
 
-| OS        | command   |
-|-----------|-----------|
-|windows    |`xcopy runtime %AppData%/helix/runtime`|
-|linux/macos|`ln -s $PWD/runtime ~/.config/helix/runtime`
+| OS                | command   |
+|-------------------|-----------|
+|windows(cmd.exe)   |`xcopy runtime %AppData%/helix/runtime`     |
+|windows(powershell)|`xcopy runtime $Env:AppData\helix\runtime`  |
+|linux/macos        |`ln -s $PWD/runtime ~/.config/helix/runtime`|
 
 This location can be overridden via the `HELIX_RUNTIME` environment variable.
 

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -61,10 +61,11 @@ Helix also needs it's runtime files so make sure to copy/symlink the `runtime/` 
 config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overridden
 via the `HELIX_RUNTIME` environment variable.
 
-| OS        | command   |
-|-----------|-----------|
-|windows    |`xcopy runtime %AppData%/helix/runtime`|
-|linux/macos|`ln -s $PWD/runtime ~/.config/helix/runtime`
+| OS                | command   |
+|-------------------|-----------|
+|windows(cmd.exe)   |`xcopy runtime %AppData%/helix/runtime`     |
+|windows(powershell)|`xcopy runtime $Env:AppData\helix\runtime`  |
+|linux/macos        |`ln -s $PWD/runtime ~/.config/helix/runtime`|
 
 ## Finishing up the installation 
 


### PR DESCRIPTION
The Windows command used to set up the runtime directory in the installation documentation is valid when run with cmd.exe, but when run with Powershell, I need to use another command.

My Powershell version

```
Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      19041  1682
```