### PR TITLE
Add instructions for gnome desktop support using the `.desktop` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ for a language.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
 
-## Gnome `.desktop` file support
+## Adding Helix to your desktop environment
 
-If you are installing from source, to use Helix in the Gnome desktop environment you will need to copy the provided `.desktop` file:
+If installing from source, to use Helix in desktop environments that supports [XDG desktop menu](https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html), including Gnome and KDE, copy the provided `.desktop` file to the correct folder:
 
 ```bash
 cp contrib/Helix.desktop ~/.local/share/applications
 ```
 
-To use another terminal than the default `gnome-terminal` you will need to modify the `.desktop` file. For example, to use `kitty`:
+To use another terminal than the default, you will need to modify the `.desktop` file. For example, to use `kitty`:
 
 ```bash
 sed -i "s|Exec=hx %F|Exec=kitty hx %F|g" ~/.local/share/applications/Helix.desktop

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ tree-sitter grammars may be manually fetched and built with `hx --grammar fetch`
 Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%AppData%/helix/runtime` on Windows).
 
-| OS                   | Command                                      |
-| -------------------- | -------------------------------------------- |
-| Windows (cmd.exe)    | `xcopy /e /i runtime %AppData%\helix\runtime`      |
-| Windows (PowerShell) | `xcopy /e /i runtime $Env:AppData\helix\runtime`   |
-| Linux/macOS          | `ln -s $PWD/runtime ~/.config/helix/runtime` |
+| OS                   | Command                                          |
+| -------------------- | ------------------------------------------------ |
+| Windows (cmd.exe)    | `xcopy /e /i runtime %AppData%\helix\runtime`    |
+| Windows (PowerShell) | `xcopy /e /i runtime $Env:AppData\helix\runtime` |
+| Linux/macOS          | `ln -s $PWD/runtime ~/.config/helix/runtime`     |
 
 This location can be overridden via the `HELIX_RUNTIME` environment variable.
 
@@ -67,6 +67,23 @@ In order to use LSP features like auto-complete, you will need to
 for a language.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
+
+## Gnome `.desktop` file support
+
+If you are installing from source, to use Helix in the Gnome desktop environment you will need to copy the provided `.desktop` file:
+
+```bash
+cp contrib/Helix.desktop ~/.local/share/applications
+```
+
+To use another terminal than the default `gnome-terminal` you will need to modify the `.desktop` file. For example, to use `kitty`:
+
+```bash
+sed -i "s|Exec=hx %F|Exec=kitty hx %F|g" ~/.local/share/applications/Helix.desktop
+sed -i "s|Terminal=true|Terminal=false|g" ~/.local/share/applications/Helix.desktop
+```
+
+Please note: there is no icon for Helix yet, so the system default will be used.
 
 ## MacOS
 

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -60,24 +60,40 @@ cargo install --path helix-term
 
 This will install the `hx` binary to `$HOME/.cargo/bin`.
 
-Helix also needs it's runtime files so make sure to copy/symlink the `runtime/` directory into the
+Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overridden
 via the `HELIX_RUNTIME` environment variable.
 
-| OS                | command   |
-|-------------------|-----------|
-|windows(cmd.exe)   |`xcopy /e /i runtime %AppData%/helix/runtime`     |
-|windows(powershell)|`xcopy /e /i runtime $Env:AppData\helix\runtime`  |
-|linux/macos        |`ln -s $PWD/runtime ~/.config/helix/runtime`|
+| OS                  | command                                          |
+| ------------------- | ------------------------------------------------ |
+| windows(cmd.exe)    | `xcopy /e /i runtime %AppData%/helix/runtime`    |
+| windows(powershell) | `xcopy /e /i runtime $Env:AppData\helix\runtime` |
+| linux/macos         | `ln -s $PWD/runtime ~/.config/helix/runtime`     |
 
-## Finishing up the installation 
+To use Helix in desktop environments that supports [XDG desktop menu](https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html), including Gnome and KDE, copy the provided `.desktop` file to the correct folder:
 
-To make sure everything is set up as expected you should finally run the helix healthcheck via 
+```bash
+cp contrib/Helix.desktop ~/.local/share/applications
+```
+
+To use another terminal than the default, you will need to modify the `.desktop` file. For example, to use `kitty`:
+
+```bash
+sed -i "s|Exec=hx %F|Exec=kitty hx %F|g" ~/.local/share/applications/Helix.desktop
+sed -i "s|Terminal=true|Terminal=false|g" ~/.local/share/applications/Helix.desktop
+```
+
+Please note: there is no icon for Helix yet, so the system default will be used.
+
+## Finishing up the installation
+
+To make sure everything is set up as expected you should finally run the helix healthcheck via
+
 ```
 hx --health
 ```
-For more information on the information displayed in the healthcheck results refer to [Healthcheck](https://github.com/helix-editor/helix/wiki/Healthcheck).
 
+For more information on the information displayed in the health check results refer to [Healthcheck](https://github.com/helix-editor/helix/wiki/Healthcheck).
 
 ### Building tree-sitter grammars
 


### PR DESCRIPTION
This should address: https://github.com/helix-editor/helix/issues/4159