### PR TITLE
feat: paste from file

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -36,6 +36,8 @@
 | `:clipboard-paste-after` | Paste system clipboard after selections. |
 | `:clipboard-paste-before` | Paste system clipboard before selections. |
 | `:clipboard-paste-replace` | Replace selections with content of system clipboard. |
+| `:file-paste-after` | Read a file from disk and paste afer selections. |
+| `:file-paste-before` | Read a file from disk and paste before selections. |
 | `:primary-clipboard-paste-after` | Paste primary clipboard after selections. |
 | `:primary-clipboard-paste-before` | Paste primary clipboard before selections. |
 | `:primary-clipboard-paste-replace` | Replace selections with content of system primary clipboard. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3485,6 +3485,29 @@ fn paste_clipboard_impl(
     }
 }
 
+fn paste_file_impl(
+    editor: &mut Editor,
+    action: Paste,
+    paths: &[PathBuf],
+    count: usize,
+) -> anyhow::Result<()> {
+    use std::io::Read;
+
+    // reverse the paths[] as its more intuative to expect the order to be respected
+    // paths[0], paths[1], paths[..N] when calling the function
+    for path in paths.iter().rev() {
+        let mut file = std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .context(format!("unable to read {:?}", path))?;
+
+        let (view, doc) = current!(editor);
+
+        paste_impl(&[contents], doc, view, action, count);
+    }
+    Ok(())
+}
+
 fn paste_clipboard_after(cx: &mut Context) {
     let _ = paste_clipboard_impl(
         cx.editor,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3485,10 +3485,23 @@ fn paste_clipboard_impl(
     }
 }
 
-fn paste_file_impl(
+pub(crate) fn paste_file_after<P: AsRef<Path>>(
+    cx: &mut compositor::Context,
+    paths: &[P],
+) -> anyhow::Result<()> {
+    paste_file_impl(cx.editor, Paste::After, paths, 1)
+}
+pub(crate) fn paste_file_before<P: AsRef<Path>>(
+    cx: &mut compositor::Context,
+    paths: &[P],
+) -> anyhow::Result<()> {
+    paste_file_impl(cx.editor, Paste::Before, paths, 1)
+}
+
+fn paste_file_impl<P: AsRef<Path>>(
     editor: &mut Editor,
     action: Paste,
-    paths: &[PathBuf],
+    paths: &[P],
     count: usize,
 ) -> anyhow::Result<()> {
     use std::io::Read;
@@ -3496,10 +3509,11 @@ fn paste_file_impl(
     // reverse the paths[] as its more intuative to expect the order to be respected
     // paths[0], paths[1], paths[..N] when calling the function
     for path in paths.iter().rev() {
-        let mut file = std::fs::File::open(&path).context(format!("unable to open {:?}", path))?;
+        let mut file =
+            std::fs::File::open(&path).context(format!("unable to open {:?}", path.as_ref()))?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)
-            .context(format!("unable to read {:?}", path))?;
+            .context(format!("unable to read {:?}", path.as_ref()))?;
 
         let (view, doc) = current!(editor);
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -846,6 +846,48 @@ fn paste_clipboard_before(
     paste_clipboard_impl(cx.editor, Paste::Before, ClipboardType::Clipboard, 1)
 }
 
+fn paste_file_after(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(!args.is_empty(), "wrong argument count");
+    let paths: Vec<PathBuf> = args
+        .iter()
+        .map(|arg| {
+            let (path, _) = args::parse_file(arg);
+            path
+        })
+        .collect();
+
+    paste_file_impl(cx.editor, Paste::After, &paths, 1)
+}
+
+fn paste_file_before(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(!args.is_empty(), "wrong argument count");
+    let paths: Vec<PathBuf> = args
+        .iter()
+        .map(|arg| {
+            let (path, _) = args::parse_file(arg);
+            path
+        })
+        .collect();
+
+    paste_file_impl(cx.editor, Paste::Before, &paths, 1)
+}
+
 fn paste_primary_clipboard_after(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -1861,6 +1903,20 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             doc: "Replace selections with content of system clipboard.",
             fun: replace_selections_with_clipboard,
             completer: None,
+        },
+        TypableCommand {
+            name: "file-paste-after",
+            aliases: &[],
+            doc: "Read a file from disk and paste afer selections.",
+            fun: paste_file_after,
+            completer: Some(completers::filename),
+        },
+        TypableCommand {
+            name: "file-paste-before",
+            aliases: &[],
+            doc: "Read a file from disk and paste before selections.",
+            fun: paste_file_before,
+            completer: Some(completers::filename),
         },
         TypableCommand {
             name: "primary-clipboard-paste-after",

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -551,6 +551,12 @@ impl<T: Item + 'static> Component for Picker<T> {
             ctrl!('t') => {
                 self.toggle_preview();
             }
+            ctrl!('o') => {
+                if let Some(option) = self.selection() {
+                    (self.callback_fn)(cx, option, Action::PasteAfter);
+                }
+                return close_fn;
+            }
             _ => {
                 self.prompt_handle_event(event, cx);
             }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -708,6 +708,8 @@ pub enum Action {
     Replace,
     HorizontalSplit,
     VerticalSplit,
+    PasteBefore,
+    PasteAfter,
 }
 
 /// Error thrown on failed document closed
@@ -1017,6 +1019,9 @@ impl Editor {
                 // initialize selection for view
                 let doc = doc_mut!(self, &id);
                 doc.ensure_view_init(view_id);
+            }
+            Action::PasteBefore | Action::PasteAfter => {
+                // do nothing?
             }
         }
 


### PR DESCRIPTION
This is an attempt to implement https://github.com/helix-editor/helix/issues/3796.

It is an alternative implementation to https://github.com/helix-editor/helix/pull/3966 using  a lot of the "paste" functionality that was already available (for better or worse). I elected to read the file "raw" without going through the Document infrastructure as eventually it was being read directly into a String and, because it reuses the `paste_impl` function already, decided to skip the overhead of processing the document first. Oh and as a bonus it supports multiple files.  

The command has been implemented as:  
`file-paste-after` and `file-paste-before`  
... to keep it in line with the current `:*-paste-[before|after|replace]` commands.

It does have basic file picker integration (which I am the most iffy with - comments/fixes expected and welcome!), using what seemed to be the easiest path - through the `Actions` enum. In particular, I'm looking for any suggestions as to what should happen in `helix-view/src/editor.rs`. It's not currently hit in any path so I've left it as a noop for now. Not great, but I just wanted something up for comments.

Beginning with rust so any code suggestions/critiques/guidance welcome. Additionally, any insight as to how to get `c-O` to work in the picker would be great 😄 
