### PR TITLE
Look for the external formatter before invoking it

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -407,7 +407,11 @@ impl Document {
     // We can't use anyhow::Result here since the output of the future has to be
     // clonable to be used as shared future. So use a custom error type.
     pub fn format(&self) -> Option<BoxFuture<'static, Result<Transaction, FormatterError>>> {
-        if let Some(formatter) = self.language_config().and_then(|c| c.formatter.clone()) {
+        if let Some(formatter) = self
+            .language_config()
+            .and_then(|c| c.formatter.clone())
+            .filter(|formatter| which::which(&formatter.command).is_ok())
+        {
             use std::process::Stdio;
             let text = self.text().clone();
             let mut process = tokio::process::Command::new(&formatter.command);


### PR DESCRIPTION
Currently it is not possible to save a file with a language that
has an external formatter configuration unless the external
formatter is installed, even if the language has a Language Server
configuration capable of auto-format. This change checks that the
external formatter exists before using it to create a formatting
callback.