### PR TITLE
Autosave all when the terminal loses focus

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -49,6 +49,7 @@ on unix operating systems.
 | `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |
+| `auto-save` | Enable automatic saving on focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal. | `false` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -37,8 +37,8 @@ use anyhow::{Context, Error};
 
 use crossterm::{
     event::{
-        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event as CrosstermEvent,
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event as CrosstermEvent,
     },
     execute, terminal,
     tty::IsTty,
@@ -102,6 +102,7 @@ fn restore_term() -> Result<(), Error> {
     execute!(
         stdout,
         DisableBracketedPaste,
+        DisableFocusChange,
         terminal::LeaveAlternateScreen
     )?;
     terminal::disable_raw_mode()?;
@@ -925,7 +926,12 @@ impl Application {
     async fn claim_term(&mut self) -> Result<(), Error> {
         terminal::enable_raw_mode()?;
         let mut stdout = stdout();
-        execute!(stdout, terminal::EnterAlternateScreen, EnableBracketedPaste)?;
+        execute!(
+            stdout,
+            terminal::EnterAlternateScreen,
+            EnableBracketedPaste,
+            EnableFocusChange
+        )?;
         execute!(stdout, terminal::Clear(terminal::ClearType::All))?;
         if self.config.load().editor.mouse {
             execute!(stdout, EnableMouseCapture)?;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -559,17 +559,11 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
     Ok(())
 }
 
-fn write_all_impl(
+pub fn write_all_impl(
     cx: &mut compositor::Context,
-    _args: &[Cow<str>],
-    event: PromptEvent,
-    quit: bool,
     force: bool,
+    write_scratch: bool,
 ) -> anyhow::Result<()> {
-    if event != PromptEvent::Validate {
-        return Ok(());
-    }
-
     let mut errors: Vec<&'static str> = Vec::new();
     let auto_format = cx.editor.config().auto_format;
     let jobs = &mut cx.jobs;
@@ -580,12 +574,13 @@ fn write_all_impl(
         .documents
         .values()
         .filter_map(|doc| {
-            if doc.path().is_none() {
-                errors.push("cannot write a buffer without a filename\n");
+            if !doc.is_modified() {
                 return None;
             }
-
-            if !doc.is_modified() {
+            if doc.path().is_none() {
+                if write_scratch {
+                    errors.push("cannot write a buffer without a filename\n");
+                }
                 return None;
             }
 
@@ -611,20 +606,6 @@ fn write_all_impl(
         cx.editor.save::<PathBuf>(id, None, force)?;
     }
 
-    if quit {
-        cx.block_try_flush_writes()?;
-
-        if !force {
-            buffers_remaining_impl(cx.editor)?;
-        }
-
-        // close all views
-        let views: Vec<_> = cx.editor.tree.views().map(|(view, _)| view.id).collect();
-        for view_id in views {
-            cx.editor.close(view_id);
-        }
-    }
-
     if !errors.is_empty() && !force {
         bail!("{:?}", errors);
     }
@@ -634,38 +615,38 @@ fn write_all_impl(
 
 fn write_all(
     cx: &mut compositor::Context,
-    args: &[Cow<str>],
+    _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
-    write_all_impl(cx, args, event, false, false)
+    write_all_impl(cx, false, true)
 }
 
 fn write_all_quit(
     cx: &mut compositor::Context,
-    args: &[Cow<str>],
+    _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
-
-    write_all_impl(cx, args, event, true, false)
+    write_all_impl(cx, false, true)?;
+    quit_all_impl(cx.editor, false)
 }
 
 fn force_write_all_quit(
     cx: &mut compositor::Context,
-    args: &[Cow<str>],
+    _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
-
-    write_all_impl(cx, args, event, true, true)
+    let _ = write_all_impl(cx, true, true);
+    quit_all_impl(cx.editor, true)
 }
 
 fn quit_all_impl(editor: &mut Editor, force: bool) -> anyhow::Result<()> {
@@ -2141,7 +2122,7 @@ pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableComma
             .collect()
     });
 
-pub fn command_mode(cx: &mut Context) {
+pub(super) fn command_mode(cx: &mut Context) {
     let mut prompt = Prompt::new(
         ":".into(),
         Some(':'),

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -634,7 +634,7 @@ fn write_all_quit(
         return Ok(());
     }
     write_all_impl(cx, false, true)?;
-    quit_all_impl(cx.editor, false)
+    quit_all_impl(cx, false)
 }
 
 fn force_write_all_quit(
@@ -646,18 +646,19 @@ fn force_write_all_quit(
         return Ok(());
     }
     let _ = write_all_impl(cx, true, true);
-    quit_all_impl(cx.editor, true)
+    quit_all_impl(cx, true)
 }
 
-fn quit_all_impl(editor: &mut Editor, force: bool) -> anyhow::Result<()> {
+fn quit_all_impl(cx: &mut compositor::Context, force: bool) -> anyhow::Result<()> {
+    cx.block_try_flush_writes()?;
     if !force {
-        buffers_remaining_impl(editor)?;
+        buffers_remaining_impl(cx.editor)?;
     }
 
     // close all views
-    let views: Vec<_> = editor.tree.views().map(|(view, _)| view.id).collect();
+    let views: Vec<_> = cx.editor.tree.views().map(|(view, _)| view.id).collect();
     for view_id in views {
-        editor.close(view_id);
+        cx.editor.close(view_id);
     }
 
     Ok(())
@@ -672,8 +673,7 @@ fn quit_all(
         return Ok(());
     }
 
-    cx.block_try_flush_writes()?;
-    quit_all_impl(cx.editor, false)
+    quit_all_impl(cx, false)
 }
 
 fn force_quit_all(
@@ -685,7 +685,7 @@ fn force_quit_all(
         return Ok(());
     }
 
-    quit_all_impl(cx.editor, true)
+    quit_all_impl(cx, true)
 }
 
 fn cquit(
@@ -703,8 +703,7 @@ fn cquit(
         .unwrap_or(1);
 
     cx.editor.exit_code = exit_code;
-    cx.block_try_flush_writes()?;
-    quit_all_impl(cx.editor, false)
+    quit_all_impl(cx, false)
 }
 
 fn force_cquit(
@@ -722,7 +721,7 @@ fn force_cquit(
         .unwrap_or(1);
     cx.editor.exit_code = exit_code;
 
-    quit_all_impl(cx.editor, true)
+    quit_all_impl(cx, true)
 }
 
 fn theme(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1426,7 +1426,15 @@ impl Component for EditorView {
 
             Event::Mouse(event) => self.handle_mouse_event(event, &mut cx),
             Event::IdleTimeout => self.handle_idle_timeout(&mut cx),
-            Event::FocusGained | Event::FocusLost => EventResult::Ignored(None),
+            Event::FocusGained => EventResult::Ignored(None),
+            Event::FocusLost => {
+                if context.editor.config().auto_save {
+                    if let Err(e) = commands::typed::write_all_impl(context, false, false) {
+                        context.editor.set_error(format!("{}", e));
+                    }
+                }
+                EventResult::Consumed(None)
+            }
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -139,7 +139,7 @@ pub struct Config {
     pub auto_completion: bool,
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
-    /// Automatic save on focus lost. Defaults to true.
+    /// Automatic save on focus lost. Defaults to false.
     pub auto_save: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
     /// Used for autocompletion, set to 0 for instant. Defaults to 400ms.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -139,6 +139,8 @@ pub struct Config {
     pub auto_completion: bool,
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
+    /// Automatic save on focus lost. Defaults to true.
+    pub auto_save: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
     /// Used for autocompletion, set to 0 for instant. Defaults to 400ms.
     #[serde(
@@ -591,6 +593,7 @@ impl Default for Config {
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
             auto_format: true,
+            auto_save: false,
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,


### PR DESCRIPTION
This listens to focus change events from the terminal and writes all files when focus is lost. It's not ready to merge, but I had a couple questions that it'd be good to answer before proceeding.

1. Should this be behind an option? I'd certainly always use it, but I could see others who only want to save when they explicitly request it.
  a. If it should, what should the option be? After this, I was thinking about adding behavior to autosave on buffers being hidden. If we add that second autosave behavior, I think an option set like the `gutters` option could make sense. For this, we'd have an option `autosave` with a default value of `["focus-lost"]` and an eventual default of `["focus-lost", "buffer-hidden"]`.
2. Do we need to do something about terminals that don't support this? It's supported by most modern terminals (Kitty, Alacritty, wezterm, iTerm 2, etc), tmux, [all the Linux terminals in this guide](https://terminalguide.namepad.de/mode/p1004/), and should be good in Windows Terminal once I finish up with the crossterm PR. I believe some older terms don't support it though. I don't think there's a way to detect support. Should I do anything other than document known working terminals?

## Before merging
- [x] Merge https://github.com/crossterm-rs/crossterm/pull/689 and depend on a released crossterm
- [x] Document behavior and known supported terminals