### PR TITLE
feat: Find diagnostics for both `C:` and `c:` forms of a path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "unicode-general-category",
  "unicode-segmentation",
  "unicode-width",
+ "url",
 ]
 
 [[package]]

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -32,6 +32,7 @@ regex = "1"
 bitflags = "1.3"
 ahash = "0.8.2"
 hashbrown = { version = "0.13.1", features = ["raw"] }
+url = "2"
 
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod line_ending;
 pub mod macros;
 pub mod match_brackets;
 pub mod movement;
+pub mod normalized_url;
 pub mod object;
 pub mod path;
 mod position;

--- a/helix-core/src/normalized_url.rs
+++ b/helix-core/src/normalized_url.rs
@@ -47,8 +47,11 @@ impl NormalizedUrl {
         Some(Self::new(base))
     }
 
-    /// Access the `Url` stored as the base of the normalized one
-    pub fn base(&self) -> &Url {
+    /// Access the `Url` stored as the base of the normalized one.
+    ///
+    /// If you have the possibility to consume `self` because it's not used later, consider using
+    /// [`Self::into_base()`], especially if you are cloning after the current `.base()` call.
+    pub fn as_base(&self) -> &Url {
         &self.base
     }
 
@@ -66,6 +69,13 @@ impl NormalizedUrl {
     /// See [`Url::path_segments()`]
     pub fn path_segments(&self) -> Option<std::str::Split<'_, char>> {
         self.base.path_segments()
+    }
+
+    /// Consumes the normalized URL to return the base url given on construction.
+    ///
+    /// If only a reference is needed, use [`Self::as_base()`].
+    pub fn into_base(self) -> Url {
+        self.base
     }
 }
 

