### PR TITLE
Exit select after rotate selections

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3946,6 +3946,7 @@ fn rotate_selection_contents(cx: &mut Context, direction: Direction) {
     );
 
     doc.apply(&transaction, view.id);
+    exit_select_mode(cx);
 }
 
 fn rotate_selection_contents_forward(cx: &mut Context) {


### PR DESCRIPTION
After rotating selections users is probably done with the rotation they want, so it would be better to exit select mode rather than they have to press v again.