### PR TITLE
Make matching brace higlighting configurable

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -208,48 +208,53 @@ These scopes are used for theming the editor interface.
       - `hover` - for hover popup ui
 
 
-| Key                       | Notes                                          |
-| ---                       | ---                                            |
-| `ui.background`           |                                                |
-| `ui.background.separator` | Picker separator below input line              |
-| `ui.cursor`               |                                                |
-| `ui.cursor.insert`        |                                                |
-| `ui.cursor.select`        |                                                |
-| `ui.cursor.match`         | Matching bracket etc.                          |
-| `ui.cursor.primary`       | Cursor with primary selection                  |
-| `ui.linenr`               | Line numbers                                   |
-| `ui.linenr.selected`      | Line number for the line the cursor is on      |
-| `ui.statusline`           | Statusline                                     |
-| `ui.statusline.inactive`  | Statusline (unfocused document)                |
-| `ui.statusline.normal`    | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.insert`    | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.select`    | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.separator` | Separator character in statusline              |
-| `ui.popup`                | Documentation popups (e.g space-k)             |
-| `ui.popup.info`           | Prompt for multiple key options                |
-| `ui.window`               | Border lines separating splits                 |
-| `ui.help`                 | Description box for commands                   |
-| `ui.text`                 | Command prompts, popup text, etc.              |
-| `ui.text.focus`           |                                                |
-| `ui.text.info`            | The key: command text in `ui.popup.info` boxes |
-| `ui.virtual.ruler`        | Ruler columns (see the [`editor.rulers` config][editor-section])|
-| `ui.virtual.whitespace`   | Visible white-space characters                 |
-| `ui.virtual.indent-guide` | Vertical indent width guides                   |
-| `ui.menu`                 | Code and command completion menus              |
-| `ui.menu.selected`        | Selected autocomplete item                     |
-| `ui.menu.scroll`          | `fg` sets thumb color, `bg` sets track color of scrollbar |
-| `ui.selection`            | For selections in the editing area             |
-| `ui.selection.primary`    |                                                |
-| `ui.cursorline.primary`   | The line of the primary cursor                 |
-| `ui.cursorline.secondary` | The lines of any other cursors                 |
-| `warning`                 | Diagnostics warning (gutter)                   |
-| `error`                   | Diagnostics error (gutter)                     |
-| `info`                    | Diagnostics info (gutter)                      |
-| `hint`                    | Diagnostics hint (gutter)                      |
-| `diagnostic`              | Diagnostics fallback style (editing area)      |
-| `diagnostic.hint`         | Diagnostics hint (editing area)                |
-| `diagnostic.info`         | Diagnostics info (editing area)                |
-| `diagnostic.warning`      | Diagnostics warning (editing area)             |
-| `diagnostic.error`        | Diagnostics error (editing area)               |
+
+
+
+| Key                         | Notes                                          |
+| ---                         | ---                                            |
+| `ui.background`             |                                                |
+| `ui.background.separator`   | Picker separator below input line              |
+| `ui.cursor`                 |                                                |
+| `ui.cursor.insert`          |                                                |
+| `ui.cursor.select`          |                                                |
+| `ui.cursor.match`           | Matching bracket etc.                          |
+| `ui.cursor.match.primary`   | Matching bracket for primary selection.        |
+| `ui.cursor.match.secondary` | Matching bracket for secondary selections.     |
+| `ui.cursor.primary`         | Cursor with primary selection                  |
+| `ui.linenr`                 | Line numbers                                   |
+| `ui.linenr.selected`        | Line number for the line the cursor is on      |
+| `ui.statusline`             | Statusline                                     |
+| `ui.statusline.inactive`    | Statusline (unfocused document)                |
+| `ui.statusline.normal`      | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.insert`      | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.select`      | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.separator`   | Separator character in statusline              |
+| `ui.popup`                  | Documentation popups (e.g space-k)             |
+| `ui.popup.info`             | Prompt for multiple key options                |
+| `ui.window`                 | Border lines separating splits                 |
+| `ui.help`                   | Description box for commands                   |
+| `ui.text`                   | Command prompts, popup text, etc.              |
+| `ui.text.focus`             |                                                |
+| `ui.text.info`              | The key: command text in `ui.popup.info` boxes |
+| `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])|
+| `ui.virtual.whitespace`     | Visible white-space characters                 |
+| `ui.virtual.indent-guide`   | Vertical indent width guides                   |
+| `ui.menu`                   | Code and command completion menus              |
+| `ui.menu.selected`          | Selected autocomplete item                     |
+| `ui.menu.scroll`            | `fg` sets thumb color, `bg` sets track color of scrollbar |
+| `ui.selection`              | For selections in the editing area             |
+| `ui.selection.primary`      |                                                |
+| `ui.cursorline.primary`     | The line of the primary cursor                 |
+| `ui.cursorline.secondary`   | The lines of any other cursors                 |
+| `warning`                   | Diagnostics warning (gutter)                   |
+| `error`                     | Diagnostics error (gutter)                     |
+| `info`                      | Diagnostics info (gutter)                      |
+| `hint`                      | Diagnostics hint (gutter)                      |
+| `diagnostic`                | Diagnostics fallback style (editing area)      |
+| `diagnostic.hint`           | Diagnostics hint (editing area)                |
+| `diagnostic.info`           | Diagnostics info (editing area)                |
+| `diagnostic.warning`        | Diagnostics warning (editing area)             |
+| `diagnostic.error`          | Diagnostics error (editing area)               |
 
 [editor-section]: ./configuration.md#editor-section

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -211,50 +211,50 @@ These scopes are used for theming the editor interface.
 
 
 
-| Key                         | Notes                                          |
-| ---                         | ---                                            |
-| `ui.background`             |                                                |
-| `ui.background.separator`   | Picker separator below input line              |
-| `ui.cursor`                 |                                                |
-| `ui.cursor.insert`          |                                                |
-| `ui.cursor.select`          |                                                |
-| `ui.cursor.match`           | Matching bracket etc.                          |
-| `ui.cursor.match.primary`   | Matching bracket for primary selection.        |
-| `ui.cursor.match.secondary` | Matching bracket for secondary selections.     |
-| `ui.cursor.primary`         | Cursor with primary selection                  |
-| `ui.linenr`                 | Line numbers                                   |
-| `ui.linenr.selected`        | Line number for the line the cursor is on      |
-| `ui.statusline`             | Statusline                                     |
-| `ui.statusline.inactive`    | Statusline (unfocused document)                |
+| Key                         | Notes                                                                                          |
+| ---                         | ---                                                                                            |
+| `ui.background`             |                                                                                                |
+| `ui.background.separator`   | Picker separator below input line                                                              |
+| `ui.cursor`                 |                                                                                                |
+| `ui.cursor.insert`          |                                                                                                |
+| `ui.cursor.select`          |                                                                                                |
+| `ui.cursor.match`           | Matching bracket etc.                                                                          |
+| `ui.cursor.match.primary`   | Matching bracket for primary selection.                                                        |
+| `ui.cursor.match.secondary` | Matching bracket for secondary selections.                                                     |
+| `ui.cursor.primary`         | Cursor with primary selection                                                                  |
+| `ui.linenr`                 | Line numbers                                                                                   |
+| `ui.linenr.selected`        | Line number for the line the cursor is on                                                      |
+| `ui.statusline`             | Statusline                                                                                     |
+| `ui.statusline.inactive`    | Statusline (unfocused document)                                                                |
 | `ui.statusline.normal`      | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
 | `ui.statusline.insert`      | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
 | `ui.statusline.select`      | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.separator`   | Separator character in statusline              |
