### PR TITLE
Update treesitter markdown

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -923,7 +923,7 @@ grammar = "markdown_inline"
 
 [[grammar]]
 name = "markdown_inline"
-source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b", subpath = "tree-sitter-markdown-inline" }
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "d5740f0fe4b8e4603f2229df107c5c9ef5eec389", subpath = "tree-sitter-markdown-inline" }
 
 [[language]]
 name = "dart"

--- a/languages.toml
+++ b/languages.toml
@@ -911,7 +911,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "markdown"
-source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b", subpath = "tree-sitter-markdown" }
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "d5740f0fe4b8e4603f2229df107c5c9ef5eec389", subpath = "tree-sitter-markdown" }
 
 [[language]]
 name = "markdown.inline"

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -7,6 +7,8 @@
 
 ((html_block) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
 
+((pipe_table_cell) @injection.content (#set! injection.language "markdown.inline") (#set! injection.include-unnamed-children))
+
 ((minus_metadata) @injection.content (#set! injection.language "yaml") (#set! injection.include-unnamed-children))
 ((plus_metadata) @injection.content (#set! injection.language "toml") (#set! injection.include-unnamed-children))
 


### PR DESCRIPTION
Fixes broken table highlighting: https://github.com/helix-editor/helix/issues/3849

[MDeiml](https://github.com/MDeiml), the creator of the treesitter syntax said there was no need to update any queries:

>Updating to the latest commit helped, because I added support for tables. The queries should be fine. You would only need to change them if you wanted some special highlighting for tables.