### PR TITLE
Add table of contents to keymap.md

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -1,7 +1,27 @@
 # Keymap
 
-- Mappings marked (**LSP**) require an active language server for the file.
-- Mappings marked (**TS**) require a tree-sitter grammar for the filetype.
+- [Normal mode](#normal-mode)
+  - [Movement](#movement)
+  - [Changes](#changes)
+    - [Shell](#shell)
+  - [Selection manipulation](#selection-manipulation)
+  - [Search](#search)
+  - [Minor modes](#minor-modes)
+    - [View mode](#view-mode)
+    - [Goto mode](#goto-mode)
+    - [Match mode](#match-mode)
+    - [Window mode](#window-mode)
+    - [Space mode](#space-mode)
+      - [Popup](#popup)
+    - [Unimpaired](#unimpaired)
+- [Insert Mode](#insert-mode)
+- [Select / extend mode](#select--extend-mode)
+- [Picker](#picker)
+- [Prompt](#prompt)
+
+> 💡 Mappings marked (**LSP**) require an active language server for the file.
+
+> 💡 Mappings marked (**TS**) require a tree-sitter grammar for the filetype.
 
 ## Normal mode
 
@@ -337,7 +357,7 @@ mode before pressing `n` or `N` makes it possible to keep the current
 selection. Toggling it on and off during your iterative searching allows
 you to selectively add search terms to your selections.
 
-# Picker
+## Picker
 
 Keys to use within picker. Remapping currently not supported.
 
@@ -356,7 +376,7 @@ Keys to use within picker. Remapping currently not supported.
 | `Ctrl-t`                     | Toggle preview    |
 | `Escape`, `Ctrl-c`           | Close picker      |
 
-# Prompt
+## Prompt
 
 Keys to use within prompt, Remapping currently not supported.
 


### PR DESCRIPTION
There are a lot of different sets of keymaps. It would be nice to index them at the top so that they're easier to jump to.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19535809/180630650-69bbd54a-e28d-4a28-be24-5b8e60c88137.png) | ![image](https://user-images.githubusercontent.com/19535809/180630670-b2052e64-3892-4695-9ecc-95b26aa77363.png) |
