### PR TITLE
Bump MSRV to 1.61 and document MSRV policy

### DIFF
--- a/.github/workflows/msrv-rust-toolchain.toml
+++ b/.github/workflows/msrv-rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59.0"
+channel = "1.61.0"
 components = ["rustfmt", "rust-src"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,6 @@ dependencies = [
  "log",
  "once_cell",
  "pulldown-cmark",
- "retain_mut",
  "serde",
  "serde_json",
  "signal-hook",
@@ -883,12 +882,6 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ropey"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,6 +37,12 @@ contributors are strongly encouraged to write integration tests for their code.
 Existing tests can be used as examples. Helpers can be found in
 [helpers.rs][helpers.rs]
 
+## Minimum Stable Rust Version (MSRV) Policy
+
+Helix follows the MSRV of Firefox.
+The current MSRV and future changes to the MSRV are listed in the [Firefox documentation].
+
+[Firefox documentation]: https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html
 [good-first-issue]: https://github.com/helix-editor/helix/labels/E-easy
 [log-file]: https://github.com/helix-editor/helix/wiki/FAQ#access-the-log-file
 [architecture.md]: ./architecture.md

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -67,9 +67,6 @@ serde = { version = "1.0", features = ["derive"] }
 grep-regex = "0.1.10"
 grep-searcher = "0.1.10"
 
-# Remove once retain_mut lands in stable rust
-retain_mut = "0.1.7"
-
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -365,10 +365,6 @@ impl<T: Item> Picker<T> {
                     .map(|(index, _option)| (index, 0)),
             );
         } else if pattern.starts_with(&self.previous_pattern) {
-            // TODO: remove when retain_mut is in stable rust
-            #[allow(unused_imports, deprecated)]
-            use retain_mut::RetainMut;
-
             // optimization: if the pattern is a more specific version of the previous one
             // then we can score the filtered set.
             #[allow(unstable_name_collisions)]


### PR DESCRIPTION
The MSRV was previously bumpbed in to 1.59 in #3896.
However the newest gitoxide version (which contains some nice API additions usable in #3890) requires 1.60, because the bstr crate bumped its MSRV.
Before #3896 the MSRV was set to 1.57 to support void linux and homebrew.
Both now ship rust 1.63.
I checked [repology](https://bugs.launchpad.net/ubuntu/+source/rustc/+bug/1986648) and all distributions that ship the newest helix version also already ship at least rust 1.61.

However setting the MSRV to some arbitrary value again seemed bad to me and so I looked into MSRV in more detail.
The (mainstream) package repository which updates rustc last are usually ubuntu, debian and enterprise distributions like REHL.
Debian and REHL ship ancient rustc versions anyway that are hard to support (and already not supported by helix).
Ubuntu bumps rustc whenever a new firefox version raises their MSRV.

Therefore I propose tying the MSRV of helix to that of firefox.
Most package managers want to ship the newest firefox releases to attain the latest security fixes and treat updating any dependencies of that as a high priority.
For example ubuntu is currently in the [process](https://bugs.launchpad.net/ubuntu/+source/rustc/+bug/1986648) of updating to rust 1.61 for firefox 105 which released today.
Firefox in turn trys to be somewhat conservative with its MSRV to remain compatible with many distributions.
Therefore firefox MSRV currently represents a lowest common denomiator among most distributions.

I apologize for the duplicate PR regarding MSRV.
However I believe that with a formal policy regarding MSRV in place such a situation can be avoided in the future.
This should make maintenance and development easier as its always clear what the current MSRV is and when it will be change.