### PR TITLE
Fix locals tracking in Rust closures

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -1,6 +1,7 @@
 ; Scopes
 
 (block) @local.scope
+(closure_expression) @local.scope
 
 ; Definitions
 
@@ -10,7 +11,7 @@
 (let_declaration
   pattern: (identifier) @local.definition)
 
-(closure_parameters (identifier)) @local.definition
+(closure_parameters (identifier) @local.definition)
 
 ; References
 (identifier) @local.reference


### PR DESCRIPTION
The fix comes from the rewriting of the `closure_parameters` stanza:
it was capturing the entire `closure_parameters` node including
`|`s, whitespace and commas. Capturing the identifiers within
fixes the tracking.

In order to make sure locals definitions from closure parameters don't
leak out of the body of the closure, though, we should also mark the
closure itself as a locals scope.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/178153007-6abbe31e-a613-4dbb-a3ec-d399d91e46e5.png) | ![after](https://user-images.githubusercontent.com/21230295/178153019-fe389a99-b78e-42d2-a60a-9031a712f4ae.png) |

Where `variable.parameter` is underlined white in my theme (notice `layer` and `r` above).