### PR TITLE
Add bufferline colors to 15 themes

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -20,6 +20,9 @@
 "diagnostic.error" = {bg="white", modifiers=["bold"]}
 "diagnostic.warning" = {bg="white", modifiers=["bold"]}
 "diagnostic.hint" = {bg="white", modifiers=["bold"]}
+"ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }
+"ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
+"ui.bufferline.background" = { fg = "indent", bg = "acme_bar_bg" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -22,7 +22,6 @@
 "diagnostic.hint" = {bg="white", modifiers=["bold"]}
 "ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }
 "ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
-"ui.bufferline.background" = { fg = "indent", bg = "acme_bar_bg" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -61,7 +61,6 @@
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
-"ui.bufferline.background" = { fg = "gray", bg = "background" }
 
 "special" = { fg = "orange" }
 

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -59,6 +59,9 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
+"ui.bufferline" = { fg = "gray", bg = "background" }
+"ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
+"ui.bufferline.background" = { fg = "gray", bg = "background" }
 
 "special" = { fg = "orange" }
 

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -59,9 +59,8 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
-"ui.bufferline" = { fg = "gray", bg = "dark_gray" }
+"ui.bufferline" = { fg = "gray", bg = "dark" }
 "ui.bufferline.active" = { fg = "dark", bg = "background" }
-"ui.bufferline.background" = { fg = "gray", bg = "dark_gray" }
 
 "special" = { fg = "orange" }
 
@@ -72,7 +71,7 @@ foreground = "#5c6166"
 black = "#e7eaed"
 blue = "#399ee6"
 cyan = "#478acc"
-dark_gray = "#e7eaed"
+dark = "#e7eaed"
 gray = "#787b8099"
 green = "#86b300"
 magenta = "#a37acc"

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -59,7 +59,7 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
-"ui.bufferline" = { fg = "gray", bg = "dark" }
+"ui.bufferline" = { fg = "gray", bg = "dark_gray" }
 "ui.bufferline.active" = { fg = "dark", bg = "background" }
 
 "special" = { fg = "orange" }
@@ -71,7 +71,7 @@ foreground = "#5c6166"
 black = "#e7eaed"
 blue = "#399ee6"
 cyan = "#478acc"
-dark = "#e7eaed"
+dark_gray = "#e7eaed"
 gray = "#787b8099"
 green = "#86b300"
 magenta = "#a37acc"

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -59,6 +59,9 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
+"ui.bufferline" = { fg = "gray", bg = "dark_gray" }
+"ui.bufferline.active" = { fg = "dark", bg = "background" }
+"ui.bufferline.background" = { fg = "gray", bg = "dark_gray" }
 
 "special" = { fg = "orange" }
 
@@ -76,3 +79,4 @@ magenta = "#a37acc"
 orange = "#fa8d3e"
 red = "#f07171"
 yellow = "#ffaa33"
+dark = "#131721"

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -61,7 +61,6 @@
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
 "ui.bufferline" = { fg = "gray", bg = "black" }
 "ui.bufferline.active" = { fg = "foreground", bg = "background" }
-"ui.bufferline.background" = { fg = "gray", bg = "black" }
 
 "special" = { fg = "orange" }
 

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -59,6 +59,9 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
+"ui.bufferline" = { fg = "gray", bg = "black" }
+"ui.bufferline.active" = { fg = "foreground", bg = "background" }
+"ui.bufferline.background" = { fg = "gray", bg = "black" }
 
 "special" = { fg = "orange" }
 

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -56,7 +56,6 @@
 
 "ui.bufferline" = { fg = "base04", bg = "base00" }
 "ui.bufferline.active" = { fg = "base06", bg = "base01" }
-"ui.bufferline.background" = { fg = "base04", bg = "base00" }
 
 [palette]
 base00 = "#181818" # Default Background

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -54,6 +54,10 @@
 "warning" = "base09"
 "error" = "base08"
 
+"ui.bufferline" = { fg = "base04", bg = "base00" }
+"ui.bufferline.active" = { fg = "base06", bg = "base01" }
+"ui.bufferline.background" = { fg = "base04", bg = "base00" }
+
 [palette]
 base00 = "#181818" # Default Background
 base01 = "#282828" # Lighter Background (Used for status bars, line number and folding marks)

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -54,6 +54,10 @@
 "warning" = "base09"
 "error" = "base08"
 
+"ui.bufferline" = { fg = "base04", bg = "base01" }
+"ui.bufferline.active" = { fg = "base07", bg = "base00" }
+"ui.bufferline.background" = { fg = "base04", bg = "base01" }
+
 [palette]
 base00 = "#f8f8f8" # Default Background
 base01 = "#e8e8e8" # Lighter Background (Used for status bars, line number and folding marks)

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -56,7 +56,6 @@
 
 "ui.bufferline" = { fg = "base04", bg = "base01" }
 "ui.bufferline.active" = { fg = "base07", bg = "base00" }
-"ui.bufferline.background" = { fg = "base04", bg = "base01" }
 
 [palette]
 base00 = "#f8f8f8" # Default Background

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -48,6 +48,9 @@
 "ui.cursorline" = { bg = "#131920" }
 "ui.statusline" = { fg = "#e5ded6", bg = "#232d38" }
 "ui.statusline.inactive" = { fg = "#c6b8ad", bg = "#232d38" }
+"ui.bufferline" = { fg = "#627d9d", bg = "#131920" }
+"ui.bufferline.active" = { fg = "#e5ded6", bg = "#232d38" }
+"ui.bufferline.background" = { fg = "#627d9d", bg = "#131920" }
 "ui.popup" = { bg = "#232d38" }
 "ui.window" = { bg = "#232d38" }
 "ui.help" = { bg = "#232d38", fg = "#e5ded6" }

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -50,7 +50,6 @@
 "ui.statusline.inactive" = { fg = "#c6b8ad", bg = "#232d38" }
 "ui.bufferline" = { fg = "#627d9d", bg = "#131920" }
 "ui.bufferline.active" = { fg = "#e5ded6", bg = "#232d38" }
-"ui.bufferline.background" = { fg = "#627d9d", bg = "#131920" }
 "ui.popup" = { bg = "#232d38" }
 "ui.window" = { bg = "#232d38" }
 "ui.help" = { bg = "#232d38", fg = "#e5ded6" }

--- a/runtime/themes/catppuccin_frappe.toml
+++ b/runtime/themes/catppuccin_frappe.toml
@@ -72,7 +72,7 @@
 
 "ui.bufferline" = { fg = "overlay1", bg = "mantle" }
 "ui.bufferline.active" = { fg = "text", bg = "surface0" }
-"ui.bufferline.background" = { fg = "overlay1", bg = "surface0" }
+"ui.bufferline.background" = { bg = "surface0" }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }

--- a/runtime/themes/catppuccin_frappe.toml
+++ b/runtime/themes/catppuccin_frappe.toml
@@ -70,6 +70,10 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
+"ui.bufferline" = { fg = "overlay1", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "surface0" }
+"ui.bufferline.background" = { fg = "overlay1", bg = "surface0" }
+
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }

