### PR TITLE
Update tree-sitter-rust and fix C, Rust and Erlang highlights

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -50,7 +50,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "a360da0a29a19c281d08295a35ecd0544d2da211" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "41e23b454f503e6fe63ec4b6d9f7f2cf7788ab8e" }
 
 [[language]]
 name = "toml"

--- a/languages.toml
+++ b/languages.toml
@@ -1104,6 +1104,14 @@ comment-token = "%%"
 indent = { tab-width = 4, unit = "    " }
 language-server = { command = "erlang_ls" }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+"'" = "'"
+'`' = "'"
+
 [[grammar]]
 name = "erlang"
 source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "0e7d677d11a7379686c53c616825714ccb728059" }

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -21,6 +21,7 @@
 "union" @keyword
 "volatile" @keyword
 "while" @keyword
+"const" @keyword
 
 [
  "#define"
@@ -50,9 +51,13 @@
 "==" @operator
 ">" @operator
 "||" @operator
+">=" @operator
+"<=" @operator
 
 "." @punctuation.delimiter
 ";" @punctuation.delimiter
+
+[(true) (false)] @constant.builtin.boolean
 
 (enumerator) @type.enum.variant
 

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -18,7 +18,7 @@
     .
     [(atom) @type (macro)]
     [
-      (tuple (atom) @variable.other.member)
+      (tuple (atom)? @variable.other.member)
       (tuple
         (binary_operator
           left: (atom) @variable.other.member

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -67,6 +67,7 @@
   "]"
   "{"
   "}"
+  "#"
 ] @punctuation.bracket
 (type_arguments
   [


### PR DESCRIPTION
Closes #3463

Updates tree-sitter-rust to the latest which fixes some edge-cases in the parsing. It doesn't look like there were any breaking changes and scanning around the code I don't see anything off.

I also have some random fixes here for:

* The `#` in rust attributes
* C booleans, `const` and `<=`/`>=` operators
* Empty Erlang records and Edoc-style auto-pairs