### PR TITLE
add spacer element to statusline

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -78,6 +78,7 @@ The following elements can be configured:
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |
 | `position` | The cursor position |
+| `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |
 
 ### `[editor.lsp]` Section
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -143,6 +143,7 @@ where
         helix_view::editor::StatusLineElement::Diagnostics => render_diagnostics,
         helix_view::editor::StatusLineElement::Selections => render_selections,
         helix_view::editor::StatusLineElement::Position => render_position,
+        helix_view::editor::StatusLineElement::Spacer => render_spacer,
     }
 }
 
@@ -333,4 +334,11 @@ where
     };
 
     write(context, title, None);
+}
+
+fn render_spacer<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    write(context, String::from(" "), None);
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -246,6 +246,9 @@ pub enum StatusLineElement {
 
     /// The cursor position
     Position,
+
+    /// A single space
+    Spacer,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs


### PR DESCRIPTION
Addresses #3106 and associated other comments. Multiple `"spacer"` elements may be specified in each statusline section.