### PR TITLE
Add good default rulers when editing git messages

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -972,6 +972,8 @@ roots = []
 file-types = ["COMMIT_EDITMSG"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
+rulers = [50, 72]
+max-line-length = 72
 
 [[grammar]]
 name = "git-commit"


### PR DESCRIPTION
Around 50 columns for the summary is good because it is often used as heading or as subject in emails. 72 columns for the body is generally good because some tools do not wrap long lines (`git log` with pager `less` is a good example). Helix's `:reflow` command is really good to help with the second point.

Linux kernel documentation says:

> For these reasons, the ``summary`` must be no more than 70-75 characters, and it must describe both what the patch changes, as well as why the patch might be necessary.  It is challenging to be both succinct and descriptive, but that is what a well-written summary should do.

Source:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst#n627

tpope:
https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Commit message style guide for Git:
https://commit.style/