### PR TITLE
feat: xtask themelint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,5 +1422,6 @@ version = "0.6.0"
 dependencies = [
  "helix-core",
  "helix-term",
+ "helix-view",
  "toml",
 ]

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -252,4 +252,16 @@ These scopes are used for theming the editor interface.
 | `diagnostic.warning`      | Diagnostics warning (editing area)             |
 | `diagnostic.error`        | Diagnostics error (editing area)               |
 
+You can check compliance to spec with
+
+```shell
+cargo xtask themelint onedark # replace onedark with <name>
+```
+
+Find all themes with issues with
+
+```shell
+cargo xtask themelint 2> /dev/null | jq 'keys'
+```
+
 [editor-section]: ./configuration.md#editor-section

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 helix-term = { version = "0.6", path = "../helix-term" }
 helix-core = { version = "0.6", path = "../helix-core" }
+helix-view = { version = "0.6", path = "../helix-view" }
 toml = "0.5"

--- a/xtask/src/docgen.rs
+++ b/xtask/src/docgen.rs
@@ -1,0 +1,117 @@
+use crate::helpers;
+use crate::paths;
+use crate::DynError;
+
+use helix_term::commands::TYPABLE_COMMAND_LIST;
+use helix_term::health::TsFeature;
+use std::fs;
+
+pub const TYPABLE_COMMANDS_MD_OUTPUT: &str = "typable-cmd.md";
+pub const LANG_SUPPORT_MD_OUTPUT: &str = "lang-support.md";
+
+fn md_table_heading(cols: &[String]) -> String {
+    let mut header = String::new();
+    header += &md_table_row(cols);
+    header += &md_table_row(&vec!["---".to_string(); cols.len()]);
+    header
+}
+
+fn md_table_row(cols: &[String]) -> String {
+    format!("| {} |\n", cols.join(" | "))
+}
+
+fn md_mono(s: &str) -> String {
+    format!("`{}`", s)
+}
+
+pub fn typable_commands() -> Result<String, DynError> {
+    let mut md = String::new();
+    md.push_str(&md_table_heading(&[
+        "Name".to_owned(),
+        "Description".to_owned(),
+    ]));
+
+    let cmdify = |s: &str| format!("`:{}`", s);
+
+    for cmd in TYPABLE_COMMAND_LIST {
+        let names = std::iter::once(&cmd.name)
+            .chain(cmd.aliases.iter())
+            .map(|a| cmdify(a))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let doc = cmd.doc.replace('\n', "<br>");
+
+        md.push_str(&md_table_row(&[names.to_owned(), doc.to_owned()]));
+    }
+
+    Ok(md)
+}
+
+pub fn lang_features() -> Result<String, DynError> {
+    let mut md = String::new();
+    let ts_features = TsFeature::all();
+
+    let mut cols = vec!["Language".to_owned()];
+    cols.append(
+        &mut ts_features
+            .iter()
+            .map(|t| t.long_title().to_string())
+            .collect::<Vec<_>>(),
+    );
+    cols.push("Default LSP".to_owned());
+
+    md.push_str(&md_table_heading(&cols));
+    let config = helpers::lang_config();
+
+    let mut langs = config
+        .language
+        .iter()
+        .map(|l| l.language_id.clone())
+        .collect::<Vec<_>>();
+    langs.sort_unstable();
+
+    let mut ts_features_to_langs = Vec::new();
+    for &feat in ts_features {
+        ts_features_to_langs.push((feat, helpers::ts_lang_support(feat)));
+    }
+
+    let mut row = Vec::new();
+    for lang in langs {
+        let lc = config
+            .language
+            .iter()
+            .find(|l| l.language_id == lang)
+            .unwrap(); // lang comes from config
+        row.push(lc.language_id.clone());
+
+        for (_feat, support_list) in &ts_features_to_langs {
+            row.push(
+                if support_list.contains(&lang) {
+                    "✓"
+                } else {
+                    ""
+                }
+                .to_owned(),
+            );
+        }
+        row.push(
+            lc.language_server
+                .as_ref()
+                .map(|s| s.command.clone())
+                .map(|c| md_mono(&c))
+                .unwrap_or_default(),
+        );
+
+        md.push_str(&md_table_row(&row));
+        row.clear();
+    }
+
+    Ok(md)
+}
+
+pub fn write(filename: &str, data: &str) {
+    let error = format!("Could not write to {}", filename);
+    let path = paths::book_gen().join(filename);
+    fs::write(path, data).expect(&error);
+}

