### PR TITLE
Fix C++ syntax highlighting, and improve C & WGSL highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -221,7 +221,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "cpp"
-source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "f40125503642845492d87fa56ece3ed26a4ef4db" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "d5e90fba898f320db48d81ddedd78d52c67c1fed" }
 
 [[language]]
 name = "c-sharp"

--- a/languages.toml
+++ b/languages.toml
@@ -184,7 +184,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "c"
-source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "f05e279aedde06a25801c3f2b2cc8ac17fac52ae" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "7175a6dd5fc1cee660dce6fe23f6043d75af424a" }
 
 [[language]]
 name = "cpp"
@@ -221,7 +221,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "cpp"
-source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "e8dcc9d2b404c542fd236ea5f7208f90be8a6e89" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "f40125503642845492d87fa56ece3ed26a4ef4db" }
 
 [[language]]
 name = "c-sharp"

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -105,9 +105,6 @@
 (number_literal) @constant.numeric.integer
 (char_literal) @constant.character
 
-((identifier) @constant
-  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
-
 (call_expression
   function: (identifier) @function)
 (call_expression
@@ -123,36 +120,16 @@
     declarator: (identifier) @variable.parameter))
 (preproc_function_def
   name: (identifier) @function.special)
-; (preproc_arg) @error
 
 (field_identifier) @variable.other.member
 (statement_identifier) @label
-(struct_specifier) @type
-(type_definition) @type
 (type_identifier) @type
 (primitive_type) @type.builtin
 (sized_type_specifier) @type
 
-(init_declarator (identifier) @variable)
-(binary_expression left: (identifier) @variable)
-(binary_expression right: (identifier) @variable)
-(compound_statement (declaration (identifier) @variable))
-(for_statement (declaration (identifier) @variable))
-(field_expression (identifier) @variable)
-(pointer_declarator (identifier) @variable)
-(pointer_expression (identifier) @variable)
-(assignment_expression (identifier) @variable)
-(unary_expression (identifier) @variable)
-(sizeof_expression (parenthesized_expression (identifier) @type))
-(parenthesized_expression (identifier) @variable)
-(initializer_list (identifier) @variable)
-(initializer_pair (identifier) @variable)
-(return_statement (identifier) @variable)
-(subscript_expression (identifier) @variable)
-(cast_expression (identifier) @variable)
-(update_expression (identifier) @variable)
-(conditional_expression (identifier) @variable)
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
 
-; (identifier) @error
+(identifier) @variable
 
 (comment) @comment

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -96,7 +96,7 @@
 
 [(true) (false)] @constant.builtin.boolean
 
-(enumerator) @type.enum.variant
+(enumerator name: (identifier) @type.enum.variant)
 
 (string_literal) @string
 (system_lib_string) @string

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -1,17 +1,22 @@
-(storage_class_specifier) @keyword.storage
+[
+  "sizeof"
+] @keyword
 
 [
-  "register"
-  "const"
   "enum"
+  "struct"
+  "union"
+] @keyword.storage.type
+
+[
+  "const"
   "extern"
   "inline"
-  "sizeof"
-  "struct"
+  "register"
   "typedef"
-  "union"
   "volatile"
-] @keyword
+  (storage_class_specifier)
+] @keyword.storage.modifier
 
 [
   "for"
@@ -46,25 +51,43 @@
 ] @keyword.directive
 
 [
-  "--"
-  "-"
-  "-="
-  "->"
-  "="
-  "!="
-  "*"
-  "&"
-  "&&"
   "+"
+  "-"
+  "*"
+  "/"
   "++"
-  "+="
-  "<"
+  "--"
+  "%"
   "=="
+  "!="
   ">"
-  "||"
+  "<"
   ">="
   "<="
+  "&&"
+  "||"
+  "!"
+  "&"
+  "|"
+  "^"
+  "~"
+  "<<"
+  ">>"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "<<="
+  ">>="
+  "&="
+  "^="
+  "|="
+  "->"
   "::"
+  "?"
+  "..."
 ] @operator
 
 ["," "." ":" ";"] @punctuation.delimiter
