### PR TITLE
theme: Add gruvbox alternate contrast modes

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -1,5 +1,5 @@
 # Author : Jakub Bartodziej <kubabartodziej@gmail.com>
-# The theme uses the gruvbox dark palette with standard contrast: github.com/morhetz/gruvbox
+# The theme uses the gruvbox dark palette with medium contrast: github.com/morhetz/gruvbox
 
 "attribute" = "aqua1"
 "keyword" = { fg = "red1" }

--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -1,6 +1,5 @@
-# Author : Rohan Jain <crodjer@pm.me>
 # Author : Jakub Bartodziej <kubabartodziej@gmail.com>
-# The theme uses the gruvbox light palette with medium contrast: github.com/morhetz/gruvbox
+# The theme uses the gruvbox dark palette with hard contrast: github.com/morhetz/gruvbox
 
 "attribute" = "aqua1"
 "keyword" = { fg = "red1" }
@@ -69,32 +68,32 @@
 "markup.raw" = "red1"
 
 [palette]
-bg0 = "#fbf1c7" # main background
-bg1 = "#ebdbb2"
-bg2 = "#d5c4a1"
-bg3 = "#bdae93"
-bg4 = "#a89984"
+bg0 = "#1d2021" # main background
+bg1 = "#3c3836"
+bg2 = "#504945"
+bg3 = "#665c54"
+bg4 = "#7c6f64"
 
-fg0 = "#282828" # main foreground
-fg1 = "#3c3836"
-fg2 = "#504945"
-fg3 = "#665c54"
-fg4 = "#7c6f64" # gray0
+fg0 = "#fbf1c7"
+fg1 = "#ebdbb2" # main foreground
+fg2 = "#d5c4a1"
+fg3 = "#bdae93"
+fg4 = "#a89984" # gray0
 
-gray0 = "#7c6f64"
+gray0 = "#a89984"
 gray1 = "#928374"
 
 red0 = "#cc241d" # neutral
-red1 = "#9d0006" # bright
+red1 = "#fb4934" # bright
 green0 = "#98971a"
-green1 = "#79740e"
+green1 = "#b8bb26"
 yellow0 = "#d79921"
-yellow1 = "#b57614"
+yellow1 = "#fabd2f"
 blue0 = "#458588"
-blue1 = "#076678"
+blue1 = "#83a598"
 purple0 = "#b16286"
-purple1 = "#8f3f71"
+purple1 = "#d3869b"
 aqua0 = "#689d6a"
-aqua1 = "#427b58"
+aqua1 = "#8ec07c"
 orange0 = "#d65d0e"
-orange1 = "#af3a03"
+orange1 = "#fe8019"

--- a/runtime/themes/gruvbox_dark_soft.toml
+++ b/runtime/themes/gruvbox_dark_soft.toml
@@ -1,6 +1,5 @@
-# Author : Rohan Jain <crodjer@pm.me>
 # Author : Jakub Bartodziej <kubabartodziej@gmail.com>
-# The theme uses the gruvbox light palette with medium contrast: github.com/morhetz/gruvbox
+# The theme uses the gruvbox dark palette with soft contrast: github.com/morhetz/gruvbox
 
 "attribute" = "aqua1"
 "keyword" = { fg = "red1" }
@@ -69,32 +68,32 @@
 "markup.raw" = "red1"
 
 [palette]
-bg0 = "#fbf1c7" # main background
-bg1 = "#ebdbb2"
-bg2 = "#d5c4a1"
-bg3 = "#bdae93"
-bg4 = "#a89984"
+bg0 = "#32302f" # main background
+bg1 = "#3c3836"
+bg2 = "#504945"
+bg3 = "#665c54"
+bg4 = "#7c6f64"
 
-fg0 = "#282828" # main foreground
-fg1 = "#3c3836"
-fg2 = "#504945"
-fg3 = "#665c54"
-fg4 = "#7c6f64" # gray0
+fg0 = "#fbf1c7"
+fg1 = "#ebdbb2" # main foreground
+fg2 = "#d5c4a1"
+fg3 = "#bdae93"
+fg4 = "#a89984" # gray0
 
-gray0 = "#7c6f64"
+gray0 = "#a89984"
 gray1 = "#928374"
 
 red0 = "#cc241d" # neutral
-red1 = "#9d0006" # bright
+red1 = "#fb4934" # bright
 green0 = "#98971a"
-green1 = "#79740e"
+green1 = "#b8bb26"
 yellow0 = "#d79921"
-yellow1 = "#b57614"
+yellow1 = "#fabd2f"
 blue0 = "#458588"
-blue1 = "#076678"
+blue1 = "#83a598"
 purple0 = "#b16286"
-purple1 = "#8f3f71"
+purple1 = "#d3869b"
 aqua0 = "#689d6a"
-aqua1 = "#427b58"
+aqua1 = "#8ec07c"
 orange0 = "#d65d0e"
-orange1 = "#af3a03"
+orange1 = "#fe8019"

--- a/runtime/themes/gruvbox_light_hard.toml
+++ b/runtime/themes/gruvbox_light_hard.toml
@@ -1,6 +1,6 @@
 # Author : Rohan Jain <crodjer@pm.me>
 # Author : Jakub Bartodziej <kubabartodziej@gmail.com>
-# The theme uses the gruvbox light palette with medium contrast: github.com/morhetz/gruvbox
+# The theme uses the gruvbox light palette with hard contrast: github.com/morhetz/gruvbox
 
 "attribute" = "aqua1"
 "keyword" = { fg = "red1" }
@@ -69,7 +69,7 @@
 "markup.raw" = "red1"
 
 [palette]
-bg0 = "#fbf1c7" # main background
+bg0 = "#f9f5d7" # main background
 bg1 = "#ebdbb2"
 bg2 = "#d5c4a1"
 bg3 = "#bdae93"

--- a/runtime/themes/gruvbox_light_soft.toml
+++ b/runtime/themes/gruvbox_light_soft.toml
@@ -1,6 +1,6 @@
 # Author : Rohan Jain <crodjer@pm.me>
 # Author : Jakub Bartodziej <kubabartodziej@gmail.com>
-# The theme uses the gruvbox light palette with medium contrast: github.com/morhetz/gruvbox
+# The theme uses the gruvbox light palette with soft contrast: github.com/morhetz/gruvbox
 
 "attribute" = "aqua1"
 "keyword" = { fg = "red1" }
@@ -69,7 +69,7 @@
 "markup.raw" = "red1"
 
 [palette]
-bg0 = "#fbf1c7" # main background
+bg0 = "#f2e5bc" # main background
 bg1 = "#ebdbb2"
 bg2 = "#d5c4a1"
 bg3 = "#bdae93"


### PR DESCRIPTION
These are the same as the existing themes, except bg0 is changed as shown here: https://github.com/morhetz/gruvbox
