### PR TITLE
Fix different document panic

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -878,6 +878,7 @@ impl Editor {
                 let view = self
                     .tree
                     .try_get(self.tree.focus)
+                    .filter(|v| id == v.doc) // Different Document
                     .cloned()
                     .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
                 let view_id = self.tree.split(


### PR DESCRIPTION
Issue #3148 

Would panic when given the view for the current document for a different document. This should fix the panic while keeping the jump history when splitting for the same file.