### PR TITLE
Add centered view mode

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -57,6 +57,7 @@ on unix operating systems.
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `centered-views` | Wether to center views by default | `false` |
 
 ### `[editor.statusline]` Section
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -244,23 +244,24 @@ Accessed by typing `Ctrl-w` in [normal mode](#normal-mode).
 
 This layer is similar to Vim keybindings as Kakoune does not support window.
 
-| Key                    | Description                                          | Command           |
-| -----                  | -------------                                        | -------           |
-| `w`, `Ctrl-w`          | Switch to next window                                | `rotate_view`     |
-| `v`, `Ctrl-v`          | Vertical right split                                 | `vsplit`          |
-| `s`, `Ctrl-s`          | Horizontal bottom split                              | `hsplit`          |
-| `f`                    | Go to files in the selection in horizontal splits    | `goto_file`       |
-| `F`                    | Go to files in the selection in vertical splits      | `goto_file`       |
-| `h`, `Ctrl-h`, `Left`  | Move to left split                                   | `jump_view_left`  |
-| `j`, `Ctrl-j`, `Down`  | Move to split below                                  | `jump_view_down`  |
-| `k`, `Ctrl-k`, `Up`    | Move to split above                                  | `jump_view_up`    |
-| `l`, `Ctrl-l`, `Right` | Move to right split                                  | `jump_view_right` |
-| `q`, `Ctrl-q`          | Close current window                                 | `wclose`          |
-| `o`, `Ctrl-o`          | Only keep the current window, closing all the others | `wonly`           |
-| `H`                    | Swap window to the left                              | `swap_view_left`  |
-| `J`                    | Swap window downwards                                | `swap_view_down`  |
-| `K`                    | Swap window upwards                                  | `swap_view_up`    |
-| `L`                    | Swap window to the right                             | `swap_view_right` |
+| Key                    | Description                                          | Command                |
+| -----                  | -------------                                        | -------                |
+| `c`                    | Toggle centered view                                 | `toggle_centered_view` |
+| `w`, `Ctrl-w`          | Switch to next window                                | `rotate_view`          |
+| `v`, `Ctrl-v`          | Vertical right split                                 | `vsplit`               |
+| `s`, `Ctrl-s`          | Horizontal bottom split                              | `hsplit`               |
+| `f`                    | Go to files in the selection in horizontal splits    | `goto_file`            |
+| `F`                    | Go to files in the selection in vertical splits      | `goto_file`            |
+| `h`, `Ctrl-h`, `Left`  | Move to left split                                   | `jump_view_left`       |
+| `j`, `Ctrl-j`, `Down`  | Move to split below                                  | `jump_view_down`       |
+| `k`, `Ctrl-k`, `Up`    | Move to split above                                  | `jump_view_up`         |
+| `l`, `Ctrl-l`, `Right` | Move to right split                                  | `jump_view_right`      |
+| `q`, `Ctrl-q`          | Close current window                                 | `wclose`               |
+| `o`, `Ctrl-o`          | Only keep the current window, closing all the others | `wonly`                |
+| `H`                    | Swap window to the left                              | `swap_view_left`       |
+| `J`                    | Swap window downwards                                | `swap_view_down`       |
+| `K`                    | Swap window upwards                                  | `swap_view_up`         |
+| `L`                    | Swap window to the right                             | `swap_view_right`      |
 
 #### Space mode
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -405,6 +405,7 @@ impl MappableCommand {
         wonly, "Close windows except current",
         select_register, "Select register",
         insert_register, "Insert register",
+        toggle_centered_view, "Toggle centered view",
         align_view_middle, "Align view middle",
         align_view_top, "Align view top",
         align_view_center, "Align view center",
@@ -4569,6 +4570,13 @@ fn insert_register(cx: &mut Context) {
             paste(cx, Paste::Cursor);
         }
     })
