### PR TITLE
fix wrong value for cursor shape config in the docs

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -60,7 +60,7 @@ hidden = false
 
 Defines the shape of cursor in each mode. Note that due to limitations
 of the terminal environment, only the primary cursor can change shape.
-Valid values for these options are `block`, `bar`, `underline`, or `none`.
+Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
 
 | Key      | Description                                | Default |
 | ---      | -----------                                | ------- |


### PR DESCRIPTION
> Valid values for these options are block, bar, underline, or none.
> [_configuration docs_](https://docs.helix-editor.com/configuration.html#editorcursor-shape-section)

This config

```toml
[editor.cursor-shape]
insert = "none"
```

leads to an error
`unknown variant 'none', expected one of 'block', 'bar', 'underline', 'hidden'`