### PR TITLE
feat: add Fennel language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -124,6 +124,21 @@ name = "fish"
 source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "84436cf24c2b3176bfbb220922a0fdbd0141e406" }
 
 [[language]]
+name = "fennel"
+scope = "source.fnl"
+injection-regex = "(fennel|fnl)"
+file-types = ["fnl"]
+shebangs = ["fennel"]
+comment-token = ";"
+formatter = { command = "fnlfmt", args = ["-"] }
+indent = { tab-width = 2, unit = "  " }
+roots = []
+
+[[grammar]]
+name = "fennel"
+source = { git = "https://github.com/travonted/tree-sitter-fennel", rev = "517195970428aacca60891b050aa53eabf4ba78d"}
+
+[[language]]
 name = "mint"
 scope = "source.mint"
 injection-regex = "mint"

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -1,0 +1,76 @@
+(comment) @comment
+
+[ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
+
+[ ":" ":until" "&" "&as" "?" ] @punctuation.special
+
+(nil) @constant.builtin
+(vararg) @punctuation.special
+
+(boolean) @constant.builtin.boolean
+(number) @constant.numeric
+
+(string) @string
+(escape_sequence) @constant.character.escape
+
+
+((symbol) @variable.builtin
+ (#match? @variable.builtin "^[$]"))
+
+(binding) @symbol
+
+[ "fn" "lambda" "hashfn" "#" ] @keyword.function
+
+(fn name: [
+  (symbol) @function
+  (multi_symbol (symbol) @function .)
+])
+
+(lambda name: [
+  (symbol) @function
+  (multi_symbol (symbol) @function .)
+])
+
+(multi_symbol
+  "." @punctuation.delimiter
+  (symbol) @variable.other.member)
+
+(multi_symbol_method
+  ":" @punctuation.delimiter
+  (symbol) @function.method .)
+
+[ "for" "each" ] @keyword.control.repeat
+((symbol) @keyword.control.repeat
+ (#eq? @keyword.control.repeat
+  "while"))
+
+[ "match" ] @keyword.control.conditional
+((symbol) @keyword.control.conditional
+ (#match? @keyword.control.conditional "^(if|when)$"))
+
+[ "global" "local" "let" "set" "var" "where" "or" ] @keyword
+((symbol) @keyword
+ (#match? @keyword
+  "^(comment|do|doc|eval-compiler|lua|macros|quote|tset|values)$"))
+
+((symbol) @keyword.control.import
+ (#match? @keyword.control.import
+  "^(require|require-macros|import-macros|include)$"))
+
+[ "collect" "icollect" "accumulate" ] @function.macro
+((symbol) @function.macro
+ (#match? @function.macro
+  "^(->|->>|-\\?>|-\\?>>|\\?\\.|doto|macro|macrodebug|partial|pick-args|pick-values|with-open)$"))
+
+; Lua builtins
+((symbol) @constant.builtin
+ (#match? @constant.builtin
+  "^(arg|_ENV|_G|_VERSION)$"))
+
+((symbol) @function.builtin
+ (#match? @function.builtin
+  "^(assert|collectgarbage|dofile|error|getmetatable|ipairs|load|loadfile|loadstring|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|warn|xpcall)$"))
+
+(list . (symbol) @function)
+(list . (multi_symbol (symbol) @function .))
+(symbol) @variable

--- a/runtime/queries/fennel/injections.scm
+++ b/runtime/queries/fennel/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
Adds support for [Fennel](https://fennel-lang.org). Queries were converted from [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/fennel/highlights.scm), should I add a comment noting that?