### PR TITLE
Improved file-picker configuration documentation

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -119,6 +119,7 @@ the default file-picker configuration below are IgnoreOptions: whether hidden
 files and files listed within ignore files are ignored by (not visible in) the
 helix file picker and global search. There is also one other key, `max-depth`
 available, which is not defined by default.
+
 All git related options are only enabled in a git repository.
 
 | Key | Description | Default |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -119,6 +119,7 @@ the default file-picker configuration below are IgnoreOptions: whether hidden
 files and files listed within ignore files are ignored by (not visible in) the
 helix file picker and global search. There is also one other key, `max-depth`
 available, which is not defined by default.
+All git related options are only enabled in a git repository.
 
 | Key | Description | Default |
 |--|--|---------|


### PR DESCRIPTION
Added statement that git related file-picker configurations only work in
a git repo.

Closes #3415

Can somebody confirm that actually all git related file-picker configurations options are only enabled in a git repo and not only the git-ignore option?