### PR TITLE
Update tree-sitter-latex and highlights

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -54,7 +54,7 @@
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ |  |  | `julia` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
-| latex | ✓ |  |  | `texlab` |
+| latex | ✓ | ✓ |  | `texlab` |
 | lean | ✓ |  |  | `lean` |
 | ledger | ✓ |  |  |  |
 | llvm | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -537,7 +537,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "latex"
-source = { git = "https://github.com/latex-lsp/tree-sitter-latex", rev = "7f720661de5316c0f8fee956526d4002fa1086d8" }
+source = { git = "https://github.com/latex-lsp/tree-sitter-latex", rev = "b3b2cf27f33e71438ebe46934900b1153901c6f2" }
 
 [[language]]
 name = "lean"

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -103,23 +103,22 @@
   name: (curly_group_text (_) @string))
 
 ;; Math
-[
-  (displayed_equation)
-  (inline_formula)
-] @text.math
+
+(displayed_equation) @markup.raw.block
+(inline_formula) @markup.raw.inline
 
 (math_environment
   (begin
-    command: _ @text.math
-    name: (curly_group_text (text) @text.math)))
+    command: _ @function.builtin
+    name: (curly_group_text (text) @markup.raw)))
 
 (math_environment
-  (text) @text.math)
+  (text) @markup.raw)
 
 (math_environment
   (end
-    command: _ @text.math
-    name: (curly_group_text (text) @text.math)))
+    command: _ @function.builtin
+    name: (curly_group_text (text) @markup.raw)))
 
 ;; Sectioning
 (title_declaration

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -1,410 +1,236 @@
-;; Math
-[
- (displayed_equation)
- (inline_formula)
-] @text.math
+;; General syntax
+(ERROR) @error
 
-;; This highlights the whole environment like vimtex does
-((environment
-  (begin
-   name: (word) @_env)) @text.math
-   (#any-of? @_env
-      "displaymath" "displaymath*"
-      "equation" "equation*"
-      "multline" "multline*"
-      "eqnarray" "eqnarray*"
-      "align" "align*"
-      "array" "array*"
-      "split" "split*"
-      "alignat" "alignat*"
-      "gather" "gather*"
-      "flalign" "flalign*"))
+(command_name) @function
+(caption
+  command: _ @function)
+
+(key_value_pair
+  key: (_) @parameter
+  value: (_))
 
 [
-  (generic_command_name)
-  "\\newcommand"
-  "\\renewcommand"
-  "\\DeclareRobustCommand"
-  "\\DeclareMathOperator"
-  "\\newglossaryentry"
-  "\\caption"
-  "\\label"
-  "\\newlabel"
-  "\\color"
-  "\\colorbox"
-  "\\textcolor"
-  "\\pagecolor"
-  "\\definecolor"
-  "\\definecolorset"
-  "\\newtheorem"
-  "\\declaretheorem"
-  "\\newacronym"
-] @function.macro
+  (comment)
+  (line_comment)
+  (block_comment)
+  (comment_environment)
+] @comment
 
 [
-    "\\ref"
-    "\\vref"
-    "\\Vref"
-    "\\autoref"
-    "\\pageref"
-    "\\cref"
-    "\\Cref"
-    "\\cref*"
-    "\\Cref*"
-    "\\namecref"
-    "\\nameCref"
-    "\\lcnamecref"
-    "\\namecrefs"
-    "\\nameCrefs"
-    "\\lcnamecrefs"
-    "\\labelcref"
-    "\\labelcpageref"
-    "\\crefrange"
-    "\\crefrange"
-    "\\Crefrange"
-    "\\Crefrange"
-    "\\crefrange*"
-    "\\crefrange*"
-    "\\Crefrange*"
-    "\\Crefrange*"
-] @function.macro
+  (brack_group)
+  (brack_group_argc)
+] @variable.parameter
 
