### PR TITLE
Remove arrow key recommendation from tutor

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -102,11 +102,11 @@ _________________________________________________________________
  --> Th stce misg so.
      This sentence is missing some text.
 
- Note: If you want to move the cursor while in Insert mode,
-       you may use the arrow keys instead of exiting and
-       reentering Insert mode.
  Note: The status bar will display your current mode.
        Notice that when you type i, 'NOR' changes to 'INS'.
+
+
+
 
 =================================================================
 =                      1.5 SAVING A FILE                        =


### PR DESCRIPTION
As a follow-up to https://github.com/helix-editor/helix/pull/3671

The tutor mentioned that arrow keys can be used in insert mode which is no longer the case

See #3808 