### PR TITLE
For removing empty scratch buffers, check that a buffer is empty rather than unmodified

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -831,8 +831,8 @@ impl Editor {
                 // If the current view is an empty scratch buffer and is not displayed in any other views, delete it.
                 // Boolean value is determined before the call to `view_mut` because the operation requires a borrow
                 // of `self.tree`, which is mutably borrowed when `view_mut` is called.
-                let remove_empty_scratch = !doc.is_modified()
-                    // If the buffer has no path and is not modified, it is an empty scratch buffer.
+                let remove_empty_scratch = doc.text() == "\n"
+                    // If the buffer has no path and contains only the default newline, it is an empty scratch buffer.
                     && doc.path().is_none()
                     // If the buffer we are changing to is not this buffer
                     && id != doc.id


### PR DESCRIPTION
This should fix #3305, although I am on a Mac, so I cannot test it myself.