### PR TITLE
Remove let_declaration from Rust locals tracking

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -8,9 +8,6 @@
 (parameter
   (identifier) @local.definition)
 
-(let_declaration
-  pattern: (identifier) @local.definition)
-
 (closure_parameters (identifier) @local.definition)
 
 ; References


### PR DESCRIPTION
This fixes some edge-cases like [here](https://github.com/helix-editor/helix/blob/9a496237215dc09ef8f639fc79f7e63e2309c080/helix-term/src/commands.rs#L1752-L1757):

| before | after |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/181211105-f4e0e0a5-5ce1-4d92-8d48-a641976d9442.png) | ![after](https://user-images.githubusercontent.com/21230295/181211136-63474190-750d-4b8e-9dce-093cc59501b0.png) |

I don't think it ever makes sense to have a let-declaration define a local, right? We want to tag parameters as `local.definition` so that you can identify function/closure parameters but let-declarations always create variable bindings even when pattern matching so we can use normal highlighting for those.
