### PR TITLE
Re-sort diagnostics after transaction transform

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -788,6 +788,8 @@ impl Document {
                 diagnostic.range.end = changes.map_pos(diagnostic.range.end, Assoc::After);
                 diagnostic.line = self.text.char_to_line(diagnostic.range.start);
             }
+            self.diagnostics
+                .sort_unstable_by_key(|diagnostic| diagnostic.range);
 
             // emit lsp notification
             if let Some(language_server) = self.language_server() {


### PR DESCRIPTION
Applying document-change transactions to diagnostic ranges is not stable with respect to the ordering of diagnostics. This can cause diagnostics to become temporarily unordered with some edits to a document, which can eventually break some invariants/assumptions in `syntax::merge`. The result can be a flash of "ghost" (duplicated) text before the language server refreshes the diagnostics (which causes the diagnostics to be re-sorted).

With this change, `Document::diagnostics` are always sorted.

I found this while debugging some broken invariants in #3695.