### PR TITLE
support toggling pickers' preview panel

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -352,6 +352,7 @@ Keys to use within picker. Remapping currently not supported.
 | `Enter`                      | Open selected     |
 | `Ctrl-s`                     | Open horizontally |
 | `Ctrl-v`                     | Open vertically   |
+| `Ctrl-t`                     | Toggle preview    |
 | `Escape`, `Ctrl-c`           | Close picker      |
 
 # Prompt

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -173,7 +173,7 @@ impl<T: Item + 'static> Component for FilePicker<T> {
         // |         | |         |
         // +---------+ +---------+
 
-        let render_preview = area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
+        let render_preview = self.picker.show_preview && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
         // -- Render the frame:
         // clear area
         let background = cx.editor.theme.get("ui.background");
@@ -300,6 +300,8 @@ pub struct Picker<T: Item> {
     previous_pattern: String,
     /// Whether to truncate the start (default true)
     pub truncate_start: bool,
+    /// Whether to show the preview panel (default true)
+    show_preview: bool,
 
     callback_fn: Box<dyn Fn(&mut Context, &T, Action)>,
 }
@@ -327,6 +329,7 @@ impl<T: Item> Picker<T> {
             prompt,
             previous_pattern: String::new(),
             truncate_start: true,
+            show_preview: true,
             callback_fn: Box::new(callback_fn),
             completion_height: 0,
         };
@@ -470,6 +473,10 @@ impl<T: Item> Picker<T> {
         self.filters.sort_unstable(); // used for binary search later
         self.prompt.clear(cx);
     }
+
+    pub fn toggle_preview(&mut self) {
+        self.show_preview = !self.show_preview;
+    }
 }
 
 // process:
@@ -537,6 +544,9 @@ impl<T: Item + 'static> Component for Picker<T> {
             }
             ctrl!(' ') => {
                 self.save_filter(cx);
+            }
+            ctrl!('t') => {
+                self.toggle_preview();
             }
             _ => {
                 if let EventResult::Consumed(_) = self.prompt.handle_event(event, cx) {


### PR DESCRIPTION
Add a key to toggle preview panel so that we can get more info when searching files with long names.