### PR TITLE
docs(tutor): add missing `-->`

### DIFF
--- a/runtime/tutor.txt
+++ b/runtime/tutor.txt
@@ -670,7 +670,7 @@ _________________________________________________________________
  3. Try using A-. with f and t, to select multiple sentences for
     instance.
 
- This is some text for you to repeat things. You can repeat
+ --> This is some text for you to repeat things. You can repeat
  insertions like changing words, or repeat selections like f/t.
 
 


### PR DESCRIPTION
Step 1, on line 668, mentions this token used throughout the tutorial, but the token is missing at the beginning of the sentence