### PR TITLE
Add a .ignore file to make ripgrep more useful

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# Things that we don't want ripgrep to search that we do want in git
+# https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering
+
+# This is some minified JS that's straight from mdbook
+book/theme/highlight.js

--- a/.ignore
+++ b/.ignore
@@ -1,5 +1,5 @@
 # Things that we don't want ripgrep to search that we do want in git
 # https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering
 
-# This is some minified JS that's straight from mdbook
+# Minified JS vendored from mdbook
 book/theme/highlight.js


### PR DESCRIPTION
I've been using this .ignore file while working on Helix to let me use ripgrep without getting a big block of spurious result in highlight.js. I thought it might be useful for others. No worries if it isn't, I can just add it to my .git/info/exclude.