### PR TITLE
Deduplicate regexes in search_selection command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1760,6 +1760,8 @@ fn search_selection(cx: &mut Context) {
         .selection(view.id)
         .iter()
         .map(|selection| regex::escape(&selection.fragment(contents)))
+        .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes
+        .into_iter()
         .collect::<Vec<_>>()
         .join("|");
 


### PR DESCRIPTION
Closes #3939.
Before when using the `search_selection` -  `*` command with multiple identical selections the resulting regex was quite redundant. For example if you had two selections on the word "hello" and hit `*` the regex would be `hello|hello` which should be simplified to just `hello`.