### PR TITLE
Remove broken ledger tag highlight

### DIFF
--- a/runtime/queries/ledger/highlights.scm
+++ b/runtime/queries/ledger/highlights.scm
@@ -11,7 +11,6 @@
 
 ((account) @variable.other.member)
 ((commodity) @text.literal)
-((tag) @tag)
 
 "include" @keyword.local.import
 


### PR DESCRIPTION
> thread 'main' panicked at 'Could not parse queries for language "ledger". Are your grammars out of sync? Try running 'hx --grammar fetch' and 'hx --grammar build'. This query could not be parsed: QueryError { row: 13, column: 2, offset: 176, message: "tag", kind: NodeType }', helix-core/src/syntax.rs:379:43

I forgot that it was removed in tree-sitter-ledger even though the query is still there.