### PR TITLE
Respect SIG_IGN for SIGTSTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "helix-view",
  "ignore",
  "indoc",
+ "libc",
  "log",
  "once_cell",
  "pulldown-cmark",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -43,7 +43,6 @@ signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 arc-swap = { version = "1.5.1" }
-libc = "0.2"
 
 # Logging
 fern = "0.6"
@@ -73,6 +72,7 @@ retain_mut = "0.1.7"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
+libc = "0.2"
 
 [build-dependencies]
 helix-loader = { version = "0.6", path = "../helix-loader" }

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -43,6 +43,7 @@ signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 arc-swap = { version = "1.5.1" }
+libc = "0.2"
 
 # Logging
 fern = "0.6"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -209,6 +209,7 @@ impl Application {
         #[cfg(windows)]
         let signals = futures_util::stream::empty();
 
+        #[cfg(not(windows))]
         let mut app_signals = vec![signal::SIGTSTP, signal::SIGCONT];
         unsafe {
             // X platform constants
@@ -223,7 +224,6 @@ impl Application {
                 ENABLE_SIGTSTP.set(true).unwrap();
             }
         }
-        #[cfg(not(windows))]
         let signals = Signals::new(app_signals).context("build signal handler")?;
 
         let app = Self {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -859,15 +859,14 @@ fn get_signals() -> Signals {
     const HX_SIG_IGN: libc::sighandler_t = 1;
     const HX_SIG_ERR: libc::sighandler_t = 0;
     let mut app_signals = vec![HX_SIGTSTP, HX_SIGCONT];
-    let mut enable_sigtstp = true;
-    unsafe {
-        // If SIGTSTP is SIG_IGN, then do not listen for it
-        if libc::signal(HX_SIGTSTP, HX_SIG_IGN) != HX_SIG_ERR {
-            log::debug!("Disabling SIGTSTP, C-z will not suspend Helix");
-            app_signals.remove(0);
-            enable_sigtstp = false;
-        }
-    }
+    // If SIGTSTP is SIG_IGN, then do not listen for it
+    let enable_sigtstp = if unsafe { libc::signal(HX_SIGTSTP, HX_SIG_IGN) } != HX_SIG_ERR {
+        log::debug!("Disabling SIGTSTP, C-z will not suspend Helix");
+        app_signals.remove(0);
+        false
+    } else {
+        true
+    };
 
     if let Err(e) = ENABLE_SIGTSTP.set(enable_sigtstp) {
         eprintln!("ENABLE_SIGTSTP error: {}", e);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -859,10 +859,10 @@ fn check_enable_suspend() -> bool {
 }
 
 #[cfg(not(windows))]
-fn get_available_signals(enable_suspend: bool) -> Result<Signals, std::io::Error> {
+fn get_available_signals(enable_suspend: bool) -> Result<Signals, Error> {
     let mut app_signals = vec![libc::SIGCONT];
     if enable_suspend {
         app_signals.push(libc::SIGTSTP);
     }
-    Signals::new(app_signals)
+    Signals::new(app_signals).context("build signal handler")
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -871,5 +871,5 @@ fn get_signals() -> Signals {
     if let Err(e) = ENABLE_SIGTSTP.set(enable_sigtstp) {
         eprintln!("ENABLE_SIGTSTP error: {}", e);
     }
-    Signals::new(app_signals).expect("build signal handler")
+    Signals::new(app_signals).context("build signal handler")
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -869,6 +869,8 @@ fn get_signals() -> Signals {
         }
     }
 
-    ENABLE_SIGTSTP.set(enable_sigtstp);
+    if let Err(e) = ENABLE_SIGTSTP.set(enable_sigtstp) {
+        eprintln!("ENABLE_SIGTSTP error: {}", e);
+    }
     Signals::new(app_signals).expect("build signal handler")
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -212,9 +212,6 @@ impl Application {
         #[cfg(not(windows))]
         let signals = get_signals();
 
-        #[cfg(windows)]
-        ENABLE_SIGTSTP.set(false);
-
         let app = Self {
             compositor,
             editor,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -868,8 +868,6 @@ fn get_signals() -> Signals {
         true
     };
 
-    if let Err(e) = ENABLE_SIGTSTP.set(enable_sigtstp) {
-        eprintln!("ENABLE_SIGTSTP error: {}", e);
-    }
+    ENABLE_SIGTSTP.set(enable_sigtstp).ok();
     Signals::new(app_signals).context("build signal handler")
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -210,7 +210,7 @@ impl Application {
         let signals = futures_util::stream::empty();
 
         #[cfg(not(windows))]
-        let signals = get_signals();
+        let signals = get_signals()?;
 
         let app = Self {
             compositor,
@@ -850,7 +850,7 @@ impl Application {
 }
 
 #[cfg(not(windows))]
-fn get_signals() -> Signals {
+fn get_signals() -> Result<Signals, std::io::Error> {
     const HX_SIGTSTP: libc::c_int = 20;
     const HX_SIGCONT: libc::c_int = 18;
     const HX_SIG_IGN: libc::sighandler_t = 1;
@@ -866,5 +866,5 @@ fn get_signals() -> Signals {
     };
 
     ENABLE_SIGTSTP.set(enable_sigtstp).ok();
-    Signals::new(app_signals).context("build signal handler")
+    Signals::new(app_signals)
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -126,14 +126,14 @@ impl Application {
 
         // Handle signals now, so we can pass flag to the Editor
         #[cfg(windows)]
-        let enable_suspend = false;
+        let suspend_enabled = false;
         #[cfg(windows)]
         let signals = futures_util::stream::empty();
 
         #[cfg(not(windows))]
-        let enable_suspend = check_enable_suspend();
+        let suspend_enabled = check_suspend_enabled();
         #[cfg(not(windows))]
-        let signals = get_available_signals(enable_suspend)?;
+        let signals = get_available_signals(suspend_enabled)?;
 
         let mut editor = Editor::new(
             compositor.size(),
@@ -142,7 +142,7 @@ impl Application {
             Box::new(Map::new(Arc::clone(&config), |config: &Config| {
                 &config.editor
             })),
-            enable_suspend,
+            suspend_enabled,
         );
 
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
@@ -854,14 +854,14 @@ impl Application {
 }
 
 #[cfg(not(windows))]
-fn check_enable_suspend() -> bool {
+fn check_suspend_enabled() -> bool {
     unsafe { libc::signal(libc::SIGTSTP, libc::SIG_IGN) == 0 }
 }
 
 #[cfg(not(windows))]
-fn get_available_signals(enable_suspend: bool) -> Result<Signals, Error> {
+fn get_available_signals(suspend_enabled: bool) -> Result<Signals, Error> {
     let mut app_signals = vec![libc::SIGCONT];
-    if enable_suspend {
+    if suspend_enabled {
         app_signals.push(libc::SIGTSTP);
     }
     Signals::new(app_signals).context("build signal handler")

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -210,9 +210,11 @@ impl Application {
 
         let mut app_signals = vec![signal::SIGTSTP, signal::SIGCONT];
         unsafe {
+            // X platform constants
+            const HX_SIG_IGN: libc::sighandler_t = 1;
+            const HX_SIG_ERR: libc::sighandler_t = 0;
             // If SIGTSTP is SIG_IGN, then do not listen for it
-            let tstp = libc::signal(signal_hook::consts::SIGTSTP, /*SIG_IGN*/ 1);
-            if tstp != /*SIG_ERR*/ 0 {
+            if libc::signal(signal_hook::consts::SIGTSTP, HX_SIG_IGN) != HX_SIG_ERR {
                 log::debug!("Disabling SIGTSTP, C-z will not suspend Helix");
                 ENABLE_SIGTSTP = false;
                 app_signals.remove(0);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -44,6 +44,7 @@ type Signals = futures_util::stream::Empty<()>;
 
 const LSP_DEADLINE: Duration = Duration::from_millis(16);
 
+// Allow compilation on Windows by forwarding these
 const HX_SIGTSTP: libc::c_int = 20;
 const HX_SIGCONT: libc::c_int = 18;
 const HX_SIG_IGN: libc::sighandler_t = 1;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -44,7 +44,7 @@ type Signals = futures_util::stream::Empty<()>;
 const LSP_DEADLINE: Duration = Duration::from_millis(16);
 
 // Allow compilation on Windows by forwarding these
-const HX_SIGTSTP: libc::c_int = 20;
+pub const HX_SIGTSTP: libc::c_int = 20;
 const HX_SIGCONT: libc::c_int = 18;
 const HX_SIG_IGN: libc::sighandler_t = 1;
 const HX_SIG_ERR: libc::sighandler_t = 0;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,7 +4647,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    if cfg!(not(windows)) && *crate::application::ENABLE_SIGTSTP.get() == Some(true) {
+    if cfg!(not(windows)) && crate::application::ENABLE_SIGTSTP.get() == Some(&true) {
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4651,7 +4651,8 @@ fn suspend(cx: &mut Context) {
         #[cfg(not(windows))]
         signal_hook::low_level::raise(libc::SIGTSTP).unwrap();
     } else {
-        cx.editor.set_status("Suspend is not supported by this terminal");
+        cx.editor
+            .set_status("Suspend is not supported by this terminal");
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,11 +4647,12 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    unsafe {
-        if crate::application::ENABLE_SIGTSTP {
-            #[cfg(not(windows))]
-            signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
-        }
+    if *crate::application::ENABLE_SIGTSTP
+        .get()
+        .expect("SIGSTOP flag must be set")
+    {
+        #[cfg(not(windows))]
+        signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,7 +4647,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    if _cx.editor.sigtstp_enabled() {
+    if _cx.editor.suspend_enabled {
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,11 +4647,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    if *crate::application::ENABLE_SIGTSTP
-        .get()
-        .expect("ENABLE_SIGTSTP flag must be set")
-    {
-        #[cfg(not(windows))]
+    if cfg!(not(windows)) && *crate::application::ENABLE_SIGTSTP.get() == Some(true) {
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4649,7 +4649,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 fn suspend(_cx: &mut Context) {
     if *crate::application::ENABLE_SIGTSTP
         .get()
-        .expect("SIGSTOP flag must be set")
+        .expect("ENABLE_SIGTSTP flag must be set")
     {
         #[cfg(not(windows))]
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,9 +4647,11 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(cx: &mut Context) {
-    if cx.editor.suspend_enabled {
+    if cfg!(not(windows)) && cx.editor.suspend_enabled {
         #[cfg(not(windows))]
         signal_hook::low_level::raise(libc::SIGTSTP).unwrap();
+    } else {
+        cx.editor.set_status("Suspend is not supported by this terminal");
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4648,6 +4648,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 
 fn suspend(_cx: &mut Context) {
     if _cx.editor.suspend_enabled {
+        #[cfg(not(windows))]
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -43,7 +43,7 @@ use insert::*;
 use movement::Movement;
 
 use crate::{
-    args,
+    application, args,
     compositor::{self, Component, Compositor},
     keymap::ReverseKeymap,
     ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
@@ -4646,10 +4646,9 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
     );
 }
 
-fn suspend(_cx: &mut Context) {
-    if _cx.editor.suspend_enabled {
-        #[cfg(not(windows))]
-        signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
+fn suspend(cx: &mut Context) {
+    if cx.editor.suspend_enabled {
+        signal_hook::low_level::raise(application::HX_SIGTSTP).unwrap();
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4648,6 +4648,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 
 fn suspend(cx: &mut Context) {
     if cx.editor.suspend_enabled {
+        #[cfg(not(windows))]
         signal_hook::low_level::raise(application::HX_SIGTSTP).unwrap();
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,8 +4647,12 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    #[cfg(not(windows))]
-    signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
+    unsafe {
+        if crate::application::ENABLE_SIGTSTP {
+            #[cfg(not(windows))]
+            signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
+        }
+    }
 }
 
 fn add_newline_above(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -43,7 +43,7 @@ use insert::*;
 use movement::Movement;
 
 use crate::{
-    application, args,
+    args,
     compositor::{self, Component, Compositor},
     keymap::ReverseKeymap,
     ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
@@ -4649,7 +4649,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 fn suspend(cx: &mut Context) {
     if cx.editor.suspend_enabled {
         #[cfg(not(windows))]
-        signal_hook::low_level::raise(application::HX_SIGTSTP).unwrap();
+        signal_hook::low_level::raise(libc::SIGTSTP).unwrap();
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4647,7 +4647,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
 }
 
 fn suspend(_cx: &mut Context) {
-    if cfg!(not(windows)) && crate::application::ENABLE_SIGTSTP.get() == Some(&true) {
+    if _cx.editor.sigtstp_enabled() {
         signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP).unwrap();
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -20,10 +20,7 @@ use std::{
     num::NonZeroUsize,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 use tokio::{
@@ -582,7 +579,7 @@ pub struct Editor {
     pub exit_code: i32,
 
     pub config_events: (UnboundedSender<ConfigEvent>, UnboundedReceiver<ConfigEvent>),
-    handle_sigtstp: AtomicBool,
+    handle_sigtstp: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -653,7 +650,7 @@ impl Editor {
             auto_pairs,
             exit_code: 0,
             config_events: unbounded_channel(),
-            handle_sigtstp: AtomicBool::new(true),
+            handle_sigtstp: true,
         }
     }
 
@@ -1165,12 +1162,12 @@ impl Editor {
     }
 
     /// Disables SIGTSTP handling
-    pub fn disable_sigtstp(&self) {
-        self.handle_sigtstp.store(false, Ordering::Relaxed)
+    pub fn disable_sigtstp(&mut self) {
+        self.handle_sigtstp = false;
     }
 
     /// Check if we should react to SIGTSTP
     pub fn sigtstp_enabled(&self) -> bool {
-        self.handle_sigtstp.load(Ordering::Relaxed)
+        self.handle_sigtstp
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -579,7 +579,7 @@ pub struct Editor {
     pub exit_code: i32,
 
     pub config_events: (UnboundedSender<ConfigEvent>, UnboundedReceiver<ConfigEvent>),
-    handle_sigtstp: bool,
+    pub suspend_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -613,6 +613,7 @@ impl Editor {
         theme_loader: Arc<theme::Loader>,
         syn_loader: Arc<syntax::Loader>,
         config: Box<dyn DynAccess<Config>>,
+        enable_suspend: bool,
     ) -> Self {
         let language_servers = helix_lsp::Registry::new();
         let conf = config.load();
@@ -650,7 +651,7 @@ impl Editor {
             auto_pairs,
             exit_code: 0,
             config_events: unbounded_channel(),
-            handle_sigtstp: true,
+            suspend_enabled: enable_suspend,
         }
     }
 
@@ -1159,15 +1160,5 @@ impl Editor {
         )
         .await
         .map(|_| ())
-    }
-
-    /// Disables SIGTSTP handling
-    pub fn disable_sigtstp(&mut self) {
-        self.handle_sigtstp = false;
-    }
-
-    /// Check if we should react to SIGTSTP
-    pub fn sigtstp_enabled(&self) -> bool {
-        self.handle_sigtstp
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -613,7 +613,7 @@ impl Editor {
         theme_loader: Arc<theme::Loader>,
         syn_loader: Arc<syntax::Loader>,
         config: Box<dyn DynAccess<Config>>,
-        enable_suspend: bool,
+        suspend_enabled: bool,
     ) -> Self {
         let language_servers = helix_lsp::Registry::new();
         let conf = config.load();
@@ -651,7 +651,7 @@ impl Editor {
             auto_pairs,
             exit_code: 0,
             config_events: unbounded_channel(),
-            suspend_enabled: enable_suspend,
+            suspend_enabled,
         }
     }
 


### PR DESCRIPTION
This implementation is probably ugly.

Any pointers to make it cleaner is much appreciated!

It works, tested with `elvish`, `bash`, `zsh` and `sh`. It correctly disables `C-z` for `elvish` but not the others.

Fixes #3321