### PR TITLE
Derive Document language name from languages.toml name key

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -863,10 +863,7 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
                 }
             };
             let doc = doc!(editor);
-            let language = doc
-                .language()
-                .and_then(|scope| scope.strip_prefix("source."))
-                .unwrap_or("");
+            let language = doc.language_name().unwrap_or("");
 
             let signature = match response
                 .signatures

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -321,10 +321,7 @@ impl Component for Completion {
             // option.documentation
 
             let (view, doc) = current!(cx.editor);
-            let language = doc
-                .language()
-                .and_then(|scope| scope.strip_prefix("source."))
-                .unwrap_or("");
+            let language = doc.language_name().unwrap_or("");
             let text = doc.text().slice(..);
             let cursor_pos = doc.selection(view.id).primary().cursor(text);
             let coords = helix_core::visual_coords_at_pos(text, cursor_pos, doc.tab_width());

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -329,7 +329,7 @@ fn render_file_type<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    let file_type = context.doc.language_id().unwrap_or("text");
+    let file_type = context.doc.language_name().unwrap_or("text");
 
     write(context, format!(" {} ", file_type), None);
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -927,22 +927,32 @@ impl Document {
     }
 
     /// Corresponding language scope name. Usually `source.<lang>`.
-    pub fn language(&self) -> Option<&str> {
+    pub fn language_scope(&self) -> Option<&str> {
         self.language
             .as_ref()
             .map(|language| language.scope.as_str())
+    }
+
+    /// Language name for the document. Corresponds to the `name` key in
+    /// `languages.toml` configuration.
+    pub fn language_name(&self) -> Option<&str> {
+        self.language
+            .as_ref()
+            .map(|language| language.language_id.as_str())
     }
 
     /// Language ID for the document. Either the `language-id` from the
     /// `language-server` configuration, or the document language if no
     /// `language-id` has been specified.
     pub fn language_id(&self) -> Option<&str> {
-        self.language_config()?
+        let language_config = self.language.as_deref()?;
+
+        language_config
             .language_server
             .as_ref()?
             .language_id
             .as_deref()
-            .or_else(|| Some(self.language()?.rsplit_once('.')?.1))
+            .or(Some(language_config.language_id.as_str()))
     }
 
     /// Corresponding [`LanguageConfiguration`].


### PR DESCRIPTION
This changes switches from deriving the language name from the
`languages.toml` `scope` key to `name` (`language_id` in the
`LanguageConfiguration` type). For the most part it works to derive
the language name from scope by chopping off `source.` or `rsplit_once`
on `.` but for some languages we have now like html (`text.html.basic`),
it doesn't. This should be a more accurate fallback for the `language_id`
method which is used in LSP and currently uses the `rsplit_once`
strategy.

Here we expose the language's name as `language_name` on `Document` and
replace ad-hoc calculations of the language name with the new method.

This is most impactful for the `file-type` statusline element which is
currently using `language_id`.

It should also improve highlighting in popups for languages like html, erb, ejs, maybe solidity. For most languages there should be no functional changes from this PR.

Supersedes https://github.com/helix-editor/helix/pull/2998
Should make https://github.com/helix-editor/helix/pull/3273 more accurate