### PR TITLE
Fix LSP formatting

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -99,7 +99,7 @@ pub mod util {
         offset_encoding: OffsetEncoding,
     ) -> Option<usize> {
         let pos_line = pos.line as usize;
-        if pos_line > doc.len_lines() - 1 {
+        if pos_line > doc.len_lines() {
             return None;
         }
 


### PR DESCRIPTION
The end position is exclusive. Thus, if the end line index is equal to
the number of lines in the document it includes the line ending
character.

Fix #1364 