### PR TITLE
Update Clojure language definition

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1526,9 +1526,9 @@ source = { git = "https://github.com/victorhqc/tree-sitter-prisma", rev = "17a59
 name = "clojure"
 scope = "source.clojure"
 injection-regex = "(clojure|clj)"
-file-types = ["clj"]
-roots = ["project.clj"]
-comment-token = ";;"
+file-types = ["clj" "cljs" "cljc" "clje" "cljr" "cljx" "edn" "boot"]
+roots = ["project.clj" "build.boot" "deps.edn" "shadow-cljs.edn"]
+comment-token = ";"
 language-server = { command = "clojure-lsp" }
 indent = { tab-width = 2, unit = "  " }
 

--- a/languages.toml
+++ b/languages.toml
@@ -1525,7 +1525,7 @@ source = { git = "https://github.com/victorhqc/tree-sitter-prisma", rev = "17a59
 [[language]]
 name = "clojure"
 scope = "source.clojure"
-injection-regex = "(clojure|clj)"
+injection-regex = "(clojure|clj|edn|boot)"
 file-types = ["clj", "cljs", "cljc", "clje", "cljr", "cljx", "edn", "boot"]
 roots = ["project.clj", "build.boot", "deps.edn", "shadow-cljs.edn"]
 comment-token = ";"

--- a/languages.toml
+++ b/languages.toml
@@ -1526,8 +1526,8 @@ source = { git = "https://github.com/victorhqc/tree-sitter-prisma", rev = "17a59
 name = "clojure"
 scope = "source.clojure"
 injection-regex = "(clojure|clj)"
-file-types = ["clj" "cljs" "cljc" "clje" "cljr" "cljx" "edn" "boot"]
-roots = ["project.clj" "build.boot" "deps.edn" "shadow-cljs.edn"]
+file-types = ["clj", "cljs", "cljc", "clje", "cljr", "cljx", "edn", "boot"]
+roots = ["project.clj", "build.boot", "deps.edn", "shadow-cljs.edn"]
 comment-token = ";"
 language-server = { command = "clojure-lsp" }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Hello,

I'd like some feedback on this PR since I don't fully understand all the fields that are being set in this table.

Does this edit look complete, or does the injection regex need to be updated in order to match some of the other file types, like `edn` and `boot`?

Otherwise, this is a simple update to add support for Clojure files supported by clojure-lsp but which aren't reflected in helix's language definition, and to correct the comment token.

File types
- `cljs` for ClojureScript
- `cljc` for cross-compiled Clojure files
- `clje` for Clojerl
- `cljr` for ClojureCLR
- `cljx` for legacy cross-compiled Clojure
- `edn` for Extensible Data Notation files, they are to Clojure what JSON is to JS
- `boot` for build files using the boot build tool

The last thing I'd like confirmation on is that `roots` defines a set of alternate files to detect a project root, and not that all must be present to detect a project, as the files here are for the major build tools, and it's quite common to have only one of these and none of the others.