### PR TITLE
Add nim language support.

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -65,6 +65,7 @@
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |
 | nickel | ✓ |  | ✓ | `nls` |
+| nim |  |  |  | `nimlangserver` |
 | nix | ✓ |  | ✓ | `rnix-lsp` |
 | nu | ✓ |  |  |  |
 | ocaml | ✓ |  | ✓ | `ocamllsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -455,6 +455,22 @@ name = "nickel"
 source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "9d83db400b6c11260b9106f131f93ddda8131933" }
 
 [[language]]
+name = "nim"
+scope = "source.nim"
+injection-regex = "nim"
+file-types = ["nim", "nims"]
+shebangs = ["nim"]
+roots = []
+auto-format = true
+comment-token = "#"
+language-server = { command = "nimlangserver" }
+indent = { tab-width = 2, unit = " " }
+
+[[grammar]]
+name = "nim"
+source = { git = "https://github.com/aMOPel/tree-sitter-nim", rev = "d8cc0eaa4ba02685690ebe014d7c808cc1f8c789" }
+
+[[language]]
 name = "nix"
 scope = "source.nix"
 injection-regex = "nix"

--- a/languages.toml
+++ b/languages.toml
@@ -461,7 +461,6 @@ injection-regex = "nim"
 file-types = ["nim", "nims"]
 shebangs = ["nim"]
 roots = []
-auto-format = true
 comment-token = "#"
 language-server = { command = "nimlangserver" }
 indent = { tab-width = 2, unit = " " }


### PR DESCRIPTION
Fixes #3117.

I had some spare time, so I just grabbed the top task in the queue as a first. I'm a bit confused though because the language server does [support completions](https://github.com/nim-lang/langserver#features), but that check doesn't get added. Further, even though I've linked the runtime in the branch and fetched and built grammar, that isn't checked either. In `--health` I get:

```
nim                  ✔ nimlangserver      None                 ✘                    ✘                    ✘
```

Not entirely sure why. Any ideas?