### PR TITLE
Separate 'brace action' and 'match selection' in keymap

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -89,14 +89,16 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "X" => extend_to_line_bounds,
         "A-x" => shrink_to_line_bounds,
 
-        "m" => { "Match"
-            "m" => match_brackets,
+        "m" => select_textobject_inner,
+        "M" => select_textobject_around,
+
+        "^" => { "Brackets"
+            "b" => match_brackets,
             "s" => surround_add,
             "r" => surround_replace,
             "d" => surround_delete,
-            "a" => select_textobject_around,
-            "i" => select_textobject_inner,
         },
+
         "[" => { "Left bracket"
             "d" => goto_prev_diag,
             "D" => goto_first_diag,


### PR DESCRIPTION
This changes the behavior of `m` to only match selections.
`m` = `mi`
`M` = `ma`
Brace actions are relocated to `^`. 

Issue: #3852 