### PR TITLE
feat(ui): sticky context

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -112,11 +112,12 @@ The following statusline elements can be configured:
 
 ### `[editor.lsp]` Section
 
-| Key                   | Description                                                 | Default |
-| ---                   | -----------                                                 | ------- |
-| `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
-| `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
-| `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
+| Key                           | Description                                                 | Default |
+| ---                           | -----------                                                 | ------- |
+| `display-messages`            | Display LSP progress messages below statusline[^1]          | `false` |
+| `auto-signature-help`         | Enable automatic popup of signature help (parameter hints)  | `true`  |
+| `display-signature-help-docs` | Display docs under signature help popup                     | `true`  |
+| `context`                     | Display context of current line if outside the view         | `false` |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -57,6 +57,7 @@ on unix operating systems.
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `sticky-context` | Display context of current line if outside the view | `false` |
 
 ### `[editor.statusline]` Section
 
@@ -112,12 +113,11 @@ The following statusline elements can be configured:
 
 ### `[editor.lsp]` Section
 
-| Key                           | Description                                                 | Default |
-| ---                           | -----------                                                 | ------- |
-| `display-messages`            | Display LSP progress messages below statusline[^1]          | `false` |
-| `auto-signature-help`         | Enable automatic popup of signature help (parameter hints)  | `true`  |
-| `display-signature-help-docs` | Display docs under signature help popup                     | `true`  |
-| `context`                     | Display context of current line if outside the view         | `false` |
+| Key                   | Description                                                 | Default |
+| ---                   | -----------                                                 | ------- |
+| `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
+| `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
+| `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -126,6 +126,9 @@ pub struct LanguageConfiguration {
     pub auto_pairs: Option<AutoPairs>,
 
     pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+
+    /// List of LSP nodes that should be displayed in the sticky context.
+    pub sticky_context_nodes: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -127,7 +127,7 @@ pub struct LanguageConfiguration {
 
     pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
 
-    /// List of LSP nodes that should be displayed in the sticky context.
+    /// List of tree-sitter nodes that should be displayed in the sticky context.
     pub sticky_context_nodes: Option<Vec<String>>,
 }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -19,7 +19,7 @@ use helix_core::{
 use helix_view::{
     apply_transaction,
     document::{Mode, SCRATCH_BUFFER_NAME},
-    editor::{CompleteAction, CursorShapeConfig},
+    editor::{CompleteAction, CursorShapeConfig, LineNumber},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
@@ -151,11 +151,12 @@ impl EditorView {
 
         Self::render_text_highlights(doc, view.offset, inner, surface, theme, highlights, &config);
 
+        let mut context_ln = None;
         if editor.config().sticky_context {
-            Self::render_sticky_context(editor, doc, view, surface, theme);
+            context_ln = Self::render_sticky_context(editor, doc, view, surface, theme);
         }
 
-        Self::render_gutter(editor, doc, view, view.area, surface, theme, is_focused);
+        Self::render_gutter(editor, doc, view, surface, theme, is_focused, context_ln);
         Self::render_rulers(editor, doc, view, inner, surface, theme);
 
         if is_focused {
@@ -414,7 +415,7 @@ impl EditorView {
         view: &View,
         surface: &mut Surface,
         theme: &Theme,
-    ) {
+    ) -> Option<Vec<usize>> {
         if let Some(syntax) = doc.syntax() {
             let tree = syntax.tree();
             let text = doc.text().slice(..);
@@ -453,11 +454,12 @@ impl EditorView {
 
             // TODO: this probably needs it's own style, although it seems to work well even with cursorline
             let context_style = theme.get("ui.cursorline.primary");
-            let mut context_area = view.inner_area();
+            let mut context_area = view.inner_area(doc);
             context_area.height = 1;
 
+            let mut line_numbers = Vec::new();
             for line_num in context {
-                if line_num > view.offset.row {
+                if line_num >= view.offset.row {
                     continue;
                 }
                 surface.clear_with(context_area, context_style);
@@ -475,7 +477,21 @@ impl EditorView {
                 );
 
                 context_area.y += 1;
+                let line_number = match editor.config().line_number {
+                    LineNumber::Absolute => line_num,
+                    LineNumber::Relative => {
+                        let res = text.byte_to_line(cursor_byte) - line_num;
+                        match res {
+                            n if n < 2 => 1,
+                            _ => res - 1,
+                        }
+                    }
+                };
+                line_numbers.push(line_number);
             }
+            Some(line_numbers)
+        } else {
+            None
         }
     }
 
@@ -780,13 +796,14 @@ impl EditorView {
         editor: &Editor,
         doc: &Document,
         view: &View,
-        viewport: Rect,
         surface: &mut Surface,
         theme: &Theme,
         is_focused: bool,
+        context_ln: Option<Vec<usize>>,
     ) {
         let text = doc.text().slice(..);
         let last_line = view.last_line(doc);
+        let viewport = view.area;
 
         // it's used inside an iterator so the collect isn't needless:
         // https://github.com/rust-lang/rust-clippy/issues/6164
@@ -809,7 +826,12 @@ impl EditorView {
             let mut gutter = gutter_type.style(editor, doc, view, theme, is_focused);
             let width = gutter_type.width(view, doc);
             text.reserve(width); // ensure there's enough space for the gutter
-            for (i, line) in (view.offset.row..(last_line + 1)).enumerate() {
+            for (i, mut line) in (view.offset.row..(last_line + 1)).enumerate() {
+                if let Some(ref line_numbers) = context_ln {
+                    if line_numbers.len() > i {
+                        line = line_numbers[i];
+                    }
+                }
                 let selected = cursors.contains(&line);
                 let x = viewport.x + offset;
                 let y = viewport.y + i as u16;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -151,7 +151,7 @@ impl EditorView {
 
         Self::render_text_highlights(doc, view.offset, inner, surface, theme, highlights, &config);
 
-        if editor.config().lsp.context {
+        if editor.config().sticky_context {
             Self::render_context(editor, doc, view, surface, theme);
         }
 
@@ -419,6 +419,9 @@ impl EditorView {
             let text = doc.text().slice(..);
             let tree = syntax.tree();
             let byte = doc.selection(view.id).primary().cursor(text);
+            let nodes_to_match = doc
+                .language_config()
+                .and_then(|lc| lc.sticky_context_nodes.as_ref());
 
             let mut parent = tree
                 .root_node()
@@ -438,7 +441,10 @@ impl EditorView {
                     }
                 }
 
-                context.push(line);
+                if nodes_to_match.map_or(true, |nodes| nodes.iter().any(|n| n == curr.kind())) {
+                    context.push(line);
+                }
+
                 parent = curr.parent();
             }
 
@@ -450,7 +456,6 @@ impl EditorView {
             let mut context_area = view.inner_area();
             context_area.height = 1;
 
-            let mut last_line = 0;
             for line_num in context {
                 if line_num > view.offset.row {
                     continue;
@@ -470,19 +475,7 @@ impl EditorView {
                 );
 
                 context_area.y += 1;
-                last_line = line_num;
             }
-
-            surface.clear_with(context_area, context_style);
-            let text_style = theme.get("ui.text");
-            let last_line = text.get_line(last_line).unwrap();
-            let padding = last_line.chars().take_while(|&c| c == ' ').count();
-            surface.set_string(
-                context_area.x,
-                context_area.y,
-                format!("{}    context ----", " ".repeat(padding)),
-                text_style,
-            );
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -178,6 +178,8 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// Display context of current cursor line if it is outside the view.
+    pub sticky_context: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -242,8 +244,6 @@ pub struct LspConfig {
     pub auto_signature_help: bool,
     /// Display docs under signature help popup
     pub display_signature_help_docs: bool,
-    /// Display context of current cursor line if it is outside the view.
-    pub context: bool,
 }
 
 impl Default for LspConfig {
@@ -252,7 +252,6 @@ impl Default for LspConfig {
             display_messages: false,
             auto_signature_help: true,
             display_signature_help_docs: true,
-            context: false,
         }
     }
 }
@@ -633,6 +632,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            sticky_context: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -242,6 +242,8 @@ pub struct LspConfig {
     pub auto_signature_help: bool,
     /// Display docs under signature help popup
     pub display_signature_help_docs: bool,
+    /// Display context of current cursor line if it is outside the view.
+    pub context: bool,
 }
 
 impl Default for LspConfig {
@@ -250,6 +252,7 @@ impl Default for LspConfig {
             display_messages: false,
             auto_signature_help: true,
             display_signature_help_docs: true,
+            context: false,
         }
     }
 }

--- a/languages.toml
+++ b/languages.toml
@@ -11,6 +11,7 @@ auto-format = true
 comment-token = "//"
 language-server = { command = "rust-analyzer" }
 indent = { tab-width = 4, unit = "    " }
+sticky-context-nodes = ["impl_item", "function_item", "struct_item", "enum_item", "match_expression", "match_arm", "let_declaration"]
 
 [language.auto-pairs]
 '(' = ')'


### PR DESCRIPTION
*Note:* This PR is ~rough~ proof of concept. I am completely fine if the final decision is _not_ to include this in the core. (although I believe it fits well with the rest of the tree-sitter support and should be part of the core).

Add option to render the context of current line if the context is outside the view. Parent Tree-sitter node(s) outside the view are displayed at the top of the view providing additional (hopefully helpful) context for the current cursor line. The nodes are filtered based on language-specific configuration to strike the right balance between helpful and too noisy.

Inspiration taken from [context.vim](https://github.com/wellle/context.vim) and a treesitter port of context.vim - https://github.com/romgrk/nvim-treesitter-context.

- [x] render only context outside the view
- [x] per-language configurable tree-sitter nodes to display
- [x] proper line numbers - maybe in a separate PR

The desired behavior should resemble this:

![context-scroll](https://user-images.githubusercontent.com/15747583/191848079-3814d755-d138-448b-ba38-f898c75e9ddd.gif)

or this

![demo](https://user-images.githubusercontent.com/15747583/191848168-a980a2a0-d777-492a-b34a-0c5ad7af8831.gif)

Fixes: https://github.com/helix-editor/helix/issues/396