### PR TITLE
Add Doom's Acario dark theme.

### DIFF
--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -42,9 +42,13 @@ namespace = { fg = 'red' }
 'ui.background'= { bg = 'bg' }
 'ui.cursor' = { bg = 'orange', fg = 'bg-alt' }
 'ui.cursor.match' = { fg = 'red', modifiers = ['bold'] }
+'ui.cursorline' = { bg = 'bg-alt' }
 'ui.linenr' = { fg = 'base4' }
 'ui.linenr.selected' = { fg = 'orange', bg = 'bg-alt', modifiers = ['bold'] }
 'ui.statusline' = { bg = 'base3' }
+'ui.statusline.normal' = { bg = 'base3' }
+'ui.statusline.insert' = { bg = 'base3' }
+'ui.statusline.select' = { bg = 'base3' }
 'ui.popup' = { bg = 'bg-alt' }
 'ui.window' = { fg = 'gray' }
 'ui.help' = { bg = 'base2' }

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -1,0 +1,89 @@
+# Author : Luna <rinnray@gliroid.com>
+#
+# This was made based on
+# https://github.com/doomemacs/themes/blob/master/themes/doom-acario-dark-theme.el
+# I've done my best to make it work completely, but there's still some things that differ from the emacs version.
+
+type = { fg = 'blue' }
+constructor = { fg = 'red' }
+constant = { fg = 'magenta' }
+'constant.numeric' = { fg = 'orange' }
+string = { fg = 'green' }
+comment = { fg = 'gray', modifiers = ['italic'] }
+'comment.block' = { fg = 'green', modifiers = ['italic'] }
+'comment.block.documentation' = { fg = 'green', modifiers = ['italic'] }
+variable = { fg = 'cyan' }
+'variable.parameter' = { fg = 'blue' }
+label = { fg = 'green' }
+keyword = { fg = 'red' }
+operator = { fg = 'blue' }
+function = { fg = 'yellow' }
+tag = { fg = 'cyan' }
+attribute = { fg = 'blue' }
+attributes = { fg = 'blue' }
+namespace = { fg = 'red' }
+
+'markup.heading' = { fg = 'red' }
+'markup.list' = { fg = 'red' }
+'markup.raw.inline' = { fg = 'green', bg = 'base4' }
+'markup.raw.block' = { fg = 'green', bg = 'base4' }
+'markup.link' = { fg = 'orange' } 
+'markup.link.url' = { fg = 'magenta' }
+'markup.link.text' = { fg = 'orange' }
+'markup.link.label' = { fg = 'green' }
+'markup.quote' = { fg = 'green', modifiers = ['italic'] }
+'markup.bold' = { fg = 'orange', modifiers = ['bold'] }
+'markup.italic' = { fg = 'magenta', modifiers = ['italic'] }
+
+'diff.plus' = { fg = 'green' }
+'diff.minus' = { fg = 'red' }
+'diff.delta' = { fg = 'green' }
+
+'ui.background'= { bg = 'bg' }
+'ui.cursor' = { bg = 'orange', fg = 'bg-alt' }
+'ui.cursor.match' = { fg = 'red', modifiers = ['bold'] }
+'ui.linenr' = { fg = 'base4' }
+'ui.linenr.selected' = { fg = 'orange', bg = 'bg-alt', modifiers = ['bold'] }
+'ui.statusline' = { bg = 'base3' }
+'ui.popup' = { bg = 'bg-alt' }
+'ui.window' = { fg = 'gray' }
+'ui.help' = { bg = 'base2' }
+'ui.text' = { fg = 'fg' }
+'ui.text.focus' = { bg = 'bg-alt', fg = 'fg' }
+'ui.text.info' = { fg = 'fg' }
+'ui.virtual.whitespace' = { fg = 'base2' }
+'ui.virtual.ruler' = { bg = 'black' }
+'ui.menu' = { bg = 'bg-alt' }
+'ui.menu.selected' = { bg = 'base3', fg = 'fg' }
+'ui.selection' = { bg = 'base2' }
+
+warning = { fg = 'orange' }
+error = { fg = 'red', modifiers = ['bold'] }
+info = { fg = 'blue', modifiers = ['bold'] }
+hint = { fg = 'blue', modifiers = ['bold'] }
+
+'diagnostic'= { fg = 'red', modifiers = ['underlined'] }
+'diagnostic.info'= { fg = 'blue', modifiers = ['underlined'] }
+'diagnostic.warning'= { fg = 'yellow', modifiers = ['underlined'] }
+'diagnostic.error'= { fg = 'red', modifiers = ['underlined'] }
+
+'special' = { fg = 'orange' }
+
+[palette]
+black = '#000000'
+red = '#D83441'
+green = '#79D836'
+blue = '#3679D8'
+yellow = '#D8B941'
+magenta = '#8041D8'
+cyan = '#36D8BD'
+gray = '#767676'
+orange = '#D85F00'
+
+# Custom to doom
+bg = '#0D0E16'
+bg-alt = '#040408'
+fg = '#C3DBE5'
+base2 = '#1E1E33'
+base3 = '#464A56'
+base4 = '#585C6C'


### PR DESCRIPTION
This theme is ported from [acario themes](https://github.com/doomemacs/themes/blob/master/themes/doom-acario-dark-theme.el) from Doom Emacs.

I've however only focused on the dark one as that's the one I'm using.