### PR TITLE
Select inserted space after join

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -129,6 +129,7 @@
 | `X`                   | Extend selection to line bounds (line-wise selection)             | `extend_to_line_bounds`              |
 | `Alt-x`               | Shrink selection to line bounds (line-wise selection)             | `shrink_to_line_bounds`              |
 | `J`                   | Join lines inside selection                                       | `join_selections`                    |
+| `A-J`                 | Join lines inside selection and select space                      | `join_selections_space`              |
 | `K`                   | Keep selections matching the regex                                | `keep_selections`                    |
 | `Alt-K`               | Remove selections matching the regex                              | `remove_selections`                  |
 | `Ctrl-c`              | Comment/uncomment the selections                                  | `toggle_comments`                    |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3729,9 +3729,18 @@ fn join_selections(cx: &mut Context) {
     // TODO: joining multiple empty lines should be replaced by a single space.
     // need to merge change ranges that touch
 
+    // select inserted spaces
+    let ranges: SmallVec<_> = changes
+        .iter()
+        .scan(0, |offset, change| {
+            let range = Range::point(change.0 - *offset);
+            *offset += change.1 - change.0 - 1; // -1 because cursor is 0-sized
+            Some(range)
+        })
+        .collect();
+    let selection = Selection::new(ranges, 0);
     let transaction = Transaction::change(doc.text(), changes.into_iter());
-    // TODO: select inserted spaces
-    // .with_selection(selection);
+    let transaction = transaction.with_selection(selection);
 
     doc.apply(&transaction, view.id);
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -345,6 +345,7 @@ impl MappableCommand {
         unindent, "Unindent selection",
         format_selections, "Format selection",
         join_selections, "Join lines inside selection",
+        join_selections_space, "Join lines inside selection and select spaces",
         keep_selections, "Keep selections matching regex",
         remove_selections, "Remove selections matching regex",
         align_selections, "Align selections in column",
@@ -3694,7 +3695,7 @@ fn format_selections(cx: &mut Context) {
     }
 }
 
-fn join_selections(cx: &mut Context) {
+fn join_selections_inner(cx: &mut Context, select_space: bool) {
     use movement::skip_while;
     let (view, doc) = current!(cx.editor);
     let text = doc.text();
@@ -3730,17 +3731,20 @@ fn join_selections(cx: &mut Context) {
     // need to merge change ranges that touch
 
     // select inserted spaces
-    let ranges: SmallVec<_> = changes
-        .iter()
-        .scan(0, |offset, change| {
-            let range = Range::point(change.0 - *offset);
-            *offset += change.1 - change.0 - 1; // -1 because cursor is 0-sized
-            Some(range)
-        })
-        .collect();
-    let selection = Selection::new(ranges, 0);
-    let transaction = Transaction::change(doc.text(), changes.into_iter());
-    let transaction = transaction.with_selection(selection);
+    let transaction = if select_space {
+        let ranges: SmallVec<_> = changes
+            .iter()
+            .scan(0, |offset, change| {
+                let range = Range::point(change.0 - *offset);
+                *offset += change.1 - change.0 - 1; // -1 because cursor is 0-sized
+                Some(range)
+            })
+            .collect();
+        let selection = Selection::new(ranges, 0);
+        Transaction::change(doc.text(), changes.into_iter()).with_selection(selection)
+    } else {
+        Transaction::change(doc.text(), changes.into_iter())
+    };
 
     doc.apply(&transaction, view.id);
 }
@@ -3766,6 +3770,14 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
             }
         },
     )
+}
+
+fn join_selections(cx: &mut Context) {
+    join_selections_inner(cx, false)
+}
+
+fn join_selections_space(cx: &mut Context) {
+    join_selections_inner(cx, true)
 }
 
 fn keep_selections(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -144,6 +144,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "<" => unindent,
         "=" => format_selections,
         "J" => join_selections,
+        "A-J" => join_selections_space,
         "K" => keep_selections,
         "A-K" => remove_selections,
 


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/Y5Jq6mJHg41UUuZeInU4jfJGw.svg)](https://asciinema.org/a/Y5Jq6mJHg41UUuZeInU4jfJGw)

Will be useful to remove those inserted space if I want.