### PR TITLE
Do not accept keydown to enter in autocomplete popup

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -306,6 +306,17 @@ impl Component for Completion {
         {
             return EventResult::Ignored(None);
         }
+        if let None = self.popup.contents().selection() {
+            if let Event::Key(KeyEvent {
+                code: KeyCode::Down,
+                ..
+            }) = event
+            {
+                if cx.editor.config().idle_timeout.as_millis() == 0 {
+                    return EventResult::Ignored(None);
+                }
+            }
+        }
         self.popup.handle_event(event, cx)
     }
 


### PR DESCRIPTION
With idle_timeout = 0 it is nearly impossible to navigate on the document with the arrows.
A solution is to ignore keydown until at least one autocompletion is selected. (`<tab><keydown>[...]` or `<ctrl-n><keydown>[...]`)

It is ignored **only if idle_timeout = 0**. I a user want to have the current behavior, the user can set idle_timeout to 1.