### PR TITLE
Elixir: update tree-sitter queries

### DIFF
--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -1,6 +1,8 @@
+; Elixir Comments
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
+; Elixir Regular Expressions
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
@@ -8,13 +10,7 @@
  (#set! injection.language "regex")
  (#set! injection.combined))
 
-((sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @injection.content)
- (#eq? @_sigil_name "H")
- (#set! injection.language "heex")
- (#set! injection.combined))
-
+; Elixir Documentation
 (unary_operator
   operator: "@"
   operand: (call
@@ -23,3 +19,25 @@
       (string (quoted_content) @injection.content)
       (sigil (quoted_content) @injection.content)
   ])) (#set! injection.language "markdown"))
+
+; Phoenix Live View HEEx Sigils
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "H")
+ (#set! injection.language "heex")
+ (#set! injection.combined))
+
+; Phoenix Live View Component Macros
+(call 
+  (identifier) @_identifier
+  (arguments
+    (atom)+
+    (keywords (pair 
+      (keyword) 
+      [
+        (string (quoted_content) @injection.content)
+        (sigil (quoted_content) @injection.content)
+      ]))
+  (#match? @_identifier "^(attr|slot)$")
+  (#set! injection.language "markdown")))

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -1,4 +1,4 @@
-; Elixir Comments
+; Elixir Code Comments
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
@@ -6,11 +6,11 @@
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
- (#match? @_sigil_name "^(r|R)$")
+ (#match? @_sigil_name "^(R|r)$")
  (#set! injection.language "regex")
  (#set! injection.combined))
 
-; Elixir Documentation
+; Elixir Markdown Documentation
 (unary_operator
   operator: "@"
   operand: (call
@@ -19,6 +19,22 @@
       (string (quoted_content) @injection.content)
       (sigil (quoted_content) @injection.content)
   ])) (#set! injection.language "markdown"))
+
+; Zigler Sigils
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(Z|z)$")
+ (#set! injection.language "zig")
+ (#set! injection.combined))
+
+; Jason Sigils
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(J|j)$")
+ (#set! injection.language "json")
+ (#set! injection.combined))
 
 ; Phoenix Live View HEEx Sigils
 ((sigil
@@ -34,7 +50,7 @@
   (arguments
     (atom)+
     (keywords (pair 
-      (keyword) 
+      ((keyword) @_keyword (#eq? @_keyword "doc: "))
       [
         (string (quoted_content) @injection.content)
         (sigil (quoted_content) @injection.content)

--- a/runtime/queries/elixir/textobjects.scm
+++ b/runtime/queries/elixir/textobjects.scm
@@ -32,4 +32,4 @@
   (do_block (_)* @test.inside)?)
  (#match? @_keyword "^(test|describe)$")) @test.around
 
-(comment) @comment.around @comment.inside
+(comment)+ @comment.around @comment.inside


### PR DESCRIPTION
This PR makes the following changes to the Elixir tree-sitter queries:
* tree-sitter text object comments are now grouped together
* markdown is injected into Phoenix Live View declarative attribute `:doc` options

See the following examples:
- https://github.com/phoenixframework/phoenix_live_view/blob/c1c4754e772de529529a046b42f5fdf02c66dede/lib/phoenix_component.ex#L1452
- https://github.com/phoenixframework/phoenix_live_view/blob/c1c4754e772de529529a046b42f5fdf02c66dede/lib/phoenix_component.ex#L1418
- https://github.com/phoenixframework/phoenix_live_view/blob/c1c4754e772de529529a046b42f5fdf02c66dede/test/phoenix_component/declarative_assigns_test.exs#L583