### PR TITLE
Do not accept keydown to enter in autocomplete popup

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -307,7 +307,7 @@ impl Component for Completion {
             return EventResult::Ignored(None);
         }
         if self.popup.contents().selection().is_none()
-            && cx.editor.config().idle_timeout.as_millis() == 0
+            && !cx.editor.config().arrows_to_enter_completion
         {
             match event {
                 Event::Key(KeyEvent {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -306,6 +306,20 @@ impl Component for Completion {
         {
             return EventResult::Ignored(None);
         }
+        if let None = self.popup.contents().selection() {
+            if cx.editor.config().idle_timeout.as_millis() == 0 {
+                match event {
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Down,
+                        ..
+                    })
+                    | Event::Key(KeyEvent {
+                        code: KeyCode::Up, ..
+                    }) => return EventResult::Ignored(None),
+                    _ => (),
+                }
+            }
+        }
         self.popup.handle_event(event, cx)
     }
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -306,18 +306,18 @@ impl Component for Completion {
         {
             return EventResult::Ignored(None);
         }
-        if let None = self.popup.contents().selection() {
-            if cx.editor.config().idle_timeout.as_millis() == 0 {
-                match event {
-                    Event::Key(KeyEvent {
-                        code: KeyCode::Down,
-                        ..
-                    })
-                    | Event::Key(KeyEvent {
-                        code: KeyCode::Up, ..
-                    }) => return EventResult::Ignored(None),
-                    _ => (),
-                }
+        if self.popup.contents().selection().is_none()
+            && cx.editor.config().idle_timeout.as_millis() == 0
+        {
+            match event {
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down,
+                    ..
+                })
+                | Event::Key(KeyEvent {
+                    code: KeyCode::Up, ..
+                }) => return EventResult::Ignored(None),
+                _ => (),
             }
         }
         self.popup.handle_event(event, cx)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -144,6 +144,7 @@ pub struct Config {
     )]
     pub idle_timeout: Duration,
     pub completion_trigger_len: u8,
+    pub arrows_to_enter_completion: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
@@ -589,6 +590,7 @@ impl Default for Config {
             auto_format: true,
             idle_timeout: Duration::from_millis(400),
             completion_trigger_len: 2,
+            arrows_to_enter_completion: true,
             auto_info: true,
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),


### PR DESCRIPTION
I must open a new PR since I have force-pushed a change for https://github.com/helix-editor/helix/pull/4141 when it was closed and I cannot reopen it.

This is a fix for #2027. If `arrows_to_enter_completion` is set to false, user must use `tab` or `C-n` to enter the autocompletion pop and can use arrows once in the pop up.

<details><summary>Old description</summary>
So, after moving around, this is just a fix for https://github.com/helix-editor/helix/issues/2027 (and related issues) if timeout is set to 0. Maybe it is better to add a new parameter instead of timeout 0 ? For instance `arrows_to_enter_autocompletion_popup` with default to `true` (current behaviour)
</details>