### PR TITLE
feat: `default-keymap-open` and `current-keymap-open` typeable commands

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -64,6 +64,8 @@
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
 | `:log-open` | Open the helix log file. |
+| `:current-keymap-open` | Open the current keymap. |
+| `:default-keymap-open` | Open the default keymap. |
 | `:insert-output` | Run shell command, inserting output after each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -60,7 +60,10 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
-use serde::de::{self, Deserialize, Deserializer};
+use serde::{
+    de::{self, Deserialize, Deserializer},
+    Serialize, Serializer,
+};
 
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
@@ -486,6 +489,15 @@ impl<'de> Deserialize<'de> for MappableCommand {
     {
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for MappableCommand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(&self.to_string())
     }
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1471,9 +1471,10 @@ fn current_keymap(
                     })
                     .collect::<Result<String, toml::ser::Error>>();
 
-                let str = match serialized_str {
-                    Ok(str) => str,
-                    Err(_) => return (),
+                let str = if let Ok(str) = serialized_str {
+                    str
+                } else {
+                    return;
                 };
 
                 let doc = Document::from(Rope::from_str(&str), None);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1446,22 +1446,32 @@ fn open_serialized_keymap(editor: &mut Editor, keymap: &HashMap<Mode, keymap::Ke
     struct ModeSelect<'a> {
         select: &'a keymap::Keymap,
     }
-    let serialized_str = keymap
-        .iter()
-        // there must be a way to make this easier i think
-        .map(|couple| match couple.0 {
-            Mode::Insert => toml::to_string(&Keys {
-                keys: ModeInsert { insert: couple.1 },
-            }),
-            Mode::Normal => toml::to_string(&Keys {
-                keys: ModeNormal { normal: couple.1 },
-            }),
-            Mode::Select => toml::to_string(&Keys {
-                keys: ModeSelect { select: couple.1 },
-            }),
-        })
-        .collect::<Result<String, toml::ser::Error>>()
-        .expect("Keymap should serialze");
+
+    let insert_str = toml::to_string(&Keys {
+                keys: ModeInsert { insert: keymap.get(&Mode::Insert).expect("Insert mode shall have entries")
+        }
+    }).expect("Insert mode shall be able to be serialized");
+
+    let normal_str = toml::to_string(&Keys {
+                keys: ModeNormal { normal: keymap.get(&Mode::Normal).expect("Normal mode shall have entries")
+        }
+    }).expect("Normal mode shall be able to be serialized");
+
+    let select_str = toml::to_string(&Keys {
+                keys: ModeSelect { select: keymap.get(&Mode::Select).expect("Select mode shall have entries")
+        }
+    }).expect("Select mode shall be able to be serialized");
+    let select_str = select_str
+        .lines()
+        .filter(|x| !normal_str
+            .lines()
+            .collect::<Vec<&str>>()
+            .contains(x))
+        .collect::<Vec<&str>>()
+        .join("\n");
+    
+    let serialized_str = format!("{}\n{}\n{}", normal_str, select_str, insert_str);
+    
     let mut doc = Document::from(
         Rope::from_str(&serialized_str),
         Some(helix_core::encoding::UTF_8),

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -13,7 +13,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{
-    borrow::Cow,
+    borrow::{Borrow, Cow},
     collections::{BTreeSet, HashMap},
     ops::{Deref, DerefMut},
     sync::Arc,
@@ -51,13 +51,7 @@ impl Serialize for KeyTrieNode {
     where
         S: Serializer,
     {
-        // 3 is the number of fields in the struct.
-        let mut state = serializer.serialize_struct("KeyTrieNode", 4)?;
-        state.serialize_field("map", &self.map)?;
-        state.serialize_field("name", &self.name)?;
-        state.serialize_field("is_sticky", &self.is_sticky)?;
-        state.serialize_field("order", &self.order)?;
-        state.end()
+        toml::ser::tables_last(&self.map, serializer)
     }
 }
 

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -210,7 +210,7 @@ pub enum KeymapResult {
     Cancelled(Vec<KeyEvent>),
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct Keymap {
     /// Always a Node

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -8,12 +8,9 @@ use arc_swap::{
     ArcSwap,
 };
 use helix_view::{document::Mode, info::Info, input::KeyEvent};
-use serde::{
-    ser::{SerializeStruct, Serializer},
-    Deserialize, Serialize,
-};
+use serde::{ser::Serializer, Deserialize, Serialize};
+use std::borrow::Cow;
 use std::{
-    borrow::{Borrow, Cow},
     collections::{BTreeSet, HashMap},
     ops::{Deref, DerefMut},
     sync::Arc,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -916,7 +916,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Error};
 use helix_core::unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidthStr};
 use serde::{
     de::{self, Deserialize, Deserializer},
-    ser::{Serialize, SerializeStruct, Serializer},
+    ser::{Serialize, Serializer},
 };
 use std::fmt;
 

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -1,7 +1,10 @@
 //! Input event handling, currently backed by crossterm.
 use anyhow::{anyhow, Error};
 use helix_core::unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidthStr};
-use serde::de::{self, Deserialize, Deserializer};
+use serde::{
+    de::{self, Deserialize, Deserializer},
+    ser::{Serialize, SerializeStruct, Serializer},
+};
 use std::fmt;
 
 use crate::keyboard::{KeyCode, KeyModifiers};
@@ -216,6 +219,15 @@ impl<'de> Deserialize<'de> for KeyEvent {
     {
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for KeyEvent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(&self.to_string())
     }
 }
 

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -1,7 +1,9 @@
 use bitflags::bitflags;
+use serde::Serialize;
 
 bitflags! {
     /// Represents key modifiers (shift, control, alt).
+    #[derive(Serialize)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct KeyModifiers: u8 {
         const SHIFT = 0b0000_0001;
@@ -54,8 +56,8 @@ impl From<crossterm::event::KeyModifiers> for KeyModifiers {
 }
 
 /// Represents a key.
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash, Serialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub enum KeyCode {
     /// Backspace key.
     Backspace,


### PR DESCRIPTION
`:current-keymap-open` will open a new buffer with the currently loaded config. 
`:default-keymap-open` will open a new buffer with the default config.