### PR TITLE
Track source and tags in diagnostics

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -29,6 +29,12 @@ pub enum NumberOrString {
     String(String),
 }
 
+#[derive(Debug, Clone)]
+pub enum DiagnosticTag {
+    Unnecessary,
+    Deprecated,
+}
+
 /// Corresponds to [`lsp_types::Diagnostic`](https://docs.rs/lsp-types/0.91.0/lsp_types/struct.Diagnostic.html)
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
@@ -37,4 +43,6 @@ pub struct Diagnostic {
     pub message: String,
     pub severity: Option<Severity>,
     pub code: Option<NumberOrString>,
+    pub tags: Option<Vec<DiagnosticTag>>,
+    pub source: Option<String>,
 }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -84,15 +84,33 @@ pub mod util {
             None => None,
         };
 
+        let tags = if let Some(ref tags) = diag.tags {
+            let new_tags = tags
+                .iter()
+                .map(|tag| match tag {
+                    helix_core::diagnostic::DiagnosticTag::Unnecessary => {
+                        lsp::DiagnosticTag::UNNECESSARY
+                    }
+                    helix_core::diagnostic::DiagnosticTag::Deprecated => {
+                        lsp::DiagnosticTag::DEPRECATED
+                    }
+                })
+                .collect();
+
+            Some(new_tags)
+        } else {
+            None
+        };
+
         // TODO: add support for Diagnostic.data
         lsp::Diagnostic::new(
             range_to_lsp_range(doc, range, offset_encoding),
             severity,
             code,
-            None,
+            diag.source.clone(),
             diag.message.to_owned(),
             None,
-            None,
+            tags,
         )
     }
 


### PR DESCRIPTION
In #3005, Haskell users have been running into an issue where many of the CodeActions supported by the `haskell-language-server` are not present in Helix.

By my read of things:

- `hls` generates diagnostics and sends them to Helix
- Helix stores these, but discards the `source` and `tags` fields
- The user triggers a codeAction query
- Helix sends `textDocument/codeAction` to `hls`, in the `context` field it includes the relevant diagnostic _but without the `source` and `tags` that have been discarded_
- `hls` generates codeActions for all diagnostics it knows about (freshly computing the diagnostics, which include the `source` and `tags` fields), [only returning them if the freshly generated diagnostic matches the diagnostic in the `textDocument/codeAction` query](https://github.com/haskell/haskell-language-server/blob/362ca34488899454f2070f098a5a2ebf25e52c5e/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs#L473)
- Since Helix removed the `source` and `tags` fields, this equality match fails and no codeActons are returned (beyond a set of always-applicable ones)

This PR simply tracks these two fields so they can be passed back to the LSP server. I am not sure it solves every case of missing codeAction, but it has solved all the cases I've tried.

I'm not very familiar with Helix's codebase nor the LSP, so please do let me know if I've missed some reason these fields were intentionally left out.