### PR TITLE
Fix cargo doc warnings, and add GitHub action to ensure it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,14 @@ jobs:
           command: clippy
           args: --all-targets -- -D warnings
 
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps --workspace --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -230,14 +230,14 @@ fn get_first_in_line(mut node: Node, byte_pos: usize, new_line: bool) -> Vec<boo
 /// - Successively add indent captures to get the (added) indent from a single line
 /// - Successively add the indent results for each line
 #[derive(Default)]
-struct Indentation {
+pub struct Indentation {
     /// The total indent (the number of indent levels) is defined as max(0, indent-outdent).
     /// The string that this results in depends on the indent style (spaces or tabs, etc.)
     indent: usize,
     outdent: usize,
 }
 impl Indentation {
-    /// Add some other [IndentResult] to this.
+    /// Add some other [Indentation] to this.
     /// The added indent should be the total added indent from one line
     fn add_line(&mut self, added: &Indentation) {
         if added.indent > 0 && added.outdent == 0 {
@@ -433,7 +433,7 @@ fn query_indents(
 ///     after pos were moved to a new line.
 ///
 /// The indentation is determined by traversing all the tree-sitter nodes containing the position.
-/// Each of these nodes produces some [AddedIndent] for:
+/// Each of these nodes produces some [Indentation] for:
 ///
 /// - The line of the (beginning of the) node. This is defined by the scope `all` if this is the first node on its line.
 /// - The line after the node. This is defined by:
@@ -441,9 +441,9 @@ fn query_indents(
 ///   - The scope `all` if this node is not the first node on its line.
 /// Intuitively, `all` applies to everything contained in this node while `tail` applies to everything except for the first line of the node.
 /// The indents from different nodes for the same line are then combined.
-/// The [IndentResult] is simply the sum of the [AddedIndent] for all lines.
+/// The [Indentation] is simply the sum of the [Indentation] for all lines.
 ///
-/// Specifying which line exactly an [AddedIndent] applies to is important because indents on the same line combine differently than indents on different lines:
+/// Specifying which line exactly an [Indentation] applies to is important because indents on the same line combine differently than indents on different lines:
 /// ```ignore
 /// some_function(|| {
 ///     // Both the function parameters as well as the contained block should be indented.

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -441,7 +441,7 @@ fn query_indents(
 ///   - The scope `all` if this node is not the first node on its line.
 /// Intuitively, `all` applies to everything contained in this node while `tail` applies to everything except for the first line of the node.
 /// The indents from different nodes for the same line are then combined.
-/// The [Indentation] is simply the sum of the [Indentation] for all lines.
+/// The result [Indentation] is simply the sum of the [Indentation] for all lines.
 ///
 /// Specifying which line exactly an [Indentation] applies to is important because indents on the same line combine differently than indents on different lines:
 /// ```ignore

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -101,7 +101,7 @@ impl Prompt {
     }
 
     /// Compute the cursor position after applying movement
-    /// Taken from: https://github.com/wez/wezterm/blob/e0b62d07ca9bf8ce69a61e30a3c20e7abc48ce7e/termwiz/src/lineedit/mod.rs#L516-L611
+    /// Taken from: <https://github.com/wez/wezterm/blob/e0b62d07ca9bf8ce69a61e30a3c20e7abc48ce7e/termwiz/src/lineedit/mod.rs#L516-L611>
     fn eval_movement(&self, movement: Movement) -> usize {
         match movement {
             Movement::BackwardChar(rep) => {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -273,7 +273,7 @@ impl Tree {
     /// Get reference to a [`view`] by index.
     /// # Panics
     ///
-    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`] . This can be checked with [`contains`]
+    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`]. This can be checked with [`Self::contains`].
     pub fn get(&self, index: ViewId) -> &View {
         self.try_get(index).unwrap()
     }
@@ -295,7 +295,7 @@ impl Tree {
     /// Get a mutable reference to a [`view`] by index.
     /// # Panics
     ///
-    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`] . This can be checked with [`Self::contains`]
+    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`]. This can be checked with [`Self::contains`].
     pub fn get_mut(&mut self, index: ViewId) -> &mut View {
         match &mut self.nodes[index] {
             Node {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -270,18 +270,18 @@ impl Tree {
             })
     }
 
-    /// Get reference to a [`view`] by index.
+    /// Get reference to a [View] by index.
     /// # Panics
     ///
-    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`]. This can be checked with [`Self::contains`].
+    /// Panics if `index` is not in self.nodes, or if the node's content is not [Content::View]. This can be checked with [Self::contains].
     pub fn get(&self, index: ViewId) -> &View {
         self.try_get(index).unwrap()
     }
 
-    /// Try to get reference to a [`view`] by index. Returns `None` if node content is not a [`Content::View`]
+    /// Try to get reference to a [View] by index. Returns `None` if node content is not a [Content::View]
     /// # Panics
     ///
-    /// Panics if `index` is not in self.nodes. This can be checked with [`Self::contains`]
+    /// Panics if `index` is not in self.nodes. This can be checked with [Self::contains]
     pub fn try_get(&self, index: ViewId) -> Option<&View> {
         match &self.nodes[index] {
             Node {
@@ -292,10 +292,10 @@ impl Tree {
         }
     }
 
-    /// Get a mutable reference to a [`view`] by index.
+    /// Get a mutable reference to a [View] by index.
     /// # Panics
     ///
-    /// Panics if `index` is not in self.nodes, or if the node's content is not [`Content::View`]. This can be checked with [`Self::contains`].
+    /// Panics if `index` is not in self.nodes, or if the node's content is not [Content::View]. This can be checked with [Self::contains].
     pub fn get_mut(&mut self, index: ViewId) -> &mut View {
         match &mut self.nodes[index] {
             Node {
@@ -306,7 +306,7 @@ impl Tree {
         }
     }
 
-    /// Check if tree contains a [`Node`] with a given index.
+    /// Check if tree contains a [Node] with a given index.
     pub fn contains(&self, index: ViewId) -> bool {
         self.nodes.contains_key(index)
     }


### PR DESCRIPTION
Resolves #3150.
Fixes cargo doc warnings, and adds GitHub action to ensure cargo doc runs without warnings