### PR TITLE
Improve sorting for inline menu (codeaction + completion)

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -465,7 +465,7 @@ pub fn code_action(cx: &mut Context) {
             // sort by CodeActionKind
             // this ensures that the most relevant codeactions (quickfix) show up first
             // while more situational commands (like refactors) show up later
-            // this behaviour is modeled after the behaviour of vscode (editor/contrib/codeAction/browser/codeActionWidget.ts)
+            // this behaviour is modeled after the behaviour of vscode (https://github.com/microsoft/vscode/blob/eaec601dd69aeb4abb63b9601a6f44308c8d8c6e/src/vs/editor/contrib/codeAction/browser/codeActionWidget.ts)
 
             actions.sort_by_key(|action| match &action {
                 lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -97,7 +97,7 @@ impl Completion {
         start_offset: usize,
         trigger_offset: usize,
     ) -> Self {
-        let menu = Menu::new(items, (), move |editor: &mut Editor, item, event| {
+        let menu = Menu::new(items, true, (), move |editor: &mut Editor, item, event| {
             fn item_to_transaction(
                 doc: &Document,
                 item: &CompletionItem,

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -97,7 +97,7 @@ impl Completion {
         start_offset: usize,
         trigger_offset: usize,
     ) -> Self {
-        let menu = Menu::new(items, true, (), move |editor: &mut Editor, item, event| {
+        let menu = Menu::new(items, (), move |editor: &mut Editor, item, event| {
             fn item_to_transaction(
                 doc: &Document,
                 item: &CompletionItem,

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -117,10 +117,7 @@ impl<T: Item> Menu<T> {
                         .map(|score| (index, score))
                 }),
         );
-        // matches.sort_unstable_by_key(|(_, score)| -score);
-        self.matches.sort_unstable_by_key(|(index, _score)| {
-            self.options[*index].sort_text(&self.editor_data)
-        });
+        self.matches.sort_unstable_by_key(|(_, score)| -score);
 
         // reset cursor position
         self.cursor = None;

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -74,6 +74,7 @@ impl<T: Item> Menu<T> {
     // rendering)
     pub fn new(
         options: Vec<T>,
+        sort: bool,
         editor_data: <T as Item>::Data,
         callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
     ) -> Self {
@@ -91,8 +92,12 @@ impl<T: Item> Menu<T> {
             recalculate: true,
         };
 
-        // TODO: scoring on empty input should just use a fastpath
-        menu.score("");
+        if sort {
+            // TODO: scoring on empty input should just use a fastpath
+            menu.score("");
+        } else {
+            menu.matches = (0..menu.options.len()).map(|i| (i, 0)).collect();
+        }
 
         menu
     }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -74,15 +74,15 @@ impl<T: Item> Menu<T> {
     // rendering)
     pub fn new(
         options: Vec<T>,
-        sort: bool,
         editor_data: <T as Item>::Data,
         callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
     ) -> Self {
-        let mut menu = Self {
+        let matches = (0..options.len()).map(|i| (i, 0)).collect();
+        Self {
             options,
             editor_data,
             matcher: Box::new(Matcher::default()),
-            matches: Vec::new(),
+            matches,
             cursor: None,
             widths: Vec::new(),
             callback_fn: Box::new(callback_fn),
@@ -90,16 +90,7 @@ impl<T: Item> Menu<T> {
             size: (0, 0),
             viewport: (0, 0),
             recalculate: true,
-        };
-
-        if sort {
-            // TODO: scoring on empty input should just use a fastpath
-            menu.score("");
-        } else {
-            menu.matches = (0..menu.options.len()).map(|i| (i, 0)).collect();
         }
-
-        menu
     }
 
     pub fn score(&mut self, pattern: &str) {


### PR DESCRIPTION
Code actions are currently sorted alphabetically because they simply reuse the `Menu` used for autocompletions.
This is extremely inconvenient in many cases.
For example rust-analyzer emits a ton of (sometimes useful) refactors code-actions that get sorted before
the quick fix (import ...) I am interested in.

This PR improves upon this in two ways:

The simplest fix is simply not sorting code actions in the `Menu`.
However many LSP implementations send their code actions unordered because they assume that the client will sort the code actions by the `kind` field.

VScode uses 8 cateogoris for code actions:

* quickfix
* refactor (extract)
* refactor (inline)
* refactor (rewrite)
* refactor (move)
* refactor (surround)
* source
* anything else

I have opted to match this behavior by sorting the code actions into these categories.
Note that I was careful to retain the original sorting by the server within these categories.

This is a huge usability improvement for people that frequently use codeactions.
Example from the helix sourcecode where an import is missing:

**before:**
![image](https://user-images.githubusercontent.com/61850714/194439067-8dea3fe8-4a60-4348-ba4c-1e43e1a07fc4.png)

**after:**
![image](https://user-images.githubusercontent.com/61850714/194439027-ba180ea9-0cce-4454-b607-a52e5bff8144.png)



Edit: This PR was originally just about code-actions, however I found #3215 and noticed that the changes there are sort of the same as in this PR: both PRs needed to handle code-actions separately from auto-completion sorting, #3215 sorted the code-actions alphabetically while this PR sorts them by category. Enabling fuzzy sorting for auto completions on top this PR is a single-line change and I have therefore opted to include it in this PR. I can drop the commit again and spin that out into a separate PR if this is controversial. The change is trivial and it made sense to me to include it here.  fixes #2508