### PR TITLE
Fix python indentation

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -79,7 +79,7 @@
 | prisma | ✓ |  |  | `prisma-language-server` |
 | prolog |  |  |  | `swipl` |
 | protobuf | ✓ |  | ✓ |  |
-| python | ✓ | ✓ |  | `pylsp` |
+| python | ✓ | ✓ | ✓ | `pylsp` |
 | r | ✓ |  |  | `R` |
 | racket |  |  |  | `racket` |
 | regex | ✓ |  |  |  |

--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -46,6 +46,19 @@ capture on the same line, the indent level isn't changed at all.
 - `@outdent` (default scope `all`):
 Decrease the indent level by 1. The same rules as for `@indent` apply.
 
+- `@extend-indented`:
+Extend the range of this node to the end of the line and to lines that
+are indented more than the line that this node starts on. This is useful
+for languages like Python, where for the purpose of indentation some nodes
+(like functions or classes) should also contain indented lines that follow them.
+
+- `@stop-extend`:
+Prevents the first extension of an ancestor of this node. For example, in Python
+a return expression always ends the block that it is in. Note that this only prevents
+the next extension of one ancestor: If multiple ancestors can be extended (for example
+multiple nested conditional blocks in python), only the extension of the innermost
+ancestor is prevented.
+
 ## Predicates
 
 In some cases, an S-expression cannot express exactly what pattern should be matched.

--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -46,16 +46,16 @@ capture on the same line, the indent level isn't changed at all.
 - `@outdent` (default scope `all`):
 Decrease the indent level by 1. The same rules as for `@indent` apply.
 
-- `@extend-indented`:
+- `@extend`:
 Extend the range of this node to the end of the line and to lines that
 are indented more than the line that this node starts on. This is useful
 for languages like Python, where for the purpose of indentation some nodes
 (like functions or classes) should also contain indented lines that follow them.
 
-- `@stop-extend`:
+- `@extend.prevent-once`:
 Prevents the first extension of an ancestor of this node. For example, in Python
 a return expression always ends the block that it is in. Note that this only stops the
-extension of the next `@extend-indented` capture. If multiple ancestors are captured,
+extension of the next `@extend` capture. If multiple ancestors are captured,
 only the extension of the innermost one is prevented. All other ancestors are unaffected
 (regardless of whether the innermost ancestor would actually have been extended).
 

--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -54,10 +54,11 @@ for languages like Python, where for the purpose of indentation some nodes
 
 - `@stop-extend`:
 Prevents the first extension of an ancestor of this node. For example, in Python
-a return expression always ends the block that it is in. Note that this only prevents
-the next extension of one ancestor: If multiple ancestors can be extended (for example
-multiple nested conditional blocks in python), only the extension of the innermost
-ancestor is prevented.
+a return expression always ends the block that it is in. Note that this only stops the
+extension of the next `@extend-indented` capture. If multiple ancestors are captured,
+only the extension of the innermost one is prevented. All other ancestors are unaffected
+(regardless of whether the innermost ancestor would actually have been extended).
+
 
 ## Predicates
 

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -662,7 +662,13 @@ pub fn treesitter_indent_for_pos(
             node = parent;
             first_in_line.pop();
         } else {
-            result.add_line(&indent_for_line_below);
+            // Only add the indentation for the line below if that line
+            // is not after the line that the indentation is calculated for.
+            if (node.start_position().row < line)
+                || (new_line && node.start_position().row == line && node.start_byte() < byte_pos)
+            {
+                result.add_line(&indent_for_line_below);
+            }
             result.add_line(&indent_for_line);
             break;
         }

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -492,6 +492,7 @@ fn query_indents(
 ///     },
 /// );
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn treesitter_indent_for_pos(
     query: &Query,
     syntax: &Syntax,

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -50,6 +50,7 @@ fn test_treesitter_indent(file_name: &str, lang_scope: &str) {
                 indent_query,
                 &syntax,
                 &IndentStyle::Spaces(4),
+                4,
                 text,
                 i,
                 text.line_to_char(i) + pos,

--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -28,11 +28,31 @@
 ] @indent
 
 [
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (with_statement)
+  (try_statement)
+
+  (function_definition)
+  (class_definition)
+] @extend-indented
+
+[
+  (return_statement)
+  (break_statement)
+  (continue_statement)
+  (raise_statement)
+  (pass_statement)
+] @stop-extend
+
+[
   ")"
   "]"
   "}"
-  (return_statement)
-  (pass_statement)
-  (raise_statement)
 ] @outdent
+(elif_clause
+  "elif" @outdent)
+(else_clause
+  "else" @outdent)
 

--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -36,7 +36,7 @@
 
   (function_definition)
   (class_definition)
-] @extend-indented
+] @extend
 
 [
   (return_statement)
@@ -44,7 +44,7 @@
   (continue_statement)
   (raise_statement)
   (pass_statement)
-] @stop-extend
+] @extend.prevent-once
 
 [
   ")"


### PR DESCRIPTION
This introduces 2 new capture types for indent queries. With this, the python indent queries have been improved and re-enabled. It should fix most of the issues from #763. We still don't update the indentation retroactively, so there is still some room for improvements:
```python
if condition:
    do_smth()
    else:
```
Here the `else` should ideally be outdented automatically, once one has finished typing it. This is tricky for 2 reasons:
- We have to figure out when and for which lines to run indentation queries. For performance reasons, we don't want to do it too often and it also shouldn't "correct" the indentation after the user has manually changed it.
- With python, the tree-sitter grammar doesn't even recognize the `else` statement since it is indented (see the discussion in #763). Either the tree-sitter grammar needs to improve here or we need a special case to recognize this and similar situations.

If you have ideas for this, please let me know. Also, if there's other languages than python that can be fixed with the new captures (i.e. languages where functions, classes, etc. end simply where the indentation level decreases), I'm happy to update them as well