### PR TITLE
Update keymap.md to have Tab and Shift-tab listed

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -363,9 +363,9 @@ Keys to use within picker. Remapping currently not supported.
 
 | Key                          | Description       |
 | -----                        | -------------     |
-| `Up`, `Ctrl-p`               | Previous entry    |
+| `Tab`, `Up`, `Ctrl-p`               | Previous entry    |
 | `PageUp`, `Ctrl-u`           | Page up           |
-| `Down`, `Ctrl-n`             | Next entry        |
+| `Shift-tab`, `Down`, `Ctrl-n`             | Next entry        |
 | `PageDown`, `Ctrl-d`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -363,9 +363,9 @@ Keys to use within picker. Remapping currently not supported.
 
 | Key                          | Description       |
 | -----                        | -------------     |
-| `Tab`, `Up`, `Ctrl-p`               | Previous entry    |
+| `Tab`, `Up`, `Ctrl-p`        | Previous entry    |
 | `PageUp`, `Ctrl-u`           | Page up           |
-| `Shift-tab`, `Down`, `Ctrl-n`             | Next entry        |
+| `Shift-tab`, `Down`, `Ctrl-n`| Next entry        |
 | `PageDown`, `Ctrl-d`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |


### PR DESCRIPTION
The docs currently don't list Tab and Shift-tab as options to scroll in the picker. This PR adds that