### PR TITLE
ordinals instead of indexes when listing grammar fetch errors

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -139,7 +139,7 @@ pub fn fetch_grammars() -> Result<()> {
         let len = errors.len();
         println!("{} grammars failed to fetch", len);
         for (i, error) in errors.into_iter().enumerate() {
-            println!("\tFailure {}/{}: {}", i, len, error);
+            println!("\tFailure {}/{}: {}", i + 1, len, error);
         }
     }
 


### PR DESCRIPTION
Currently errors are listed from 0 up until 1 less than the total number, like so:

```
107 grammars failed to fetch
	Failure 0/107: ...
	...
	Failure 105/107: ...
	Failure 106/107: ...
```

This just makes it start at 1 and go until 107/107 for this example