### PR TITLE
feat: rust plugins poc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "helix-plugin"
+version = "0.6.0"
+dependencies = [
+ "helix-core",
+ "helix-tui",
+ "helix-view",
+]
+
+[[package]]
 name = "helix-term"
 version = "0.6.0"
 dependencies = [
@@ -479,6 +488,7 @@ dependencies = [
  "helix-dap",
  "helix-loader",
  "helix-lsp",
+ "helix-plugin",
  "helix-tui",
  "helix-view",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "helix-lsp",
   "helix-dap",
   "helix-loader",
+  "helix-plugin",
   "xtask",
 ]
 

--- a/helix-plugin/Cargo.toml
+++ b/helix-plugin/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "helix-plugin"
+version = "0.6.0"
+authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
+description = """
+A library to build plugins for Helix
+"""
+edition = "2021"
+license = "MPL-2.0"
+categories = ["editor"]
+repository = "https://github.com/helix-editor/helix"
+homepage = "https://helix-editor.com"
+include = ["src/**/*", "README.md"]
+
+[dependencies]
+helix-core = { version = "0.6", path = "../helix-core" }
+helix-view = { version = "0.6", path = "../helix-view" }
+tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }

--- a/helix-plugin/src/lib.rs
+++ b/helix-plugin/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod plugin;
+pub mod sample;

--- a/helix-plugin/src/plugin.rs
+++ b/helix-plugin/src/plugin.rs
@@ -1,0 +1,66 @@
+use helix_view::{graphics::Rect, Document, Editor, Theme, View};
+use tui::buffer::Buffer as Surface;
+
+/// Somewhere, all plugins needs to be added
+/// Probably in helix-loader ?
+/// This means that a new plugin PR;
+///   will at least touch one additional file outside its folder
+use crate::sample::sample_plugin::SamplePlugin;
+
+pub struct Plugins {
+    plugins: Vec<Box<dyn BasePlugin>>,
+}
+
+/// This is the interface to all the loaded plugins
+/// For the demo, it simply creates a list every time it's needed
+/// Should be cached/memoized after loading from config
+/// The plan would be to have some sort of plugins = ["my", "list", "of", "plugins"]
+/// Which would instantiate and report in to the common list of plugins
+impl Plugins {
+    pub fn new() -> Plugins {
+        //TODO: load from config and cache in context?
+        Plugins {
+            plugins: vec![Box::new(SamplePlugin)],
+        }
+    }
+
+    // the first example plugin feature, render some extras to the surface
+    pub fn render_extras(
+        editor: &Editor,
+        doc: &Document,
+        view: &View,
+        viewport: Rect,
+        surface: &mut Surface,
+        theme: &Theme,
+    ) {
+        Plugins::new()
+            .plugins
+            .iter()
+            .for_each(|p| p.do_render_extras(editor, doc, view, viewport, surface, theme));
+    }
+}
+
+impl Default for Plugins {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The base trait for plugins
+/// Every "hook" needs to be added here
+pub trait BasePlugin {
+    fn name(&self) -> &'static str;
+    /// Hook in to rendering, ability to render extras
+    /// API not at all "designed", simply
+    fn do_render_extras(
+        &self,
+        _: &Editor,
+        _: &Document,
+        _: &View,
+        _: Rect,
+        _: &mut Surface,
+        _: &Theme,
+    ) {
+        // Default to doing nothing
+    }
+}

--- a/helix-plugin/src/sample/mod.rs
+++ b/helix-plugin/src/sample/mod.rs
@@ -1,0 +1,1 @@
+pub mod sample_plugin;

--- a/helix-plugin/src/sample/sample_plugin.rs
+++ b/helix-plugin/src/sample/sample_plugin.rs
@@ -1,0 +1,43 @@
+/*
+
+This is just a silly plugin
+It will render a hard coded watermark/ruler at 20 cols from the left
+
+This is more a demo of one way to do "rust plugins"
+
+*/
+use helix_view::{
+    graphics::Rect,
+    theme::{Color, Style},
+    Document, Editor, Theme, View,
+};
+use tui::buffer::Buffer as Surface;
+
+use crate::plugin::BasePlugin;
+
+pub struct SamplePlugin;
+
+impl BasePlugin for SamplePlugin {
+    fn name(&self) -> &'static str {
+        "sample"
+    }
+    fn do_render_extras(
+        &self,
+        _: &Editor,
+        _: &Document,
+        _: &View,
+        viewport: Rect,
+        surface: &mut Surface,
+        theme: &Theme,
+    ) {
+        let ruler_theme = theme
+            .try_get("ui.virtual.ruler")
+            .unwrap_or_else(|| Style::default().bg(Color::Red));
+
+        //HACK: super stupid hard coded ruler at 20
+        vec![20u16]
+            .iter()
+            .map(|ruler| viewport.clip_left(*ruler).with_width(1))
+            .for_each(|area| surface.set_style(area, ruler_theme))
+    }
+}

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -30,6 +30,7 @@ helix-view = { version = "0.6", path = "../helix-view" }
 helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
+helix-plugin = { version = "0.6", path = "../helix-plugin" }
 
 anyhow = "1"
 once_cell = "1.14"

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -6,6 +6,8 @@ use crate::{
     ui::{Completion, ProgressSpinners},
 };
 
+use helix_plugin::plugin::Plugins;
+
 use helix_core::{
     graphemes::{
         ensure_grapheme_boundary_next_byte, next_grapheme_boundary, prev_grapheme_boundary,
@@ -145,6 +147,7 @@ impl EditorView {
         );
         Self::render_gutter(editor, doc, view, view.area, surface, theme, is_focused);
         Self::render_rulers(editor, doc, view, inner, surface, theme);
+        Plugins::render_extras(editor, doc, view, inner, surface, theme);
 
         if is_focused {
             Self::render_focused_view_elements(view, doc, inner, theme, surface);


### PR DESCRIPTION
Playing around with an idea for writing plugins in rust and have them all be part of the binary.

Made for discussion purposes. I'll close this in a few weeks, unless we agree not to.

## High level idea

We add a plugins field to the config:

```toml
[editor.plugins.sample]
enabled = true
some-other-config = "yes"
```

Now, this will load the already compiled `SamplePlugin`.

A plugin will get its chance to override a set of callbacks. We call these for all plugins (see `Plugins` in `plugin.rs`) at the appropriate times - in order of load. This means a latter plugin takes precedence over a previous one (say if both render something custom to our view).

## Demo

The included `SamplePlugin` is a _really_ stupid ruler/watermark (as in it does not scroll) at col 20. It was just something random to have a POC going that does something graphical.

## TLDR

`Plugins::something()`  will call `do_something()` for all loaded plugins.
We call `Plugins::something()` where we want to let plugins do ... something.