### PR TITLE
packaging: Point to homebrew-core instead of tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ for a language.
 
 ## MacOS
 
-Helix can be installed on MacOS through homebrew via:
+Helix can be installed on MacOS through homebrew:
 
 ```
-brew tap helix-editor/helix
 brew install helix
 ```
 

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -6,10 +6,9 @@ We provide pre-built binaries on the [GitHub Releases page](https://github.com/h
 
 ## OSX
 
-A Homebrew tap is available:
+Helix is available in homebrew-core:
 
 ```
-brew tap helix-editor/helix
 brew install helix
 ```
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -23,7 +23,7 @@ we'll use `<tag>` as a placeholder for the tag being published.
 * Post to reddit
     * [Example post](https://www.reddit.com/r/rust/comments/uzp5ze/helix_editor_2205_released/)
 
-[homebrew formula]: https://github.com/helix-editor/homebrew-helix/blob/master/Formula/helix.rb
+[homebrew formula]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/helix.rb
 
 ## Changelog Curation
 


### PR DESCRIPTION
Now that helix is packaged in homebrew-core, I don't think it's necessary to run the tap anymore.

It's difficult to install a formula from a tap because core has higher precedence than taps: you need to first tap helix `brew tap helix-editor/homebrew-helix` and then `brew install helix-editor/homebrew-helix/helix` (https://docs.brew.sh/Taps#formula-with-duplicate-names).