### PR TITLE
Overlay all diagnostics with highest severity on top

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -119,8 +119,15 @@ impl EditorView {
             Self::highlight_cursorline(doc, view, surface, theme);
         }
 
-        let highlights = Self::doc_syntax_highlights(doc, view.offset, inner.height, theme);
-        let highlights = syntax::merge(highlights, Self::doc_diagnostics_highlights(doc, theme));
+        let mut highlights = Self::doc_syntax_highlights(doc, view.offset, inner.height, theme);
+        for diagnostic in Self::doc_diagnostics_highlights(doc, theme) {
+            // Most of the `diagnostic` Vecs are empty most of the time. Skipping
+            // a merge for any empty Vec saves a significant amount of work.
+            if diagnostic.is_empty() {
+                continue;
+            }
+            highlights = Box::new(syntax::merge(highlights, diagnostic));
+        }
         let highlights: Box<dyn Iterator<Item = HighlightEvent>> = if is_focused {
             Box::new(syntax::merge(
                 highlights,
@@ -264,7 +271,7 @@ impl EditorView {
     pub fn doc_diagnostics_highlights(
         doc: &Document,
         theme: &Theme,
-    ) -> Vec<(usize, std::ops::Range<usize>)> {
+    ) -> [Vec<(usize, std::ops::Range<usize>)>; 5] {
         use helix_core::diagnostic::Severity;
         let get_scope_of = |scope| {
             theme
@@ -285,22 +292,42 @@ impl EditorView {
         let error = get_scope_of("diagnostic.error");
         let r#default = get_scope_of("diagnostic"); // this is a bit redundant but should be fine
 
-        doc.diagnostics()
-            .iter()
-            .map(|diagnostic| {
-                let diagnostic_scope = match diagnostic.severity {
-                    Some(Severity::Info) => info,
-                    Some(Severity::Hint) => hint,
-                    Some(Severity::Warning) => warning,
-                    Some(Severity::Error) => error,
-                    _ => r#default,
-                };
-                (
-                    diagnostic_scope,
-                    diagnostic.range.start..diagnostic.range.end,
-                )
-            })
-            .collect()
+        let mut default_vec: Vec<(usize, std::ops::Range<usize>)> = Vec::new();
+        let mut info_vec = Vec::new();
+        let mut hint_vec = Vec::new();
+        let mut warning_vec = Vec::new();
+        let mut error_vec = Vec::new();
+
+        let diagnostics = doc.diagnostics();
+
+        // Diagnostics must be sorted by range. Otherwise, the merge strategy
+        // below would not be accurate.
+        debug_assert!(diagnostics
+            .windows(2)
+            .all(|window| window[0].range.start <= window[1].range.start
+                && window[0].range.end <= window[1].range.end));
+
+        for diagnostic in diagnostics {
+            // Separate diagnostics into different Vecs by severity.
+            let (vec, scope) = match diagnostic.severity {
+                Some(Severity::Info) => (&mut info_vec, info),
+                Some(Severity::Hint) => (&mut hint_vec, hint),
+                Some(Severity::Warning) => (&mut warning_vec, warning),
+                Some(Severity::Error) => (&mut error_vec, error),
+                _ => (&mut default_vec, r#default),
+            };
+
+            // If any diagnostic overlaps ranges with the prior diagnostic,
+            // merge the two together. Otherwise push a new span.
+            match vec.last_mut() {
+                Some((_, range)) if diagnostic.range.start <= range.end => {
+                    range.end = diagnostic.range.end.max(range.end)
+                }
+                _ => vec.push((scope, diagnostic.range.start..diagnostic.range.end)),
+            }
+        }
+
+        [default_vec, info_vec, hint_vec, warning_vec, error_vec]
     }
 
     /// Get highlight spans for selections in a document view.


### PR DESCRIPTION
Here we separate the diagnostics by severity and then overlay the Vec of spans for each severity on top of the highlights. The error diagnostics end up overlaid on the warning diagnostics, which are overlaid on the hints, overlaid on info, overlaid on any other severity (default), then overlaid on the syntax highlights.

Kudos to @pascalkuthe for coming up with this idea 🎉

This fixes two things:

* Error diagnostics are now always visible when overlapped with other diagnostics.
    * In order to see this, you need `diagnostic.*` theming that makes the severities look visually different (#4061 / #3015 are good for this, or using `bg` highlighting).
* Ghost text is eliminated.
    * Ghost text was caused by duplicate diagnostics at the EOF: overlaps within the merged `Vec<(usize, Range<usize>)>` violate assumptions in `helix_core::syntax::Merge`.
    * When we push a new range, we check it against the last range and merge the two if they overlap. This is safe because they both have the same severity and therefore highlight.

The actual merge is skipped for any of these when they are empty, so this is very fast in practice. For some data, I threw together an FPS counter which renders as fast as possible and logs the renders per second: https://github.com/the-mikedavis/helix/commit/02ae7adc8a0214b105dc441a6cb2f3ea89f1e4fb.

With no diagnostics, I see an FPS gain from this change from 868 FPS to 878 (+1.1%) on a release build on a Rust file. This makes sense: we eliminate the work of merging an empty diagnostics Vec into the highlight stream. On an Erlang file with 12 error diagnostics and 6 warnings in view (233 errors and 66 warnings total), I see a decrease in average FPS from 795 to 790 (-0.6%) on a release build.

Closes https://github.com/helix-editor/helix/issues/2248
See prior work: https://github.com/helix-editor/helix/pull/4042, https://github.com/helix-editor/helix/pull/3695

Opening as a draft for now: I'd like to add some comments and `debug_assert!`s.