### PR TITLE
Fix some typos

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -241,8 +241,8 @@ This layer is a kludge of mappings, mostly pickers.
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                             |
 | `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                     |
 | `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`           |
-| `g`     | Open document diagnosics picker (**LSP**)                               | `diagnostics_picker`                |
-| `G`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnosics_picker`
+| `g`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                |
+| `G`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`
 | `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                     |
 | `a`     | Apply code action  (**LSP**)                                            | `code_action`                       |
 | `'`     | Open last fuzzy picker                                                  | `last_picker`                       |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ represented by a `Selection`. Each `Range` in the selection consists of a moving
 a selection with a single range, with the head and the anchor in the same
 position.
 
-Ropes are modified by constructing an OT-like `Transaction`. It's represents
+Ropes are modified by constructing an OT-like `Transaction`. It represents
 a single coherent change to the document and can be applied to the rope.
 A transaction can be inverted to produce an undo. Selections and marks can be
 mapped over a transaction to translate to a position in the new text state after

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -453,7 +453,7 @@ fn query_indents(
 ///
 /// ```ignore
 /// some_function(
-///     parm1,
+///     param1,
 ///     || {
 ///         // Here we get 2 indent levels because the 'parameters' and the 'block' node begin on different lines
 ///     },

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -204,7 +204,7 @@ impl Markdown {
 
                     tags.push(Tag::Item);
 
-                    // get the approriate bullet for the current list
+                    // get the appropriate bullet for the current list
                     let bullet = list_stack
                         .last()
                         .unwrap_or(&None) // use the '- ' bullet in case the list stack would be empty

--- a/runtime/queries/elm/highlights.scm
+++ b/runtime/queries/elm/highlights.scm
@@ -49,7 +49,7 @@
 ] @keyword
 
 
-(import) @keyword.contol.import
+(import) @keyword.control.import
 (module) @keyword.other
 
 (number_constant_expr) @constant.numeric

--- a/runtime/queries/git-commit/highlights.scm
+++ b/runtime/queries/git-commit/highlights.scm
@@ -10,5 +10,5 @@
 (change kind: "modified" @diff.delta)
 (change kind: "renamed" @diff.delta.moved)
 
-[":" "->" (scissors)] @punctuation.delimeter
+[":" "->" (scissors)] @punctuation.delimiter
 (comment) @comment

--- a/runtime/queries/kotlin/highlights.scm
+++ b/runtime/queries/kotlin/highlights.scm
@@ -217,7 +217,7 @@
 (function_declaration
 	. (simple_identifier) @function)
 
-; TODO: Seperate labeled returns/breaks/continue/super/this
+; TODO: Separate labeled returns/breaks/continue/super/this
 ;       Must be implemented in the parser first
 (label) @label
 

--- a/runtime/queries/lean/highlights.scm
+++ b/runtime/queries/lean/highlights.scm
@@ -197,7 +197,7 @@
 (interpolated_string) @string
 ; (escape_sequence) @string.escape
 
-; Reset highlighing in string interpolation
+; Reset highlighting in string interpolation
 (interpolation) @none
 
 (interpolation

--- a/runtime/queries/make/highlights.scm
+++ b/runtime/queries/make/highlights.scm
@@ -155,7 +155,7 @@
   (word) @clean @constant.builtin
   (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS\.VARIABLES|\.FEATURES|\.INCLUDE_DIRS|\.LOADED)$"))
 
-;; Standart targets
+;; Standard targets
 (targets
   (word) @constant.macro
   (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -50,7 +50,7 @@
   name:  (identifier) @function)
 (yul_evm_builtin) @function.builtin
 
-; Use contructor coloring for special functions
+; Use constructor coloring for special functions
 (constructor_definition "constructor" @constructor)
 (fallback_receive_definition "receive" @constructor)
 (fallback_receive_definition "fallback" @constructor)
@@ -64,7 +64,7 @@
 (call_expression . (identifier) @function)
 
 ; Function parameters
-(event_paramater name: (identifier) @variable.parameter)
+(event_parameter name: (identifier) @variable.parameter)
 (function_definition
   function_name:  (identifier) @variable.parameter)
 
@@ -131,7 +131,7 @@
 
 (import_directive "as" @keyword)
 (import_directive "from" @keyword)
-(event_paramater "indexed" @keyword)
+(event_parameter "indexed" @keyword)
 
 ; Punctuation
 

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -64,7 +64,7 @@
 (call_expression . (identifier) @function)
 
 ; Function parameters
-(event_parameter name: (identifier) @variable.parameter)
+(event_paramater name: (identifier) @variable.parameter) ; TODO fix spelling once fixed upstream
 (function_definition
   function_name:  (identifier) @variable.parameter)
 
@@ -131,7 +131,7 @@
 
 (import_directive "as" @keyword)
 (import_directive "from" @keyword)
-(event_parameter "indexed" @keyword)
+(event_paramater "indexed" @keyword) ; TODO fix spelling once fixed upstream
 
 ; Punctuation
 

--- a/runtime/queries/verilog/highlights.scm
+++ b/runtime/queries/verilog/highlights.scm
@@ -1,7 +1,7 @@
 ; Keywords
 
 [
-  ; block delimeters
+  ; block delimiters
   (module_keyword)
   "endmodule"
   "program"

--- a/runtime/queries/verilog/textobjects.scm
+++ b/runtime/queries/verilog/textobjects.scm
@@ -3,4 +3,4 @@
  (function_body_declaration
   (function_identifier
      (function_identifier
-        (simple_identifier) @function.inside)))) @funtions.around
+        (simple_identifier) @function.inside)))) @functions.around

--- a/runtime/queries/verilog/textobjects.scm
+++ b/runtime/queries/verilog/textobjects.scm
@@ -3,4 +3,4 @@
  (function_body_declaration
   (function_identifier
      (function_identifier
-        (simple_identifier) @function.inside)))) @functions.around
+        (simple_identifier) @function.inside)))) @function.around

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -41,7 +41,7 @@
 "constant.builtin" = "nord4"
 "namespace" = "nord4"
 
-# nord5 - suble UI text
+# nord5 - subtle UI text
 
 # nord6 - base text, punctuation
 "ui.text" = { fg = "nord6" }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -71,7 +71,7 @@ namespace = { fg = 'orangeL' }
 'variable.other.member' = { fg = 'orangeH' }
 'variable.function' = { fg = 'blueL' }
 'punctuation' = { fg = 'blueL' }
-'punctuation.delimeter' = { fg = 'blueH' }
+'punctuation.delimiter' = { fg = 'blueH' }
 'punctuation.bracket' = { fg = 'orangeN' }
 'keyword' = { fg = 'blueH' }
 'keyword.control' = { fg = 'blueL' }


### PR DESCRIPTION
Ran the typos tool to find typos, and manually corrected them. Mostly in comments, some in docs (the book + architecture.md), as well as some typos in themes/queries.