@@ -87,14 +110,16 @@
 (call_expression
   function: (field_expression
     field: (field_identifier) @function))
-(function_declarator) @function
 (function_declarator
-  parameters: (parameter_list) @variable.parameter)
+  declarator: (identifier) @function)
+(parameter_declaration
+  declarator: (identifier) @variable.parameter)
+(parameter_declaration
+  (pointer_declarator
+    declarator: (identifier) @variable.parameter))
 (preproc_function_def
   name: (identifier) @function.special)
 
-(compound_statement) @variable
-(init_declarator) @variable
 (field_identifier) @variable.other.member
 (statement_identifier) @label
 (struct_specifier) @type
@@ -105,5 +130,7 @@
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+
+(identifier) @variable
 
 (comment) @comment

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -105,13 +105,17 @@
 (number_literal) @constant.numeric.integer
 (char_literal) @constant.character
 
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+
 (call_expression
   function: (identifier) @function)
 (call_expression
   function: (field_expression
     field: (field_identifier) @function))
+(call_expression (argument_list (identifier) @variable))
 (function_declarator
-  declarator: (identifier) @function)
+  declarator: [(identifier) (field_identifier)] @function)
 (parameter_declaration
   declarator: (identifier) @variable.parameter)
 (parameter_declaration
@@ -119,6 +123,7 @@
     declarator: (identifier) @variable.parameter))
 (preproc_function_def
   name: (identifier) @function.special)
+; (preproc_arg) @error
 
 (field_identifier) @variable.other.member
 (statement_identifier) @label
@@ -128,9 +133,26 @@
 (primitive_type) @type.builtin
 (sized_type_specifier) @type
 
-((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+(init_declarator declarator: (identifier) @variable)
+(binary_expression left: (identifier) @variable)
+(binary_expression right: (identifier) @variable)
+(compound_statement (declaration (identifier) @variable))
+(for_statement (declaration (identifier) @variable))
+(field_expression (identifier) @variable)
+(pointer_declarator (identifier) @variable)
+(pointer_expression (identifier) @variable)
+(assignment_expression (identifier) @variable)
+(unary_expression (identifier) @variable)
+(sizeof_expression (parenthesized_expression (identifier) @type))
+(parenthesized_expression (identifier) @variable)
+(initializer_list (identifier) @variable)
+(initializer_pair (identifier) @variable)
+(return_statement (identifier) @variable)
+(subscript_expression (identifier) @variable)
+(cast_expression (identifier) @variable)
+(update_expression (identifier) @variable)
+(conditional_expression (identifier) @variable)
 
-(identifier) @variable
+; (identifier) @error
 
 (comment) @comment

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -88,6 +88,8 @@
   "?"
 ] @operator
 
+(conditional_expression ":" @operator)
+
 "..." @punctuation
 
 ["," "." ":" ";" "->" "::"] @punctuation.delimiter

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -121,6 +121,9 @@
 (preproc_function_def
   name: (identifier) @function.special)
 
+(attribute
+  name: (identifier) @attribute)
+
 (field_identifier) @variable.other.member
 (statement_identifier) @label
 (type_identifier) @type

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -133,7 +133,7 @@
 (primitive_type) @type.builtin
 (sized_type_specifier) @type
 
-(init_declarator declarator: (identifier) @variable)
+(init_declarator (identifier) @variable)
 (binary_expression left: (identifier) @variable)
 (binary_expression right: (identifier) @variable)
 (compound_statement (declaration (identifier) @variable))

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -1,10 +1,9 @@
-[
-  "sizeof"
-] @keyword
+"sizeof" @keyword
 
 [
   "enum"
   "struct"
+  "typedef"
   "union"
 ] @keyword.storage.type
 
@@ -13,21 +12,23 @@
   "extern"
   "inline"
   "register"
-  "typedef"
   "volatile"
   (storage_class_specifier)
 ] @keyword.storage.modifier
 
 [
-  "for"
-  "do"
-  "while"
+  "goto"
   "break"
   "continue"
+] @keyword.control
+
+[
+  "do"
+  "for"
+  "while"
 ] @keyword.control.repeat
 
 [
-  "goto"
   "if"
   "else"
   "switch"
@@ -84,13 +85,12 @@
   "&="
   "^="
   "|="
-  "->"
-  "::"
   "?"
-  "..."
 ] @operator
 
