### PR TITLE
helix-term: send the STOP signal to all processes in the process group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ checksum = "a20cebf73229debaa82574c4fd20dcaf00fa8d4bfce823a862c4e990d7a0b5b4"
 dependencies = [
  "gix-command",
  "gix-config-value",
- "nix",
+ "nix 0.26.1",
  "parking_lot",
  "thiserror",
 ]
@@ -1178,6 +1178,7 @@ dependencies = [
  "ignore",
  "indoc",
  "log",
+ "nix 0.25.1",
  "once_cell",
  "pulldown-cmark",
  "serde",
@@ -1506,6 +1507,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ checksum = "a20cebf73229debaa82574c4fd20dcaf00fa8d4bfce823a862c4e990d7a0b5b4"
 dependencies = [
  "gix-command",
  "gix-config-value",
- "nix 0.26.1",
+ "nix",
  "parking_lot",
  "thiserror",
 ]
@@ -1177,8 +1177,8 @@ dependencies = [
  "helix-view",
  "ignore",
  "indoc",
+ "libc",
  "log",
- "nix 0.25.1",
  "once_cell",
  "pulldown-cmark",
  "serde",
@@ -1507,18 +1507,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -68,6 +68,7 @@ grep-searcher = "0.1.11"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
+nix = { version = "0.25.0", features = ["signal", "process"], default-features = false }
 
 [build-dependencies]
 helix-loader = { version = "0.6", path = "../helix-loader" }

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -68,7 +68,7 @@ grep-searcher = "0.1.11"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
-nix = { version = "0.25.0", features = ["signal", "process"], default-features = false }
+libc = "0.2.132"
 
 [build-dependencies]
 helix-loader = { version = "0.6", path = "../helix-loader" }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -458,7 +458,9 @@ impl Application {
                 };
 
                 if res != 0 {
-                    eprintln!("{}", std::io::Error::from_raw_os_error(res));
+                    let err = std::io::Error::last_os_error();
+                    eprintln!("{}", err);
+                    let res = err.raw_os_error().unwrap_or(1);
                     std::process::exit(res);
                 }
             }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -454,6 +454,13 @@ impl Application {
                     // A pid of 0 sends the signal to the entire process group, allowing the user to
                     // regain control of their terminal if the editor was spawned under another process
                     // (e.g. when running `git commit`).
+                    //
+                    // We have to send SIGSTOP (not SIGTSTP) to the entire process group, because,
+                    // as mentioned above, the terminal will get stuck if `helix` was spawned from
+                    // an external process and that process waits for `helix` to complete. This may
+                    // be an issue with signal-hook-tokio, but the author of signal-hook believes it
+                    // could be a tokio issue instead:
+                    // https://github.com/vorner/signal-hook/issues/132
                     libc::kill(0, signal::SIGSTOP)
                 };
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -445,6 +445,11 @@ impl Application {
             signal::SIGTSTP => {
                 self.restore_term().unwrap();
 
+                // SAFETY:
+                //
+                // - helix must have permissions to send signals to all processes in its signal
+                //   group, either by already having the requisite permission, or by having the
+                //   user's UID / EUID / SUID match that of the receiving process(es).
                 let res = unsafe {
                     // A pid of 0 sends the signal to the entire process group, allowing the user to
                     // regain control of their terminal if the editor was spawned under another process


### PR DESCRIPTION
From kill(3p):

    If pid is 0, sig shall be sent to all processes (excluding an unspecified set
    of  system processes) whose process group ID is equal to the process group ID
    of the sender, and for which the process has permission to send a signal.

This fixes the issue of running `git commit`, attempting to suspend
helix with ^Z, and then not regaining control over the terminal and
having to press ^Z again.

---

Fixes https://github.com/helix-editor/helix/issues/3522.

---

I opted to add the `nix` crate because it has nice Rust wrappers around e.g. `kill`, handling error cases and other stuff for us. However, I could easily port it to the `libc` crate directly, if desired.