### PR TITLE
lint: flatwhite

### DIFF
--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -57,6 +57,7 @@
 "ui.linenr.selected" = { bg = "base6", modifiers = ["reversed"] }
 
 "ui.statusline" = { fg = "base7", bg = "base1", modifiers = ["bold"] }
+"ui.statusline.inactive" = { fg = "base7", bg = "base3" }
 "ui.statusline.normal" = { fg = "base7", bg = "base1", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "purple_text", bg = "purple_bg", modifiers = [
   "bold",


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187050901-7f1f45e1-62fd-45aa-b3a2-361fee819b2b.png)
