### PR TITLE
Fix terminal cursor shape reset

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -801,7 +801,7 @@ impl Application {
     fn restore_term(&mut self) -> Result<(), Error> {
         let mut stdout = stdout();
         // reset cursor shape
-        write!(stdout, "\x1B[2 q")?;
+        write!(stdout, "\x1B[0 q")?;
         // Ignore errors on disabling, this might trigger on windows if we call
         // disable without calling enable previously
         let _ = execute!(stdout, DisableMouseCapture);


### PR DESCRIPTION
I changed [this line](https://github.com/helix-editor/helix/blob/55b45ec4a4cb958b241a93cc7c3f4e499379890e/helix-term/src/application.rs#L791) by changing the 2 to a 0.

The previous escape code `\x1B[2 q` sets the cursor to be a static block according to [this specification](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_). The new escape code `\x1B[0 q` restores the cursor to the user's default.

To be honest, I'm not sure if this will fix the issue for everyone. It fixes it for me on arch linux using gnome and with the alacritty terminal. With this change, when I exit out of helix, my terminal cursor is restored to a blinking underscore.

@DivergentClouds found the solution, which he shared in issue #2684. 

There are also several other terminal-based editors that have had this same issue of not restoring the user's terminal cursor style, such as [here](https://github.com/alacritty/alacritty/issues/2839#issuecomment-537619961) and [here](https://github.com/microsoft/terminal/issues/1604).