### PR TITLE
Add some vertical characters to the editor.indent-guides documentation

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -249,6 +249,6 @@ Example:
 ```toml
 [editor.indent-guides]
 render = true
-character = "╎"
+character = "╎", # Some characters that work well: "▏", "┆", "┊", "⸽"
 skip-levels = 1
 ```

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -249,6 +249,6 @@ Example:
 ```toml
 [editor.indent-guides]
 render = true
-character = "╎", # Some characters that work well: "▏", "┆", "┊", "⸽"
+character = "╎" # Some characters that work well: "▏", "┆", "┊", "⸽"
 skip-levels = 1
 ```


### PR DESCRIPTION
This PR updates the default indent-guide character from a vertically aligned pipe (`|`) to a left aligned pipe (`▏`).

This makes a big difference visually as the indent guides are now aligned precisely to the indent level instead of starting half a character later.

* Before

![before](https://user-images.githubusercontent.com/115335378/194763618-10299a7d-3bd4-490e-b3e5-78a48ac34743.png)

* After

![after](https://user-images.githubusercontent.com/115335378/194763624-e01a3c54-3651-48f3-a40e-4f410c2f07f1.png)
