### PR TITLE
Add layout-direction option for file picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -12,7 +12,7 @@ use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
 use fuzzy_matcher::FuzzyMatcher;
 use tui::widgets::Widget;
 
-use std::{borrow::Borrow, time::Instant};
+use std::time::Instant;
 use std::{
     cmp::Reverse,
     collections::HashMap,
@@ -91,11 +91,10 @@ fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Opt
 
     let (split_direction, picker_weight, preview_weight) = {
         let config = editor.config();
-        let config = config.borrow();
 
         (
             config.picker.layout_direction,
-            core::cmp::max(config.picker.picker_weight, 1),
+            config.picker.picker_weight.max(1),
             config.picker.preview_weight,
         )
     };

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -84,7 +84,7 @@ impl Preview<'_, '_> {
 }
 
 fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Option<Rect>) {
-    use helix_view::editor::PickerSplitDirection::*;
+    use helix_view::editor::PickerLayoutDirection::*;
 
     const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
     const MIN_AREA_HEIGHT_FOR_PREVIEW: u16 = 18; // This leaves 12 lines for picker + preview
@@ -94,13 +94,13 @@ fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Opt
         let config = config.borrow();
 
         (
-            config.picker.split_direction,
+            config.picker.layout_direction,
             core::cmp::max(config.picker.picker_weight, 1),
             config.picker.preview_weight,
         )
     };
 
-    // Vertical split:            Horizontal split:
+    // Horizontal layout:         Vertival layout:
     // +---------+ +---------+    +---------------------+
     // |prompt   | |preview  |    | prompt              |
     // +---------+ |         |    +---------------------+
@@ -110,7 +110,7 @@ fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Opt
     // |         | |         |    | preview             |
     // +---------+ +---------+    +---------------------+
 
-    let space_available = if split_direction == Vertical {
+    let space_available = if split_direction == Horizontal {
         area.width > MIN_AREA_WIDTH_FOR_PREVIEW
     } else {
         area.height > MIN_AREA_HEIGHT_FOR_PREVIEW
@@ -124,7 +124,7 @@ fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Opt
 
     let ratio = preview_weight as u16 + picker_weight as u16;
 
-    let picker_area = if split_direction == Vertical {
+    let picker_area = if split_direction == Horizontal {
         // Width of the picker should never go below 20 (arbitrary value)
         let picker_width = std::cmp::max(20, (area.width * picker_weight as u16) / ratio);
         area.with_width(picker_width)
@@ -135,7 +135,7 @@ fn layout_picker(area: &Rect, show_preview: bool, editor: &Editor) -> (Rect, Opt
     };
 
     let preview_area = if preview_weight > 0 {
-        if split_direction == Vertical {
+        if split_direction == Horizontal {
             Some(area.clip_left(picker_area.width))
         } else {
             Some(area.clip_top(picker_area.height))

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -67,9 +67,35 @@ where
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum FilePickerLayoutDirection {
+pub enum PickerSplitDirection {
     Horizontal,
     Vertical,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    /// The weight of the picker. The heavier compared to the other weights, the more
+    /// space will be allocated to the picker.
+    pub picker_weight: u8,
+    /// The weight of the picker. The heavier compared to the other weights, the more
+    /// space will be allocated to the preview.
+    ///
+    /// A weight of 0 will disable the preview entirely.
+    pub preview_weight: u8,
+    /// The direction in which to split the file picker. Possible values are `horizontal` or
+    /// `vertical`.
+    pub split_direction: PickerSplitDirection,
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        Self {
+            picker_weight: 1,
+            preview_weight: 1,
+            split_direction: PickerSplitDirection::Horizontal,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -99,9 +125,6 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
-    /// The direction in which to lay out the file picker. Possible values are `horizontal` or
-    /// `vertical`.
-    pub layout_direction: FilePickerLayoutDirection,
 }
 
 impl Default for FilePickerConfig {
@@ -115,7 +138,6 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
-            layout_direction: FilePickerLayoutDirection::Horizontal,
         }
     }
 }
@@ -157,6 +179,7 @@ pub struct Config {
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
+    pub picker: PickerConfig,
     pub file_picker: FilePickerConfig,
     /// Configuration of the statusline elements
     pub statusline: StatusLineConfig,
@@ -601,6 +624,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
             auto_info: true,
+            picker: PickerConfig::default(),
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -65,6 +65,13 @@ where
     )
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum FilePickerLayoutDirection {
+    Horizontal,
+    Vertical,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
@@ -92,6 +99,9 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
+    /// The direction in which to lay out the file picker. Possible values are `horizontal` or
+    /// `vertical`.
+    pub layout_direction: FilePickerLayoutDirection,
 }
 
 impl Default for FilePickerConfig {
@@ -105,6 +115,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            layout_direction: FilePickerLayoutDirection::Horizontal,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -93,7 +93,7 @@ impl Default for PickerConfig {
         Self {
             picker_weight: 1,
             preview_weight: 1,
-            split_direction: PickerSplitDirection::Horizontal,
+            split_direction: PickerSplitDirection::Vertical,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -67,7 +67,7 @@ where
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum PickerSplitDirection {
+pub enum PickerLayoutDirection {
     Horizontal,
     Vertical,
 }
@@ -83,9 +83,9 @@ pub struct PickerConfig {
     ///
     /// A weight of 0 will disable the preview entirely.
     pub preview_weight: u8,
-    /// The direction in which to split the file picker. Possible values are `horizontal` or
-    /// `vertical`.
-    pub split_direction: PickerSplitDirection,
+    /// The direction in which to split the file picker. Possible values are `horizontal`
+    /// (picker next to preview) or `vertical` (picker above preview).
+    pub layout_direction: PickerLayoutDirection,
 }
 
 impl Default for PickerConfig {
@@ -93,7 +93,7 @@ impl Default for PickerConfig {
         Self {
             picker_weight: 1,
             preview_weight: 1,
-            split_direction: PickerSplitDirection::Vertical,
+            layout_direction: PickerLayoutDirection::Horizontal,
         }
     }
 }


### PR DESCRIPTION
Add a configuration option for Pickers to define the `split-direction` with the possible values of `vertical` (default) and `horizontal`.

This is how hx looks with the currently implemented vsplit between picker and preview in tall but narrow terminals:
![hx_vsplit](https://user-images.githubusercontent.com/73267/190896056-a9cb1de7-0a18-44c0-8335-cb93057641ee.png)

This is the new hsplit-based layout option:
![hx_hsplit](https://user-images.githubusercontent.com/73267/190896074-2c586c03-aa8f-4b4a-ad98-5d4f4613a9b9.png)

I find that this is way more helpful as paths get clipped less often and I can see more of the relevant lines in the preview.

> Note: This is only implemented for the file picker at this time, but it would probably make sense to extend to all pickers with a preview.