### PR TITLE
feat: add cue support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -10,6 +10,7 @@
 | cpon | ✓ |  | ✓ |  |
 | cpp | ✓ | ✓ | ✓ | `clangd` |
 | css | ✓ |  |  | `vscode-css-language-server` |
+| cue | ✓ |  |  | `cuelsp` |
 | dart | ✓ |  | ✓ | `dart` |
 | devicetree | ✓ |  | ✓ |  |
 | dockerfile | ✓ |  |  | `docker-langserver` |

--- a/languages.toml
+++ b/languages.toml
@@ -1584,3 +1584,18 @@ language-server = { command = "dot-language-server", args = ["--stdio"] }
 [[grammar]]
 name = "dot"
 source = { git = "https://github.com/rydesun/tree-sitter-dot", rev = "917230743aa10f45a408fea2ddb54bbbf5fbe7b7" }
+
+[[language]]
+name = "cue"
+scope = "source.cue"
+injection-regex = "cue"
+file-types = ["cue"]
+roots = ["cue.mod"]
+auto-format = true
+comment-token = "//"
+language-server = { command = "cuelsp" }
+indent = { tab-width = 4, unit = "\t" }
+
+[[grammar]]
+name = "cue"
+source = { git = "https://github.com/eonpatapon/tree-sitter-cue", rev = "61843e3beebf19417e4fede4e8be4df1084317ad" }

--- a/runtime/queries/cue/highlights.scm
+++ b/runtime/queries/cue/highlights.scm
@@ -1,0 +1,110 @@
+(package_clause "package" @keyword.control.import)
+
+(package_identifier) @variable
+
+(import_declaration "import" @keyword.control.import)
+
+[
+  "!"
+  "*"
+  "|"
+  "&"
+  "||"
+  "&&"
+  "=="
+  "!="
+  "<"
+  "<="
+  ">"
+  ">="
+  "=~"
+  "!~"
+  "+"
+  "-"
+  "*"
+  "/"
+] @operator
+
+(unary_expression "*" @operator.default)
+
+(unary_expression "=~" @operator.regexp)
+
+(unary_expression "!~" @operator.regexp)
+
+(binary_expression _ "&" @operator.unify _)
+
+(binary_expression _ "|" @operator.disjunct _)
+
+(builtin) @function.builtin
+
+(qualified_identifier) @function.builtin
+
+(let_clause "let" @keyword.storage.type)
+
+(for_clause "for" @keyword.control.repeat)
+(for_clause "in" @keyword.control.repeat)
+
+(guard_clause "if" @keyword.control.conditional)
+
+(comment) @comment
+
+[
+  (string_type)
+  (simple_string_lit)
+  (multiline_string_lit)
+  (bytes_type)
+  (simple_bytes_lit)
+  (multiline_bytes_lit)
+] @string
+
+[
+  (number_type)
+  (int_lit)
+  (int_type)
+  (uint_type)
+] @constant.numeric.integer
+
+[
+  (float_lit)
+  (float_type)
+] @constant.numeric.float
+
+[
+  (bool_type)
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+(null) @constant.builtin
+
+(ellipsis) @punctuation.bracket
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(interpolation "\\(" @punctuation.bracket (_) ")" @punctuation.bracket) @variable.other.member
+
+(field (label (identifier) @variable.other.member))
+
+(
+  (identifier) @keyword.storage.type
+  (#match? @keyword.storage.type "^#")
+)
+
+(field (label alias: (identifier) @label))
+
+(let_clause left: (identifier) @label)
+
+
+(attribute (identifier) @tag)


### PR DESCRIPTION
This PR add support for [CUE](https://github.com/cue-lang/cue) using [dagger/cuelsp](https://github.com/dagger/cuelsp) and [eonpatapon/tree-sitter-cue](https://github.com/eonpatapon/tree-sitter-cue).

I'm wondering if it's there's a way to give the `format` command another command than the lsp (`cue fmt`)?
It's not a big caveheat since https://github.com/dagger/cuelsp/issues/44 should resolve that anyway.