### PR TITLE
Fix non-msvc grammar compile on Windows

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -319,7 +319,7 @@ fn build_tree_sitter_library(src_path: &Path, grammar: GrammarConfiguration) -> 
         command.env(key, value);
     }
 
-    if cfg!(windows) {
+    if cfg!(all(windows, target_env = "msvc")) {
         command
             .args(&["/nologo", "/LD", "/I"])
             .arg(header_path)


### PR DESCRIPTION
Only send msvc args to the grammar compiler if we're targetting msvc.
Fixes https://github.com/helix-editor/helix/issues/1973