### PR TITLE
Strip release binary by setting `profile.release.strip` in a pre-build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,19 +140,6 @@ jobs:
           command: build
           args: --release --locked --target ${{ matrix.target }}
 
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || endsWith(matrix.build, 'macos')
-        run: strip "target/${{ matrix.target }}/release/hx"
-
-      - name: Strip release binary (arm)
-        if: matrix.build == 'aarch64-linux'
-        run: |
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:${{ matrix.target }} \
-            aarch64-linux-gnu-strip \
-            /target/${{ matrix.target }}/release/hx
-
       - name: Build AppImage
         shell: bash
         if: matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,14 @@ jobs:
           command: test
           args: --release --locked --target ${{ matrix.target }} --workspace
 
+      - name: Set profile.release.strip = true
+        shell: bash
+        run: |
+          cat >> .cargo/config.toml <<EOF
+          [profile.release]
+          strip = true
+          EOF
+
       - name: Build release binary
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Replaces the post-build strip step with a new pre-build step that sets `profile.release.strip = true`. The effect is identical to #3327, but this approach sidesteps [the MSRV issue](https://github.com/helix-editor/helix/pull/3327#issuecomment-1205158407) by not committing the change.

~~*Note:* Untested! We should check the result using #3757 just in case.~~ https://github.com/helix-editor/helix/pull/3780#issuecomment-1242755396