### PR TITLE
Fix nondeterministic highlighting

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1358,11 +1358,12 @@ impl HighlightConfiguration {
 
                 let mut best_index = None;
                 let mut best_match_len = 0;
-                let mut best_leftmost = usize::MAX;
+                let mut best_positions = Vec::new();
+                let mut positions = Vec::new();
                 for (i, recognized_name) in recognized_names.iter().enumerate() {
                     let recognized_name = recognized_name;
                     let mut match_len = 0;
-                    let mut leftmost = usize::MAX;
+                    positions.clear();
                     let mut matches = true;
                     for part in recognized_name.split('.') {
                         let pos = capture_parts.iter().position(|a| *a == part);
@@ -1371,20 +1372,21 @@ impl HighlightConfiguration {
                                 matches = false;
                                 break;
                             }
-                            Some(p) => {
-                                if p < leftmost {
-                                    leftmost = p;
-                                }
+                            Some(pos) => {
+                                positions.push(pos);
                                 match_len += 1;
                             }
                         }
                     }
+                    positions.sort_unstable();
 
                     let better_len = match_len > best_match_len;
-                    let better_leftmost = match_len == best_match_len && leftmost < best_leftmost;
-                    if matches && (better_len || better_leftmost) {
+                    let better_positions =
+                        match_len == best_match_len && positions < best_positions; // Vec comparison is lexicographic
+                    if matches && (better_len || better_positions) {
                         best_index = Some(i);
-                        best_leftmost = leftmost;
+                        best_positions.clear();
+                        best_positions.extend_from_slice(positions.as_slice());
                         best_match_len = match_len;
                     }
                 }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1358,12 +1358,12 @@ impl HighlightConfiguration {
 
                 let mut best_index = None;
                 let mut best_match_len = 0;
-                let mut best_positions = Vec::new();
-                let mut positions = Vec::new();
+                let mut best_positions = 0;
+                let capture_parts_len = capture_parts.len();
                 for (i, recognized_name) in recognized_names.iter().enumerate() {
                     let recognized_name = recognized_name;
                     let mut match_len = 0;
-                    positions.clear();
+                    let mut positions = 0; // bitmask for where it matches
                     let mut matches = true;
                     for part in recognized_name.split('.') {
                         let pos = capture_parts.iter().position(|a| *a == part);
@@ -1373,20 +1373,20 @@ impl HighlightConfiguration {
                                 break;
                             }
                             Some(pos) => {
-                                positions.push(pos);
+                                positions += 1 << (capture_parts_len - pos);
                                 match_len += 1;
                             }
                         }
                     }
-                    positions.sort_unstable();
 
                     let better_len = match_len > best_match_len;
+
+                    // bigger positions means that the matches are closer to the start and therefore better.
                     let better_positions =
-                        match_len == best_match_len && positions < best_positions; // Vec comparison is lexicographic
+                        match_len == best_match_len && positions > best_positions;
                     if matches && (better_len || better_positions) {
                         best_index = Some(i);
-                        best_positions.clear();
-                        best_positions.extend_from_slice(positions.as_slice());
+                        best_positions = positions;
                         best_match_len = match_len;
                     }
                 }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1358,20 +1358,34 @@ impl HighlightConfiguration {
 
                 let mut best_index = None;
                 let mut best_match_len = 0;
+                let mut best_leftmost = usize::MAX;
                 for (i, recognized_name) in recognized_names.iter().enumerate() {
                     let recognized_name = recognized_name;
-                    let mut len = 0;
+                    let mut match_len = 0;
+                    let mut leftmost = usize::MAX;
                     let mut matches = true;
                     for part in recognized_name.split('.') {
-                        len += 1;
-                        if !capture_parts.contains(&part) {
-                            matches = false;
-                            break;
+                        let pos = capture_parts.iter().position(|a| *a == part);
+                        match pos {
+                            None => {
+                                matches = false;
+                                break;
+                            }
+                            Some(p) => {
+                                if p < leftmost {
+                                    leftmost = p;
+                                }
+                                match_len += 1;
+                            }
                         }
                     }
-                    if matches && len > best_match_len {
+
+                    let better_len = match_len > best_match_len;
+                    let better_leftmost = match_len == best_match_len && leftmost < best_leftmost;
+                    if matches && (better_len || better_leftmost) {
                         best_index = Some(i);
-                        best_match_len = len;
+                        best_leftmost = leftmost;
+                        best_match_len = match_len;
                     }
                 }
                 best_index.map(Highlight)


### PR DESCRIPTION
Resolves #2986.
Resolves #3230.
Probably resolves #2484 as well, although I didn't have the code to copy paste in order to check :P

This is done by preferring matches in the beginning, i.e. for `keyword.function`, `keyword` is a better match than `function`.

### Explanation of original problem:
Source for non-determinism: `HashMap` traverse order is different each time.

According to comments: 
> Consumers of these queries can choose to recognize highlights with different levels of specificity.
For example, the string `function.builtin` will match against `function.method.builtin` 
and `function.builtin.constructor`, but will not match `function.method`.

`keyword.function `can therefore match both `keyword` and `function`.
 - Both of these matches have the same `match_len` which is what is used to rank them
 - The list of scopes is traversed in order to find the match with the best `match_len`, in the 
   *random* order it came from the HashMap.