### PR TITLE
Enable CI builds for `aarch64-macos`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           args: --release --locked --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
+        if: matrix.build == 'x86_64-linux' || endsWith(matrix.build, 'macos')
         run: strip "target/${{ matrix.target }}/release/hx"
 
       - name: Strip release binary (arm)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,12 @@ jobs:
           rust: stable
           target: x86_64-pc-windows-msvc
           cross: false
-        # - build: aarch64-macos
-        #   os: macos-latest
-        #   rust: stable
-        #   target: aarch64-apple-darwin
+        - build: aarch64-macos
+          os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
+          cross: false
+          skip_tests: true  # x86_64 host can't run aarch64 code
         # - build: x86_64-win-gnu
         #   os: windows-2019
         #   rust: stable-x86_64-gnu
@@ -100,6 +102,7 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        if: "!matrix.skip_tests"
         with:
           use-cross: ${{ matrix.cross }}
           command: test
@@ -113,7 +116,7 @@ jobs:
           args: --release --locked --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos'
+        if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
         run: strip "target/${{ matrix.target }}/release/hx"
 
       - name: Strip release binary (arm)

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -318,6 +318,7 @@ fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> 
     for (key, value) in compiler.env() {
         command.env(key, value);
     }
+    command.args(compiler.args());
 
     if cfg!(windows) {
         command

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -92,8 +92,12 @@ pub fn fetch_grammars() -> Result<()> {
     run_parallel(grammars, fetch_grammar, "fetch")
 }
 
-pub fn build_grammars() -> Result<()> {
-    run_parallel(get_grammar_configs()?, build_grammar, "build")
+pub fn build_grammars(target: Option<String>) -> Result<()> {
+    run_parallel(
+        get_grammar_configs()?,
+        move |grammar| build_grammar(grammar, target.as_deref()),
+        "build",
+    )
 }
 
 // Returns the set of grammar configurations the user requests.
@@ -124,13 +128,14 @@ fn get_grammar_configs() -> Result<Vec<GrammarConfiguration>> {
 
 fn run_parallel<F>(grammars: Vec<GrammarConfiguration>, job: F, action: &'static str) -> Result<()>
 where
-    F: Fn(GrammarConfiguration) -> Result<()> + std::marker::Send + 'static + Copy,
+    F: Fn(GrammarConfiguration) -> Result<()> + std::marker::Send + 'static + Clone,
 {
     let pool = threadpool::Builder::new().build();
     let (tx, rx) = channel();
 
     for grammar in grammars {
         let tx = tx.clone();
+        let job = job.clone();
 
         pool.execute(move || {
             // Ignore any SendErrors, if any job in another thread has encountered an
@@ -240,7 +245,7 @@ where
     }
 }
 
-fn build_grammar(grammar: GrammarConfiguration) -> Result<()> {
+fn build_grammar(grammar: GrammarConfiguration, target: Option<&str>) -> Result<()> {
     let grammar_dir = if let GrammarSource::Local { path } = &grammar.source {
         PathBuf::from(&path)
     } else {
@@ -273,10 +278,14 @@ fn build_grammar(grammar: GrammarConfiguration) -> Result<()> {
     }
     .join("src");
 
-    build_tree_sitter_library(&path, grammar)
+    build_tree_sitter_library(&path, grammar, target)
 }
 
-fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> Result<()> {
+fn build_tree_sitter_library(
+    src_path: &Path,
+    grammar: GrammarConfiguration,
+    target: Option<&str>,
+) -> Result<()> {
     let header_path = src_path;
     let parser_path = src_path.join("parser.c");
     let mut scanner_path = src_path.join("scanner.c");
@@ -311,7 +320,7 @@ fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> 
         .opt_level(3)
         .cargo_metadata(false)
         .host(BUILD_TARGET)
-        .target(BUILD_TARGET);
+        .target(target.unwrap_or(BUILD_TARGET));
     let compiler = config.get_compiler();
     let mut command = Command::new(compiler.path());
     command.current_dir(src_path);

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -19,7 +19,8 @@ fn main() {
 
     if std::env::var("HELIX_DISABLE_AUTO_GRAMMAR_BUILD").is_err() {
         fetch_grammars().expect("Failed to fetch tree-sitter grammars");
-        build_grammars().expect("Failed to compile tree-sitter grammars");
+        build_grammars(Some(std::env::var("TARGET").unwrap()))
+            .expect("Failed to compile tree-sitter grammars");
     }
 
     println!("cargo:rerun-if-changed=../runtime/grammars/");

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -108,7 +108,7 @@ FLAGS:
     }
 
     if args.build_grammars {
-        helix_loader::grammar::build_grammars()?;
+        helix_loader::grammar::build_grammars(None)?;
         return Ok(0);
     }
 


### PR DESCRIPTION
Closes #1647.

A preview CI run based on this patch and the built artifacts can be found at <https://github.com/yvt/helix/actions/runs/2709143241>.