### PR TITLE
fix: Recalculate completion when going through prompt history

### DIFF
--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -580,7 +580,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
             None => return,
         };
         let callback = Box::pin(async move {
-            let call: Callback = Box::new(move |_editor, compositor| {
+            let call: Callback = Box::new(move |editor, compositor| {
                 let mut prompt = Prompt::new(
                     "condition:".into(),
                     None,
@@ -605,7 +605,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
                     },
                 );
                 if let Some(condition) = breakpoint.condition {
-                    prompt.insert_str(&condition)
+                    prompt.insert_str(&condition, editor)
                 }
                 compositor.push(Box::new(prompt));
             });
@@ -622,7 +622,7 @@ pub fn dap_edit_log(cx: &mut Context) {
             None => return,
         };
         let callback = Box::pin(async move {
-            let call: Callback = Box::new(move |_editor, compositor| {
+            let call: Callback = Box::new(move |editor, compositor| {
                 let mut prompt = Prompt::new(
                     "log-message:".into(),
                     None,
@@ -646,7 +646,7 @@ pub fn dap_edit_log(cx: &mut Context) {
                     },
                 );
                 if let Some(log_message) = breakpoint.log_message {
-                    prompt.insert_str(&log_message);
+                    prompt.insert_str(&log_message, editor);
                 }
                 compositor.push(Box::new(prompt));
             });

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -35,10 +35,10 @@ pub fn prompt(
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
     callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
 ) {
-    show_prompt(
-        cx,
-        Prompt::new(prompt, history_register, completion_fn, callback_fn),
-    );
+    let mut prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn);
+    // Calculate the initial completion
+    prompt.recalculate_completion(cx.editor);
+    cx.push_layer(Box::new(prompt));
 }
 
 pub fn prompt_with_input(
@@ -49,15 +49,8 @@ pub fn prompt_with_input(
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
     callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
 ) {
-    show_prompt(
-        cx,
-        Prompt::new(prompt, history_register, completion_fn, callback_fn).with_line(input),
-    );
-}
-
-fn show_prompt(cx: &mut crate::commands::Context, mut prompt: Prompt) {
-    // Calculate initial completion
-    prompt.recalculate_completion(cx.editor);
+    let prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn)
+        .with_line(input, cx.editor);
     cx.push_layer(Box::new(prompt));
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -466,12 +466,12 @@ impl<T: Item> Picker<T> {
             .map(|(index, _score)| &self.options[*index])
     }
 
-    pub fn save_filter(&mut self, cx: &Context) {
+    pub fn save_filter(&mut self, cx: &mut Context) {
         self.filters.clear();
         self.filters
             .extend(self.matches.iter().map(|(index, _)| *index));
         self.filters.sort_unstable(); // used for binary search later
-        self.prompt.clear(cx);
+        self.prompt.clear(cx.editor);
     }
 
     pub fn toggle_preview(&mut self) {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -466,7 +466,7 @@ impl<T: Item> Picker<T> {
             .map(|(index, _score)| &self.options[*index])
     }
 
-    pub fn save_filter(&mut self, cx: &mut Context) {
+    pub fn save_filter(&mut self, cx: &Context) {
         self.filters.clear();
         self.filters
             .extend(self.matches.iter().map(|(index, _)| *index));

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -88,7 +88,6 @@ impl Prompt {
         let cursor = line.len();
         self.line = line;
         self.cursor = cursor;
-        self.exit_selection();
         self.recalculate_completion(editor);
         self
     }
@@ -98,6 +97,7 @@ impl Prompt {
     }
 
     pub fn recalculate_completion(&mut self, editor: &Editor) {
+        self.exit_selection();
         self.completion = (self.completion_fn)(editor, &self.line);
     }
 
@@ -215,14 +215,12 @@ impl Prompt {
         if let Ok(Some(pos)) = cursor.next_boundary(&self.line, 0) {
             self.cursor = pos;
         }
-        self.exit_selection();
         self.recalculate_completion(cx.editor);
     }
 
     pub fn insert_str(&mut self, s: &str, editor: &Editor) {
         self.line.insert_str(self.cursor, s);
         self.cursor += s.len();
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -244,7 +242,6 @@ impl Prompt {
         self.line.replace_range(pos..self.cursor, "");
         self.cursor = pos;
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -252,7 +249,6 @@ impl Prompt {
         let pos = self.eval_movement(Movement::ForwardChar(1));
         self.line.replace_range(self.cursor..pos, "");
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -261,7 +257,6 @@ impl Prompt {
         self.line.replace_range(pos..self.cursor, "");
         self.cursor = pos;
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -269,7 +264,6 @@ impl Prompt {
         let pos = self.eval_movement(Movement::ForwardWord(1));
         self.line.replace_range(self.cursor..pos, "");
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -278,7 +272,6 @@ impl Prompt {
         self.line.replace_range(pos..self.cursor, "");
         self.cursor = pos;
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -286,7 +279,6 @@ impl Prompt {
         let pos = self.eval_movement(Movement::EndOfLine);
         self.line.replace_range(self.cursor..pos, "");
 
-        self.exit_selection();
         self.recalculate_completion(editor);
     }
 
@@ -294,7 +286,6 @@ impl Prompt {
         self.line.clear();
         self.cursor = 0;
         self.recalculate_completion(editor);
-        self.exit_selection();
     }
 
     pub fn change_history(
@@ -324,7 +315,6 @@ impl Prompt {
         self.history_pos = Some(index);
 
         self.move_end();
-        self.exit_selection();
         self.recalculate_completion(cx.editor);
     }
 
@@ -538,7 +528,6 @@ impl Component for Prompt {
             key!(Enter) => {
                 if self.selection.is_some() && self.line.ends_with(std::path::MAIN_SEPARATOR) {
                     self.recalculate_completion(cx.editor);
-                    self.exit_selection();
                 } else {
                     // handle executing with last command in history if nothing entered
                     let input: Cow<str> = if self.line.is_empty() {
@@ -578,7 +567,6 @@ impl Component for Prompt {
                 // if single completion candidate is a directory list content in completion
                 if self.completion.len() == 1 && self.line.ends_with(std::path::MAIN_SEPARATOR) {
                     self.recalculate_completion(cx.editor);
-                    self.exit_selection();
                 }
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update)
             }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -550,6 +550,8 @@ impl Component for Prompt {
                 if let Some(register) = self.history_register {
                     let register = cx.editor.registers.get_mut(register);
                     self.change_history(register.read(), CompletionDirection::Backward);
+                    self.recalculate_completion(cx.editor);
+                    self.exit_selection();
                     (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }
@@ -557,6 +559,8 @@ impl Component for Prompt {
                 if let Some(register) = self.history_register {
                     let register = cx.editor.registers.get_mut(register);
                     self.change_history(register.read(), CompletionDirection::Forward);
+                    self.recalculate_completion(cx.editor);
+                    self.exit_selection();
                     (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -84,10 +84,12 @@ impl Prompt {
         }
     }
 
-    pub fn with_line(mut self, line: String) -> Self {
+    pub fn with_line(mut self, line: String, editor: &Editor) -> Self {
         let cursor = line.len();
         self.line = line;
         self.cursor = cursor;
+        self.exit_selection();
+        self.recalculate_completion(editor);
         self
     }
 

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -21,5 +21,6 @@ mod test {
     mod auto_pairs;
     mod commands;
     mod movement;
+    mod prompt;
     mod write;
 }

--- a/helix-term/tests/test/prompt.rs
+++ b/helix-term/tests/test/prompt.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+use helix_term::application::Application;
+
+#[tokio::test]
+async fn test_history_completion() -> anyhow::Result<()> {
+    test_key_sequence(
+        &mut Application::new(Args::default(), Config::default())?,
+        Some(":asdf<ret>:theme d<C-n><tab>"),
+        Some(&|app| {
+            assert!(!app.editor.is_err());
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes a panic related to completion when using the arrow keys to navigate through the prompt history.

Minimal reproduction steps for the panic
```
<launch helix>
:asdf<Enter> <- Anything that is shorter than what you will be trying to complete next works.
:theme d <- Note that triggering completion is not necessary since it's recalculated on each character entry.
<up arrow>
<tab>
```

It should not be possible to modify the prompt `line` without also updating completion list. Most functions modifying the `line` update the completions. `Prompt::insert_str` and `Prompt::change_history` does not which allows this panic to happen. This means that the `<c-s>` shortcut probably also can create a panic and there are also possible panics in the DAP prompt as well (`helix-term/src/commands/dap.rs`).

This PR fixes the immediate problem, but I think I real solution should force update the completion list when updating the prompt line in some centralized way. Another solution might be to tie the completion list more tightly to the prompt line itself so that it can be recalculated if needed when completing.