### PR TITLE
Add cwd parameter which is not optional anymore

### DIFF
--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -216,6 +216,8 @@ pub fn dap_start_impl(
         }
     }
 
+    args.insert("cwd", to_value(std::env::current_dir().unwrap())?);
+
     let args = to_value(args).unwrap();
 
     let callback = |_editor: &mut Editor, _compositor: &mut Compositor, _response: Value| {


### PR DESCRIPTION
cwd field has been changed in #2959 by making it a required field.
However, when starting the debugging session, cwd is not set, causing
an error in the deserialization part. Manually set cwd to the current
directory as a quick fix.