### PR TITLE
fix! render highlights over rulers

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -128,6 +128,7 @@ impl EditorView {
             Box::new(highlights)
         };
 
+        Self::render_rulers(editor, doc, view, inner, surface, theme);
         Self::render_text_highlights(
             doc,
             view.offset,
@@ -138,7 +139,6 @@ impl EditorView {
             &editor.config(),
         );
         Self::render_gutter(editor, doc, view, view.area, surface, theme, is_focused);
-        Self::render_rulers(editor, doc, view, inner, surface, theme);
 
         if is_focused {
             Self::render_focused_view_elements(view, doc, inner, theme, surface);


### PR DESCRIPTION
Bug pointed out here: https://github.com/helix-editor/helix/pull/3587#issuecomment-1230525446

This fix is so easy I'm thinking I may have missed something?
EDIT: Ref ChrHorn below; themes that use `ui.ruler.fg` will not work anymore.