### PR TITLE
Fix indent guide styling

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -430,7 +430,7 @@ impl EditorView {
                     viewport.x + (i * tab_width as u16) - offset.col as u16,
                     viewport.y + line,
                     &indent_guide_char,
-                    indent_style,
+                    text_style.patch(indent_style),
                 );
             }
         };
@@ -487,14 +487,7 @@ impl EditorView {
                                 );
                             }
 
-                            // This is an empty line; draw indent guides at previous line's
-                            // indent level to avoid breaking the guides on blank lines.
-                            if visual_x == 0 {
-                                draw_indent_guides(last_line_indent_level, line, surface);
-                            } else if is_in_indent_area {
-                                // A line with whitespace only
-                                draw_indent_guides(visual_x, line, surface);
-                            }
+                            draw_indent_guides(last_line_indent_level, line, surface);
 
                             visual_x = 0;
                             line += 1;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -414,7 +414,11 @@ impl EditorView {
 
         let mut is_in_indent_area = true;
         let mut last_line_indent_level = 0;
-        let indent_style = theme.get("ui.virtual.indent-guide");
+
+        // use whitespace style as fallback for indent-guide
+        let indent_guide_style = theme
+            .try_get("ui.virtual.indent-guide")
+            .unwrap_or_else(|| theme.get("ui.virtual.whitespace"));
 
         let draw_indent_guides = |indent_level, line, surface: &mut Surface| {
             if !config.indent_guides.render {
@@ -430,7 +434,7 @@ impl EditorView {
                     viewport.x + (i * tab_width as u16) - offset.col as u16,
                     viewport.y + line,
                     &indent_guide_char,
-                    text_style.patch(indent_style),
+                    text_style.patch(indent_guide_style),
                 );
             }
         };

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -416,9 +416,11 @@ impl EditorView {
         let mut last_line_indent_level = 0;
 
         // use whitespace style as fallback for indent-guide
-        let indent_guide_style = theme
-            .try_get("ui.virtual.indent-guide")
-            .unwrap_or_else(|| theme.get("ui.virtual.whitespace"));
+        let indent_guide_style = text_style.patch(
+            theme
+                .try_get("ui.virtual.indent-guide")
+                .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
+        );
 
         let draw_indent_guides = |indent_level, line, surface: &mut Surface| {
             if !config.indent_guides.render {
@@ -434,7 +436,7 @@ impl EditorView {
                     viewport.x + (i * tab_width as u16) - offset.col as u16,
                     viewport.y + line,
                     &indent_guide_char,
-                    text_style.patch(indent_guide_style),
+                    indent_guide_style,
                 );
             }
         };

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -81,7 +81,6 @@
 
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
-"ui.virtual.indent-guide" = { bg = "dark_gray4" }
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -81,6 +81,7 @@
 
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
+"ui.virtual.indent-guide" = { fg = "dark_gray4" }
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }


### PR DESCRIPTION
Resolves #3298.
The problem was that the indent guides would render on top of whitespace, and get their theme. The incorrect looking white indent guides were actually correct according to the theme.
The first part of the fix is to make the indent guides actually use the indent guide theme.
The second part is to make indent guides a sub theme of whitespace so that when not defined they will look like whitespace, which is the desired behavior. I updated all themes that set `ui.virtual.indent-guide` to use `ui.virtual.whitespace.indent-guide`, as well as updating the documentation.