### PR TITLE
Add support for the Godot Language Server

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -38,7 +38,7 @@
 | esdl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
 | fortran | ✓ |  | ✓ | `fortls` |
-| gdscript | ✓ | ✓ | ✓ |  |
+| gdscript | ✓ | ✓ | ✓ | `nc` |
 | git-attributes | ✓ |  |  |  |
 | git-commit | ✓ |  |  |  |
 | git-config | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1533,6 +1533,8 @@ roots = ["project.godot"]
 auto-format = true
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
+# Change this to port 6005 for Godot 4.
+language-server = { command = "nc", args = ["localhost", "6008"] }
 
 [[grammar]]
 name = "gdscript"


### PR DESCRIPTION
By default Godot 3 uses port 6008, but this will be changed to 6005 in Godot 4.

Launch command copied from https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/gdscript.lua

Users who use Godot 4 right now need to change the port in the editor settings.

This also changes the indent to tabs, based on the [official style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#encoding-and-special-characters).