### PR TITLE
Resolve clippy lints

### DIFF
--- a/helix-core/src/increment/date_time.rs
+++ b/helix-core/src/increment/date_time.rs
@@ -5,6 +5,7 @@ use ropey::RopeSlice;
 
 use std::borrow::Cow;
 use std::cmp;
+use std::fmt::Write;
 
 use super::Increment;
 use crate::{Range, Tendril};
@@ -162,7 +163,7 @@ impl Format {
             fields.push(field);
             max_len += field.max_len + remaining[..i].len();
             regex += &remaining[..i];
-            regex += &format!("({})", field.regex);
+            write!(regex, "({})", field.regex).unwrap();
             remaining = &after[spec_len..];
         }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1011,7 +1011,7 @@ impl EditorView {
                     None => return EventResult::Ignored(None),
                 }
 
-                let offset = config.scroll_lines.abs() as usize;
+                let offset = config.scroll_lines.unsigned_abs();
                 commands::scroll(cxt, offset, direction);
 
                 cxt.editor.tree.focus = current_view;

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -4,6 +4,7 @@ use helix_core::Selection;
 use helix_dap::{self as dap, Client, Payload, Request, ThreadId};
 use helix_lsp::block_on;
 use log::warn;
+use std::fmt::Write;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
@@ -180,10 +181,10 @@ impl Editor {
 
                     let mut status = format!("{} stopped because of {}", scope, reason);
                     if let Some(desc) = description {
-                        status.push_str(&format!(" {}", desc));
+                        write!(status, " {}", desc).unwrap();
                     }
                     if let Some(text) = text {
-                        status.push_str(&format!(" {}", text));
+                        write!(status, " {}", text).unwrap();
                     }
                     if all_threads_stopped {
                         status.push_str(" (all threads stopped)");


### PR DESCRIPTION
Clippy was complaining about using `format!` to append to an existing `String`.