### PR TITLE
add `bass` language + highlighting

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -3,6 +3,7 @@
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ |  |  | `bash-language-server` |
+| bass | ✓ |  |  | `bass` |
 | beancount | ✓ |  |  |  |
 | c | ✓ | ✓ | ✓ | `clangd` |
 | c-sharp | ✓ | ✓ |  | `OmniSharp` |

--- a/languages.toml
+++ b/languages.toml
@@ -1779,4 +1779,4 @@ language-server = { command = "bass", args = ["--lsp"] }
 
 [[grammar]]
 name = "bass"
-source = { git = "https://github.com/vito/tree-sitter-bass", rev = "333dc1365535d12d94f83d409304fb433c5e3800" }
+source = { git = "https://github.com/vito/tree-sitter-bass", rev = "501133e260d768ed4e1fd7374912ed5c86d6fd90" }

--- a/languages.toml
+++ b/languages.toml
@@ -1766,3 +1766,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "astro"
 source = { git = "https://github.com/virchau13/tree-sitter-astro", rev = "5f5c3e73c45967df9aa42f861fad2d77cd4e0900" }
+
+[[language]]
+name = "bass"
+scope = "source.bass"
+injection-regex = "bass"
+file-types = ["bass"]
+roots = []
+comment-token = ";"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "bass", args = ["--lsp"] }
+
+[[grammar]]
+name = "bass"
+source = { git = "https://github.com/vito/tree-sitter-bass", rev = "333dc1365535d12d94f83d409304fb433c5e3800" }

--- a/runtime/queries/bass/highlights.scm
+++ b/runtime/queries/bass/highlights.scm
@@ -1,25 +1,47 @@
 ; GENERATED VIA https://github.com/vito/tree-sitter-bass
 
+;;; comments
+
 (comment) @comment.line
+
+;;; punctuation
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
-[(ignore) (null) (bool)] @constant.builtin
+;;; constants
 
-(int) @constant.numeric
+[(ignore) (null)] @constant.builtin
 
-(string (string_escape) @constant.character.escape)
+(bool) @constant.builtin.boolean
+
+(int) @constant.numeric.integer
+
+;;; strings
+
+;; string literals
 
 (string) @string
+(string (string_escape) @constant.character.escape)
 
-[(command) (path) (relpath)] @namespace
+;; keywords (symbol literals)
 
 (keyword) @string.special.symbol
 
+;; paths
 
-;;; specific queries take precedence
+(dot) @string.special.path
+(dotdot) @string.special.path
+(command) @string.special.path
+(subpath (symbol) @string.special.path)
 
