### PR TITLE
highlight closure pipes as brackets

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -78,6 +78,8 @@
     "<"
     ">"
   ] @punctuation.bracket)
+(closure_parameters
+  "|" @punctuation.bracket)
 
 ; ---
 ; Variables


### PR DESCRIPTION
Currently closure pipes highlight as operators, even though semantically they should be brackets. This PR adds an explicit highlight for pipes within the `closure_parameters` scope.