### PR TITLE
adds xcopy param to recursively copy runtime folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%App
 
 | OS                   | Command                                      |
 | -------------------- | -------------------------------------------- |
-| Windows (cmd.exe)    | `xcopy runtime %AppData%\helix\runtime`      |
-| Windows (PowerShell) | `xcopy runtime $Env:AppData\helix\runtime`   |
+| Windows (cmd.exe)    | `xcopy /e runtime %AppData%\helix\runtime`      |
+| Windows (PowerShell) | `xcopy /e runtime $Env:AppData\helix\runtime`   |
 | Linux/macOS          | `ln -s $PWD/runtime ~/.config/helix/runtime` |
 
 This location can be overridden via the `HELIX_RUNTIME` environment variable.

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -67,8 +67,8 @@ via the `HELIX_RUNTIME` environment variable.
 
 | OS                | command   |
 |-------------------|-----------|
-|windows(cmd.exe)   |`xcopy runtime %AppData%/helix/runtime`     |
-|windows(powershell)|`xcopy runtime $Env:AppData\helix\runtime`  |
+|windows(cmd.exe)   |`xcopy /e runtime %AppData%/helix/runtime`     |
+|windows(powershell)|`xcopy /e runtime $Env:AppData\helix\runtime`  |
 |linux/macos        |`ln -s $PWD/runtime ~/.config/helix/runtime`|
 
 ## Finishing up the installation 


### PR DESCRIPTION
xcopy doesn't copy recursively, so subfolders (themes, grammars etc.) aren't getting copied atm (see [here](https://docs.microsoft.com/de-de/windows-server/administration/windows-commands/xcopy))
adding `/e` fixes that.