### PR TITLE
Update TSQ queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -707,7 +707,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "tsq"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-tsq", rev = "ea68fc2b571ca1c8f70936855130c380f518ff35" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-tsq", rev = "48b5e9f82ae0a4727201626f33a17f69f8e0ff86" }
 
 [[language]]
 name = "cmake"

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -6,7 +6,7 @@
 
 ; highlight inheritance comments
 ((query . (comment) @keyword.directive)
- (#match? @keyword.directive "^;\ +inherits *:"))
+ (#match? @keyword.directive "^; +inherits *:"))
 
 [
   "("
@@ -40,8 +40,11 @@
 
 (capture) @label
 
-(predicate_name) @function
+((predicate_name) @function
+ (#match? @function "^#(eq\\?|match\\?|is\\?|is-not\\?|not-same-line\\?|not-kind-eq\\?|set!|select-adjacent!|strip!)$"))
+(predicate_name) @error
 
 (escape_sequence) @constant.character.escape
 
-(node_name) @variable
+(node_name) @tag
+(variable) @variable

--- a/runtime/queries/tsq/injections.scm
+++ b/runtime/queries/tsq/injections.scm
@@ -1,2 +1,8 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+((predicate
+   (predicate_name) @_predicate
+   (string) @injection.content)
+ (#eq? @_predicate "#match?")
+ (#set! injection.language "regex"))


### PR DESCRIPTION
A few changes to make TSQ highlights better:

* A parsing error has been fixed in the grammar itself
    * Previously tree-sitter-tsq did not parse the variables
      in predicates like `(#set! injection.language "javascript")`
* Theme nodes as `tag`
    * The newly added node to the parser (from the above fix) is
      `variable` which takes over the `variable` capture from nodes
* Highlight known predicates as `function` and unsupported
  predicates as `error`
    * This may help when translating queries from nvim-treesitter.
      For example `#any-of?` is a common one used in nvim-treesitter
      queries but not implemented in Helix or tree-sitter-cli.
* Inject tree-sitter-regex into `#match?` predicates