--- a/runtime/themes/catppuccin_frappe.toml
+++ b/runtime/themes/catppuccin_frappe.toml
@@ -70,9 +70,8 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
-"ui.bufferline" = { fg = "overlay1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "surface0" }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext1", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -72,7 +72,6 @@
 
 "ui.bufferline" = { fg = "overlay2", bg = "surface1" }
 "ui.bufferline.active" = { fg = "text", bg = "surface0" }
-"ui.bufferline.background" = { fg = "overlay2", bg = "surface1" }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -70,8 +70,9 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
-"ui.bufferline" = { fg = "overlay2", bg = "surface1" }
-"ui.bufferline.active" = { fg = "text", bg = "surface0" }
+"ui.bufferline" = { fg = "overlay2", bg = "surface1", modifiers = ["italic"] }
+"ui.bufferline.active" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "surface1" }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -70,6 +70,10 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
+"ui.bufferline" = { fg = "overlay2", bg = "surface1" }
+"ui.bufferline.active" = { fg = "text", bg = "surface0" }
+"ui.bufferline.background" = { fg = "overlay2", bg = "surface1" }
+
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }

--- a/runtime/themes/catppuccin_macchiato.toml
+++ b/runtime/themes/catppuccin_macchiato.toml
@@ -70,7 +70,6 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
-"ui.bufferline.background" = { fg = "overlay1", bg = "mantle" }
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
 "ui.bufferline" = { fg = "overlay1", bg = "mantle" }
 

