### PR TITLE
undo change, no magically added space please, just add Spacer by default

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -41,7 +41,7 @@ You may also specify a file to use for configuration with the `-c` or
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `cursorline` | Highlight all lines with a cursor. | `false` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "line-numbers"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints. | `["diagnostics", "line-numbers", "spacer"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -124,7 +124,7 @@ pub struct Config {
     pub line_number: LineNumber,
     /// Highlight the lines cursors are currently on. Defaults to false.
     pub cursorline: bool,
-    /// Gutters. Default ["diagnostics", "line-numbers"]
+    /// Gutters. Default ["diagnostics", "line-numbers", "spacer"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
@@ -557,7 +557,11 @@ impl Default for Config {
             },
             line_number: LineNumber::Absolute,
             cursorline: false,
-            gutters: vec![GutterType::Diagnostics, GutterType::LineNumbers],
+            gutters: vec![
+                GutterType::Diagnostics,
+                GutterType::LineNumbers,
+                GutterType::Spacer,
+            ],
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,


### PR DESCRIPTION
I believe the idea for https://github.com/helix-editor/helix/pull/2996 was to be able to add a spacer if desired.

Looking ahead to https://github.com/helix-editor/helix/pull/1623 I prefer to have that space filled by git status.

This PR reverts functionality to give this choice back to the user.