### PR TITLE
lint: dark_plus

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -56,9 +56,9 @@
 "ui.background" = { fg = "light_gray", bg = "dark_gray2" }
 
 "ui.window" = { bg = "widget" }
-"ui.popup" = { bg = "widget" }
-"ui.help" = { bg = "widget" }
-"ui.menu" = { bg = "widget" }
+"ui.popup" = { fg = "text", bg = "widget" }
+"ui.help" = { fg = "text", bg = "widget" }
+"ui.menu" = { fg = "text", bg = "widget" }
 "ui.menu.selected" = { bg = "dark_blue2" }
 
 # TODO: Alternate bg colour for `ui.cursor.match` and `ui.selection`.


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187050829-371c53b9-22b8-4cad-96da-bf04f897f5c3.png)
