### PR TITLE
Add extend variants for tree-sitter textobjects

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -389,6 +389,8 @@ fn reached_target(target: WordMotionTarget, prev_ch: char, next_ch: char) -> boo
     }
 }
 
+/// Finds the range of the next or previous textobject in the syntax sub-tree of `node`.
+/// Returns the range in the forwards direction.
 pub fn goto_treesitter_object(
     slice: RopeSlice,
     range: Range,
@@ -419,8 +421,8 @@ pub fn goto_treesitter_object(
                 .filter(|n| n.start_byte() > byte_pos)
                 .min_by_key(|n| n.start_byte())?,
             Direction::Backward => nodes
-                .filter(|n| n.start_byte() < byte_pos)
-                .max_by_key(|n| n.start_byte())?,
+                .filter(|n| n.end_byte() < byte_pos)
+                .max_by_key(|n| n.end_byte())?,
         };
 
         let len = slice.len_bytes();
@@ -434,7 +436,7 @@ pub fn goto_treesitter_object(
         let end_char = slice.byte_to_char(end_byte);
 
         // head of range should be at beginning
-        Some(Range::new(end_char, start_char))
+        Some(Range::new(start_char, end_char))
     };
     (0..count).fold(range, |range, _| get_range(range).unwrap_or(range))
 }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -122,12 +122,22 @@ impl Range {
         }
     }
 
-    // flips the direction of the selection
+    /// Flips the direction of the selection
     pub fn flip(&self) -> Self {
         Self {
             anchor: self.head,
             head: self.anchor,
             horiz: self.horiz,
+        }
+    }
+
+    /// Returns the selection if it goes in the direction of `direction`,
+    /// flipping the selection otherwise.
+    pub fn with_direction(self, direction: Direction) -> Self {
+        if self.direction() == direction {
+            self
+        } else {
+            self.flip()
         }
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2159,10 +2159,7 @@ fn ensure_selections_forward(cx: &mut Context) {
     let selection = doc
         .selection(view.id)
         .clone()
-        .transform(|r| match r.direction() {
-            Direction::Forward => r,
-            Direction::Backward => r.flip(),
-        });
+        .transform(|r| r.with_direction(Direction::Forward));
 
     doc.set_selection(view.id, selection);
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4269,6 +4269,7 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
                     lang_config,
                     count,
                 )
+                .with_direction(direction)
             });
 
             doc.set_selection(view.id, selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4257,7 +4257,7 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
             let root = syntax.tree().root_node();
 
             let selection = doc.selection(view.id).clone().transform(|range| {
-                movement::goto_treesitter_object(
+                let new_range = movement::goto_treesitter_object(
                     text,
                     range,
                     object,
@@ -4265,8 +4265,19 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
                     root,
                     lang_config,
                     count,
-                )
-                .with_direction(direction)
+                );
+
+                if editor.mode == Mode::Select {
+                    let head = if new_range.head < range.anchor {
+                        new_range.anchor
+                    } else {
+                        new_range.head
+                    };
+
+                    Range::new(range.anchor, head)
+                } else {
+                    new_range.with_direction(direction)
+                }
             });
 
             doc.set_selection(view.id, selection);


### PR DESCRIPTION
https://asciinema.org/a/523187

This is a somewhat significant behavior change for tree-sitter textobject motion. Prior to this change you could select all functions in a file with repeated `]f`. With this change, nested functions are not selected with repeated `]f` but I think the new behavior makes sense.

The new behavior is something like

* `]f` selects the function textobject with a `start_byte()` after the current selection's cursor
* `[f` selects the function textobject with an `end_byte()` before the current selection's cursor

After a bit of adjustment, I think the new behavior 'feels' right.

Enabled with that change, I've added `doc.mode == Mode::Select` behavior for `goto_treesitter_object` which behaves as option 1 of #3263.

~Based on #3264 for simplicity's sake~
Supersedes #2802
Closes #3263