### PR TITLE
Allow tab virtual whitespace padding

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -192,7 +192,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 | Key | Description | Default |
 |-----|-------------|---------|
 | `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `tab`, and `newline`. | `"none"` |
-| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp` or `newline` | See example below |
+| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad` | See example below |
 
 Example
 
@@ -210,6 +210,7 @@ space = "·"
 nbsp = "⍽"
 tab = "→"
 newline = "⏎"
+tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 ```
 
 ### `[editor.indent-guides]` Section

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -390,19 +390,23 @@ impl EditorView {
         // of times than it is to always call Rope::slice/get_slice (it will internally always hit RSEnum::Light).
         let text = doc.text().slice(..);
 
+        let characters = &whitespace.characters;
+
         let mut spans = Vec::new();
         let mut visual_x = 0u16;
         let mut line = 0u16;
         let tab_width = doc.tab_width();
         let tab = if whitespace.render.tab() == WhitespaceRenderValue::All {
-            (1..tab_width).fold(whitespace.characters.tab.to_string(), |s, _| s + " ")
+            std::iter::once(characters.tab)
+                .chain(std::iter::repeat(characters.tabpad).take(tab_width - 1))
+                .collect()
         } else {
             " ".repeat(tab_width)
         };
-        let space = whitespace.characters.space.to_string();
-        let nbsp = whitespace.characters.nbsp.to_string();
+        let space = characters.space.to_string();
+        let nbsp = characters.nbsp.to_string();
         let newline = if whitespace.render.newline() == WhitespaceRenderValue::All {
-            whitespace.characters.newline.to_string()
+            characters.newline.to_string()
         } else {
             " ".to_string()
         };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -438,6 +438,7 @@ pub struct WhitespaceCharacters {
     pub space: char,
     pub nbsp: char,
     pub tab: char,
+    pub tabpad: char,
     pub newline: char,
 }
 
@@ -448,6 +449,7 @@ impl Default for WhitespaceCharacters {
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE
+            tabpad: ' ',
         }
     }
 }


### PR DESCRIPTION
Resolves #3427.
Added new `whitespace.characters.tabpad` option which sets the padding for tabs
Example:
![image](https://user-images.githubusercontent.com/58790821/184972272-6f9ec7cd-2c3b-4f32-b4df-ef28591fe9fe.png)
