### PR TITLE
add option to automatically `hover`

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -421,7 +421,10 @@ impl Application {
     }
 
     pub fn handle_idle_timeout(&mut self) {
-        if self.compositor.has_overlay() {
+        if self
+            .compositor
+            .has_component_by(|type_name| type_name.contains("Picker"))
+        {
             return;
         }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -421,6 +421,10 @@ impl Application {
     }
 
     pub fn handle_idle_timeout(&mut self) {
+        if self.compositor.has_overlay() {
+            return;
+        }
+
         use crate::compositor::EventResult;
         let editor_view = self
             .compositor

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -972,6 +972,15 @@ pub fn hover(cx: &mut Context) {
     );
 }
 
+pub fn idle_hover(cx: &mut Context) {
+    // TODO: let this have a different timeout than idle_complete
+    let (view, doc) = current!(cx.editor);
+    if doc.language_server().is_none() {
+        return;
+    }
+    hover(cx)
+}
+
 pub fn rename_symbol(cx: &mut Context) {
     let (view, doc) = current_ref!(cx.editor);
     let text = doc.text().slice(..);

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -973,10 +973,19 @@ pub fn hover(cx: &mut Context) {
 }
 
 pub fn idle_hover(cx: &mut Context) {
-    let (_, doc) = current!(cx.editor);
+    let (view, doc) = current!(cx.editor);
     if doc.language_server().is_none() {
         return;
     }
+
+    let text = doc.text().slice(..);
+    let cursor = doc.selection(view.id).primary().cursor(text);
+
+    use helix_core::chars::char_is_word;
+    if !char_is_word(text.char(cursor)) {
+        return;
+    }
+
     hover(cx)
 }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -974,7 +974,7 @@ pub fn hover(cx: &mut Context) {
 
 pub fn idle_hover(cx: &mut Context) {
     // TODO: let this have a different timeout than idle_complete
-    let (view, doc) = current!(cx.editor);
+    let (_, doc) = current!(cx.editor);
     if doc.language_server().is_none() {
         return;
     }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -973,7 +973,6 @@ pub fn hover(cx: &mut Context) {
 }
 
 pub fn idle_hover(cx: &mut Context) {
-    // TODO: let this have a different timeout than idle_complete
     let (_, doc) = current!(cx.editor);
     if doc.language_server().is_none() {
         return;

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -229,6 +229,13 @@ impl Compositor {
             .any(|component| component.type_name() == type_name)
     }
 
+    pub fn has_component_by(&self, predicate: impl Fn(&str) -> bool) -> bool {
+        self.layers
+            .iter()
+            .map(|component| component.type_name())
+            .any(predicate)
+    }
+
     pub fn find<T: 'static>(&mut self) -> Option<&mut T> {
         let type_name = std::any::type_name::<T>();
         self.layers
@@ -242,10 +249,6 @@ impl Compositor {
             .iter_mut()
             .find(|component| component.id() == Some(id))
             .and_then(|component| component.as_any_mut().downcast_mut())
-    }
-
-    pub fn has_overlay(&self) -> bool {
-        self.layers.len() > 1
     }
 }
 

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -243,6 +243,10 @@ impl Compositor {
             .find(|component| component.id() == Some(id))
             .and_then(|component| component.as_any_mut().downcast_mut())
     }
+
+    pub fn has_overlay(&self) -> bool {
+        self.layers.len() > 1
+    }
 }
 
 // View casting, taken straight from Cursive

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -134,6 +134,8 @@ pub struct Config {
     pub auto_pairs: AutoPairConfig,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
     pub auto_completion: bool,
+    /// Automatic hover, automatically pop up window without user trigger. Defaults to false.
+    pub auto_hover: bool,
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
@@ -561,6 +563,7 @@ impl Default for Config {
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
+            auto_hover: false,
             auto_format: true,
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -139,7 +139,7 @@ pub struct Config {
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
-    /// Used for autocompletion, set to 0 for instant. Defaults to 400ms.
+    /// Used for autocompletion and auto-hover, set to 0 for instant. Defaults to 400ms.
     #[serde(
         serialize_with = "serialize_duration_millis",
         deserialize_with = "deserialize_duration_millis"


### PR DESCRIPTION
Hi! Thanks for this project, I've been trying it out the last week and really enjoying it 🙂 

This PR introduces the option to enable `auto-hover`, similar to `auto-completion` but for the `hover` command. This is an intrusive option so I've kept it `false` by default, but I've been using on this PR and found it quite useful!

This is my first PR to the project, so there's some design questions I had but didn't know how to answer. I'll leave them inline so it's easier to cross-reference w/ the code in question.