### PR TITLE
add penumbra+ theme

### DIFF
--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -1,0 +1,122 @@
+##########
+# SYNTAX #
+##########
+
+comment = "sky-"
+
+type = "green"
+"type.enum.variant" = "green"
+label = "blue"
+tag = "blue"
+
+constant = "purple"
+"constant.numeric" = "cyan"
+"constant.character" = "purple"
+
+string = "yellow"
+"string.special.symbol" = "cyan"
+"string.special.path" = "cyan"
+
+variable = "sky"
+"variable.builtin" = "red"
+
+keyword = "magenta"
+
+function = "blue"
+"function.macro" = "purple"
+
+punctuation = "sky"
+operator = "magenta"
+namespace = "sky"
+
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "cyan"
+
+
+##########
+#   UI   #
+##########
+
+hint = "sky-"
+info = "sky"
+warning = "yellow"
+error = "red"
+
+diagnostic = { modifiers = ["underlined"] }
+
+"ui.background" = "sky+"
+"ui.background.separator" = "sky"
+
+"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { bg = "shade+" }
+
+"ui.cursorline.primary" = { bg = "shade-" }
+# "ui.cursorline.secondary" = { bg = "shade+" }
+
+"ui.linenr" = "sky-"
+"ui.linenr.selected" = "sky"
+
+# Using themed status line:
+"ui.statusline" = { fg = "shade", bg = "sky" }
+"ui.statusline.inactive" = { fg = "sky", bg = "shade+" }
+"ui.statusline.normal" = { fg = "shade", bg = "blue" }
+"ui.statusline.insert" = { fg = "shade", bg = "green" }
+"ui.statusline.select" = { fg = "shade", bg = "purple" }
+
+# Without themed status line:
+# "ui.statusline" = { fg = "shade-", bg = "blue" }
+# "ui.statusline.inactive" = { fg = "sky", bg = "shade+" }
+
+"ui.popup" = { bg = "shade-" }
+"ui.popup.info" = { bg = "shade" }
+
+"ui.window" = "sky"
+"ui.help" = "sky"
+
+"ui.text" = "sky"
+"ui.text.focus" = "blue"
+"ui.text.info" = "sky"
+
+"ui.virtual.ruler" = { bg = "shade+" }
+"ui.virtual.whitespace" = "sky-"
+"ui.virtual.indent-guide" = "shade+"
+
+"ui.menu" = { fg = "sky", bg = "shade-" }
+"ui.menu.selected" = { fg = "blue", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "sky", bg = "shade+" }
+
+"ui.selection" = { bg = "shade+" }
+
+"markup.heading" = { fg = "sky+", modifiers = ["bold"] }
+"markup.list" = "sky"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link.url" = { modifiers = ["underlined"] }
+"markup.link.text" = "magenta"
+"markup.quote" = "green"
+"markup.raw" = "orange"
+
+
+[palette]
+
+# contrast+ accents
+red = "#DF7F78"
+orange = "#CE9042"
+yellow = "#9CA748"
+green = "#50B584"
+cyan = "#00B3C2"
+blue = "#61A3E6"
+purple = "#A48FE1"
+magenta = "#D080B6"
+
+# contrast+ base
+"sun+" = "#FFFDFB"
+"sun" = "#FFF7ED"
+"sun-" = "#F2E6D4"
+"sky+" = "#CECECE"
+"sky" = "#9E9E9E"
+"sky-" = "#636363"
+"shade+" = "#3E4044"
+"shade" = "#24272B"
+"shade-" = "#181B1F"


### PR DESCRIPTION
From Penumbra's [README](https://github.com/nealmckee/penumbra):

> Penumbra is a mathematically balanced colour scheme constructed in a perceptually uniform colour space with base colours inspired by the shades of colour occurring in nature due to the light of the sun and the sky. It cleanly separates the perceptual properties of colours while optimally utilizing the available colour space of typical displays.

This PR adds a new built-in theme to Helix using the Penumbra+ color scheme. The "+" is for "higher-contrast". Similar versions of this theme for the "balanced" (lower-contrast) and "++" (even higher contrast) variants of Penumbra can be created just be modifying the palette at the bottom of the theme according to the values in Penumbra's README.

---

This PR is currently in draft status because there are a few questions I wanted to get feedback on.

- [x] The biggest issue is whether punctuation should remain visually de-emphasized like comments are. This was my addition to the theme and wasn't suggested by Penumbra. Arguably a theme named "Penumbra" shouldn't make too many novel decisions on top of the original colors.
- [ ] Should references be colored like the type or as a modifier on the type? Should they be visually distinct? In this version, they're distinct.
- [ ] Is the yellow for text too distracting? Does it draw too much attention to text? We could try to shuffle around colors so that text is something less obtrusive.
- [ ] I haven't put a ton of thought into languages other than Rust. I briefly considered HTML and Markdown. It would be great if someone could try out their own preferred languages and report back deficiencies. 
- [ ] Should this PR include the higher- and lower-contrast variants of Penumbra (i.e. "balanced" and "++")?