### PR TITLE
improve fleetish theme

### DIFF
--- a/runtime/themes/fleetish.toml
+++ b/runtime/themes/fleetish.toml
@@ -64,11 +64,12 @@
 "ui.window" = { fg = "dark", bg = "darkest" }
 "ui.help" = { fg = "light", bg = "dark" }
 "ui.text" = { fg = "light" } # .focus / .info
-# "ui.virtual" = {} # .ruler / .whitespace
+"ui.virtual" = { fg = "dark" } # .ruler / .whitespace
 "ui.virtual.ruler" = { bg = "darker"}
 "ui.menu" = { fg = "light", bg = "dark" } # .selected
 "ui.menu.selected" = { fg = "lightest", bg = "blue_accent" } # .selected
-"ui.selection" = { bg = "select" } # .primary
+"ui.selection" = { bg = "darker" } # .primary
+"ui.selection.primary" = { bg = "select" } # .primary
 "hint" = { fg = "blue_accent"}
 "info" = { fg = "yellow_accent" }
 "warning" = { fg = "orange_accent" }


### PR DESCRIPTION
- Adjusted the readability of whitespace
- Primary selection highlight should be more readable now (#3842).

<img width="1624" alt="Screenshot 2022-09-15 at 01 58 48" src="https://user-images.githubusercontent.com/2630397/190283270-c66a9cad-de7e-4481-87ee-f2213f0921f3.png">
