### PR TITLE
`feat` add new command to launch external terminal

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -425,6 +425,7 @@ impl MappableCommand {
         shell_insert_output, "Insert shell command output before selections",
         shell_append_output, "Append shell command output after selections",
         shell_keep_pipe, "Filter selections with shell predicate",
+        launch_external_terminal, "Launch external terminal",
         suspend, "Suspend and return to shell",
         rename_symbol, "Rename symbol",
         increment, "Increment item under cursor",
@@ -4644,6 +4645,28 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
             shell(cx, input, &behavior);
         },
     );
+}
+
+fn launch_external_terminal(cx: &mut Context) {
+    let terminal = &cx.editor.config().terminal;
+
+    if terminal.is_empty() {
+        cx.editor.set_error("Missing terminal config");
+        return;
+    }
+
+    match std::env::current_dir() {
+        Ok(current_dir) => match std::process::Command::new(terminal)
+            .arg(current_dir)
+            .spawn()
+        {
+            Ok(_) => (),
+            Err(_) => cx
+                .editor
+                .set_error("Launching terminal failed, make sure it's configured correctly"),
+        },
+        Err(_) => cx.editor.set_error("Launching terminal failed"),
+    }
 }
 
 fn suspend(_cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -212,6 +212,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "G" => workspace_diagnostics_picker,
             "a" => code_action,
             "'" => last_picker,
+            "`" => launch_external_terminal,
             "d" => { "Debug (experimental)" sticky=true
                 "l" => dap_launch,
                 "b" => dap_toggle_breakpoint,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -120,6 +120,8 @@ pub struct Config {
     pub mouse: bool,
     /// Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
     pub shell: Vec<String>,
+    /// Path to terminal executable file
+    pub terminal: String,
     /// Line number mode.
     pub line_number: LineNumber,
     /// Highlight the lines cursors are currently on. Defaults to false.
@@ -479,6 +481,7 @@ impl Default for Config {
             } else {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },
+            terminal: String::new(),
             line_number: LineNumber::Absolute,
             cursorline: false,
             gutters: vec![GutterType::Diagnostics, GutterType::LineNumbers],


### PR DESCRIPTION
Add a new command to launch external `terminal`, defined in the config file, with **Space+`**