### PR TITLE
rust: Highlight function signatures as functions

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -253,6 +253,9 @@
 (function_item
   name: (identifier) @function)
 
+(function_signature_item
+  name: (identifier) @function)
+
 ; ---
 ; Macros
 ; ---


### PR DESCRIPTION
This stanza highlights functions within trait definitions. For example, in:

```rust
pub trait Widget {
    fn render(self, area: Rect, buf: &mut Buffer);
}
```

`render` is currently highlighted as a variable. With this change it's highlighted as a function.