### PR TITLE
Revert conditional setting of stdin handle

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4552,14 +4552,23 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-    let mut process = match Command::new(&shell[0])
+let mut process = Command::new(&shell[0]);
+    process
         .args(&shell[1..])
         .arg(cmd)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::piped())
-        .spawn()
+        .stderr(Stdio::piped());
+
+    #[cfg(not(target_family = "windows"))]
+    if input.is_some() {
+        process.stdin(Stdio::piped());
+    }
+    #[cfg(target_family = "windows")]
     {
+        process.stdin(Stdio::piped());
+    }
+
+    let mut process = match process.spawn() {
         Ok(process) => process,
         Err(e) => {
             log::error!("Failed to start shell: {}", e);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4552,18 +4552,14 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-    let mut process = Command::new(&shell[0]);
-    process
+    let mut process = match Command::new(&shell[0])
         .args(&shell[1..])
         .arg(cmd)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    if input.is_some() {
-        process.stdin(Stdio::piped());
-    }
-
-    let mut process = match process.spawn() {
+        .stderr(Stdio::piped())
+        .stdin(Stdio::piped())
+        .spawn()
+    {
         Ok(process) => process,
         Err(e) => {
             log::error!("Failed to start shell: {}", e);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4559,12 +4559,7 @@ fn shell_impl(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    #[cfg(not(target_family = "windows"))]
-    if input.is_some() {
-        process.stdin(Stdio::piped());
-    }
-    #[cfg(target_family = "windows")]
-    {
+    if input.is_some() || cfg!(windows) {
         process.stdin(Stdio::piped());
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4552,7 +4552,7 @@ fn shell_impl(
     use std::process::{Command, Stdio};
     ensure!(!shell.is_empty(), "No shell set");
 
-let mut process = Command::new(&shell[0]);
+    let mut process = Command::new(&shell[0]);
     process
         .args(&shell[1..])
         .arg(cmd)


### PR DESCRIPTION
fixes #3374

I still like the change to avoid setting stdio if necessary, but it looks like this causes an issue on Windows.

After attempting other fixes, reverting the changes was the only thing that worked.

P.S. Conditional compilation could be added for non-Windows targets, but I think this would not add value to the codebase or Helix.