### PR TITLE
goto_window_* extends selection

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -890,7 +890,6 @@ fn goto_window(cx: &mut Context, align: Align) {
         .selection(view.id)
         .clone()
         .transform(|range| range.put_cursor(text, pos, cx.editor.mode == Mode::Select));
-    push_jump(view, doc);
     doc.set_selection(view.id, selection);
 }
 


### PR DESCRIPTION
This PR changes:
 - `goto_window_{top|center|bottom}` now extend the current selection instead of dumping it when in select mode.
 
Not sure what the desired functionality is here and if this isn't it feel free to close this PR or ask me to close this PR. Personally I expected it to extend the selection. 

Before. You can see that I enter `SEL` mode, navigate the file and the selection _is not_ extended:
https://asciinema.org/a/5cgczWE5znBuFfLVcSh47RKyk

Now. You can see I enter `SEL` mode, navigate the file and the selection _is_ extended:
https://asciinema.org/a/aBlH5PFjZXhBoiJzPQsggGqP8

Apologies if I'm not following procedure around here. Looked like a quick fix so I went for it. By all means let me know how to do this the right way if this isn't it! Cheers and thanks for a great editor!