### PR TITLE
Fix highlighting on single-character Rust consts

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -183,7 +183,7 @@
 ; -------
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+ (#match? @constant "^[A-Z][A-Z\\d_]*$"))
 
 ; ---
 ; PascalCase identifiers in call_expressions (e.g. `Ok()`)

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -184,9 +184,6 @@
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
-(const_item
-  name: (identifier) @constant
-)
 
 ; ---
 ; PascalCase identifiers in call_expressions (e.g. `Ok()`)

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -184,6 +184,9 @@
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+(const_item
+  name: (identifier) @constant
+)
 
 ; ---
 ; PascalCase identifiers in call_expressions (e.g. `Ok()`)


### PR DESCRIPTION
Resolves #3922 with the fix suggested by @the-mikedavis