### PR TITLE
Fix goto/view center mismatch

### DIFF
--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -53,12 +53,12 @@ pub fn align_view(doc: &Document, view: &mut View, align: Align) {
         .cursor(doc.text().slice(..));
     let line = doc.text().char_to_line(pos);
 
-    let height = view.inner_area().height as usize;
+    let last_line_height = view.inner_area().height.saturating_sub(1) as usize;
 
     let relative = match align {
-        Align::Center => height / 2,
+        Align::Center => last_line_height / 2,
         Align::Top => 0,
-        Align::Bottom => height,
+        Align::Bottom => last_line_height,
     };
 
     view.offset.row = line.saturating_sub(relative);


### PR DESCRIPTION
A pretty minor issue but it was personally bugging me.

**Reproduction:**
1. Open helix. Resize your terminal height until you have an even number of lines displayed in the editor.
2. Navigate to the middle of a long file and perform a view center (`zc`). The currently selected line is moved to right below the midpoint.
3. Perform a goto center (`gc`). The cursor moves one line up.

**Expected:**
I would expect the second command to not result in any cursor movement. This issue does not occur with an odd number of editor lines. Goto/view with top/bottom also do not have such discrepancies.

**Root cause:**
- `goto_window` is operating relative to the top of the first line until the top of the last line while `align_view` is operating from the top of the first line until the bottom of the last line.
- `align_view` is the one who is in the wrong here. From the code, `align_view(Bottom)` would push the currently selected line offscreen.
- This does not actually happen in practice because of `scrolloff` or when `scrolloff` is configured to be 0, some failsafes in the code.