### PR TITLE
lint: doom_acario_dark

### DIFF
--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -49,7 +49,7 @@
 'ui.cursorline' = { bg = 'bg-alt' }
 'ui.linenr' = { fg = 'base4' }
 'ui.linenr.selected' = { fg = 'orange', bg = 'bg-alt', modifiers = ['bold'] }
-'ui.statusline' = { bg = 'base3' }
+'ui.statusline' = { fg = 'fg', bg = 'base3' }
 'ui.statusline.normal' = { bg = 'base3' }
 'ui.statusline.insert' = { bg = 'base3' }
 'ui.statusline.select' = { bg = 'base3' }
@@ -61,7 +61,7 @@
 'ui.text.info' = { fg = 'fg' }
 'ui.virtual.whitespace' = { fg = 'base2' }
 'ui.virtual.ruler' = { bg = 'black' }
-'ui.menu' = { bg = 'bg-alt' }
+'ui.menu' = { fg = 'fg', bg = 'bg-alt' }
 'ui.menu.selected' = { bg = 'base3', fg = 'fg' }
 'ui.selection' = { bg = 'base2' }
 


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187050866-9b0249d2-b309-4921-b7ad-50c10bd6d4d7.png)
