### PR TITLE
Track document changes in the jumplist

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2346,7 +2346,7 @@ fn jumplist_picker(cx: &mut Context) {
                 view.jumps
                     .get()
                     .iter()
-                    .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
+                    .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.borrow().clone()))
             })
             .collect(),
         (),
@@ -2644,9 +2644,8 @@ fn try_restore_indent(doc: &mut Document, view_id: ViewId) {
 }
 
 // Store a jump on the jumplist.
-fn push_jump(view: &mut View, doc: &Document) {
-    let jump = (doc.id(), doc.selection(view.id).clone());
-    view.jumps.push(jump);
+fn push_jump(view: &mut View, doc: &mut Document) {
+    view.jumps.push(doc, doc.selection(view.id).clone());
 }
 
 fn goto_line(cx: &mut Context) {
@@ -4048,7 +4047,7 @@ fn jump_forward(cx: &mut Context) {
 
     if let Some((id, selection)) = view.jumps.forward(count) {
         view.doc = *id;
-        let selection = selection.clone();
+        let selection = selection.borrow().clone();
         let (view, doc) = current!(cx.editor); // refetch doc
         doc.set_selection(view.id, selection);
 
@@ -4062,7 +4061,7 @@ fn jump_backward(cx: &mut Context) {
 
     if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
         view.doc = *id;
-        let selection = selection.clone();
+        let selection = selection.borrow().clone();
         let (view, doc) = current!(cx.editor); // refetch doc
         doc.set_selection(view.id, selection);
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -69,7 +69,6 @@ pub fn regex_prompt(
     fun: impl Fn(&mut View, &mut Document, Regex, PromptEvent) + 'static,
 ) {
     let (view, doc) = current!(cx.editor);
-    let doc_id = view.doc;
     let snapshot = doc.selection(view.id).clone();
     let offset_snapshot = view.offset;
     let config = cx.editor.config();
@@ -109,8 +108,7 @@ pub fn regex_prompt(
                             doc.set_selection(view.id, snapshot.clone());
 
                             if event == PromptEvent::Validate {
-                                // Equivalent to push_jump to store selection just before jump
-                                view.jumps.push((doc_id, snapshot.clone()));
+                                view.jumps.push(doc, snapshot.clone());
                             }
 
                             fun(view, doc, regex, event);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -905,8 +905,7 @@ impl Editor {
                         view.remove_document(&id);
                     }
                 } else {
-                    let jump = (view.doc, doc.selection(view.id).clone());
-                    view.jumps.push(jump);
+                    view.jumps.push(doc, doc.selection(view.id).clone());
                     // Set last accessed doc if it is a different document
                     if doc.id != id {
                         view.add_to_history(view.doc);


### PR DESCRIPTION
Previously, the jumplist was not updated by changes to the document. This meant that the jumplist entries were prone to being incorrect after some edits and that usages of the jumplist were prone to panics if, for example, some edits truncated the document.

This change applies `Transaction`s (document edits) to the selections stored in any jumplists.

Implementation-wise I used a `Rc<RefCell<Selection>>` so that the `Document` could edit the selections when applying transactions and then the `View` could use the updated selections for jumping. Kakoune does this by waiting to apply transactions until `C-o`/`C-i` are used. I would prefer to do all of that work incrementally though since we have the jumplist picker (we would need to update all selections with all changes since the jumps were saved which seems like it could be a lot of work).

Closes https://github.com/helix-editor/helix/issues/3550
Closes https://github.com/helix-editor/helix/issues/2489