### PR TITLE
Add languages-open command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -63,7 +63,7 @@
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
-| `:lang-open` | Open the user languages.toml file. |
+| `:languages-open` | Open the user languages.toml file. |
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output after each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -63,6 +63,7 @@
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
+| `:lang-open` | Open the user languages.toml file. |
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output after each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -1,9 +1,14 @@
 # Languages
 
-Language-specific settings and settings for language servers are configured
+Language-specific settings, and language server settings, are configured
 in `languages.toml` files.
 
 ## `languages.toml` files
+
+* Linux and Mac: `~/.config/helix/languages.toml`
+* Windows: `%AppData%\helix\languages.toml`
+
+> Hint: You can easily open the languages config file by typing `:lang-open` within Helix normal mode.
 
 There are three possible `languages.toml` files. The first is compiled into
 Helix and lives in the [Helix repository](https://github.com/helix-editor/helix/blob/master/languages.toml).

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -8,7 +8,7 @@ in `languages.toml` files.
 * Linux and Mac: `~/.config/helix/languages.toml`
 * Windows: `%AppData%\helix\languages.toml`
 
-> Hint: You can easily open the languages config file by typing `:lang-open` within Helix normal mode.
+> Hint: You can easily open the languages config file by typing `:languages-open` within Helix normal mode.
 
 There are three possible `languages.toml` files. The first is compiled into
 Helix and lives in the [Helix repository](https://github.com/helix-editor/helix/blob/master/languages.toml).

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1411,6 +1411,21 @@ fn open_config(
     Ok(())
 }
 
+/// Open User Languages File
+fn open_lang_config(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .open(&helix_loader::lang_config_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_log(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -1957,6 +1972,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Open the user config.toml file.",
             fun: open_config,
+            completer: None,
+        },
+        TypableCommand {
+            name: "languages-open",
+            aliases: &[],
+            doc: "Open the user languages.toml file.",
+            fun: open_lang_config,
             completer: None,
         },
         TypableCommand {


### PR DESCRIPTION
Solves #3206, which was opened by myself.

Adds `:languages-open` as a command.