### PR TITLE
Update everforest theme

### DIFF
--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -8,11 +8,12 @@
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"constant.character.escape" = "orange"
 "type" = "yellow"
 "constant" = "purple"
 "constant.numeric" = "purple"
+"constant.character.escape" = "orange"
 "string" = "green"
+"string.regexp" = "blue"
 "comment" = "grey0"
 "variable" = "fg"
 "variable.builtin" = "blue"
@@ -23,6 +24,7 @@
 "punctuation.delimiter" = "grey2"
 "punctuation.bracket" = "fg"
 "keyword" = "red"
+"keyword.directive" = "aqua"
 "operator" = "orange"
 "function" = "green"
 "function.builtin" = "blue"
@@ -54,32 +56,39 @@
 "diff.minus" = "red"
 
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "grey0"
 "ui.cursor" = { fg = "bg0", bg = "fg" }
 "ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
 "ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursorline.primary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.selection" = { bg = "bg3" }
 "ui.linenr" = "grey0"
 "ui.linenr.selected" = "fg"
-"ui.cursorline" = { bg = "bg1" }
-"ui.statusline" = { fg = "grey2", bg = "bg2" }
+"ui.statusline" = { fg = "grey2", bg = "bg3" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
-"ui.popup" = { fg = "grey2", bg = "bg1" }
-"ui.window" = { fg = "grey2", bg = "bg1" }
-"ui.help" = { fg = "fg", bg = "bg1" }
+"ui.statusline.normal" = { fg = "bg0", bg = "grey2", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "bg0", bg = "yellow", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "grey0", bg = "bg1" }
+"ui.bufferline.active" = { fg = "fg", bg = "bg3", modifiers = ["bold"] }
+"ui.popup" = { fg = "grey2", bg = "bg2" }
+"ui.window" = { fg = "grey0", bg = "bg0" }
+"ui.help" = { fg = "fg", bg = "bg2" }
 "ui.text" = "fg"
 "ui.text.focus" = "fg"
-"ui.menu" = { fg = "fg", bg = "bg2" }
+"ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
-"ui.selection" = { bg = "bg3" }
-"ui.virtual.whitespace" = "grey0"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.whitespace" = { fg = "bg4" }
+"ui.virtual.indent-guide" = { fg = "bg4" }
+"ui.virtual.ruler" = { bg = "bg3" }
 
 "hint" = "blue"
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { modifiers = ["underlined"] }
-
 
 [palette]
 

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -8,11 +8,12 @@
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"constant.character.escape" = "orange"
 "type" = "yellow"
 "constant" = "purple"
 "constant.numeric" = "purple"
+"constant.character.escape" = "orange"
 "string" = "green"
+"string.regexp" = "blue"
 "comment" = "grey0"
 "variable" = "fg"
 "variable.builtin" = "blue"
@@ -23,6 +24,7 @@
 "punctuation.delimiter" = "grey2"
 "punctuation.bracket" = "fg"
 "keyword" = "red"
+"keyword.directive" = "aqua"
 "operator" = "orange"
 "function" = "green"
 "function.builtin" = "blue"
@@ -54,32 +56,39 @@
 "diff.minus" = "red"
 
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "grey0"
 "ui.cursor" = { fg = "bg0", bg = "fg" }
 "ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
 "ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursorline.primary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.selection" = { bg = "bg3" }
 "ui.linenr" = "grey0"
 "ui.linenr.selected" = "fg"
-"ui.cursorline" = { bg = "bg1" }
-"ui.statusline" = { fg = "grey2", bg = "bg2" }
+"ui.statusline" = { fg = "grey2", bg = "bg3" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
-"ui.popup" = { fg = "grey2", bg = "bg1" }
-"ui.window" = { fg = "grey2", bg = "bg1" }
-"ui.help" = { fg = "fg", bg = "bg1" }
+"ui.statusline.normal" = { fg = "bg0", bg = "grey2", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "bg0", bg = "yellow", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "grey0", bg = "bg1" }
+"ui.bufferline.active" = { fg = "fg", bg = "bg3", modifiers = ["bold"] }
+"ui.popup" = { fg = "grey2", bg = "bg2" }
+"ui.window" = { fg = "grey0", bg = "bg0" }
+"ui.help" = { fg = "fg", bg = "bg2" }
 "ui.text" = "fg"
 "ui.text.focus" = "fg"
-"ui.menu" = { fg = "fg", bg = "bg2" }
+"ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
-"ui.selection" = { bg = "bg3" }
-"ui.virtual.whitespace" = "grey0"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.whitespace" = { fg = "bg4" }
+"ui.virtual.indent-guide" = { fg = "bg4" }
+"ui.virtual.ruler" = { bg = "bg3" }
 
 "hint" = "blue"
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { modifiers = ["underlined"] }
-
 
 [palette]
 


### PR DESCRIPTION
This syncs the latest version of the `everforest` theme, which I've kept up to date in my [theme repo](https://github.com/CptPotato/helix-themes).

It mostly adds missing theme keys and includes some smaller adjustments.

![image](https://user-images.githubusercontent.com/3957610/192589312-5d6ed85d-f41b-47b8-8700-f2a5ff1a8e9a.png)
*edit: for whatever reason GitHub slightly tints the image on upload, so this is not 100% accurate.*