### PR TITLE
Fix off-by-one in extend_line_above

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1971,7 +1971,7 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
         let (start_line, end_line) = range.line_range(text.slice(..));
 
         let start = text.line_to_char(match extend {
-            Extend::Above => start_line.saturating_sub(count),
+            Extend::Above => start_line.saturating_sub(count - 1),
             Extend::Below => start_line,
         });
         let end = text.line_to_char(
@@ -1985,7 +1985,7 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
         // extend to previous/next line if current line is selected
         let (anchor, head) = if range.from() == start && range.to() == end {
             match extend {
-                Extend::Above => (end, text.line_to_char(start_line.saturating_sub(count + 1))),
+                Extend::Above => (end, text.line_to_char(start_line.saturating_sub(count))),
                 Extend::Below => (
                     start,
                     text.line_to_char((end_line + count + 1).min(text.len_lines())),


### PR DESCRIPTION
`extend_line_above` (and `extend_line` when facing backwards) skip
a line when the current range does not fully cover a line.

Before this change:

    foo
    b#[|a]#r
    baz

With `extend_line_above` or `extend_line` selected the line above.

    #[|foo
    bar]#
    baz

Which is inconsistent with `extend_line_below`. This commit changes
the behavior to select the current line when it is not already
selected.

    foo
    #[|bar]#
    baz

Then further calls of `extend_line_above` extend the selection up
line-wise.