### PR TITLE
Add rust-version (MSRV) to helix-term package

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 default-run = "hx"
+rust-version = "1.57"
 
 [package.metadata.nix]
 build = true


### PR DESCRIPTION
Adding rust-version ensure a check at compile that the compiler version can build helix. I have used [`cargo-msrv`](https://github.com/foresterre/cargo-msrv) to retrieve this value and it can be checked using `cargo msrv verify`.

This value is also useful to contributors, because they know which features they can use.