### PR TITLE
Theme: Papercolor: Tune inactive statusline

### DIFF
--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -10,7 +10,7 @@
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
-"ui.statusline.inactive" = {bg="background", fg="bright0"}
+"ui.statusline.inactive" = {bg="selection_foreground", fg="foreground"}
 "ui.virtual.whitespace" = { fg = "regular5" }
 "ui.virtual.ruler" = {bg="cursorline_background"}
 "ui.cursor.match" = {bg = "regular5", fg = "regular0"}

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -10,7 +10,7 @@
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
-"ui.statusline.inactive" = {bg="background", fg="bright0"}
+"ui.statusline.inactive" = {bg="bright0", fg="foreground"}
 "ui.virtual" = "indent"
 "ui.virtual.whitespace" = { fg = "regular5" }
 "ui.virtual.ruler" = {bg="cursorline_background"}


### PR DESCRIPTION
With horizontal splits it was hard to visually distinguish
the beginning of the adjacent splits content.

Only went by eye for the closest match from (1). Feedback appreciated!

(1): https://github.com/NLKNguyen/papercolor-theme