+}
+
+fn toggle_centered_view(cx: &mut Context) {
+    let mut view = view_mut!(cx.editor);
+    view.is_centered = !view.is_centered;
+
+    cx.editor.tree.recalculate();
 }
 
 fn align_view_top(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -179,6 +179,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "C-d" => half_page_down,
 
         "C-w" => { "Window"
+            "c" => toggle_centered_view,
             "C-w" | "w" => rotate_view,
             "C-s" | "s" => hsplit,
             "C-v" | "v" => vsplit,
@@ -242,6 +243,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
                 "E" => dap_disable_exceptions,
             },
             "w" => { "Window"
+                "c" => toggle_centered_view,
                 "C-w" | "w" => rotate_view,
                 "C-s" | "s" => hsplit,
                 "C-v" | "v" => vsplit,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -274,6 +274,8 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     pub soft_wrap: SoftWrap,
+    /// Whether to center views by default, Defaults to `false`.
+    pub centered_views: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -772,6 +774,7 @@ impl Default for Config {
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
             soft_wrap: SoftWrap::default(),
+            centered_views: false,
         }
     }
 }
@@ -1241,7 +1244,13 @@ impl Editor {
                     .try_get(self.tree.focus)
                     .filter(|v| id == v.doc) // Different Document
                     .cloned()
-                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
+                    .unwrap_or_else(|| {
+                        View::new(
+                            id,
+                            self.config().gutters.clone(),
+                            self.config().centered_views,
+                        )
+                    });
                 let view_id = self.tree.split(
                     view,
                     match action {
@@ -1398,7 +1407,11 @@ impl Editor {
                 .map(|(&doc_id, _)| doc_id)
                 .next()
                 .unwrap_or_else(|| self.new_document(Document::default(self.config.clone())));
-            let view = View::new(doc_id, self.config().gutters.clone());
+            let view = View::new(
+                doc_id,
+                self.config().gutters.clone(),
+                self.config().centered_views,
+            );
             let view_id = self.tree.insert(view);
             let doc = doc_mut!(self, &doc_id);
             doc.ensure_view_init(view_id);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -107,6 +107,7 @@ pub struct View {
     pub id: ViewId,
     pub offset: ViewPosition,
     pub area: Rect,
+    pub is_centered: bool,
     pub doc: DocumentId,
     pub jumps: JumpList,
     // documents accessed from this view from the oldest one to last viewed one
@@ -138,7 +139,7 @@ impl fmt::Debug for View {
 }
 
 impl View {
-    pub fn new(doc: DocumentId, gutters: GutterConfig) -> Self {
+    pub fn new(doc: DocumentId, gutters: GutterConfig, is_centered: bool) -> Self {
         Self {
             id: ViewId::default(),
             doc,
@@ -148,6 +149,7 @@ impl View {
                 vertical_offset: 0,
             },
             area: Rect::default(), // will get calculated upon inserting into tree
+            is_centered,
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
             docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
@@ -597,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords() {
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
         let doc = Document::from(
@@ -771,6 +773,7 @@ mod tests {
                 layout: vec![GutterType::Diagnostics],
                 line_numbers: GutterLineNumbersConfig::default(),
             },
+            false,
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
@@ -800,6 +803,7 @@ mod tests {
                 layout: vec![],
                 line_numbers: GutterLineNumbersConfig::default(),
             },
+            false,
         );
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("abc\n\tdef");
@@ -823,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_cjk() {
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hi! こんにちは皆さん");
         let doc = Document::from(
@@ -906,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_text_pos_at_screen_coords_graphemes() {
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), false);
         view.area = Rect::new(40, 40, 40, 40);
         let rope = Rope::from_str("Hèl̀l̀ò world!");
         let doc = Document::from(


### PR DESCRIPTION
Resolves #3203

Add a new `toggle_centered_view` command in Window mode and a `centered-views` to the editor config, change the behaviour of the `recalculate` function in `Tree` to center a `View` when it has the `is_centered` set to `true` to center it in the available space if the `View` isn't a child of a vertical container with more than 1 children.

I found that is the "standard" behaviour of the "centered mode" in most editors I use.

![image](https://user-images.githubusercontent.com/16986491/181724252-821bfea2-dbb2-4a8f-9419-7b457fc360d5.png)
