### PR TITLE
Add option to skip the first indent guide

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -222,7 +222,7 @@ Options for rendering vertical indent guides.
 | ---           | ---                                                     | ---     |
 | `render`      | Whether to render indent guides.                        | `false` |
 | `character`   | Literal character to use for rendering the indent guide | `│`     |
-| `skip-levels` | amount of indent levels to skip                         | `0`     |
+| `skip-levels` | Number of indent levels to skip                         | `0`     |
 
 Example:
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -218,10 +218,11 @@ tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 
 Options for rendering vertical indent guides.
 
-| Key         | Description                                             | Default |
-| ---         | ---                                                     | ---     |
-| `render`    | Whether to render indent guides.                        | `false` |
-| `character` | Literal character to use for rendering the indent guide | `│`     |
+| Key           | Description                                             | Default |
+| ---           | ---                                                     | ---     |
+| `render`      | Whether to render indent guides.                        | `false` |
+| `character`   | Literal character to use for rendering the indent guide | `│`     |
+| `skip-levels` | amount of indent levels to skip                         | `0`     |
 
 Example:
 
@@ -229,4 +230,5 @@ Example:
 [editor.indent-guides]
 render = true
 character = "╎"
+skip-levels = 1
 ```

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -436,8 +436,8 @@ impl EditorView {
                 return;
             }
 
-            let mut starting_indent = (offset.col / tab_width) as u16;
-            starting_indent += config.indent_guides.skip_levels;
+            let starting_indent =
+                (offset.col / tab_width) as u16 + config.indent_guides.skip_levels;
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -417,6 +417,7 @@ impl EditorView {
             " ".to_string()
         };
         let indent_guide_char = config.indent_guides.character.to_string();
+        let skip_first_indent_guide = config.indent_guides.skip_first;
 
         let text_style = theme.get("ui.text");
         let whitespace_style = theme.get("ui.virtual.whitespace");
@@ -436,7 +437,10 @@ impl EditorView {
                 return;
             }
 
-            let starting_indent = (offset.col / tab_width) as u16;
+            let mut starting_indent = (offset.col / tab_width) as u16;
+            if skip_first_indent_guide {
+                starting_indent += 1
+            }
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -417,7 +417,6 @@ impl EditorView {
             " ".to_string()
         };
         let indent_guide_char = config.indent_guides.character.to_string();
-        let skip_first_indent_guide = config.indent_guides.skip_first;
 
         let text_style = theme.get("ui.text");
         let whitespace_style = theme.get("ui.virtual.whitespace");
@@ -438,9 +437,7 @@ impl EditorView {
             }
 
             let mut starting_indent = (offset.col / tab_width) as u16;
-            if skip_first_indent_guide {
-                starting_indent += 1
-            }
+            starting_indent += config.indent_guides.skip;
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -437,7 +437,7 @@ impl EditorView {
             }
 
             let mut starting_indent = (offset.col / tab_width) as u16;
-            starting_indent += config.indent_guides.skip;
+            starting_indent += config.indent_guides.skip_levels;
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -533,13 +533,13 @@ impl Default for WhitespaceCharacters {
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
-    pub skip_first: bool,
+    pub skip: u16,
 }
 
 impl Default for IndentGuidesConfig {
     fn default() -> Self {
         Self {
-            skip_first: false,
+            skip: 0,
             render: false,
             character: '│',
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -529,8 +529,9 @@ impl Default for WhitespaceCharacters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct IndentGuidesConfig {
+    pub skip_first: bool,
     pub render: bool,
     pub character: char,
 }
@@ -538,6 +539,7 @@ pub struct IndentGuidesConfig {
 impl Default for IndentGuidesConfig {
     fn default() -> Self {
         Self {
+            skip_first: false,
             render: false,
             character: '│',
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -533,13 +533,13 @@ impl Default for WhitespaceCharacters {
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
-    pub skip: u16,
+    pub skip_levels: u16,
 }
 
 impl Default for IndentGuidesConfig {
     fn default() -> Self {
         Self {
-            skip: 0,
+            skip_levels: 0,
             render: false,
             character: '│',
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -531,9 +531,9 @@ impl Default for WhitespaceCharacters {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct IndentGuidesConfig {
-    pub skip_first: bool,
     pub render: bool,
     pub character: char,
+    pub skip_first: bool,
 }
 
 impl Default for IndentGuidesConfig {


### PR DESCRIPTION
coming from my previous setup, the first indent guide are a bit distracting. Therefore the option to disable this

current:

![image](https://user-images.githubusercontent.com/22073483/189832778-b0fd407e-80b1-4deb-aaf4-878954a86f33.png)


enabled:
![image](https://user-images.githubusercontent.com/22073483/189832506-b3d75b07-8b6d-48a0-b2e2-f0cb13f23c85.png)


my neovim config for comparison (using indent-blankline with `show_first_indent_level = false`

![image](https://user-images.githubusercontent.com/22073483/189833875-e43988cd-61f2-460e-b709-26b0550f8c9c.png)
