### PR TITLE
Themes update

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -3,14 +3,20 @@
 "ui.background" = {bg="acme_bg"}
 "ui.text" = "black"
 "ui.selection" = {bg="selected"}
-"ui.statusline" = {bg="acme_bar_bg"}
-"ui.statusline.inactive" = {bg="acme_bar_inactive"}
+"ui.cursorline" = {bg="acme_bar_bg"}
+"ui.statusline" = {fg="black", bg="acme_bar_bg"}
+"ui.statusline.inactive" = {fg="black", bg="acme_bar_inactive"}
 "ui.virtual" = "indent"
+"ui.virtual.ruler" = { bg = "acme_bar_bg" }
 "ui.cursor.match" = {bg="acme_bar_bg"}
 "ui.cursor" = {bg="cursor", fg="white"}
 "string" = "red"
 "comment" = "green"
+"ui.help" = {fg="black", bg="acme_bg"}
+"ui.popup" = {fg="black", bg="acme_bg"}
+"ui.menu" = {fg="black", bg="acme_bg"}
 "ui.menu.selected" = {bg="selected"}
+"ui.window" = {bg="acme_bg"}
 "diagnostic.error" = {bg="white", modifiers=["bold"]}
 "diagnostic.warning" = {bg="white", modifiers=["bold"]}
 "diagnostic.hint" = {bg="white", modifiers=["bold"]}

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -16,6 +16,7 @@
 "ui.linenr.selected" = { fg = "my_gray6", bg = "my_gray1"}
 "ui.selection" = { bg = "my_gray3" }
 "comment" = { fg = "my_gray4", modifiers = ["italic"] }
+"ui.cursorline" = { bg = "my_gray2" }
 "ui.statusline" = { fg = "my_gray6", bg = "my_gray2" }
 "ui.statusline.inactive" = { fg = 'my_gray4', bg = 'my_gray2' }
 "ui.statusline.insert" = {fg = "my_black", bg = "my_gray5", modifiers = ["bold"]}

--- a/runtime/themes/autumn_night.toml
+++ b/runtime/themes/autumn_night.toml
@@ -16,7 +16,7 @@
 "ui.linenr.selected" = { fg = "my_gray6", bg = "my_gray1"}
 "ui.selection" = { bg = "my_gray3" }
 "comment" = { fg = "my_gray4", modifiers = ["italic"] }
-"ui.cursorline" = { fg = "my_gray6", bg = "my_gray2" }
+"ui.cursorline" = { bg = "my_gray2" }
 "ui.statusline" = { fg = "my_gray6", bg = "my_gray2" }
 "ui.statusline.inactive" = { fg = 'my_gray4', bg = 'my_gray2' }
 "ui.statusline.insert" = {fg = "my_black", bg = "my_gray5", modifiers = ["bold"]}

--- a/runtime/themes/autumn_night.toml
+++ b/runtime/themes/autumn_night.toml
@@ -16,6 +16,7 @@
 "ui.linenr.selected" = { fg = "my_gray6", bg = "my_gray1"}
 "ui.selection" = { bg = "my_gray3" }
 "comment" = { fg = "my_gray4", modifiers = ["italic"] }
+"ui.cursorline" = { fg = "my_gray6", bg = "my_gray2" }
 "ui.statusline" = { fg = "my_gray6", bg = "my_gray2" }
 "ui.statusline.inactive" = { fg = 'my_gray4', bg = 'my_gray2' }
 "ui.statusline.insert" = {fg = "my_black", bg = "my_gray5", modifiers = ["bold"]}

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -38,16 +38,17 @@
 "ui.cursor.match" = { fg = "orange" }
 "ui.linenr" = { fg = "dark_gray" }
 "ui.linenr.selected" = { fg = "orange" }
-"ui.statusline" = { bg = "black" }
-"ui.popup" = { bg = "black" }
+"ui.statusline" = { fg = "foreground", bg = "black" }
+"ui.cursorline" = { bg = "black" }
+"ui.popup" = { fg = "#7B91b3", bg = "black" }
 "ui.window" = { fg = "dark_gray" }
