### PR TITLE
Ensure cursor in view after format

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2504,14 +2504,16 @@ async fn make_format_callback(
 ) -> anyhow::Result<job::Callback> {
     let format = format.await?;
     let call: job::Callback = Box::new(move |editor, _compositor| {
-        let view_id = view!(editor).id;
         let scrolloff = editor.config().scrolloff;
-        let doc = doc_mut!(editor, &doc_id);
+        let doc = match editor.documents.get_mut(&doc_id) {
+            Some(doc) => doc,
+            None => return,
+        };
         let view = view_mut!(editor);
         if doc.version() == doc_version {
-            doc.apply(&format, view_id);
+            doc.apply(&format, view.id);
             view.ensure_cursor_in_view(doc, scrolloff);
-            doc.append_changes_to_history(view_id);
+            doc.append_changes_to_history(view.id);
             doc.detect_indent_and_line_ending();
             if let Modified::SetUnmodified = modified {
                 doc.reset_modified();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2504,17 +2504,18 @@ async fn make_format_callback(
 ) -> anyhow::Result<job::Callback> {
     let format = format.await?;
     let call: job::Callback = Box::new(move |editor, _compositor| {
+        if !editor.documents.contains_key(&doc_id) {
+            return;
+        }
+
         let scrolloff = editor.config().scrolloff;
-        let doc = match editor.documents.get_mut(&doc_id) {
-            Some(doc) => doc,
-            None => return,
-        };
+        let doc = doc_mut!(editor, &doc_id);
         let view = view_mut!(editor);
         if doc.version() == doc_version {
             doc.apply(&format, view.id);
-            view.ensure_cursor_in_view(doc, scrolloff);
             doc.append_changes_to_history(view.id);
             doc.detect_indent_and_line_ending();
+            view.ensure_cursor_in_view(doc, scrolloff);
             if let Modified::SetUnmodified = modified {
                 doc.reset_modified();
             }


### PR DESCRIPTION
addresses #4038 and "follow up" from PR #4043

credits to https://github.com/helix-editor/helix/pull/4043#pullrequestreview-1126084661 
I did not know that resetting the head would close the PR. Hope this is ok
