### PR TITLE
Hide cursorline when into SelectMode

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -114,7 +114,7 @@ impl EditorView {
             }
         }
 
-        if is_focused && editor.config().cursorline {
+        if is_focused && doc.mode != Mode::Select && editor.config().cursorline {
             Self::highlight_cursorline(doc, view, surface, theme);
         }
 


### PR DESCRIPTION
 I  think we don't need double background colors when we select some  text .  Because it hinders the focus of reading.
![Jul-28-2022 14-12-03](https://user-images.githubusercontent.com/716514/181433630-3478e2f1-d4ac-4a02-8ac6-5db0c8fee12a.gif)