### PR TITLE
Use split_parser branch for markdown grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -62,6 +62,7 @@
 | lua | ✓ |  | ✓ | `lua-language-server` |
 | make | ✓ |  |  |  |
 | markdown | ✓ |  |  |  |
+| markdown.inline | ✓ |  |  |  |
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |
 | nickel | ✓ |  | ✓ | `nls` |

--- a/languages.toml
+++ b/languages.toml
@@ -884,7 +884,20 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "markdown"
-source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "ab15701d8f3f68aeb74e30573b7d669a6ef2a7ed" }
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b", subpath = "tree-sitter-markdown" }
+
+[[language]]
+name = "markdown.inline"
+scope = "source.markdown.inline"
+injection-regex = "markdown\\.inline"
+file-types = []
+roots = []
+indent = { tab-width = 2, unit = "  " }
+grammar = "markdown_inline"
+
+[[grammar]]
+name = "markdown_inline"
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b", subpath = "tree-sitter-markdown-inline" }
 
 [[language]]
 name = "dart"

--- a/languages.toml
+++ b/languages.toml
@@ -892,7 +892,6 @@ scope = "source.markdown.inline"
 injection-regex = "markdown\\.inline"
 file-types = []
 roots = []
-indent = { tab-width = 2, unit = "  " }
 grammar = "markdown_inline"
 
 [[grammar]]

--- a/runtime/queries/markdown.inline/highlights.scm
+++ b/runtime/queries/markdown.inline/highlights.scm
@@ -13,6 +13,8 @@
 
 (strong_emphasis) @markup.bold
 
+(strikethrough) @markup.strikethrough
+
 [
   (link_destination)
   (uri_autolink)

--- a/runtime/queries/markdown.inline/highlights.scm
+++ b/runtime/queries/markdown.inline/highlights.scm
@@ -1,0 +1,37 @@
+;; From nvim-treesitter/nvim-treesitter
+[
+  (code_span)
+  (link_title)
+] @markup.raw.inline
+
+[
+  (emphasis_delimiter)
+  (code_span_delimiter)
+] @punctuation.bracket
+
+(emphasis) @markup.italic
+
+(strong_emphasis) @markup.bold
+
+[
+  (link_destination)
+  (uri_autolink)
+] @markup.link.url
+
+[
+  (link_text)
+  (image_description)
+] @markup.link.text
+
+(link_label) @markup.link.label
+
+[
+  (backslash_escape)
+  (hard_line_break)
+] @constant.character.escape
+
+(image ["[" "]" "(" ")"] @punctuation.bracket)
+(image "!" @punctuation.special)
+(inline_link ["[" "]" "(" ")"] @punctuation.bracket)
+(shortcut_link ["[" "]"] @punctuation.bracket)
+

--- a/runtime/queries/markdown.inline/injections.scm
+++ b/runtime/queries/markdown.inline/injections.scm
@@ -1,0 +1,2 @@
+
+((html_tag) @injection.content (#set! injection.language "html"))

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -1,54 +1,53 @@
-(setext_heading (heading_content) @markup.heading.1 (setext_h1_underline) @markup.heading.marker)
-(setext_heading (heading_content) @markup.heading.2 (setext_h2_underline) @markup.heading.marker)
 
-(atx_heading (atx_h1_marker) @markup.heading.marker (heading_content) @markup.heading.1)
-(atx_heading (atx_h2_marker) @markup.heading.marker (heading_content) @markup.heading.2)
-(atx_heading (atx_h3_marker) @markup.heading.marker (heading_content) @markup.heading.3)
-(atx_heading (atx_h4_marker) @markup.heading.marker (heading_content) @markup.heading.4)
-(atx_heading (atx_h5_marker) @markup.heading.marker (heading_content) @markup.heading.5)
-(atx_heading (atx_h6_marker) @markup.heading.marker (heading_content) @markup.heading.6)
+(setext_heading (paragraph) @markup.heading.1 (setext_h1_underline) @markup.heading.marker)
+(setext_heading (paragraph) @markup.heading.2 (setext_h2_underline) @markup.heading.marker)
+
+(atx_heading (atx_h1_marker) @markup.heading.marker (inline) @markup.heading.1)
+(atx_heading (atx_h2_marker) @markup.heading.marker (inline) @markup.heading.2)
+(atx_heading (atx_h3_marker) @markup.heading.marker (inline) @markup.heading.3)
+(atx_heading (atx_h4_marker) @markup.heading.marker (inline) @markup.heading.4)
+(atx_heading (atx_h5_marker) @markup.heading.marker (inline) @markup.heading.5)
+(atx_heading (atx_h6_marker) @markup.heading.marker (inline) @markup.heading.6)
 
 [
   (indented_code_block)
-  (code_fence_content)
+  (fenced_code_block)
 ] @markup.raw.block
-
-(block_quote) @markup.quote
-
-(code_span) @markup.raw.inline
-
-(emphasis) @markup.italic
-
-(strong_emphasis) @markup.bold
-
-(link_destination) @markup.link.url
-(link_label) @markup.link.label
 
 (info_string) @label
 
 [
-  (link_text)
-  (image_description)
-] @markup.link.text
+  (fenced_code_block_delimiter)
+] @punctuation.bracket
+
+[
+  (link_destination)
+] @markup.link.url
+
+[
+  (link_label)
+] @markup.link.label
 
 [
   (list_marker_plus)
   (list_marker_minus)
   (list_marker_star)
-] @markup.list.numbered
+] @markup.list.unnumbered
 
 [
   (list_marker_dot)
   (list_marker_parenthesis)
-] @markup.list.unnumbered
-
-[
-  (backslash_escape)
-  (hard_line_break)
-] @constant.character.escape
+] @markup.list.numbered
 
 (thematic_break) @punctuation.delimiter
 
-(inline_link ["[" "]" "(" ")"] @punctuation.bracket)
-(image ["[" "]" "(" ")"] @punctuation.bracket)
-(fenced_code_block_delimiter) @punctuation.bracket
+[
+  (block_continuation)
+  (block_quote_marker)
+] @punctuation.special
+
+[
+  (backslash_escape)
+] @string.escape
+
+(block_quote) @markup.quote

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,9 +1,15 @@
-(fenced_code_block
-  (info_string) @injection.language
-  (code_fence_content) @injection.content
-  (#set! injection.include-children))
+; From nvim-treesitter/nvim-treesitter
 
-((html_block) @injection.content
- (#set! injection.language "html"))
-((html_tag) @injection.content
- (#set! injection.language "html"))
+(fenced_code_block
+  (info_string
+    (language) @injection.language)
+  (code_fence_content) @injection.content (#set! injection.include-unnamed-children))
+
+((html_block) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
+
+([
+  (minus_metadata)
+  (plus_metadata)
+] @injection.content (#set! injection.language "yaml") (#set! injection.include-unnamed-children))
+
+((inline) @injection.content (#set! injection.language "markdown.inline") (#set! injection.include-unnamed-children))


### PR DESCRIPTION
See #3072.

Only a draft because `markdown_inline` grammar is not injected properly, but to me it seems like this is a problem with helix and not the language config? After a few experiments I think the grammar _is_ injected, but highlighting is still not done according to the injected language. I'm not very sure though.

Another weird behavior is with fenced code blocks. They seem to work to some degree, but if you enter something like
~~~markdown
```rust
let foo = "bar";
```
~~~
then `let` is highlighted correctly while `"bar"` is not highlighted at all.