### PR TITLE
Remove duplicates from the picker

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -692,7 +692,7 @@ pub fn apply_workspace_edit(
 fn goto_impl(
     editor: &mut Editor,
     compositor: &mut Compositor,
-    locations: Vec<lsp::Location>,
+    mut locations: Vec<lsp::Location>,
     offset_encoding: OffsetEncoding,
 ) {
     let cwdir = std::env::current_dir().unwrap_or_default();
@@ -705,6 +705,11 @@ fn goto_impl(
             editor.set_error("No definition found.");
         }
         _locations => {
+            for i in (1..locations.len()).rev() {
+                if locations.as_slice()[..i].contains(&locations[i]) {
+                    locations.remove(i);
+                }
+            }
             let picker = FilePicker::new(
                 locations,
                 cwdir,


### PR DESCRIPTION
Trying to find references for example in goto_reference in commands.rs brings up a lot of duplicate matches.
This change removes the duplicates from lsp goto_*  commands.

Before:
![picker_old](https://user-images.githubusercontent.com/45574139/193718330-13d99461-cada-4209-9063-d709a2c6e812.png)

After:
![picker_new](https://user-images.githubusercontent.com/45574139/193718350-baeada2c-a0ee-4805-a35d-42314f9f7ae7.png)
