### PR TITLE
Fix tutor typo

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -967,7 +967,7 @@ lines.
 
 
 =================================================================
-=              10.1 CYCLING AND REMOVING SELECIONS              =
+=             10.1 CYCLING AND REMOVING SELECTIONS              =
 =================================================================
 
  Type ) and ( to cycle the primary selection forward and backward


### PR DESCRIPTION
This PR fixes as minor typo in `runtime/tutor`.