### PR TITLE
Adjust `m` textobject description and minor code clarification

### DIFF
--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -198,26 +198,26 @@ pub fn textobject_paragraph(
     Range::new(anchor, head)
 }
 
-pub fn textobject_surround(
+pub fn pair_surround(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     ch: char,
     count: usize,
 ) -> Range {
-    textobject_surround_impl(slice, range, textobject, Some(ch), count)
+    pair_surround_impl(slice, range, textobject, Some(ch), count)
 }
 
-pub fn textobject_surround_closest(
+pub fn pair_surround_closest(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     count: usize,
 ) -> Range {
-    textobject_surround_impl(slice, range, textobject, None, count)
+    pair_surround_impl(slice, range, textobject, None, count)
 }
 
-fn textobject_surround_impl(
+fn pair_surround_impl(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
@@ -562,7 +562,7 @@ mod test {
             let slice = doc.slice(..);
             for &case in scenario {
                 let (pos, objtype, expected_range, ch, count) = case;
-                let result = textobject_surround(slice, Range::point(pos), objtype, ch, count);
+                let result = pair_surround(slice, Range::point(pos), objtype, ch, count);
                 assert_eq!(
                     result,
                     expected_range.into(),

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -198,26 +198,26 @@ pub fn textobject_paragraph(
     Range::new(anchor, head)
 }
 
-pub fn pair_surround(
+pub fn textobject_pair_surround(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     ch: char,
     count: usize,
 ) -> Range {
-    pair_surround_impl(slice, range, textobject, Some(ch), count)
+    textobject_pair_surround_impl(slice, range, textobject, Some(ch), count)
 }
 
-pub fn pair_surround_closest(
+pub fn textobject_pair_surround_closest(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     count: usize,
 ) -> Range {
-    pair_surround_impl(slice, range, textobject, None, count)
+    textobject_pair_surround_impl(slice, range, textobject, None, count)
 }
 
-fn pair_surround_impl(
+fn textobject_pair_surround_impl(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
@@ -562,7 +562,7 @@ mod test {
             let slice = doc.slice(..);
             for &case in scenario {
                 let (pos, objtype, expected_range, ch, count) = case;
-                let result = pair_surround(slice, Range::point(pos), objtype, ch, count);
+                let result = textobject_pair_surround(slice, Range::point(pos), objtype, ch, count);
                 assert_eq!(
                     result,
                     expected_range.into(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4332,10 +4332,10 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'o' => textobject_treesitter("comment", range),
                         't' => textobject_treesitter("test", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
-                        'm' => textobject::textobject_surround_closest(text, range, objtype, count),
+                        'm' => textobject::pair_surround_closest(text, range, objtype, count),
                         // TODO: cancel new ranges if inconsistent surround matches across lines
                         ch if !ch.is_ascii_alphanumeric() => {
-                            textobject::textobject_surround(text, range, objtype, ch, count)
+                            textobject::pair_surround(text, range, objtype, ch, count)
                         }
                         _ => range,
                     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4361,7 +4361,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("a", "Argument/parameter (tree-sitter)"),
             ("o", "Comment (tree-sitter)"),
             ("t", "Test (tree-sitter)"),
-            ("m", "Closest pair to cursor"),
+            ("m", "Closest surrounding pair to cursor"),
             (" ", "... or any character acting as a pair"),
         ];
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4361,7 +4361,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("a", "Argument/parameter (tree-sitter)"),
             ("o", "Comment (tree-sitter)"),
             ("t", "Test (tree-sitter)"),
-            ("m", "Nearest matching brace-like pair"),
+            ("m", "Closest pair to cursor"),
             (" ", "... or any character acting as a pair"),
         ];
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4332,10 +4332,12 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'o' => textobject_treesitter("comment", range),
                         't' => textobject_treesitter("test", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
-                        'm' => textobject::pair_surround_closest(text, range, objtype, count),
+                        'm' => textobject::textobject_pair_surround_closest(
+                            text, range, objtype, count,
+                        ),
                         // TODO: cancel new ranges if inconsistent surround matches across lines
                         ch if !ch.is_ascii_alphanumeric() => {
-                            textobject::pair_surround(text, range, objtype, ch, count)
+                            textobject::textobject_pair_surround(text, range, objtype, ch, count)
                         }
                         _ => range,
                     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4361,7 +4361,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
             ("a", "Argument/parameter (tree-sitter)"),
             ("o", "Comment (tree-sitter)"),
             ("t", "Test (tree-sitter)"),
-            ("m", "Matching delimiter under cursor"),
+            ("m", "Nearest matching brace-like pair"),
             (" ", "... or any character acting as a pair"),
         ];
 


### PR DESCRIPTION
Minor cleanups for easier understanding of functionality and code.