--- a/xtask/src/helpers.rs
+++ b/xtask/src/helpers.rs
@@ -1,0 +1,58 @@
+use std::path::{Path, PathBuf};
+
+use crate::paths;
+use helix_core::syntax::Configuration as LangConfig;
+use helix_term::health::TsFeature;
+
+/// Get the list of languages that support a particular tree-sitter
+/// based feature.
+pub fn ts_lang_support(feat: TsFeature) -> Vec<String> {
+    let queries_dir = paths::ts_queries();
+
+    find_files(&queries_dir, feat.runtime_filename())
+        .iter()
+        .map(|f| {
+            // .../helix/runtime/queries/python/highlights.scm
+            let tail = f.strip_prefix(&queries_dir).unwrap(); // python/highlights.scm
+            let lang = tail.components().next().unwrap(); // python
+            lang.as_os_str().to_string_lossy().to_string()
+        })
+        .collect()
+}
+
+/// Get the list of languages that have any form of tree-sitter
+/// queries defined in the runtime directory.
+pub fn langs_with_ts_queries() -> Vec<String> {
+    std::fs::read_dir(paths::ts_queries())
+        .unwrap()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            entry
+                .file_type()
+                .ok()?
+                .is_dir()
+                .then(|| entry.file_name().to_string_lossy().to_string())
+        })
+        .collect()
+}
+
+// naive implementation, but suffices for our needs
+pub fn find_files(dir: &Path, filename: &str) -> Vec<PathBuf> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.is_dir() {
+                Some(find_files(&path, filename))
+            } else {
+                (path.file_name()?.to_string_lossy() == filename).then(|| vec![path])
+            }
+        })
+        .flatten()
+        .collect()
+}
+
+pub fn lang_config() -> LangConfig {
+    let bytes = std::fs::read(paths::lang_config()).unwrap();
+    toml::from_slice(&bytes).unwrap()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,220 +1,28 @@
+mod docgen;
+mod helpers;
+mod paths;
+mod themelint;
+
 use std::{env, error::Error};
 
 type DynError = Box<dyn Error>;
 
-pub mod helpers {
-    use std::path::{Path, PathBuf};
-
-    use crate::path;
-    use helix_core::syntax::Configuration as LangConfig;
-    use helix_term::health::TsFeature;
-
-    /// Get the list of languages that support a particular tree-sitter
-    /// based feature.
-    pub fn ts_lang_support(feat: TsFeature) -> Vec<String> {
-        let queries_dir = path::ts_queries();
-
-        find_files(&queries_dir, feat.runtime_filename())
-            .iter()
-            .map(|f| {
-                // .../helix/runtime/queries/python/highlights.scm
-                let tail = f.strip_prefix(&queries_dir).unwrap(); // python/highlights.scm
-                let lang = tail.components().next().unwrap(); // python
-                lang.as_os_str().to_string_lossy().to_string()
-            })
-            .collect()
-    }
-
-    /// Get the list of languages that have any form of tree-sitter
-    /// queries defined in the runtime directory.
-    pub fn langs_with_ts_queries() -> Vec<String> {
-        std::fs::read_dir(path::ts_queries())
-            .unwrap()
-            .filter_map(|entry| {
-                let entry = entry.ok()?;
-                entry
-                    .file_type()
-                    .ok()?
-                    .is_dir()
-                    .then(|| entry.file_name().to_string_lossy().to_string())
-            })
-            .collect()
-    }
-
-    // naive implementation, but suffices for our needs
-    pub fn find_files(dir: &Path, filename: &str) -> Vec<PathBuf> {
-        std::fs::read_dir(dir)
-            .unwrap()
-            .filter_map(|entry| {
-                let path = entry.ok()?.path();
-                if path.is_dir() {
-                    Some(find_files(&path, filename))
-                } else {
-                    (path.file_name()?.to_string_lossy() == filename).then(|| vec![path])
-                }
-            })
-            .flatten()
-            .collect()
-    }
-
-    pub fn lang_config() -> LangConfig {
-        let bytes = std::fs::read(path::lang_config()).unwrap();
-        toml::from_slice(&bytes).unwrap()
-    }
-}
-
-pub mod md_gen {
-    use crate::DynError;
-
-    use crate::helpers;
-    use crate::path;
-    use helix_term::commands::TYPABLE_COMMAND_LIST;
-    use helix_term::health::TsFeature;
-    use std::fs;
-
-    pub const TYPABLE_COMMANDS_MD_OUTPUT: &str = "typable-cmd.md";
-    pub const LANG_SUPPORT_MD_OUTPUT: &str = "lang-support.md";
-
-    fn md_table_heading(cols: &[String]) -> String {
-        let mut header = String::new();
-        header += &md_table_row(cols);
-        header += &md_table_row(&vec!["---".to_string(); cols.len()]);
-        header
-    }
-
-    fn md_table_row(cols: &[String]) -> String {
-        format!("| {} |\n", cols.join(" | "))
-    }
-
-    fn md_mono(s: &str) -> String {
-        format!("`{}`", s)
-    }
-
-    pub fn typable_commands() -> Result<String, DynError> {
-        let mut md = String::new();
-        md.push_str(&md_table_heading(&[
-            "Name".to_owned(),
-            "Description".to_owned(),
-        ]));
-
-        let cmdify = |s: &str| format!("`:{}`", s);
-
-        for cmd in TYPABLE_COMMAND_LIST {
-            let names = std::iter::once(&cmd.name)
-                .chain(cmd.aliases.iter())
-                .map(|a| cmdify(a))
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            let doc = cmd.doc.replace('\n', "<br>");
-
-            md.push_str(&md_table_row(&[names.to_owned(), doc.to_owned()]));
-        }
-
-        Ok(md)
-    }
-
-    pub fn lang_features() -> Result<String, DynError> {
-        let mut md = String::new();
-        let ts_features = TsFeature::all();
-
-        let mut cols = vec!["Language".to_owned()];
-        cols.append(
-            &mut ts_features
-                .iter()
-                .map(|t| t.long_title().to_string())
-                .collect::<Vec<_>>(),
-        );
-        cols.push("Default LSP".to_owned());
-
-        md.push_str(&md_table_heading(&cols));
-        let config = helpers::lang_config();
-
-        let mut langs = config
-            .language
-            .iter()
-            .map(|l| l.language_id.clone())
-            .collect::<Vec<_>>();
-        langs.sort_unstable();
-
-        let mut ts_features_to_langs = Vec::new();
-        for &feat in ts_features {
-            ts_features_to_langs.push((feat, helpers::ts_lang_support(feat)));
-        }
-
-        let mut row = Vec::new();
-        for lang in langs {
-            let lc = config
-                .language
-                .iter()
-                .find(|l| l.language_id == lang)
-                .unwrap(); // lang comes from config
-            row.push(lc.language_id.clone());
-
-            for (_feat, support_list) in &ts_features_to_langs {
-                row.push(
-                    if support_list.contains(&lang) {
-                        "✓"
-                    } else {
-                        ""
-                    }
-                    .to_owned(),
-                );
-            }
-            row.push(
-                lc.language_server
-                    .as_ref()
-                    .map(|s| s.command.clone())
-                    .map(|c| md_mono(&c))
-                    .unwrap_or_default(),
-            );
-
-            md.push_str(&md_table_row(&row));
-            row.clear();
-        }
-
-        Ok(md)
-    }
-
-    pub fn write(filename: &str, data: &str) {
-        let error = format!("Could not write to {}", filename);
-        let path = path::book_gen().join(filename);
-        fs::write(path, data).expect(&error);
-    }
-}
-
-pub mod path {
-    use std::path::{Path, PathBuf};
-
-    pub fn project_root() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .to_path_buf()
-    }
-
-    pub fn book_gen() -> PathBuf {
-        project_root().join("book/src/generated/")
-    }
-
-    pub fn ts_queries() -> PathBuf {
-        project_root().join("runtime/queries")
-    }
-
-    pub fn lang_config() -> PathBuf {
-        project_root().join("languages.toml")
-    }
-}
-
 pub mod tasks {
-    use crate::md_gen;
+    use crate::docgen::*;
+    use crate::themelint::*;
     use crate::DynError;
 
     pub fn docgen() -> Result<(), DynError> {
-        use md_gen::*;
         write(TYPABLE_COMMANDS_MD_OUTPUT, &typable_commands()?);
         write(LANG_SUPPORT_MD_OUTPUT, &lang_features()?);
         Ok(())
+    }
+
+    pub fn themelint(file: Option<String>) -> Result<(), DynError> {
+        match file {
+            Some(file) => lint(file),
+            None => lint_all(),
+        }
     }
 
     pub fn print_help() {
@@ -224,6 +32,7 @@ Usage: Run with `cargo xtask <task>`, eg. `cargo xtask docgen`.
 
     Tasks:
         docgen: Generate files to be included in the mdbook output.
+        themelint <theme>: Report errors for <theme>, or all themes if no theme is specified.
 "
         );
     }
