### PR TITLE
Handle formatter errors, and save anyway

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -543,12 +543,19 @@ impl Document {
             }
 
             if let Some(fmt) = formatting {
-                let transaction = fmt.await?;
-                let success = transaction.changes().apply(&mut text);
-                if !success {
-                    // This shouldn't happen, because the transaction changes were generated
-                    // from the same text we're saving.
-                    log::error!("failed to apply format changes before saving");
+                match fmt.await {
+                    Ok(transaction) => {
+                        let success = transaction.changes().apply(&mut text);
+                        if !success {
+                            // This shouldn't happen, because the transaction changes were generated
+                            // from the same text we're saving.
+                            log::error!("failed to apply format changes before saving");
+                        }
+                    }
+                    Err(err) => {
+                        // formatting failed: report error, and save file without modifications
+                        log::error!("{}", err);
+                    }
                 }
             }
 


### PR DESCRIPTION
Adresses [comment](https://github.com/helix-editor/helix/pull/3670#issuecomment-1236150951)
If formatting fails, report error to log and save without formatting.
log entry looks something like this:
`2022-09-04T13:17:52.359 helix_view::document [ERROR] Formatter exited with non zero exit status`
![image](https://user-images.githubusercontent.com/58790821/188308714-da6ed7ad-6dc5-4455-be21-8c533439e48c.png)
(tested by adding formatter to `$PATH` which is just a shell script that returns exit status)
```bash
#!/usr/bin/env bash
exit 1
```