### PR TITLE
Add Markdown LSP via Marksman

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -67,7 +67,7 @@
 | llvm-mir-yaml | ✓ |  | ✓ |  |
 | lua | ✓ |  | ✓ | `lua-language-server` |
 | make | ✓ |  |  |  |
-| markdown | ✓ |  |  |  |
+| markdown | ✓ |  |  | `marksman` |
 | markdown.inline | ✓ |  |  |  |
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |

--- a/languages.toml
+++ b/languages.toml
@@ -905,7 +905,8 @@ name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"
 file-types = ["md", "markdown"]
-roots = []
+roots = [".marksman.toml"]
+language-server = { command = "marksman", args=["server"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Marksman is an LSP server for Markdown: https://github.com/artempyanykh/marksman
It supports a bunch of LSP features: symbols, references, rename, diag, etc. and already has integrations with emacs, neovim, and vscode. I think it can be a good addition to Helix.

_Context_:
I'm the author of Marksman. I've recently got [a bug-report](https://github.com/artempyanykh/marksman/issues/45) from a user that Marksman doesn't work with Helix. I haven't heard about Helix before, but it looked like an awesome project, so I  fixed a couple things and now the latest release of Marksman seems to work pretty well with Helix.