### PR TITLE
Expose line numbers width in config

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -168,6 +168,7 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    pub line_numbers_width: u16,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -577,6 +578,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            line_numbers_width: 5,
         }
     }
 }
@@ -973,7 +975,13 @@ impl Editor {
                     .try_get(self.tree.focus)
                     .filter(|v| id == v.doc) // Different Document
                     .cloned()
-                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
+                    .unwrap_or_else(|| {
+                        View::new(
+                            id,
+                            self.config().gutters.clone(),
+                            self.config().line_numbers_width,
+                        )
+                    });
                 let view_id = self.tree.split(
                     view,
                     match action {
@@ -1111,7 +1119,11 @@ impl Editor {
                 .map(|(&doc_id, _)| doc_id)
                 .next()
                 .unwrap_or_else(|| self.new_document(Document::default()));
-            let view = View::new(doc_id, self.config().gutters.clone());
+            let view = View::new(
+                doc_id,
+                self.config().gutters.clone(),
+                self.config().line_numbers_width,
+            );
             let view_id = self.tree.insert(view);
             let doc = doc_mut!(self, &doc_id);
             doc.ensure_view_init(view_id);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -98,14 +98,18 @@ impl fmt::Debug for View {
 }
 
 impl View {
-    pub fn new(doc: DocumentId, gutter_types: Vec<crate::editor::GutterType>) -> Self {
+    pub fn new(
+        doc: DocumentId,
+        gutter_types: Vec<crate::editor::GutterType>,
+        line_numbers_width: u16,
+    ) -> Self {
         let mut gutters: Vec<(Gutter, usize)> = vec![];
         let mut gutter_offset = 0;
         use crate::editor::GutterType;
         for gutter_type in &gutter_types {
             let width = match gutter_type {
                 GutterType::Diagnostics => 1,
-                GutterType::LineNumbers => 5,
+                GutterType::LineNumbers => line_numbers_width,
                 GutterType::Spacer => 1,
             };
             gutter_offset += width;


### PR DESCRIPTION
Here is an image of helix running with line numbers limited to 3 digits
![image](https://user-images.githubusercontent.com/39845673/192076447-11081e18-62c6-4642-ab39-f2899b4501e9.png)
