### PR TITLE
Fix Rust attribute highlights

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -258,6 +258,9 @@
 ; ---
 (meta_item
   (identifier) @function.macro)
+(attr_item
+  (identifier) @function.macro
+  (token_tree (identifier) @function.macro)?)
 
 (inner_attribute_item) @attribute
 


### PR DESCRIPTION
With the update in https://github.com/helix-editor/helix/pull/3467, attribute identifiers were no longer marked as `@function.macro` - the grammar now marks these as `attr_item`s containing a `token_tree`.