### PR TITLE
customizable file type mapping

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -75,7 +75,7 @@ The following elements can be configured:
 | `file-name` | The path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
-| `file-type` | The type of the opened file |
+| `file-type` | The type of the opened file (see `editor.file-type-indicator` below) |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |
 | `position` | The cursor position |
@@ -224,7 +224,7 @@ render = true
 character = "╎"
 ```
 
-### `[editor.file-type]` Section
+### `[editor.file-type-indicator]` Section
 
 Remaps / overrides the standard file type strings to custom strings. If a file type is
 defined in this section, the string value assigned will be used instead of the default.
@@ -232,10 +232,10 @@ Any file types not defined in this section will use the default file type string
 Example:
 
 ```toml
-[editor.file-type]
+[editor.file-type-indicator]
 "rust" = "rs"
 "typescript" = "ts"
 ```
 In the above example, Rust and TypeScript files will use "rs" and "ts" as their respective
 file type indicators, while JavaScript and others not defined will use the Helix default.
-
+Currently, the file type indicator string is used only by the `file-type` statusline element.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -223,3 +223,19 @@ Example:
 render = true
 character = "╎"
 ```
+
+### `[editor.file-type]` Section
+
+Remaps / overrides the standard file type strings to custom strings. If a file type is
+defined in this section, the string value assigned will be used instead of the default.
+Any file types not defined in this section will use the default file type string.
+Example:
+
+```toml
+[editor.file-type]
+"rust" = "rs"
+"typescript" = "ts"
+```
+In the above example, Rust and TypeScript files will use "rs" and "ts" as their respective
+file type indicators, while JavaScript and others not defined will use the Helix default.
+

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -75,7 +75,7 @@ The following elements can be configured:
 | `file-name` | The path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
-| `file-type` | The type of the opened file (see `editor.file-type-indicator` below) |
+| `file-type` | The type of the opened file (see `editor.file-type-indicators` below) |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |
 | `position` | The cursor position |
@@ -224,7 +224,7 @@ render = true
 character = "╎"
 ```
 
-### `[editor.file-type-indicator]` Section
+### `[editor.file-type-indicators]` Section
 
 Remaps / overrides the standard file type strings to custom strings. If a file type is
 defined in this section, the string value assigned will be used instead of the default.
@@ -232,7 +232,7 @@ Any file types not defined in this section will use the default file type string
 Example:
 
 ```toml
-[editor.file-type-indicator]
+[editor.file-type-indicators]
 "rust" = "rs"
 "typescript" = "ts"
 ```

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -330,6 +330,12 @@ where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
     let file_type = context.doc.language_id().unwrap_or("text");
+    let editor_config = context.editor.config();
+    let file_type = editor_config
+        .file_types
+        .get(file_type)
+        .map(|x| x.as_str())
+        .unwrap_or(file_type);
 
     write(context, format!(" {} ", file_type), None);
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -332,7 +332,7 @@ where
     let file_type = context.doc.language_id().unwrap_or("text");
     let editor_config = context.editor.config();
     let file_type = editor_config
-        .file_types
+        .file_type_indicators
         .get(file_type)
         .map(|x| x.as_str())
         .unwrap_or(file_type);

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -334,8 +334,7 @@ where
     let file_type = editor_config
         .file_type_indicators
         .get(file_type)
-        .map(|x| x.as_str())
-        .unwrap_or(file_type);
+        .map_or(file_type, String::as_str);
 
     write(context, format!(" {} ", file_type), None);
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -166,7 +166,7 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     /// File type icon/string map for overriding file type.
-    pub file_types: FileTypeConfig,
+    pub file_type_indicators: FileTypeConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -532,7 +532,7 @@ impl Default for Config {
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
-            file_types: FileTypeConfig::default(),
+            file_type_indicators: FileTypeConfig::default(),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -165,6 +165,8 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// File type icon/string map for overriding file type.
+    pub file_types: FileTypeConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -310,6 +312,37 @@ impl std::ops::Deref for CursorShapeConfig {
 impl Default for CursorShapeConfig {
     fn default() -> Self {
         Self([CursorKind::Block; 3])
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct FileTypeConfig(HashMap<String, String>);
+
+impl<'de> Deserialize<'de> for FileTypeConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let m = HashMap::<String, String>::deserialize(deserializer)?;
+        Ok(FileTypeConfig(m))
+    }
+}
+
+impl Serialize for FileTypeConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let map = serializer.serialize_map(Some(self.len()))?;
+        map.end()
+    }
+}
+
+impl std::ops::Deref for FileTypeConfig {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -499,6 +532,7 @@ impl Default for Config {
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            file_types: FileTypeConfig::default(),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -166,7 +166,7 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     /// File type icon/string map for overriding file type.
-    pub file_type_indicators: FileTypeConfig,
+    pub file_type_indicators: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -312,37 +312,6 @@ impl std::ops::Deref for CursorShapeConfig {
 impl Default for CursorShapeConfig {
     fn default() -> Self {
         Self([CursorKind::Block; 3])
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct FileTypeConfig(HashMap<String, String>);
-
-impl<'de> Deserialize<'de> for FileTypeConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let m = HashMap::<String, String>::deserialize(deserializer)?;
-        Ok(FileTypeConfig(m))
-    }
-}
-
-impl Serialize for FileTypeConfig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let map = serializer.serialize_map(Some(self.len()))?;
-        map.end()
-    }
-}
-
-impl std::ops::Deref for FileTypeConfig {
-    type Target = HashMap<String, String>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -532,7 +501,7 @@ impl Default for Config {
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
-            file_type_indicators: FileTypeConfig::default(),
+            file_type_indicators: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
ref: #3164 

This PR introduces a new `[editor.file-types]` config section that will allow custom mappings between the default file type strings and user-defined custom strings. An example:
```toml
[editor.file-types]
"rust" = "rs"
```

will remap the "rust" file type string to "rs" (currently used by the statusline). Glyphs/icons should be supported, if available in the user's font definition.

cc @etienne-k 