### PR TITLE
Detect indent-style in `:set-language`

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1254,6 +1254,7 @@ fn language(
 
     let doc = doc_mut!(cx.editor);
     doc.set_language_by_language_id(&args[0], cx.editor.syn_loader.clone());
+    doc.detect_indent_and_line_ending();
 
     let id = doc.id();
     cx.editor.refresh_language_server(id);


### PR DESCRIPTION
Indent style may change when choosing a language with `:set-language`.
Line-endings most likely will not change, but `:set-language` should
have a similar effect as reloading a file (`:reload`), plus the two
are currently grouped in the implementation and line-ending detection
is not particularly expensive.

That this didn't happen (prior to this change) is more noticeable because of https://github.com/helix-editor/helix/pull/3095