### PR TITLE
lsp: Add workspace/applyEdit to client capabilites

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -294,6 +294,7 @@ impl Client {
                         dynamic_registration: Some(false),
                     }),
                     workspace_folders: Some(true),
+                    apply_edit: Some(true),
                     ..Default::default()
                 }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {


### PR DESCRIPTION
The functionality already existed, but the capability wasn't being reported correctly to the server:

https://github.com/helix-editor/helix/blob/230ba264bf78d9b4ecd42440f0cbb20529f9c235/helix-term/src/application.rs#L716-L728

