### PR TITLE
Advertise WorkspaceSymbolClientCapabilities support

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -295,6 +295,10 @@ impl Client {
                     }),
                     workspace_folders: Some(true),
                     apply_edit: Some(true),
+                    symbol: Some(lsp::WorkspaceSymbolClientCapabilities {
+                        dynamic_registration: Some(false),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {


### PR DESCRIPTION
I was looking at workspace symbols in Go based on some Matrix discussion. This doesn't appear to be related to `gopls` and workspace symbols not working but we should probably advertise the client capability anyways since it's implemented.