### PR TITLE
Remove `do_block` from Ruby indents

### DIFF
--- a/runtime/queries/ruby/indents.scm
+++ b/runtime/queries/ruby/indents.scm
@@ -6,7 +6,6 @@
   (call)
   (class)
   (case)
-  (do_block)
   (elsif)
   (if)
   (hash)


### PR DESCRIPTION
`do_block` and `block` seem to conflict, causing double-indentation in some cases. Removing `do_block` does not seem to have any negative effect, while fixing the double-indentation issue.