### PR TITLE
Add :character-info command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -43,6 +43,7 @@
 | `:change-current-directory`, `:cd` | Change the current working directory. |
 | `:show-directory`, `:pwd` | Show the current working directory. |
 | `:encoding` | Set encoding. Based on `https://encoding.spec.whatwg.org`. |
+| `:character-info`, `:char` | Get info about the character under the primary cursor. |
 | `:reload` | Discard changes and reload from the source file. |
 | `:reload-all` | Discard changes and reload all documents from the source files. |
 | `:update` | Write changes only if the file has been modified. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1140,9 +1140,7 @@ fn get_character_info(
             );
 
             if let encoding::EncoderResult::Unmappable(char) = result {
-                cx.editor
-                    .set_error(format!("{char:?} cannot be mapped to {}", encoding.name()));
-                return Ok(());
+                bail!("{char:?} cannot be mapped to {}", encoding.name());
             }
 
             for byte in &bytes[current_byte..] {

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -354,3 +354,61 @@ async fn test_extend_line() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_character_info() -> anyhow::Result<()> {
+    // UTF-8, single byte
+    test_key_sequence(
+        &mut helpers::AppBuilder::new().build()?,
+        Some("ih<esc>h:char<ret>"),
+        Some(&|app| {
+            assert_eq!(
+                r#""h" (U+0068) Dec 104 Hex 68"#,
+                app.editor.get_status().unwrap().0
+            );
+        }),
+        false,
+    )
+    .await?;
+
+    // UTF-8, multi-byte
+    test_key_sequence(
+        &mut helpers::AppBuilder::new().build()?,
+        Some("ië<esc>h:char<ret>"),
+        Some(&|app| {
+            assert_eq!(
+                r#""ë" (U+0065 U+0308) Hex 65 + cc 88"#,
+                app.editor.get_status().unwrap().0
+            );
+        }),
+        false,
+    )
+    .await?;
+
+    // Multiple characters displayed as one, escaped characters
+    test_key_sequence(
+        &mut helpers::AppBuilder::new().build()?,
+        Some(":line<minus>ending crlf<ret>:char<ret>"),
+        Some(&|app| {
+            assert_eq!(
+                r#""\r\n" (U+000d U+000a) Hex 0d + 0a"#,
+                app.editor.get_status().unwrap().0
+            );
+        }),
+        false,
+    )
+    .await?;
+
+    // Non-UTF-8
+    test_key_sequence(
+        &mut helpers::AppBuilder::new().build()?,
+        Some(":encoding ascii<ret>ih<esc>h:char<ret>"),
+        Some(&|app| {
+            assert_eq!(r#""h" Dec 104 Hex 68"#, app.editor.get_status().unwrap().0);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This is my take on Vim's get ascii (<kbd>g</kbd><kbd>a</kbd>) / get utf8 (<kbd>g</kbd><kbd>8</kbd>) command. This works on graphemes not characters, so it correctly handles things like emoji with skin tone modifiers or characters with combining diacritics.

I'm open to opinions on what the output should look like. Atm, it outputs the decimal value only for single byte characters in an ascii-compatible encoding. For UTF-8, it also prints the decoded codepoints. (The decoder is based on [fasterthanlime's article](https://fasterthanli.me/articles/working-with-strings-in-rust) since I could not find anything in std or already in helix, or on crates.io for that matter, and it's pretty concise).

| Character | Encoding | Output |
|-|-|-|
| a | UTF-8 | `"a" (U+0061) Dec 97 Hex 61` |
| a | windows-1252 / extended ascii | `"a" Dec 97 Hex 61` |
| newline | UTF-8 | `"\n" (U+000a) Dec 10 Hex 0a` |
| CRLF | UTF-8 | `"\r\n" (U+000d U+000a) Hex 0d + 0a` |
| é | UTF-8 | `"é" (U+00e9) Hex c3 a9` |
| é | windows-1252 | `"é" Hex e9` |
| ë | UTF-8 | `"ë" (U+0065 U+0308) Hex 65 + cc 88` |
| 👍🏽 | UTF-8 | `"👍🏽" (U+1f44d U+1f3fd) Hex f0 9f 91 8d + f0 9f 8f bd` |

Remaining tasks:
- [x] Improve the help text
- [x] Replace `Debug` formatting of character with something more appropriate. `Debug` handles escaping non-printable & whitespace characters, but it also escapes the combining diaeresis on the ë…
	- Now the only escapes are `\0`, `\t`, `\n`, and `\r`
- [x] Tests

I'm not familiar with the codebase, so let me know if there's anything that could be more idiomatic. It does not have any tests yet, but it looks like most commands don't?

closes #3885