### PR TITLE
feat: ESC will escape out of selections in normal mode

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -483,6 +483,11 @@ impl Selection {
         Self::single(pos, pos)
     }
 
+    /// Converts selection to point
+    pub fn into_point(self) -> Self {
+        Self::single(self.ranges[0].anchor, self.ranges[0].anchor)
+    }
+
     /// Normalizes a `Selection`.
     fn normalize(mut self) -> Self {
         let primary = self.ranges[self.primary_index];

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2587,6 +2587,8 @@ fn normal_mode(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     if doc.mode == Mode::Normal {
+        // escape out of current selection if any
+        doc.set_selection(view.id, doc.selection(view.id).clone().into_point());
         return;
     }
 


### PR DESCRIPTION
This will enable you to back out of normal mode selections with ESC.

`xxxESC` will put you right back to where you started
`vxxxESC` will place you in normal mode with everything selected, ESC again will get you back to start
`waESC` still works and corrects the cursor placement