### PR TITLE
update `x_offset` calculation in `Buffer::set_string_truncated`

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -343,14 +343,14 @@ impl Buffer {
             let mut start_index = self.index_of(x, y);
             let mut index = self.index_of(max_offset as u16, y);
 
-            let total_width = string.width();
-            let truncated = total_width > width;
+            let content_width = string.width();
+            let truncated = content_width > width;
             if ellipsis && truncated {
                 self.content[start_index].set_symbol("…");
                 start_index += 1;
             }
             if !truncated {
-                index -= width - total_width;
+                index -= width - content_width;
             }
             for (byte_offset, s) in graphemes.rev() {
                 let width = s.width();
@@ -367,6 +367,7 @@ impl Buffer {
                     self.content[i].reset();
                 }
                 index -= width;
+                x_offset += width;
             }
         }
         (x_offset as u16, y)


### PR DESCRIPTION
Hello. First time contributor here.

SUMMARY:
With these changes, when `truncate_start` is `true` in a call to `Buffer::set_string_truncated`, the `x_offset` is now properly updated according to the (potentially truncated) content width.

Previously, the `x_offset` was never updated in this branch of code, which caused a layout error when rendering a Picker with items whose calculated labels contained multiple Spans. Since `x_offset` was not updated between calls to `set_string_truncated`, each span's content would render starting from the leftmost edge of the item's line, causing the content items to overlap each other. For example, in a menu item with two spans with content `some_directory/` and `14.5 KB`, it would render as `14.5 KBrectory/`.

Also, I took the liberty of renaming a variable for added clarity.