### PR TITLE
Make initial editing mode configurable

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -49,6 +49,7 @@ You may also specify a file to use for configuration with the `-c` or
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
+| `initial-mode` | The initial mode for newly opened editors. | `"normal"` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 
 ### `[editor.statusline]` Section

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -163,6 +163,8 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,
+    /// The initial mode for newly opened editors. Defaults to `"normal"`.
+    pub initial_mode: Mode,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
 }
@@ -498,6 +500,7 @@ impl Default for Config {
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
+            initial_mode: Mode::Normal,
             color_modes: false,
         }
     }
@@ -906,6 +909,7 @@ impl Editor {
 
     /// Generate an id for a new document and register it.
     fn new_document(&mut self, mut doc: Document) -> DocumentId {
+        doc.mode = self.config().initial_mode;
         let id = self.next_document_id;
         // Safety: adding 1 from 1 is fine, probably impossible to reach usize max
         self.next_document_id =


### PR DESCRIPTION
This simple change makes it possible to set the default editing mode for newly opened editors to something other than normal mode. For example, to start in insert mode, just add

```toml
[editor]
initial-mode = "insert"
```

to the config.

I've always wished that Vim provided this option, since I find starting in insert mode more useful when I launch the editor to quickly write something down.
