### PR TITLE
Add mode colors (`color-modes`) to the "onedark" theme

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -65,6 +65,9 @@ diagnostic = { modifiers = ["underlined"] }
 
 "ui.statusline" = { fg = "white", bg = "light-black" }
 "ui.statusline.inactive" = { fg = "light-gray", bg = "light-black" }
+"ui.statusline.normal" = { fg = "light-black", bg = "blue" }
+"ui.statusline.insert" = { fg = "light-black", bg = "green" }
+"ui.statusline.select" = { fg = "light-black", bg = "purple" }
 
 "ui.text" = { fg = "white" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }


### PR DESCRIPTION
After the following themes:
```
autumn
autumn_night
meliora
night_owl
rose_pine
solarized_dark
solarized_light
```

...comes **onedark**!

Regarding the colors (blue for normal, green for insert and purple for selection), I took inspiration from lualine, which uses these colors by default.
Additionally, I find it especially intuitive to have green for insertion (which we know from diffs) and blue for the regular, default state.

I opted for a dark foreground, as a light foreground simply lacks any minimal amount of contrast. A very dark gray ("light-black") seemed to yield the best results.

_For those who didn't know yet: This wonderful coloring feature comes from #2676 and must be enabled in the configuration by setting `color-modes = true` under `[editor]`._

![image](https://user-images.githubusercontent.com/2804556/179560326-de0da4f5-c9d2-4a53-9f8c-27f687e4b915.png)
![image](https://user-images.githubusercontent.com/2804556/179560384-4bebdde1-350b-41c1-8576-3f9bc1824e2f.png)
![image](https://user-images.githubusercontent.com/2804556/179561391-21c340d6-3ffc-4621-aef4-e37d299045d8.png)