### PR TITLE
feat: implement :read typed command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -72,3 +72,4 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:read`, `:r` | Load a file into buffer |

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -31,6 +31,33 @@ async fn test_write_quit_fail() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_read_file() -> anyhow::Result<()> {
+    let mut file = tempfile::NamedTempFile::new()?;
+    let expected_content = String::from("some contents");
+    let output_file = helpers::temp_file_with_contents(&expected_content)?;
+    let mut command = String::new();
+    let cmd = format!(":r {:?}<ret><esc>:w<ret>", output_file.path());
+    command.push_str(&cmd);
+
+    test_key_sequence(
+        &mut helpers::AppBuilder::new()
+            .with_file(file.path(), None)
+            .build()?,
+        Some(&command),
+        Some(&|app| {
+            assert!(!app.editor.is_err(), "error: {:?}", app.editor.get_status());
+        }),
+        false,
+    )
+    .await?;
+
+    helpers::assert_file_has_content(file.as_file_mut(), expected_content.as_str())?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_buffer_close_concurrent() -> anyhow::Result<()> {
     test_key_sequences(
         &mut helpers::AppBuilder::new().build()?,


### PR DESCRIPTION
This is a naive attempt at partially implementing #3796

Adds a typed command `:read` with alias `:r` (following vim) that reads the contents of a file into the current buffer.

At this stage, I just would like to validate my approach and obviously would love to finish it off after implementing some integration tests.

I also appreciate any pointers and guidance around reading the file contents into the buffer more efficiently. I am loading the file into a String for now.