### PR TITLE
Marks

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -713,6 +713,19 @@ impl Selection {
 
         Selection::new(ranges, self.primary_index)
     }
+
+    /// Creates a new selection in which all ranges are merged into one.
+    ///
+    /// The new range covers from the lowest [Range::from] to the highest
+    /// [Range::to].
+    pub fn join_ranges(&self) -> Selection {
+        // SAFETY: selections created with Selection::new are asserted to have
+        // non-empty range vectors.
+        let first = self.ranges.first().unwrap();
+        let last = self.ranges.last().unwrap();
+
+        Selection::new(smallvec![first.union(*last)], 0)
+    }
 }
 
 impl<'a> IntoIterator for &'a Selection {

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -211,10 +211,14 @@ impl Range {
 
     /// Returns a range that encompasses both input ranges.
     ///
-    /// This is like `extend()`, but tries to negotiate the
-    /// anchor/head ordering between the two input ranges.
+    /// This is like `extend()`, but negotiates the anchor/head ordering
+    /// between the two input ranges. The returned range covers the area
+    /// of both input ranges and any space between them.
+    ///
+    /// The range is [Direction::Backward] if both input ranges are
+    /// [Direction::Backward], [Direction::Forward] otherwise.
     #[must_use]
-    pub fn merge(&self, other: Self) -> Self {
+    pub fn union(&self, other: Self) -> Self {
         if self.anchor > self.head && other.anchor > other.head {
             Range {
                 anchor: self.anchor.max(other.anchor),
@@ -533,7 +537,7 @@ impl Selection {
 
         self.ranges.dedup_by(|curr_range, prev_range| {
             if prev_range.overlaps(curr_range) {
-                let new_range = curr_range.merge(*prev_range);
+                let new_range = curr_range.union(*prev_range);
                 if prev_range == &primary || curr_range == &primary {
                     primary = new_range;
                 }
@@ -559,7 +563,7 @@ impl Selection {
 
         self.ranges.dedup_by(|curr_range, prev_range| {
             if prev_range.to() == curr_range.from() {
-                let new_range = curr_range.merge(*prev_range);
+                let new_range = curr_range.union(*prev_range);
                 if prev_range == &primary || curr_range == &primary {
                     primary = new_range;
                 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -375,7 +375,7 @@ impl MappableCommand {
         select_prev_sibling, "Select previous sibling in syntax tree",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
-        save_selection, "Save current selection to jumplist",
+        push_selection, "Save current selection to jumplist",
         jump_view_right, "Jump to right split",
         jump_view_left, "Jump to left split",
         jump_view_up, "Jump to split above",
@@ -4298,7 +4298,7 @@ fn jump_backward(cx: &mut Context) {
     };
 }
 
-fn save_selection(cx: &mut Context) {
+fn push_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     push_jump(view, doc);
     cx.editor.set_status("Selection saved to jumplist");

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -462,6 +462,7 @@ impl MappableCommand {
         select_shortest_selection_to_register, "Select shortest selection for each pair and save to register",
         select_longest_selection_from_register, "Select longest selection for each pair from register",
         select_longest_selection_to_register, "Select longest selection for each pair and save to register",
+        join_selections, "Join all selections into one",
     );
 }
 
@@ -5426,4 +5427,19 @@ pub mod range_combination {
             }
         }
     }
+}
+
+fn join_selections(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let doc_selection = doc.selection(view.id);
+    let range_count = doc_selection.ranges().len();
+
+    let selection = doc_selection.join_ranges();
+
+    doc.set_selection(view.id, selection);
+    cx.editor.set_status(format!(
+        "Joined {} range{}",
+        range_count,
+        if range_count == 1 { "" } else { "s" }
+    ));
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5365,7 +5365,7 @@ pub mod range_combination {
                 ));
                 return;
             }
-            Action::Union => doc_selection.merge_ranges(&saved_selection, |(s, o)| s.merge(*o)),
+            Action::Union => doc_selection.merge_ranges(&saved_selection, |(s, o)| s.union(*o)),
             Action::Intersect => {
                 doc_selection.merge_ranges(&saved_selection, |(s, o)| s.intersect(*o))
             }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -355,8 +355,8 @@ impl MappableCommand {
         indent, "Indent selection",
         unindent, "Unindent selection",
         format_selections, "Format selection",
-        join_selections, "Join lines inside selection",
-        join_selections_space, "Join lines inside selection and select spaces",
+        join_lines, "Join lines inside selection",
+        join_lines_space, "Join lines inside selection and select spaces",
         keep_selections, "Keep selections matching regex",
         remove_selections, "Remove selections matching regex",
         align_selections, "Align selections in column",
@@ -3900,7 +3900,7 @@ fn format_selections(cx: &mut Context) {
     apply_transaction(&transaction, doc, view);
 }
 
-fn join_selections_impl(cx: &mut Context, select_space: bool) {
+fn join_lines_inner(cx: &mut Context, select_space: bool) {
     use movement::skip_while;
     let (view, doc) = current!(cx.editor);
     let text = doc.text();
@@ -3978,12 +3978,12 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
     )
 }
 
-fn join_selections(cx: &mut Context) {
-    join_selections_impl(cx, false)
+fn join_lines(cx: &mut Context) {
+    join_lines_inner(cx, false)
 }
 
-fn join_selections_space(cx: &mut Context) {
-    join_selections_impl(cx, true)
+fn join_lines_space(cx: &mut Context) {
+    join_lines_inner(cx, true)
 }
 
 fn keep_selections(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -134,7 +134,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "^" => { "Selections"
             "s" => save_selection_to_register,
             "S" => restore_selection,
-            // "j" => join_selections,
+            "j" => join_selections,
             "c" => { "Combine selection from register"
                 "a" => append_selection_from_register,
                 "u" => union_selection_from_register,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -205,7 +205,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "C-i" | "tab" => jump_forward, // tab == <C-i>
         "C-o" => jump_backward,
-        "C-s" => save_selection,
+        "C-s" => push_selection,
 
         "space" => { "Space"
             "f" => file_picker,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -131,6 +131,30 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "N" => search_prev,
         "*" => search_selection,
 
+        "^" => { "Selections"
+            "s" => save_selection_to_register,
+            "S" => restore_selection,
+            // "j" => join_selections,
+            "c" => { "Combine selection from register"
+                "a" => append_selection_from_register,
+                "u" => union_selection_from_register,
+                "i" => intersect_selection_from_register,
+                "lt" => select_leftmost_cursor_selection_from_register,
+                "gt" => select_rightmost_cursor_selection_from_register,
+                "minus" => select_shortest_selection_from_register,
+                "+" => select_longest_selection_from_register,
+            },
+            "C" => { "Combine selection to register"
+                "a" => append_selection_to_register,
+                "u" => union_selection_to_register,
+                "i" => intersect_selection_to_register,
+                "lt" => select_leftmost_cursor_selection_to_register,
+                "gt" => select_rightmost_cursor_selection_to_register,
+                "minus" => select_shortest_selection_to_register,
+                "+" => select_longest_selection_to_register,
+            },
+        },
+
         "u" => undo,
         "U" => redo,
         "A-u" => earlier,
@@ -155,9 +179,6 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "," => keep_primary_selection,
         "A-," => remove_primary_selection,
-
-        // "q" => record_macro,
-        // "Q" => replay_macro,
 
         "&" => align_selections,
         "_" => trim_selections,
@@ -200,8 +221,6 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         // move under <space>c
         "C-c" => toggle_comments,
-
-        // z family for save/restore/combine from/to sels from register
 
         "C-i" | "tab" => jump_forward, // tab == <C-i>
         "C-o" => jump_backward,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -148,8 +148,8 @@ pub fn default() -> HashMap<Mode, Keymap> {
         ">" => indent,
         "<" => unindent,
         "=" => format_selections,
-        "J" => join_selections,
-        "A-J" => join_selections_space,
+        "J" => join_lines,
+        "A-J" => join_lines_space,
         "K" => keep_selections,
         "A-K" => remove_selections,
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -378,3 +378,23 @@ async fn test_union_marker() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_join_selections() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+                #(foo|)#
+                bar
+                #[baz|]#"
+        },
+        "^j",
+        indoc! {"\
+                #[foo
+                bar
+                baz|]#"
+        },
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Marks are a way of recording selections/ranges in a way that can be used later. It's like the ability to store jumplist entry in a registers plus commands to combine selections to/from registers. This PR implements [kakoune's marks commands](https://github.com/mawww/kakoune/blob/master/doc/pages/keys.asciidoc#marks) and also adds a function that joins the ranges of a given selection together.

I would like to explore basing LSP snippets on marks so I'll keep this as a draft for now.

Questions:

* The implementation (prior to this change) knows "multiple selections" as one `helix_core::selection::Selection` with many `helix_core::selection::Range`s. Colloquially we call this multiple selections though. Should the marks commands say "selections" or "ranges"?
* Where to put the marks commands? `z`/`Z` is taken and the normal mode keymap is pretty much full. I'm using `^` for now which is a bit hidden but it's nice that it matches the default marks register.

Closes https://github.com/helix-editor/helix/issues/703