### PR TITLE
Discard LSP publishDiagnostic when LS is not initialized

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -510,7 +510,12 @@ impl Application {
                                     use helix_core::diagnostic::{Diagnostic, Range, Severity::*};
                                     use lsp::DiagnosticSeverity;
 
-                                    let language_server = doc.language_server().unwrap();
+                                    let language_server = if let Some(language_server) = doc.language_server() {
+                                        language_server
+                                    } else {
+                                        log::warn!("Discarding diagnostic because language server is not initialized: {:?}", diagnostic);
+                                        return None;
+                                    };
 
                                     // TODO: convert inside server
                                     let start = if let Some(start) = lsp_pos_to_pos(


### PR DESCRIPTION
This is invalid according to the [LSP spec]:

> In addition the server is not allowed to send any requests
> or notifications to the client until it has responded with an
> InitializeResult, with the exception that during the initialize
> request the server is allowed to send the notifications
> window/showMessage, window/logMessage and telemetry/event as well
> as the window/showMessageRequest request to the client.

So we should discard the message when the language server is not
yet initialized. This can happen if the server sends
textDocument/publishDiagnostics before responding to the initialize
request. clojure-lsp appears to exhibit this behavior in the wild.

[LSP Spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize