### PR TITLE
Add `trim` to remove trailing whitespace

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -72,3 +72,4 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:trim` | Trim trailing whitespace. Args: 'all' (default), 'spaces', 'lines' |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1794,7 +1794,10 @@ fn trim(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
     let mode = args.get(0).unwrap_or(&Cow::Borrowed("all"));
     let (view, doc) = current!(cx.editor);
 
+    let selections = doc.selection(view.id)
+
     if mode == "all" || mode == "spaces" {
+        
         let mut pos = 0;
         let transaction = Transaction::change(
             doc.text(),


### PR DESCRIPTION
Resolves #1481

~Currently it doesn't delete empty trailing lines. Is this a desired behavior?~