### PR TITLE
Add custom event type replacing crossterm's Event

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use crate::{
     args::Args,
     commands::apply_workspace_edit,
-    compositor::Compositor,
+    compositor::{Compositor, Event},
     config::Config,
     job::Jobs,
     keymap::Keymaps,
@@ -29,7 +29,7 @@ use std::{
 use anyhow::{Context, Error};
 
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture, Event},
+    event::{DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent},
     execute, terminal,
     tty::IsTty,
 };
@@ -418,7 +418,7 @@ impl Application {
         }
     }
 
-    pub fn handle_terminal_events(&mut self, event: Result<Event, crossterm::ErrorKind>) {
+    pub fn handle_terminal_events(&mut self, event: Result<CrosstermEvent, crossterm::ErrorKind>) {
         let mut cx = crate::compositor::Context {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
@@ -426,13 +426,12 @@ impl Application {
         };
         // Handle key events
         let should_redraw = match event {
-            Ok(Event::Resize(width, height)) => {
+            Ok(CrosstermEvent::Resize(width, height)) => {
                 self.compositor.resize(width, height);
-
                 self.compositor
                     .handle_event(Event::Resize(width, height), &mut cx)
             }
-            Ok(event) => self.compositor.handle_event(event, &mut cx),
+            Ok(event) => self.compositor.handle_event(event.into(), &mut cx),
             Err(x) => panic!("{}", x),
         };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4846,7 +4846,7 @@ fn replay_macro(cx: &mut Context) {
     cx.callback = Some(Box::new(move |compositor, cx| {
         for _ in 0..count {
             for &key in keys.iter() {
-                compositor.handle_event(crossterm::event::Event::Key(key.into()), cx);
+                compositor.handle_event(compositor::Event::Key(key), cx);
             }
         }
         // The macro under replay is cleared at the end of the callback, not in the

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -4,8 +4,6 @@
 use helix_core::Position;
 use helix_view::graphics::{CursorKind, Rect};
 
-use crossterm::event::Event;
-
 #[cfg(feature = "integration")]
 use tui::backend::TestBackend;
 use tui::buffer::Buffer as Surface;
@@ -18,9 +16,10 @@ pub enum EventResult {
     Consumed(Option<Callback>),
 }
 
+use crate::job::Jobs;
 use helix_view::Editor;
 
-use crate::job::Jobs;
+pub use helix_view::input::Event;
 
 pub struct Context<'a> {
     pub editor: &'a mut Editor,
@@ -161,7 +160,7 @@ impl Compositor {
     pub fn handle_event(&mut self, event: Event, cx: &mut Context) -> bool {
         // If it is a key event and a macro is being recorded, push the key event to the recording.
         if let (Event::Key(key), Some((_, keys))) = (event, &mut cx.editor.macro_recording) {
-            keys.push(key.into());
+            keys.push(key);
         }
 
         let mut callbacks = Vec::new();

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,5 +1,4 @@
-use crate::compositor::{Component, Context, EventResult};
-use crossterm::event::{Event, KeyCode, KeyEvent};
+use crate::compositor::{Component, Context, Event, EventResult};
 use helix_view::editor::CompleteAction;
 use tui::buffer::Buffer as Surface;
 use tui::text::Spans;
@@ -7,7 +6,11 @@ use tui::text::Spans;
 use std::borrow::Cow;
 
 use helix_core::{Change, Transaction};
-use helix_view::{graphics::Rect, Document, Editor};
+use helix_view::{
+    graphics::Rect,
+    input::{KeyCode, KeyEvent},
+    Document, Editor,
+};
 
 use crate::commands;
 use crate::ui::{menu, Markdown, Menu, Popup, PromptEvent};

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,10 +1,9 @@
 use std::{borrow::Cow, path::PathBuf};
 
 use crate::{
-    compositor::{Callback, Component, Compositor, Context, EventResult},
+    compositor::{Callback, Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
 };
-use crossterm::event::Event;
 use tui::{buffer::Buffer as Surface, text::Spans, widgets::Table};
 
 pub use tui::widgets::{Cell, Row};
@@ -237,7 +236,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             compositor.pop();
         }));
 
-        match event.into() {
+        match event {
             // esc or ctrl-c aborts the completion and closes the menu
             key!(Esc) | ctrl!('c') => {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Abort);

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -1,4 +1,3 @@
-use crossterm::event::Event;
 use helix_core::Position;
 use helix_view::{
     graphics::{CursorKind, Rect},
@@ -6,7 +5,7 @@ use helix_view::{
 };
 use tui::buffer::Buffer;
 
-use crate::compositor::{Component, Context, EventResult};
+use crate::compositor::{Component, Context, Event, EventResult};
 
 /// Contains a component placed in the center of the parent component
 pub struct Overlay<T> {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1,9 +1,8 @@
 use crate::{
-    compositor::{Component, Compositor, Context, EventResult},
+    compositor::{Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
     ui::{self, EditorView},
 };
-use crossterm::event::Event;
 use tui::{
     buffer::Buffer as Surface,
     widgets::{Block, BorderType, Borders},
@@ -502,7 +501,7 @@ impl<T: Item + 'static> Component for Picker<T> {
             compositor.last_picker = compositor.pop();
         })));
 
-        match key_event.into() {
+        match key_event {
             shift!(Tab) | key!(Up) | ctrl!('p') => {
                 self.move_by(1, Direction::Backward);
             }

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -1,9 +1,8 @@
 use crate::{
     commands::Open,
-    compositor::{Callback, Component, Context, EventResult},
+    compositor::{Callback, Component, Context, Event, EventResult},
     ctrl, key,
 };
-use crossterm::event::Event;
 use tui::buffer::Buffer as Surface;
 
 use helix_core::Position;
@@ -149,7 +148,7 @@ impl<T: Component> Component for Popup<T> {
             _ => return EventResult::Ignored(None),
         };
 
-        if key!(Esc) == key.into() && self.ignore_escape_key {
+        if key!(Esc) == key && self.ignore_escape_key {
             return EventResult::Ignored(None);
         }
 
@@ -158,7 +157,7 @@ impl<T: Component> Component for Popup<T> {
             compositor.remove(self.id.as_ref());
         });
 
-        match key.into() {
+        match key {
             // esc or ctrl-c aborts the completion and closes the menu
             key!(Esc) | ctrl!('c') => {
                 let _ = self.contents.handle_event(event, cx);

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,6 +1,5 @@
-use crate::compositor::{Component, Compositor, Context, EventResult};
+use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
-use crossterm::event::Event;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
 use std::{borrow::Cow, ops::RangeFrom};
@@ -479,7 +478,7 @@ impl Component for Prompt {
             compositor.pop();
         })));
 
-        match event.into() {
+        match event {
             ctrl!('c') | key!(Esc) => {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
                 return close_fn;

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -4,8 +4,53 @@ use helix_core::unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidth
 use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 
-use crate::keyboard::{KeyCode, KeyModifiers};
+pub use crate::keyboard::{KeyCode, KeyModifiers};
 
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum Event {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    Resize(u16, u16),
+}
+
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct MouseEvent {
+    /// The kind of mouse event that was caused.
+    pub kind: MouseEventKind,
+    /// The column that the event occurred on.
+    pub column: u16,
+    /// The row that the event occurred on.
+    pub row: u16,
+    /// The key modifiers active when the event occurred.
+    pub modifiers: KeyModifiers,
+}
+
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum MouseEventKind {
+    /// Pressed mouse button. Contains the button that was pressed.
+    Down(MouseButton),
+    /// Released mouse button. Contains the button that was released.
+    Up(MouseButton),
+    /// Moved the mouse cursor while pressing the contained mouse button.
+    Drag(MouseButton),
+    /// Moved the mouse cursor while not pressing a mouse button.
+    Moved,
+    /// Scrolled mouse wheel downwards (towards the user).
+    ScrollDown,
+    /// Scrolled mouse wheel upwards (away from the user).
+    ScrollUp,
+}
+
+/// Represents a mouse button.
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum MouseButton {
+    /// Left mouse button.
+    Left,
+    /// Right mouse button.
+    Right,
+    /// Middle mouse button.
+    Middle,
+}
 /// Represents a key event.
 // We use a newtype here because we want to customize Deserialize and Display.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
@@ -216,6 +261,61 @@ impl<'de> Deserialize<'de> for KeyEvent {
     {
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(de::Error::custom)
+    }
+}
+
+#[cfg(feature = "term")]
+impl From<crossterm::event::Event> for Event {
+    fn from(event: crossterm::event::Event) -> Self {
+        match event {
+            crossterm::event::Event::Key(key) => Self::Key(key.into()),
+            crossterm::event::Event::Mouse(mouse) => Self::Mouse(mouse.into()),
+            crossterm::event::Event::Resize(w, h) => Self::Resize(w, h),
+        }
+    }
+}
+
+#[cfg(feature = "term")]
+impl From<crossterm::event::MouseEvent> for MouseEvent {
+    fn from(
+        crossterm::event::MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers,
+        }: crossterm::event::MouseEvent,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            column,
+            row,
+            modifiers: modifiers.into(),
+        }
+    }
+}
+
+#[cfg(feature = "term")]
+impl From<crossterm::event::MouseEventKind> for MouseEventKind {
+    fn from(kind: crossterm::event::MouseEventKind) -> Self {
+        match kind {
+            crossterm::event::MouseEventKind::Down(button) => Self::Down(button.into()),
+            crossterm::event::MouseEventKind::Up(button) => Self::Down(button.into()),
+            crossterm::event::MouseEventKind::Drag(button) => Self::Drag(button.into()),
+            crossterm::event::MouseEventKind::Moved => Self::Moved,
+            crossterm::event::MouseEventKind::ScrollDown => Self::ScrollDown,
+            crossterm::event::MouseEventKind::ScrollUp => Self::ScrollUp,
+        }
+    }
+}
+
+#[cfg(feature = "term")]
+impl From<crossterm::event::MouseButton> for MouseButton {
+    fn from(button: crossterm::event::MouseButton) -> Self {
+        match button {
+            crossterm::event::MouseButton::Left => MouseButton::Left,
+            crossterm::event::MouseButton::Right => MouseButton::Right,
+            crossterm::event::MouseButton::Middle => MouseButton::Middle,
+        }
     }
 }
 

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -55,7 +55,6 @@ impl From<crossterm::event::KeyModifiers> for KeyModifiers {
 
 /// Represents a key.
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyCode {
     /// Backspace key.
     Backspace,


### PR DESCRIPTION
Add custom event type replacing crossterm's Event

Ported over from 61365dfbf3 in the `gui` branch. This will allow adding our own events, most notably an idle timer event (useful for adding debounced input in [dynamic pickers][1] used by interactive global search and workspace symbols).

[1]: https://github.com/helix-editor/helix/pull/3110
