### PR TITLE
inject language based on file extension & shebang

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,3 +16,4 @@
   - [Adding languages](./guides/adding_languages.md)
   - [Adding textobject queries](./guides/textobject.md)
   - [Adding indent queries](./guides/indent.md)
+  - [Adding injection queries](./guides/injection.md)

--- a/book/src/guides/injection.md
+++ b/book/src/guides/injection.md
@@ -1,0 +1,57 @@
+# Adding Injection Queries
+
+Writing language injection queries allows one to highlight a specific node as a different language.
+In addition to the [standard](upstream-docs) language injection options used by tree-sitter, there
+are a few Helix specific extensions that allow for more control.
+
+And example of a simple query that would highlight all strings as bash in Nix:
+```scm
+((string_expression (string_fragment) @injection.content)
+  (#set! injection.language "bash"))
+```
+
+## Capture Types
+
+- `@injection.language` (standard):
+The captured node may contain the language name used to highlight the node captured by
+`@injection.content`.
+
+- `@injection.content` (standard):
+Marks the content to be highlighted as the language captured with `@injection.language` _et al_.
+
+- `@injection.filename` (extension):
+The captured node may contain a filename with a file-extension known to Helix,
+highlighting `@injection.content` as that language. This uses the language extensions defined in
+both the default languages.toml distributed with Helix, as well as user defined languages.
+
+- `@injection.shebang` (extension):
+The captured node may contain a shebang used to choose a language to highlight as. This also uses
+the shebangs defined in the default and user `languages.toml`.
+
+## Settings
+
+- `injection.combined` (standard):
+Indicates that all the matching nodes in the tree should have their content parsed as one
+nested document.
+
+- `injection.language` (standard):
+Forces the captured content to be highlighted as the given language
+
+- `injection.include-children` (standard):
+Indicates that the content node’s entire text should be re-parsed, including the text of its child
+nodes. By default, child nodes’ text will be excluded from the injected document.
+
+- `injection.include-unnamed-children` (extension):
+Same as `injection.include-children` but only for unnamed child nodes.
+
+## Predicates
+
+- `#eq?` (standard):
+The first argument (a capture) must be equal to the second argument
+(a capture or a string).
+
+- `#match?` (standard):
+The first argument (a capture) must match the regex given in the
+second argument (a string).
+
+[upstream-docs]: http://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag};
 
 use helix_core::{
-    syntax::{self, HighlightEvent, InjectionCapture, Syntax},
+    syntax::{self, HighlightEvent, InjectionLanguageMarker, Syntax},
     Rope,
 };
 use helix_view::{
@@ -47,7 +47,9 @@ pub fn highlighted_code_block<'a>(
 
     let rope = Rope::from(text.as_ref());
     let syntax = config_loader
-        .language_configuration_for_injection_string(&InjectionCapture::Name(language.into()))
+        .language_configuration_for_injection_string(&InjectionLanguageMarker::Name(
+            language.into(),
+        ))
         .and_then(|config| config.highlight_config(theme.scopes()))
         .map(|config| Syntax::new(&rope, config, Arc::clone(&config_loader)));
 

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag};
 
 use helix_core::{
-    syntax::{self, HighlightEvent, Syntax},
+    syntax::{self, HighlightEvent, InjectionCapture, Syntax},
     Rope,
 };
 use helix_view::{
@@ -47,7 +47,7 @@ pub fn highlighted_code_block<'a>(
 
     let rope = Rope::from(text.as_ref());
     let syntax = config_loader
-        .language_configuration_for_injection_string(language)
+        .language_configuration_for_injection_string(&InjectionCapture::Name(language.into()))
         .and_then(|config| config.highlight_config(theme.scopes()))
         .map(|config| Syntax::new(&rope, config, Arc::clone(&config_loader)));
 

--- a/languages.toml
+++ b/languages.toml
@@ -591,7 +591,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nix"
-source = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "6b71a810c0acd49b980c50fc79092561f7cee307" }
+source = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "1b69cf1fa92366eefbe6863c184e5d2ece5f187d" }
 
 [[language]]
 name = "ruby"

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,6 +1,10 @@
 ; From nvim-treesitter/nvim-treesitter
 
 (fenced_code_block
+  (code_fence_content) @injection.shebang @injection.content
+  (#set! injection.include-unnamed-children))
+
+(fenced_code_block
   (info_string
     (language) @injection.language)
   (code_fence_content) @injection.content (#set! injection.include-unnamed-children))

--- a/runtime/queries/nix/highlights.scm
+++ b/runtime/queries/nix/highlights.scm
@@ -47,8 +47,10 @@
 (float_expression) @constant.numeric.float
 
 (escape_sequence) @constant.character.escape
+(dollar_escape) @constant.character.escape
 
 (function_expression
+  "@"? @punctuation.delimiter
   universal: (identifier) @variable.parameter
   "@"? @punctuation.delimiter
 )
@@ -82,7 +84,8 @@
 (binding
   attrpath: (attrpath attr: (identifier)) @variable.other.member)
 
-(inherit_from attrs: (inherited_attrs attr: (identifier) @variable))
+(inherit_from attrs: (inherited_attrs attr: (identifier) @variable.other.member))
+(inherited_attrs attr: (identifier) @variable)
 
 (has_attr_expression
   expression: (_)

--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -10,9 +10,11 @@
 ; such as those of stdenv.mkDerivation.
 ((binding
    attrpath: (attrpath (identifier) @_path)
-   expression: (indented_string_expression
-     (string_fragment) @injection.content))
- (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
+   expression: [
+     (indented_string_expression (string_fragment) @injection.content)
+     (binary_expression (indented_string_expression (string_fragment) @injection.content))
+   ])
+ (#match? @_path "(^\\w*Phase|command|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
  (#set! injection.language "bash")
  (#set! injection.combined))
 

--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -157,3 +157,6 @@
    argument: (indented_string_expression (string_fragment) @injection.content))
  (#match? @_func "(^|\\.)write(Text|Script(Bin)?)$")
  (#set! injection.combined))
+
+((indented_string_expression (string_fragment) @injection.shebang @injection.content)
+  (#set! injection.combined))

--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -150,3 +150,10 @@
 ;  (#match? @_func "(^|\\.)writeFSharp(Bin)?$")
 ;  (#set! injection.language "f-sharp")
 ;  (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression function: (_) @_func
+     argument: (string_expression (string_fragment) @injection.filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_func "(^|\\.)write(Text|Script(Bin)?)$")
+ (#set! injection.combined))


### PR DESCRIPTION
Nodes can now be captured with "injection.filename". If this capture contains a valid file extension known to Helix, then the content will be highlighted as that language. In addition, a new "injection.shebang" is added which injects based on a valid shebang.

For consistency, both implementations use the same logic as used to detect the document filetype as a whole.

~~I'm not sure if the following is the most efficient way to capture the built in configuration, or if it can be passed in from somewhere else:
https://github.com/nrdxp/helix/blob/7f61de137f07cf5897d5a3240b1ece98febc0eb0/helix-core/src/syntax.rs#L1836~~

~~Also, it would probably be nice to extend this to user defined languages as well.~~ 65bc9da1f4b0b67dc3189c4a21e5cd551a733b07

Also includes an additional query for Nix so one can test this behavior themselves. A few screens with that query:
![image](https://user-images.githubusercontent.com/34083928/192896522-642d93ce-7edb-413e-8d9c-680bb9ddaf80.png)
![image](https://user-images.githubusercontent.com/34083928/192896601-5067d90f-d980-43f7-856e-e6efde472f9c.png)

This PR also includes a new document briefly describing language injeciton.