### PR TITLE
Update tree-sitter-ruby

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -482,7 +482,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ruby"
-source = { git = "https://github.com/tree-sitter/tree-sitter-ruby", rev = "dfff673b41df7fadcbb609c6338f38da3cdd018e" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-ruby", rev = "4c600a463d97e36a0ca5ac57e11f3ac8c297a0fa" }
 
 [[language]]
 name = "bash"


### PR DESCRIPTION
Closes #3504

tree-sitter-ruby master has a fix for the external scanner that prevents it from hanging from the changes in tree-sitter v0.20.8. There are quite a lot of changes to the grammar in the compare between the old & new commits but no breaking changes so the queries don't need any fixes.