### PR TITLE
nix: fix highlighting rules

### DIFF
--- a/runtime/queries/nix/highlights.scm
+++ b/runtime/queries/nix/highlights.scm
@@ -1,16 +1,20 @@
 (comment) @comment
 
+"assert" @keyword.control.exception
+"or" @keyword.operator
+"rec" @keyword.control.repeat
+
 [
   "if" 
   "then"
   "else"
+] @keyword.control.conditional
+
+[
   "let"
   "inherit"
   "in"
-  "rec"
   "with" 
-  "assert"
-  "or"
 ] @keyword
 
 ((identifier) @variable.builtin
@@ -42,14 +46,11 @@
 (integer_expression) @constant.numeric.integer
 (float_expression) @constant.numeric.float
 
-(interpolation
-  "${" @punctuation.special
-  "}" @punctuation.special) @embedded
-
 (escape_sequence) @constant.character.escape
 
 (function_expression
   universal: (identifier) @variable.parameter
+  "@"? @punctuation.delimiter
 )
 
 (formal
@@ -57,11 +58,15 @@
   "?"? @punctuation.delimiter)
 
 (select_expression
-  attrpath: (attrpath (identifier)) @variable.other.member)
+  attrpath: (attrpath attr: (identifier)) @variable.other.member)
+
+(interpolation
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
 
 (apply_expression
   function: [
-    (variable_expression (identifier)) @function
+    (variable_expression name: (identifier) @function)
     (select_expression
       attrpath: (attrpath
         attr: (identifier) @function .))])
@@ -72,14 +77,18 @@
 (binary_expression
   operator: _ @operator)
 
-(variable_expression (identifier) @variable)
+(variable_expression name: (identifier) @variable)
 
 (binding
-  attrpath: (attrpath (identifier)) @variable.other.member)
+  attrpath: (attrpath attr: (identifier)) @variable.other.member)
 
-(identifier) @variable.other.member
+(inherit_from attrs: (inherited_attrs attr: (identifier) @variable))
 
-(inherit_from attrs: (inherited_attrs attr: (identifier) @variable.other.member) )
+(has_attr_expression
+  expression: (_)
+  "?" @operator
+  attrpath: (attrpath
+    attr: (identifier) @variable.other.member))
 
 [
   ";"


### PR DESCRIPTION
* avoid coloring `identifier`s globally
* fix function application when not part of `select_expression`
* add `has_attribute_expression` highlighting
* fix precendence for interpolation, which should be after select
* highlight `@` as delimiter