### PR TITLE
Add rabl/jbuilder/jb extensions for Ruby

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -459,7 +459,7 @@ source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile"]
+file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"

--- a/languages.toml
+++ b/languages.toml
@@ -459,7 +459,7 @@ source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder"]
+file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder", "jb"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
These are regular ruby files used for templating JSON API responses:

https://github.com/nesquena/rabl
https://github.com/rails/jbuilder
https://github.com/amatsuda/jb