### PR TITLE
Support "preview" release CI runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
     tags:
     - '[0-9]+.[0-9]+'
     - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+    - 'patch/ci-release-*'
+  pull_request:
+    paths:
+    - '.github/workflows/release.yml'
+
+env:
+  # Preview mode: Publishes the build output as a CI artifact instead of creating
+  # a release, allowing for manual inspection of the output. This mode is
+  # activated if the CI run was triggered by events other than pushed tags, or
+  # if the repository is a fork.
+  preview: ${{ !startsWith(github.ref, 'refs/tags/') || github.repository != 'helix-editor/helix' }}
 
 jobs:
   fetch-grammars:
@@ -263,9 +275,17 @@ jobs:
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
+        if: env.preview == 'false'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*
           file_glob: true
           tag: ${{ steps.tagname.outputs.val }}
           overwrite: true
+      
+      - name: Upload binaries as artifact
+        uses: actions/upload-artifact@v2
+        if: env.preview == 'true'
+        with:
+          name: release
+          path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
           overwrite: true
       
       - name: Upload binaries as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: env.preview == 'true'
         with:
           name: release


### PR DESCRIPTION
Expands the trigger sources of the release CI workflow (`release.yml`), allowing the developers to test changes to `.github/workflows/release.yml` easily. The new trigger sources start the workflow in a *preview* mode, in which it publishes build outputs as a CI artifact ([example](https://github.com/yvt/helix/actions/runs/2987431541)) instead of creating a new release so that they can be manually inspected.

The following events trigger the preview mode:

- Pushing to any branch matching the glob pattern `patch/ci-release-*`.
- Opening a pull request that modifies `.github/workflows/release.yml`.
- Pushing versioning tags to a forked repository (they would create a release otherwise).