--- a/runtime/themes/catppuccin_macchiato.toml
+++ b/runtime/themes/catppuccin_macchiato.toml
@@ -70,6 +70,10 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
+"ui.bufferline.background" = { fg = "overlay1", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "overlay1", bg = "mantle" }
+
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -70,7 +70,6 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
-"ui.bufferline.background" = { fg = "overlay1", bg = "mantle" }
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
 "ui.bufferline" = { fg = "overlay1", bg = "mantle" }
 

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -70,6 +70,10 @@
 "ui.statusline.insert" = { fg = "surface0", bg = "green", modifiers = ["bold"]  }
 "ui.statusline.select" = { fg = "surface0", bg = "flamingo", modifiers = ["bold"]  }
 
+"ui.bufferline.background" = { fg = "overlay1", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "overlay1", bg = "mantle" }
+
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -23,6 +23,9 @@
 "ui.virtual.ruler" = { bg = "grey02" }
 "ui.virtual.indent-guide" = "grey02"
 "ui.virtual.whitespace" = "grey03"
+"ui.bufferline" = { fg = "grey04", bg = "grey00" }
+"ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
+"ui.bufferline.background" = { fg = "grey04", bg = "grey00" }
 
 "operator" = "grey05"
 "variable" = "white"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -25,7 +25,6 @@
 "ui.virtual.whitespace" = "grey03"
 "ui.bufferline" = { fg = "grey04", bg = "grey00" }
 "ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
-"ui.bufferline.background" = { fg = "grey04", bg = "grey00" }
 
 "operator" = "grey05"
 "variable" = "white"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -76,6 +76,10 @@
 "ui.statusline" = { fg = "white", bg = "blue" }
 "ui.statusline.inactive" = { fg = "white", bg = "blue" }
 
+"ui.bufferline" = { fg = "text", bg = "widget" }
+"ui.bufferline.active" = { fg = "white", bg = "blue" }
+"ui.bufferline.background" = { fg = "text", bg = "background" }
+
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "white" }
 

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -78,7 +78,7 @@
 
 "ui.bufferline" = { fg = "text", bg = "widget" }
 "ui.bufferline.active" = { fg = "white", bg = "blue" }
-"ui.bufferline.background" = { fg = "text", bg = "background" }
+"ui.bufferline.background" = { bg = "background" }
 
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "white" }

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -55,7 +55,7 @@
 'ui.statusline.select' = { bg = 'base3' }
 'ui.bufferline' = { fg = 'gray', bg = 'base2' }
 'ui.bufferline.active' = { fg = 'white', bg = 'base4' }
-'ui.bufferline.background' = { fg = 'gray', bg = 'bg' }
+'ui.bufferline.background' = { bg = 'bg' }
 'ui.popup' = { bg = 'bg-alt' }
 'ui.window' = { fg = 'gray' }
 'ui.help' = { fg = 'fg', bg = 'base2' }

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -53,6 +53,9 @@
 'ui.statusline.normal' = { bg = 'base3' }
 'ui.statusline.insert' = { bg = 'base3' }
 'ui.statusline.select' = { bg = 'base3' }
+'ui.bufferline' = { fg = 'gray', bg = 'base2' }
+'ui.bufferline.active' = { fg = 'white', bg = 'base4' }
+'ui.bufferline.background' = { fg = 'gray', bg = 'bg' }
 'ui.popup' = { bg = 'bg-alt' }
 'ui.window' = { fg = 'gray' }
 'ui.help' = { fg = 'fg', bg = 'base2' }

--- a/runtime/themes/emacs.toml
+++ b/runtime/themes/emacs.toml
@@ -54,6 +54,9 @@
 "ui.linenr.selected" = { fg = "gray80" }
 "ui.statusline" = { fg = "black", bg = "gray75" }
 "ui.statusline.inactive" = { fg = "gray20", bg = "gray90" }
+"ui.bufferline" = { fg = "gray36", bg = "gray90", modifiers = ["underlined"] }
+"ui.bufferline.active" = { fg = "gray0", bg = "gray99" }
+"ui.bufferline.background" = { bg = "gray75" }
 "ui.popup" = { fg = "black", bg = "gray97" }
 "ui.popup.info" = { fg = "black", bg = "gray97" }
 "ui.window" = { fg = "black" }


### PR DESCRIPTION
Fixes visual discrepancy with a few themes by adding bufferline colors. There's one issue in a few commits where I've added `fg` to `ui.bufferline.background` where it was unnecessary. I only realized later. It does not break anything though.