### PR TITLE
Add `vh` verilog header file type to `file-types`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1416,7 +1416,7 @@ source = { git = "https://github.com/vlang/vls", subpath = "tree_sitter_v", rev 
 [[language]]
 name = "verilog"
 scope = "source.verilog"
-file-types = ["v", "sv", "svh"]
+file-types = ["v", "vh", "sv", "svh"]
 roots = []
 comment-token = "//"
 language-server = { command = "svlangserver", args = [] }


### PR DESCRIPTION
Add missing `vh` verilog header file type to `file-types`