### PR TITLE
Add "markdown" as a possible filetype

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -904,7 +904,7 @@ source = { git = "https://github.com/Flakebi/tree-sitter-tablegen", rev = "568dd
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"
-file-types = ["md"]
+file-types = ["md", "markdown"]
 roots = []
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
Markdown files can also end with `.markdown`.

This fixed the highlighting not being enabled in files that end with `.markdown` for me.