### PR TITLE
feat: document abbreviations

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -73,3 +73,7 @@
 | `:pipe` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:insert-abbreviation`, `:abbr` | Insert a new abbreviation |
+| `:delete-abbreviation`, `:rabbr` | Delete an abbreviation |
+| `:load-abbreviation-from-file`, `:labbr` | Load abbreviations from a file that contains abbreviations such as:<br><br>nvm nevermind<br>brb be right back<br>... |
+| `:write-abbreviation-to-file`, `:wabbr` | Write abbreviations to a file using the following format:<br><br>nvm nevermind<br>brb be right back<br>... |

--- a/helix-core/src/abbreviations.rs
+++ b/helix-core/src/abbreviations.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use ropey::Rope;
 
 use crate::{movement, Change, Range, Selection, Tendril, Transaction};
+use serde::{Deserialize, Serialize};
 
 /// The type that represents the collection of abbreviations,
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Abbreviations(HashMap<String, String>);
 
 impl Abbreviations {

--- a/helix-core/src/abbreviations.rs
+++ b/helix-core/src/abbreviations.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use ropey::Rope;
+
+use crate::{movement, Change, Range, Selection, Tendril, Transaction};
+
+/// The type that represents the collection of abbreviations,
+#[derive(Debug, Clone)]
+pub struct Abbreviations(HashMap<String, String>);
+
+impl Abbreviations {
+    pub fn default() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Look up the word under the main cursor and trigger abbreviation for all selections if there is a match.
+    pub fn expand_or_insert(
+        &self,
+        doc: &Rope,
+        selection: &Selection,
+        c: char,
+    ) -> Option<Transaction> {
+        // Default function to insert the original char when we should not expand an abbreviation
+        fn insert(c: char, cursor: usize) -> Change {
+            let mut t = Tendril::new();
+            t.push(c);
+            (cursor, cursor, Some(t))
+        }
+
+        let transaction = Transaction::change_by_selection(doc, selection, |range| {
+            let cursor = range.cursor(doc.slice(..));
+
+            // Do not look for previous word at start of file
+            if cursor == 0 {
+                return insert(c, cursor);
+            }
+
+            // Do not look for previous word if previous char is non-alphanumeric (works for line returns too)
+            match doc.get_char(cursor - 1) {
+                Some(previous_char) => {
+                    if !previous_char.is_alphanumeric() {
+                        return insert(c, cursor);
+                    }
+                }
+                None => return insert(c, cursor),
+            };
+
+            // Move 1 char left to be right on the previous word
+            let mut current_word_range = Range {
+                anchor: cursor - 1,
+                head: cursor - 1,
+                horiz: None,
+            };
+            current_word_range =
+                movement::move_prev_word_start(doc.slice(..), current_word_range, 1);
+
+            // Get current word and check if we know it as an abbreviation
+            let current_word = doc.slice(current_word_range.head..current_word_range.anchor);
+            let whole_word = self.0.get(&current_word.to_string());
+
+            // Expand abbreviation if needed, insert the original char otherwise
+            match whole_word {
+                Some(w) => {
+                    let mut t = Tendril::new();
+                    t.push_str(w);
+                    t.push(c);
+                    (current_word_range.cursor(doc.slice(..)), cursor, Some(t))
+                }
+                None => insert(c, cursor),
+            }
+        });
+        Some(transaction)
+    }
+
+    pub fn insert(&mut self, abbr: &str, whole_word: &str) {
+        self.0.insert(abbr.to_string(), whole_word.to_string());
+    }
+
+    pub fn map(&self) -> &HashMap<String, String> {
+        &self.0
+    }
+
+    pub fn map_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.0
+    }
+
+    pub fn remove(&mut self, key: &str) {
+        self.0.remove(key);
+    }
+}

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub use encoding_rs as encoding;
 
+pub mod abbreviations;
 pub mod auto_pairs;
 pub mod chars;
 pub mod comment;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3078,12 +3078,19 @@ pub mod insert {
         let text = doc.text();
         let selection = doc.selection(view.id);
         let auto_pairs = doc.auto_pairs(cx.editor);
+        let abbreviations = &doc.abbreviations;
 
+        // Autopairs and abbreviations
         let transaction = auto_pairs
             .as_ref()
             .and_then(|ap| auto_pairs::hook(text, selection, c, ap))
-            .or_else(|| insert(text, selection, c));
-
+            .or_else(|| {
+                if !c.is_alphanumeric() {
+                    abbreviations.expand_or_insert(text, selection, c)
+                } else {
+                    insert(text, selection, c)
+                }
+            });
         let (view, doc) = current!(cx.editor);
         if let Some(t) = transaction {
             apply_transaction(&t, doc, view);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -429,6 +429,32 @@ pub mod completers {
             .collect()
     }
 
+    pub fn abbreviations(editor: &Editor, input: &str) -> Vec<Completion> {
+        let (_, doc) = current_ref!(editor);
+        let matcher = Matcher::default();
+
+        let mut matches: Vec<_> = doc
+            .abbreviations
+            .map()
+            .clone()
+            .into_iter()
+            .filter_map(|abbr| {
+                matcher
+                    .fuzzy_match(&abbr.0, input)
+                    .map(move |score| (abbr.0, score))
+            })
+            .collect();
+
+        matches.sort_unstable_by(|(abbr1, score1), (abbr2, score2)| {
+            (Reverse(*score1), abbr1).cmp(&(Reverse(*score2), abbr2))
+        });
+
+        matches
+            .into_iter()
+            .map(|(abbr, _score)| ((0..), abbr.into()))
+            .collect()
+    }
+
     pub fn directory(editor: &Editor, input: &str) -> Vec<Completion> {
         filename_impl(editor, input, |entry| {
             let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -175,7 +175,7 @@ impl<T: Item> FilePicker<T> {
                             }
                             _ => {
                                 // TODO: enable syntax highlighting; blocked by async rendering
-                                Document::open(path, None, None)
+                                Document::open(path, None, None, None)
                                     .map(|doc| CachedPreview::Document(Box::new(doc)))
                                     .unwrap_or(CachedPreview::NotFound)
                             }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, bail, Context, Error};
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
+use helix_core::abbreviations::Abbreviations;
 use helix_core::auto_pairs::AutoPairs;
 use helix_core::Range;
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
@@ -138,6 +139,8 @@ pub struct Document {
     language_server: Option<Arc<helix_lsp::Client>>,
 
     diff_handle: Option<DiffHandle>,
+
+    pub abbreviations: Abbreviations,
 }
 
 use std::{fmt, mem};
@@ -377,6 +380,7 @@ impl Document {
             modified_since_accessed: false,
             language_server: None,
             diff_handle: None,
+            abbreviations: Abbreviations::default(),
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1140,7 +1140,6 @@ impl Editor {
         let id = if let Some(id) = id {
             id
         } else {
-            log::error!("abbrs: {:?}", self.abbreviations);
             let mut doc = Document::open(
                 &path,
                 None,

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -430,7 +430,7 @@ mod tests {
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
-        let doc = Document::from(rope, None);
+        let doc = Document::from(rope, None, None);
 
         assert_eq!(view.text_pos_at_screen_coords(&doc, 40, 2, 4), None);
 
@@ -476,7 +476,7 @@ mod tests {
         let mut view = View::new(DocumentId::default(), vec![GutterType::Diagnostics]);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
-        let doc = Document::from(rope, None);
+        let doc = Document::from(rope, None, None);
         assert_eq!(
             view.text_pos_at_screen_coords(&doc, 41, 40 + OFFSET_WITHOUT_LINE_NUMBERS + 1, 4),
             Some(4)
@@ -488,7 +488,7 @@ mod tests {
         let mut view = View::new(DocumentId::default(), vec![]);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
-        let doc = Document::from(rope, None);
+        let doc = Document::from(rope, None, None);
         assert_eq!(view.text_pos_at_screen_coords(&doc, 41, 40 + 1, 4), Some(4));
     }
 
@@ -500,7 +500,7 @@ mod tests {
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
-        let doc = Document::from(rope, None);
+        let doc = Document::from(rope, None, None);
 
         assert_eq!(
             view.text_pos_at_screen_coords(&doc, 40, 40 + OFFSET, 4),
@@ -540,7 +540,7 @@ mod tests {
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");
-        let doc = Document::from(rope, None);
+        let doc = Document::from(rope, None, None);
 
         assert_eq!(
             view.text_pos_at_screen_coords(&doc, 40, 40 + OFFSET, 4),


### PR DESCRIPTION
![Peek 2022-07-10 00-26](https://user-images.githubusercontent.com/43273245/178124559-78fa2f12-0348-4de3-89e8-4bb20304da71.gif)


This feature introduces four new typed commands to handle vim-like abbreviations:

- `insert-abbreviation` (alias `abbr`): adds a new abbreviation, or overwrites an existing one (with completion, local to current document only)
- `delete-abbreviation` (alias `rabbr`): removes an abbreviation (with completion)
- `load-abbreviations-from-file `(alias `labbr`): loads abbreviations from a file. Each line is an abbreviation, for instance:

    ```    
    nvm nevermind
    brb be right back
    ```
    
- `write-abbreviations-to-file` (alias `wabbr`): writes to file with the same format as above

I have tested and solved edge cases (beginning of the file, of a line, etc), but would be happy to have someone test this.

Closes #1471.