### PR TITLE
removes deprecated stdio flag for omnisharp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -217,7 +217,7 @@ file-types = ["cs"]
 roots = ["sln", "csproj"]
 comment-token = "//"
 indent = { tab-width = 4, unit = "\t" }
-language-server = { command = "OmniSharp", args = [ "--languageserver", "--stdio" ] }
+language-server = { command = "OmniSharp", args = [ "--languageserver" ] }
 
 [[grammar]]
 name = "c-sharp"


### PR DESCRIPTION
while still [documented](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/doc/Using-Omnisharp.md) the `--stdio` flag for omnisharp is deprecated since 2019...

see: [here](https://github.com/OmniSharp/omnisharp-roslyn/pull/1362)
as well as [here](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Stdio/StdioCommandLineApplication.cs), [here ](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Host/CommandLineApplication.cs) and [here](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Http/HttpCommandLineApplication.cs)