### PR TITLE
Move default comment toggle binding to pound

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -192,8 +192,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             },
         },
 
-        // move under <space>c
-        "C-c" => toggle_comments,
+        "#" => toggle_comments,
 
         // z family for save/restore/combine from/to sels from register
 


### PR DESCRIPTION
This is a common rebind in both the helix and kakoune community.
Some reasons this is desirable:

* Pound is a common symbol for commenting in many languages
* Pound is not bound to anything else, and it is not obvious what else
  it would be bound to
* `C-c` should really be reserved for cancelling subshells from `:sh`,
  `|` and friends

Most sensible alternatives are taken:

* `/` is search
* `*` adds selection to search register
* `-` is not common, and though not currently taken, may make sense
  as the opposite of `_`, for another PR to implement.
* `c` change selection
* `A-c` change selection w/o yank
* `C` copy selection down
* `A-C` copy selection up
