### PR TITLE
Adjust fuzzy matching to be more inline with other editors

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -376,7 +376,6 @@ Keys to use within picker. Remapping currently not supported.
 | `PageDown`, `Ctrl-d`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |
-| `Ctrl-space`                 | Filter options    |
 | `Enter`                      | Open selected     |
 | `Ctrl-s`                     | Open horizontally |
 | `Ctrl-v`                     | Open vertically   |

--- a/helix-term/src/ui/fuzzy_match.rs
+++ b/helix-term/src/ui/fuzzy_match.rs
@@ -1,0 +1,74 @@
+use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
+use fuzzy_matcher::FuzzyMatcher;
+
+#[cfg(test)]
+mod test;
+
+pub struct FuzzyQuery {
+    queries: Vec<String>,
+}
+
+impl FuzzyQuery {
+    pub fn new(query: &str) -> FuzzyQuery {
+        let mut saw_backslash = false;
+        let queries = query
+            .split(|c| {
+                saw_backslash = match c {
+                    ' ' if !saw_backslash => return true,
+                    '\\' => true,
+                    _ => false,
+                };
+                false
+            })
+            .filter_map(|query| {
+                if query.is_empty() {
+                    None
+                } else {
+                    Some(query.replace("\\ ", " "))
+                }
+            })
+            .collect();
+        FuzzyQuery { queries }
+    }
+
+    pub fn fuzzy_match(&self, item: &str, matcher: &Matcher) -> Option<i64> {
+        // use the rank of the first query for the rank, because merging ranks is not really possible
+        // this behaviour matches fzf and skim
+        let score = matcher.fuzzy_match(item, self.queries.get(0)?)?;
+        if self
+            .queries
+            .iter()
+            .any(|query| matcher.fuzzy_match(item, query).is_none())
+        {
+            return None;
+        }
+        Some(score)
+    }
+
+    pub fn fuzzy_indicies(&self, item: &str, matcher: &Matcher) -> Option<(i64, Vec<usize>)> {
+        if self.queries.len() == 1 {
+            return matcher.fuzzy_indices(item, &self.queries[0]);
+        }
+
+        // use the rank of the first query for the rank, because merging ranks is not really possible
+        // this behaviour matches fzf and skim
+        let (score, mut indicies) = matcher.fuzzy_indices(item, self.queries.get(0)?)?;
+
+        // fast path for the common case of not using a space
+        // during matching this branch should be free thanks to branch prediction
+        if self.queries.len() == 1 {
+            return Some((score, indicies));
+        }
+
+        for query in &self.queries[1..] {
+            let (_, matched_indicies) = matcher.fuzzy_indices(item, query)?;
+            indicies.extend_from_slice(&matched_indicies);
+        }
+
+        // deadup and remove duplicate matches
+        indicies.sort_unstable();
+        indicies.dedup();
+
+        Some((score, indicies))
+    }
+}

--- a/helix-term/src/ui/fuzzy_match/test.rs
+++ b/helix-term/src/ui/fuzzy_match/test.rs
@@ -1,0 +1,47 @@
+use crate::ui::fuzzy_match::FuzzyQuery;
+use crate::ui::fuzzy_match::Matcher;
+
+fn run_test<'a>(query: &str, items: &'a [&'a str]) -> Vec<String> {
+    let query = FuzzyQuery::new(query);
+    let matcher = Matcher::default();
+    items
+        .iter()
+        .filter_map(|item| {
+            let (_, indicies) = query.fuzzy_indicies(item, &matcher)?;
+            let matched_string = indicies
+                .iter()
+                .map(|&pos| item.chars().nth(pos).unwrap())
+                .collect();
+            Some(matched_string)
+        })
+        .collect()
+}
+
+#[test]
+fn match_single_value() {
+    let matches = run_test("foo", &["foobar", "foo", "bar"]);
+    assert_eq!(matches, &["foo", "foo"])
+}
+
+#[test]
+fn match_multiple_values() {
+    let matches = run_test(
+        "foo bar",
+        &["foo bar", "foo   bar", "bar foo", "bar", "foo"],
+    );
+    assert_eq!(matches, &["foobar", "foobar", "barfoo"])
+}
+
+#[test]
+fn space_escape() {
+    let matches = run_test(r"foo\ bar", &["bar foo", "foo bar", "foobar"]);
+    assert_eq!(matches, &["foo bar"])
+}
+
+#[test]
+fn trim() {
+    let matches = run_test(r" foo bar ", &["bar foo", "foo bar", "foobar"]);
+    assert_eq!(matches, &["barfoo", "foobar", "foobar"]);
+    let matches = run_test(r" foo bar\ ", &["bar foo", "foo bar", "foobar"]);
+    assert_eq!(matches, &["bar foo"])
+}

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -1,5 +1,6 @@
 mod completion;
 pub(crate) mod editor;
