### PR TITLE
WGSL syntax highlighting fix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -848,7 +848,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "wgsl"
-source = { git = "https://github.com/szebniok/tree-sitter-wgsl", rev = "f00ff52251edbd58f4d39c9c3204383253032c11" }
+source = { git = "https://github.com/szebniok/tree-sitter-wgsl", rev = "272e89ef2aeac74178edb9db4a83c1ffef80a463" }
 
 [[language]]
 name = "llvm"

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -1,23 +1,41 @@
-(const_literal) @constant.numeric
+(int_literal) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+(bool_literal) @constant.builtin.boolean
 
-(type_declaration) @type
+(global_constant_declaration) @variable
+(global_variable_declaration) @variable
+(compound_statement) @variable
+(const_expression) @function
+
+(variable_identifier_declaration
+    (identifier) @variable
+    (type_declaration) @type)
 
 (function_declaration
-    (identifier) @function)
+    (identifier) @function
+    (function_return_type_declaration
+        (type_declaration) @type))
+
+(parameter
+    (variable_identifier_declaration
+        (identifier) @variable.parameter
+        (type_declaration) @type))
 
 (struct_declaration
     (identifier) @type)
+        
+(struct_declaration
+  	(struct_member
+        (variable_identifier_declaration
+            (identifier) @variable.other.member
+            (type_declaration) @type)))
 
 (type_constructor_or_function_call_expression
     (type_declaration) @function)
 
-(parameter
-    (variable_identifier_declaration (identifier) @variable.parameter))
-
 [
     "struct"
     "bitcast"
-    ; "block"
     "discard"
     "enable"
     "fallthrough"
@@ -26,36 +44,28 @@
     "private"
     "read"
     "read_write"
-    "return"
     "storage"
     "type"
     "uniform"
     "var"
     "workgroup"
     "write"
+    "override"
     (texel_format)
-] @keyword ; TODO reserved keywords
+] @keyword
 
-[
-    (true)
-    (false)
-] @constant.builtin.boolean
+"fn" @keyword.function
+
+"return" @keyword.control.return
 
 [ "," "." ":" ";" ] @punctuation.delimiter
 
-;; brackets
-[
-    "("
-    ")"
-    "["
-    "]"
-    "{"
-    "}"
-] @punctuation.bracket
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [
     "loop"
     "for"
+    "while"
     "break"
     "continue"
     "continuing"
@@ -64,7 +74,6 @@
 [
     "if"
     "else"
-    "elseif"
     "switch"
     "case"
     "default"
@@ -92,10 +101,13 @@
     "*"
     "~"
     "^"
+    "@"
+    "++"
+    "--"
 ] @operator
 
 (attribute
-    (identifier) @variable.other.member)
+    (identifier) @attribute)
 
 (comment) @comment
 

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -25,7 +25,7 @@
     (identifier) @type)
         
 (struct_declaration
-  	(struct_member
+    (struct_member
         (variable_identifier_declaration
             (identifier) @variable.other.member
             (type_declaration) @type)))
@@ -58,7 +58,7 @@
 
 "return" @keyword.control.return
 
-[ "," "." ":" ";" ] @punctuation.delimiter
+["," "." ":" ";"] @punctuation.delimiter
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 


### PR DESCRIPTION
![no more red](https://user-images.githubusercontent.com/6290295/192587561-1fc62508-de9d-486d-b9a5-361fa545c053.png)

This PR adresses #3982. tree-sitter-wgsl is bumped to the latest commit and highlights.scm is updated accordingly.

The updated highlights file is based on the one in the tree-sitter-wgsl repository but with a few changes to make it work properly in Helix. If there are any problems with it let me know.