### PR TITLE
Scan back to the containing syntax ancestor to compute highlights

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -967,6 +967,18 @@ impl Syntax {
     // TODO: Folding
 }
 
+/// Gets the child of `node` that includes the given range
+pub fn child_for_byte_range(node: Node, start: usize, end: usize) -> Option<Node> {
+    for child in node.children(&mut node.walk()) {
+        let child_range = child.byte_range();
+        if start >= child_range.start && end <= child_range.end {
+            return Some(child);
+        }
+    }
+
+    None
+}
+
 #[derive(Debug)]
 pub struct LanguageLayer {
     // mode


### PR DESCRIPTION
This change starts the syntax highlight iterator before the
first visible byte of the source and then filters out highlights
which are not in the visible range.

The highlights iterator has some context that builds as it handles
tree-sitter QueryCaptures: locals/scopes tracking and the rainbow
matches nesting level. By starting at the start of the largest
containing node (if one exists), we can cover most cases where
locals tracking is noticeable and all cases for rainbow brackets
matching.

One edge-case remains for #1151: if the root node is
itself a `local.scope`, this change will not start far enough
back in the document to catch locals definitions which are out
of view.

---

For example, here's a fixed case for the locals tracking:

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/178152034-8ddb65cd-9622-4134-b49e-7753c874cbf3.png) | ![after](https://user-images.githubusercontent.com/21230295/178152043-b1fc9726-f47f-453e-ba94-eb8dc76fc53c.png) |

([source](https://github.com/helix-editor/helix/blob/e109022bfd34b9297905b9da5904f6aa2279e74f/helix-core/src/syntax.rs#L914-L952))

`cursor`, `captures`, and `layers` are recognized as `variable` (italic white) rather than `variable.other.member` (blue) even though their `local.definition` is not within view. Some for `source`, `range` and `cancellation_flag` recognized as `variable.parameter` (underlined white) from the function's definition which is a few pages out of view.

And this fixes the rainbow view problem: https://asciinema.org/a/507564