### PR TITLE
xcopy - assume destination is a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%App
 
 | OS                   | Command                                      |
 | -------------------- | -------------------------------------------- |
-| Windows (cmd.exe)    | `xcopy /e runtime %AppData%\helix\runtime`      |
-| Windows (PowerShell) | `xcopy /e runtime $Env:AppData\helix\runtime`   |
+| Windows (cmd.exe)    | `xcopy /e /i runtime %AppData%\helix\runtime`      |
+| Windows (PowerShell) | `xcopy /e /i runtime $Env:AppData\helix\runtime`   |
 | Linux/macOS          | `ln -s $PWD/runtime ~/.config/helix/runtime` |
 
 This location can be overridden via the `HELIX_RUNTIME` environment variable.

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -66,8 +66,8 @@ via the `HELIX_RUNTIME` environment variable.
 
 | OS                | command   |
 |-------------------|-----------|
-|windows(cmd.exe)   |`xcopy /e runtime %AppData%/helix/runtime`     |
-|windows(powershell)|`xcopy /e runtime $Env:AppData\helix\runtime`  |
+|windows(cmd.exe)   |`xcopy /e /i runtime %AppData%/helix/runtime`     |
+|windows(powershell)|`xcopy /e /i runtime $Env:AppData\helix\runtime`  |
 |linux/macos        |`ln -s $PWD/runtime ~/.config/helix/runtime`|
 
 ## Finishing up the installation 


### PR DESCRIPTION
By default xcopy asks if the destination is a file or directory. Since we know it's a directory we can add the `/i` flag and prevent an extra prompt.

Description of `/i`
```
If source is a directory or contains wildcards and destination does not exist, 
xcopy assumes destination specifies a directory name and creates a new directory. 
Then, xcopy copies all specified files into the new directory.
```


