### PR TITLE
fix: prevents storing last prompt if is top of stack

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1977,7 +1977,7 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
         let end = text.line_to_char(
             match extend {
                 Extend::Above => end_line + 1, // the start of next line
-                Extend::Below => (end_line + count),
+                Extend::Below => end_line + count,
             }
             .min(text.len_lines()),
         );

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -529,18 +529,24 @@ impl Component for Prompt {
                     self.recalculate_completion(cx.editor);
                     self.exit_selection();
                 } else {
+                    let last_item = self
+                        .history_register
+                        .and_then(|reg| cx.editor.registers.last(reg).cloned())
+                        .map(|entry| entry.into())
+                        .unwrap_or_else(|| Cow::from(""));
+
                     // handle executing with last command in history if nothing entered
                     let input: Cow<str> = if self.line.is_empty() {
-                        // latest value in the register list
-                        self.history_register
-                            .and_then(|reg| cx.editor.registers.last(reg).cloned())
-                            .map(|entry| entry.into())
-                            .unwrap_or_else(|| Cow::from(""))
+                        last_item
                     } else {
-                        if let Some(register) = self.history_register {
+                        if last_item != self.line {
                             // store in history
-                            let register = cx.editor.registers.get_mut(register);
-                            register.push(self.line.clone());
+                            if let Some(register) = self.history_register {
+                                cx.editor
+                                    .registers
+                                    .get_mut(register)
+                                    .push(self.line.clone());
+                            };
                         }
 
                         self.line.as_str().into()


### PR DESCRIPTION
This PR prevents putting the last entered prompt command into the history stack if it was already the top. For example, if you execute `:o <file>` first and then execute `:w` three times in the prompt, the current state stores the `:w` command three times in the history register and you have to scroll three times up to retrieve the entered `:o <file>` command. This PR fixes it.