### PR TITLE
Improve dart indent

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -923,7 +923,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "dart"
-source = { git = "https://github.com/UserNobody14/tree-sitter-dart", rev = "6a25376685d1d47968c2cef06d4db8d84a70025e" }
+source = { git = "https://github.com/UserNobody14/tree-sitter-dart", rev = "2d7f66651c9319c1a0e4dda226cc2628fbb66528" }
 
 [[language]]
 name = "scala"

--- a/runtime/queries/dart/indents.scm
+++ b/runtime/queries/dart/indents.scm
@@ -3,7 +3,6 @@
   (template_substitution)
   (list_literal)
   (set_or_map_literal)
-;   (inferred_parameters) ; this one is not actually used
   (parenthesized_expression)
   (arguments)
   (index_selector)
@@ -16,16 +15,12 @@
   (enum_body)
   (class_body)
   (extension_body)
-;   (constructor_body) ; this one is not actually used
   (parameter_type_list)
   (optional_positional_parameter_types)
   (named_parameter_types)
   (formal_parameter_list)
-;   (positional_parameters) ; this one is not actually used
   (optional_formal_parameters)
 ] @indent
-
-; dimensions is not actuallly used
 
 ; control flow statement which accept one line as body
 

--- a/runtime/queries/dart/indents.scm
+++ b/runtime/queries/dart/indents.scm
@@ -1,16 +1,100 @@
+; things surrounded by ({[]})
 [
-  (class_body)
-  (function_body)
-  (function_expression_body)
-  (declaration)
-  (initializers)
-  (switch_block)
-  (if_statement)
-  (formal_parameter_list)
-  (formal_parameter)
+  (template_substitution)
   (list_literal)
-  (return_statement)
+  (set_or_map_literal)
+;   (inferred_parameters) ; this one is not actually used
+  (parenthesized_expression)
   (arguments)
+  (index_selector)
+  (block)
+  (assertion_arguments)
+  (switch_block)
+  (catch_parameters)
+  (for_loop_parts)
+  (configuration_uri_condition)
+  (enum_body)
+  (class_body)
+  (extension_body)
+;   (constructor_body) ; this one is not actually used
+  (parameter_type_list)
+  (optional_positional_parameter_types)
+  (named_parameter_types)
+  (formal_parameter_list)
+;   (positional_parameters) ; this one is not actually used
+  (optional_formal_parameters)
+] @indent
+
+; dimensions is not actuallly used
+
+; control flow statement which accept one line as body
+
+(for_statement
+  body: _ @indent
+  (#not-kind-eq? @indent block)
+  (#set! "scope" "all")
+)
+
+(while_statement
+  body: _ @indent
+  (#not-kind-eq? @indent block)
+  (#set! "scope" "all")
+)
+
+(do_statement
+  body: _ @indent
+  (#not-kind-eq? @indent block)
+  (#set! "scope" "all")
+)
+
+(if_statement
+  consequence: _ @indent
+  (#not-kind-eq? @indent block)
+  (#set! "scope" "all")
+)
+(if_statement
+  alternative: _ @indent
+  (#not-kind-eq? @indent if_statement)
+  (#not-kind-eq? @indent block)
+  (#set! "scope" "all")
+)
+(if_statement
+  "else" @else
+  alternative: (if_statement) @indent
+  (#not-same-line? @indent @else)
+  (#set! "scope" "all")
+)
+
+(if_element
+  consequence: _ @indent
+  (#set! "scope" "all")
+)
+(if_element
+  alternative: _ @indent
+  (#not-kind-eq? @indent if_element)
+  (#set! "scope" "all")
+)
+(if_element
+  "else" @else
+  alternative: (if_element) @indent
+  (#not-same-line? @indent @else)
+  (#set! "scope" "all")
+)
+
+(for_element
+  body: _ @indent
+  (#set! "scope" "all")
+)
+
+; simple statements
+[
+  (local_variable_declaration)
+  (break_statement)
+  (continue_statement)
+  (return_statement)
+  (yield_statement)
+  (yield_each_statement)
+  (expression_statement)
 ] @indent
 
 [
@@ -18,3 +102,4 @@
   "]"
   ")"
 ] @outdent
+


### PR DESCRIPTION
This PR improves the indentation for dart. It is based on a more recent version of the grammar, so it updates it in addition to changing `runtime/queries/dart/indents.scm`