### PR TITLE
feat(statusline): add option to show total line numbers in file

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -79,6 +79,7 @@ The following elements can be configured:
 | `file-name` | The path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
+| `total-line-numbers` | The total line numbers of the opened file |
 | `file-type` | The type of the opened file |
 | `diagnostics` | The number of warnings and/or errors |
 | `selections` | The number of active selections |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -144,6 +144,7 @@ where
         helix_view::editor::StatusLineElement::Selections => render_selections,
         helix_view::editor::StatusLineElement::Position => render_position,
         helix_view::editor::StatusLineElement::PositionPercentage => render_position_percentage,
+        helix_view::editor::StatusLineElement::TotalLineNumbers => render_total_line_numbers,
         helix_view::editor::StatusLineElement::Separator => render_separator,
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
     }
@@ -274,6 +275,15 @@ where
         format!(" {}:{} ", position.row + 1, position.col + 1),
         None,
     );
+}
+
+fn render_total_line_numbers<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let total_line_numbers = context.doc.text().len_lines();
+
+    write(context, format!(" {} ", total_line_numbers), None);
 }
 
 fn render_position_percentage<F>(context: &mut RenderContext, write: F)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -311,6 +311,9 @@ pub enum StatusLineElement {
     /// The cursor position as a percent of the total file
     PositionPercentage,
 
+    /// The total line numbers of the current file
+    TotalLineNumbers,
+
     /// A single space
     Spacer,
 }


### PR DESCRIPTION
I made a PR for this feature a while back, however I was told to make another one after the status line config was implemented. It is a small feature however I think a few people would like the option