### PR TITLE
Fix process spawning error handling

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4580,10 +4580,16 @@ fn shell_impl(
 
     if !output.status.success() {
         if !output.stderr.is_empty() {
-            let err = String::from_utf8_lossy(&output.stderr);
-            bail!("Shell error: {}", err.to_string());
+            let err = String::from_utf8_lossy(&output.stderr).to_string();
+            log::error!("Shell error: {}", err);
+            bail!("Shell error: {}", err);
         }
         bail!("Shell command failed");
+    } else if !output.stderr.is_empty() {
+        log::debug!(
+            "Command printed to stderr: {}",
+            String::from_utf8_lossy(&output.stderr).to_string()
+        );
     }
 
     let str = std::str::from_utf8(&output.stdout)


### PR DESCRIPTION
As mentioned by @dead10ck in https://github.com/helix-editor/helix/pull/2942#discussion_r939606221 if something is printed to stderr it doesn't mean that the process failed, so we need to check the exit code and then print stderr if there is anything. This should also be valid when calling the shell from helix