### PR TITLE
change to openscad-lsp

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -75,7 +75,7 @@
 | ocaml | ✓ |  | ✓ | `ocamllsp` |
 | ocaml-interface | ✓ |  |  | `ocamllsp` |
 | odin | ✓ |  |  | `ols` |
-| openscad | ✓ |  |  | `openscad-language-server` |
+| openscad | ✓ |  |  | `openscad-lsp` |
 | org | ✓ |  |  |  |
 | pascal | ✓ | ✓ |  | `pasls` |
 | perl | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1523,7 +1523,7 @@ injection-regex = "openscad"
 file-types = ["scad"]
 roots = []
 comment-token = "//"
-language-server = { command = "openscad-language-server" }
+language-server = { command = "openscad-lsp", args = ["--stdio"] }
 indent = { tab-width = 2, unit = "\t" }
 
 [[grammar]]


### PR DESCRIPTION
Old one is abandoned and lacks many features and fixes therefore it is necessary to use https://github.com/Leathong/openscad-LSP instead.