### PR TITLE
feat(lang): Add esdl grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -24,6 +24,7 @@
 | elvish | ✓ |  |  | `elvish` |
 | erb | ✓ |  |  |  |
 | erlang | ✓ | ✓ |  | `erlang_ls` |
+| esdl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
 | fortran | ✓ |  | ✓ | `fortls` |
 | gdscript | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1653,3 +1653,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "task"
 source = { git = "https://github.com/alexanderbrevig/tree-sitter-task", rev = "f2cb435c5dbf3ee19493e224485d977cb2d36d8b" }
+
+[[language]]
+name = "esdl"
+scope = "source.esdl"
+injection-regex = "esdl"
+file-types = ["esdl"]
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }
+roots = ["edgedb.toml"]
+
+[[grammar]]
+name ="esdl"
+# source = { git = "https://github.com/greym0uth/tree-sitter-esdl", rev = "9b7fa6c7f59738f6aa9e11ee18feb71b00045ea6" }
+source = { path = "/Users/grey/Development/oss/tree-sitter-esdl" }

--- a/languages.toml
+++ b/languages.toml
@@ -1665,5 +1665,4 @@ roots = ["edgedb.toml"]
 
 [[grammar]]
 name ="esdl"
-# source = { git = "https://github.com/greym0uth/tree-sitter-esdl", rev = "9b7fa6c7f59738f6aa9e11ee18feb71b00045ea6" }
-source = { path = "/Users/grey/Development/oss/tree-sitter-esdl" }
+source = { git = "https://github.com/greym0uth/tree-sitter-esdl", rev = "b840c8a8028127e0a7c6e6c45141adade2bd75cf" }

--- a/runtime/queries/esdl/highlights.scm
+++ b/runtime/queries/esdl/highlights.scm
@@ -1,0 +1,78 @@
+; Keywords
+[
+  "module"
+  "using"
+  "single"
+  "multi"
+  "link"
+  "property"
+  "constraint"
+  "tuple"
+  "annotation"
+  "abstract"
+  "scalar"
+  "type"
+  "required"
+  "optional"
+  "extension"
+  "function"
+] @keyword
+
+(modifier) @keyword
+(extending) @keyword
+
+(module name: (identifier) @namespace)
+(object_type) @type
+
+(comment) @comment
+
+; Properties
+(property) @property
+(link) @property
+
+; Links
+(identifier) @variable
+(string) @string
+(edgeql_fragment) @string
+
+; Annotations
+; (annotation) @property
+
+; Builtins
+
+(type) @type
+[
+  "str"
+  "bool"
+  "int16"
+  "int32"
+  "int64"
+  "float32"
+  "float64"
+  "bigint"
+  "decimal"
+  "json"
+  "uuid"
+  "bytes"
+  "datetime"
+  "duration"
+  "sequence"
+  "anytype"
+] @type.builtin
+
+(true) @constant.builtin
+(false) @constant.builtin
+(null) @constant.builtin
+
+; Delimiters
+[
+  ";"
+  ","
+] @punctuation.delimiter
+
+; Operators
+[
+  "->"
+  ":="
+] @operator
+

--- a/runtime/queries/esdl/highlights.scm
+++ b/runtime/queries/esdl/highlights.scm
@@ -27,17 +27,13 @@
 (comment) @comment
 
 ; Properties
-(property) @property
-(link) @property
+(property) @variable.other.member
+(link) @variable.other.member
+(annotation) @variable.other.member
 
-; Links
 (identifier) @variable
 (string) @string
 (edgeql_fragment) @string
-
-; Annotations
-; (annotation) @property
-
 ; Builtins
 
 (type) @type


### PR DESCRIPTION
Adds grammar for EdgeDB's SDL as well as highlight queries.

ESDL: https://www.edgedb.com/docs/datamodel/index
Grammar: https://github.com/greym0uth/tree-sitter-esdl