### PR TITLE
Add goto line preview

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1160,18 +1160,41 @@ pub(super) fn goto_line_number(
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
-    if event != PromptEvent::Validate {
-        return Ok(());
+    match event {
+        PromptEvent::Abort => {
+            if let Some(line_number) = cx.editor.last_line_number {
+                goto_line_impl(cx.editor, NonZeroUsize::new(line_number));
+                let (view, doc) = current!(cx.editor);
+                view.ensure_cursor_in_view(doc, line_number);
+                cx.editor.last_line_number = None;
+            }
+            return Ok(());
+        }
+        PromptEvent::Validate => {
+            ensure!(!args.is_empty(), "Line number required");
+            cx.editor.last_line_number = None;
+        }
+        PromptEvent::Update => {
+            if args.is_empty() {
+                if let Some(line_number) = cx.editor.last_line_number {
+                    // When a user hits backspace and there are no numbers left,
+                    // we can bring them back to their original line
+                    goto_line_impl(cx.editor, NonZeroUsize::new(line_number));
+                    let (view, doc) = current!(cx.editor);
+                    view.ensure_cursor_in_view(doc, line_number);
+                    cx.editor.last_line_number = None;
+                }
+                return Ok(());
+            }
+            let (view, doc) = current!(cx.editor);
+            let text = doc.text().slice(..);
+            let line = doc.selection(view.id).primary().cursor_line(text);
+            cx.editor.last_line_number.get_or_insert(line + 1);
+        }
     }
-
-    ensure!(!args.is_empty(), "Line number required");
-
     let line = args[0].parse::<usize>()?;
-
     goto_line_impl(cx.editor, NonZeroUsize::new(line));
-
     let (view, doc) = current!(cx.editor);
-
     view.ensure_cursor_in_view(doc, line);
     Ok(())
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -481,7 +481,7 @@ pub struct Editor {
     /// The currently applied editor theme. While previewing a theme, the previewed theme
     /// is set here.
     pub theme: Theme,
-
+    pub last_line_number: Option<usize>,
     pub status_msg: Option<(Cow<'static, str>, Severity)>,
     pub autoinfo: Option<Info>,
 
@@ -555,6 +555,7 @@ impl Editor {
             syn_loader,
             theme_loader,
             last_theme: None,
+            last_line_number: None,
             registers: Registers::default(),
             clipboard_provider: get_clipboard_provider(),
             status_msg: None,


### PR DESCRIPTION
This PR adds a preview to `:goto`:
 
https://user-images.githubusercontent.com/19535809/177451164-5dff41b5-5af1-4388-a6f4-8c9b5e9e7e1e.mov

Added behaviours:

- `:g <line-number>` previews the line that is asked for
- backspacing to just `:g ` takes them back to their original line
- aborting brings them back to their original line

---

Definitely looking for some refactoring suggestions here. This bit is repeated quite a bit:

```rust
goto_line_impl(cx.editor, NonZeroUsize::new(line_number));
let (view, doc) = current!(cx.editor);
view.ensure_cursor_in_view(doc, line_number);
```

I figure we can toss that into a separate function, I just don't know what to name it 👀 

Also, would it be preferred to put the `last_theme` and `last_line_number` into a history struct of some sort just for organization?