-["," "." ":" ";"] @punctuation.delimiter
+"..." @punctuation
+
+["," "." ":" ";" "->" "::"] @punctuation.delimiter
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -1,61 +1,75 @@
 (storage_class_specifier) @keyword.storage
 
-"goto" @keyword
-"register" @keyword
-"break" @keyword
-"case" @keyword
-"continue" @keyword
-"default" @keyword
-"do" @keyword
-"else" @keyword
-"enum" @keyword
-"extern" @keyword
-"for" @keyword
-"if" @keyword
-"inline" @keyword
-"return" @keyword
-"sizeof" @keyword
-"struct" @keyword
-"switch" @keyword
-"typedef" @keyword
-"union" @keyword
-"volatile" @keyword
-"while" @keyword
-"const" @keyword
+[
+  "register"
+  "const"
+  "enum"
+  "extern"
+  "inline"
+  "sizeof"
+  "struct"
+  "typedef"
+  "union"
+  "volatile"
+] @keyword
 
 [
- "#define"
- "#elif"
- "#else"
- "#endif"
- "#if"
- "#ifdef"
- "#ifndef"
- "#include"
- (preproc_directive)
+  "for"
+  "do"
+  "while"
+  "break"
+  "continue"
+] @keyword.control.repeat
+
+[
+  "goto"
+  "if"
+  "else"
+  "switch"
+  "case"
+  "default"
+] @keyword.control.conditional
+
+"return" @keyword.control.return
+
+[
+  "defined"
+  "#define"
+  "#elif"
+  "#else"
+  "#endif"
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#include"
+  (preproc_directive)
 ] @keyword.directive
 
-"--" @operator
-"-" @operator
-"-=" @operator
-"->" @operator
-"=" @operator
-"!=" @operator
-"*" @operator
-"&" @operator
-"&&" @operator
-"+" @operator
-"++" @operator
-"+=" @operator
-"<" @operator
-"==" @operator
-">" @operator
-"||" @operator
-">=" @operator
-"<=" @operator
+[
+  "--"
+  "-"
+  "-="
+  "->"
+  "="
+  "!="
+  "*"
+  "&"
+  "&&"
+  "+"
+  "++"
+  "+="
+  "<"
+  "=="
+  ">"
+  "||"
+  ">="
+  "<="
+  "::"
+] @operator
 
-"." @punctuation.delimiter
-";" @punctuation.delimiter
+["," "." ":" ";"] @punctuation.delimiter
+
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [(true) (false)] @constant.builtin.boolean
 
@@ -73,20 +87,23 @@
 (call_expression
   function: (field_expression
     field: (field_identifier) @function))
+(function_declarator) @function
 (function_declarator
-  declarator: (identifier) @function)
+  parameters: (parameter_list) @variable.parameter)
 (preproc_function_def
   name: (identifier) @function.special)
 
+(compound_statement) @variable
+(init_declarator) @variable
 (field_identifier) @variable.other.member
 (statement_identifier) @label
+(struct_specifier) @type
+(type_definition) @type
 (type_identifier) @type
-(primitive_type) @type
+(primitive_type) @type.builtin
 (sized_type_specifier) @type
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
-
-(identifier) @variable
 
 (comment) @comment

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -12,13 +12,6 @@
 (template_method
   name: (field_identifier) @function)
 
