### PR TITLE
Use the current document and view for mode-change hooks

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1140,7 +1140,8 @@ impl Component for EditorView {
                 // clear status
                 cx.editor.status_msg = None;
 
-                let doc = doc!(cx.editor);
+                let (view, doc) = current!(cx.editor);
+                let focus = view.id;
                 let mode = doc.mode();
 
                 if let Some(on_next_key) = self.on_next_key.take() {
@@ -1204,7 +1205,9 @@ impl Component for EditorView {
                     return EventResult::Ignored(None);
                 }
                 let config = cx.editor.config();
-                let (view, doc) = current!(cx.editor);
+                let view = cx.editor.tree.get_mut(focus);
+                let doc = cx.editor.documents.get_mut(&view.doc).unwrap();
+
                 view.ensure_cursor_in_view(doc, config.scrolloff);
 
                 // Store a history state if not in insert mode. This also takes care of


### PR DESCRIPTION
When changing the focused view with C-w for example, the w event was
being handled in the EditorView event handler as if it belonged to
the newly focused window.

~Instead of handling the event for the newly focused window, we should
return early. We don't want the change in focus to trigger a history
checkpoint (following block) and we don't want to execute the mode
transition hooks (the block after). With some configs this can cause
a panic, for example~

    keys.normal.w = ["no_op"]
    # or
    keys.normal.C-w.m = "rotate_view"

~since these fall into the `unimplemented!` in the mode transition block.~

Instead of handling the event in the newly focused view, we should handle
the event in the original view.