### PR TITLE
Fix Nix flake devShell on aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,8 +92,9 @@
             prev.packages
             ++ (
               with common.pkgs;
-                [lld_13 lldb cargo-flamegraph rust-analyzer]
+                [lld_13 cargo-flamegraph rust-analyzer]
                 ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
+                ++ (lib.optional stdenv.isLinux lldb)
             );
           env =
             prev.env


### PR DESCRIPTION
LLDB is marked broken on ~all arches except for x86_64-linux~ aarch64-darwin. So we can fix `nix develop` by removing lldb for it on aarch64-darwin