### PR TITLE
Make gutters padding automatic

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -38,7 +38,7 @@ hidden = false
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `cursorline` | Highlight all lines with a cursor. | `false` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `padding`, note that `diagnostics` also includes other features like breakpoints | `["diagnostics", "line-numbers", "padding"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `padding`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "line-numbers", "padding"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -118,6 +118,9 @@ impl View {
                 width as usize,
             ));
         }
+        if !gutter_types.is_empty() {
+            gutter_offset += 1;
+        }
         Self {
             id: ViewId::default(),
             doc,
@@ -346,11 +349,7 @@ mod tests {
     fn test_text_pos_at_screen_coords() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![
-                GutterType::Diagnostics,
-                GutterType::LineNumbers,
-                GutterType::Padding,
-            ],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
@@ -397,10 +396,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_without_line_numbers_gutter() {
-        let mut view = View::new(
-            DocumentId::default(),
-            vec![GutterType::Diagnostics, GutterType::Padding],
-        );
+        let mut view = View::new(DocumentId::default(), vec![GutterType::Diagnostics]);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
         let text = rope.slice(..);
@@ -426,11 +422,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_cjk() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![
-                GutterType::Diagnostics,
-                GutterType::LineNumbers,
-                GutterType::Padding,
-            ],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
@@ -470,11 +462,7 @@ mod tests {
     fn test_text_pos_at_screen_coords_graphemes() {
         let mut view = View::new(
             DocumentId::default(),
-            vec![
-                GutterType::Diagnostics,
-                GutterType::LineNumbers,
-                GutterType::Padding,
-            ],
+            vec![GutterType::Diagnostics, GutterType::LineNumbers],
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");


### PR DESCRIPTION
Remove padding gutter type, and automatically add 1 padding if gutters is
non-empty.

Fix #3111

cc @kchibisov hopefully this solves your issue

Sad to see a breaking change but it should be fine given that we haven't do a release yet