### PR TITLE
Support different kinds of underline rendering (updated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,12 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxterminfo"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da92c5e3aaf2cc1fea346d9b3bac0c59c6ffc1d1d46f18d991d449912a3e6f07"
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,10 +504,10 @@ dependencies = [
  "bitflags",
  "cassowary",
  "crossterm",
- "cxterminfo",
  "helix-core",
  "helix-view",
  "serde",
+ "termini",
  "unicode-segmentation",
 ]
 
@@ -1103,6 +1097,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termini"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00733d628ac0a8bd4fd3171a28eb6c09759ae1b43d8b587eadebaccee01d01a3"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxterminfo"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da92c5e3aaf2cc1fea346d9b3bac0c59c6ffc1d1d46f18d991d449912a3e6f07"
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +510,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "crossterm",
+ "cxterminfo",
  "helix-core",
  "helix-view",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "termini"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00733d628ac0a8bd4fd3171a28eb6c09759ae1b43d8b587eadebaccee01d01a3"
+checksum = "394766021ef3dae8077f080518cdf5360831990f77f5708d5e3594c9b3efa2f9"
 dependencies = [
  "dirs-next",
 ]

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -16,7 +16,7 @@ Each line in the theme file is specified as below:
 key = { fg = "#ffffff", bg = "#000000", underline-color = "#ff0000", underline-style = "curl", modifiers = ["bold", "italic"] }
 ```
 
-where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline_style` the underline style, `underline_color` the underline color (only meaningful if an underline style is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
+where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline-style` the underline style, `underline-color` the underline color (only meaningful if an underline style is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
 
 To specify only the foreground color:
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -13,10 +13,10 @@ The default theme.toml can be found [here](https://github.com/helix-editor/helix
 Each line in the theme file is specified as below:
 
 ```toml
-key = { fg = "#ffffff", bg = "#000000", underline = "#ff0000", modifiers = ["bold", "italic", "undercurled"] }
+key = { fg = "#ffffff", bg = "#000000", underline_color = "#ff0000", underline_style = "curl", modifiers = ["bold", "italic"] }
 ```
 
-where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline` the underline color (only meaningful if an underline modifier is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
+where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline_style` the underline style, `underline_color` the underline color (only meaningful if an underline style is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
 
 To specify only the foreground color:
 
@@ -83,15 +83,26 @@ Less common modifiers might not be supported by your terminal emulator.
 | `dim`                |
 | `italic`             |
 | `underlined`         |
-| `undercurled`        |
-| `underdashed`        |
-| `underdotted`        |
-| `double-underlined`  |
 | `slow_blink`         |
 | `rapid_blink`        |
 | `reversed`           |
 | `hidden`             |
 | `crossed_out`        |
+
+### Underline Style
+
+One of the following values may be used as an `underline_styles`. 
+
+Some styles might not be supported by your terminal emulator.
+
+| Modifier       |
+| ---            |
+| `line`         |
+| `curl`         |
+| `dashed`       |
+| `dot`          |
+| `double-line`  |
+
 
 ### Scopes
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -89,6 +89,9 @@ Less common modifiers might not be supported by your terminal emulator.
 | `hidden`             |
 | `crossed_out`        |
 
+> Note: The `underlined` modifier is deprecated and only available for backwards compatability.
+> It's behaviour is equivalent to `underline-style="line"`
+
 ### Underline Style
 
 One of the following values may be used as an `underline-style`. 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -13,10 +13,10 @@ The default theme.toml can be found [here](https://github.com/helix-editor/helix
 Each line in the theme file is specified as below:
 
 ```toml
-key = { fg = "#ffffff", bg = "#000000", modifiers = ["bold", "italic"] }
+key = { fg = "#ffffff", bg = "#000000", underline = "#ff0000", modifiers = ["bold", "italic", "undercurled"] }
 ```
 
-where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, and `modifiers` is a list of style modifiers. `bg` and `modifiers` can be omitted to defer to the defaults.
+where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline` the underline color (only meaningful if an underline modifier is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
 
 To specify only the foreground color:
 
@@ -77,17 +77,21 @@ The following values may be used as modifiers.
 
 Less common modifiers might not be supported by your terminal emulator.
 
-| Modifier       |
-| ---            |
-| `bold`         |
-| `dim`          |
-| `italic`       |
-| `underlined`   |
-| `slow_blink`   |
-| `rapid_blink`  |
-| `reversed`     |
-| `hidden`       |
-| `crossed_out`  |
+| Modifier             |
+| ---                  |
+| `bold`               |
+| `dim`                |
+| `italic`             |
+| `underlined`         |
+| `undercurled`        |
+| `underdashed`        |
+| `underdotted`        |
+| `double-underlined`  |
+| `slow_blink`         |
+| `rapid_blink`        |
+| `reversed`           |
+| `hidden`             |
+| `crossed_out`        |
 
 ### Scopes
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -90,7 +90,7 @@ Less common modifiers might not be supported by your terminal emulator.
 | `crossed_out`        |
 
 > Note: The `underlined` modifier is deprecated and only available for backwards compatability.
-> It's behaviour is equivalent to `underline-style="line"`
+> Its behaviour is equivalent to `underline-style="line"`.
 
 ### Underline Style
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -13,10 +13,10 @@ The default theme.toml can be found [here](https://github.com/helix-editor/helix
 Each line in the theme file is specified as below:
 
 ```toml
-key = { fg = "#ffffff", bg = "#000000", underline-color = "#ff0000", underline-style = "curl", modifiers = ["bold", "italic"] }
+key = { fg = "#ffffff", bg = "#000000", underline = { color = "#ff0000", style = "curl"}, modifiers = ["bold", "italic"] }
 ```
 
-where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline-style` the underline style, `underline-color` the underline color (only meaningful if an underline style is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
+where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline` the underline `style`/`color`, and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
 
 To specify only the foreground color:
 
@@ -89,12 +89,12 @@ Less common modifiers might not be supported by your terminal emulator.
 | `hidden`             |
 | `crossed_out`        |
 
-> Note: The `underlined` modifier is deprecated and only available for backwards compatability.
-> Its behaviour is equivalent to `underline-style="line"`.
+> Note: The `underlined` modifier is deprecated and only available for backwards compatibility.
+> Its behavior is equivalent to setting `underline.style="line"`.
 
 ### Underline Style
 
-One of the following values may be used as an `underline-style`. 
+One of the following values may be used as a value for `underline.style`. 
 
 Some styles might not be supported by your terminal emulator.
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -13,7 +13,7 @@ The default theme.toml can be found [here](https://github.com/helix-editor/helix
 Each line in the theme file is specified as below:
 
 ```toml
-key = { fg = "#ffffff", bg = "#000000", underline_color = "#ff0000", underline_style = "curl", modifiers = ["bold", "italic"] }
+key = { fg = "#ffffff", bg = "#000000", underline-color = "#ff0000", underline-style = "curl", modifiers = ["bold", "italic"] }
 ```
 
 where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline_style` the underline style, `underline_color` the underline color (only meaningful if an underline style is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
@@ -91,7 +91,7 @@ Less common modifiers might not be supported by your terminal emulator.
 
 ### Underline Style
 
-One of the following values may be used as an `underline_styles`. 
+One of the following values may be used as an `underline-style`. 
 
 Some styles might not be supported by your terminal emulator.
 
@@ -101,7 +101,7 @@ Some styles might not be supported by your terminal emulator.
 | `curl`         |
 | `dashed`       |
 | `dot`          |
-| `double-line`  |
+| `double_line`  |
 
 
 ### Scopes

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.10"
 crossterm = { version = "0.25", optional = true }
-cxterminfo = "0.2"
+termini = "0.1"
 serde = { version = "1", "optional" = true, features = ["derive"]}
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -20,6 +20,7 @@ bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.10"
 crossterm = { version = "0.25", optional = true }
+cxterminfo = "0.2"
 serde = { version = "1", "optional" = true, features = ["derive"]}
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -153,7 +153,7 @@ impl ModifierDiff {
         if removed.contains(Modifier::ITALIC) {
             map_error(queue!(w, SetAttribute(CAttribute::NoItalic)))?;
         }
-        if removed.contains(Modifier::UNDERLINED) {
+        if removed.intersects(Modifier::ANY_UNDERLINE) {
             map_error(queue!(w, SetAttribute(CAttribute::NoUnderline)))?;
         }
         if removed.contains(Modifier::DIM) {
@@ -178,6 +178,18 @@ impl ModifierDiff {
         }
         if added.contains(Modifier::UNDERLINED) {
             map_error(queue!(w, SetAttribute(CAttribute::Underlined)))?;
+        }
+        if added.contains(Modifier::UNDERCURLED) {
+            map_error(queue!(w, SetAttribute(CAttribute::Undercurled)))?;
+        }
+        if added.contains(Modifier::UNDERDOTTED) {
+            map_error(queue!(w, SetAttribute(CAttribute::Underdotted)))?;
+        }
+        if added.contains(Modifier::UNDERDASHED) {
+            map_error(queue!(w, SetAttribute(CAttribute::Underdashed)))?;
+        }
+        if added.contains(Modifier::DOUBLE_UNDERLINED) {
+            map_error(queue!(w, SetAttribute(CAttribute::DoubleUnderlined)))?;
         }
         if added.contains(Modifier::DIM) {
             map_error(queue!(w, SetAttribute(CAttribute::Dim)))?;

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -113,21 +113,21 @@ where
             }
 
             let mut new_underline_style = cell.underline_style;
-            if !self.capabilities.has_extended_underlines {
-                match new_underline_style {
-                    UnderlineStyle::Reset | UnderlineStyle::Line => (),
-                    _ => new_underline_style = UnderlineStyle::Line,
-                }
-
+            if self.capabilities.has_extended_underlines {
                 if cell.underline_color != underline_color {
                     let color = CColor::from(cell.underline_color);
                     map_error(queue!(self.buffer, SetUnderlineColor(color)))?;
                     underline_color = cell.underline_color;
                 }
+            } else {
+                match new_underline_style {
+                    UnderlineStyle::Reset | UnderlineStyle::Line => (),
+                    _ => new_underline_style = UnderlineStyle::Line,
+                }
             }
 
             if new_underline_style != underline_style {
-                let attr = CAttribute::from(cell.underline_style);
+                let attr = CAttribute::from(new_underline_style);
                 map_error(queue!(self.buffer, SetAttribute(attr)))?;
                 underline_style = new_underline_style;
             }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -27,13 +27,13 @@ impl Capabilities {
     /// on the $TERM environment variable. If detection fails, returns
     /// a default value where no capability is supported.
     pub fn from_env_or_default() -> Self {
-        match cxterminfo::terminfo::TermInfo::from_env() {
+        match termini::TermInfo::from_env() {
             Err(_) => Capabilities::default(),
             Ok(t) => Capabilities {
                 // Smulx, VTE: https://unix.stackexchange.com/a/696253/246284
                 // Su (used by kitty): https://sw.kovidgoyal.net/kitty/underlines
-                has_extended_underlines: t.get_ext_string("Smulx").is_some()
-                    || *t.get_ext_bool("Su").unwrap_or(&false)
+                has_extended_underlines: t.extended_cap("Smulx").is_some()
+                    || t.extended_cap("Su").is_some()
                     || vte_version() >= Some(5102),
             },
         }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -4,7 +4,7 @@ use crossterm::{
     execute, queue,
     style::{
         Attribute as CAttribute, Color as CColor, Print, SetAttribute, SetBackgroundColor,
-        SetForegroundColor,
+        SetForegroundColor, SetUnderlineColor,
     },
     terminal::{self, Clear, ClearType},
 };
@@ -47,6 +47,7 @@ where
     {
         let mut fg = Color::Reset;
         let mut bg = Color::Reset;
+        let mut underline = Color::Reset;
         let mut modifier = Modifier::empty();
         let mut last_pos: Option<(u16, u16)> = None;
         for (x, y, cell) in content {
@@ -72,6 +73,11 @@ where
                 let color = CColor::from(cell.bg);
                 map_error(queue!(self.buffer, SetBackgroundColor(color)))?;
                 bg = cell.bg;
+            }
+            if cell.underline != underline {
+                let color = CColor::from(cell.underline);
+                map_error(queue!(self.buffer, SetUnderlineColor(color)))?;
+                underline = cell.underline;
             }
 
             map_error(queue!(self.buffer, Print(&cell.symbol)))?;

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -3,7 +3,7 @@ use helix_core::unicode::width::UnicodeWidthStr;
 use std::cmp::min;
 use unicode_segmentation::UnicodeSegmentation;
 
-use helix_view::graphics::{Color, Modifier, Rect, Style};
+use helix_view::graphics::{Color, Modifier, Rect, Style, UnderlineStyle};
 
 /// A buffer cell
 #[derive(Debug, Clone, PartialEq)]
@@ -11,7 +11,8 @@ pub struct Cell {
     pub symbol: String,
     pub fg: Color,
     pub bg: Color,
-    pub underline: Color,
+    pub underline_color: Color,
+    pub underline_style: UnderlineStyle,
     pub modifier: Modifier,
 }
 
@@ -45,9 +46,13 @@ impl Cell {
         if let Some(c) = style.bg {
             self.bg = c;
         }
-        if let Some(c) = style.underline {
-            self.underline = c;
+        if let Some(c) = style.underline_color {
+            self.underline_color = c;
         }
+        if let Some(style) = style.underline_style {
+            self.underline_style = style;
+        }
+
         self.modifier.insert(style.add_modifier);
         self.modifier.remove(style.sub_modifier);
         self
@@ -57,7 +62,8 @@ impl Cell {
         Style::default()
             .fg(self.fg)
             .bg(self.bg)
-            .underline(self.underline)
+            .underline_color(self.underline_color)
+            .underline_style(self.underline_style)
             .add_modifier(self.modifier)
     }
 
@@ -66,7 +72,8 @@ impl Cell {
         self.symbol.push(' ');
         self.fg = Color::Reset;
         self.bg = Color::Reset;
-        self.underline = Color::Reset;
+        self.underline_color = Color::Reset;
+        self.underline_style = UnderlineStyle::Reset;
         self.modifier = Modifier::empty();
     }
 }
@@ -77,7 +84,8 @@ impl Default for Cell {
             symbol: " ".into(),
             fg: Color::Reset,
             bg: Color::Reset,
-            underline: Color::Reset,
+            underline_color: Color::Reset,
+            underline_style: UnderlineStyle::Reset,
             modifier: Modifier::empty(),
         }
     }
@@ -94,7 +102,7 @@ impl Default for Cell {
 ///
 /// ```
 /// use helix_tui::buffer::{Buffer, Cell};
-/// use helix_view::graphics::{Rect, Color, Style, Modifier};
+/// use helix_view::graphics::{Rect, Color, UnderlineStyle, Style, Modifier};
 ///
 /// let mut buf = Buffer::empty(Rect{x: 0, y: 0, width: 10, height: 5});
 /// buf[(0, 2)].set_symbol("x");
@@ -104,7 +112,8 @@ impl Default for Cell {
 ///     symbol: String::from("r"),
 ///     fg: Color::Red,
 ///     bg: Color::White,
-///     underline: Color::Reset,
+///     underline_color: Color::Reset,
+///     underline_style: UnderlineStyle::Reset,
 ///     modifier: Modifier::empty(),
 /// });
 /// buf[(5, 0)].set_char('x');

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -57,7 +57,7 @@ impl Cell {
         Style::default()
             .fg(self.fg)
             .bg(self.bg)
-            .underline(self.bg)
+            .underline(self.underline)
             .add_modifier(self.modifier)
     }
 
@@ -104,7 +104,8 @@ impl Default for Cell {
 ///     symbol: String::from("r"),
 ///     fg: Color::Red,
 ///     bg: Color::White,
-///     modifier: Modifier::empty()
+///     underline: Color::Reset,
+///     modifier: Modifier::empty(),
 /// });
 /// buf[(5, 0)].set_char('x');
 /// assert_eq!(buf[(5, 0)].symbol, "x");

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -11,6 +11,7 @@ pub struct Cell {
     pub symbol: String,
     pub fg: Color,
     pub bg: Color,
+    pub underline: Color,
     pub modifier: Modifier,
 }
 
@@ -44,6 +45,9 @@ impl Cell {
         if let Some(c) = style.bg {
             self.bg = c;
         }
+        if let Some(c) = style.underline {
+            self.underline = c;
+        }
         self.modifier.insert(style.add_modifier);
         self.modifier.remove(style.sub_modifier);
         self
@@ -53,6 +57,7 @@ impl Cell {
         Style::default()
             .fg(self.fg)
             .bg(self.bg)
+            .underline(self.bg)
             .add_modifier(self.modifier)
     }
 
@@ -61,6 +66,7 @@ impl Cell {
         self.symbol.push(' ');
         self.fg = Color::Reset;
         self.bg = Color::Reset;
+        self.underline = Color::Reset;
         self.modifier = Modifier::empty();
     }
 }
@@ -71,6 +77,7 @@ impl Default for Cell {
             symbol: " ".into(),
             fg: Color::Reset,
             bg: Color::Reset,
+            underline: Color::Reset,
             modifier: Modifier::empty(),
         }
     }

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -134,7 +134,8 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
-    ///                 underline: None,
+    ///                 underline_color: None,
+    ///                 underline_style: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -144,7 +145,8 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
-    ///                 underline: None,
+    ///                 underline_color: None,
+    ///                 underline_style: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -154,7 +156,8 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
-    ///                 underline: None,
+    ///                 underline_color: None,
+    ///                 underline_style: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -164,7 +167,8 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
-    ///                 underline: None,
+    ///                 underline_color: None,
+    ///                 underline_style: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -134,6 +134,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -143,6 +144,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -152,6 +154,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -161,6 +164,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -405,6 +405,7 @@ impl FromStr for Modifier {
 ///         fg: Some(Color::Yellow),
 ///         bg: Some(Color::Red),
 ///         add_modifier: Modifier::BOLD,
+///         underline: Some(Color::Reset),
 ///         sub_modifier: Modifier::empty(),
 ///     },
 ///     buffer[(0, 0)].style(),
@@ -429,6 +430,7 @@ impl FromStr for Modifier {
 ///     Style {
 ///         fg: Some(Color::Yellow),
 ///         bg: Some(Color::Reset),
+///         underline: Some(Color::Reset),
 ///         add_modifier: Modifier::empty(),
 ///         sub_modifier: Modifier::empty(),
 ///     },

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -440,6 +440,7 @@ impl FromStr for Modifier {
 pub struct Style {
     pub fg: Option<Color>,
     pub bg: Option<Color>,
+    pub underline: Option<Color>,
     pub add_modifier: Modifier,
     pub sub_modifier: Modifier,
 }
@@ -449,6 +450,7 @@ impl Default for Style {
         Style {
             fg: None,
             bg: None,
+            underline: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::empty(),
         }
@@ -461,6 +463,7 @@ impl Style {
         Style {
             fg: Some(Color::Reset),
             bg: Some(Color::Reset),
+            underline: Some(Color::Reset),
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::all(),
         }
@@ -493,6 +496,21 @@ impl Style {
     /// ```
     pub fn bg(mut self, color: Color) -> Style {
         self.bg = Some(color);
+        self
+    }
+
+    /// Changes the underline color.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use helix_view::graphics::{Color, Style};
+    /// let style = Style::default().underline(Color::Blue);
+    /// let diff = Style::default().underline(Color::Red);
+    /// assert_eq!(style.patch(diff), Style::default().underline(Color::Red));
+    /// ```
+    pub fn underline(mut self, color: Color) -> Style {
+        self.underline = Some(color);
         self
     }
 
@@ -552,6 +570,7 @@ impl Style {
     pub fn patch(mut self, other: Style) -> Style {
         self.fg = other.fg.or(self.fg);
         self.bg = other.bg.or(self.bg);
+        self.underline = other.underline.or(self.underline);
 
         self.add_modifier.remove(other.sub_modifier);
         self.add_modifier.insert(other.add_modifier);

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -327,17 +327,27 @@ bitflags! {
     ///
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "kebab-case"))]
     pub struct Modifier: u16 {
-        const BOLD              = 0b0000_0000_0001;
-        const DIM               = 0b0000_0000_0010;
-        const ITALIC            = 0b0000_0000_0100;
-        const UNDERLINED        = 0b0000_0000_1000;
-        const SLOW_BLINK        = 0b0000_0001_0000;
-        const RAPID_BLINK       = 0b0000_0010_0000;
-        const REVERSED          = 0b0000_0100_0000;
-        const HIDDEN            = 0b0000_1000_0000;
-        const CROSSED_OUT       = 0b0001_0000_0000;
+        const BOLD              = 0b0000_0000_0000_0001;
+        const DIM               = 0b0000_0000_0000_0010;
+        const ITALIC            = 0b0000_0000_0000_0100;
+        const UNDERLINED        = 0b0000_0000_0000_1000;
+        const SLOW_BLINK        = 0b0000_0000_0001_0000;
+        const RAPID_BLINK       = 0b0000_0000_0010_0000;
+        const REVERSED          = 0b0000_0000_0100_0000;
+        const HIDDEN            = 0b0000_0000_1000_0000;
+        const CROSSED_OUT       = 0b0000_0001_0000_0000;
+        const UNDERCURLED       = 0b0000_0010_0000_0000;
+        const UNDERDOTTED       = 0b0000_0100_0000_0000;
+        const UNDERDASHED       = 0b0000_1000_0000_0000;
+        const DOUBLE_UNDERLINED = 0b0001_0000_0000_0000;
+
+        const ANY_UNDERLINE     = Self::UNDERLINED.bits
+                                    | Self::UNDERCURLED.bits
+                                    | Self::UNDERDOTTED.bits
+                                    | Self::UNDERDASHED.bits
+                                    | Self::DOUBLE_UNDERLINED.bits;
     }
 }
 
@@ -355,6 +365,10 @@ impl FromStr for Modifier {
             "reversed" => Ok(Self::REVERSED),
             "hidden" => Ok(Self::HIDDEN),
             "crossed_out" => Ok(Self::CROSSED_OUT),
+            "undercurled" => Ok(Self::UNDERCURLED),
+            "underdotted" => Ok(Self::UNDERDOTTED),
+            "underdashed" => Ok(Self::UNDERDASHED),
+            "double_underlined" => Ok(Self::DOUBLE_UNDERLINED),
             _ => Err("Invalid modifier"),
         }
     }

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -365,16 +365,16 @@ bitflags! {
     ///
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "kebab-case"))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Modifier: u16 {
-        const BOLD              = 0b0000_0000_0000_0001;
-        const DIM               = 0b0000_0000_0000_0010;
-        const ITALIC            = 0b0000_0000_0000_0100;
-        const SLOW_BLINK        = 0b0000_0000_0001_0000;
-        const RAPID_BLINK       = 0b0000_0000_0010_0000;
-        const REVERSED          = 0b0000_0000_0100_0000;
-        const HIDDEN            = 0b0000_0000_1000_0000;
-        const CROSSED_OUT       = 0b0000_0001_0000_0000;
+        const BOLD              = 0b0000_0000_0001;
+        const DIM               = 0b0000_0000_0010;
+        const ITALIC            = 0b0000_0000_0100;
+        const SLOW_BLINK        = 0b0000_0001_0000;
+        const RAPID_BLINK       = 0b0000_0010_0000;
+        const REVERSED          = 0b0000_0100_0000;
+        const HIDDEN            = 0b0000_1000_0000;
+        const CROSSED_OUT       = 0b0001_0000_0000;
     }
 }
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::{
-    graphics::{Color, Modifier, Style},
+    graphics::{Color, Style, UnderlineStyle},
     Document, Editor, Theme, View,
 };
 
@@ -147,7 +147,7 @@ pub fn breakpoints<'doc>(
             .find(|breakpoint| breakpoint.line == line)?;
 
         let mut style = if breakpoint.condition.is_some() && breakpoint.log_message.is_some() {
-            error.add_modifier(Modifier::UNDERLINED)
+            error.underline_style(UnderlineStyle::Line)
         } else if breakpoint.condition.is_some() {
             error
         } else if breakpoint.log_message.is_some() {

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -277,8 +277,8 @@ impl ThemePalette {
                 match name.as_str() {
                     "fg" => *style = style.fg(self.parse_color(value)?),
                     "bg" => *style = style.bg(self.parse_color(value)?),
-                    "underline_color" => *style = style.underline_color(self.parse_color(value)?),
-                    "underline_style" => {
+                    "underline-color" => *style = style.underline_color(self.parse_color(value)?),
+                    "underline-style" => {
                         warn!("found style");
                         *style = style.underline_style(Self::parse_underline_style(&value)?)
                     }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -268,7 +268,7 @@ impl ThemePalette {
         value
             .as_str()
             .and_then(|s| s.parse().ok())
-            .ok_or(format!("Theme: invalid underline_style: {}", value))
+            .ok_or(format!("Theme: invalid underline-style: {}", value))
     }
 
     pub fn parse_style(&self, style: &mut Style, value: Value) -> Result<(), String> {
@@ -279,7 +279,6 @@ impl ThemePalette {
                     "bg" => *style = style.bg(self.parse_color(value)?),
                     "underline-color" => *style = style.underline_color(self.parse_color(value)?),
                     "underline-style" => {
-                        warn!("found style");
                         *style = style.underline_style(Self::parse_underline_style(&value)?)
                     }
                     "modifiers" => {

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer};
 use toml::Value;
 
+use crate::graphics::UnderlineStyle;
 pub use crate::graphics::{Color, Modifier, Style};
 
 pub static DEFAULT_THEME: Lazy<Theme> = Lazy::new(|| {
@@ -263,20 +264,38 @@ impl ThemePalette {
             .ok_or(format!("Theme: invalid modifier: {}", value))
     }
 
+    pub fn parse_underline_style(value: &Value) -> Result<UnderlineStyle, String> {
+        value
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .ok_or(format!("Theme: invalid underline_style: {}", value))
+    }
+
     pub fn parse_style(&self, style: &mut Style, value: Value) -> Result<(), String> {
         if let Value::Table(entries) = value {
             for (name, value) in entries {
                 match name.as_str() {
                     "fg" => *style = style.fg(self.parse_color(value)?),
                     "bg" => *style = style.bg(self.parse_color(value)?),
-                    "underline" => *style = style.underline(self.parse_color(value)?),
+                    "underline_color" => *style = style.underline_color(self.parse_color(value)?),
+                    "underline_style" => {
+                        warn!("found style");
+                        *style = style.underline_style(Self::parse_underline_style(&value)?)
+                    }
                     "modifiers" => {
                         let modifiers = value
                             .as_array()
                             .ok_or("Theme: modifiers should be an array")?;
 
                         for modifier in modifiers {
-                            *style = style.add_modifier(Self::parse_modifier(modifier)?);
+                            if modifier
+                                .as_str()
+                                .map_or(false, |modifier| modifier == "underlined")
+                            {
+                                *style = style.underline_style(UnderlineStyle::Line);
+                            } else {
+                                *style = style.add_modifier(Self::parse_modifier(modifier)?);
+                            }
                         }
                     }
                     _ => return Err(format!("Theme: invalid style attribute: {}", name)),

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -268,18 +268,29 @@ impl ThemePalette {
         value
             .as_str()
             .and_then(|s| s.parse().ok())
-            .ok_or(format!("Theme: invalid underline-style: {}", value))
+            .ok_or(format!("Theme: invalid underline style: {}", value))
     }
 
     pub fn parse_style(&self, style: &mut Style, value: Value) -> Result<(), String> {
         if let Value::Table(entries) = value {
-            for (name, value) in entries {
+            for (name, mut value) in entries {
                 match name.as_str() {
                     "fg" => *style = style.fg(self.parse_color(value)?),
                     "bg" => *style = style.bg(self.parse_color(value)?),
-                    "underline-color" => *style = style.underline_color(self.parse_color(value)?),
-                    "underline-style" => {
-                        *style = style.underline_style(Self::parse_underline_style(&value)?)
+                    "underline" => {
+                        let table = value
+                            .as_table_mut()
+                            .ok_or("Theme: underline must be table")?;
+                        if let Some(value) = table.remove("color") {
+                            *style = style.underline_color(self.parse_color(value)?);
+                        }
+                        if let Some(value) = table.remove("style") {
+                            *style = style.underline_style(Self::parse_underline_style(&value)?);
+                        }
+
+                        if let Some(attr) = table.keys().next() {
+                            return Err(format!("Theme: invalid underline attribute: {attr}"));
+                        }
                     }
                     "modifiers" => {
                         let modifiers = value

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -269,6 +269,7 @@ impl ThemePalette {
                 match name.as_str() {
                     "fg" => *style = style.fg(self.parse_color(value)?),
                     "bg" => *style = style.bg(self.parse_color(value)?),
+                    "underline" => *style = style.underline(self.parse_color(value)?),
                     "modifiers" => {
                         let modifiers = value
                             .as_array()

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -92,7 +92,8 @@
 "info" = { fg = "light_blue" }
 "hint" = { fg = "light_gray3" }
 
-diagnostic = { modifiers = ["underlined"] }
+"diagnostic.error" = {underline = "red", modifiers = ["undercurled"] }
+"diagnostic" = {underline = "gold", modifiers = ["undercurled"] }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -92,8 +92,8 @@
 "info" = { fg = "light_blue" }
 "hint" = { fg = "light_gray3" }
 
-"diagnostic.error" = {underline = "red", modifiers = ["undercurled"] }
-"diagnostic" = {underline = "gold", modifiers = ["undercurled"] }
+"diagnostic.error" = {underline_color = "red", underline_style = "curl"}
+"diagnostic" = {underline_color = "gold", underline_style = "curl" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -92,8 +92,8 @@
 "info" = { fg = "light_blue" }
 "hint" = { fg = "light_gray3" }
 
-"diagnostic.error" = {underline-color = "red", underline-style = "curl"}
-"diagnostic" = {underline-color = "gold", underline-style = "curl" }
+"diagnostic.error".underline = { color = "red", style = "curl" }
+"diagnostic".underline = { color = "gold", style = "curl" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -92,8 +92,8 @@
 "info" = { fg = "light_blue" }
 "hint" = { fg = "light_gray3" }
 
-"diagnostic.error" = {underline_color = "red", underline_style = "curl"}
-"diagnostic" = {underline_color = "gold", underline_style = "curl" }
+"diagnostic.error" = {underline-color = "red", underline-style = "curl"}
+"diagnostic" = {underline-color = "gold", underline-style = "curl" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -39,10 +39,10 @@
 "diff.delta" = "gold"
 "diff.minus" = "red"
 
-"diagnostic.info" = { underline = "blue", modifiers = ["undercurled"] }
-"diagnostic.hint" = { underline = "green", modifiers = ["undercurled"] }
-"diagnostic.warning" = { underline = "yellow", modifiers = ["undercurled"] }
-"diagnostic.error" = { underline = "red", modifiers = ["undercurled"] }
+"diagnostic.info" = { underline_color = "blue", underline_style = "curl" }
+"diagnostic.hint" = { underline_color = "green", underline_style = "curl" }
+"diagnostic.warning" = { underline_color = "yellow", underline_style = "curl" }
+"diagnostic.error" = { underline_color = "red", underline_style = "curl" }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -39,10 +39,10 @@
 "diff.delta" = "gold"
 "diff.minus" = "red"
 
-"diagnostic.info" = { underline-color = "blue", underline-style = "curl" }
-"diagnostic.hint" = { underline-color = "green", underline-style = "curl" }
-"diagnostic.warning" = { underline-color = "yellow", underline-style = "curl" }
-"diagnostic.error" = { underline-color = "red", underline-style = "curl" }
+"diagnostic.info".underline = { color = "blue", style = "curl" } 
+"diagnostic.hint".underline = { color = "green", style = "curl" } 
+"diagnostic.warning".underline = { color = "yellow", style = "curl" } 
+"diagnostic.error".underline = { color = "red", style = "curl" } 
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -39,7 +39,7 @@
 "diff.delta" = "gold"
 "diff.minus" = "red"
 
-diagnostic = { modifiers = ["underlined"] }
+diagnostic = { modifiers = ["undercurled"] }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -39,10 +39,10 @@
 "diff.delta" = "gold"
 "diff.minus" = "red"
 
-"diagnostic.info" = { underline_color = "blue", underline_style = "curl" }
-"diagnostic.hint" = { underline_color = "green", underline_style = "curl" }
-"diagnostic.warning" = { underline_color = "yellow", underline_style = "curl" }
-"diagnostic.error" = { underline_color = "red", underline_style = "curl" }
+"diagnostic.info" = { underline-color = "blue", underline-style = "curl" }
+"diagnostic.hint" = { underline-color = "green", underline-style = "curl" }
+"diagnostic.warning" = { underline-color = "yellow", underline-style = "curl" }
+"diagnostic.error" = { underline-color = "red", underline-style = "curl" }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -39,7 +39,10 @@
 "diff.delta" = "gold"
 "diff.minus" = "red"
 
-diagnostic = { modifiers = ["undercurled"] }
+"diagnostic.info" = { underline = "blue", modifiers = ["undercurled"] }
+"diagnostic.hint" = { underline = "green", modifiers = ["undercurled"] }
+"diagnostic.warning" = { underline = "yellow", modifiers = ["undercurled"] }
+"diagnostic.error" = { underline = "red", modifiers = ["undercurled"] }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }


### PR DESCRIPTION
Supersedes  #3015 (and closes #2809).

I have rebased the original PR on master and addressed the issues raised in the original PR.
The reasons for the disappearing undercurls/underlines was that the orignal PR
treated them as modifiers. However, underlines styles behave more like colors than modifiers:
There are multiple different underline styles that are incompatible, overwrite each other and
are removed with a single escape sequence.
Modifiers on the other hand can be added and removed independent of other modifiers.

Tracking underline styles in the modifier set can not work correctly.
The fix suggested by @archseer of only emitting `NoUnderline` if there is no
underline left in `to` does not work for nested highlights.
Consider the following example of 3 nested highlights (underline used by syntax highlight, underdotted used by diagnostic, undercurl used by cursor):

The input highlight ranges look like this (which correspond to the modifier sets)

```
  ~
 ...
______
foobar
```

The expected output looks like this:

```
foobar
_.~.__
```

The corresponding escape sequences look like this:

```
[_]f[.]o[~]o[.]b[_]ar[nounderline]
```

From the `modifier` set it is not possible to build these escape sequences.
Because the modifier set only contains which modifiers are present but not
the order in which they were added removed (so after the `foo` it's impossible
to determine which underline should be shown).

This example might seem contrived, but I noticed this almost immediately in real world use.
To fix the problems in the original PR I renamed the `underline` style attribute to `underline_color`
and added the `underline_style` attribute for underline styles.
Now underline styles are tracked through the same mechanisms that `fg`/`bg`/`underline-color` are tracked
and therefore cases with nested highlights are handled correctly.

To esnure backwards compatibility of themes the `underlined` modifier will keep working and is equivalent to `underline-style="line"`

Edit:  This updated PR also improves upon the original PR by using a much more robust terminfo parsing library (called `termini` written by me), because `cxterminfo` was barely tested and caused crashes. Furthermore a workaround for an issue in crossterm was implemented that caused visual artifacts in terminal emulators that do not support underline colors.