### PR TITLE
lint: catppuccin

### DIFF
--- a/runtime/themes/catppuccin_macchiato.toml
+++ b/runtime/themes/catppuccin_macchiato.toml
@@ -64,6 +64,7 @@
 "ui.linenr" = { fg = "surface1" }
 "ui.linenr.selected" = { fg = "lavender" }
 
+"ui.cursorline" = { bg = "surface0" }
 "ui.statusline" = { fg = "overlay1", bg = "surface0" }
 "ui.statusline.inactive" = { fg = "overlay1", bg = "mantle" }
 "ui.statusline.normal" = { fg = "surface0", bg = "lavender", modifiers = ["bold"] }


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187050621-1852aa99-c0ce-4e67-98a1-95f0245fd87a.png)
