### PR TITLE
build(nix): update nci, refactor flake, seperate wrapping, add source filtering

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -23,4 +23,4 @@ jobs:
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - name: Build nix flake
-      run: nix build
+      run: nix build -L

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "crane": {
       "flake": false,
       "locked": {
-        "lastModified": 1654444508,
-        "narHash": "sha256-4OBvQ4V7jyt7afs6iKUvRzJ1u/9eYnKzVQbeQdiamuY=",
+        "lastModified": 1661875961,
+        "narHash": "sha256-f1h/2c6Teeu1ofAHWzrS8TwBPcnN+EEu+z1sRVmMQTk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "db5482bf225acc3160899124a1df5a617cfa27b5",
+        "rev": "d9f394e4e20e97c2a60c3ad82c2b6ef99be19e24",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "devshell": {
       "flake": false,
       "locked": {
-        "lastModified": 1655976588,
-        "narHash": "sha256-VreHyH6ITkf/1EX/8h15UqhddJnUleb0HgbC3gMkAEQ=",
+        "lastModified": 1660811669,
+        "narHash": "sha256-V6lmsaLNFz41myppL0yxglta92ijkSvpZ+XVygAh+bU=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "899ca4629020592a13a46783587f6e674179d1db",
+        "rev": "c2feacb46ee69949124c835419861143c4016fb5",
         "type": "github"
       },
       "original": {
@@ -35,49 +35,45 @@
     "dream2nix": {
       "inputs": {
         "alejandra": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "crane": "crane",
         "devshell": [
-          "nixCargoIntegration",
+          "nci",
           "devshell"
         ],
         "flake-utils-pre-commit": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "gomod2nix": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "mach-nix": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "nixpkgs": [
-          "nixCargoIntegration",
-          "nixpkgs"
-        ],
-        "node2nix": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "poetry2nix": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ],
         "pre-commit-hooks": [
-          "nixCargoIntegration",
+          "nci",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1655975833,
-        "narHash": "sha256-g8sdfuglIZ24oWVbntVzniNTJW+Z3n9DNL9w9Tt+UCE=",
+        "lastModified": 1662083074,
+        "narHash": "sha256-GL4/CLKPYUzkKD1l7oi2XB+vi3z4xGpCVLDdG3tRqvs=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "4e75e665ec3a1cddae5266bed0dd72fce0b74a23",
+        "rev": "c6c039fcc6abdf4d828b940b576944a224cf8622",
         "type": "github"
       },
       "original": {
@@ -88,11 +84,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -101,7 +97,7 @@
         "type": "github"
       }
     },
-    "nixCargoIntegration": {
+    "nci": {
       "inputs": {
         "devshell": "devshell",
         "dream2nix": "dream2nix",
@@ -113,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656453541,
-        "narHash": "sha256-ZCPVnS6zJOZJvIlwU3rKR8MBVm6A3F4/0mA7G1lQ3D0=",
+        "lastModified": 1662143940,
+        "narHash": "sha256-3eJfehnZLWJGXylfpAMeLR0Q3sx8pAjGiHBQPqOH9+U=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "9eb74345b30cd2e536d9dac9d4435d3c475605c7",
+        "rev": "e83f2598aecbe1114783ff9bdae0b85939de35a3",
         "type": "github"
       },
       "original": {
@@ -128,11 +124,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655624069,
-        "narHash": "sha256-7g1zwTdp35GMTERnSzZMWJ7PG3QdDE8VOX3WsnOkAtM=",
+        "lastModified": 1662019588,
+        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0d68d7c857fe301d49cdcd56130e0beea4ecd5aa",
+        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
         "type": "github"
       },
       "original": {
@@ -144,7 +140,7 @@
     },
     "root": {
       "inputs": {
-        "nixCargoIntegration": "nixCargoIntegration",
+        "nci": "nci",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -157,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655779671,
-        "narHash": "sha256-6feeiGa6fb7ZPVHR71uswkmN1701TAJpwYQA8QffmRk=",
+        "lastModified": 1662087605,
+        "narHash": "sha256-Gpf2gp2JenKGf+TylX/YJpttY2bzsnvAMLdLaxoZRyU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8159585609a772b041cce6019d5c21d240709244",
+        "rev": "60c2cfaa8b90ed8cebd18b214fac8682dcf222dd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,128 +7,134 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixCargoIntegration = {
+    nci = {
       url = "github:yusdacra/nix-cargo-integration";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.rust-overlay.follows = "rust-overlay";
     };
   };
 
-  outputs = inputs @ {
+  outputs = {
+    self,
     nixpkgs,
-    nixCargoIntegration,
+    nci,
     ...
   }: let
-    outputs = config:
-      nixCargoIntegration.lib.makeOutputs {
-        root = ./.;
-        renameOutputs = {"helix-term" = "helix";};
-        # Set default app to hx (binary is from helix-term release build)
-        # Set default package to helix-term release build
-        defaultOutputs = {
-          app = "hx";
-          package = "helix";
-        };
-        overrides = {
-          cCompiler = common:
-            with common.pkgs;
-              if stdenv.isLinux
-              then gcc
-              else clang;
-          crateOverrides = common: _: {
-            helix-term = prev: let
-              inherit (common) pkgs;
-              mkRootPath = rel:
-                builtins.path {
-                  path = "${common.root}/${rel}";
-                  name = rel;
-                };
-              grammars = pkgs.callPackage ./grammars.nix config;
-              runtimeDir = pkgs.runCommandNoCC "helix-runtime" {} ''
-                mkdir -p $out
-                ln -s ${mkRootPath "runtime"}/* $out
-                rm -r $out/grammars
-                ln -s ${grammars} $out/grammars
-              '';
-              overridedAttrs = {
-                # disable fetching and building of tree-sitter grammars in the helix-term build.rs
-                HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-                # link languages and theme toml files since helix-term expects them (for tests)
-                preConfigure =
-                  pkgs.lib.concatMapStringsSep
-                  "\n"
-                  (path: "ln -sf ${mkRootPath path} ..")
-                  ["languages.toml" "theme.toml" "base16_theme.toml"];
-                buildInputs = (prev.buildInputs or []) ++ [common.cCompiler.cc.lib];
-                nativeBuildInputs = [pkgs.makeWrapper];
-
-                postFixup = ''
-                  if [ -f "$out/bin/hx" ]; then
-                    wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
-                  fi
-                '';
-              };
-            in
-              overridedAttrs
-              // (
-                pkgs.lib.optionalAttrs
-                (config ? makeWrapperArgs)
-                {inherit (config) makeWrapperArgs;}
-              );
-          };
-          shell = common: prev: {
-            packages =
-              prev.packages
-              ++ (
-                with common.pkgs;
-                [lld_13 lldb cargo-flamegraph rust-analyzer] ++
-                (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
-              );
-            env =
-              prev.env
-              ++ [
-                {
-                  name = "HELIX_RUNTIME";
-                  eval = "$PWD/runtime";
-                }
-                {
-                  name = "RUST_BACKTRACE";
-                  value = "1";
-                }
-                {
-                  name = "RUSTFLAGS";
-                  value =
-                    if common.pkgs.stdenv.isLinux
-                    then "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"
-                    else "";
-                }
-              ];
+    lib = nixpkgs.lib;
+    mkRootPath = rel:
+      builtins.path {
+        path = "${toString ./.}/${rel}";
+        name = rel;
+      };
+    outputs = nci.lib.makeOutputs {
+      root = ./.;
+      renameOutputs = {"helix-term" = "helix";};
+      # Set default app to hx (binary is from helix-term release build)
+      # Set default package to helix-term release build
+      defaultOutputs = {
+        app = "hx";
+        package = "helix";
+      };
+      overrides = {
+        cCompiler = common:
+          with common.pkgs;
+            if stdenv.isLinux
+            then gcc
+            else clang;
+        crateOverrides = common: _: {
+          helix-term = prev: {
+            # disable fetching and building of tree-sitter grammars in the helix-term build.rs
+            HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+            # link languages and theme toml files since helix-term expects them (for tests)
+            preConfigure =
+              lib.concatMapStringsSep
+              "\n"
+              (path: "ln -sf ${mkRootPath path} ..")
+              ["languages.toml" "theme.toml" "base16_theme.toml"];
+            buildInputs = (prev.buildInputs or []) ++ [common.cCompiler.cc.lib];
           };
         };
+        shell = common: prev: {
+          packages =
+            prev.packages
+            ++ (
+              with common.pkgs;
+                [lld_13 lldb cargo-flamegraph rust-analyzer]
+                ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
+            );
+          env =
+            prev.env
+            ++ [
+              {
+                name = "HELIX_RUNTIME";
+                eval = "$PWD/runtime";
+              }
+              {
+                name = "RUST_BACKTRACE";
+                value = "1";
+              }
+              {
+                name = "RUSTFLAGS";
+                value =
+                  if common.pkgs.stdenv.isLinux
+                  then "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"
+                  else "";
+              }
+            ];
+        };
       };
-    defaultOutputs = outputs {};
-    makeOverridableHelix = system: old:
-      old
-      // {
-        override = args:
-          makeOverridableHelix
-          system
-          (outputs args).packages.${system}.helix;
-      };
+    };
+    makeOverridableHelix = system: old: config: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      grammars = pkgs.callPackage ./grammars.nix config;
+      runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+        mkdir -p $out
+        ln -s ${mkRootPath "runtime"}/* $out
+        rm -r $out/grammars
+        ln -s ${grammars} $out/grammars
+      '';
+      helix-wrapped =
+        pkgs.runCommand "${old.name}-wrapped"
+        {
+          nativeBuildInputs = [pkgs.makeWrapper];
+          makeWrapperArgs = config.makeWrapperArgs or [];
+          meta.mainProgram = "hx";
+        }
+        ''
+          mkdir -p $out
+          cp -r ${old}/* $out/
+          wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
+        '';
+    in
+      helix-wrapped
+      // {override = makeOverridableHelix system old;};
   in
-    defaultOutputs
+    outputs
     // {
-      packages =
-        nixpkgs.lib.mapAttrs
+      apps =
+        lib.mapAttrs
         (
-          system: packages:
-            packages
-            // rec {
-              default = helix;
-              helix = makeOverridableHelix system packages.helix;
-            }
+          system: apps: rec {
+            default = hx;
+            hx = {
+              type = "app";
+              program = lib.getExe self.${system}.packages.helix;
+            };
+          }
         )
-        defaultOutputs.packages;
+        outputs.apps;
+      packages =
+        lib.mapAttrs
+        (
+          system: packages: rec {
+            default = helix;
+            helix = makeOverridableHelix system helix-unwrapped {};
+            helix-debug = makeOverridableHelix system helix-unwrapped-debug {};
+            helix-unwrapped = packages.helix;
+            helix-unwrapped-debug = packages.helix-debug;
+          }
+        )
+        outputs.packages;
     };
 
   nixConfig = {


### PR DESCRIPTION
Updates NCI, separates wrapping of hx binary to another derivation so that helix doesn't get recompiled when grammars or runtime get changed, adds filtering to source for helix-term build so that unnecessary rebuilds are reduced.