### PR TITLE
Adds a run-shell-command-no-output command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -69,3 +69,4 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:run-shell-command-no-output`, `:sh!` | Run a shell command ignoring output |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -69,4 +69,4 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |
-| `:run-shell-command-no-output`, `:sh!` | Run a shell command ignoring output |
+| `:run-shell-command-no-output`, `:shush` | Run a shell command ignoring output |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2115,7 +2115,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         },
         TypableCommand {
             name: "run-shell-command-no-output",
-            aliases: &["sh!"],
+            aliases: &["shush"],
             doc: "Run a shell command ignoring output",
             fun: run_shell_command_no_output,
             completer: Some(completers::directory)

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1590,7 +1590,7 @@ fn run_shell_command_impl(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
     event: PromptEvent,
-    behavior: ShellBehavior
+    behavior: ShellBehavior,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());


### PR DESCRIPTION
Hi!
This PR adds an additional command to run a shell command ignoring the output.

The command is `:run-shell-command-no-output` (alias `:sh!`).

I'm a bit uncertain about the usage of `ShellBehavior::Ignore` and `Append`, but I didn't want to use a boolean.