### PR TITLE
lint: penumbra+

### DIFF
--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -45,7 +45,7 @@ error = "red"
 
 diagnostic = { modifiers = ["underlined"] }
 
-"ui.background" = "sky+"
+"ui.background" = { bg = "shade" }
 "ui.background.separator" = "sky"
 
 "ui.cursor" = { modifiers = ["reversed"] }
@@ -72,7 +72,7 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.popup.info" = { bg = "shade" }
 
 "ui.window" = "sky"
-"ui.help" = "sky"
+"ui.help" = { bg = "sky" }
 
 "ui.text" = "sky"
 "ui.text.focus" = "blue"


### PR DESCRIPTION
passes linter from https://github.com/helix-editor/helix/pull/3234
![image](https://user-images.githubusercontent.com/721090/187051021-50773f86-0497-47a8-bbfb-33e88bf50c36.png)
