### PR TITLE
Make whitespace in monokai-pro-spectrum theme one step dimmer

### DIFF
--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -6,7 +6,7 @@
 "ui.text.focus" = { fg = "yellow", modifiers= ["bold"] }
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
-"ui.virtual.whitespace" = "base5"
+"ui.virtual.whitespace" = "base4"
 "ui.virtual.ruler" = { bg = "base1" }
 
 "info" = "base8"


### PR DESCRIPTION
Make whitespace in monokai-pro-spectrum theme one step dimmer to avoid the white space confusion with hyphen.

before:
![image](https://user-images.githubusercontent.com/4949019/189626493-2d394f89-54b2-4065-b34f-2f3ef6bc6720.png)

after:
![image](https://user-images.githubusercontent.com/4949019/189626580-a43b38d2-9918-4e57-aeb1-2e7db5379f43.png)
