### PR TITLE
Automatically track pseudo-pending text

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -652,7 +652,6 @@ pub struct Editor {
 
     pub idle_timer: Pin<Box<Sleep>>,
     pub last_motion: Option<Motion>,
-    pub pseudo_pending: Option<String>,
 
     pub last_completion: Option<CompleteAction>,
 
@@ -724,7 +723,6 @@ impl Editor {
             idle_timer: Box::pin(sleep(conf.idle_timeout)),
             last_motion: None,
             last_completion: None,
-            pseudo_pending: None,
             config,
             auto_pairs,
             exit_code: 0,


### PR DESCRIPTION
This change automatically tracks pending text for for commands which use on-next-key callbacks. For example, `t` will await the next key event and "t" will be shown in the bottom right-hand corner to show that we're in a pending state.

Previously, the text for these on-next-key commands needed to be hard-coded into the command definition which had some drawbacks:

* It was easy to forget to write and clear the pending text.
* If a command was remapped in a custom config, the pending text would still show the old key.

With this change, pending text is automatically tracked based on the key events that lead to the command being executed. This works even when the command is remapped in config and when the on-next-key callback is nested under some key sequence (for example `mi`).

Closes https://github.com/helix-editor/helix/pull/3381
Closes https://github.com/helix-editor/helix/issues/3223