### PR TITLE
Adding 'goto error' support for open documents

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -307,6 +307,7 @@ impl MappableCommand {
         goto_line_end, "Goto line end",
         goto_next_buffer, "Goto next buffer",
         goto_previous_buffer, "Goto previous buffer",
+        goto_error, "Goto error(s)",
         // TODO: different description ?
         goto_line_end_newline, "Goto line end",
         goto_first_nonwhitespace, "Goto first non-blank in line",

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -55,6 +55,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "n" => goto_next_buffer,
             "p" => goto_previous_buffer,
             "." => goto_last_modification,
+            "," => goto_error,
         },
         ":" => command_mode,
 


### PR DESCRIPTION
The point of this is unobtrusively add support for quickly navigating to errors detected by the LSP. This integrates error navigation into the "goto" menu with keypresses "g,". 