### PR TITLE
Rename I/A "Insert at start/end of line"

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -69,7 +69,7 @@
 | `i`         | Insert before selection                                              | `insert_mode`             |
 | `a`         | Insert after selection (append)                                      | `append_mode`             |
 | `I`         | Insert at the start of the line                                      | `prepend_to_line`         |
-| `A`         | Insert at the end of the line                                        | `append_to_line`          |
+| `A`         | Insert at the end of the line                                        | `insert_at_line_end`      |
 | `o`         | Open new line below selection                                        | `open_below`              |
 | `O`         | Open new line above selection                                        | `open_above`              |
 | `.`         | Repeat last insert                                                   | N/A                       |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -68,7 +68,7 @@
 | `` Alt-` `` | Set the selected text to upper case                                  | `switch_to_uppercase`     |
 | `i`         | Insert before selection                                              | `insert_mode`             |
 | `a`         | Insert after selection (append)                                      | `append_mode`             |
-| `I`         | Insert at the start of the line                                      | `prepend_to_line`         |
+| `I`         | Insert at the start of the line                                      | `insert_at_line_start`    |
 | `A`         | Insert at the end of the line                                        | `insert_at_line_end`      |
 | `o`         | Open new line below selection                                        | `open_below`              |
 | `O`         | Open new line above selection                                        | `open_above`              |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -274,7 +274,7 @@ impl MappableCommand {
         workspace_diagnostics_picker, "Open workspace diagnostic picker",
         last_picker, "Open last picker",
         prepend_to_line, "Insert at start of line",
-        append_to_line, "Append to end of line",
+        insert_at_line_end, "Insert at end of line",
         open_below, "Open new line below selection",
         open_above, "Open new line above selection",
         normal_mode, "Enter normal mode",
@@ -2468,7 +2468,7 @@ fn prepend_to_line(cx: &mut Context) {
 }
 
 // A inserts at the end of each line with a selection
-fn append_to_line(cx: &mut Context) {
+fn insert_at_line_end(cx: &mut Context) {
     enter_insert_mode(cx);
     let (view, doc) = current!(cx.editor);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -273,7 +273,7 @@ impl MappableCommand {
         diagnostics_picker, "Open diagnostic picker",
         workspace_diagnostics_picker, "Open workspace diagnostic picker",
         last_picker, "Open last picker",
-        prepend_to_line, "Insert at start of line",
+        insert_at_line_start, "Insert at start of line",
         insert_at_line_end, "Insert at end of line",
         open_below, "Open new line below selection",
         open_above, "Open new line above selection",
@@ -2462,7 +2462,7 @@ fn last_picker(cx: &mut Context) {
 }
 
 // I inserts at the first nonwhitespace character of each line with a selection
-fn prepend_to_line(cx: &mut Context) {
+fn insert_at_line_start(cx: &mut Context) {
     goto_first_nonwhitespace(cx);
     enter_insert_mode(cx);
 }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -59,7 +59,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         ":" => command_mode,
 
         "i" => insert_mode,
-        "I" => prepend_to_line,
+        "I" => insert_at_line_start,
         "a" => append_mode,
         "A" => insert_at_line_end,
         "o" => open_below,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -61,7 +61,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "i" => insert_mode,
         "I" => prepend_to_line,
         "a" => append_mode,
-        "A" => append_to_line,
+        "A" => insert_at_line_end,
         "o" => open_below,
         "O" => open_above,
 


### PR DESCRIPTION
The language for the `A` binding is potentially confusing because `A` behaves like `i` done at the end of the line rather than `a`. This change renames the command to match Kakoune's language[^1].

This is a breaking change since the name of the command changes.

See https://github.com/helix-editor/helix/issues/3744#issuecomment-1240726094

[^1]: https://github.com/mawww/kakoune/blob/021da117cf90bf25b65e3344fa8e43ab4262b714/src/normal.cc#L2229