### PR TITLE
Exit gracefully when close operation fails

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -866,8 +866,15 @@ impl Application {
         }));
 
         self.event_loop(input_stream).await;
-        self.close().await?;
+
+        let err = self.close().await.err();
+
         restore_term()?;
+
+        if let Some(err) = err {
+            self.editor.exit_code = 1;
+            eprintln!("Error: {}", err);
+        }
 
         Ok(self.editor.exit_code)
     }


### PR DESCRIPTION
If the close method fails, the editor will quit before restoring the terminal. This causes the shell to break if, e.g. the LS times out shutting down.

This fixes this by always restoring the terminal after closing, and printing out a message to stderr if there is an error.