### PR TITLE
Julia queries: update grammar, major refactoring

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -571,7 +571,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "julia"
-source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "12ea597262125fc22fd2e91aa953ac69b19c26ca" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "fc60b7cce87da7a1b7f8cb0f9371c3dc8b684500" }
 
 [[language]]
 name = "java"

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -1,112 +1,142 @@
+; ----------
+; Primitives
+; ----------
 
-(string_literal) @string
+[
+  (line_comment)
+  (block_comment)
+] @comment
 
-(prefixed_string_literal
-  prefix: (identifier) @constant.builtin)
-
-(macro_identifier) @function.macro
-(macro_identifier (identifier) @function.macro) ; for any one using the variable highlight
-(macro_definition
-  name: (identifier) @function.macro
-  ["macro" "end" @keyword])
-
-(field_expression
-  (identifier)
-  (identifier) @variable.other.member .)
-
-(function_definition
-  name: (identifier) @function)
-(call_expression
-  (identifier) @function)
-(call_expression
-  (field_expression (identifier) @function.method .))
-(broadcast_call_expression
-  (identifier) @function)
-(broadcast_call_expression
-  (field_expression (identifier) @function.method .))
-(parameter_list
-  (identifier) @variable.parameter)
-(parameter_list
-  (optional_parameter .
-    (identifier) @variable.parameter))
-(typed_parameter
-  (identifier) @variable.parameter
-  (identifier) @type)
-(type_parameter_list
-  (identifier) @type)
-(typed_parameter
-  (identifier) @variable.parameter
-  (parameterized_identifier) @type)
-(function_expression
-  . (identifier) @variable.parameter)
-(spread_parameter) @variable.parameter
-(spread_parameter
-  (identifier) @variable.parameter)
-(named_argument
-    . (identifier) @variable.parameter)
-(argument_list
-  (typed_expression
-    (identifier) @variable.parameter
-    (identifier) @type))
-(argument_list
-  (typed_expression
-    (identifier) @variable.parameter
-    (parameterized_identifier) @type))
-
-;; Symbol expressions (:my-wanna-be-lisp-keyword)
-(quote_expression
- (identifier)) @string.special.symbol
-
-;; Parsing error! foo (::Type) get's parsed as two quote expressions
-(argument_list 
-  (quote_expression
-    (quote_expression
-      (identifier) @type)))
-
-(type_argument_list
-  (identifier) @type)
-(parameterized_identifier (_)) @type
-(argument_list
-  (typed_expression . (identifier) @variable.parameter))
-
-(typed_expression
-  (identifier) @type .)
-(typed_expression
-  (parameterized_identifier) @type .)
-
-(struct_definition
-  name: (identifier) @type)
+(((identifier) @constant.builtin) (match? @constant.builtin "^(nothing|missing|Inf|NaN)$"))
+(((identifier) @constant.builtin.boolean) (#eq? @constant.builtin.boolean "true"))
+(((identifier) @constant.builtin.boolean) (#eq? @constant.builtin.boolean "false"))
 
 (integer_literal) @constant.numeric.integer
 (float_literal) @constant.numeric.float
 
-(range_expression
-    (identifier) @constant.numeric.integer
-      (eq? @constant.numeric.integer "end"))
-(range_expression
-  (_
-    (identifier) @constant.numeric.integer
-      (eq? @constant.numeric.integer "end")))
-(coefficient_expression
-  [
-    (integer_literal)
-    (float_literal)
-  ]
-  (identifier) @constant.builtin)
+(character_literal) @constant.character
+(escape_sequence) @constant.character.escape
 
-;; TODO: operators.
-;; Those are a bit difficult to implement since the respective nodes are hidden right now (_power_operator)
-;; and heavily use Unicode chars (support for those are bad in vim/lua regexes)
-;[;
-    ;(power_operator);
-    ;(times_operator);
-    ;(plus_operator);
-    ;(arrow_operator);
-    ;(comparison_operator);
-    ;(assign_operator);
-;] @operator ;
+(string_literal) @string
 
-"end" @keyword
+(prefixed_string_literal
+  prefix: (identifier) @function.macro) @string
+
+(quote_expression
+  (identifier) @string.special.symbol) 
+  
+; -------------------
+; Modules and Imports
+; -------------------
+
+(module_definition
+  name: (identifier) @namespace)
+  
+(import_statement
+  (identifier) @namespace)
+  
+(selected_import
+  . (identifier) @namespace)
+
+(scoped_identifier
+  (identifier) @namespace)
+
+; -----
+; Types
+; -----
+
+(abstract_definition
+  name: (identifier) @type)
+  
+(primitive_definition
+  name: (identifier) @type)
+
+(struct_definition
+  name: (identifier) @type)
+
+(struct_definition
+  . (_)
+    (identifier) @variable.other.member)
+
+(struct_definition
+  . (_)
+  (typed_expression
+    . (identifier) @variable.other.member))
+    
+(type_parameter_list
+  (identifier) @type)
+
+(constrained_parameter
+  (identifier) @type)
+  
+(subtype_clause
+  (identifier) @type)
+
+(typed_expression
+  (identifier) @type . )
+
+(parameterized_identifier
+  (identifier) @type)
+  
+(type_argument_list
+  (identifier) @type)
+
+; -------------------
+; Function definition
+; -------------------
+
+(function_definition
+  name: (identifier) @function)
+
+(parameter_list
+  (identifier) @variable.parameter)
+
+(typed_parameter
+  (identifier) @variable.parameter
+  (identifier)? @type)
+
+(optional_parameter
+  . (identifier) @variable.parameter)
+
+(spread_parameter
+  (identifier) @variable.parameter)
+
+(function_expression
+  . (identifier) @variable.parameter)
+
+; ---------------
+; Functions calls
+; ---------------
+
+(call_expression
+  (identifier) @function)
+
+(broadcast_call_expression
+  (identifier) @function)
+
+(call_expression
+  (field_expression (identifier) @function .))
+
+(broadcast_call_expression
+  (field_expression (identifier) @function .))
+
+; ------
+; Macros
+; ------
+
+(macro_definition
+  name: (identifier) @function.macro)
+
+(macro_identifier
+  "@" @function.macro
+  (identifier) @function.macro)
+
+; --------
+; Keywords
+; --------
+
+(function_definition 
+  ["function" "end"] @keyword.function)
 
 (if_statement
   ["if" "end"] @keyword.control.conditional)
@@ -117,36 +147,6 @@
 (ternary_expression
   ["?" ":"] @keyword.control.conditional)
 
-(function_definition ["function" "end"] @keyword.function)
-
-[
-  (line_comment)
-  (block_comment)
-] @comment
-
-[
-  "const"
-  "return"
-  "macro"
-  "struct"
-  "primitive"
-  "type"
-] @keyword
-
-((identifier) @keyword (match? @keyword "global|local"))
-
-(compound_expression
-  ["begin" "end"] @keyword)
-(try_statement
-  ["try" "end" ] @keyword.control.exception)
-(finally_clause
-  "finally" @keyword.control.exception)
-(catch_clause
-  "catch" @keyword.control.exception)
-(quote_statement
-  ["quote" "end"] @keyword)
-(let_statement
-  ["let" "end"] @keyword)
 (for_statement
   ["for" "end"] @keyword.control.repeat)
 (while_statement
@@ -157,33 +157,90 @@
   "in" @keyword.control.repeat)
 (for_clause
   "for" @keyword.control.repeat)
-(do_clause
-  ["do" "end"] @keyword)
 
-(export_statement
-  ["export"] @keyword.control.import)
+(try_statement
+  ["try" "end" ] @keyword.control.exception)
+(finally_clause
+  "finally" @keyword.control.exception)
+(catch_clause
+  "catch" @keyword.control.exception)
 
 [
-  "using"
-  "module"
+  "export"
   "import"
+  "using"
 ] @keyword.control.import
 
-((identifier) @keyword.control.import (#eq? @keyword.control.import "baremodule"))
+[
+  "abstract"
+  "begin"
+  "const"
+  "do"
+  "end"
+  "let"
+  "macro"
+  "module"
+  "mutable"
+  "primitive"
+  "quote"
+  "return"
+  "struct"
+  "type"
+] @keyword
 
-(((identifier) @constant.builtin) (match? @constant.builtin "^(nothing|Inf|NaN)$"))
-(((identifier) @constant.builtin.boolean) (#eq? @constant.builtin.boolean "true"))
-(((identifier) @constant.builtin.boolean) (#eq? @constant.builtin.boolean "false"))
+; TODO: fix this
+((identifier) @keyword (match? @keyword "global|local"))
 
+; ---------
+; Operators
+; ---------
 
-["::" ":" "." "," "..."] @punctuation.delimiter
-["[" "]" "(" ")" "{" "}"] @punctuation.bracket
+[
+  (operator)
+  "::"
+  "<:"
+  ":"
+  "=>"
+  "..."
+  "$"
+] @operator
 
-["="] @operator
+; ------------
+; Punctuations
+; ------------
+
+[
+  "."
+  "," 
+  ";"
+] @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "("
+  ")" 
+  "{" 
+  "}"
+] @punctuation.bracket
+
+; ---------------------
+; Remaining identifiers
+; ---------------------
+
+; could also be namespace but this should cover the majority
+(field_expression
+  . (_)
+  (identifier) @variable.other.member)
+
+(const_statement
+  (variable_declaration
+    . (identifier) @constant))
+
+((identifier) @type
+  (match? @type "([A-Z][a-z0-9]+)+$"))
+
+((identifier) @constant
+  (match? @constant "^[A-Z][A-Z0-9_]+$"))
 
 (identifier) @variable
-;; In case you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
-;((identifier) @type ; exception: mark `A_foo` sort of identifiers as variables
-  ;(match? @type "^[A-Z][^_]"))
-((identifier) @constant
-  (match? @constant "^[A-Z][A-Z_]{2}[A-Z_]*$"))

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -85,8 +85,11 @@
 ; Function definition
 ; -------------------
 
-(function_definition
-  name: (identifier) @function)
+(
+  (function_definition
+    name: (identifier) @function)
+  ; prevent constructors (PascalCase) to be highlighted as functions
+  (#match? @function "^[^A-Z]"))
 
 (parameter_list
   (identifier) @variable.parameter)
@@ -108,17 +111,26 @@
 ; Functions calls
 ; ---------------
 
-(call_expression
-  (identifier) @function)
+(
+  (call_expression
+    (identifier) @function)
+  ; prevent constructors (PascalCase) to be highlighted as functions
+  (#match? @function "^[^A-Z]"))
 
-(broadcast_call_expression
-  (identifier) @function)
+(
+  (broadcast_call_expression
+    (identifier) @function)
+  (#match? @function "^[^A-Z]"))
 
-(call_expression
-  (field_expression (identifier) @function .))
+(
+  (call_expression
+    (field_expression (identifier) @function .))
+  (#match? @function "^[^A-Z]"))
 
-(broadcast_call_expression
-  (field_expression (identifier) @function .))
+(
+  (broadcast_call_expression
+    (field_expression (identifier) @function .))
+  (#match? @function "^[^A-Z]"))
 
 ; ------
 ; Macros
@@ -228,19 +240,25 @@
 ; Remaining identifiers
 ; ---------------------
 
-; could also be namespace but this should cover the majority
-(field_expression
-  . (_)
-  (identifier) @variable.other.member)
-
 (const_statement
   (variable_declaration
     . (identifier) @constant))
 
-((identifier) @type
-  (match? @type "([A-Z][a-z0-9]+)+$"))
+; SCREAMING_SNAKE_CASE
+(
+  (identifier) @constant
+  (match? @constant "^[A-Z][A-Z0-9_]*$"))
 
-((identifier) @constant
-  (match? @constant "^[A-Z][A-Z0-9_]+$"))
+; remaining identifiers that start with capital letters should be types (PascalCase)
+(
+  (identifier) @type
+  (match? @type "^[A-Z]"))
+
+; Field expressions are either module content or struct fields.
+; Module types and constants should already be captured, so this
+; assumes the remaining identifiers to be struct fields.
+(field_expression
+  (_)
+  (identifier) @variable.other.member)
 
 (identifier) @variable

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -1,10 +1,7 @@
 
-[
-  (triple_string)
-  (string)
-] @string
+(string_literal) @string
 
-(string
+(prefixed_string_literal
   prefix: (identifier) @constant.builtin)
 
 (macro_identifier) @function.macro
@@ -80,7 +77,9 @@
 (struct_definition
   name: (identifier) @type)
 
-(number) @constant.numeric.integer
+(integer_literal) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+
 (range_expression
     (identifier) @constant.numeric.integer
       (eq? @constant.numeric.integer "end"))
@@ -89,7 +88,10 @@
     (identifier) @constant.numeric.integer
       (eq? @constant.numeric.integer "end")))
 (coefficient_expression
-  (number)
+  [
+    (integer_literal)
+    (float_literal)
+  ]
   (identifier) @constant.builtin)
 
 ;; TODO: operators.
@@ -117,7 +119,10 @@
 
 (function_definition ["function" "end"] @keyword.function)
 
-(comment) @comment
+[
+  (line_comment)
+  (block_comment)
+] @comment
 
 [
   "const"
@@ -171,7 +176,7 @@
 (((identifier) @constant.builtin.boolean) (#eq? @constant.builtin.boolean "false"))
 
 
-["::" ":" "." "," "..." "!"] @punctuation.delimiter
+["::" ":" "." "," "..."] @punctuation.delimiter
 ["[" "]" "(" ")" "{" "}"] @punctuation.bracket
 
 ["="] @operator

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,5 +1,8 @@
-((triple_string) @injection.content
- (#set! injection.language "markdown"))
+; ((string_literal) @injection.content
+;  (#set! injection.language "markdown"))
 
-((comment) @injection.content
- (#set! injection.language "comment"))
+; ((line_comment) @injection.content
+;  (#set! injection.language "comment"))
+
+; ((block_comment) @injection.content
+;  (#set! injection.language "comment"))

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,8 +1,16 @@
-; ((string_literal) @injection.content
-;  (#set! injection.language "markdown"))
+(
+  (string_literal) @injection.content
+  (#set! injection.language "markdown"))
 
-; ((line_comment) @injection.content
-;  (#set! injection.language "comment"))
+(
+  [
+    (line_comment) 
+    (block_comment)
+  ] @injection.content
+  (#set! injection.language "comment"))
 
-; ((block_comment) @injection.content
-;  (#set! injection.language "comment"))
+(
+  (prefixed_string_literal
+    prefix: (identifier) @function.macro) @injection.content
+  (#eq? @function.macro "re")
+  (#set! injection.language "regex"))

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,18 +1,17 @@
 (
   (source_file
-    (
-      (string_literal) @injection.content
-      [
-        (module_definition)
-        (function_definition)
-        (macro_definition)
-        (primitive_definition)
-        (abstract_definition)
-        (struct_definition)
-        (assignment_expression)
-        (const_statement)
-      ]
-    ))
+    (string_literal) @injection.content
+    .
+    [
+      (module_definition)
+      (function_definition)
+      (macro_definition)
+      (primitive_definition)
+      (abstract_definition)
+      (struct_definition)
+      (assignment_expression)
+      (const_statement)
+    ])
   (#set! injection.language "markdown"))
 
 (

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,5 +1,18 @@
 (
-  (string_literal) @injection.content
+  (source_file
+    (
+      (string_literal) @injection.content
+      [
+        (module_definition)
+        (function_definition)
+        (macro_definition)
+        (primitive_definition)
+        (abstract_definition)
+        (struct_definition)
+        (assignment_expression)
+        (const_statement)
+      ]
+    ))
   (#set! injection.language "markdown"))
 
 (

--- a/runtime/queries/julia/locals.scm
+++ b/runtime/queries/julia/locals.scm
@@ -1,59 +1,43 @@
+; -----------
+; Definitions
+; -----------
 
+; Imports
 (import_statement
- (identifier) @definition.import)
-(variable_declaration
- (identifier) @local.definition)
-(variable_declaration
- (tuple_expression
-  (identifier) @local.definition))
-(for_binding
- (identifier) @local.definition)
-(for_binding
- (tuple_expression
-  (identifier) @local.definition))
+  (identifier) @local.definition)
+  
+; Constants
+(const_statement
+  (variable_declaration
+    . (identifier) @local.definition))
 
-(assignment_expression
- (tuple_expression
-  (identifier) @local.definition))
-(assignment_expression
- (bare_tuple_expression
-  (identifier) @local.definition))
-(assignment_expression
- (identifier) @local.definition)
-
-(type_parameter_list
-  (identifier) @definition.type)
-(type_argument_list
-  (identifier) @definition.type)
-(struct_definition
-  name: (identifier) @definition.type)
-
+; Parameters
 (parameter_list
- (identifier) @definition.parameter)
+  (identifier) @local.definition)
+
 (typed_parameter
- (identifier) @definition.parameter
- (identifier))
-(function_expression
- . (identifier) @definition.parameter)
-(argument_list
- (typed_expression
-  (identifier) @definition.parameter
-  (identifier)))
+  . (identifier) @local.definition)
+
+(optional_parameter .
+  (identifier) @local.definition)
+
 (spread_parameter
- (identifier) @definition.parameter)
+  (identifier) @local.definition)
 
-(function_definition
- name: (identifier) @definition.function) @local.scope
-(macro_definition 
- name: (identifier) @definition.macro) @local.scope
-
-(identifier) @local.reference
+(function_expression
+  . (identifier) @local.definition)
+ 
+; ------
+; Scopes
+; ------
 
 [
-  (try_statement)
-  (finally_clause)
-  (quote_statement)
-  (let_statement)
-  (compound_expression)
-  (for_statement)
+  (function_definition)
+  (macro_definition)
 ] @local.scope
+
+; ----------
+; References
+; ----------
+
+(identifier) @local.reference


### PR DESCRIPTION
This PR updates the grammar to the newest version and does a major refactoring of the `highlights.scm`.

I reorganized the file to make it more managable and fixed the broken, obsolete and missing queries (there was a lot). This will probably need another polishing pass in the future but this should be enough for now.

I also added regex injections and some locals.