### PR TITLE
Add colours "color-modes" to ayu_light theme

### DIFF
--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -61,7 +61,7 @@
 "ui.bufferline" = { fg = "ui_foreground", bg = "ui_background" }
 "ui.bufferline.active" = { fg = "ui_background", bg = "ui_foreground" }
 "ui.statusline" = { fg = "ui_foreground", bg = "ui_background" }
-"ui.statusline.inactive" = { fg = "ui_foreground", bg = "light_gray" }
+"ui.statusline.inactive" = { fg = "ui_foreground", bg = "ui_background" }
 "ui.statusline.normal" = { fg = "white", bg = "light_blue" }
 "ui.statusline.insert" = { fg = "white", bg = "orange" }
 "ui.statusline.select" = { fg = "white", bg = "magenta" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -34,23 +34,23 @@
 
 # Interface
 "ui.background"= { bg = "background" }
-"ui.cursor" = { bg = "yellow", fg = "dark_gray" }
+"ui.cursor" = { bg = "yellow", fg = "light_gray" }
 "ui.cursor.match" = { fg = "orange" }
-"ui.linenr" = { fg = "dark_gray" }
+"ui.linenr" = { fg = "light_gray" }
 "ui.linenr.selected" = { fg = "orange" }
 "ui.cursorline" = { bg = "black" }
 "ui.statusline" = { fg = "foreground", bg = "black" }
 "ui.popup" = { bg = "black" }
-"ui.window" = { fg = "dark_gray" }
+"ui.window" = { fg = "light_gray" }
 "ui.help" = { fg  = "foreground", bg = "black" }
 "ui.text" = { fg = "foreground" }
-"ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
+"ui.text.focus" = { bg = "light_gray", fg = "foreground" }
 "ui.text.info" = { fg = "foreground" }
-"ui.virtual.whitespace" = { fg = "dark_gray" }
+"ui.virtual.whitespace" = { fg = "light_gray" }
 "ui.virtual.ruler" = { bg = "black" }
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "orange", fg = "background" }
-"ui.selection" = { bg = "dark_gray" }
+"ui.selection" = { bg = "light_gray" }
 "warning" = { fg = "yellow" }
 "error" = { fg = "red", modifiers = ["bold"] }
 "info" = { fg = "blue", modifiers = ["bold"] }
@@ -71,7 +71,7 @@ foreground = "#5c6166"
 black = "#e7eaed"
 blue = "#399ee6"
 cyan = "#478acc"
-dark_gray = "#e7eaed"
+light_gray = "#e7eaed"
 gray = "#787b8099"
 green = "#86b300"
 magenta = "#a37acc"

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -39,7 +39,6 @@
 "ui.linenr" = { fg = "light_gray" }
 "ui.linenr.selected" = { fg = "orange" }
 "ui.cursorline" = { bg = "black" }
-"ui.statusline" = { fg = "foreground", bg = "black" }
 "ui.popup" = { bg = "black" }
 "ui.window" = { fg = "light_gray" }
 "ui.help" = { fg  = "foreground", bg = "black" }
@@ -59,8 +58,13 @@
 "diagnostic.info"= { fg = "blue", modifiers = ["underlined"] }
 "diagnostic.warning"= { fg = "yellow", modifiers = ["underlined"] }
 "diagnostic.error"= { fg = "red", modifiers = ["underlined"] }
-"ui.bufferline" = { fg = "gray", bg = "dark_gray" }
-"ui.bufferline.active" = { fg = "dark", bg = "background" }
+"ui.bufferline" = { fg = "ui_foreground", bg = "ui_background" }
+"ui.bufferline.active" = { fg = "ui_background", bg = "ui_foreground" }
+"ui.statusline" = { fg = "ui_foreground", bg = "ui_background" }
+"ui.statusline.inactive" = { fg = "ui_foreground", bg = "light_gray" }
+"ui.statusline.normal" = { fg = "white", bg = "light_blue" }
+"ui.statusline.insert" = { fg = "white", bg = "orange" }
+"ui.statusline.select" = { fg = "white", bg = "magenta" }
 
 "special" = { fg = "orange" }
 
@@ -68,8 +72,13 @@
 background = "#fcfcfc"
 foreground = "#5c6166"
 
+ui_foreground = "#8a9199"
+ui_background = "#f8f9fa"
+
 black = "#e7eaed"
+white = "#fcfcfc"
 blue = "#399ee6"
+light_blue = "#55b4d4"
 cyan = "#478acc"
 light_gray = "#e7eaed"
 gray = "#787b8099"
@@ -78,4 +87,3 @@ magenta = "#a37acc"
 orange = "#fa8d3e"
 red = "#f07171"
 yellow = "#ffaa33"
-dark = "#131721"


### PR DESCRIPTION
This PR adds statusline mode colours to the ayu light theme when the `editor.color-modes` option is true. 

I've also renamed the `dark_gray` colour to `light_gray` since it's lighter than the default `gray`, so being called "dark" didn't make much sense. 

## Screenshots

Normal:
<img width="1073" alt="Screenshot 2022-10-05 at 15 50 18" src="https://user-images.githubusercontent.com/933535/194091140-fe9452da-444a-40c8-b586-75f6141a8c7f.png">

Insert:
<img width="1073" alt="Screenshot 2022-10-05 at 15 50 15" src="https://user-images.githubusercontent.com/933535/194091163-bc3bf01f-d899-41f3-ad9e-86f6c87e2d41.png">

Select:
<img width="1073" alt="Screenshot 2022-10-05 at 15 50 10" src="https://user-images.githubusercontent.com/933535/194091191-62b89641-94c1-4178-9d8a-3e8801e5b18f.png">

Modes are in the right split, the left split shows the inactive colours. 
