### PR TITLE
Improve diagnostics picker formatting

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -572,15 +572,11 @@ impl Application {
                             doc.set_diagnostics(diagnostics);
                         }
 
-                        // Sort diagnostics first by URL and then by severity.
+                        // Sort diagnostics first by severity and then by line numbers.
                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
-                        params.diagnostics.sort_unstable_by(|a, b| {
-                            if let (Some(a), Some(b)) = (a.severity, b.severity) {
-                                a.partial_cmp(&b).unwrap()
-                            } else {
-                                std::cmp::Ordering::Equal
-                            }
-                        });
+                        params
+                            .diagnostics
+                            .sort_unstable_by_key(|d| (d.severity, d.range.start));
 
                         // Insert the original lsp::Diagnostics here because we may have no open document
                         // for diagnosic message and so we can't calculate the exact position.

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -132,11 +132,12 @@ impl ui::menu::Item for PickerDiagnostic {
             .into_owned();
 
         Spans::from(vec![
-            Span::styled(truncated_path, style),
-            Span::raw(" - "),
-            Span::styled(code, style.add_modifier(Modifier::BOLD)),
+            Span::raw(truncated_path),
             Span::raw(": "),
             Span::styled(&self.diag.message, style),
+            Span::raw(" ("),
+            Span::styled(code, style.add_modifier(Modifier::BOLD)),
+            Span::raw(")"),
         ])
     }
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -132,11 +132,6 @@ impl ui::menu::Item for PickerDiagnostic {
             .into_owned();
 
         Spans::from(vec![
-            Span::styled(
-                self.diag.source.clone().unwrap_or_default(),
-                style.add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(": "),
             Span::styled(truncated_path, style),
             Span::raw(" - "),
             Span::styled(code, style.add_modifier(Modifier::BOLD)),

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -125,6 +125,7 @@ impl ui::menu::Item for PickerDiagnostic {
                 NumberOrString::Number(n) => n.to_string(),
                 NumberOrString::String(s) => s.to_string(),
             })
+            .map(|code| format!(" ({})", code))
             .unwrap_or_default();
 
         let truncated_path = path::get_truncated_path(self.url.path())
@@ -135,9 +136,7 @@ impl ui::menu::Item for PickerDiagnostic {
             Span::raw(truncated_path),
             Span::raw(": "),
             Span::styled(&self.diag.message, style),
-            Span::raw(" ("),
-            Span::styled(code, style.add_modifier(Modifier::BOLD)),
-            Span::raw(")"),
+            Span::styled(code, style),
         ])
     }
 }


### PR DESCRIPTION
- Remove source (usually the name of the LSP) from diagnostic picker display
- Display diagnostic text before code in picker
- Sub sort diagnostics by line number
- Display error code only if not none
- Show file path only in workspace diagnostic picker
