### PR TITLE
Fix rendering of indented code blocks in markdown

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -229,10 +229,7 @@ impl Markdown {
                 Event::End(tag) => {
                     tags.pop();
                     match tag {
-                        Tag::Heading(_, _, _)
-                        | Tag::Paragraph
-                        | Tag::CodeBlock(CodeBlockKind::Fenced(_))
-                        | Tag::Item => {
+                        Tag::Heading(_, _, _) | Tag::Paragraph | Tag::CodeBlock(_) | Tag::Item => {
                             push_line(&mut spans, &mut lines);
                         }
                         _ => (),
@@ -240,17 +237,18 @@ impl Markdown {
 
                     // whenever heading, code block or paragraph closes, empty line
                     match tag {
-                        Tag::Heading(_, _, _)
-                        | Tag::Paragraph
-                        | Tag::CodeBlock(CodeBlockKind::Fenced(_)) => {
+                        Tag::Heading(_, _, _) | Tag::Paragraph | Tag::CodeBlock(_) => {
                             lines.push(Spans::default());
                         }
                         _ => (),
                     }
                 }
                 Event::Text(text) => {
-                    // TODO: temp workaround
-                    if let Some(Tag::CodeBlock(CodeBlockKind::Fenced(language))) = tags.last() {
+                    if let Some(Tag::CodeBlock(kind)) = tags.last() {
+                        let language = match kind {
+                            CodeBlockKind::Fenced(language) => language,
+                            CodeBlockKind::Indented => "",
+                        };
                         let tui_text = highlighted_code_block(
                             text.to_string(),
                             language,


### PR DESCRIPTION
Relates to https://github.com/helix-editor/helix/pull/3425 and https://github.com/elixir-lsp/elixir-ls/issues/694

Properly handles the rendering of indented code blocks in markdown. Given that we do not have a language identifier available, we style these blocks as generic code (visually distinct from markdown text, but no highlighting via tree-sitter).

This improves the experience of writing Elixir in Helix, as the majority of documentation favors indentation over fences.

**Before** ☹️ 
![image](https://user-images.githubusercontent.com/6548350/185831364-30dc265b-d275-48dd-9745-a16094545501.png)

**After** 😁 
![image](https://user-images.githubusercontent.com/6548350/185830932-14c7e578-a4fc-44f3-87f8-15839bd69b32.png)