### PR TITLE
Enable incremental mode for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-members = [
 
 [profile.dev]
 split-debuginfo = "unpacked"
+incremental = true
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Incremental mode should help with compile times for everyone working on Helix. AFAIK, incremental won't create any artifacts in release builds, but I'd rather not risk slowing final executables down.