+mod fuzzy_match;
 mod info;
 pub mod lsp;
 mod markdown;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -286,8 +286,6 @@ pub struct Picker<T: Item> {
     matcher: Box<Matcher>,
     /// (index, score)
     matches: Vec<(usize, i64)>,
-    /// Filter over original options.
-    filters: Vec<usize>, // could be optimized into bit but not worth it now
 
     /// Current height of the completions box
     completion_height: u16,
@@ -322,7 +320,6 @@ impl<T: Item> Picker<T> {
             editor_data,
             matcher: Box::new(Matcher::default()),
             matches: Vec::new(),
-            filters: Vec::new(),
             cursor: 0,
             prompt,
             previous_pattern: String::new(),
@@ -391,13 +388,6 @@ impl<T: Item> Picker<T> {
                     .iter()
                     .enumerate()
                     .filter_map(|(index, option)| {
-                        // filter options first before matching
-                        if !self.filters.is_empty() {
-                            // TODO: this filters functionality seems inefficient,
-                            // instead store and operate on filters if any
-                            self.filters.binary_search(&index).ok()?;
-                        }
-
                         let text = option.filter_text(&self.editor_data);
 
                         query
@@ -459,14 +449,6 @@ impl<T: Item> Picker<T> {
         self.matches
             .get(self.cursor)
             .map(|(index, _score)| &self.options[*index])
-    }
-
-    pub fn save_filter(&mut self, cx: &Context) {
-        self.filters.clear();
-        self.filters
-            .extend(self.matches.iter().map(|(index, _)| *index));
-        self.filters.sort_unstable(); // used for binary search later
-        self.prompt.clear(cx.editor);
     }
 
     pub fn toggle_preview(&mut self) {
@@ -545,9 +527,6 @@ impl<T: Item + 'static> Component for Picker<T> {
                     (self.callback_fn)(cx, option, Action::VerticalSplit);
                 }
                 return close_fn;
-            }
-            ctrl!(' ') => {
-                self.save_filter(cx);
             }
             ctrl!('t') => {
                 self.toggle_preview();

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1,7 +1,7 @@
 use crate::{
     compositor::{Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
-    ui::{self, EditorView},
+    ui::{self, fuzzy_match::FuzzyQuery, EditorView},
 };
 use tui::{
     buffer::Buffer as Surface,
@@ -9,7 +9,6 @@ use tui::{
 };
 
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
-use fuzzy_matcher::FuzzyMatcher;
 use tui::widgets::Widget;
 
 use std::time::Instant;
@@ -365,13 +364,14 @@ impl<T: Item> Picker<T> {
                     .map(|(index, _option)| (index, 0)),
             );
         } else if pattern.starts_with(&self.previous_pattern) {
+            let query = FuzzyQuery::new(pattern);
             // optimization: if the pattern is a more specific version of the previous one
             // then we can score the filtered set.
             self.matches.retain_mut(|(index, score)| {
                 let option = &self.options[*index];
                 let text = option.sort_text(&self.editor_data);
 
-                match self.matcher.fuzzy_match(&text, pattern) {
+                match query.fuzzy_match(&text, &self.matcher) {
                     Some(s) => {
                         // Update the score
                         *score = s;
@@ -384,6 +384,7 @@ impl<T: Item> Picker<T> {
             self.matches
                 .sort_unstable_by_key(|(_, score)| Reverse(*score));
         } else {
+            let query = FuzzyQuery::new(pattern);
             self.matches.clear();
             self.matches.extend(
                 self.options
@@ -399,8 +400,8 @@ impl<T: Item> Picker<T> {
 
                         let text = option.filter_text(&self.editor_data);
 
-                        self.matcher
-                            .fuzzy_match(&text, pattern)
+                        query
+                            .fuzzy_match(&text, &self.matcher)
                             .map(|score| (index, score))
                     }),
             );
@@ -630,9 +631,8 @@ impl<T: Item + 'static> Component for Picker<T> {
             }
 
             let spans = option.label(&self.editor_data);
-            let (_score, highlights) = self
-                .matcher
-                .fuzzy_indices(&String::from(&spans), self.prompt.line())
+            let (_score, highlights) = FuzzyQuery::new(self.prompt.line())
+                .fuzzy_indicies(&String::from(&spans), &self.matcher)
                 .unwrap_or_default();
 
             spans.0.into_iter().fold(inner, |pos, span| {


### PR DESCRIPTION
Closes #2290 and #2564

This PR makes helix treat spaces as seperators instead of a normal character during matching.
This means that "foo bar" also matches "bar/foo" for example.
To match spaces as characeters they must now be escaped.
For example "foo\ bar" matches "foo bar" but not "bar foo" or "foobar".

This behaviour is inline with other IDEs (VScode and Intellij) and fuzzy finders (fzf and skim).
Therefore most people will expect helix to behave the same (I personally still trip up over this
even after using helix quite a while)

While a similar effect can be achieved by pressing C-space, this is quite inconvenient.
Especially in cases where you do not exactly know what you are looking for and often have to adjust the search.
Furthermore this approach also doesn't handle scenarios where spaces are typed by accident (like #2564).