### PR TITLE
Fix Document::language_id returning None if there is no lang server

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -99,7 +99,7 @@ pub struct Document {
     pub line_ending: LineEnding,
 
     syntax: Option<Syntax>,
-    /// Corresponding language scope name. Usually `source.<lang>`.
+    /// Corresponding language configuration as deserialized from languages.toml
     pub(crate) language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -854,12 +854,12 @@ impl Document {
     /// `language-server` configuration, or the document language if no
     /// `language-id` has been specified.
     pub fn language_id(&self) -> Option<&str> {
-        self.language_config()?
+        let config = self.language_config()?;
+        config
             .language_server
-            .as_ref()?
-            .language_id
-            .as_deref()
-            .or_else(|| Some(self.language()?.rsplit_once('.')?.1))
+            .as_ref()
+            .and_then(|server| server.language_id.as_deref())
+            .or(Some(&config.language_id))
     }
 
     /// Corresponding [`LanguageConfiguration`].


### PR DESCRIPTION
As mentioned in https://github.com/helix-editor/helix/pull/2434#discussion_r915483996 this was always returning `None` if no language server was configured because of early returning with `?` operator.
Also switched to relying on `config.language_id` instead of the last part of the scope because not all languages have `scope` configured and sometimes scope is configured as `"source.md"` so we would end up with `"md"` but returning `"markdown"` would make more sense, at least for the purposes of #2434