### PR TITLE
Improve python highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -423,7 +423,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "python"
-source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "d6210ceab11e8d812d4ab59c07c81458ec6e5184" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "de221eccf9a221f5b85474a553474a69b4b5784d" }
 
 [[language]]
 name = "nickel"

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -108,9 +108,11 @@
 (string) @string
 (escape_sequence) @constant.character.escape
 
+"(" ")" "[" "]" "{" "}"] @punctuation.bracket
+["," "." ":" ";" (ellipsis)] @punctuation.delimiter
 (interpolation
   "{" @punctuation.special
-  "}" @punctuation.special) @embedded
+  "}" @punctuation.special)
 
 [
   "-"

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -108,11 +108,11 @@
 (string) @string
 (escape_sequence) @constant.character.escape
 
-"(" ")" "[" "]" "{" "}"] @punctuation.bracket
 ["," "." ":" ";" (ellipsis)] @punctuation.delimiter
 (interpolation
   "{" @punctuation.special
   "}" @punctuation.special)
+"(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [
   "-"

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -1,3 +1,6 @@
+(dotted_name
+  (identifier)* @namespace)
+
 ; Builtin functions
 
 ((call
@@ -7,6 +10,11 @@
    "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
 
 ; Function calls
+
+[
+  "def"
+  "lambda"
+] @keyword.function
 
 (call
   function: (attribute attribute: (identifier) @constructor)
@@ -49,6 +57,13 @@
 (parameters (typed_default_parameter name: (identifier) @variable.parameter))
 (keyword_argument name: (identifier) @variable.parameter)
 
+(parameters
+  (list_splat_pattern ; *args
+    (identifier) @parameter))
+(parameters
+  (dictionary_splat_pattern ; **kwargs
+    (identifier) @parameter))
+
 ; Types
 
 ((identifier) @type.builtin
@@ -81,12 +96,11 @@
 (identifier) @variable
 
 ; Literals
-
+(none) @constant.builtin
 [
-  (none)
   (true)
   (false)
-] @constant.builtin
+] @constant.builtin.boolean
 
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float
@@ -135,24 +149,39 @@
   "as"
   "assert"
   "await"
-  "break"
-  "continue"
+  "from"
+  "pass"
+
+  "with"
+] @keyword.control
+
+[
+  "if"
   "elif"
   "else"
+] @keyword.control.conditional
+
+[
+  "while"
+  "for"
+  "break"
+  "continue"
+] @keyword.control.repeat
+
+[
+  "return"
+  "yield"
+] @keyword.control.return
+(yield "from" @keyword.control.return)
+
+[
+  "raise"
+  "try"
   "except"
   "finally"
-  "for"
-  "from"
-  "if"
-  "import"
-  "pass"
-  "raise"
-  "return"
-  "try"
-  "while"
-  "with"
-  "yield"
-] @keyword.control
+] @keyword.control.except
+(raise_statement "from" @keyword.control.except)
+"import" @keyword.control.import
 
 (for_statement "in" @keyword.control)
 (for_in_clause "in" @keyword.control)
@@ -161,16 +190,22 @@
   "and"
   "async"
   "class"
-  "def"
-  "del"
   "exec"
   "global"
-  "in"
-  "is"
-  "lambda"
   "nonlocal"
-  "not"
-  "or"
   "print"
 ] @keyword
+[
+  "and"
+  "or"
+  "in"
+  "not"
+  "del"
+  "is"
+] @keyword.operator
 
+((identifier) @type.builtin
+  (#match? @type.builtin
+    "^(BaseException|Exception|ArithmeticError|BufferError|LookupError|AssertionError|AttributeError|EOFError|FloatingPointError|GeneratorExit|ImportError|ModuleNotFoundError|IndexError|KeyError|KeyboardInterrupt|MemoryError|NameError|NotImplementedError|OSError|OverflowError|RecursionError|ReferenceError|RuntimeError|StopIteration|StopAsyncIteration|SyntaxError|IndentationError|TabError|SystemError|SystemExit|TypeError|UnboundLocalError|UnicodeError|UnicodeEncodeError|UnicodeDecodeError|UnicodeTranslateError|ValueError|ZeroDivisionError|EnvironmentError|IOError|WindowsError|BlockingIOError|ChildProcessError|ConnectionError|BrokenPipeError|ConnectionAbortedError|ConnectionRefusedError|ConnectionResetError|FileExistsError|FileNotFoundError|InterruptedError|IsADirectoryError|NotADirectoryError|PermissionError|ProcessLookupError|TimeoutError|Warning|UserWarning|DeprecationWarning|PendingDeprecationWarning|SyntaxWarning|RuntimeWarning|FutureWarning|ImportWarning|UnicodeWarning|BytesWarning|ResourceWarning)$"))
+
+(ERROR) @error

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -59,10 +59,10 @@
 
 (parameters
   (list_splat_pattern ; *args
-    (identifier) @parameter))
+    (identifier) @variable.parameter))
 (parameters
   (dictionary_splat_pattern ; **kwargs
-    (identifier) @parameter))
+    (identifier) @variable.parameter))
 
 ; Types
 

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -111,7 +111,7 @@
 ["," "." ":" ";" (ellipsis)] @punctuation.delimiter
 (interpolation
   "{" @punctuation.special
-  "}" @punctuation.special)
+  "}" @punctuation.special) @embedded
 "(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [


### PR DESCRIPTION
These changes were based on `nvim-treesitter`.

- Highlight import identifiers as `@namespace`
- Highlight boolean values as `@constant.builtin.boolean`
- Made `@keyword` captures more granular with the existing scopes. No new scopes were introduced.
- Added `@punctuation` captures.