### PR TITLE
Gleam: add support for built-in language server

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -30,7 +30,7 @@
 | git-diff | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
-| gleam | ✓ | ✓ |  |  |
+| gleam | ✓ | ✓ |  | `gleam` |
 | glsl | ✓ | ✓ | ✓ |  |
 | go | ✓ | ✓ | ✓ | `gopls` |
 | gomod | ✓ |  |  | `gopls` |

--- a/languages.toml
+++ b/languages.toml
@@ -1140,6 +1140,7 @@ file-types = ["gleam"]
 roots = ["gleam.toml"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
+language-server = { command = "gleam", args = ["lsp"] }
 
 [[grammar]]
 name = "gleam"


### PR DESCRIPTION
See: https://gleam.run/news/v0.21-introducing-the-gleam-language-server/

Gleam has a built-in language server we can use in Helix 🙂 

I lifted this from the vscode plugin for Gleam: https://github.com/gleam-lang/vscode-gleam/blob/19a4a82f1afc769dfa32bbc9be22215249a8d1c2/src/extension.ts#L34

cc @lpil @the-mikedavis 