### PR TITLE
nix flake: make the binary cache "just work"

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -22,8 +22,12 @@ the project root. The flake can also be used to spin up a reproducible developme
 shell for working on Helix with `nix develop`.
 
 Flake outputs are cached for each push to master using
-[Cachix](https://www.cachix.org/). With Cachix
-[installed](https://docs.cachix.org/installation), `cachix use helix` will
+[Cachix](https://www.cachix.org/). The flake is configured to
+automatically make use of this cache assuming the user accepts
+the new settings on first use.
+
+If you are using a version of Nix without flakes enabled you can
+[install Cachix cli](https://docs.cachix.org/installation); `cachix use helix` will
 configure Nix to use cached outputs when possible.
 
 ### Arch Linux

--- a/flake.nix
+++ b/flake.nix
@@ -96,4 +96,9 @@
         };
       };
     };
+
+  nixConfig = {
+    extra-substituters = ["https://helix.cachix.org"];
+    extra-trusted-public-keys = ["helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs="];
+  };
 }


### PR DESCRIPTION
For those not familiar, Nix will ask on first use if you would like to adopt these settings from the flake, if accepted then users will pull artifacts from the official cache when available instead of needlessly building them whenever running a Nix flake command such as `nix build`.