### PR TITLE
[WIP] Add option to disable mouse support in specific modes

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1336,7 +1336,17 @@ impl Component for EditorView {
                 EventResult::Consumed(callback)
             }
 
-            Event::Mouse(event) => self.handle_mouse_event(event, &mut cx),
+            Event::Mouse(event) => {
+                let config = cx.editor.config();
+                let mode = cx.editor.mode();
+
+                if config.mouse_in.contains(mode) {
+                    self.handle_mouse_event(event, &mut cx)
+                } else {
+                    EventResult::Ignored(None)
+                }
+            }
+
             Event::FocusGained | Event::FocusLost => EventResult::Ignored(None),
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -118,6 +118,8 @@ pub struct Config {
     pub scroll_lines: isize,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
+    /// Which modes mouse support is enabled in.
+    pub mouse_in: MouseIn,
     /// Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
     pub shell: Vec<String>,
     /// Line number mode.
@@ -388,6 +390,34 @@ impl Default for BufferLine {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct MouseIn {
+    normal: bool,
+    select: bool,
+    insert: bool,
+}
+
+impl MouseIn {
+    pub fn contains(&self, mode: Mode) -> bool {
+        match mode {
+            Mode::Normal => self.normal,
+            Mode::Select => self.select,
+            Mode::Insert => self.insert,
+        }
+    }
+}
+
+impl Default for MouseIn {
+    fn default() -> Self {
+        MouseIn {
+            normal: true,
+            select: true,
+            insert: true,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LineNumber {
     /// Show absolute line number
@@ -550,6 +580,7 @@ impl Default for Config {
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,
+            mouse_in: MouseIn::default(),
             shell: if cfg!(windows) {
                 vec!["cmd".to_owned(), "/C".to_owned()]
             } else {


### PR DESCRIPTION
See #3764.

A few things that need to be resolved:
- What should the config option be called?
- It might be better to merge this option with the `mouse` option. Note that the `mouse` option currently cannot be set interactively.
  - Would it be preferable to use a vim-style option format? (a sequence of characters representing which modes mouse support is enabled in)