### PR TITLE
feat(rust): highlight try operator (?) as operator

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -320,6 +320,8 @@
   "'"
 ] @operator
 
+(try_expression "?" @operator)
+(removed_trait_bound "?" @operator)
 
 
 ; -------
@@ -357,8 +359,6 @@
 ; -------
 ; Remaining Identifiers
 ; -------
-
-"?" @special
 
 (type_identifier) @type
 (identifier) @variable


### PR DESCRIPTION
Fixes #3490.

I restricted this highlight to the `try_expression` tree-sitter scope. I think this makes sense if we don't want to highlight `?` in other places as an operator, for example in `?Sized`.