### PR TITLE
Update tree-sitter-fish to latest commit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -121,7 +121,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "fish"
-source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f" }
+source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "84436cf24c2b3176bfbb220922a0fdbd0141e406" }
 
 [[language]]
 name = "mint"


### PR DESCRIPTION
Fixes #3698 and #3699. It looks like the queries don't need updating.

@sshilovsky: You can test this by adding the following to your `~/.config/helix/languages.toml` and running `hx -g fetch && hx -g build`:

```toml
[[grammar]]
name = "fish"
source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "84436cf24c2b3176bfbb220922a0fdbd0141e406" }
```