### PR TITLE
lint: bogster

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -45,6 +45,7 @@
 "ui.background" = { bg = "#161c23" }
 "ui.linenr" = { fg = "#415367" }
 "ui.linenr.selected" = { fg = "#e5ded6" }  # TODO
+"ui.cursorline" = { bg = "#131920" }
 "ui.statusline" = { fg = "#e5ded6", bg = "#232d38" }
 "ui.statusline.inactive" = { fg = "#c6b8ad", bg = "#232d38" }
 "ui.popup" = { bg = "#232d38" }
@@ -54,6 +55,7 @@
 "ui.text" = { fg = "#e5ded6" }
 "ui.text.focus" = { fg = "#e5ded6", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "#627d9d"
+"ui.virtual.ruler" = { bg = "#131920" }
 
 "ui.selection" = { bg = "#313f4e" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187050783-ee7bfd10-ae3b-429f-a4d4-6d201421ab72.png)
