### PR TITLE
Add completion for nested settings

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -289,7 +289,7 @@ pub mod completers {
                 .as_object()
                 .unwrap()
                 .iter()
-                .map(|(key, value)| {
+                .flat_map(|(key, value)| {
                     if let Some(map) = value.as_object() {
                         let mut v: Vec<String> = map
                             .keys()
@@ -301,7 +301,6 @@ pub mod completers {
                         vec![key.clone()]
                     }
                 })
-                .flatten()
                 .collect()
         });
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -288,8 +288,20 @@ pub mod completers {
             serde_json::json!(Config::default())
                 .as_object()
                 .unwrap()
-                .keys()
-                .cloned()
+                .iter()
+                .map(|(key, value)| {
+                    if let Some(map) = value.as_object() {
+                        let mut v: Vec<String> = map
+                            .keys()
+                            .map(|sub_key| format!("{}.{}", key, sub_key))
+                            .collect();
+                        v.push(key.clone());
+                        v
+                    } else {
+                        vec![key.clone()]
+                    }
+                })
+                .flatten()
                 .collect()
         });
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -292,7 +292,9 @@ pub mod completers {
                     None => key.clone(),
                 };
                 get_keys(value, vec, Some(&key));
-                vec.push(key);
+                if !value.is_object() {
+                    vec.push(key);
+                }
             }
         }
     }


### PR DESCRIPTION
Nested settings such as `search.wrap-around` are now also completed.
Addresses part of #2772 (show suggestion for sub-keys such as `cursor-shape.normal` but still no suggestions for valid values for that option)