### PR TITLE
add config option to disable log

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -51,6 +51,7 @@ You may also specify a file to use for configuration with the `-c` or
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `log` | Whether to add entries to helix.log | `true` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -114,8 +114,6 @@ FLAGS:
         return Ok(0);
     }
 
-    setup_logging(logpath, args.verbosity).context("failed to initialize logging")?;
-
     let config_dir = helix_loader::config_dir();
     if !config_dir.exists() {
         std::fs::create_dir_all(&config_dir).ok();
@@ -136,6 +134,10 @@ FLAGS:
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Config::default(),
         Err(err) => return Err(Error::new(err)),
     };
+
+    if config.editor.log {
+        setup_logging(logpath, args.verbosity).context("failed to initialize logging")?;
+    }
 
     // TODO: use the thread local executor to spawn the application task separately from the work pool
     let mut app = Application::new(args, config).context("unable to create new application")?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -168,6 +168,8 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// Whether to add entries to helix.log. Defaults to `true`.
+    pub log: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -577,6 +579,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            log: true,
         }
     }
 }


### PR DESCRIPTION
Appending to the log file can cause write amplification on SSDs causing lots of unnecessary wear so I propose adding a configuration entry to disable it. The proposed changes do not change the current behaviour by default however it might be beneficial to turn it off by default and only turn it on when trying to diagnose a problem.