-"ui.help" = { bg = "black" }
+"ui.help" = { fg = "#7B91b3", bg = "black" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "black" }
-"ui.menu" = { bg = "black" }
+"ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "orange", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }
 "warning" = { fg = "yellow" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -38,16 +38,17 @@
 "ui.cursor.match" = { fg = "orange" }
 "ui.linenr" = { fg = "dark_gray" }
 "ui.linenr.selected" = { fg = "orange" }
-"ui.statusline" = { bg = "black" }
+"ui.cursorline" = { bg = "black" }
+"ui.statusline" = { fg = "foreground", bg = "black" }
 "ui.popup" = { bg = "black" }
 "ui.window" = { fg = "dark_gray" }
-"ui.help" = { bg = "black" }
+"ui.help" = { fg="foreground", bg = "black" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "black" }
-"ui.menu" = { bg = "black" }
+"ui.menu" = { fg="foreground", bg = "black" }
 "ui.menu.selected" = { bg = "orange", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }
 "warning" = { fg = "yellow" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -48,7 +48,7 @@
 "ui.text.info" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "black" }
-"ui.menu" = { fg="foreground", bg = "black" }
+"ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "orange", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }
 "warning" = { fg = "yellow" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -42,7 +42,7 @@
 "ui.statusline" = { fg = "foreground", bg = "black" }
 "ui.popup" = { bg = "black" }
 "ui.window" = { fg = "dark_gray" }
-"ui.help" = { fg="foreground", bg = "black" }
+"ui.help" = { fg  = "foreground", bg = "black" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = { fg = "foreground" }

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -38,16 +38,17 @@
 "ui.cursor.match" = { fg = "orange" }
 "ui.linenr" = { fg = "dark_gray" }
 "ui.linenr.selected" = { fg = "orange" }
-"ui.statusline" = { bg = "black" }
+"ui.cursorline" = { bg = "black" }
+"ui.statusline" = { fg = "foreground", bg = "black" }
 "ui.popup" = { bg = "black" }
 "ui.window" = { fg = "dark_gray" }
-"ui.help" = { bg = "black" }
+"ui.help" = { fg = "foreground", bg = "black" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "black" }
-"ui.menu" = { bg = "black" }
+"ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "orange", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }
 "warning" = { fg = "yellow" }

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -45,6 +45,7 @@
 "ui.background" = { bg = "#161c23" }
 "ui.linenr" = { fg = "#415367" }
 "ui.linenr.selected" = { fg = "#e5ded6" }  # TODO
+"ui.cursorline" = { bg = "#131920" }
 "ui.statusline" = { fg = "#e5ded6", bg = "#232d38" }
 "ui.statusline.inactive" = { fg = "#c6b8ad", bg = "#232d38" }
 "ui.popup" = { bg = "#232d38" }
@@ -54,6 +55,7 @@
 "ui.text" = { fg = "#e5ded6" }
 "ui.text.focus" = { fg = "#e5ded6", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "#627d9d"
+"ui.virtual.ruler" = { bg = "#131920" }
 
 "ui.selection" = { bg = "#313f4e" }
 # "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -34,6 +34,7 @@
 "ui.cursor.insert" = { fg = "berry", bg = "mint" }
 "ui.linenr" = { fg = "berry_desaturated" }
 "ui.linenr.selected" = { fg = "lilac" }
+"ui.cursorline" = { fg = "lilac", bg = "berry_saturated" }
 "ui.statusline" = { fg = "lilac", bg = "berry_saturated" }
 "ui.statusline.inactive" = { fg = "berry_desaturated", bg = "berry_saturated" }
 "ui.popup" = { fg = "lilac", bg = "berry_saturated" }

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -34,7 +34,7 @@
 "ui.cursor.insert" = { fg = "berry", bg = "mint" }
 "ui.linenr" = { fg = "berry_desaturated" }
 "ui.linenr.selected" = { fg = "lilac" }
-"ui.cursorline" = { fg = "lilac", bg = "berry_saturated" }
+"ui.cursorline" = { fg = "lilac", bg = "berry_dim" }
 "ui.statusline" = { fg = "lilac", bg = "berry_saturated" }
 "ui.statusline.inactive" = { fg = "berry_desaturated", bg = "berry_saturated" }
 "ui.popup" = { fg = "lilac", bg = "berry_saturated" }
@@ -46,7 +46,7 @@
 "ui.menu.selected" = { fg = "mint", bg = "berry_saturated" }
 "ui.selection" = { bg = "berry_saturated" }
 "ui.virtual.whitespace" = { fg = "berry_desaturated" }
-"ui.virtual.ruler" = { bg ="berry_desaturated" }
+"ui.virtual.ruler" = { bg ="berry_dim" }
 
 "diff.plus" = { fg = "mint" }
 "diff.delta" = { fg = "gold" }
@@ -60,6 +60,7 @@
 
 [palette]
 berry = "#3A2A4D"
+berry_dim = "#47345E"
 berry_saturated = "#2B1C3D"
 berry_desaturated = "#886C9C"
 bubblegum = "#D678B5"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -56,9 +56,9 @@
 "ui.background" = { fg = "light_gray", bg = "dark_gray2" }
 
 "ui.window" = { bg = "widget" }
-"ui.popup" = { bg = "widget" }
-"ui.help" = { bg = "widget" }
-"ui.menu" = { bg = "widget" }
+"ui.popup" = { fg = "text", bg = "widget" }
+"ui.help" = { fg = "text", bg = "widget" }
+"ui.menu" = { fg = "text", bg = "widget" }
 "ui.menu.selected" = { bg = "dark_blue2" }
 
 # TODO: Alternate bg colour for `ui.cursor.match` and `ui.selection`.

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -55,7 +55,7 @@
 'ui.statusline.select' = { bg = 'base3' }
 'ui.popup' = { bg = 'bg-alt' }
 'ui.window' = { fg = 'gray' }
-'ui.help' = { bg = 'base2' }
+'ui.help' = { fg = 'fg', bg = 'base2' }
 'ui.text' = { fg = 'fg' }
 'ui.text.focus' = { bg = 'bg-alt', fg = 'fg' }
 'ui.text.info' = { fg = 'fg' }

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -49,7 +49,7 @@
 'ui.cursorline' = { bg = 'bg-alt' }
 'ui.linenr' = { fg = 'base4' }
 'ui.linenr.selected' = { fg = 'orange', bg = 'bg-alt', modifiers = ['bold'] }
-'ui.statusline' = { bg = 'base3' }
+'ui.statusline' = { fg = 'fg', bg = 'base3' }
 'ui.statusline.normal' = { bg = 'base3' }
 'ui.statusline.insert' = { bg = 'base3' }
 'ui.statusline.select' = { bg = 'base3' }
@@ -61,7 +61,7 @@
 'ui.text.info' = { fg = 'fg' }
 'ui.virtual.whitespace' = { fg = 'base2' }
 'ui.virtual.ruler' = { bg = 'black' }
-'ui.menu' = { bg = 'bg-alt' }
+'ui.menu' = { fg = 'fg', bg = 'bg-alt' }
 'ui.menu.selected' = { bg = 'base3', fg = 'fg' }
 'ui.selection' = { bg = 'base2' }
 

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -41,6 +41,7 @@
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "comment" }
+"ui.virtual.ruler" = { bg = "background_dark"}
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -32,6 +32,7 @@
 "ui.popup" = { fg = "foreground", bg = "background_dark" }
 "ui.selection" = { fg = "background", bg = "purple", modifiers = ["dim"] }
 "ui.selection.primary" = { fg = "background", bg = "pink" }
+"ui.cursorline" = { bg = "background_dark" }
 "ui.statusline" = { fg = "foreground", bg = "background_dark" }
 "ui.statusline.inactive" = { fg = "comment", bg = "background_dark" }
 "ui.statusline.normal" = { fg = "background_dark", bg = "cyan" }
@@ -40,6 +41,7 @@
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
+"ui.virtual.ruler" = { bg = "background_dark" }
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -60,6 +60,7 @@
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
 "ui.linenr" = "grey0"
 "ui.linenr.selected" = "fg"
+"ui.cursorline" = { bg = "bg1" }
 "ui.statusline" = { fg = "grey2", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
 "ui.popup" = { fg = "grey2", bg = "bg1" }
@@ -71,6 +72,7 @@
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.selection" = { bg = "bg3" }
 "ui.virtual.whitespace" = "grey0"
+"ui.virtual.ruler" = { bg = "bg1" }
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -60,6 +60,7 @@
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
 "ui.linenr" = "grey0"
 "ui.linenr.selected" = "fg"
+"ui.cursorline" = { bg = "bg1" }
 "ui.statusline" = { fg = "grey2", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
 "ui.popup" = { fg = "grey2", bg = "bg1" }
@@ -71,6 +72,7 @@
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.selection" = { bg = "bg3" }
 "ui.virtual.whitespace" = "grey0"
+"ui.virtual.ruler" = { bg = "bg1" }
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -57,6 +57,7 @@
 "ui.linenr.selected" = { bg = "base6", modifiers = ["reversed"] }
 
 "ui.statusline" = { fg = "base7", bg = "base1", modifiers = ["bold"] }
+"ui.statusline.inactive" = { fg = "base7", bg = "base3" }
 "ui.statusline.normal" = { fg = "base7", bg = "base1", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "purple_text", bg = "purple_bg", modifiers = [
   "bold",

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -41,7 +41,7 @@
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg4" }
 "ui.linenr.selected" = { fg = "yellow1" }
-"ui.cursorline" = { bg = "bg0" }
+"ui.cursorline" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.normal" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.insert" = { fg = "fg1", bg = "blue0" }

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -41,6 +41,7 @@
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg4" }
 "ui.linenr.selected" = { fg = "yellow1" }
+"ui.cursorline" = { bg = "bg0" }
 "ui.statusline" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.normal" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.insert" = { fg = "fg1", bg = "blue0" }
@@ -57,6 +58,7 @@
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
+"ui.virtual.ruler" = { bg = "bg1" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -42,6 +42,7 @@
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg4" }
 "ui.linenr.selected" = { fg = "yellow1" }
+"ui.cursorline" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.normal" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.insert" = { fg = "fg1", bg = "blue0" }
@@ -58,6 +59,7 @@
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
+"ui.virtual.ruler" = { bg = "bg1" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -44,7 +44,7 @@
 
 "ui.background" = { bg = "#FFFCFD" }
 "ui.linenr" = { fg = "#bbbbbb" }
-"ui.linenr.selected" = { fg = "#999999" }
+"ui.linenr.selected" = { fg = "#ED5466", modifiers = ["bold"] }
 "ui.cursorline" = { bg = "#F3EAE9" }
 "ui.statusline" = { fg = "#250E07", bg = "#F3EAE9" }
 "ui.statusline.inactive" = { fg = "#7b91b3", bg = "#F3EAE9" }
@@ -57,9 +57,9 @@
 "ui.virtual.whitespace" = "#A6B6CE"
 "ui.virtual.ruler" = { bg = "#F3EAE9" }
 
-"ui.selection" = { bg = "#540099" }
-"ui.cursor.primary" = { bg = "#7420b9" }
-"ui.cursor.match" = { bg = "#bbbbbb" }
+"ui.selection" = { bg = "#F3EAE9" }
+"ui.cursor.primary" = { bg = "#ED5466", fg = "#FFFCFD", modifiers = ["bold"] }
+"ui.cursor.match" = { bg = "#F3EAE9", fg = "#ED5466", modifiers = ["bold"] }
 "ui.menu" = { fg = "#7B91B3", bg = "#F3EAE9" }
 "ui.menu.selected" = { fg = "#D74E50", bg = "#F3EAE9" }
 

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -44,19 +44,22 @@
 
 "ui.background" = { bg = "#FFFCFD" }
 "ui.linenr" = { fg = "#bbbbbb" }
-"ui.linenr.selected" = { fg = "#F3EAE9" }  # TODO
+"ui.linenr.selected" = { fg = "#999999" }
+"ui.cursorline" = { bg = "#F3EAE9" }
 "ui.statusline" = { fg = "#250E07", bg = "#F3EAE9" }
 "ui.statusline.inactive" = { fg = "#7b91b3", bg = "#F3EAE9" }
-"ui.popup" = { bg = "#F3EAE9" }
+"ui.popup" = { fg = "#7B91b3", bg = "#F3E8E9" }
 "ui.window" = { bg = "#D8B8B3" }
 "ui.help" = { bg = "#D8B8B3", fg = "#250E07" }
 
 "ui.text" = { fg = "#7B91B3" }
 "ui.text.focus" = { fg = "#250E07", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "#A6B6CE"
+"ui.virtual.ruler" = { bg = "#F3EAE9" }
 
 "ui.selection" = { bg = "#540099" }
-# "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
+"ui.cursor.primary" = { bg = "#7420b9" }
+"ui.cursor.match" = { bg = "#bbbbbb" }
 "ui.menu" = { fg = "#7B91B3", bg = "#F3EAE9" }
 "ui.menu.selected" = { fg = "#D74E50", bg = "#F3EAE9" }
 

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -33,6 +33,7 @@
 
 "comment" = { fg = "#88846F" }
 "ui.virtual.whitespace" = "#88846F"
+"ui.virtual.ruler" = { bg = "#24241e" }
 
 "string" = { fg = "#e6db74" }
 "constant.character" = { fg = "#e6db74" }
@@ -57,9 +58,9 @@
 "ui.background" = { fg = "text", bg = "background" }
 
 "ui.window" = { bg = "widget" }
-"ui.popup" = { bg = "widget" }
-"ui.help" = { bg = "widget" }
-"ui.menu" = { bg = "widget" }
+"ui.popup" = { fg = "text", bg = "widget" }
+"ui.help" = { fg = "text", bg = "widget" }
+"ui.menu" = { fg = "text", bg = "widget" }
 "ui.menu.selected" = { bg = "#414339" }
 
 "ui.cursor" = { fg = "cursor", modifiers = ["reversed"] }
@@ -72,6 +73,7 @@
 "ui.linenr" = { fg = "#90908a" }
 "ui.linenr.selected" = { fg = "#c2c2bf" }
 
+"ui.cursorline" = { bg = "#24241e" }
 "ui.statusline" = { fg = "active_text", bg = "#414339" }
 "ui.statusline.inactive" = { fg = "active_text", bg = "#75715e" }
 

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -20,7 +20,7 @@
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
-"ui.help" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
 
 # active line, highlighting
 "ui.selection" = { bg = "base4" }

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -7,16 +7,17 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"
 "hint" = "base8"
 
 # background color
 "ui.background" = { bg = "base2" }
-"ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 
 # status bars, panels, modals, autocompletion
-"ui.statusline" = { bg = "base4" }
+"ui.statusline" = { fg = "base8", bg = "base4" }
+"ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { bg = "base3" }
@@ -24,6 +25,7 @@
 # active line, highlighting
 "ui.selection" = { bg = "base4" }
 "ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
 
 # comments, nord3 based lighter color
 "comment" = { fg = "base5", modifiers = ["italic"] }

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -20,7 +20,7 @@
 "ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
-"ui.help" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
 
 # active line, highlighting
 "ui.selection" = { bg = "base4" }

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -7,6 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"
 "hint" = "base8"
@@ -16,7 +17,7 @@
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 
 # status bars, panels, modals, autocompletion
-"ui.statusline" = { bg = "base4" }
+"ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { bg = "base3" }
@@ -24,6 +25,7 @@
 # active line, highlighting
 "ui.selection" = { bg = "base4" }
 "ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
 
 # comments, nord3 based lighter color
 "comment" = { fg = "base5", modifiers = ["italic"] }

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -20,7 +20,7 @@
 "ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
-"ui.help" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
 
 # active line, highlighting
 "ui.selection" = { bg = "base4" }

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -7,6 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"
 "hint" = "base8"
@@ -16,7 +17,7 @@
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 
 # status bars, panels, modals, autocompletion
-"ui.statusline" = { bg = "base4" }
+"ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { bg = "base3" }
@@ -24,6 +25,7 @@
 # active line, highlighting
 "ui.selection" = { bg = "base4" }
 "ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
 
 # comments, nord3 based lighter color
 "comment" = { fg = "base5", modifiers = ["italic"] }

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -20,7 +20,7 @@
 "ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
-"ui.help" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
 
 # active line, highlighting
 "ui.selection" = { bg = "base4" }

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -7,6 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"
 "hint" = "base8"
@@ -16,7 +17,7 @@
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 
 # status bars, panels, modals, autocompletion
-"ui.statusline" = { bg = "base4" }
+"ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { bg = "base3" }
@@ -24,6 +25,7 @@
 # active line, highlighting
 "ui.selection" = { bg = "base4" }
 "ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
 
 # comments, nord3 based lighter color
 "comment" = { fg = "base5", modifiers = ["italic"] }

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -20,7 +20,7 @@
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
-"ui.help" = { bg = "base3" }
+"ui.help" = { fg = "base8", bg = "base3" }
 
 # active line, highlighting
 "ui.selection" = { bg = "base4" }

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -7,16 +7,17 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
+"ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"
 "hint" = "base8"
 
 # background color
 "ui.background" = { bg = "base2" }
-"ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 
 # status bars, panels, modals, autocompletion
-"ui.statusline" = { bg = "base4" }
+"ui.statusline" = { fg = "base8", bg = "base4" }
+"ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { bg = "base3" }
@@ -24,6 +25,7 @@
 # active line, highlighting
 "ui.selection" = { bg = "base4" }
 "ui.cursor.match" = { bg = "base4" }
+"ui.cursorline" = { bg = "base1" }
 
 # comments, nord3 based lighter color
 "comment" = { fg = "base5", modifiers = ["italic"] }

--- a/runtime/themes/noctis_bordo.toml
+++ b/runtime/themes/noctis_bordo.toml
@@ -24,6 +24,7 @@
 
 "ui.background" = { bg = "base00" }
 "ui.virtual" = "base03"
+"ui.virtual.ruler" = { bg = "base01" }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base0B", bg = "base01" }
 "ui.popup" = { bg = "base01" }
@@ -31,6 +32,7 @@
 "ui.linenr" = { fg = "#715b63", bg = "base01" }
 "ui.linenr.selected" = { fg = "base02", bg = "base01", modifiers = ["bold"] }
 "ui.selection" = { fg = "base05", bg = "base02" }
+"ui.cursorline" = { bg = "base01" }
 "ui.statusline" = { fg = "base02", bg = "base01" }
 "ui.cursor" = { fg = "base04", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -6,6 +6,7 @@
 "ui.menu" = { fg = "nord6", bg = "#232d38" }
 "ui.menu.selected" = { fg = "nord8", bg = "nord2" }
 "ui.virtual.whitespace" = "gray"
+"ui.virtual.ruler" = { bg = "nord1" }
 
 "info" = "nord8"
 "hint" = "nord8"

--- a/runtime/themes/nord_light.toml
+++ b/runtime/themes/nord_light.toml
@@ -3,9 +3,11 @@
 "ui.background" = {bg="nord6"}
 "ui.text" = "nord0"
 "ui.selection" = {bg="nord7", fg="nord6"}
+"ui.cursorline" = {bg="nord4"}
 "ui.statusline" = {bg="nord4", fg="nord0"}
-"ui.statusline.inactive" = {bg="nord8"}
+"ui.statusline.inactive" = {bg="nord5", fg="nord0"}
 "ui.virtual" = "nord8"
+"ui.virtual.ruler" = {bg="nord4"}
 "ui.cursor.match" = {bg="nord8"}
 "ui.cursor" = {bg="nord10", fg="nord6"}
 "ui.cursorline.primary" = {bg="nord5"}
@@ -16,6 +18,7 @@
 "ui.popup" = {bg="nord4"}
 "ui.popup.info" = {bg="nord4",fg="nord0"}
 "ui.help" = {bg="nord4",fg="nord0"}
+"ui.window" = {bg="nord4"}
 
 
 "ui.statusline.normal" = { fg = "nord0", bg = "nord8" }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -71,7 +71,7 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.text" = { fg = "white" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 
-"ui.help" = { bg = "gray" }
+"ui.help" = { fg = "white", bg = "gray" }
 "ui.popup" = { bg = "gray" }
 "ui.window" = { fg = "gray" }
 "ui.menu" = { fg = "white", bg = "gray" }

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -72,7 +72,7 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.popup.info" = { bg = "shade" }
 
 "ui.window" = "sky"
-"ui.help" = { bg = "shade-" }
+"ui.help" = { fg = "sky", bg = "shade-" }
 
 "ui.text" = "sky"
 "ui.text.focus" = "blue"

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -45,7 +45,7 @@ error = "red"
 
 diagnostic = { modifiers = ["underlined"] }
 
-"ui.background" = "sky+"
+"ui.background" = { bg = "shade" }
 "ui.background.separator" = "sky"
 
 "ui.cursor" = { modifiers = ["reversed"] }
@@ -72,7 +72,7 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.popup.info" = { bg = "shade" }
 
 "ui.window" = "sky"
-"ui.help" = "sky"
+"ui.help" = { bg = "sky" }
 
 "ui.text" = "sky"
 "ui.text.focus" = "blue"

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -72,13 +72,13 @@ diagnostic = { modifiers = ["underlined"] }
 "ui.popup.info" = { bg = "shade" }
 
 "ui.window" = "sky"
-"ui.help" = { bg = "sky" }
+"ui.help" = { bg = "shade-" }
 
 "ui.text" = "sky"
 "ui.text.focus" = "blue"
 "ui.text.info" = "sky"
 
-"ui.virtual.ruler" = { bg = "shade+" }
+"ui.virtual.ruler" = { bg = "shade-" }
 "ui.virtual.whitespace" = "sky-"
 "ui.virtual.indent-guide" = "shade+"
 

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -24,15 +24,16 @@ diagnostic = { fg = 'greyT', bg = 'redD' }
 'ui.selection.primary' = { bg = 'blueD', fg = 'white' }
 'ui.linenr' = { bg = "brownN", fg = 'greyL' }
 'ui.linenr.selected' = { bg = 'brownH', fg = 'orangeH' }
-'ui.statusline' = { bg = 'brownH' }
-'ui.statusline.inactive' = { bg = 'brownN' }
+'ui.cursorline' = { bg = 'brownD' }
+'ui.statusline' = { fg = "greyT", bg = 'brownH' }
+'ui.statusline.inactive' = { fg = "greyT", bg = 'brownN' }
 'ui.help' = { bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }
 'ui.virtual.ruler' = { bg = 'brownR' }
 'ui.virtual.whitespace' = { fg = 'brownV' }
 'ui.virtual.indent-guide' = { fg = 'brownR' }
-'ui.menu' = { bg = 'brownD' }
+'ui.menu' = { fg = "greyT", bg = 'brownD' }
 'ui.menu.selected' = { fg = 'orangeH', bg = 'brownH' }
 'ui.popup' = { bg = 'brownD' }
 'ui.popup.info' = { bg = 'brownH', fg = 'greyT' }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -27,7 +27,7 @@ diagnostic = { fg = 'greyT', bg = 'redD' }
 'ui.cursorline' = { bg = 'brownD' }
 'ui.statusline' = { fg = "greyT", bg = 'brownH' }
 'ui.statusline.inactive' = { fg = "greyT", bg = 'brownN' }
-'ui.help' = { bg = 'brownD' }
+'ui.help' = { fg = "greyT", bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }
 'ui.virtual.ruler' = { bg = 'brownR' }

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -8,6 +8,7 @@
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
+"ui.cursorline" = { bg = "surface" }
 "ui.statusline" = {fg = "foam", bg = "surface" }
 "ui.statusline.insert" = {fg = "base", bg = "foam", modifiers = ["bold"]}
 "ui.statusline.normal" = {fg = "base", bg = "rose", modifiers = ["bold"]}
@@ -18,6 +19,7 @@
 "ui.text.focus" = { fg = "foam", modifiers = ["bold"]}
 "ui.text.info" = {fg = "pine", modifiers = ["bold"]}
 "ui.virtual.whitespace" = "highlight"
+"ui.virtual.ruler" = { bg = "surface" }
 "operator" = "rose"
 "variable" = "text"
 "constant.numeric" = "iris"
@@ -39,7 +41,6 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"

--- a/runtime/themes/rose_pine_dawn.toml
+++ b/runtime/themes/rose_pine_dawn.toml
@@ -8,6 +8,7 @@
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
+"ui.cursorline" = {bg = "base" }
 "ui.statusline" = {fg = "foam", bg = "surface" }
 "ui.statusline.inactive" = { fg = "iris", bg = "surface" }
 "ui.cursor" = { fg = "rose", modifiers = ["reversed"] }
@@ -15,6 +16,7 @@
 "ui.text.focus" = { fg = "foam", modifiers = ["bold"]}
 "ui.text.info" = {fg = "pine", modifiers = ["bold"]}
 "ui.virtual.whitespace" = "highlight"
+"ui.virtual.ruler" = { bg = "base" }
 "operator" = "rose"
 "variable" = "text"
 "number" = "iris"
@@ -36,7 +38,6 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"

--- a/runtime/themes/rose_pine_moon.toml
+++ b/runtime/themes/rose_pine_moon.toml
@@ -11,6 +11,7 @@
 "ui.liner.selected" = "highlightOverlay"
 "ui.selection" = { bg = "highlight" }
 "comment" = "subtle"
+"ui.cursorline" = {bg = "dimBase" }
 "ui.statusline" = {fg = "foam", bg = "surface" }
 "ui.statusline.insert" = {fg = "base", bg = "foam", modifiers = ["bold"]}
 "ui.statusline.normal" = {fg = "base", bg = "rose", modifiers = ["bold"]}
@@ -21,6 +22,7 @@
 "ui.text.focus" = { fg = "foam", modifiers = ["bold"]}
 "ui.text.info" = {fg = "pine", modifiers = ["bold"]}
 "ui.virtual.whitespace" = "highlight"
+"ui.virtual.ruler" = {bg = "dimBase" }
 "operator" = "rose"
 "variable" = "text"
 "constant.numeric" = "iris"
@@ -42,7 +44,6 @@
 "ui.popup.info" = { bg = "surface" }
 "ui.window" = { bg = "base" }
 "ui.help" = { bg = "overlay", fg = "foam" }
-"ui.text" = "text"
 "diff.plus" = "foam"
 "diff.delta" = "rose"
 "diff.minus" = "love"
@@ -69,6 +70,7 @@
 "markup.raw" = { fg = "foam" }
 
 [palette]
+dimBase  = "#201e30" 
 base     = "#232136" 
 surface  = "#2a273f" 
 overlay  = "#393552"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -39,6 +39,7 @@
 "ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
 "ui.linenr" = "yellow"
 "ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
+"ui.cursorline" = { fg = "grey1", bg = "bg2" }
 "ui.statusline" = { fg = "grey1", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "grey2", bg = "bg1" }
 "ui.popup" = { fg = "grey2", bg = "bg1" }
@@ -49,7 +50,8 @@
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
 "ui.selection" = { bg = "bg3" }
-"ui.virtual.whitespace" = "grey2"
+"ui.virtual.whitespace" = "bg2"
+"ui.virtual.ruler" = { bg = "grey2" } 
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -57,7 +57,7 @@
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "nasty-red"
-"diagnostic" = { fg = "dark-red", modifiers = ["underlined"] }
+"diagnostic" = { fg = "nasty-red", modifiers = ["underlined"] }
 
 "diff.plus" = { fg = "green" }
 "diff.delta" = { fg = "orange" }

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -39,6 +39,7 @@
 "ui.cursor.select" = { fg = "bg0", bg = "bg_yellow" }
 "ui.linenr" = "yellow"
 "ui.linenr.selected" = { fg = "fg", modifiers = ["bold", "underlined"] }
+"ui.cursorline" = { bg = "bg01" }
 "ui.statusline" = { fg = "grey1", bg = "bg5" }
 "ui.statusline.inactive" = { fg = "grey2", bg = "bg1" }
 "ui.popup" = { fg = "bg0", bg = "bg5" }
@@ -50,6 +51,7 @@
 "ui.menu.selected" = { fg = "bg0", bg = "bg_yellow" }
 "ui.selection" = { fg = "bg0", bg = "bg3" }
 "ui.virtual.whitespace" = { fg = "bg2" }
+"ui.virtual.ruler" = { bg = "bg01" }
 
 "hint" = "blue"
 "info" = "aqua"
@@ -74,6 +76,7 @@
 [palette]
 
 bg0 = "#e1e1e3"
+bg01 = "#eaeaec"
 bg1 = "#494c50"
 bg2 = "#55585e"
 bg3 = "#61656b"

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -57,7 +57,7 @@
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "nasty-red"
-"diagnostic" = { fg = "dark-red", modifiers = ["underlined"] }
+"diagnostic" = { fg = "nasty-red", modifiers = ["underlined"] }
 
 "diff.plus" = { fg = "green" }
 "diff.delta" = { fg = "orange" }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -33,12 +33,14 @@
 "ui.popup" = { fg = "foreground", bg = "background_dark" }
 "ui.selection" = { bg = "secondary_highlight" }
 "ui.selection.primary" = { bg = "primary_highlight" }
+"ui.cursorline" = { bg = "background_dark" }
 "ui.statusline" = { fg = "foreground", bg = "background_dark" }
 "ui.statusline.inactive" = { fg = "comment", bg = "background_dark" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
 "ui.virtual.whitespace" = { fg = "comment" }
+"ui.virtual.ruler" = { bg = "background_dark" }
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -45,6 +45,8 @@
 "ui.linenr" = { fg = "base0", bg = "base02" }
 # 当前行号栏
 "ui.linenr.selected" = { fg = "blue", modifiers = ["bold"] }
+#cursorline
+"ui.cursorline" = { bg = "base03" }
 
 # 状态栏
 "ui.statusline" = { fg = "base03", bg = "base0" }

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -48,6 +48,8 @@
 # 当前行号栏
 # current line number column
 "ui.linenr.selected" = { fg = "blue", modifiers = ["bold"] }
+# cursorline
+"ui.cursorline" = { bg = "base0" }
 
 # 状态栏
 # status bar

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -51,6 +51,7 @@
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg3" }
 "ui.linenr.selected" = { fg = "theme_yellow" }
+"ui.cursorline" = { bg = "bg2" }
 "ui.statusline" = { fg = "fg1", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "fg4", bg = "bg1" }
 "ui.statusline.normal" = { fg = "bg1", bg = "theme_cyan" }


### PR DESCRIPTION
This is a collection of changes made to force themes to handle in a predictable way. It also enforces a response to enabling features (like `cursorline`) so users who want these features will still see them even if they change themes.

I've tried my best to stick to the spirit of the theme, but some themes relied so much on terminal colors that I just had to guess and base some assumptions from other editors with similar themes.

Status from original authors (in terms of approvals)
- [x] snazzy @nrdxp 
- [ ] pop-dark @workingj 
- [x] penumbra @vlmutolo 
- [ ] noctis_bordo @jharrilim 
- [x] ingrid @intarga 
- [x] flatwhite @AlexanderBrevig 
- [x] doom_acario_dark @Rinnray 
- [x] dark_plus @kirawi 
- [x] boo_berry @bootradev 
- [x] bogster @vv9k 
- [x] everforest @CptPotato @WindSoilder 
- [ ] acme @two-six 
- [x] serika @VuiMuich 
- [ ] nord @raygervais @two-six 
- [x] dracula @samsartor 
- [ ] gruvbox @crodjer @jbaa 
- [x] autumn @getreu 
- [ ] ayu @enkodr 
- [x] rose_pine @raygervais @chunghha @atahabaki 
- [x] monokai @WindSoilder 
- [ ] solarized @kirawi @cossonleo 
- [x] spacebones @atog 