### PR TITLE
build(nix): add a way to override what grammars get built

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,83 +18,115 @@
     nixpkgs,
     nixCargoIntegration,
     ...
-  }:
-    nixCargoIntegration.lib.makeOutputs {
-      root = ./.;
-      renameOutputs = {"helix-term" = "helix";};
-      # Set default app to hx (binary is from helix-term release build)
-      # Set default package to helix-term release build
-      defaultOutputs = {
-        app = "hx";
-        package = "helix";
-      };
-      overrides = {
-        cCompiler = common:
-          with common.pkgs;
-            if stdenv.isLinux
-            then gcc
-            else clang;
-        crateOverrides = common: _: {
-          helix-term = prev: let
-            inherit (common) pkgs;
-            mkRootPath = rel:
-              builtins.path {
-                path = "${common.root}/${rel}";
-                name = rel;
-              };
-            grammars = pkgs.callPackage ./grammars.nix {};
-            runtimeDir = pkgs.runCommandNoCC "helix-runtime" {} ''
-              mkdir -p $out
-              ln -s ${mkRootPath "runtime"}/* $out
-              rm -r $out/grammars
-              ln -s ${grammars} $out/grammars
-            '';
-          in {
-            # disable fetching and building of tree-sitter grammars in the helix-term build.rs
-            HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-            # link languages and theme toml files since helix-term expects them (for tests)
-            preConfigure =
-              pkgs.lib.concatMapStringsSep
-              "\n"
-              (path: "ln -sf ${mkRootPath path} ..")
-              ["languages.toml" "theme.toml" "base16_theme.toml"];
-            buildInputs = (prev.buildInputs or []) ++ [common.cCompiler.cc.lib];
-            nativeBuildInputs = [pkgs.makeWrapper];
+  }: let
+    outputs = config:
+      nixCargoIntegration.lib.makeOutputs {
+        root = ./.;
+        renameOutputs = {"helix-term" = "helix";};
+        # Set default app to hx (binary is from helix-term release build)
+        # Set default package to helix-term release build
+        defaultOutputs = {
+          app = "hx";
+          package = "helix";
+        };
+        overrides = {
+          cCompiler = common:
+            with common.pkgs;
+              if stdenv.isLinux
+              then gcc
+              else clang;
+          crateOverrides = common: _: {
+            helix-term = prev: let
+              inherit (common) pkgs;
+              mkRootPath = rel:
+                builtins.path {
+                  path = "${common.root}/${rel}";
+                  name = rel;
+                };
+              grammars = pkgs.callPackage ./grammars.nix config;
+              runtimeDir = pkgs.runCommandNoCC "helix-runtime" {} ''
+                mkdir -p $out
+                ln -s ${mkRootPath "runtime"}/* $out
+                rm -r $out/grammars
+                ln -s ${grammars} $out/grammars
+              '';
+              overridedAttrs = {
+                # disable fetching and building of tree-sitter grammars in the helix-term build.rs
+                HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+                # link languages and theme toml files since helix-term expects them (for tests)
+                preConfigure =
+                  pkgs.lib.concatMapStringsSep
+                  "\n"
+                  (path: "ln -sf ${mkRootPath path} ..")
+                  ["languages.toml" "theme.toml" "base16_theme.toml"];
+                buildInputs = (prev.buildInputs or []) ++ [common.cCompiler.cc.lib];
+                nativeBuildInputs = [pkgs.makeWrapper];
 
-            postFixup = ''
-              if [ -f "$out/bin/hx" ]; then
-                wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
-              fi
-            '';
+                postFixup = ''
+                  if [ -f "$out/bin/hx" ]; then
+                    wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
+                  fi
+                '';
+              };
+            in
+              overridedAttrs
+              // (
+                pkgs.lib.optionalAttrs
+                (config ? makeWrapperArgs)
+                {inherit (config) makeWrapperArgs;}
+              );
+          };
+          shell = common: prev: {
+            packages =
+              prev.packages
+              ++ (
+                with common.pkgs; [lld_13 lldb cargo-tarpaulin cargo-flamegraph rust-analyzer]
+              );
+            env =
+              prev.env
+              ++ [
+                {
+                  name = "HELIX_RUNTIME";
+                  eval = "$PWD/runtime";
+                }
+                {
+                  name = "RUST_BACKTRACE";
+                  value = "1";
+                }
+                {
+                  name = "RUSTFLAGS";
+                  value =
+                    if common.pkgs.stdenv.isLinux
+                    then "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"
+                    else "";
+                }
+              ];
           };
         };
-        shell = common: prev: {
-          packages =
-            prev.packages
-            ++ (
-              with common.pkgs; [lld_13 lldb cargo-tarpaulin cargo-flamegraph rust-analyzer]
-            );
-          env =
-            prev.env
-            ++ [
-              {
-                name = "HELIX_RUNTIME";
-                eval = "$PWD/runtime";
-              }
-              {
-                name = "RUST_BACKTRACE";
-                value = "1";
-              }
-              {
-                name = "RUSTFLAGS";
-                value =
-                  if common.pkgs.stdenv.isLinux
-                  then "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"
-                  else "";
-              }
-            ];
-        };
       };
+    defaultOutputs = outputs {};
+    makeOverridableHelix = system: old:
+      old
+      // {
+        override = args:
+          makeOverridableHelix
+          system
+          (outputs args).packages.${system}.helix;
+      };
+  in
+    defaultOutputs
+    // {
+      packages =
+        nixpkgs.lib.mapAttrs
+        (
+          system: packages:
+            packages
+            // rec {
+              default = helix;
+              helix = makeOverridableHelix system packages.helix;
+            }
+        )
+        defaultOutputs.packages;
     };
 
   nixConfig = {

--- a/grammars.nix
+++ b/grammars.nix
@@ -4,6 +4,8 @@
   runCommandLocal,
   runCommandNoCC,
   yj,
+  includeGrammarIf ? _: true,
+  ...
 }: let
   # HACK: nix < 2.6 has a bug in the toml parser, so we convert to JSON
   # before parsing
@@ -102,12 +104,13 @@
         runHook postFixup
       '';
     };
+  grammarsToBuild = builtins.filter includeGrammarIf gitGrammars;
   builtGrammars =
     builtins.map (grammar: {
       inherit (grammar) name;
       artifact = buildGrammar grammar;
     })
-    gitGrammars;
+    grammarsToBuild;
   grammarLinks =
     builtins.map (grammar: "ln -s ${grammar.artifact}/${grammar.name}.so $out/${grammar.name}.so")
     builtGrammars;


### PR DESCRIPTION
Adds a way change which grammars get built and included by adding an `override` function to the helix package that takes an `includeGrammarIf` attribute which is a function that decided whether the grammar should be included (`true`) or not (`false`). This also avoid fetching all of the grammars if you don't need them (like me) which speeds up fetching stuff when you are fetching when the sources aren't cached already. I also added `makeWrapperArgs` to the `override` function so it can be set there, I think @nrdxp asked about this.