-(template_function
-  name: (identifier) @function)
-
-(function_declarator
-  declarator: (qualified_identifier
-    name: (identifier) @function))
-
 (function_declarator
   declarator: (qualified_identifier
     name: (identifier) @function))
@@ -28,9 +21,7 @@
 
 ; Types
 
-((namespace_identifier) @type
- (#match? @type "^[A-Z]"))
-
+(namespace_identifier) @namespace
 (auto) @type
 
 ; Constants
@@ -40,27 +31,36 @@
 
 ; Keywords
 
-"catch" @keyword
-"class" @keyword
-"constexpr" @keyword
-"delete" @keyword
-"explicit" @keyword
-"final" @keyword
-"friend" @keyword
-"mutable" @keyword
-"namespace" @keyword
-"noexcept" @keyword
-"new" @keyword
-"override" @keyword
-"private" @keyword
-"protected" @keyword
-"public" @keyword
-"template" @keyword
-"throw" @keyword
-"try" @keyword
-"typename" @keyword
-"using" @keyword
-"virtual" @keyword
+[
+ "catch"
+ "class"
+ "co_await"
+ "co_return"
+ "co_yield"
+ "constexpr"
+ "constinit"
+ "consteval"
+ "delete"
+ "explicit"
+ "final"
+ "friend"
+ "mutable"
+ "namespace"
+ "noexcept"
+ "new"
+ "override"
+ "private"
+ "protected"
+ "public"
+ "template"
+ "throw"
+ "try"
+ "typename"
+ "using"
+ "virtual"
+ "concept"
+ "requires"
+] @keyword
 
 ; Strings
 

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -13,8 +13,11 @@
   name: (field_identifier) @function)
 
 (function_declarator
-  declarator: (qualified_identifier
-    name: (identifier) @function))
+  (qualified_identifier (identifier) @function))
+
+(function_declarator
+  (qualified_identifier
+    (qualified_identifier (identifier) @function)))
 
 (function_declarator
   declarator: (field_identifier) @function)
@@ -71,3 +74,5 @@
 ; Strings
 
 (raw_string_literal) @string
+
+(identifier) @variable

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -24,8 +24,9 @@
 
 ; Types
 
+(using_declaration ("using" "namespace" (identifier) @namespace))
+(using_declaration ("using" "namespace" (qualified_identifier name: (identifier) @namespace)))
 (namespace_definition name: (identifier) @namespace)
-(using_declaration (identifier) @namespace)
 (namespace_identifier) @namespace
 
 (qualified_identifier name: (identifier) @type.enum.variant)
@@ -37,26 +38,38 @@
 
 ; Keywords
 
+(template_argument_list (["<" ">"] @punctuation.bracket))
+(template_parameter_list (["<" ">"] @punctuation.bracket))
+(default_method_clause "default" @keyword)
+
+"static_assert" @function.special
+
 [
-  "catch"
+  "<=>"
+  "[]"
+  "()"
+] @operator
+
+[
   "co_await"
   "co_return"
   "co_yield"
   "concept"
-  "consteval"
-  "constinit"
   "delete"
   "final"
-  "noexcept"
   "new"
+  "operator"
   "requires"
-  "throw"
-  "try"
-  "typename"
   "using"
 ] @keyword
 
