### PR TITLE
Add pseudo_pending for ms/mr/md

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4377,7 +4377,9 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
 }
 
 fn surround_add(cx: &mut Context) {
+    cx.editor.pseudo_pending = Some("ma".to_string());
     cx.on_next_key(move |cx, event| {
+        cx.editor.pseudo_pending = None;
         let ch = match event.char() {
             Some(ch) => ch,
             None => return,
@@ -4403,7 +4405,9 @@ fn surround_add(cx: &mut Context) {
 
 fn surround_replace(cx: &mut Context) {
     let count = cx.count();
+    cx.editor.pseudo_pending = Some("mr".to_string());
     cx.on_next_key(move |cx, event| {
+        cx.editor.pseudo_pending = None;
         let surround_ch = match event.char() {
             Some('m') => None, // m selects the closest surround pair
             Some(ch) => Some(ch),
@@ -4443,7 +4447,9 @@ fn surround_replace(cx: &mut Context) {
 
 fn surround_delete(cx: &mut Context) {
     let count = cx.count();
+    cx.editor.pseudo_pending = Some("md".to_string());
     cx.on_next_key(move |cx, event| {
+        cx.editor.pseudo_pending = None;
         let surround_ch = match event.char() {
             Some('m') => None, // m selects the closest surround pair
             Some(ch) => Some(ch),


### PR DESCRIPTION
implements #3223

Adds pseudo pending text for `ms`/`mr`/`md` commands (match surround, replace, and delete).

Currently hard-coded as there appears to be an issue with appending to the current `editor.pseudo_pending` value.

* Can leave it open to not be cleared on the next key press. Leaves lingering pseudo text.
* Can append it, only to have it immediately cleared (appending in the target locations would be cleared immediately before appending).