### PR TITLE
Change MonokaiProSpectrum theme error background from red to magenta.

### DIFF
--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -65,7 +65,7 @@
 "variable.parameter" = "#f59762"
 
 # error
-"error" = { bg = "red", fg = "yellow" }
+"error" = { bg = "magenta", fg = "yellow" }
 
 # annotations, decorators
 "special" = "#f59762"


### PR DESCRIPTION
Text painted in red (JSON object keys for example) is not visible in case
of error. Change to magenta can fix this.

before:
![image](https://user-images.githubusercontent.com/4949019/187874615-18caa94e-c3b2-4c6b-a8fc-71663e1e8c5e.png)

after:
![image](https://user-images.githubusercontent.com/4949019/187874695-aa95cbea-8b61-4cd2-af70-00aca95aff00.png)
