### PR TITLE
Update C and C++ tree-sitter grammars

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -184,7 +184,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "c"
-source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "f05e279aedde06a25801c3f2b2cc8ac17fac52ae" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "7175a6dd5fc1cee660dce6fe23f6043d75af424a" }
 
 [[language]]
 name = "cpp"
@@ -221,7 +221,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "cpp"
-source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "e8dcc9d2b404c542fd236ea5f7208f90be8a6e89" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "d5e90fba898f320db48d81ddedd78d52c67c1fed" }
 
 [[language]]
 name = "c-sharp"

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -77,6 +77,9 @@
   declarator: (identifier) @function)
 (preproc_function_def
   name: (identifier) @function.special)
+  
+(attribute
+  name: (identifier) @attribute)
 
 (field_identifier) @variable.other.member
 (statement_identifier) @label

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -42,7 +42,10 @@
 
 "catch" @keyword
 "class" @keyword
+"concept" @keyword
+"consteval" @keyword
 "constexpr" @keyword
+"constinit" @keyword
 "delete" @keyword
 "explicit" @keyword
 "final" @keyword
@@ -55,12 +58,27 @@
 "private" @keyword
 "protected" @keyword
 "public" @keyword
+"requires" @keyword
 "template" @keyword
 "throw" @keyword
 "try" @keyword
 "typename" @keyword
 "using" @keyword
 "virtual" @keyword
+
+; Operators
+"<=>" @operator
+[
+  "or"
+  "and"
+  "bitor"
+  "xor"
+  "bitand"
+  "not_eq"
+  "and_eq"
+  "or_eq"
+  "xor_eq"
+] @keyword.operator
 
 ; Strings
 


### PR DESCRIPTION
I'm mainly interested in this because of the [support for alternative operators in C++](https://github.com/tree-sitter/tree-sitter-cpp/pull/179) but there are also some more improvements, such as support for C++20 concepts and attributes in C. I've checked that all our queries still work but if there's anything obvious missing, please let me know.