### PR TITLE
Reuse table widget in picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5,7 +5,7 @@ pub(crate) mod typed;
 pub use dap::*;
 use helix_vcs::Hunk;
 pub use lsp::*;
-use tui::text::Spans;
+use tui::widgets::Row;
 pub use typed::*;
 
 use helix_core::{
@@ -1858,7 +1858,7 @@ fn global_search(cx: &mut Context) {
     impl ui::menu::Item for FileResult {
         type Data = Option<PathBuf>;
 
-        fn label(&self, current_path: &Self::Data) -> Spans {
+        fn format(&self, current_path: &Self::Data) -> Row {
             let relative_path = helix_core::path::get_relative_path(&self.path)
                 .to_string_lossy()
                 .into_owned();
@@ -2309,7 +2309,7 @@ fn buffer_picker(cx: &mut Context) {
     impl ui::menu::Item for BufferMeta {
         type Data = ();
 
-        fn label(&self, _data: &Self::Data) -> Spans {
+        fn format(&self, _data: &Self::Data) -> Row {
             let path = self
                 .path
                 .as_deref()
@@ -2378,7 +2378,7 @@ fn jumplist_picker(cx: &mut Context) {
     impl ui::menu::Item for JumpMeta {
         type Data = ();
 
-        fn label(&self, _data: &Self::Data) -> Spans {
+        fn format(&self, _data: &Self::Data) -> Row {
             let path = self
                 .path
                 .as_deref()
@@ -2451,7 +2451,7 @@ fn jumplist_picker(cx: &mut Context) {
 impl ui::menu::Item for MappableCommand {
     type Data = ReverseKeymap;
 
-    fn label(&self, keymap: &Self::Data) -> Spans {
+    fn format(&self, keymap: &Self::Data) -> Row {
         let fmt_binding = |bindings: &Vec<Vec<KeyEvent>>| -> String {
             bindings.iter().fold(String::new(), |mut acc, bind| {
                 if !acc.is_empty() {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -12,7 +12,7 @@ use helix_view::editor::Breakpoint;
 
 use serde_json::{to_value, Value};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tui::text::Spans;
+use tui::{text::Spans, widgets::Row};
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -25,7 +25,7 @@ use helix_view::handlers::dap::{breakpoints_changed, jump_to_stack_frame, select
 impl ui::menu::Item for StackFrame {
     type Data = ();
 
-    fn label(&self, _data: &Self::Data) -> Spans {
+    fn format(&self, _data: &Self::Data) -> Row {
         self.name.as_str().into() // TODO: include thread_states in the label
     }
 }
@@ -33,7 +33,7 @@ impl ui::menu::Item for StackFrame {
 impl ui::menu::Item for DebugTemplate {
     type Data = ();
 
-    fn label(&self, _data: &Self::Data) -> Spans {
+    fn format(&self, _data: &Self::Data) -> Row {
         self.name.as_str().into()
     }
 }
@@ -41,7 +41,7 @@ impl ui::menu::Item for DebugTemplate {
 impl ui::menu::Item for Thread {
     type Data = ThreadStates;
 
-    fn label(&self, thread_states: &Self::Data) -> Spans {
+    fn format(&self, thread_states: &Self::Data) -> Row {
         format!(
             "{} ({})",
             self.name,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -5,7 +5,10 @@ use helix_lsp::{
     util::{diagnostic_to_lsp_diagnostic, lsp_pos_to_pos, lsp_range_to_range, range_to_lsp_range},
     OffsetEncoding,
 };
-use tui::text::{Span, Spans};
+use tui::{
+    text::{Span, Spans},
+    widgets::Row,
+};
 
 use super::{align_view, push_jump, Align, Context, Editor, Open};
 
@@ -46,7 +49,7 @@ impl ui::menu::Item for lsp::Location {
     /// Current working directory.
     type Data = PathBuf;
 
-    fn label(&self, cwdir: &Self::Data) -> Spans {
+    fn format(&self, cwdir: &Self::Data) -> Row {
         // The preallocation here will overallocate a few characters since it will account for the
         // URL's scheme, which is not used most of the time since that scheme will be "file://".
         // Those extra chars will be used to avoid allocating when writing the line number (in the
@@ -80,7 +83,7 @@ impl ui::menu::Item for lsp::SymbolInformation {
     /// Path to currently focussed document
     type Data = Option<lsp::Url>;
 
-    fn label(&self, current_doc_path: &Self::Data) -> Spans {
+    fn format(&self, current_doc_path: &Self::Data) -> Row {
         if current_doc_path.as_ref() == Some(&self.location.uri) {
             self.name.as_str().into()
         } else {
@@ -110,7 +113,7 @@ struct PickerDiagnostic {
 impl ui::menu::Item for PickerDiagnostic {
     type Data = (DiagnosticStyles, DiagnosticsFormat);
 
-    fn label(&self, (styles, format): &Self::Data) -> Spans {
+    fn format(&self, (styles, format): &Self::Data) -> Row {
         let mut style = self
             .diag
             .severity
@@ -149,6 +152,7 @@ impl ui::menu::Item for PickerDiagnostic {
             Span::styled(&self.diag.message, style),
             Span::styled(code, style),
         ])
+        .into()
     }
 }
 
@@ -467,7 +471,7 @@ pub fn workspace_diagnostics_picker(cx: &mut Context) {
 
 impl ui::menu::Item for lsp::CodeActionOrCommand {
     type Data = ();
-    fn label(&self, _data: &Self::Data) -> Spans {
+    fn format(&self, _data: &Self::Data) -> Row {
         match self {
             lsp::CodeActionOrCommand::CodeAction(action) => action.title.as_str().into(),
             lsp::CodeActionOrCommand::Command(command) => command.title.as_str().into(),
@@ -662,7 +666,7 @@ pub fn code_action(cx: &mut Context) {
 
 impl ui::menu::Item for lsp::Command {
     type Data = ();
-    fn label(&self, _data: &Self::Data) -> Spans {
+    fn format(&self, _data: &Self::Data) -> Row {
         self.title.as_str().into()
     }
 }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,7 +1,6 @@
 use crate::compositor::{Component, Context, Event, EventResult};
 use helix_view::{apply_transaction, editor::CompleteAction, ViewId};
 use tui::buffer::Buffer as Surface;
-use tui::text::Spans;
 
 use std::borrow::Cow;
 
@@ -33,11 +32,7 @@ impl menu::Item for CompletionItem {
             .into()
     }
 
-    fn label(&self, _data: &Self::Data) -> Spans {
-        self.label.as_str().into()
-    }
-
-    fn row(&self, _data: &Self::Data) -> menu::Row {
+    fn format(&self, _data: &Self::Data) -> menu::Row {
         menu::Row::new(vec![
             menu::Cell::from(self.label.as_str()),
             menu::Cell::from(match self.kind {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -6,7 +6,9 @@ use crate::{
 use futures_util::future::BoxFuture;
 use tui::{
     buffer::Buffer as Surface,
-    widgets::{Block, BorderType, Borders},
+    layout::Constraint,
+    text::{Span, Spans},
+    widgets::{Block, BorderType, Borders, Cell, Table},
 };
 
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
@@ -19,10 +21,11 @@ use std::{
 use std::{collections::HashMap, io::Read, path::PathBuf};
 
 use crate::ui::{Prompt, PromptEvent};
-use helix_core::{movement::Direction, Position};
+use helix_core::{movement::Direction, unicode::segmentation::UnicodeSegmentation, Position};
 use helix_view::{
     editor::Action,
     graphics::{CursorKind, Margin, Modifier, Rect},
+    theme::Style,
     Document, DocumentId, Editor,
 };
 
@@ -388,6 +391,8 @@ pub struct Picker<T: Item> {
     pub truncate_start: bool,
     /// Whether to show the preview panel (default true)
     show_preview: bool,
+    /// Constraints for tabular formatting
+    widths: Vec<Constraint>,
 
     callback_fn: Box<dyn Fn(&mut Context, &T, Action)>,
 }
@@ -405,6 +410,26 @@ impl<T: Item> Picker<T> {
             |_editor: &mut Context, _pattern: &str, _event: PromptEvent| {},
         );
 
+        let n = options
+            .first()
+            .map(|option| option.row(&editor_data).cells.len())
+            .unwrap_or_default();
+        let max_lens = options.iter().fold(vec![0; n], |mut acc, option| {
+            let row = option.row(&editor_data);
+            // maintain max for each column
+            for (acc, cell) in acc.iter_mut().zip(row.cells.iter()) {
+                let width = cell.content.width();
+                if width > *acc {
+                    *acc = width;
+                }
+            }
+            acc
+        });
+        let widths = max_lens
+            .into_iter()
+            .map(|len| Constraint::Length(len as u16))
+            .collect();
+
         let mut picker = Self {
             options,
             editor_data,
@@ -417,6 +442,7 @@ impl<T: Item> Picker<T> {
             show_preview: true,
             callback_fn: Box::new(callback_fn),
             completion_height: 0,
+            widths,
         };
 
         // scoring on empty input:
@@ -436,8 +462,6 @@ impl<T: Item> Picker<T> {
     }
 
     pub fn score(&mut self) {
-        let now = Instant::now();
-
         let pattern = self.prompt.line();
 
         if pattern == &self.previous_pattern {
@@ -478,8 +502,6 @@ impl<T: Item> Picker<T> {
         } else {
             self.force_score();
         }
-
-        log::debug!("picker score {:?}", Instant::now().duration_since(now));
 
         // reset cursor position
         self.cursor = 0;
@@ -651,7 +673,7 @@ impl<T: Item + 'static> Component for Picker<T> {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let text_style = cx.editor.theme.get("ui.text");
         let selected = cx.editor.theme.get("ui.text.focus");
-        let highlighted = cx.editor.theme.get("special").add_modifier(Modifier::BOLD);
+        let highlight_style = cx.editor.theme.get("special").add_modifier(Modifier::BOLD);
 
         // -- Render the frame:
         // clear area
@@ -691,61 +713,119 @@ impl<T: Item + 'static> Component for Picker<T> {
         }
 
         // -- Render the contents:
-        // subtract area of prompt from top and current item marker " > " from left
-        let inner = inner.clip_top(2).clip_left(3);
+        // subtract area of prompt from top
+        let inner = inner.clip_top(2);
 
         let rows = inner.height;
         let offset = self.cursor - (self.cursor % std::cmp::max(1, rows as usize));
+        let cursor = self.cursor.saturating_sub(offset);
 
-        let files = self
+        let options = self
             .matches
             .iter()
             .skip(offset)
-            .map(|pmatch| (pmatch.index, self.options.get(pmatch.index).unwrap()));
+            .take(rows as usize)
+            .map(|pmatch| &self.options[pmatch.index])
+            .map(|option| option.row(&self.editor_data))
+            .map(|mut row| {
+                const TEMP_CELL_SEP: &str = " ";
 
-        for (i, (_index, option)) in files.take(rows as usize).enumerate() {
-            let is_active = i == (self.cursor - offset);
-            if is_active {
-                surface.set_string(
-                    inner.x.saturating_sub(3),
-                    inner.y + i as u16,
-                    " > ",
-                    selected,
-                );
-                surface.set_style(
-                    Rect::new(inner.x, inner.y + i as u16, inner.width, 1),
-                    selected,
-                );
-            }
+                let line = row.cell_text().join(TEMP_CELL_SEP);
 
-            let spans = option.label(&self.editor_data);
-            let (_score, highlights) = FuzzyQuery::new(self.prompt.line())
-                .fuzzy_indicies(&String::from(&spans), &self.matcher)
-                .unwrap_or_default();
+                // Items are filtered by using the text returned by menu::Item::filter_text
+                // but we do highlighting here using the text in Row and therefore there
+                // might be inconsistencies. This is the best we can do since only the
+                // text in Row is displayed to the end user.
+                let (_score, highlights) = FuzzyQuery::new(self.prompt.line())
+                    .fuzzy_indicies(&line, &self.matcher)
+                    .unwrap_or_default();
 
-            spans.0.into_iter().fold(inner, |pos, span| {
-                let new_x = surface
-                    .set_string_truncated(
-                        pos.x,
-                        pos.y + i as u16,
-                        &span.content,
-                        pos.width as usize,
-                        |idx| {
-                            if highlights.contains(&idx) {
-                                highlighted.patch(span.style)
-                            } else if is_active {
-                                selected.patch(span.style)
+                let highlight_byte_ranges: Vec<_> = line
+                    .char_indices()
+                    .enumerate()
+                    .filter_map(|(char_idx, (byte_offset, ch))| {
+                        highlights
+                            .contains(&char_idx)
+                            .then(|| byte_offset..byte_offset + ch.len_utf8())
+                    })
+                    .collect();
+
+                // The starting byte index of the current (iterating) cell
+                let mut cell_start_byte_offset = 0;
+                for cell in row.cells.iter_mut() {
+                    let spans = match cell.content.lines.get(0) {
+                        Some(s) => s,
+                        None => continue,
+                    };
+
+                    let mut cell_len = 0;
+
+                    let graphemes_with_style: Vec<_> = spans
+                        .0
+                        .iter()
+                        .flat_map(|span| {
+                            span.content
+                                .grapheme_indices(true)
+                                .zip(std::iter::repeat(span.style))
+                        })
+                        .map(|((grapheme_byte_offset, grapheme), style)| {
+                            cell_len += grapheme.len();
+                            let start = cell_start_byte_offset;
+
+                            let grapheme_byte_range =
+                                grapheme_byte_offset..grapheme_byte_offset + grapheme.len();
+
+                            if highlight_byte_ranges.iter().any(|hl_rng| {
+                                hl_rng.start >= start + grapheme_byte_range.start
+                                    && hl_rng.end <= start + grapheme_byte_range.end
+                            }) {
+                                (grapheme, style.patch(highlight_style))
                             } else {
-                                text_style.patch(span.style)
+                                (grapheme, style)
                             }
-                        },
-                        true,
-                        self.truncate_start,
-                    )
-                    .0;
-                pos.clip_left(new_x - pos.x)
+                        })
+                        .collect();
+
+                    let mut span_list: Vec<(String, Style)> = Vec::new();
+                    for (grapheme, style) in graphemes_with_style {
+                        if span_list.last().map(|(_, sty)| sty) == Some(&style) {
+                            let (string, _) = span_list.last_mut().unwrap();
+                            string.push_str(grapheme);
+                        } else {
+                            span_list.push((String::from(grapheme), style))
+                        }
+                    }
+
+                    let spans: Vec<Span> = span_list
+                        .into_iter()
+                        .map(|(string, style)| Span::styled(string, style))
+                        .collect();
+                    let spans: Spans = spans.into();
+                    *cell = Cell::from(spans);
+
+                    cell_start_byte_offset += cell_len + TEMP_CELL_SEP.len();
+                }
+
+                row
             });
-        }
+
+        let table = Table::new(options)
+            .style(text_style)
+            .highlight_style(selected)
+            .highlight_symbol(" > ")
+            .column_spacing(1)
+            .widths(&self.widths);
+
+        use tui::widgets::TableState;
+
+        table.render_table(
+            inner,
+            surface,
+            &mut TableState {
+                offset: 0,
+                selected: Some(cursor),
+            },
+        );
     }
 
     fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -409,10 +409,10 @@ impl<T: Item> Picker<T> {
 
         let n = options
             .first()
-            .map(|option| option.row(&editor_data).cells.len())
+            .map(|option| option.format(&editor_data).cells.len())
             .unwrap_or_default();
         let max_lens = options.iter().fold(vec![0; n], |mut acc, option| {
-            let row = option.row(&editor_data);
+            let row = option.format(&editor_data);
             // maintain max for each column
             for (acc, cell) in acc.iter_mut().zip(row.cells.iter()) {
                 let width = cell.content.width();
@@ -723,7 +723,7 @@ impl<T: Item + 'static> Component for Picker<T> {
             .skip(offset)
             .take(rows as usize)
             .map(|pmatch| &self.options[pmatch.index])
-            .map(|option| option.row(&self.editor_data))
+            .map(|option| option.format(&self.editor_data))
             .map(|mut row| {
                 const TEMP_CELL_SEP: &str = " ";
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -727,7 +727,11 @@ impl<T: Item + 'static> Component for Picker<T> {
             .map(|mut row| {
                 const TEMP_CELL_SEP: &str = " ";
 
-                let line = row.cell_text().join(TEMP_CELL_SEP);
+                let line = row.cell_text().fold(String::new(), |mut s, frag| {
+                    s.push_str(&frag);
+                    s.push_str(TEMP_CELL_SEP);
+                    s
+                });
 
                 // Items are filtered by using the text returned by menu::Item::filter_text
                 // but we do highlighting here using the text in Row and therefore there

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -14,10 +14,7 @@ use tui::{
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
 use tui::widgets::Widget;
 
-use std::{
-    cmp::{self, Ordering},
-    time::Instant,
-};
+use std::cmp::{self, Ordering};
 use std::{collections::HashMap, io::Read, path::PathBuf};
 
 use crate::ui::{Prompt, PromptEvent};

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -436,6 +436,19 @@ impl<'a> From<Vec<Spans<'a>>> for Text<'a> {
     }
 }
 
+impl<'a> From<Text<'a>> for String {
+    fn from(text: Text<'a>) -> String {
+        let lines: Vec<String> = text.lines.iter().map(String::from).collect();
+        lines.join("\n")
+    }
+}
+
+impl<'a> From<&Text<'a>> for String {
+    fn from(text: &Text<'a>) -> String {
+        let lines: Vec<String> = text.lines.iter().map(String::from).collect();
+        lines.join("\n")
+    }
+}
 impl<'a> IntoIterator for Text<'a> {
     type Item = Spans<'a>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -438,17 +438,30 @@ impl<'a> From<Vec<Spans<'a>>> for Text<'a> {
 
 impl<'a> From<Text<'a>> for String {
     fn from(text: Text<'a>) -> String {
-        let lines: Vec<String> = text.lines.iter().map(String::from).collect();
-        lines.join("\n")
+        String::from(&text)
     }
 }
 
 impl<'a> From<&Text<'a>> for String {
     fn from(text: &Text<'a>) -> String {
-        let lines: Vec<String> = text.lines.iter().map(String::from).collect();
-        lines.join("\n")
+        let size = text
+            .lines
+            .iter()
+            .flat_map(|spans| spans.0.iter().map(|span| span.content.len()))
+            .sum::<usize>()
+            + text.lines.len().saturating_sub(1); // for newline after each line
+        let mut output = String::with_capacity(size);
+
+        for spans in &text.lines {
+            for span in &spans.0 {
+                output.push_str(&span.content);
+            }
+            output.push('\n');
+        }
+        output
     }
 }
+
 impl<'a> IntoIterator for Text<'a> {
     type Item = Spans<'a>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -127,6 +127,12 @@ impl<'a> Row<'a> {
     }
 }
 
+impl<'a, T: Into<Cell<'a>>> From<T> for Row<'a> {
+    fn from(cell: T) -> Self {
+        Row::new(vec![cell.into()])
+    }
+}
+
 /// A widget to display data in formatted columns.
 ///
 /// It is a collection of [`Row`]s, themselves composed of [`Cell`]s:

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -126,6 +126,14 @@ impl<'a> Row<'a> {
     fn total_height(&self) -> u16 {
         self.height.saturating_add(self.bottom_margin)
     }
+
+    /// Returns the contents of cells as plain text, without styles and colors.
+    pub fn cell_text(&self) -> Vec<String> {
+        self.cells
+            .iter()
+            .map(|cell| String::from(&cell.content))
+            .collect()
+    }
 }
 
 /// A widget to display data in formatted columns.
@@ -477,6 +485,9 @@ impl<'a> Table<'a> {
             };
             let mut col = table_row_start_col;
             for (width, cell) in columns_widths.iter().zip(table_row.cells.iter()) {
+                if is_selected {
+                    buf.set_style(table_row_area, self.highlight_style);
+                }
                 render_cell(
                     buf,
                     cell,
@@ -488,9 +499,6 @@ impl<'a> Table<'a> {
                     },
                 );
                 col += *width + self.column_spacing;
-            }
-            if is_selected {
-                buf.set_style(table_row_area, self.highlight_style);
             }
         }
     }

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -122,11 +122,8 @@ impl<'a> Row<'a> {
     }
 
     /// Returns the contents of cells as plain text, without styles and colors.
-    pub fn cell_text(&self) -> Vec<String> {
-        self.cells
-            .iter()
-            .map(|cell| String::from(&cell.content))
-            .collect()
+    pub fn cell_text(&self) -> impl Iterator<Item = String> + '_ {
+        self.cells.iter().map(|cell| String::from(&cell.content))
     }
 }
 


### PR DESCRIPTION
Continues #2814. This change reuses the table widget directly in the picker, finally allowing items to be formatted as columns 🎉. Column formatting can be done by implementing `menu::Item::row()` on the picker items.

### Behavioral Changes

- There was a subtle bug in rendering the highlights for matching text which produced incorrect highlighting with multi byte characters. The algorithm to calculate highlights had to be re-written anyway to be injectable into a row of the table, and the issue was fixed along with this:

```
    The fuzzy matcher returns char indices of the choice that matched
    the pattern, while highlighting can only be done on whole graphemes.
    The earlier code assumed char indices == grapheme indices which
    broke highlighting with characters like å.
    
    This commit solves this issue by converting highlighting char indices
    to byte ranges, finding the grapheme which has this byte range as
    it's subrange, and then highlighting the whole grapheme.
```

| Before | After |
| --- | --- |
| ![picker-unicode-highlighting-incorrect-before](https://user-images.githubusercontent.com/23398472/178573279-246f977d-287c-45a7-977f-622779cc2c0c.png) | ![picker-unicode-highlighting-correct-after](https://user-images.githubusercontent.com/23398472/178573292-53c5ad7f-333e-420c-b74e-90a7d36685c1.png) |

- Pickers that previously aligned items to the right (like the file picker which shows the end of the filename if the window is too narrow) cannot do so anymore; this will require a new `align` property on table cells.

### Bugs 

- [x] I noticed problems with some columns not being displayed randomly when moving up and down the picker (with a modified column formatted version of the diagnostics picker). Requires proper investigation. 

### Future Work
- Use column formatting in buffer picker, symbol picker, etc.
- Add align property to `table::Cell`
