### PR TITLE
Improve HEEx comment highlights and injections

### DIFF
--- a/runtime/queries/heex/highlights.scm
+++ b/runtime/queries/heex/highlights.scm
@@ -2,14 +2,10 @@
 ; HEEx delimiters
 [
   "<!"
-  "<!--"
   "<"
-  "<%!--"
   "<%#"
   ">"
   "</"
-  "--%>"
-  "-->"
   "/>"
   ; These could be `@keyword`s but the closing `>` wouldn't be highlighted
   ; as `@keyword`
@@ -34,7 +30,13 @@
 (doctype) @constant
 
 ; HEEx comments are highlighted as such
-(comment) @comment
+[
+  "<!--"
+  "-->"
+  "<%!--"
+  "--%>"
+  (comment)
+] @comment
 
 ; HEEx tags are highlighted as HTML
 (tag_name) @tag

--- a/runtime/queries/heex/injections.scm
+++ b/runtime/queries/heex/injections.scm
@@ -19,3 +19,6 @@
 ;     <link href={ Routes.static_path(..) } />
 ((expression (expression_value) @injection.content)
  (#set! injection.language "elixir"))
+
+((comment) @injection.content 
+ (#set! injection.language "comment"))


### PR DESCRIPTION
* Highlights the open and close tags for comments as comments
* Injects the comment lang into HEEx comments

![image](https://user-images.githubusercontent.com/6548350/180619011-b107d33c-dff4-40ca-8065-f0e121f98679.png)
