### PR TITLE
fix: add elvish completions

### DIFF
--- a/contrib/completion/hx.elv
+++ b/contrib/completion/hx.elv
@@ -1,0 +1,49 @@
+# You can move it here ~/.config/elvish/lib/hx.elv
+# Or add `eval (slurp < ~/$REPOS/helix/contrib/completion/hx.elv)`
+# Be sure to replace `$REPOS` with something that makes sense for you!
+
+### Renders a pretty completion candidate
+var candidate = { | _stem  _desc | 
+  edit:complex-candidate $_stem &display=(styled $_stem bold)(styled " "$_desc dim)
+}
+
+### These commands will invalidate further input (i.e. not react to them)
+var skips = [ "--tutor" "--help" "--version" "-V" "--health" ]
+
+### Grammar commands
+var grammar = [ "--grammar" "-g" ]
+
+### Config commands
+var config = [ "--config" "-c" ]
+
+### Set an arg-completer for the `hx` binary
+set edit:completion:arg-completer[hx] = {|@args|
+  var n = (count $args)
+  if (>= $n 3) {
+    # Stop completions if passed arg will take presedence
+    # and invalidate further input
+    if (has-value $skips $args[-2]) {
+      return
+    } 
+    # If the previous arg == --grammar, then only suggest:
+    if (has-value $grammar $args[-2]) {
+      $candidate "fetch" "Fetch the tree-sitter grammars"
+      $candidate "build" "Build the tree-sitter grammars"
+      return
+    } 
+    # When we have --config, we need a file
+    if (has-values $config $args[-2]) {
+      edit:complete-filename $args[-1] | each { |v| put $v[stem] }
+      return
+    } 
+  } 
+  edit:complete-filename $args[-1] | each { |v| put $v[stem]}
+  $candidate "--help" "(Prints help information)"
+  $candidate "--version" "(Prints version information)"
+  $candidate "--tutor" "(Loads the tutorial)"
+  $candidate "--health" "(Checks for errors in editor setup)"
+  $candidate "--grammar" "(Fetch or build the tree-sitter grammars)"
+  $candidate "--vsplit" "(Splits all given files vertically)"
+  $candidate "--hsplit" "(Splits all given files horizontally)"
+  $candidate "--config" "(Specifies a file to use for configuration)"
+}


### PR DESCRIPTION
# Completions for the _awesome_ [Elvish](elv.sh) shell!

It has the expected basics:

![image](https://user-images.githubusercontent.com/721090/182932821-9b3cf3bf-514c-4414-8395-b961c09becfa.png)

But then `-g` and `--grammar` leads to only two suggestions

![image](https://user-images.githubusercontent.com/721090/182932963-1e836383-d10a-4b2d-b988-cd5a9a5f968d.png)

`--config` will only show files in it's completions.

Finally, flags that will not open the editor will stop further suggestions.