### PR TITLE
Cycled to end/beginning + no more matches msgs

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1597,11 +1597,7 @@ fn search_impl(
                     regex.find_iter(&contents[start..]).last()
                 }
             };
-            let msg = match direction {
-                Direction::Forward => "Cycled to beginning of file",
-                Direction::Backward => "Cycled to end of file",
-            };
-            editor.set_status(msg);
+            editor.set_status("Wrapped around document");
         } else {
             editor.set_error("No more matches");
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1549,7 +1549,6 @@ fn split_selection_on_newline(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
-// #[allow(clippy::too_many_arguments)]
 fn search_impl(
     editor: &mut Editor,
     contents: &str,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1589,19 +1589,23 @@ fn search_impl(
         Direction::Backward => regex.find_iter(&contents[..start]).last(),
     };
 
-    if wrap_around && mat.is_none() {
-        mat = match direction {
-            Direction::Forward => regex.find(contents),
-            Direction::Backward => {
-                offset = start;
-                regex.find_iter(&contents[start..]).last()
-            }
-        };
-        let msg = match direction {
-            Direction::Forward => "Cycled to beginning of file",
-            Direction::Backward => "Cycled to end of file",
-        };
-        editor.set_status(msg);
+    if mat.is_none() {
+        if wrap_around {
+            mat = match direction {
+                Direction::Forward => regex.find(contents),
+                Direction::Backward => {
+                    offset = start;
+                    regex.find_iter(&contents[start..]).last()
+                }
+            };
+            let msg = match direction {
+                Direction::Forward => "Cycled to beginning of file",
+                Direction::Backward => "Cycled to end of file",
+            };
+            editor.set_status(msg);
+        } else {
+            editor.set_error("No more matches");
+        }
     }
 
     let (view, doc) = current!(editor);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -103,16 +103,14 @@ pub fn regex_prompt(
                         .build()
                     {
                         Ok(regex) => {
-                            {
-                                let (view, doc) = current!(cx.editor);
+                            let (view, doc) = current!(cx.editor);
 
-                                // revert state to what it was before the last update
-                                doc.set_selection(view.id, snapshot.clone());
+                            // revert state to what it was before the last update
+                            doc.set_selection(view.id, snapshot.clone());
 
-                                if event == PromptEvent::Validate {
-                                    // Equivalent to push_jump to store selection just before jump
-                                    view.jumps.push((doc_id, snapshot.clone()));
-                                }
+                            if event == PromptEvent::Validate {
+                                // Equivalent to push_jump to store selection just before jump
+                                view.jumps.push((doc_id, snapshot.clone()));
                             }
 
                             fun(cx.editor, regex, event);


### PR DESCRIPTION
Resolves #3153.
[asciinema demonstration](https://asciinema.org/a/x2wbGSRBtnKPDacB48EFbUCPd)


Made `search_impl`, and `regex_prompt's fun` take `&mut Editor` instead of `&mut View, &mut Document` to make this possible.
