### PR TITLE
nix: pass makeWrapperArgs to wrapProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
 
             postFixup = ''
               if [ -f "$out/bin/hx" ]; then
-                wrapProgram "$out/bin/hx" --set HELIX_RUNTIME "${runtimeDir}"
+                wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
               fi
             '';
           };


### PR DESCRIPTION
Even though in the default package this list is empty, it is still useful to apply extra wrapper args downstream. 

For example, one may wish to wrap Helix with the `PATH` set to include various language servers by default if not installed with the `--suffix` arg.

Full list of possible args:
https://github.com/NixOS/nixpkgs/blob/1c70b694fe0fece5ae74beb747a40f1b7237d251/pkgs/build-support/setup-hooks/make-wrapper.sh#L14-L35

One can see a real world example in this commit:
https://github.com/nrdxp/nrdos/commit/d8bf68e639343566d33545f189616bba57e0ed3f