### PR TITLE
Add cursorcolumn

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -45,6 +45,7 @@ on unix operating systems.
 | `shell` | Shell to use when running external commands. | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `cursorline` | Highlight all lines with a cursor. | `false` |
+| `cursorcolumn` | Highlight all columns with a cursor. | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "line-numbers"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -210,51 +210,53 @@ These scopes are used for theming the editor interface.
       - `hover` - for hover popup ui
 
 
-| Key                       | Notes                                          |
-| ---                       | ---                                            |
-| `ui.background`           |                                                |
-| `ui.background.separator` | Picker separator below input line              |
-| `ui.cursor`               |                                                |
-| `ui.cursor.insert`        |                                                |
-| `ui.cursor.select`        |                                                |
-| `ui.cursor.match`         | Matching bracket etc.                          |
-| `ui.cursor.primary`       | Cursor with primary selection                  |
-| `ui.gutter`               | Gutter                                         |
-| `ui.gutter.selected`      | Gutter for the line the cursor is on           |
-| `ui.linenr`               | Line numbers                                   |
-| `ui.linenr.selected`      | Line number for the line the cursor is on      |
-| `ui.statusline`           | Statusline                                     |
-| `ui.statusline.inactive`  | Statusline (unfocused document)                |
-| `ui.statusline.normal`    | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.insert`    | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.select`    | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.separator` | Separator character in statusline              |
-| `ui.popup`                | Documentation popups (e.g space-k)             |
-| `ui.popup.info`           | Prompt for multiple key options                |
-| `ui.window`               | Border lines separating splits                 |
-| `ui.help`                 | Description box for commands                   |
-| `ui.text`                 | Command prompts, popup text, etc.              |
-| `ui.text.focus`           |                                                |
-| `ui.text.info`            | The key: command text in `ui.popup.info` boxes |
-| `ui.virtual.ruler`        | Ruler columns (see the [`editor.rulers` config][editor-section])|
-| `ui.virtual.whitespace`   | Visible white-space characters                 |
-| `ui.virtual.indent-guide` | Vertical indent width guides                   |
-| `ui.menu`                 | Code and command completion menus              |
-| `ui.menu.selected`        | Selected autocomplete item                     |
-| `ui.menu.scroll`          | `fg` sets thumb color, `bg` sets track color of scrollbar |
-| `ui.selection`            | For selections in the editing area             |
-| `ui.selection.primary`    |                                                |
-| `ui.cursorline.primary`   | The line of the primary cursor                 |
-| `ui.cursorline.secondary` | The lines of any other cursors                 |
-| `warning`                 | Diagnostics warning (gutter)                   |
-| `error`                   | Diagnostics error (gutter)                     |
-| `info`                    | Diagnostics info (gutter)                      |
-| `hint`                    | Diagnostics hint (gutter)                      |
-| `diagnostic`              | Diagnostics fallback style (editing area)      |
-| `diagnostic.hint`         | Diagnostics hint (editing area)                |
-| `diagnostic.info`         | Diagnostics info (editing area)                |
-| `diagnostic.warning`      | Diagnostics warning (editing area)             |
-| `diagnostic.error`        | Diagnostics error (editing area)               |
+| Key                         | Notes                                                                                          |
+| ---                         | ---                                                                                            |
+| `ui.background`             |                                                                                                |
+| `ui.background.separator`   | Picker separator below input line                                                              |
+| `ui.cursor`                 |                                                                                                |
+| `ui.cursor.insert`          |                                                                                                |
+| `ui.cursor.select`          |                                                                                                |
+| `ui.cursor.match`           | Matching bracket etc.                                                                          |
+| `ui.cursor.primary`         | Cursor with primary selection                                                                  |
+| `ui.gutter`                 | Gutter                                                                                         |
+| `ui.gutter.selected`        | Gutter for the line the cursor is on                                                           |
+| `ui.linenr`                 | Line numbers                                                                                   |
+| `ui.linenr.selected`        | Line number for the line the cursor is on                                                      |
+| `ui.statusline`             | Statusline                                                                                     |
+| `ui.statusline.inactive`    | Statusline (unfocused document)                                                                |
+| `ui.statusline.normal`      | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.insert`      | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.select`      | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.separator`   | Separator character in statusline                                                              |
+| `ui.popup`                  | Documentation popups (e.g space-k)                                                             |
+| `ui.popup.info`             | Prompt for multiple key options                                                                |
+| `ui.window`                 | Border lines separating splits                                                                 |
+| `ui.help`                   | Description box for commands                                                                   |
+| `ui.text`                   | Command prompts, popup text, etc.                                                              |
+| `ui.text.focus`             |                                                                                                |
+| `ui.text.info`              | The key: command text in `ui.popup.info` boxes                                                 |
+| `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
+| `ui.virtual.whitespace`     | Visible white-space characters                                                                 |
+| `ui.virtual.indent-guide`   | Vertical indent width guides                                                                   |
+| `ui.menu`                   | Code and command completion menus                                                              |
+| `ui.menu.selected`          | Selected autocomplete item                                                                     |
+| `ui.menu.scroll`            | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |
+| `ui.selection`              | For selections in the editing area                                                             |
+| `ui.selection.primary`      |                                                                                                |
+| `ui.cursorline.primary`     | The line of the primary cursor ([if cursorline is enabled][editor-section])                    |
+| `ui.cursorline.secondary`   | The lines of any other cursors ([if cursorline is enabled][editor-section])                    |
+| `ui.cursorcolumn.primary`   | The column of the primary cursor ([if cursorcolumn is enabled][editor-section])                |
+| `ui.cursorcolumn.secondary` | The columns of any other cursors ([if cursorcolumn is enabled][editor-section])                |
+| `warning`                   | Diagnostics warning (gutter)                                                                   |
+| `error`                     | Diagnostics error (gutter)                                                                     |
+| `info`                      | Diagnostics info (gutter)                                                                      |
+| `hint`                      | Diagnostics hint (gutter)                                                                      |
+| `diagnostic`                | Diagnostics fallback style (editing area)                                                      |
+| `diagnostic.hint`           | Diagnostics hint (editing area)                                                                |
+| `diagnostic.info`           | Diagnostics info (editing area)                                                                |
+| `diagnostic.warning`        | Diagnostics warning (editing area)                                                             |
+| `diagnostic.error`          | Diagnostics error (editing area)                                                               |
 
 You can check compliance to spec with
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -844,9 +844,11 @@ impl EditorView {
 
         let primary_style = theme
             .try_get("ui.cursorcolumn.primary")
+            .or_else(|| theme.try_get("ui.cursorcolumn"))
             .unwrap_or_else(|| theme.get("ui.cursorline.primary"));
         let secondary_style = theme
             .try_get("ui.cursorcolumn.secondary")
+            .or_else(|| theme.try_get("ui.cursorcolumn"))
             .unwrap_or_else(|| theme.get("ui.cursorline.secondary"));
 
         let inner_area = view.inner_area();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -842,13 +842,15 @@ impl EditorView {
     ) {
         let text = doc.text().slice(..);
 
+        // Manual fallback behaviour:
+        // ui.cursorcolumn.{p/s} -> ui.cursorcolumn -> ui.cursorline.{p/s}
         let primary_style = theme
-            .try_get("ui.cursorcolumn.primary")
-            .or_else(|| theme.try_get("ui.cursorcolumn"))
+            .try_get_exact("ui.cursorcolumn.primary")
+            .or_else(|| theme.try_get_exact("ui.cursorcolumn"))
             .unwrap_or_else(|| theme.get("ui.cursorline.primary"));
         let secondary_style = theme
-            .try_get("ui.cursorcolumn.secondary")
-            .or_else(|| theme.try_get("ui.cursorcolumn"))
+            .try_get_exact("ui.cursorcolumn.secondary")
+            .or_else(|| theme.try_get_exact("ui.cursorcolumn"))
             .unwrap_or_else(|| theme.get("ui.cursorline.secondary"));
 
         let inner_area = view.inner_area();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -842,8 +842,12 @@ impl EditorView {
     ) {
         let text = doc.text().slice(..);
 
-        let primary_style = theme.get("ui.cursorline.primary");
-        let secondary_style = theme.get("ui.cursorline.secondary");
+        let primary_style = theme
+            .try_get("ui.cursorcolumn.primary")
+            .unwrap_or_else(|| theme.get("ui.cursorline.primary"));
+        let secondary_style = theme
+            .try_get("ui.cursorcolumn.secondary")
+            .unwrap_or_else(|| theme.get("ui.cursorline.secondary"));
 
         let inner_area = view.inner_area();
         let offset = view.offset.col;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -124,6 +124,8 @@ pub struct Config {
     pub line_number: LineNumber,
     /// Highlight the lines cursors are currently on. Defaults to false.
     pub cursorline: bool,
+    /// Highlight the columns cursors are currently on. Defaults to false.
+    pub cursorcolumn: bool,
     /// Gutters. Default ["diagnostics", "line-numbers"]
     pub gutters: Vec<GutterType>,
     /// Middle click paste support. Defaults to true.
@@ -582,6 +584,7 @@ impl Default for Config {
             },
             line_number: LineNumber::Absolute,
             cursorline: false,
+            cursorcolumn: false,
             gutters: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -277,6 +277,13 @@ impl Theme {
             .find_map(|s| self.styles.get(s).copied())
     }
 
+    /// Get the style of a scope, without falling back to dot separated broader
+    /// scopes. For example if `ui.text.focus` is not defined in the theme, it
+    /// will return `None`, even if `ui.text` is.
+    pub fn try_get_exact(&self, scope: &str) -> Option<Style> {
+        self.styles.get(scope).copied()
+    }
+
     #[inline]
     pub fn scopes(&self) -> &[String] {
         &self.scopes


### PR DESCRIPTION
Closes #4015.

Currently uses the same theme keys as cursorline, but they could be separated if that would be preferred.
![image](https://user-images.githubusercontent.com/58790821/193626568-5af4fe74-fb6b-416d-913e-7c595e0b0cb4.png)
