### PR TITLE
Fix: indent guides out of bound.

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -422,12 +422,18 @@ impl EditorView {
             }
 
             for i in 0..(indent_level / tab_width as u16) {
-                surface.set_string(
-                    viewport.x + (i * tab_width as u16) - offset.col as u16,
-                    viewport.y + line,
-                    &indent_guide_char,
-                    indent_style,
-                );
+                let visual_x = i * tab_width as u16;
+                let out_of_bounds =
+                    visual_x < offset.col as u16 || visual_x >= viewport.width + offset.col as u16;
+
+                if !out_of_bounds {
+                    surface.set_string(
+                        viewport.x + visual_x - offset.col as u16,
+                        viewport.y + line,
+                        &indent_guide_char,
+                        indent_style,
+                    );
+                }
             }
         };
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -416,12 +416,17 @@ impl EditorView {
         let mut last_line_indent_level = 0;
         let indent_style = theme.get("ui.virtual.indent-guide");
 
-        let draw_indent_guides = |indent_level, line, surface: &mut Surface| {
+        let mut hide_indent_level = 0u16;
+        let mut draw_indent_guides = |indent_level, line, surface: &mut Surface| {
             if !config.indent_guides.render {
                 return;
             }
 
             for i in 0..(indent_level / tab_width as u16) {
+                if i < hide_indent_level {
+                    continue;
+                }
+
                 let visual_x = i * tab_width as u16;
                 let out_of_bounds =
                     visual_x < offset.col as u16 || visual_x >= viewport.width + offset.col as u16;
@@ -433,6 +438,8 @@ impl EditorView {
                         &indent_guide_char,
                         indent_style,
                     );
+                } else {
+                    hide_indent_level = i;
                 }
             }
         };


### PR DESCRIPTION
when Insufficient width of split window
<img width="769" alt="WX20220719-145548@2x" src="https://user-images.githubusercontent.com/716514/179686984-f49780b8-62ee-4614-bdc7-9483907daa95.png">