--- a/helix-core/src/normalized_url.rs
+++ b/helix-core/src/normalized_url.rs
@@ -1,0 +1,175 @@
+//! [`NormalizedUrl`]s are used to make comparisons more logical for URLs, notably those holding
+//! Windows paths.
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::fmt;
+#[cfg(windows)]
+use std::path::{Component, Prefix};
+use std::path::{Path, PathBuf};
+
+use url::Url;
+
+/// Normalize a [`Url`] to make it comparable across idiosyncracies from different tools.
+///
+/// # Example case
+///
+/// Helix gets paths from other sources, like LSPs. In such a case, Helix can't know in advance for
+/// every source what the case will be for the prefix component on Windows (`C:` or `c:`). Since
+/// this can hinder comparisons, especially in [`Url`]s, this structure gives access to the opposite
+/// casing of the `Url` on Windows and uses it to compare.
+#[derive(Debug, Clone)]
+pub struct NormalizedUrl {
+    base: Url,
+    /// This field is only available on Windows since differences in casing on other OSes are not
+    /// limited to the prefix and should be dealt with differently.
+    #[cfg(windows)]
+    opposite_case: Option<Url>,
+}
+
+impl NormalizedUrl {
+    pub fn from_file_path(path: &Path) -> Option<Self> {
+        let path: Cow<'_, Path> = if path.is_absolute() {
+            Cow::Borrowed(path)
+        } else {
+            Cow::Owned(crate::path::get_canonicalized_path(path).ok()?)
+        };
+        // If we managed to canonicalize, this should never fail else its a bug
+        let base = Url::from_file_path(&path).unwrap();
+        #[cfg(windows)]
+        let opposite_case =
+            path_prefix_opposite_casing(&path).map(|x| Url::from_file_path(&x).unwrap());
+
+        Some(Self {
+            base,
+            #[cfg(windows)]
+            opposite_case,
+        })
+    }
+
+    /// Access the `Url` stored as the base of the normalized one
+    pub fn base(&self) -> &Url {
+        &self.base
+    }
+
+    /// See [`Url::path()`]
+    pub fn path(&self) -> &str {
+        self.base.path()
+    }
+
+    /// See [`Url::to_file_path()`]
+    #[allow(clippy::result_unit_err)]
+    pub fn to_file_path(&self) -> Result<PathBuf, ()> {
+        self.base.to_file_path()
+    }
+
+    /// See [`Url::path_segments()`]
+    pub fn path_segments(&self) -> Option<std::str::Split<'_, char>> {
+        self.base.path_segments()
+    }
+}
+
+impl PartialEq<Self> for NormalizedUrl {
+    fn eq(&self, other: &Self) -> bool {
+        // Since the other fields are derived from this one deterministically, we can simply
+        // compare `.base` to know if two `NormalizedUrl`s are equal.
+        self.base.eq(&other.base)
+    }
+}
+
+impl Eq for NormalizedUrl {}
+
+impl PartialOrd<Self> for NormalizedUrl {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.base.partial_cmp(&other.base)
+    }
+}
+
+impl Ord for NormalizedUrl {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.base.cmp(&other.base)
+    }
+}
+
+impl fmt::Display for NormalizedUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.base.fmt(f)
+    }
+}
+
+// Interactions with the original Url type are below
+
+impl From<Url> for NormalizedUrl {
+    fn from(u: Url) -> Self {
+        let path = Path::new(u.path());
+        Self::from_file_path(path).expect("URL failed to convert to absolute path")
+    }
+}
+
+impl PartialEq<Url> for NormalizedUrl {
+    #[cfg(windows)]
+    fn eq(&self, other: &Url) -> bool {
+        self.base.eq(other) || self.opposite_case.as_ref().map_or(false, |oc| oc.eq(other))
+    }
+
+    #[cfg(not(windows))]
+    fn eq(&self, other: &Url) -> bool {
+        self.base.eq(other)
+    }
+}
+
+impl PartialOrd<Url> for NormalizedUrl {
+    fn partial_cmp(&self, other: &Url) -> Option<Ordering> {
+        self.base.partial_cmp(other)
+    }
+}
+
+/// Utility function to get the opposite casing of a Windows path, if any
+#[cfg(windows)]
+fn path_prefix_opposite_casing(default_case_path: &Path) -> Option<PathBuf> {
+    let mut components = default_case_path.components();
+    let first_comp = components.next()?;
+
+    match first_comp {
+        Component::Prefix(prefix)
+        // Anything else than `Disk` variants is not subject to this casing issue
+        if matches!(prefix.kind(), Prefix::VerbatimDisk(_) | Prefix::Disk(_)) => {
+            let cased_prefix = {
+                // Hard to get data on this, but most drive letter should be uppercased by
+                // default so lowercasing first means not having to then uppercase ?
+                let mut prefix_str = prefix.as_os_str().to_ascii_lowercase();
+                if prefix_str == prefix.as_os_str() {
+                    prefix_str.make_ascii_uppercase();
+                }
+                prefix_str
+            };
+
+            // The `push`s should be free thanks to this
+            let mut updated_case_path = PathBuf::with_capacity(default_case_path.as_os_str().len());
+            updated_case_path.push(&cased_prefix);
+            for cp in components {
+                updated_case_path.push(cp.as_os_str());
+            }
+            Some(updated_case_path)
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[cfg(windows)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn different_drives_case_are_equal() {
+        let p1 = Path::new("C:\\one\\path\\Here");
+        let p2 = Path::new("c:\\one\\path\\Here");
+
+        assert_eq!(p1, p2);
+
+        let norm = NormalizedUrl::new(p1).unwrap();
+        let u = Url::from_file_path(p2).unwrap();
+
+        assert_eq!(norm, u);
+    }
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -690,7 +690,7 @@ impl Application {
                                 doc.language_id().map(ToOwned::to_owned).unwrap_or_default();
 
                             tokio::spawn(language_server.text_document_did_open(
-                                url,
+                                &url,
                                 doc.version(),
                                 doc.text(),
                                 language_id,
@@ -815,7 +815,7 @@ impl Application {
                         // When using them later in the diagnostics picker, we calculate them on-demand.
                         self.editor
                             .diagnostics
-                            .insert(params.uri, params.diagnostics);
+                            .insert(params.uri.into(), params.diagnostics);
                     }
                     Notification::ShowMessage(params) => {
                         log::warn!("unhandled window/showMessage: {:?}", params);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -690,7 +690,7 @@ impl Application {
                                 doc.language_id().map(ToOwned::to_owned).unwrap_or_default();
 
                             tokio::spawn(language_server.text_document_did_open(
-                                &url,
+                                url.into_base(),
                                 doc.version(),
                                 doc.text(),
                                 language_id,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -309,7 +309,7 @@ fn diag_picker(
             }
         },
         move |_editor, PickerDiagnostic { url, diag }| {
-            let location = lsp::Location::new(url.base().clone(), diag.range);
+            let location = lsp::Location::new(url.as_base().clone(), diag.range);
             Some(location_to_file_location(&location))
         },
     )

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1141,11 +1141,11 @@ impl Document {
 
     #[inline]
     pub fn identifier(&self) -> lsp::TextDocumentIdentifier {
-        lsp::TextDocumentIdentifier::new(self.url().unwrap().base().clone())
+        lsp::TextDocumentIdentifier::new(self.url().unwrap().into_base())
     }
 
     pub fn versioned_identifier(&self) -> lsp::VersionedTextDocumentIdentifier {
-        lsp::VersionedTextDocumentIdentifier::new(self.url().unwrap().base().clone(), self.version)
+        lsp::VersionedTextDocumentIdentifier::new(self.url().unwrap().into_base(), self.version)
     }
 
     pub fn position(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -967,7 +967,7 @@ impl Editor {
 
                 // TODO: this now races with on_init code if the init happens too quickly
                 tokio::spawn(language_server.text_document_did_open(
-                    &doc_url,
+                    doc_url.into_base(),
                     doc.version(),
                     doc.text(),
                     language_id,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -38,12 +38,12 @@ use anyhow::{anyhow, bail, Error};
 
 pub use helix_core::diagnostic::Severity;
 pub use helix_core::register::Registers;
-use helix_core::Position;
 use helix_core::{
     auto_pairs::AutoPairs,
     syntax::{self, AutoPairConfig},
     Change,
 };
+use helix_core::{normalized_url::NormalizedUrl, Position};
 use helix_dap as dap;
 use helix_lsp::lsp;
 
@@ -692,7 +692,7 @@ pub struct Editor {
     pub macro_recording: Option<(char, Vec<KeyEvent>)>,
     pub macro_replaying: Vec<char>,
     pub language_servers: helix_lsp::Registry,
-    pub diagnostics: BTreeMap<lsp::Url, Vec<lsp::Diagnostic>>,
+    pub diagnostics: BTreeMap<NormalizedUrl, Vec<lsp::Diagnostic>>,
     pub diff_providers: DiffProviderRegistry,
 
     pub debugger: Option<dap::Client>,
@@ -967,7 +967,7 @@ impl Editor {
 
                 // TODO: this now races with on_init code if the init happens too quickly
                 tokio::spawn(language_server.text_document_did_open(
-                    doc_url,
+                    &doc_url,
                     doc.version(),
                     doc.text(),
                     language_id,


### PR DESCRIPTION
`Document::url()` uses `Document::path()` which is just a reference to `Document.path`. Since LSPs
can send either a path with an uppercase or lowercase drive letter, we need to check for the other
option when the first fails.

We do this throughout Helix by introducing `NormalizedUrl` which takes care of the conversion and
delegates to its base `Url` when needed. If future conversions are needed, they can be added here
instead of having to repeat them all over the place.

Closes #3267
