### PR TITLE
Avoid copying fragments

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -222,9 +222,12 @@ impl Range {
 
     // groupAt
 
+    /// This returns a RopeSlice since returning a string might imply copying
+    /// the entire content within the range. If you really need the text in a
+    /// continuous slice, you can call Cow::<str>.from(...).
     #[inline]
-    pub fn fragment<'a, 'b: 'a>(&'a self, text: RopeSlice<'b>) -> Cow<'b, str> {
-        text.slice(self.from()..self.to()).into()
+    pub fn fragment<'a, 'b: 'a>(&'a self, text: RopeSlice<'b>) -> RopeSlice<'b> {
+        text.slice(self.from()..self.to())
     }
 
     //--------------------------------
@@ -544,7 +547,7 @@ impl Selection {
         self.transform(|range| Range::point(range.cursor(text)))
     }
 
-    pub fn fragments<'a>(&'a self, text: RopeSlice<'a>) -> impl Iterator<Item = Cow<str>> + 'a {
+    pub fn fragments<'a>(&'a self, text: RopeSlice<'a>) -> impl Iterator<Item = RopeSlice> + 'a {
         self.ranges.iter().map(move |range| range.fragment(text))
     }
 
@@ -611,7 +614,7 @@ pub fn keep_or_remove_matches(
 ) -> Option<Selection> {
     let result: SmallVec<_> = selection
         .iter()
-        .filter(|range| regex.is_match(&range.fragment(text)) ^ remove)
+        .filter(|range| regex.is_match(&Cow::from(range.fragment(text))) ^ remove)
         .copied()
         .collect();
 
@@ -636,7 +639,7 @@ pub fn select_on_matches(
         let sel_start = sel.from();
         let start_byte = text.char_to_byte(sel_start);
 
-        for mat in regex.find_iter(&fragment) {
+        for mat in regex.find_iter(&Cow::from(fragment)) {
             // TODO: retain range direction
 
             let start = text.byte_to_char(start_byte + mat.start());
@@ -678,7 +681,7 @@ pub fn split_on_matches(
 
         let mut start = sel_start;
 
-        for mat in regex.find_iter(&fragment) {
+        for mat in regex.find_iter(&Cow::from(fragment)) {
             // TODO: retain range direction
             let end = text.byte_to_char(start_byte + mat.start());
             result.push(Range::new(start, end));
@@ -1024,7 +1027,10 @@ mod test {
         );
 
         assert_eq!(
-            result.fragments(text.slice(..)).collect::<Vec<_>>(),
+            result
+                .fragments(text.slice(..))
+                .map(Cow::from)
+                .collect::<Vec<_>>(),
             &["", "abcd", "efg", "rs", "xyz"]
         );
     }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -222,12 +222,20 @@ impl Range {
 
     // groupAt
 
-    /// Consider using `slice` instead.
+    /// Returns the text inside this range given the text of the whole buffer.
+    ///
+    /// The returned `Cow` is a reference if the range of text is inside a single
+    /// chunk of the rope. Otherwise a copy of the text is returned. Consider
+    /// using `slice` instead if you do not need a `Cow` or `String` to avoid copying.
     #[inline]
     pub fn fragment<'a, 'b: 'a>(&'a self, text: RopeSlice<'b>) -> Cow<'b, str> {
         self.slice(text).into()
     }
 
+    /// Returns the text inside this range given the text of the whole buffer.
+    ///
+    /// The returned value is a reference to the passed slice. This method never
+    /// copies any contents.
     #[inline]
     pub fn slice<'a, 'b: 'a>(&'a self, text: RopeSlice<'b>) -> RopeSlice<'b> {
         text.slice(self.from()..self.to())

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1291,7 +1291,7 @@ fn sort_impl(
     let selection = doc.selection(view.id);
 
     let mut fragments: Vec<_> = selection
-        .fragments(text)
+        .slices(text)
         .map(|fragment| fragment.chunks().collect())
         .collect();
 
@@ -1346,7 +1346,7 @@ fn reflow(
     let selection = doc.selection(view.id);
     let transaction = Transaction::change_by_selection(rope, selection, |range| {
         let fragment = range.fragment(rope.slice(..));
-        let reflowed_text = helix_core::wrap::reflow_hard_wrap(&Cow::from(fragment), max_line_len);
+        let reflowed_text = helix_core::wrap::reflow_hard_wrap(&fragment, max_line_len);
 
         (range.from(), range.to(), Some(reflowed_text))
     });

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1292,7 +1292,7 @@ fn sort_impl(
 
     let mut fragments: Vec<_> = selection
         .fragments(text)
-        .map(|fragment| Tendril::from(fragment.as_ref()))
+        .map(|fragment| fragment.chunks().collect())
         .collect();
 
     fragments.sort_by(match reverse {
@@ -1346,7 +1346,7 @@ fn reflow(
     let selection = doc.selection(view.id);
     let transaction = Transaction::change_by_selection(rope, selection, |range| {
         let fragment = range.fragment(rope.slice(..));
-        let reflowed_text = helix_core::wrap::reflow_hard_wrap(&fragment, max_line_len);
+        let reflowed_text = helix_core::wrap::reflow_hard_wrap(&Cow::from(fragment), max_line_len);
 
         (range.from(), range.to(), Some(reflowed_text))
     });

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1029,8 +1029,8 @@ impl EditorView {
                 if doc
                     .selection(view.id)
                     .primary()
-                    .fragment(doc.text().slice(..))
-                    .width()
+                    .slice(doc.text().slice(..))
+                    .len_chars()
                     <= 1
                 {
                     return EventResult::Ignored(None);


### PR DESCRIPTION
~Might fix #3127.~

This changes the `Range::fragment` and `Selection::fragments` to return `RopeSlice`. This way we can avoid copying the ropes' contents in a few cases, specifically

* `shell_impl`
* Sometimes one less copy in `switch_to_*case`
* Sometimes one less copy in all commands that "yank"
* Sometimes one less copy in `sort` and `rotate_selection_contents`

Also, it will make the computational overhead of copying the fragments more apparent in places where `Range::fragment` is used (until now it almost looked like there was no copy, since a `Cow` was returned).

(I also rewrite the mouse event handling because (I think, without optimizations) until now it copied the entire file on each mouse up event)