### PR TITLE
Fix Markdown Metadata

### DIFF
--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -7,9 +7,7 @@
 
 ((html_block) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
 
-([
-  (minus_metadata)
-  (plus_metadata)
-] @injection.content (#set! injection.language "yaml") (#set! injection.include-unnamed-children))
+((minus_metadata) @injection.content (#set! injection.language "yaml") (#set! injection.include-unnamed-children))
+((plus_metadata) @injection.content (#set! injection.language "toml") (#set! injection.include-unnamed-children))
 
 ((inline) @injection.content (#set! injection.language "markdown.inline") (#set! injection.include-unnamed-children))


### PR DESCRIPTION
TOML identified by opening and closing +++.
YAML identified by opening and closing ---.

- https://gohugo.io/content-management/front-matter/#front-matter-formats
- https://docs.gitlab.com/ee/user/markdown.html#front-matter
- https://www.getzola.org/documentation/content/section/#front-matter