### PR TITLE
add language `idris`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -40,6 +40,7 @@
 | hcl | ✓ |  | ✓ | `terraform-ls` |
 | heex | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server` |
+| idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | java | ✓ |  |  | `jdtls` |
 | javascript | ✓ |  | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -1503,3 +1503,14 @@ grammar = "elvish"
 [[grammar]]
 name = "elvish"
 source = { git = "https://github.com/ckafi/tree-sitter-elvish", rev = "e50787cadd3bc54f6d9c0704493a79078bb8a4e5" }
+
+[[language]]
+name = "idris"
+scope = "source.idr"
+injection-regex = "idr"
+file-types = ["idr"]
+shebangs = []
+roots = []
+comment-token = "--"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "idris2-lsp" }


### PR DESCRIPTION
This pull request adds support for the [Idris2](https://github.com/idris-lang/Idris2) language. No grammar is included yet because I don't believe there is one (but I'm happy to be proven wrong if someone is able to find one). The only repo I could find was [this one](https://github.com/gwerbin/tree-sitter-idris2), but it's incomplete.

I have tested the language server and it works without issues.

The only thing I was unsure about is whether the filetype should be called `idris` or `idris2`, since there are breaking changes between the two languages. I lean towards `idris`, because:

- files of both types share the `.idr` extension, so we couldn't really support both even if we wanted to since there's no simple way to distinguish between the languages
- [Idris 1 is not actively maintained](https://github.com/idris-lang/Idris-dev#status)