### PR TITLE
Exclude only named children without injection.include-children

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1457,7 +1457,7 @@ fn intersect_ranges(
         };
 
         for excluded_range in node
-            .children(&mut cursor)
+            .named_children(&mut cursor)
             .filter_map(|child| {
                 if includes_children {
                     None


### PR DESCRIPTION
This fixes problems arising in #3108.

The markdown parser needs to exclude children for language injection, but only named ones. This is *different* from the behavior in tree-sitter-highlight, but to me it seems more sensible. 

To give a technical example: Otherwise there is almost no way to write something like
```js
rule: $ => seq('(', repeat(choice($._content, $.excluded)), ')'),
```
where `$._content` and the parentheses should be included and `$.excluded` excluded. This is because there will always be `'('` and `')'` nodes as a child of `rule`.