### PR TITLE
Add `file_picker_in_current_directory` to `keymap.md`

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -257,6 +257,7 @@ This layer is a kludge of mappings, mostly pickers.
 | Key     | Description                                                             | Command                             |
 | -----   | -----------                                                             | -------                             |
 | `f`     | Open file picker                                                        | `file_picker`                       |
+| `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`  |
 | `b`     | Open buffer picker                                                      | `buffer_picker`                     |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                   |
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                             |


### PR DESCRIPTION
I wanted to remap the file picker for the current working directory but didn't know which command it uses because it's missing from https://docs.helix-editor.com/keymap.html#space-mode. It was easy to find that it's `file_picker_in_current_directory` by looking at the code but I figured it would be good to update the documentation so the next person doesn't have to do this again.