### PR TITLE
Theme Related Fixes

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -125,8 +125,6 @@ We use a similar set of scopes as
     - `url`
     - `symbol` - Erlang/Elixir atoms, Ruby symbols, Clojure keywords
 
-- `property` - Regex group names
-
 - `comment` - Code comments
   - `line` - Single line comments (`//`)
   - `block` - Block comments (e.g. (`/*     */`)

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -103,6 +103,8 @@ We use a similar set of scopes as
 [SublimeText](https://www.sublimetext.com/docs/scope_naming.html). See also
 [TextMate](https://macromates.com/manual/en/language_grammars) scopes.
 
+- `attribute` - Class attributes, html tag attributes
+
 - `type` - Types
   - `builtin` - Primitive types provided by the language (`int`, `usize`)
 - `constructor`
@@ -123,6 +125,8 @@ We use a similar set of scopes as
     - `url`
     - `symbol` - Erlang/Elixir atoms, Ruby symbols, Clojure keywords
 
+- `property` - Regex group names
+
 - `comment` - Code comments
   - `line` - Single line comments (`//`)
   - `block` - Block comments (e.g. (`/*     */`)
@@ -133,13 +137,13 @@ We use a similar set of scopes as
   - `parameter` - Function parameters
   - `other`
     - `member` - Fields of composite data types (e.g. structs, unions)
-  - `function` (TODO: ?)
 
 - `label`
 
 - `punctuation`
   - `delimiter` - Commas, colons
   - `bracket` - Parentheses, angle brackets, etc.
+  - `special` - String interpolation brackets.
 
 - `keyword`
   - `control`

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -35,7 +35,7 @@
   (non_boundary_assertion)
 ] @constant.character.escape
 
-(group_name) @property
+(group_name) @label
 
 (count_quantifier
   [

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -31,7 +31,7 @@
 "variable" = "my_white3"
 "constant.numeric" = "my_turquoise"
 "constant" = "my_white3"
-"attributes" = "my_turquoise"
+"attribute" = "my_turquoise"
 "type" = { fg = "my_white3", modifiers = ["italic"] }
 "ui.cursor.match" = { fg = "my_white3", modifiers = ["underlined"] }
 "string"  = "my_green"

--- a/runtime/themes/autumn_night.toml
+++ b/runtime/themes/autumn_night.toml
@@ -31,7 +31,7 @@
 "variable" = "my_white3"
 "constant.numeric" = "my_turquoise"
 "constant" = "my_white3"
-"attributes" = "my_turquoise"
+"attribute" = "my_turquoise"
 "type" = { fg = "my_white3", modifiers = ["italic"] }
 "ui.cursor.match" = { fg = "my_white3", modifiers = ["underlined"] }
 "string"  = "my_green"

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -19,7 +19,7 @@
 "variable" = "base08"
 "constant.numeric" = "base09"
 "constant" = "base09"
-"attributes" = "base09"
+"attribute" = "base09"
 "type" = "base0A"
 "ui.cursor.match" = { fg = "base0A", modifiers = ["underlined"] }
 "string"  = "base0B"

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -19,7 +19,7 @@
 "variable" = "base08"
 "constant.numeric" = "base09"
 "constant" = "base09"
-"attributes" = "base09"
+"attribute" = "base09"
 "type" = "base0A"
 "ui.cursor.match" = { fg = "base0A", modifiers = ["underlined"] }
 "string"  = "base0B"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -17,7 +17,7 @@
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"
-"attributes" = "yellow"
+"attribute" = "yellow"
 "type" = "light-yellow"
 "ui.cursor.match" = { fg = "light-yellow", modifiers = ["underlined"] }
 "string"  = "light-green"

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -28,7 +28,7 @@
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"
-"attributes" = "yellow"
+"attribute" = "yellow"
 "type" = "light-yellow"
 "string"  = "light-green"
 "variable.other.member" = "green"

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -20,7 +20,7 @@ operator = { fg = 'blue' }
 function = { fg = 'yellow' }
 tag = { fg = 'cyan' }
 attribute = { fg = 'blue' }
-attributes = { fg = 'blue' }
+attribute = { fg = 'blue' }
 namespace = { fg = 'red' }
 
 'markup.heading' = { fg = 'red' }

--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -13,7 +13,6 @@
 "label" = { modifiers = ["bold"] }
 "namespace" = { fg = "teal_text", bg = "teal_bg" }
 "operator" = { fg = "base1", bg = "base7" }
-"property" = { fg = "blue_text", bg = "blue_bg" }
 "punctuation.bracket" = { modifiers = ["bold"] }
 "special" = { fg = "blue_text", bg = "blue_bg" }
 "string" = { fg = "green_text", bg = "green_bg" }

--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -60,7 +60,6 @@
 'function.special' = { fg = 'pink' }
 'tag' = { fg = 'blue' }
 'namespace' = { fg = 'peach' }
-'property' = { fg = 'green' }
 'special' = { fg = 'greyE' }
 'module' = { fg = 'greyE' }
 'attribute' = { fg = 'paleblue' }

--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -62,7 +62,6 @@
 # SYNTAX HIGHLIGHTING ==============================
 # All the keys here are Treesitter scopes.
 
-'property' = { fg = "red" } # Regex group names.
 'special' = { fg = "mid-blue"} # Special symbols e.g `?` in Rust, `...` in Hare.
 'attribute' = { fg = "yellow" } # Class attributes, html tag attributes.
 

--- a/runtime/themes/noctis_bordo.toml
+++ b/runtime/themes/noctis_bordo.toml
@@ -1,6 +1,6 @@
 # Author: Joseph Harrison-Lim <josephharrisonlim@gmail.com>
 
-"attributes" = { fg = "#7060eb", modifiers = ["bold"] }
+"attribute" = { fg = "#7060eb", modifiers = ["bold"] }
 "comment" = { fg = "base03", modifiers = ["italic"] }
 "comment.block.documentation" = { fg = "base06", modifiers = ["italic"] }
 "constant" = "base09"

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -18,7 +18,6 @@
 "namespace" = { fg = "blue" }
 "operator" = { fg = "purple" }
 "keyword.operator" = { fg = "purple" }
-"property" = { fg = "red" }
 "special" = { fg = "blue" }
 "string" = { fg = "green" }
 "type" = { fg = "yellow" }

--- a/runtime/themes/onelight.toml
+++ b/runtime/themes/onelight.toml
@@ -27,7 +27,6 @@
 "label" = { fg = "cyan" }
 "namespace" = { fg = "red" }
 "operator" = { fg = "red" }
-"property" = { fg = "red" }
 "special" = { fg = "purple" }
 "string" = { fg = "green" }
 "module" = { fg = "cyan" }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -43,7 +43,7 @@ special = { fg = 'orangeW' }
 operator = { fg = 'orangeY' }
 property = { bg = 'blueH' }
 attribute = { fg = 'orangeL' }
-attributes = { fg = 'orangeL' }
+attribute = { fg = 'orangeL' }
 namespace = { fg = 'orangeL' }
 'type' = { fg = 'redH' }
 'type.builtin' = { fg = 'orangeL' }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -41,7 +41,6 @@ label = { fg = 'greenS' }
 module = { bg = 'orangeL' }
 special = { fg = 'orangeW' }
 operator = { fg = 'orangeY' }
-property = { bg = 'blueH' }
 attribute = { fg = 'orangeL' }
 attribute = { fg = 'orangeL' }
 namespace = { fg = 'orangeL' }

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -26,7 +26,6 @@
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
-"property" = "foam"
 "constant.character.escape" = "subtle"
 "function" = "rose"
 "function.builtin" = "rose"

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -22,7 +22,7 @@
 "variable" = "text"
 "constant.numeric" = "iris"
 "constant" = "gold"
-"attributes" = "gold" 
+"attribute" = "gold" 
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
@@ -40,7 +40,7 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"text" = "text"
+"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -19,7 +19,7 @@
 "variable" = "text"
 "number" = "iris"
 "constant" = "gold"
-"attributes" = "gold" 
+"attribute" = "gold" 
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
@@ -37,7 +37,7 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"text" = "text"
+"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -23,7 +23,6 @@
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
-"property" = "foam"
 "escape" = "subtle"
 "function" = "rose"
 "function.builtin" = "rose"

--- a/runtime/themes/rose_pine_moon.toml
+++ b/runtime/themes/rose_pine_moon.toml
@@ -29,7 +29,6 @@
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
-"property" = "foam"
 "constant.character.escape" = "subtle"
 "function" = "rose"
 "function.builtin" = "rose"

--- a/runtime/themes/rose_pine_moon.toml
+++ b/runtime/themes/rose_pine_moon.toml
@@ -25,7 +25,7 @@
 "variable" = "text"
 "constant.numeric" = "iris"
 "constant" = "gold"
-"attributes" = "gold" 
+"attribute" = "gold" 
 "type" = "foam"
 "ui.cursor.match" = { fg = "gold", modifiers = ["underlined"] }
 "string"  = "gold"
@@ -43,7 +43,7 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"text" = "text"
+"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -30,7 +30,6 @@
 "attribute" = "aqua"
 "constructor" = "yellow"
 "module" = "blue"
-"property" = "yellow"
 "special" = "orange"
 
 "ui.background" = { bg = "bg0" }

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -30,7 +30,6 @@
 "attribute" = "aqua"
 "constructor" = "yellow"
 "module" = "blue"
-"property" = "yellow"
 "special" = "orange"
 
 "ui.background" = { bg = "bg0" }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -8,7 +8,6 @@
 "operator" = { fg = "magenta" }
 "punctuation" = { fg = "foreground" }
 "string" = { fg = "yellow" }
-"path" = { fg = "blue" }
 "string.regexp" = { fg = "red" }
 "tag" = { fg = "magenta" }
 "type" = { fg = "cyan", modifiers = ["italic"] }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -8,6 +8,7 @@
 "operator" = { fg = "magenta" }
 "punctuation" = { fg = "foreground" }
 "string" = { fg = "yellow" }
+"string.special.path" = { fg = "blue" }
 "string.regexp" = { fg = "red" }
 "tag" = { fg = "magenta" }
 "type" = { fg = "cyan", modifiers = ["italic"] }

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -10,7 +10,6 @@
 "punctuation.delimiter" = "#6c3163"
 "operator" = "#ba2f59"
 "special" = "#ba2f59"
-"property" = "#7590db"
 "variable.property" = "#7590db"
 "variable" = "#715ab1"
 "variable.builtin" = "#715ab1"


### PR DESCRIPTION
- Replace "text" with "ui.text" in rose_pine* themes
- Change "attributes" to "attribute" in many included themes
- Document "attribute", "property" and "punctuation.special" in the theme section of the book.
- Remove "variable.function" from the documentation: it doesn't appear to exist in any highlights.scm.
- Remove "path" from snazzy; maybe it should be string.special.path?