### PR TITLE
Only add cargo-tarpaulin on x86_64

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
               ++ (
                 with common.pkgs;
                 [lld_13 lldb cargo-flamegraph rust-analyzer] ++
-                (lib.optionals stdenv.isx86_64 [cargo-tarpaulin])
+                (lib.optional stdenv.isx86_64 cargo-tarpaulin)
               );
             env =
               prev.env

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
               ++ (
                 with common.pkgs;
                 [lld_13 lldb cargo-flamegraph rust-analyzer] ++
-                (lib.optional stdenv.isx86_64 cargo-tarpaulin)
+                (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
               );
             env =
               prev.env

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,9 @@
             packages =
               prev.packages
               ++ (
-                with common.pkgs; [lld_13 lldb cargo-tarpaulin cargo-flamegraph rust-analyzer]
+                with common.pkgs;
+                [lld_13 lldb cargo-flamegraph rust-analyzer] ++
+                (lib.optionals stdenv.isx86_64 [cargo-tarpaulin])
               );
             env =
               prev.env


### PR DESCRIPTION
It only supports that platform: https://github.com/NixOS/nixpkgs/blob/433bd5e89cbb5fec3d16e90a9df4734ef2fe9fcb/pkgs/development/tools/analysis/cargo-tarpaulin/default.nix#L29

Without this `nix develop` fails with this error on my system:

```
error: Package ‘cargo-tarpaulin-0.20.1’ in /nix/store/.../cargo-tarpaulin/default.nix:25
is not supported on ‘aarch64-linux’, refusing to evaluate.
```