### PR TITLE
Avoid setting stdin handle when not necessary

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4541,18 +4541,18 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-    let mut process_ = Command::new(&shell[0]);
-    process_
+    let mut process = Command::new(&shell[0]);
+    process
         .args(&shell[1..])
         .arg(cmd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
     if input.is_some() {
-        process_.stdin(Stdio::piped());
+        process.stdin(Stdio::piped());
     }
 
-    let mut process = match process_.spawn() {
+    let mut process = match process.spawn() {
         Ok(process) => process,
         Err(e) => {
             log::error!("Failed to start shell: {}", e);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4542,14 +4542,13 @@ fn shell_impl(
     ensure!(!shell.is_empty(), "No shell set");
 
     let mut process_ = Command::new(&shell[0]);
-
     process_
         .args(&shell[1..])
         .arg(cmd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    if let Some(_) = input {
+    if input.is_some() {
         process_.stdin(Stdio::piped());
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4541,25 +4541,19 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-    let process_ = match input {
-        Some(_) => Command::new(&shell[0])
-                     .args(&shell[1..])
-                     .arg(cmd)
-                     .stdin(Stdio::piped())
-                     .stdout(Stdio::piped())
-                     .stderr(Stdio::piped())
-                     .spawn(),
-        None => Command::new(&shell[0])
-                     .args(&shell[1..])
-                     .arg(cmd)
-                     .stdout(Stdio::piped())
-                     .stderr(Stdio::piped())
-                     .spawn()
-    };
+    let mut process_ = Command::new(&shell[0]);
 
+    process_
+        .args(&shell[1..])
+        .arg(cmd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
-    let mut process = match process_
-    {
+    if let Some(_) = input {
+        process_.stdin(Stdio::piped());
+    }
+
+    let mut process = match process_.spawn() {
         Ok(process) => process,
         Err(e) => {
             log::error!("Failed to start shell: {}", e);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4541,13 +4541,24 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-    let mut process = match Command::new(&shell[0])
-        .args(&shell[1..])
-        .arg(cmd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+    let process_ = match input {
+        Some(_) => Command::new(&shell[0])
+                     .args(&shell[1..])
+                     .arg(cmd)
+                     .stdin(Stdio::piped())
+                     .stdout(Stdio::piped())
+                     .stderr(Stdio::piped())
+                     .spawn(),
+        None => Command::new(&shell[0])
+                     .args(&shell[1..])
+                     .arg(cmd)
+                     .stdout(Stdio::piped())
+                     .stderr(Stdio::piped())
+                     .spawn()
+    };
+
+
+    let mut process = match process_
     {
         Ok(process) => process,
         Err(e) => {


### PR DESCRIPTION
Hi!

Another small PR which avoids adding the stdin handler in `shell_impl` when not necessary.
This allows to run commands that don't expect any stdin whtout getting a `ENOTTY` error.

While this works, I have no experience with terminals (and rust), so it might be the completely wrong approach.
