### PR TITLE
Add keybinds for toggling common settings

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -251,30 +251,34 @@ This layer is similar to vim keybindings as kakoune does not support window.
 
 #### Space mode
 
-This layer is a kludge of mappings, mostly pickers.
+This layer contains high-level commands like pickers, some LSP/DAP operations,
+clipboard interaction, window management and other miscellaneous commands.
 
-
-| Key     | Description                                                             | Command                             |
-| -----   | -----------                                                             | -------                             |
-| `f`     | Open file picker                                                        | `file_picker`                       |
-| `b`     | Open buffer picker                                                      | `buffer_picker`                     |
-| `j`     | Open jumplist picker                                                    | `jumplist_picker`                   |
-| `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                             |
-| `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                     |
-| `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`           |
-| `g`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                |
-| `G`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`
-| `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                     |
-| `a`     | Apply code action  (**LSP**)                                            | `code_action`                       |
-| `'`     | Open last fuzzy picker                                                  | `last_picker`                       |
-| `w`     | Enter [window mode](#window-mode)                                       | N/A                                 |
-| `p`     | Paste system clipboard after selections                                 | `paste_clipboard_after`             |
-| `P`     | Paste system clipboard before selections                                | `paste_clipboard_before`            |
-| `y`     | Join and yank selections to clipboard                                   | `yank_joined_to_clipboard`          |
-| `Y`     | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`  |
-| `R`     | Replace selections by clipboard contents                                | `replace_selections_with_clipboard` |
-| `/`     | Global search in workspace folder                                       | `global_search`                     |
-| `?`     | Open command palette                                                    | `command_palette`                   |
+| Key     | Description                                                             | Command                                    |
+| -----   | -----------                                                             | -------                                    |
+| `f`     | Open file picker                                                        | `file_picker`                              |
+| `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`         |
+| `b`     | Open buffer picker                                                      | `buffer_picker`                            |
+| `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
+| `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                            |
+| `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`                  |
+| `g`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                       |
+| `G`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`             |
+| `a`     | Apply code action  (**LSP**)                                            | `code_action`                              |
+| `'`     | Open last fuzzy picker                                                  | `last_picker`                              |
+| `d`     | Debug (experimental)                                                    | N/A                                        |
+| `w`     | Enter [window mode](#window-mode)                                       | N/A                                        |
+| `y`     | Join and yank selections to clipboard                                   | `yank_joined_to_clipboard`                 |
+| `Y`     | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`         |
+| `p`     | Paste system clipboard after selections                                 | `paste_clipboard_after`                    |
+| `P`     | Paste system clipboard before selections                                | `paste_clipboard_before`                   |
+| `R`     | Replace selections by clipboard contents                                | `replace_selections_with_clipboard`        |
+| `t`     | Toggle setting                                                          | `toggle_setting`                           |
+| `/`     | Global search in workspace folder                                       | `global_search`                            |
+| `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
+| `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                            |
+| `h`     | Select symbol references (**LSP**)                                      | `select_references_to_symbol_under_cursor` |
+| `?`     | Open command palette                                                    | `command_palette`                          |
 
 > TIP: Global search displays results in a fuzzy picker, use `space + '` to bring it back up after opening a file.
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4872,9 +4872,10 @@ fn toggle_setting(cx: &mut Context) {
                 'i' => config.indent_guides.render = !config.indent_guides.render,
                 'c' => config.cursorline = !config.cursorline,
                 'r' => {
-                    config.rulers = match config.rulers.as_slice() {
-                        [80] => vec![],
-                        _ => vec![80],
+                    config.rulers = if config.rulers.is_empty() {
+                        vec![80]
+                    } else {
+                        vec![]
                     };
                 }
                 'p' => {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4886,6 +4886,14 @@ fn toggle_setting(cx: &mut Context) {
                         _ => Enable(false),
                     }
                 }
+                'l' => {
+                    use helix_view::editor::LineNumber::{Absolute, Relative};
+
+                    config.line_number = match config.line_number {
+                        Absolute => Relative,
+                        Relative => Absolute,
+                    };
+                }
                 _ => cx.editor.set_error(format!("Unknown setting '{}'", ch)),
             }
 
@@ -4908,6 +4916,8 @@ fn toggle_setting(cx: &mut Context) {
         ("c", "Cursorline"),
         ("r", "Ruler at 80 columns"),
         ("p", "Auto-pairs"),
+        ("l", "Line-number (absolute/relative)"),
+        ("l", "Line-number (absolute, relative)"),
     ];
 
     cx.editor.autoinfo = Some(Info::new(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4911,12 +4911,11 @@ fn toggle_setting(cx: &mut Context) {
     });
 
     let help_text = [
-        ("w", "Whitespace"),
-        ("i", "Indent guides"),
-        ("c", "Cursorline"),
-        ("r", "Ruler at 80 columns"),
-        ("p", "Auto-pairs"),
-        ("l", "Line-number (absolute/relative)"),
+        ("w", "Whitespace (visible, invisible)"),
+        ("i", "Indent guides (on, off)"),
+        ("c", "Cursorline (on, off)"),
+        ("r", "Ruler (80 columns, none)"),
+        ("p", "Auto-pairs (on, off)"),
         ("l", "Line-number (absolute, relative)"),
     ];
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -259,6 +259,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "p" => paste_clipboard_after,
             "P" => paste_clipboard_before,
             "R" => replace_selections_with_clipboard,
+            "t" => toggle_setting,
             "/" => global_search,
             "k" => hover,
             "r" => rename_symbol,


### PR DESCRIPTION
https://user-images.githubusercontent.com/21230295/182493839-da8e7a34-e3b0-4633-bca1-a6c3e67995b5.mp4

This adds a `<space>t` binding that can toggle a few select settings:

* visible whitespace
* indent guides
* cursorline
* a ruler at 80

It's has limitations:

* it's not configurable what is toggled[^1]
* the value of the setting you had before toggling is not possible to restore in all cases without using `:set`


[^1]: IMO this should wait for a more general purpose config language. It's possible to do it in TOML but it wouldn't be particularly elegant. It could be pretty elegant to do it if keymaps were written in something like lisp :P

Closes #2849