### PR TITLE
Always send a did save notification

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -596,15 +596,12 @@ impl Client {
 
         let include_text = match &capabilities.text_document_sync {
             Some(lsp::TextDocumentSyncCapability::Options(lsp::TextDocumentSyncOptions {
-                save: Some(options),
+                save:
+                    Some(lsp::TextDocumentSyncSaveOptions::SaveOptions(lsp_types::SaveOptions {
+                        include_text,
+                    })),
                 ..
-            })) => match options {
-                lsp::TextDocumentSyncSaveOptions::SaveOptions(lsp_types::SaveOptions {
-                    include_text,
-                }) => include_text.unwrap_or(false),
-                _ => false,
-            },
-            // unsupported
+            })) => include_text.unwrap_or(false),
             _ => false,
         };
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -566,11 +566,9 @@ impl Document {
                 if !language_server.is_initialized() {
                     return Ok(());
                 }
-                if let Some(notification) =
-                    language_server.text_document_did_save(identifier, &text)
-                {
-                    notification.await?;
-                }
+                language_server
+                    .text_document_did_save(identifier, &text)
+                    .await?;
             }
 
             Ok(())


### PR DESCRIPTION
For some reason Helix only sends the [textDocument/didSave](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didSave) notification if the [includeText](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#saveOptions) option is set to true. 