### PR TITLE
Fix append cursor location when selection anchor is at end of document

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2224,7 +2224,7 @@ fn append_mode(cx: &mut Context) {
         .iter()
         .last()
         .expect("selection should always have at least one range");
-    if !last_range.is_empty() && last_range.head == end {
+    if !last_range.is_empty() && (last_range.head == end || last_range.anchor == end) {
         let transaction = Transaction::change(
             doc.text(),
             [(end, end, Some(doc.line_ending.as_str().into()))].into_iter(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2224,7 +2224,7 @@ fn append_mode(cx: &mut Context) {
         .iter()
         .last()
         .expect("selection should always have at least one range");
-    if !last_range.is_empty() && (last_range.head == end || last_range.anchor == end) {
+    if !last_range.is_empty() && last_range.to() == end {
         let transaction = Transaction::change(
             doc.text(),
             [(end, end, Some(doc.line_ending.as_str().into()))].into_iter(),

--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -88,20 +88,22 @@ async fn cursor_position_newly_opened_file() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn cursor_position_append_eof() -> anyhow::Result<()> {
+    // Selection is fowards
     test((
-        "#[f|]#oo",
-        "eabar<esc>",
-        helpers::platform_line("#[foobar|]#\n").as_ref()
+        "#[foo|]#",
+        "abar<esc>",
+        helpers::platform_line("#[foobar|]#\n").as_ref(),
     ))
     .await?;
-    
+
+    // Selection is backwards
     test((
-        "foo#[|]#",
-        "babar<esc>",
-        helpers::platform_line("#[foobar|]#\n").as_ref()
+        "#[|foo]#",
+        "abar<esc>",
+        helpers::platform_line("#[foobar|]#\n").as_ref(),
     ))
     .await?;
-    
+
     Ok(())
 }
 

--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -87,6 +87,25 @@ async fn cursor_position_newly_opened_file() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn cursor_position_append_eof() -> anyhow::Result<()> {
+    test((
+        "#[f|]#oo",
+        "eabar<esc>",
+        helpers::platform_line("#[foobar|]#\n").as_ref()
+    ))
+    .await?;
+    
+    test((
+        "foo#[|]#",
+        "babar<esc>",
+        helpers::platform_line("#[foobar|]#\n").as_ref()
+    ))
+    .await?;
+    
+    Ok(())
+}
+
+#[tokio::test]
 async fn select_mode_tree_sitter_next_function_is_union_of_objects() -> anyhow::Result<()> {
     test_with_config(
         Args {


### PR DESCRIPTION
Fixes #4074. Cursor position was set to the wrong location when the anchor of a selection was at the end of a file. There was already a fix for the head of a selection being at the end, it just has to apply when the anchor is at the end as well.