-[
-    "\\cite"
-    "\\cite*"
-    "\\Cite"
-    "\\nocite"
-    "\\citet"
-    "\\citep"
-    "\\citet*"
-    "\\citep*"
-    "\\citeauthor"
-    "\\citeauthor*"
-    "\\Citeauthor"
-    "\\Citeauthor*"
-    "\\citetitle"
-    "\\citetitle*"
-    "\\citeyear"
-    "\\citeyear*"
-    "\\citedate"
-    "\\citedate*"
-    "\\citeurl"
-    "\\fullcite"
-    "\\citeyearpar"
-    "\\citealt"
-    "\\citealp"
-    "\\citetext"
-    "\\parencite"
-    "\\parencite*"
-    "\\Parencite"
-    "\\footcite"
-    "\\footfullcite"
-    "\\footcitetext"
-    "\\textcite"
-    "\\Textcite"
-    "\\smartcite"
-    "\\Smartcite"
-    "\\supercite"
-    "\\autocite"
-    "\\Autocite"
-    "\\autocite*"
-    "\\Autocite*"
-    "\\volcite"
-    "\\Volcite"
-    "\\pvolcite"
-    "\\Pvolcite"
-    "\\fvolcite"
-    "\\ftvolcite"
-    "\\svolcite"
-    "\\Svolcite"
-    "\\tvolcite"
-    "\\Tvolcite"
-    "\\avolcite"
-    "\\Avolcite"
-    "\\notecite"
-    "\\notecite"
-    "\\pnotecite"
-    "\\Pnotecite"
-    "\\fnotecite"
-] @function.macro
-
-[
-    "\\ref"
-    "\\vref"
-    "\\Vref"
-    "\\autoref"
-    "\\pageref"
-    "\\cref"
-    "\\Cref"
-    "\\cref*"
-    "\\Cref*"
-    "\\namecref"
-    "\\nameCref"
-    "\\lcnamecref"
-    "\\namecrefs"
-    "\\nameCrefs"
-    "\\lcnamecrefs"
-    "\\labelcref"
-    "\\labelcpageref"
-] @function.macro
-
-
-[
-    "\\crefrange"
-    "\\crefrange"
-    "\\Crefrange"
-    "\\Crefrange"
-    "\\crefrange*"
-    "\\crefrange*"
-    "\\Crefrange*"
-    "\\Crefrange*"
-] @function.macro
-
-
-[
-  "\\gls"
-  "\\Gls"
-  "\\GLS"
-  "\\glspl"
-  "\\Glspl"
-  "\\GLSpl"
-  "\\glsdisp"
-  "\\glslink"
-  "\\glstext"
-  "\\Glstext"
-  "\\GLStext"
-  "\\glsfirst"
-  "\\Glsfirst"
-  "\\GLSfirst"
-  "\\glsplural"
-  "\\Glsplural"
-  "\\GLSplural"
-  "\\glsfirstplural"
-  "\\Glsfirstplural"
-  "\\GLSfirstplural"
-  "\\glsname"
-  "\\Glsname"
-  "\\GLSname"
-  "\\glssymbol"
-  "\\Glssymbol"
-  "\\glsdesc"
-  "\\Glsdesc"
-  "\\GLSdesc"
-  "\\glsuseri"
-  "\\Glsuseri"
-  "\\GLSuseri"
-  "\\glsuserii"
-  "\\Glsuserii"
-  "\\GLSuserii"
-  "\\glsuseriii"
-  "\\Glsuseriii"
-  "\\GLSuseriii"
-  "\\glsuseriv"
-  "\\Glsuseriv"
-  "\\GLSuseriv"
-  "\\glsuserv"
-  "\\Glsuserv"
-  "\\GLSuserv"
-  "\\glsuservi"
-  "\\Glsuservi"
-  "\\GLSuservi"
-] @function.macro
-
-
-[
-  "\\acrshort"
-  "\\Acrshort"
-  "\\ACRshort"
-  "\\acrshortpl"
-  "\\Acrshortpl"
-  "\\ACRshortpl"
-  "\\acrlong"
-  "\\Acrlong"
-  "\\ACRlong"
-  "\\acrlongpl"
-  "\\Acrlongpl"
-  "\\ACRlongpl"
-  "\\acrfull"
-  "\\Acrfull"
-  "\\ACRfull"
-  "\\acrfullpl"
-  "\\Acrfullpl"
-  "\\ACRfullpl"
-  "\\acs"
-  "\\Acs"
-  "\\acsp"
-  "\\Acsp"
-  "\\acl"
-  "\\Acl"
-  "\\aclp"
-  "\\Aclp"
-  "\\acf"
-  "\\Acf"
-  "\\acfp"
-  "\\Acfp"
-  "\\ac"
-  "\\Ac"
-  "\\acp"
-  "\\glsentrylong"
-  "\\Glsentrylong"
-  "\\glsentrylongpl"
-  "\\Glsentrylongpl"
-  "\\glsentryshort"
-  "\\Glsentryshort"
-  "\\glsentryshortpl"
-  "\\Glsentryshortpl"
-  "\\glsentryfullpl"
-  "\\Glsentryfullpl"
-] @function.macro
-
-(comment) @comment
-
-(bracket_group) @variable.parameter
-
-[(math_operator) "="] @operator
-
-[
-  "\\usepackage"
-  "\\documentclass"
-  "\\input"
-  "\\include"
-  "\\subfile"
-  "\\subfileinclude"
-  "\\subfileinclude"
-  "\\includegraphics"
-  "\\addbibresource"
-  "\\bibliography"
-  "\\includesvg"
-  "\\includeinkscape"
-  "\\usepgflibrary"
-  "\\usetikzlibrary"
-] @keyword.control.import
-
-[
-  "\\part"
-  "\\chapter"
-  "\\section"
-  "\\subsection"
-  "\\subsubsection"
-  "\\paragraph"
-  "\\subparagraph"
-] @type
+[(operator) "="] @operator
 
 "\\item" @punctuation.special
 
 ((word) @punctuation.delimiter
-(#eq? @punctuation.delimiter "&"))
+  (#eq? @punctuation.delimiter "&"))
 
-["$" "\\[" "\\]" "\\(" "\\)"] @punctuation.delimiter
+["[" "]" "{" "}"] @punctuation.bracket ; "(" ")" has no syntactical meaning in LaTeX
 
-(label_definition
- name: (_) @text.reference)
-(label_reference
- label: (_) @text.reference)
-(equation_label_reference
- label: (_) @text.reference)
-(label_reference
- label: (_) @text.reference)
-(label_number
- label: (_) @text.reference)
-
-(citation
- key: (word) @text.reference)
-
-(key_val_pair
-  key: (_) @variable.parameter
-  value: (_))
-
-["[" "]" "{" "}"] @punctuation.bracket ;"(" ")" is has no special meaning in LaTeX
-
-(chapter
-  text: (brace_group) @markup.heading)
-
-(part
-  text: (brace_group) @markup.heading)
-
-(section
-  text: (brace_group) @markup.heading)
-
-(subsection
-  text: (brace_group) @markup.heading)
-
-(subsubsection
-  text: (brace_group) @markup.heading)
-
-(paragraph
-  text: (brace_group) @markup.heading)
-
-(subparagraph
-  text: (brace_group) @markup.heading)
-
-((environment
-  (begin
-   name: (word) @_frame)
-   (brace_group
-        child: (text) @markup.heading))
- (#eq? @_frame "frame"))
-
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (brace_group
-          (text) @markup.heading))
- (#eq? @_name "\\frametitle"))
-
-;; Formatting
-
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @markup.italic)
- (#eq? @_name "\\emph"))
-
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @markup.italic)
- (#match? @_name "^(\\\\textit|\\\\mathit)$"))
-
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @markup.bold)
- (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
-
-((generic_command
-  name:(generic_command_name) @_name
-  .
-  arg: (_) @markup.link.url)
- (#match? @_name "^(\\\\url|\\\\href)$"))
-
-(ERROR) @error
-
-[
-  "\\begin"
-  "\\end"
-] @text.environment
-
+;; General environments
 (begin
- name: (_) @text.environment.name
-  (#not-any-of? @text.environment.name
-      "displaymath" "displaymath*"
-      "equation" "equation*"
-      "multline" "multline*"
-      "eqnarray" "eqnarray*"
-      "align" "align*"
-      "array" "array*"
-      "split" "split*"
-      "alignat" "alignat*"
-      "gather" "gather*"
-      "flalign" "flalign*"))
+  command: _ @function.builtin
+  name: (curly_group_text (text) @function.macro))
 
 (end
- name: (_) @text.environment.name
-  (#not-any-of? @text.environment.name
-      "displaymath" "displaymath*"
-      "equation" "equation*"
-      "multline" "multline*"
-      "eqnarray" "eqnarray*"
-      "align" "align*"
-      "array" "array*"
-      "split" "split*"
-      "alignat" "alignat*"
-      "gather" "gather*"
-      "flalign" "flalign*"))
+  command: _ @function.builtin
+  name: (curly_group_text (text) @function.macro))
+
+;; Definitions and references
+(new_command_definition
+  command: _ @function.macro
+  declaration: (curly_group_command_name (_) @function))
+(old_command_definition
+  command: _ @function.macro
+  declaration: (_) @function)
+(let_command_definition
+  command: _ @function.macro
+  declaration: (_) @function)
+
+(environment_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @constant))
+
+(theorem_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @constant))
+
+(paired_delimiter_definition
+  command: _ @function.macro
+  declaration: (curly_group_command_name (_) @function))
+
+(label_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @label))
+(label_reference_range
+  command: _ @function.macro
+  from: (curly_group_text (_) @label)
+  to: (curly_group_text (_) @label))
+(label_reference
+  command: _ @function.macro
+  names: (curly_group_text_list (_) @label))
+(label_number
+  command: _ @function.macro
+  name: (curly_group_text (_) @label)
+  number: (_) @text.reference)
+
+(citation
+  command: _ @function.macro
+  keys: (curly_group_text_list) @string)
+
+(glossary_entry_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+(glossary_entry_reference
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+
+(acronym_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+(acronym_reference
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+
+(color_definition
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+(color_reference
+  command: _ @function.macro
+  name: (curly_group_text (_) @string))
+
+;; Math
+[
+  (displayed_equation)
+  (inline_formula)
+] @text.math
+
+(math_environment
+  (begin
+    command: _ @text.math
+    name: (curly_group_text (text) @text.math)))
+
+(math_environment
+  (text) @text.math)
+
+(math_environment
+  (end
+    command: _ @text.math
+    name: (curly_group_text (text) @text.math)))
+
+;; Sectioning
+(title_declaration
+  command: _ @namespace
+  options: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(author_declaration
+  command: _ @namespace
+  authors: (curly_group_author_list
+             ((author)+ @markup.heading)))
+
+(chapter
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(part
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(section
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(subsection
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(subsubsection
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(paragraph
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+(subparagraph
+  command: _ @namespace
+  toc: (brack_group (_) @markup.heading)?
+  text: (curly_group (_) @markup.heading))
+
+;; Beamer frames
+(generic_environment
+  (begin
+    name: (curly_group_text
+            (text) @markup.heading)
+    (#any-of? @markup.heading "frame"))
+  .
+  (curly_group (_) @markup.heading))
+
+((generic_command
+  command: (command_name) @_name
+  arg: (curly_group
+          (text) @markup.heading))
+  (#eq? @_name "\\frametitle"))
+
+;; Formatting
+((generic_command
+  command: (command_name) @_name
+  arg: (curly_group (_) @markup.italic))
+  (#eq? @_name "\\emph"))
+
+((generic_command
+  command: (command_name) @_name
+  arg: (curly_group (_) @markup.italic))
+  (#match? @_name "^(\\\\textit|\\\\mathit)$"))
+
+((generic_command
+  command: (command_name) @_name
+  arg: (curly_group (_) @markup.bold))
+  (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
+
+((generic_command
+  command: (command_name) @_name
+  .
+  arg: (curly_group (_) @markup.link.uri))
+  (#match? @_name "^(\\\\url|\\\\href)$"))
+
+;; File inclusion commands
+(class_include
+  command: _ @keyword.storage.type
+  path: (curly_group_path) @string)
+
+(package_include
+  command: _ @keyword.storage.type
+  paths: (curly_group_path_list) @string)
+
+(latex_include
+  command: _ @keyword.control.import
+  path: (curly_group_path) @string)
+(import_include
+  command: _ @keyword.control.import
+  directory: (curly_group_path) @string
+  file: (curly_group_path) @string)
+
+(bibtex_include
+  command: _ @keyword.control.import
+  path: (curly_group_path) @string)
+(biblatex_include
+  "\\addbibresource" @include
+  glob: (curly_group_glob_pattern) @string.regex)
+
+(graphics_include
+  command: _ @keyword.control.import
+  path: (curly_group_path) @string)
+(tikz_library_import
+  command: _ @keyword.control.import
+  paths: (curly_group_path_list) @string)

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -75,7 +75,7 @@
 (label_number
   command: _ @function.macro
   name: (curly_group_text (_) @label)
-  number: (_) @text.reference)
+  number: (_) @markup.link.label)
 
 (citation
   command: _ @function.macro

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -6,7 +6,7 @@
   command: _ @function)
 
 (key_value_pair
-  key: (_) @parameter
+  key: (_) @variable.parameter
   value: (_))
 
 [

--- a/runtime/queries/latex/textobjects.scm
+++ b/runtime/queries/latex/textobjects.scm
@@ -1,0 +1,13 @@
+[
+  (generic_command)
+] @function.around
+
+[
+  (chapter)
+  (part)
+  (section)
+  (subsection)
+  (subsubsection)
+  (paragraph)
+  (subparagraph)
+] @class.around


### PR DESCRIPTION
update tree-sitter-latex 

update highlights from https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/latex/highlights.scm
add textobject from https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/master/queries/latex/textobjects.scm

About highlights

I'm not sure about the markup for the Math section， It wasn't marked before. I left it as it was.