### PR TITLE
Rust queries: add `(function_item)` as a local scope

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -1,7 +1,10 @@
 ; Scopes
 
-(block) @local.scope
-(closure_expression) @local.scope
+[
+  (function_item)
+  (closure_expression)
+  (block)
+] @local.scope
 
 ; Definitions
 


### PR DESCRIPTION
Function parameter highlighting was leaking into other scopes.

before:
![image](https://user-images.githubusercontent.com/17070041/183241218-22e4cc54-609f-42ef-9744-41646a5e7e8f.png)

after:
![image](https://user-images.githubusercontent.com/17070041/183241249-d3b3dbab-0609-4b21-8f30-26ce2ab14aff.png)