### PR TITLE
doc: add theme inheritance example

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -89,6 +89,14 @@ Less common modifiers might not be supported by your terminal emulator.
 | `hidden`       |
 | `crossed_out`  |
 
+### Inheritance
+
+Extend upon other themes by setting the `inherits` property to an existing theme.
+
+```toml
+inherits = "boo_berry"
+```
+
 ### Scopes
 
 The following is a list of scopes available to use for styling.

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -95,6 +95,13 @@ Extend upon other themes by setting the `inherits` property to an existing theme
 
 ```toml
 inherits = "boo_berry"
+
+# Override the theming for "keyword"s:
+"keyword" = { fg = "gold" }
+
+# Override colors in the palette:
+[palette]
+berry = "#2A2A4D"
 ```
 
 ### Scopes


### PR DESCRIPTION
With the introduction of #3067 this adds some simple documentation, with an example, on using the `inherits` property to the theme page.