### PR TITLE
Improve `:set-language` command

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1254,14 +1254,10 @@ fn language(
 
     let doc = doc_mut!(cx.editor);
 
-    let loader = cx.editor.syn_loader.clone();
     if args[0] == "text" {
-        doc.set_language(None, Some(loader))
+        doc.set_language(None, None)
     } else {
-        let ok = doc.set_language_by_language_id(&args[0], loader);
-        if !ok {
-            anyhow::bail!("invalid language: {}", args[0]);
-        }
+        doc.set_language_by_language_id(&args[0], cx.editor.syn_loader.clone())?;
     }
     doc.detect_indent_and_line_ending();
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1253,7 +1253,16 @@ fn language(
     }
 
     let doc = doc_mut!(cx.editor);
-    doc.set_language_by_language_id(&args[0], cx.editor.syn_loader.clone());
+
+    let loader = cx.editor.syn_loader.clone();
+    if args[0] == "text" {
+        doc.set_language(None, Some(loader))
+    } else {
+        let ok = doc.set_language_by_language_id(&args[0], loader);
+        if !ok {
+            anyhow::bail!("invalid language: {}", args[0]);
+        }
+    }
     doc.detect_indent_and_line_ending();
 
     let id = doc.id();

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -336,13 +336,19 @@ pub mod completers {
     pub fn language(editor: &Editor, input: &str) -> Vec<Completion> {
         let matcher = Matcher::default();
 
-        let mut matches: Vec<_> = editor
+        let text: String = "text".into();
+
+        let language_ids = editor
             .syn_loader
             .language_configs()
-            .filter_map(|config| {
+            .map(|config| &config.language_id)
+            .chain(std::iter::once(&text));
+
+        let mut matches: Vec<_> = language_ids
+            .filter_map(|language_id| {
                 matcher
-                    .fuzzy_match(&config.language_id, input)
-                    .map(|score| (&config.language_id, score))
+                    .fuzzy_match(language_id, input)
+                    .map(|score| (language_id, score))
             })
             .collect();
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -671,13 +671,12 @@ impl Document {
         &mut self,
         language_id: &str,
         config_loader: Arc<syntax::Loader>,
-    ) -> bool {
-        let language_config = config_loader.language_config_for_language_id(language_id);
-        if language_config.is_none() {
-            return false;
-        }
-        self.set_language(language_config, Some(config_loader));
-        true
+    ) -> anyhow::Result<()> {
+        let language_config = config_loader
+            .language_config_for_language_id(language_id)
+            .ok_or_else(|| anyhow!("invalid language id: {}", language_id))?;
+        self.set_language(Some(language_config), Some(config_loader));
+        Ok(())
     }
 
     /// Set the LSP.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -671,9 +671,13 @@ impl Document {
         &mut self,
         language_id: &str,
         config_loader: Arc<syntax::Loader>,
-    ) {
+    ) -> bool {
         let language_config = config_loader.language_config_for_language_id(language_id);
+        if language_config.is_none() {
+            return false;
+        }
         self.set_language(language_config, Some(config_loader));
+        true
     }
 
     /// Set the LSP.


### PR DESCRIPTION
Add `text` to completion for possible languages, and report error if user inputs invalid language.