### PR TITLE
Indent with tabs by default (when no specific indentation settings apply)

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -26,7 +26,7 @@ use crate::{DocumentId, Editor, ViewId};
 /// 8kB of buffer space for encoding and decoding `Rope`s.
 const BUF_SIZE: usize = 8192;
 
-const DEFAULT_INDENT: IndentStyle = IndentStyle::Spaces(4);
+const DEFAULT_INDENT: IndentStyle = IndentStyle::Tabs;
 
 pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
 


### PR DESCRIPTION
This tiny code change adjusts the default indentation behavior when no language-specific or user-defined setting applies.

_Wait, don't run away... We're not having the tabs vs. spaces discussion!_

Keep in mind we're talking about the behavior when Helix is opened for **regular text files** or with an **empty scratch buffer**:
At that moment, as a user, I expect the editor to act like a simple, "dumb editor".
At that moment I _don't_ expect Helix to replace tabs with spaces because Helix _thinks_ I could be programming in a language where spaces _could_ be more important.

A simple, dumb editor, inserts a tab when I press [Tab], and a space when I press [Space].

There's many examples of default behavior in simple editors; KWrite, Notepad, Writer on Mac, ... but also Vim and Emacs (when they're not applying language-specific settings). They all insert a tab by default.

Therefore, for the sake of consistency with existing "expected" behavior, and because Helix is not an IDE at that moment, I suggest to change its default behavior.