### PR TITLE
Fix byte index error in signature help highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "smartstring",
+ "str_indices",
  "textwrap",
  "toml",
  "tree-sitter",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -18,6 +18,7 @@ integration = []
 helix-loader = { version = "0.6", path = "../helix-loader" }
 
 ropey = { version = "1.5", default-features = false, features = ["simd"] }
+str_indices = "0.4.0"
 smallvec = "1.9"
 smartstring = "1.0.1"
 unicode-segmentation = "1.9"

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -52,7 +52,12 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> Option<std::pat
         .cloned()
 }
 
-pub use ropey::{str_utils, Rope, RopeBuilder, RopeSlice};
+pub use ropey::{Rope, RopeBuilder, RopeSlice};
+
+pub mod str_utils {
+    pub use ropey::str_utils::*;
+    pub use str_indices::utf16;
+}
 
 // pub use tendril::StrTendril as Tendril;
 pub use smartstring::SmartString;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -904,7 +904,12 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
                         Some((start, start + string.len()))
                     }
                     lsp::ParameterLabel::LabelOffsets([start, end]) => {
-                        Some((*start as usize, *end as usize))
+                        // LS sends offsets based on utf-16 based string representation
+                        // but highlighting in helix is done using byte offset.
+                        use helix_core::str_utils::utf16::to_byte_idx;
+                        let from = to_byte_idx(&signature.label, *start as usize);
+                        let to = to_byte_idx(&signature.label, *end as usize);
+                        Some((from, to))
                     }
                 }
             };


### PR DESCRIPTION
Fixes #3120.

The language server sends a char offset range within the signature help label text to highlight as the current parameter, but helix uses byte offset ranges for rendering highlights. This was brought up in the [review of the original signature help PR][1], but the ranges were being highlighted correctly, and there were no out of bound or indexing panics. Turns out rust-analyzer was [incorrectly sending byte offsets][2] instead of char offsets and this made it seem like all was well and good with offsets in helix during initial testing.

[1]: https://github.com/helix-editor/helix/pull/1755#discussion_r906715371
[2]: https://github.com/rust-lang/rust-analyzer/pull/12272

