### PR TITLE
Avoid command execution hooks on closed docs

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -781,7 +781,10 @@ impl EditorView {
 
         let mut execute_command = |command: &commands::MappableCommand| {
             command.execute(cxt);
-            let doc = cxt.editor.documents.get_mut(&doc_id).unwrap();
+            let doc = match cxt.editor.documents.get(&doc_id) {
+                Some(doc) => doc,
+                None => return,
+            };
             let current_mode = doc.mode();
             match (last_mode, current_mode) {
                 (Mode::Normal, Mode::Insert) => {


### PR DESCRIPTION
Fixes a panic with a config like:

    [keys.normal.space]
    x = [":buffer-close"]

by bailing out of the command-execution handling if the document
doesn't exist after handling a command.

See https://github.com/helix-editor/helix/pull/2634#discussion_r959288551