### PR TITLE
Update tree-sitter-org

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1157,7 +1157,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "org"
-source = { git = "https://github.com/milisims/tree-sitter-org", rev = "1c3eb533a9cf6800067357b59e03ac3f91fc3a54" }
+source = { git = "https://github.com/milisims/tree-sitter-org", rev = "698bb1a34331e68f83fc24bdd1b6f97016bb30de" }
 
 [[language]]
 name = "solidity"


### PR DESCRIPTION
The update fixes a bug that caused the external scanner to hang during
error recovery.

Looking at the diff, there are no structural changes in this update.
There are a few new fields and it looks like some edge-case fixes
but nothing that breaks compatibility with the current queries.

Closes #3376 