### PR TITLE
LSP match on TextDocumentSyncKind capability

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -611,6 +611,7 @@ impl Client {
                 // Supported(false)
                 _ => return None,
             },
+            Some(lsp::TextDocumentSyncCapability::Kind(lsp::TextDocumentSyncKind::FULL)) => true,
             // unsupported
             _ => return None,
         };


### PR DESCRIPTION
Hi!

`text_document_did_save` at the moment is ignoring some `TextDocumentSyncCapability` values. 
This results in Purescript LSP server not working properly, as it's never getting the save message.

From the code documentation it looks like `Kind(FULL)` should send the full content of the document, so I'm returning `true` here for `include_text`, but it's a bit of a shot in the dark.
It works, but I fear it might not be the proper solution.