-"<=>" @operator
+[
+  "catch"
+  "noexcept"
+  "throw"
+  "try"
+] @keyword.control.exception
+
 
 [
   "and"
@@ -73,7 +86,9 @@
 
 [
   "class"
+  "decltype"
   "namespace"
+  "typename"
   (auto)
 ] @keyword.storage.type
 

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -24,8 +24,11 @@
 
 ; Types
 
+(namespace_definition name: (identifier) @namespace)
+(using_declaration (identifier) @namespace)
 (namespace_identifier) @namespace
-(auto) @type
+
+(qualified_identifier name: (identifier) @type.enum.variant)
 
 ; Constants
 
@@ -56,20 +59,22 @@
 "<=>" @operator
 
 [
-  "or"
   "and"
-  "bitor"
-  "xor"
-  "bitand"
-  "not_eq"
   "and_eq"
+  "bitor"
+  "bitand"
+  "not"
+  "not_eq"
+  "or"
   "or_eq"
+  "xor"
   "xor_eq"
 ] @keyword.operator
 
 [
   "class"
   "namespace"
+  (auto)
 ] @keyword.storage.type
 
 [

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -27,40 +27,46 @@
 ; Constants
 
 (this) @variable.builtin
-(nullptr) @constant
+(nullptr) @constant.builtin
 
 ; Keywords
 
 [
- "catch"
- "class"
- "co_await"
- "co_return"
- "co_yield"
- "constexpr"
- "constinit"
- "consteval"
- "delete"
- "explicit"
- "final"
- "friend"
- "mutable"
- "namespace"
- "noexcept"
- "new"
- "override"
- "private"
- "protected"
- "public"
- "template"
- "throw"
- "try"
- "typename"
- "using"
- "virtual"
- "concept"
- "requires"
+  "catch"
+  "co_await"
+  "co_return"
+  "co_yield"
+  "concept"
+  "delete"
+  "final"
+  "noexcept"
+  "new"
+  "requires"
+  "throw"
+  "try"
+  "typename"
+  "using"
 ] @keyword
+
+[
+  "class"
+  "namespace"
+] @keyword.storage.type
+
+[
+  "constexpr"
+  "constinit"
+  "consteval"
+  "explicit"
+  "friend"
+  "mutable"
+  "private"
+  "protected"
+  "public"
+  "override"
+  "template"
+  "virtual"
+] @keyword.storage.modifier
 
 ; Strings
 

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -1,5 +1,3 @@
-; inherits: c
-
 ; Functions
 
 (call_expression
@@ -13,11 +11,13 @@
   name: (field_identifier) @function)
 
 (function_declarator
-  (qualified_identifier (identifier) @function))
+  declarator: (qualified_identifier
+    name: (identifier) @function))
 
 (function_declarator
-  (qualified_identifier
-    (qualified_identifier (identifier) @function)))
+  declarator: (qualified_identifier
+    name: (qualified_identifier
+      name: (identifier) @function)))
 
 (function_declarator
   declarator: (field_identifier) @function)
@@ -75,4 +75,4 @@
 
 (raw_string_literal) @string
 
-(identifier) @variable
+; inherits: c

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -40,6 +40,8 @@
   "co_return"
   "co_yield"
   "concept"
+  "consteval"
+  "constinit"
   "delete"
   "final"
   "noexcept"
@@ -50,6 +52,20 @@
   "typename"
   "using"
 ] @keyword
+
+"<=>" @operator
+
+[
+  "or"
+  "and"
+  "bitor"
+  "xor"
+  "bitand"
+  "not_eq"
+  "and_eq"
+  "or_eq"
+  "xor_eq"
+] @keyword.operator
 
 [
   "class"

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -30,7 +30,9 @@
 (namespace_identifier) @namespace
 
 (qualified_identifier name: (identifier) @type.enum.variant)
+
 (auto) @type
+"decltype" @type
 
 ; Constants
 
@@ -86,8 +88,7 @@
 ] @keyword.operator
 
 [
-  "class"
-  "decltype"
+  "class"  
   "namespace"
   "typename"
 ] @keyword.storage.type

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -30,6 +30,7 @@
 (namespace_identifier) @namespace
 
 (qualified_identifier name: (identifier) @type.enum.variant)
+(auto) @type
 
 ; Constants
 
@@ -89,7 +90,6 @@
   "decltype"
   "namespace"
   "typename"