@@ -235,6 +44,7 @@ fn main() -> Result<(), DynError> {
         None => tasks::print_help(),
         Some(t) => match t.as_str() {
             "docgen" => tasks::docgen()?,
+            "themelint" => tasks::themelint(env::args().nth(2))?,
             invalid => return Err(format!("Invalid task name: {}", invalid).into()),
         },
     };

--- a/xtask/src/paths.rs
+++ b/xtask/src/paths.rs
@@ -1,0 +1,24 @@
+use std::path::{Path, PathBuf};
+
+pub fn project_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+pub fn book_gen() -> PathBuf {
+    project_root().join("book/src/generated/")
+}
+
+pub fn ts_queries() -> PathBuf {
+    project_root().join("runtime/queries")
+}
+
+pub fn lang_config() -> PathBuf {
+    project_root().join("languages.toml")
+}
+
+pub fn themes() -> PathBuf {
+    project_root().join("runtime/themes")
+}

--- a/xtask/src/themelint.rs
+++ b/xtask/src/themelint.rs
@@ -1,0 +1,71 @@
+use crate::paths;
+use crate::DynError;
+use helix_view::theme::Style;
+use helix_view::Theme;
+
+pub fn lint_all() -> Result<(), DynError> {
+    let files = std::fs::read_dir(paths::themes())
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.is_dir() {
+                None
+            } else {
+                Some(path.file_name()?.to_string_lossy().to_string())
+            }
+        })
+        .collect::<Vec<String>>();
+    let mut errors = vec![];
+    files
+        .into_iter()
+        .for_each(|path| match lint(path.replace(".toml", "")) {
+            Err(err) => {
+                let errs: String = err.to_string();
+                errors.push(errs)
+            }
+            _ => return,
+        });
+    if errors.len() > 0 {
+        Err(errors.join(" ").into())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn lint(file: String) -> Result<(), DynError> {
+    let path = paths::themes().join(file + ".toml");
+    let theme = std::fs::read(&path).unwrap();
+    let theme: Theme = toml::from_slice(&theme).expect("Failed to parse theme");
+    let check = vec![
+        "ui.background",
+        "ui.virtual",
+        "ui.cursor",
+        "ui.selection",
+        "ui.linenr",
+        "ui.text",
+        "ui.popup",
+        "ui.window",
+        "ui.menu",
+        "ui.statusline",
+        "ui.cursorline.primary",
+    ];
+
+    let lint_errors: Vec<String> = check
+        .into_iter()
+        .filter_map(|path| {
+            let style = theme.get(path);
+            if style.eq(&Style::default()) {
+                Some(path.split(".").take(2).collect::<Vec<&str>>().join("."))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if lint_errors.len() > 0 {
+        println!("{:?}", path);
+        println!("{:?}", lint_errors);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
> This is meant as a basis of discussion, and a WIP / POC implementation.

## TL;DR - content of PR
1. Refactor `./xtask/src/main.rs` into separate modules
2. Add `themelint` task 

`themelint` will check to see that every "required"* key is present for a theme.

*required is not really defined, I've just used the `book/src/themes.md` as a guide.

## Try it
`cargo xtask themelint` will lint every theme, you can process the output with `jq` by `cargo xtask themelint 2> /dev/null | jq 'keys'` for instance, to get a list of all themes with issues.

Drill down to one theme with `cargo xtask themelint onedark` or `cargo xtask themelint 2> /dev/null | jq '.gruvbox'`

## Status
There's only a few themes that has no "errors". 40 of 45 themes has missing fields. This may be because I am too eagerly checking. 

I hope you want to help and try it out. It's already been helpful for me for playing with custom themes.