-;; classification based highlighting
+; slashes in a path denote a combiner call
+(subpath (slash) @function)
+
+
+
+;;; specific highlighting for builtins & special forms
+
+;; symbol classification based highlighting
 
 (list . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
 (cons . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
@@ -67,7 +89,7 @@
   (_)
   (symbol) @function)
 
-;;; generic highlight rules
+;;; generic highlighting for all forms
 
 ; first symbol in a list form is a combiner call
 (list . (symbol) @function)
@@ -75,5 +97,5 @@
 ; highlight symbols as vars only when they're clearly vars
 (cons (symbol) @variable)
 (scope (symbol) @variable)
-(subpath form: (symbol) @variable)
-(subbind form: (symbol) @variable)
+(path form: (symbol) @variable)
+(symbind form: (symbol) @variable)

--- a/runtime/queries/bass/highlights.scm
+++ b/runtime/queries/bass/highlights.scm
@@ -1,0 +1,79 @@
+; GENERATED VIA https://github.com/vito/tree-sitter-bass
+
+(comment) @comment.line
+
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+[(ignore) (null) (bool)] @constant.builtin
+
+(int) @constant.numeric
+
+(string (string_escape) @constant.character.escape)
+
+(string) @string
+
+[(command) (path) (relpath)] @namespace
+
+(keyword) @string.special.symbol
+
+
+;;; specific queries take precedence
+
+;; classification based highlighting
+
+(list . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
+(cons . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
+
+(list . (symbol) @keyword.control.repeat (#match? @keyword.control.repeat "^(each)$"))
+(cons . (symbol) @keyword.control.repeat (#match? @keyword.control.repeat "^(each)$"))
+
+(list . (symbol) @label (#match? @label "^(def|defop|defn)$"))
+(cons . (symbol) @label (#match? @label "^(def|defop|defn)$"))
+
+(list . (symbol) @function.builtin (#match? @function.builtin "^(dump|mkfs|json|log|error|now|cons|wrap|unwrap|eval|make-scope|bind|meta|with-meta|null\\?|ignore\\?|boolean\\?|number\\?|string\\?|symbol\\?|scope\\?|sink\\?|source\\?|list\\?|pair\\?|applicative\\?|operative\\?|combiner\\?|path\\?|empty\\?|thunk\\?|\\+|\\*|quot|-|max|min|=|>|>=|<|<=|list->source|across|emit|next|reduce-kv|assoc|symbol->string|string->symbol|str|substring|trim|scope->list|string->fs-path|string->cmd-path|string->dir|subpath|path-name|path-stem|with-image|with-dir|with-args|with-cmd|with-stdin|with-env|with-insecure|with-label|with-port|with-tls|with-mount|thunk-cmd|thunk-args|resolve|start|addr|wait|read|cache-dir|binds\\?|recall-memo|store-memo|mask|list|list\\*|first|rest|length|second|third|map|map-pairs|foldr|foldl|append|filter|conj|list->scope|merge|apply|id|always|vals|keys|memo|succeeds\\?|run|last|take|take-all|insecure!|from|cd|wrap-cmd|mkfile|path-base|not)$"))
+(cons . (symbol) @function.builtin (#match? @function.builtin "^(dump|mkfs|json|log|error|now|cons|wrap|unwrap|eval|make-scope|bind|meta|with-meta|null\\?|ignore\\?|boolean\\?|number\\?|string\\?|symbol\\?|scope\\?|sink\\?|source\\?|list\\?|pair\\?|applicative\\?|operative\\?|combiner\\?|path\\?|empty\\?|thunk\\?|\\+|\\*|quot|-|max|min|=|>|>=|<|<=|list->source|across|emit|next|reduce-kv|assoc|symbol->string|string->symbol|str|substring|trim|scope->list|string->fs-path|string->cmd-path|string->dir|subpath|path-name|path-stem|with-image|with-dir|with-args|with-cmd|with-stdin|with-env|with-insecure|with-label|with-port|with-tls|with-mount|thunk-cmd|thunk-args|resolve|start|addr|wait|read|cache-dir|binds\\?|recall-memo|store-memo|mask|list|list\\*|first|rest|length|second|third|map|map-pairs|foldr|foldl|append|filter|conj|list->scope|merge|apply|id|always|vals|keys|memo|succeeds\\?|run|last|take|take-all|insecure!|from|cd|wrap-cmd|mkfile|path-base|not)$"))
+
+(list . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
+(cons . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
+
+(list . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
+(cons . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
+
+(list . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))
+(cons . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))
+
+
+;; special cases
+
+; [a & b] highlights & as operator rather than a regular symbol
+(list (symbol) @operator (#match? @operator "&"))
+(cons (symbol) @operator (#match? @operator "&"))
+
+; (-> x y z) highlights first x as var, y z as function
+(list
+  .
+  (symbol) @function.macro
+  (#eq? @function.macro "->")
+  .
+  (symbol) @variable.parameter
+  (symbol) @function)
+
+; (-> 42 x y) highlights 42 as regular number
+(list
+  .
+  (symbol) @function.macro
+  (#eq? @function.macro "->")
+  .
+  (_)
+  (symbol) @function)
+
+;;; generic highlight rules
+
+; first symbol in a list form is a combiner call
+(list . (symbol) @function)
+
+; highlight symbols as vars only when they're clearly vars
+(cons (symbol) @variable)
+(scope (symbol) @variable)
+(subpath form: (symbol) @variable)
+(subbind form: (symbol) @variable)


### PR DESCRIPTION
Hiya, I'm working on an admittedly pretty obscure language called [Bass](https://bass-lang.org). I just finished writing a tree-sitter grammar and highlighter for it, and then got the itch to try out Helix, having been a fan of Kakoune in the past. I'm really impressed with the out-of-the-box experience. :)

I initially tried configuring this in my own `~/.config/helix/languages.toml` but I'm on NixOS so the grammar install path is read-only. Adding it directly to Helix seems to be the only way at the moment. (#3310 & #3346)

My language is still very young so I'll take no offense if you prefer to just close this, but I figured I'd shoot my shot!