### PR TITLE
respond to SIGUSR1 by reloading config

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -28,6 +28,10 @@ hidden = false
 You may also specify a file to use for configuration with the `-c` or
 `--config` CLI argument: `hx -c path/to/custom-config.toml`.
 
+It is also possible to trigger configuration file reloading by sending the `USR1`
+signal to the helix process, e.g. via `pkill -USR1 hx`. This is only supported 
+on unix operating systems.
+
 ## Editor
 
 ### `[editor]` Section

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -224,8 +224,8 @@ impl Application {
         #[cfg(windows)]
         let signals = futures_util::stream::empty();
         #[cfg(not(windows))]
-        let signals =
-            Signals::new(&[signal::SIGTSTP, signal::SIGCONT]).context("build signal handler")?;
+        let signals = Signals::new(&[signal::SIGTSTP, signal::SIGCONT, signal::SIGUSR1])
+            .context("build signal handler")?;
 
         let app = Self {
             compositor,
@@ -424,6 +424,10 @@ impl Application {
                 let Rect { width, height, .. } = self.compositor.size();
                 self.compositor.resize(width, height);
                 self.compositor.load_cursor();
+                self.render();
+            }
+            signal::SIGUSR1 => {
+                self.refresh_config();
                 self.render();
             }
             _ => unreachable!(),


### PR DESCRIPTION
Small PR to add handling for the USR1 signal on unix machines, whereby the config is reloaded from disk. This is useful in settings where automation rewrites the config (or parts thereof, such as the theme config) and we want it reflected immediately instead of manually executing `config-reload` each time. 