### PR TITLE
Add textobjects.scm to GLSL

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -31,7 +31,7 @@
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
 | gleam | ✓ | ✓ |  |  |
-| glsl | ✓ |  | ✓ |  |
+| glsl | ✓ | ✓ | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
 | gomod | ✓ |  |  | `gopls` |
 | gowork | ✓ |  |  | `gopls` |

--- a/runtime/queries/glsl/textobjects.scm
+++ b/runtime/queries/glsl/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: c


### PR DESCRIPTION
Hello, I added  textobjects support to GLSL, based on C. After some testing this seems to work as expected.