### PR TITLE
Reduce health tick width

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -142,7 +142,7 @@ pub fn languages_all() -> std::io::Result<()> {
 
     let check_binary = |cmd: Option<String>| match cmd {
         Some(cmd) => match which::which(&cmd) {
-            Ok(_) => column(&format!("✔ {}", cmd), Color::Green),
+            Ok(_) => column(&format!("✓ {}", cmd), Color::Green),
             Err(_) => column(&format!("✘ {}", cmd), Color::Red),
         },
         None => column("None", Color::Yellow),
@@ -162,7 +162,7 @@ pub fn languages_all() -> std::io::Result<()> {
 
         for ts_feat in TsFeature::all() {
             match load_runtime_file(&lang.language_id, ts_feat.runtime_filename()).is_ok() {
-                true => column("✔", Color::Green),
+                true => column("✓", Color::Green),
                 false => column("✘", Color::Red),
             }
         }
@@ -271,7 +271,7 @@ fn probe_treesitter_feature(lang: &str, feature: TsFeature) -> std::io::Result<(
     let mut stdout = stdout.lock();
 
     let found = match load_runtime_file(lang, feature.runtime_filename()).is_ok() {
-        true => "✔".green(),
+        true => "✓".green(),
         false => "✘".red(),
     };
     writeln!(stdout, "{} queries: {}", feature.short_title(), found)?;


### PR DESCRIPTION
Use the same tick as book to reduce margin of whitespace errors.

Before
![Screenshot_20220822_214053](https://user-images.githubusercontent.com/4687791/185935241-d8dd9ab7-5c53-4e1e-86f6-5469ec57a61e.png)

After
![Screenshot_20220822_214126](https://user-images.githubusercontent.com/4687791/185935349-6ec79138-ba24-4386-b034-2968f2a1cd17.png)

This may be a terminal issue, but at the same time I just make it consistent with the docs. Also, I noticed this because I saw the same symbol in https://rsdlt.github.io/posts/rust-nvim-ide-guide-walkthrough-development-debug/.