### PR TITLE
Render html `<code>` tags as code in markdown

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -178,6 +178,21 @@ impl Markdown {
             .map(|key| get_theme(key))
             .collect();
 
+        // Transform text in `<code>` blocks into `Event::Code`
+        let mut in_code = false;
+        let parser = parser.filter_map(|event| match event {
+            Event::Html(tag) if *tag == *"<code>" => {
+                in_code = true;
+                None
+            }
+            Event::Html(tag) if *tag == *"</code>" => {
+                in_code = false;
+                None
+            }
+            Event::Text(text) if in_code => Some(Event::Code(text)),
+            _ => Some(event),
+        });
+
         for event in parser {
             match event {
                 Event::Start(Tag::List(list)) => {


### PR DESCRIPTION
Resolves #3411.
Before:
![image](https://user-images.githubusercontent.com/58790821/184526136-0a44451c-22d4-4e3f-b292-0270bbff133f.png)
After:
![image](https://user-images.githubusercontent.com/58790821/184526152-17816e89-0153-4906-bc2b-82d6e0d484e8.png)
