### PR TITLE
Fix signature help panic when too large

### DIFF
--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -68,8 +68,9 @@ impl Component for SignatureHelp {
 
         let (_, sig_text_height) = crate::ui::text::required_size(&sig_text, area.width);
         let sig_text_area = area.clip_top(1).with_height(sig_text_height);
+        let sig_text_area = sig_text_area.inner(&margin).intersection(surface.area);
         let sig_text_para = Paragraph::new(sig_text).wrap(Wrap { trim: false });
-        sig_text_para.render(sig_text_area.inner(&margin), surface);
+        sig_text_para.render(sig_text_area, surface);
 
         if self.signature_doc.is_none() {
             return;


### PR DESCRIPTION
When signature help is too large it may cause a panic when it is too large, now I just make the hover do an intersection with surface to make sure it never overflow.

How it looks like when it was fully expanded, cursor at the top.

![image](https://user-images.githubusercontent.com/4687791/193070315-a96c0e76-292d-43ab-b93e-455431531878.png)

But if the signature shows up at the bottom of the screen it will cause a panic since it is too huge.

<details><summary>stacktrace</summary>

```
thread 'main' panicked at 'Trying to access position outside the buffer: x=1, y=24, area=Rect { x: 0, y: 0, width: 80, height: 24 }', helix-tui/src/buffer.rs:218:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panicking.rs:143:14
   2: helix_tui::buffer::Buffer::index_of
             at /home/ivan/src/pickfire/rs/helix/helix-tui/src/buffer.rs:218:9
   3: <helix_tui::buffer::Buffer as core::ops::index::IndexMut<(u16,u16)>>::index_mut
             at /home/ivan/src/pickfire/rs/helix/helix-tui/src/buffer.rs:599:17
   4: helix_tui::buffer::Buffer::set_style
             at /home/ivan/src/pickfire/rs/helix/helix-tui/src/buffer.rs:458:17
   5: <helix_tui::widgets::paragraph::Paragraph as helix_tui::widgets::Widget>::render
             at /home/ivan/src/pickfire/rs/helix/helix-tui/src/widgets/paragraph.rs:137:9
   6: <helix_term::ui::lsp::SignatureHelp as helix_term::compositor::Component>::render
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/ui/lsp.rs:73:9
   7: <helix_term::ui::popup::Popup<T> as helix_term::compositor::Component>::render
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/ui/popup.rs:230:9
   8: helix_term::compositor::Compositor::render
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/compositor.rs:208:13
   9: helix_term::application::Application::render
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/application.rs:257:9
  10: helix_term::application::Application::event_loop_until_idle::{{closure}}
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/application.rs:319:21
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
  12: helix_term::application::Application::event_loop::{{closure}}
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/application.rs:268:57
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
  14: helix_term::application::Application::run::{{closure}}
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/application.rs:868:38
  15: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
  16: hx::main_impl::{{closure}}
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/main.rs:145:53
  17: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/future/mod.rs:91:19
  18: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/park/thread.rs:267:54
  19: tokio::coop::with_budget::{{closure}}
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/coop.rs:102:9
  20: std::thread::local::LocalKey<T>::try_with
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:442:16
  21: std::thread::local::LocalKey<T>::with
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/thread/local.rs:418:9
  22: tokio::coop::with_budget
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/coop.rs:95:5
  23: tokio::coop::budget
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/coop.rs:72:5
  24: tokio::park::thread::CachedParkThread::block_on
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/park/thread.rs:267:31
  25: tokio::runtime::enter::Enter::block_on
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/runtime/enter.rs:152:13
  26: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/runtime/scheduler/multi_thread/mod.rs:79:9
  27: tokio::runtime::Runtime::block_on
             at /home/ivan/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.1/src/runtime/mod.rs:492:44
  28: hx::main_impl
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/main.rs:147:5
  29: hx::main
             at /home/ivan/src/pickfire/rs/helix/helix-term/src/main.rs:37:21
  30: core::ops::function::FnOnce::call_once
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
</summary>

Side note, I will also look into manually triggering the signature help in insert mode, since I now disabled it due to the help flooding my screen and blocking my small terminal, and I can't see the text that I typed on previous line, haven't decided on the key yet.