### PR TITLE
Enable CI builds for `riscv64-linux`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
           rust: stable
           target: aarch64-unknown-linux-gnu
           cross: true
+        - build: riscv64-linux
+          os: ubuntu-20.04
+          rust: stable
+          target: riscv64gc-unknown-linux-gnu
+          cross: true
         - build: x86_64-macos
           os: macos-latest
           rust: stable


### PR DESCRIPTION
AppImage build is not possible for now because [AppImageKit](https://github.com/AppImage/AppImageKit/blob/729a1a60e41cdd90554462495576cdae4a2896ed/src/appimagetool.c#L68-L73) does not recognize the architecture name.

~~A preview CI run based on this patch + `22.08.1` can be found at <https://github.com/yvt/helix/actions/runs/2987576146>.~~ (out of date)