### PR TITLE
theme(onedark): Remove bg for window separator

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -71,7 +71,7 @@ diagnostic = { modifiers = ["underlined"] }
 
 "ui.help" = { bg = "gray" }
 "ui.popup" = { bg = "gray" }
-"ui.window" = { bg = "gray" }
+"ui.window" = { fg = "gray" }
 "ui.menu" = { fg = "white", bg = "gray" }
 "ui.menu.selected" = { fg = "black", bg = "blue" }
 "ui.menu.scroll" = { fg = "white", bg = "light-gray" }


### PR DESCRIPTION
(before on left)

![Screenshot_2022-07-09_01-27-55](https://user-images.githubusercontent.com/23398472/178062538-75ce1066-467e-4257-8419-1a5037e644bb.png)
