### PR TITLE
Make shell_impl concurrent

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4544,10 +4544,7 @@ fn shell_keep_pipe(cx: &mut Context) {
 }
 
 fn shell_impl(shell: &[String], cmd: &str, input: Option<Rope>) -> anyhow::Result<(Tendril, bool)> {
-    tokio::task::block_in_place(|| {
-        let runtime = tokio::runtime::Handle::current();
-        runtime.block_on(shell_impl_async(shell, cmd, input))
-    })
+    tokio::task::block_in_place(|| helix_lsp::block_on(shell_impl_async(shell, cmd, input)))
 }
 
 async fn shell_impl_async(


### PR DESCRIPTION
Based on #3136. Fixes #3127 and might fix #3133.

This changes `shell_impl` to concurrently write to `stdin` while reading from `stdout` and `stderr`. This way processes will not block, if their input buffer is full, which is the current behavior.

I renamed `shell_impl` to `shell_impl_async` and added a new `shell_impl` as a blocking wrapper.

## Performance considerations

~Since `shell_impl_async` needs to take ownership of the input, I changed the input type to `Rope`. This can be constructed from the `RopeSlice` with `RopeSlice::into` in O(log n). We might want to copy the whole rope and give the current selection as an extra parameter which would be O(1), but a bit more ugly.~
This is not true. It's O(log n) either way. And obviously O(n) to pipe everything into the process. Don't know what I thought.