### PR TITLE
remove `split-debuginfo` setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ default-members = [
   "helix-term"
 ]
 
-[profile.dev]
-split-debuginfo = "unpacked"
-
 [profile.release]
 lto = "thin"
 # debug = true


### PR DESCRIPTION
According to [the rustc book](https://doc.rust-lang.org/rustc/codegen-options/index.html#split-debuginfo), this is not supported on Windows. It also prevents Helix from compiling on the latest nightly on Windows.