### PR TITLE
Add LSP workspace command picker

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -45,6 +45,7 @@
 | `:encoding` | Set encoding. Based on `https://encoding.spec.whatwg.org`. |
 | `:reload` | Discard changes and reload from the source file. |
 | `:update` | Write changes only if the file has been modified. |
+| `:lsp-workspace-command` | Open workspace command picker |
 | `:lsp-restart` | Restarts the Language Server that is in use by the current doc |
 | `:tree-sitter-scopes` | Display tree sitter scopes, primarily for theming and development. |
 | `:debug-start`, `:dbg` | Start a debug session from a given template with given parameters. |

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -298,6 +298,9 @@ impl Client {
                         dynamic_registration: Some(false),
                         ..Default::default()
                     }),
+                    execute_command: Some(lsp::DynamicRegistrationClientCapabilities {
+                        dynamic_registration: Some(false),
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -268,7 +268,6 @@ impl MappableCommand {
         file_picker, "Open file picker",
         file_picker_in_current_directory, "Open file picker at current working directory",
         code_action, "Perform code action",
-        workspace_command_picker, "Open workspace command picker",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
         symbol_picker, "Open symbol picker",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -268,6 +268,7 @@ impl MappableCommand {
         file_picker, "Open file picker",
         file_picker_in_current_directory, "Open file picker at current working directory",
         code_action, "Perform code action",
+        workspace_command_picker, "Open workspace command picker",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
         symbol_picker, "Open symbol picker",

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -611,34 +611,6 @@ impl ui::menu::Item for lsp::Command {
     }
 }
 
-pub fn workspace_command_picker(cx: &mut Context) {
-    let (_, doc) = current!(cx.editor);
-
-    let language_server = language_server!(cx.editor, doc);
-
-    let options = match &language_server.capabilities().execute_command_provider {
-        Some(options) => options,
-        None => return,
-    };
-    let commands = options
-        .commands
-        .iter()
-        .map(|command| lsp::Command {
-            title: command.clone(),
-            command: command.clone(),
-            arguments: None,
-        })
-        .collect::<Vec<_>>();
-    cx.callback = Some(Box::new(
-        |compositor: &mut Compositor, _cx: &mut compositor::Context| {
-            let picker = ui::Picker::new(commands, (), |cx, command, _action| {
-                execute_lsp_command(cx.editor, command.clone());
-            });
-            compositor.push(Box::new(overlayed(picker)))
-        },
-    ));
-}
-
 pub fn execute_lsp_command(editor: &mut Editor, cmd: lsp::Command) {
     let doc = doc!(editor);
     let language_server = language_server!(editor, doc);

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -603,6 +603,42 @@ pub fn code_action(cx: &mut Context) {
         },
     )
 }
+
+impl ui::menu::Item for lsp::Command {
+    type Data = ();
+    fn label(&self, _data: &Self::Data) -> Spans {
+        self.title.as_str().into()
+    }
+}
+
+pub fn workspace_command_picker(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+
+    let language_server = language_server!(cx.editor, doc);
+
+    let options = match &language_server.capabilities().execute_command_provider {
+        Some(options) => options,
+        None => return,
+    };
+    let commands = options
+        .commands
+        .iter()
+        .map(|command| lsp::Command {
+            title: command.clone(),
+            command: command.clone(),
+            arguments: None,
+        })
+        .collect::<Vec<_>>();
+    cx.callback = Some(Box::new(
+        |compositor: &mut Compositor, _cx: &mut compositor::Context| {
+            let picker = ui::Picker::new(commands, (), |cx, command, _action| {
+                execute_lsp_command(cx.editor, command.clone());
+            });
+            compositor.push(Box::new(overlayed(picker)))
+        },
+    ));
+}
+
 pub fn execute_lsp_command(editor: &mut Editor, cmd: lsp::Command) {
     let doc = doc!(editor);
     let language_server = language_server!(editor, doc);


### PR DESCRIPTION
LSPs can communicate that they can run additional commands via the `executeCommandProvider`. This adds a picker for these commands. To use it you need to map it to e.g. `<space>W`.