### PR TITLE
Fix preview bug

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -715,7 +715,9 @@ fn theme(
             cx.editor.unset_theme_preview();
         }
         PromptEvent::Update => {
-            if let Some(theme_name) = args.first() {
+            if args.is_empty() {
+                cx.editor.unset_theme_preview();
+            } else if let Some(theme_name) = args.first() {
                 if let Ok(theme) = cx.editor.theme_loader.load(theme_name) {
                     if !(true_color || theme.is_16_color()) {
                         bail!("Unsupported theme: theme requires true color support");

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -716,6 +716,7 @@ fn theme(
         }
         PromptEvent::Update => {
             if args.is_empty() {
+                // Ensures that a preview theme gets cleaned up if the user backspaces until the prompt is empty.
                 cx.editor.unset_theme_preview();
             } else if let Some(theme_name) = args.first() {
                 if let Ok(theme) = cx.editor.theme_loader.load(theme_name) {

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -293,6 +293,7 @@ impl Prompt {
         register: char,
         direction: CompletionDirection,
     ) {
+        (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
         let register = cx.editor.registers.get_mut(register).read();
 
         if register.is_empty() {
@@ -314,6 +315,7 @@ impl Prompt {
         self.history_pos = Some(index);
 
         self.move_end();
+        (self.callback_fn)(cx, &self.line, PromptEvent::Update);
         self.recalculate_completion(cx.editor);
     }
 
@@ -564,13 +566,11 @@ impl Component for Prompt {
             ctrl!('p') | key!(Up) => {
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Backward);
-                    (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }
             ctrl!('n') | key!(Down) => {
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Forward);
-                    (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }
             key!(Tab) => {


### PR DESCRIPTION
closes https://github.com/helix-editor/helix/issues/3620.

This works by ensuring an abort is sent to the original command. The update callback being moved is for ensuring the completion shows for the correct command.