### PR TITLE
Step to previous and next item from the last picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -271,6 +271,8 @@ impl MappableCommand {
         diagnostics_picker, "Open diagnostic picker",
         workspace_diagnostics_picker, "Open workspace diagnostic picker",
         last_picker, "Open last picker",
+        goto_next_from_last_picker, "Goto next from last picker",
+        goto_prev_from_last_picker, "Goto previous from last picker",
         prepend_to_line, "Insert at start of line",
         append_to_line, "Append to end of line",
         open_below, "Open new line below selection",
@@ -2436,6 +2438,26 @@ fn last_picker(cx: &mut Context) {
         // XXX: figure out how to show error when no last picker lifetime
         // cx.editor.set_error("no last picker")
     }));
+}
+
+fn goto_next_from_last_picker(cx: &mut Context) {
+    cx.callback = Some(Box::new(
+        move |compositor: &mut Compositor, cx: &mut compositor::Context| {
+            if let Some(picker) = &mut compositor.last_picker {
+                picker.as_pickstepper().unwrap().next(cx);
+            }
+        },
+    ));
+}
+
+fn goto_prev_from_last_picker(cx: &mut Context) {
+    cx.callback = Some(Box::new(
+        move |compositor: &mut Compositor, cx: &mut compositor::Context| {
+            if let Some(picker) = &mut compositor.last_picker {
+                picker.as_pickstepper().unwrap().prev(cx);
+            }
+        },
+    ));
 }
 
 // I inserts at the first nonwhitespace character of each line with a selection

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -16,7 +16,7 @@ pub enum EventResult {
     Consumed(Option<Callback>),
 }
 
-use crate::job::Jobs;
+use crate::{job::Jobs, ui::PickStepper};
 use helix_view::Editor;
 
 pub use helix_view::input::Event;
@@ -61,6 +61,10 @@ pub trait Component: Any + AnyComponent {
     }
 
     fn id(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn as_pickstepper(&mut self) -> Option<&mut dyn PickStepper> {
         None
     }
 }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -106,6 +106,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "o" => goto_prev_comment,
             "t" => goto_prev_test,
             "p" => goto_prev_paragraph,
+            "'" => goto_prev_from_last_picker,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -117,6 +118,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "o" => goto_next_comment,
             "t" => goto_next_test,
             "p" => goto_next_paragraph,
+            "'" => goto_next_from_last_picker,
             "space" => add_newline_below,
         },
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -16,7 +16,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{FileLocation, FilePicker, Picker};
+pub use picker::{FileLocation, FilePicker, PickStepper, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -69,4 +69,8 @@ impl<T: Component + 'static> Component for Overlay<T> {
         let dimensions = (self.calc_child_size)(area);
         self.content.cursor(dimensions, ctx)
     }
+
+    fn as_pickstepper(&mut self) -> Option<&mut dyn super::PickStepper> {
+        self.content.as_pickstepper()
+    }
 }


### PR DESCRIPTION
You can do this with `space ' down ret`, but this gets it down to `] '`. Feels nicer to me when going through a big set of global search matches.