### PR TITLE
Canonicalize executable path

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -42,8 +42,10 @@ pub fn runtime_dir() -> PathBuf {
     }
 
     // fallback to location of the executable being run
+    // canonicalize the path in case the executable is symlinked
     std::env::current_exe()
         .ok()
+        .and_then(|path| std::fs::canonicalize(path).ok())
         .and_then(|path| path.parent().map(|path| path.to_path_buf().join(RT_DIR)))
         .unwrap()
 }


### PR DESCRIPTION
When looking up the runtime/ directory relative to the executable path, canonicalize the path first in case the executable is a symbolic link.

Fixes #3768