### PR TITLE
Hotfix: Remove .git extension from SCSS url

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -392,7 +392,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "scss"
-source = { git = "https://github.com/serenadeai/tree-sitter-scss.git", rev = "c478c6868648eff49eb04a4df90d703dc45b312a" }
+source = { git = "https://github.com/serenadeai/tree-sitter-scss", rev = "c478c6868648eff49eb04a4df90d703dc45b312a" }
 
 [[language]]
 name = "html"


### PR DESCRIPTION
The current build fails when publishing flake:

https://github.com/helix-editor/helix/runs/7376788959?check_suite_focus=true

This URL fails:

https://api.github.com/repos/serenadeai/tree-sitter-scss.git/tarball/c478c6868648eff49eb04a4df90d703dc45b312a

This one works:

https://api.github.com/repos/serenadeai/tree-sitter-scss/tarball/c478c6868648eff49eb04a4df90d703dc45b312a