### PR TITLE
Enable CI builds for `aarch64-linux`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build AppImage
         shell: bash
-        if: matrix.build == 'x86_64-linux'
+        if: matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-linux'
         run: |
           mkdir dist
 
@@ -147,8 +147,10 @@ jobs:
             name=${GITHUB_REF:10}
           fi
 
+          build="${{ matrix.build }}"
+
           export VERSION="$name"
-          export ARCH=x86_64
+          export ARCH=${build%-linux}
           export APP=helix
           export OUTPUT="helix-$VERSION-$ARCH.AppImage"
           export UPDATE_INFORMATION="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|helix|latest|$APP-*-$ARCH.AppImage.zsync"
@@ -245,7 +247,7 @@ jobs:
               mv bins-$platform/hx$exe $pkgname
               chmod +x $pkgname/hx$exe
 
-              if [[ "$platform" = "x86_64-linux" ]]; then
+              if [[ "$platform" = "aarch64-linux" || "$platform" = "x86_64-linux" ]]; then
                   mv bins-$platform/helix-*.AppImage* dist/
               fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,14 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
+      # Install a pre-release version of Cross
+      # TODO: We need to pre-install Cross because we need cross-rs/cross#591 to
+      #       get a newer C++ compiler toolchain. Remove this step when Cross
+      #       0.3.0, which includes cross-rs/cross#591, is released.
+      - name: Install Cross
+        if: "matrix.cross"
+        run: cargo install cross --git https://github.com/cross-rs/cross.git --rev 47df5c76e7cba682823a0b6aa6d95c17b31ba63a
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         if: "!matrix.skip_tests"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,11 @@ jobs:
           rust: stable
           target: x86_64-unknown-linux-gnu
           cross: false
-        # - build: aarch64-linux
-        #   os: ubuntu-20.04
-        #   rust: stable
-        #   target: aarch64-unknown-linux-gnu
-        #   cross: true
+        - build: aarch64-linux
+          os: ubuntu-20.04
+          rust: stable
+          target: aarch64-unknown-linux-gnu
+          cross: true
         - build: x86_64-macos
           os: macos-latest
           rust: stable


### PR DESCRIPTION
Closes #3237

A preview CI run based on this patch + `22.08.1` can be found at <https://github.com/yvt/helix/actions/runs/2987431541>. The "release" artifact contains `helix-dev-aarch64{.AppImage,-linux.tar.xz}`.