-| `ui.popup`                  | Documentation popups (e.g space-k)             |
-| `ui.popup.info`             | Prompt for multiple key options                |
-| `ui.window`                 | Border lines separating splits                 |
-| `ui.help`                   | Description box for commands                   |
-| `ui.text`                   | Command prompts, popup text, etc.              |
-| `ui.text.focus`             |                                                |
-| `ui.text.info`              | The key: command text in `ui.popup.info` boxes |
-| `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])|
-| `ui.virtual.whitespace`     | Visible white-space characters                 |
-| `ui.virtual.indent-guide`   | Vertical indent width guides                   |
-| `ui.menu`                   | Code and command completion menus              |
-| `ui.menu.selected`          | Selected autocomplete item                     |
-| `ui.menu.scroll`            | `fg` sets thumb color, `bg` sets track color of scrollbar |
-| `ui.selection`              | For selections in the editing area             |
-| `ui.selection.primary`      |                                                |
-| `ui.cursorline.primary`     | The line of the primary cursor                 |
-| `ui.cursorline.secondary`   | The lines of any other cursors                 |
-| `warning`                   | Diagnostics warning (gutter)                   |
-| `error`                     | Diagnostics error (gutter)                     |
-| `info`                      | Diagnostics info (gutter)                      |
-| `hint`                      | Diagnostics hint (gutter)                      |
-| `diagnostic`                | Diagnostics fallback style (editing area)      |
-| `diagnostic.hint`           | Diagnostics hint (editing area)                |
-| `diagnostic.info`           | Diagnostics info (editing area)                |
-| `diagnostic.warning`        | Diagnostics warning (editing area)             |
-| `diagnostic.error`          | Diagnostics error (editing area)               |
+| `ui.statusline.separator`   | Separator character in statusline                                                              |
+| `ui.popup`                  | Documentation popups (e.g space-k)                                                             |
+| `ui.popup.info`             | Prompt for multiple key options                                                                |
+| `ui.window`                 | Border lines separating splits                                                                 |
+| `ui.help`                   | Description box for commands                                                                   |
+| `ui.text`                   | Command prompts, popup text, etc.                                                              |
+| `ui.text.focus`             |                                                                                                |
+| `ui.text.info`              | The key: command text in `ui.popup.info` boxes                                                 |
+| `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
+| `ui.virtual.whitespace`     | Visible white-space characters                                                                 |
+| `ui.virtual.indent-guide`   | Vertical indent width guides                                                                   |
+| `ui.menu`                   | Code and command completion menus                                                              |
+| `ui.menu.selected`          | Selected autocomplete item                                                                     |
+| `ui.menu.scroll`            | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |
+| `ui.selection`              | For selections in the editing area                                                             |
+| `ui.selection.primary`      |                                                                                                |
+| `ui.cursorline.primary`     | The line of the primary cursor                                                                 |
+| `ui.cursorline.secondary`   | The lines of any other cursors                                                                 |
+| `warning`                   | Diagnostics warning (gutter)                                                                   |
+| `error`                     | Diagnostics error (gutter)                                                                     |
+| `info`                      | Diagnostics info (gutter)                                                                      |
+| `hint`                      | Diagnostics hint (gutter)                                                                      |
+| `diagnostic`                | Diagnostics fallback style (editing area)                                                      |
+| `diagnostic.hint`           | Diagnostics hint (editing area)                                                                |
+| `diagnostic.info`           | Diagnostics info (editing area)                                                                |
+| `diagnostic.warning`        | Diagnostics warning (editing area)                                                             |
+| `diagnostic.error`          | Diagnostics error (editing area)                                                               |
 
 [editor-section]: ./configuration.md#editor-section


### PR DESCRIPTION
Resolves  #3228 by making matching brace highlighting configurable:
`none`, `all`, `primary`, defaulting to `all`.

New default behavior:
![image](https://user-images.githubusercontent.com/58790821/181749006-028e2cac-5d59-4b01-bf65-954282849635.png)
