### PR TITLE
Xtask theme previews

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,4 +9,9 @@ edition = "2021"
 helix-term = { version = "0.6", path = "../helix-term" }
 helix-core = { version = "0.6", path = "../helix-core" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
+helix-view = { version = "0.6", path = "../helix-view" }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
+crossterm = { version = "0.25", features = ["event-stream"] }
 toml = "0.5"
+gag = "1.0"
+temp-file = "0.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -256,7 +256,7 @@ pub mod tasks {
         Ok(())
     }
 
-    pub fn snap_theme() -> Result<(), DynError> {
+    pub fn gen_theme_previews() -> Result<(), DynError> {
         use crossterm::event::EventStream;
         use helix_term::{application::Application, args::Args, config::Config};
         use helix_view::theme;
@@ -288,7 +288,7 @@ pub mod tasks {
                     .create(true)
                     .open(tmp_file.path())
                     .unwrap();
-                let redirect = gag::Redirect::stdout(opts).unwrap();
+                let _redirect = gag::Redirect::stdout(opts).unwrap();
 
                 // render the editor and stop the application after some time
                 let mut stream = EventStream::new();
@@ -327,7 +327,7 @@ Usage: Run with `cargo xtask <task>`, eg. `cargo xtask docgen`.
     Tasks:
         docgen: Generate files to be included in the mdbook output.
         query-check: Check that tree-sitter queries are valid.
-        snap-theme: Make a snapshot of a theme
+        gen-theme-previews: Make a snapshot of a theme
 "
         );
     }
@@ -340,7 +340,7 @@ fn main() -> Result<(), DynError> {
         Some(t) => match t.as_str() {
             "docgen" => tasks::docgen()?,
             "query-check" => tasks::query_check()?,
-            "snap-theme" => tasks::snap_theme()?,
+            "gen-theme-previews" => tasks::gen_theme_previews()?,
             invalid => return Err(format!("Invalid task name: {}", invalid).into()),
         },
     };


### PR DESCRIPTION
Add xtask to generate html previews for all themes. Requires the `aha` tool installed to convert ANSI sequences to HTML. `aha` should be available for your linux distribution of choice.

This is still WIP and needs some discussion how and where to integrate the previews to the docs.

fixes #3608