### PR TITLE
add statusline element to display file line endings

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -62,7 +62,7 @@ Statusline elements can be defined as follows:
 [editor.statusline]
 left = ["mode", "spinner"]
 center = ["file-name"]
-right = ["diagnostics", "selections", "position", "file-encoding", "file-line-endings", "file-type"]
+right = ["diagnostics", "selections", "position", "file-encoding", "file-line-ending", "file-type"]
 ```
 
 The following elements can be configured:
@@ -73,7 +73,7 @@ The following elements can be configured:
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
-| `file-line-endings` | The file line endings (CRLF or LF) |
+| `file-line-ending` | The file line endings (CRLF or LF) |
 | `file-type` | The type of the opened file |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -62,7 +62,7 @@ Statusline elements can be defined as follows:
 [editor.statusline]
 left = ["mode", "spinner"]
 center = ["file-name"]
-right = ["diagnostics", "selections", "position", "file-encoding", "file-type"]
+right = ["diagnostics", "selections", "position", "file-encoding", "file-line-endings", "file-type"]
 ```
 
 The following elements can be configured:
@@ -73,6 +73,7 @@ The following elements can be configured:
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
+| `file-line-endings` | The file line endings (CRLF or LF) |
 | `file-type` | The type of the opened file |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -413,11 +413,10 @@ fn set_line_ending(
 
     // Attempt to parse argument as a line ending.
     let line_ending = match arg {
-        // We check for CR first because it shares a common prefix with CRLF.
-        #[cfg(feature = "unicode-lines")]
-        arg if arg.starts_with("cr") => CR,
         arg if arg.starts_with("crlf") => Crlf,
         arg if arg.starts_with("lf") => LF,
+        #[cfg(feature = "unicode-lines")]
+        arg if arg.starts_with("cr") => CR,
         #[cfg(feature = "unicode-lines")]
         arg if arg.starts_with("ff") => FF,
         #[cfg(feature = "unicode-lines")]

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -289,6 +289,18 @@ where
     let line_ending = match context.doc.line_ending {
         Crlf => "CRLF",
         LF => "LF",
+        #[cfg(feature = "unicode-lines")]
+        VT => "VT", // U+000B -- VerticalTab
+        #[cfg(feature = "unicode-lines")]
+        FF => "FF", // U+000C -- FormFeed
+        #[cfg(feature = "unicode-lines")]
+        CR => "CR", // U+000D -- CarriageReturn
+        #[cfg(feature = "unicode-lines")]
+        Nel => "NEL", // U+0085 -- NextLine
+        #[cfg(feature = "unicode-lines")]
+        LS => "LS", // U+2028 -- Line Separator
+        #[cfg(feature = "unicode-lines")]
+        PS => "PS", // U+2029 -- ParagraphSeparator
     };
 
     write(context, format!(" {} ", line_ending), None);

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -138,7 +138,7 @@ where
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
         helix_view::editor::StatusLineElement::FileEncoding => render_file_encoding,
-        helix_view::editor::StatusLineElement::FileLineEndings => render_file_line_endings,
+        helix_view::editor::StatusLineElement::FileLineEnding => render_file_line_ending,
         helix_view::editor::StatusLineElement::FileType => render_file_type,
         helix_view::editor::StatusLineElement::Diagnostics => render_diagnostics,
         helix_view::editor::StatusLineElement::Selections => render_selections,
@@ -281,7 +281,7 @@ where
     }
 }
 
-fn render_file_line_endings<F>(context: &mut RenderContext, write: F)
+fn render_file_line_ending<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -138,6 +138,7 @@ where
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
         helix_view::editor::StatusLineElement::FileEncoding => render_file_encoding,
+        helix_view::editor::StatusLineElement::FileLineEndings => render_file_line_endings,
         helix_view::editor::StatusLineElement::FileType => render_file_type,
         helix_view::editor::StatusLineElement::Diagnostics => render_diagnostics,
         helix_view::editor::StatusLineElement::Selections => render_selections,
@@ -278,6 +279,19 @@ where
     if enc != encoding::UTF_8 {
         write(context, format!(" {} ", enc.name()), None);
     }
+}
+
+fn render_file_line_endings<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    use helix_core::LineEnding::*;
+    let line_ending = match context.doc.line_ending {
+        Crlf => "CRLF",
+        LF => "LF",
+    };
+
+    write(context, format!(" {} ", line_ending), None);
 }
 
 fn render_file_type<F>(context: &mut RenderContext, write: F)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -231,7 +231,10 @@ pub enum StatusLineElement {
 
     /// The file encoding
     FileEncoding,
-
+    
+    /// The file line endings (CRLF or LF)
+    FileLineEndings,
+    
     /// The file type (language ID or "text")
     FileType,
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -231,10 +231,10 @@ pub enum StatusLineElement {
 
     /// The file encoding
     FileEncoding,
-    
+
     /// The file line endings (CRLF or LF)
     FileLineEndings,
-    
+
     /// The file type (language ID or "text")
     FileType,
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -233,7 +233,7 @@ pub enum StatusLineElement {
     FileEncoding,
 
     /// The file line endings (CRLF or LF)
-    FileLineEndings,
+    FileLineEnding,
 
     /// The file type (language ID or "text")
     FileType,


### PR DESCRIPTION
File line endings: CRLF or LF.

![image](https://user-images.githubusercontent.com/55039048/179862475-596027e2-6adb-46c8-a09f-adbfcdb95c71.png)

![image](https://user-images.githubusercontent.com/55039048/179862512-74779822-d6e6-40e7-b63d-560c1bff465e.png)