-  (auto)
 ] @keyword.storage.type
 
 [

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -68,14 +68,16 @@
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
-"break" @keyword.control
+[
+  "break"
+  "continue"
+  "continuing"
+] @keyword.control
 
 [
   "loop"
   "for"
   "while"
-  "continue"
-  "continuing"
 ] @keyword.control.repeat
 
 [

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -2,24 +2,12 @@
 (float_literal) @constant.numeric.float
 (bool_literal) @constant.builtin.boolean
 
-(global_constant_declaration) @variable
-(global_variable_declaration) @variable
-(compound_statement) @variable
-(const_expression) @function
-
-(variable_identifier_declaration
-  (identifier) @variable
-  (type_declaration) @type)
-
 (function_declaration
-  (identifier) @function
-  (function_return_type_declaration
-    (type_declaration) @type))
+  (identifier) @function)
 
 (parameter
   (variable_identifier_declaration
-    (identifier) @variable.parameter
-    (type_declaration) @type))
+    (identifier) @variable.parameter))
 
 (struct_declaration
   (identifier) @type)
@@ -27,11 +15,17 @@
 (struct_declaration
   (struct_member
     (variable_identifier_declaration
-      (identifier) @variable.other.member
-      (type_declaration) @type)))
+      (identifier) @variable.other.member)))
+
+(type_constructor_or_function_call_expression
+  (type_declaration (identifier) @function))
 
 (type_constructor_or_function_call_expression
   (type_declaration) @function)
+
+(type_declaration (type_declaration) @type)
+(type_declaration (identifier) @type)
+(type_declaration) @type
 
 [
   "bitcast"
@@ -130,3 +124,5 @@
   (identifier) @attribute)
 
 (comment) @comment
+
+(identifier) @variable

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -68,6 +68,8 @@
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
+(type_declaration ["<" ">"] @punctuation.bracket)
+
 [
   "break"
   "continue"

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -8,51 +8,57 @@
 (const_expression) @function
 
 (variable_identifier_declaration
-    (identifier) @variable
-    (type_declaration) @type)
+  (identifier) @variable
+  (type_declaration) @type)
 
 (function_declaration
-    (identifier) @function
-    (function_return_type_declaration
-        (type_declaration) @type))
+  (identifier) @function
+  (function_return_type_declaration
+    (type_declaration) @type))
 
 (parameter
-    (variable_identifier_declaration
-        (identifier) @variable.parameter
-        (type_declaration) @type))
+  (variable_identifier_declaration
+    (identifier) @variable.parameter
+    (type_declaration) @type))
 
 (struct_declaration
-    (identifier) @type)
-        
+  (identifier) @type)
+
 (struct_declaration
-    (struct_member
-        (variable_identifier_declaration
-            (identifier) @variable.other.member
-            (type_declaration) @type)))
+  (struct_member
+    (variable_identifier_declaration
+      (identifier) @variable.other.member
+      (type_declaration) @type)))
 
 (type_constructor_or_function_call_expression
-    (type_declaration) @function)
+  (type_declaration) @function)
 
 [
-    "struct"
-    "bitcast"
-    "discard"
-    "enable"
-    "fallthrough"
-    "fn"
-    "let"
-    "private"
-    "read"
-    "read_write"
-    "storage"
-    "type"
-    "uniform"
-    "var"
-    "workgroup"
-    "write"
-    "override"
-    (texel_format)
+  "bitcast"
+  "discard"
+  "enable"
+  "fallthrough"
 ] @keyword
+
+[
+  "let"
+  "override"
+  "struct"
+  "type"
+  "var"
+  (texel_format)
+] @keyword.storage.type
+
+[
+  "function"
+  "private"
+  "read"
+  "read_write"
+  "storage"
+  "uniform"
+  "workgroup"
+  "write"
+] @keyword.storage.modifier
 
 "fn" @keyword.function
 
