### PR TITLE
fix: unreachable panic because of crossterms default-enabled brackete…

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -38,7 +38,7 @@ which = "4.2"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.25", features = ["event-stream"] }
+crossterm = { version = "0.25", default-features = false, features = ["event-stream"] }
 signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -19,7 +19,7 @@ default = ["crossterm"]
 bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.9"
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.25", default-features = false, optional = true }
 serde = { version = "1", "optional" = true, features = ["derive"]}
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1"
 helix-core = { version = "0.6", path = "../helix-core" }
 helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.25", default-features = false, optional = true }
 
 # Conversion traits
 once_cell = "1.13"

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -276,9 +276,6 @@ impl From<crossterm::event::Event> for Event {
             crossterm::event::Event::Resize(w, h) => Self::Resize(w, h),
             crossterm::event::Event::FocusGained => Self::FocusGained,
             crossterm::event::Event::FocusLost => Self::FocusLost,
-            crossterm::event::Event::Paste(_) => {
-                unreachable!("crossterm shouldn't emit Paste events without them being enabled")
-            }
         }
     }
 }


### PR DESCRIPTION
…d-paste

When trying to paste using `ctrl-shift-v`, `helix` would `panic!`.
This is the case because in `crossterm 0.25`
```
[features]
default = ["bracketed-paste"]
```
is enabled, which would lead to a panic in `helix-view/src/input.rs`
` unreachable!("crossterm shouldn't emit Paste events without them being enabled")`
After setting `default-features = false` for `crossterm 0.25`, the use of `crossterm::event::Event::Paste` now leads to a compiler error because it is no longer included.
After removing the single use of Event::Paste, helix successfully compiles, doesn't panic, the tests pass and pasting using ctrl-shift-v also works.