### PR TITLE
feat: Syntax highlighting for Astro files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -1,5 +1,6 @@
 | Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Default LSP |
 | --- | --- | --- | --- | --- |
+| astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ |  |  | `bash-language-server` |
 | beancount | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1754,3 +1754,15 @@ language-server = { command = "jsonnet-language-server", args= ["-t", "--lint"] 
 [[grammar]]
 name = "jsonnet"
 source = { git = "https://github.com/sourcegraph/tree-sitter-jsonnet", rev = "0475a5017ad7dc84845d1d33187f2321abcb261d" }
+
+[[language]]
+name = "astro"
+scope = "source.astro"
+injection-regex = "astro"
+file-types = ["astro"]
+roots = []
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "astro"
+source = { git = "https://github.com/virchau13/tree-sitter-astro", rev = "5f5c3e73c45967df9aa42f861fad2d77cd4e0900" }

--- a/runtime/queries/astro/highlights.scm
+++ b/runtime/queries/astro/highlights.scm
@@ -1,0 +1,3 @@
+; inherits: html
+
+["---"] @punctuation.delimiter

--- a/runtime/queries/astro/injections.scm
+++ b/runtime/queries/astro/injections.scm
@@ -1,0 +1,9 @@
+; inherits: html
+
+((frontmatter
+	(raw_text) @injection.content)
+ (#set! injection.language "typescript"))
+
+((interpolation
+	(raw_text) @injection.content)
+ (#set! injection.language "tsx"))


### PR DESCRIPTION
Adding syntax highlighting for Astro files using the grammar defined here: https://github.com/virchau13/tree-sitter-astro.

This is my first time attempting a contribution to Helix, please let me know if I've missed a step or if any alterations should be made. Aside from verifying these additions with some Astro files, I have run `cargo xtask docgen` and `cargo integration-test` according to the contribution guidelines to update the docs and verify all tests still pass.