@@ -63,50 +69,59 @@
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [
-    "loop"
-    "for"
-    "while"
-    "break"
-    "continue"
-    "continuing"
+  "loop"
+  "for"
+  "while"
+  "break"
+  "continue"
+  "continuing"
 ] @keyword.control.repeat
 
 [
-    "if"
-    "else"
-    "switch"
-    "case"
-    "default"
+  "if"
+  "else"
+  "switch"
+  "case"
+  "default"
 ] @keyword.control.conditional
 
 [
-    "&"
-    "&&"
-    "/"
-    "!"
-    "="
-    "=="
-    "!="
-    ">"
-    ">="
-    ">>"
-    "<"
-    "<="
-    "<<"
-    "%"
-    "-"
-    "+"
-    "|"
-    "||"
-    "*"
-    "~"
-    "^"
-    "@"
-    "++"
-    "--"
+  "!"
+  "!="
+  "%"
+  "%="
+  "&"
+  "&&"
+  "&="
+  "*"
+  "*="
+  "+"
+  "++"
+  "+="
+  "-"
+  "--"
+  "-="
+  "->"
+  "/"
+  "/="
+  "<"
+  "<<"
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  "@"
+  "^"
+  "^="
+  "|"
+  "|="
+  "||"
+  "~"
 ] @operator
 
 (attribute
-    (identifier) @attribute)
+  (identifier) @attribute)
 
 (comment) @comment

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -23,7 +23,6 @@
 (type_constructor_or_function_call_expression
   (type_declaration) @function)
 
-(type_declaration (type_declaration) @type)
 (type_declaration (identifier) @type)
 (type_declaration) @type
 

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -2,30 +2,6 @@
 (float_literal) @constant.numeric.float
 (bool_literal) @constant.builtin.boolean
 
-(function_declaration
-  (identifier) @function)
-
-(parameter
-  (variable_identifier_declaration
-    (identifier) @variable.parameter))
-
-(struct_declaration
-  (identifier) @type)
-
-(struct_declaration
-  (struct_member
-    (variable_identifier_declaration
-      (identifier) @variable.other.member)))
-
-(type_constructor_or_function_call_expression
-  (type_declaration (identifier) @function))
-
-(type_constructor_or_function_call_expression
-  (type_declaration) @function)
-
-(type_declaration (identifier) @type)
-(type_declaration) @type
-
 [
   "bitcast"
   "discard"
@@ -43,14 +19,8 @@
 ] @keyword.storage.type
 
 [
-  "function"
-  "private"
-  "read"
-  "read_write"
-  "storage"
-  "uniform"
-  "workgroup"
-  "write"
+  (access_mode)
+  (address_space)
 ] @keyword.storage.modifier
 
 "fn" @keyword.function
@@ -119,9 +89,29 @@
   "~"
 ] @operator
 
+(function_declaration
+  (identifier) @function)
+
+(parameter
+  (variable_identifier_declaration
+    (identifier) @variable.parameter))
+
+(struct_declaration
+  (identifier) @type)
+
+(struct_declaration
+  (struct_member
+    (variable_identifier_declaration
+      (identifier) @variable.other.member)))
+
+(type_constructor_or_function_call_expression
+  (type_declaration (identifier) @function))
+
+(type_declaration _ @type)
+
 (attribute
   (identifier) @attribute)
 
-(comment) @comment
-
 (identifier) @variable
+
+(comment) @comment

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -68,11 +68,12 @@
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
+"break" @keyword.control
+
 [
   "loop"
   "for"
   "while"
-  "break"
   "continue"
   "continuing"
 ] @keyword.control.repeat

--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -110,5 +110,3 @@
     (identifier) @attribute)
 
 (comment) @comment
-
-(ERROR) @error


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6290295/195483731-10eab0a6-78ec-4efa-877b-91f75803fc75.png)

Fixes #3788, and adds various missing operators & highlights and organises keywords better for C, C++, and WGSL. Also contains a couple of fixes to WGSL highlighting to prevent text from being highlighted as an error as it's being typed, and remove edge cases where `@variable` text modifiers could leak to other theme keys.

(theme is onedark but modified to make all variables red as shown in the issue)