### PR TITLE
Introduce storage highlighting for typescript/javascript

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -151,7 +151,9 @@ We use a similar set of scopes as
   - `operator` - `or`, `in`
   - `directive` - Preprocessor directives (`#if` in C) 
   - `function` - `fn`, `func`
-  - `storage` - Keywords that affect the storage of a variable, function or data structure `static`, `mut`, `const`, `ref`
+  - `storage` - Keywords that affect the storage of variables, functions, data structures etc. 
+    - `type` - Keywords for declaring the storage of variables, functions, data structures  etc. eg `let`, `trait`, `struct` in rust 
+    - `modifier` - Keywords that modify a declaration. eg `static`, `mut`, `const`, `ref` in rust
 
 - `operator` - `||`, `+=`, `>`
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -151,9 +151,9 @@ We use a similar set of scopes as
   - `operator` - `or`, `in`
   - `directive` - Preprocessor directives (`#if` in C) 
   - `function` - `fn`, `func`
-  - `storage` - Keywords that affect the storage of variables, functions, data structures etc. 
-    - `type` - Keywords for declaring the storage of variables, functions, data structures  etc. eg `let`, `trait`, `struct` in rust 
-    - `modifier` - Keywords that modify a declaration. eg `static`, `mut`, `const`, `ref` in rust
+  - `storage` - Keywords describing how things are stored
+    - `type` - The type of something, `class`, `function`, `var`, `let`, etc. 
+    - `modifier` - Storage modifiers like `static`, `mut`, `const`, `ref`, etc.
 
 - `operator` - `||`, `+=`, `>`
 

--- a/runtime/queries/javascript/highlights.scm
+++ b/runtime/queries/javascript/highlights.scm
@@ -163,19 +163,14 @@
 [
   "as"
   "async"
-  "class"
-  "const"
   "debugger"
   "delete"
-  "export"
   "extends"
   "from"
   "function"
   "get"
-  "import"
   "in"
   "instanceof"
-  "let"
   "new"
   "of"
   "set"
@@ -183,10 +178,16 @@
   "target"
   "try"
   "typeof"
-  "var"
   "void"
   "with"
 ] @keyword
+
+[
+  "class"
+  "let"
+  "const"
+  "var"
+] @keyword.storage.type
 
 [
   "switch"
@@ -206,3 +207,9 @@
   "do"
   "await"
 ] @keyword.control
+
+[
+  "import"
+  "export"
+] @keyword.control.import 
+

--- a/runtime/queries/typescript/highlights.scm
+++ b/runtime/queries/typescript/highlights.scm
@@ -22,15 +22,21 @@
 [
   "abstract"
   "declare"
-  "enum"
   "export"
   "implements"
-  "interface"
   "keyof"
   "namespace"
+] @keyword
+
+[
+  "type"
+  "interface"
+  "enum"
+] @keyword.storage.type
+
+[
+  "public"
   "private"
   "protected"
-  "public"
-  "type"
   "readonly"
-] @keyword
+] @keyword.storage.modifier


### PR DESCRIPTION
Inspired by and following the patterns of #2731.
Adds `keyword.storage.type` and `keyword.storage.modifier` scopes for syntax highlighting.