### PR TITLE
raise msrv to 1.59

### DIFF
--- a/.github/workflows/msrv-rust-toolchain.toml
+++ b/.github/workflows/msrv-rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57.0"
+channel = "1.59.0"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
Almost all distributions (even ubuntu) now support 1.59.0.
The original MSRV was set to 1.57 to support void linux and homebrew.
Both now ship version 1.63.

This MSRV bump is required to use gitoxide (see #3890) but many crates
have bumped their MSRV to 1.59 and therefore the same problem will likely also occur for other dependencies in the future.