### PR TITLE
Fix rendering of lines longer than 2^16

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -441,7 +441,8 @@ impl EditorView {
                 return;
             }
 
-            let starting_indent = (offset.col / tab_width) + config.indent_guides.skip_levels;
+            let starting_indent =
+                (offset.col / tab_width) + config.indent_guides.skip_levels as usize;
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -443,16 +443,14 @@ impl EditorView {
 
             let starting_indent =
                 (offset.col / tab_width) + config.indent_guides.skip_levels as usize;
-            // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
-            // extra loops if the code is deeply nested.
 
             for i in starting_indent..(indent_level / tab_width) {
-                surface.set_string(
-                    (viewport.x as usize + (i * tab_width) - offset.col) as u16,
-                    viewport.y + line,
-                    &indent_guide_char,
-                    indent_guide_style,
-                );
+                let x = (viewport.x as usize + (i * tab_width) - offset.col) as u16;
+                let y = viewport.y + line;
+                if !surface.in_bounds(x, y) {
+                    break;
+                }
+                surface.set_string(x, y, &indent_guide_char, indent_guide_style);
             }
         };
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -404,7 +404,7 @@ impl EditorView {
         let characters = &whitespace.characters;
 
         let mut spans = Vec::new();
-        let mut visual_x = 0u16;
+        let mut visual_x = 0usize;
         let mut line = 0u16;
         let tab_width = doc.tab_width();
         let tab = if whitespace.render.tab() == WhitespaceRenderValue::All {
@@ -441,14 +441,13 @@ impl EditorView {
                 return;
             }
 
-            let starting_indent =
-                (offset.col / tab_width) as u16 + config.indent_guides.skip_levels;
+            let starting_indent = (offset.col / tab_width) + config.indent_guides.skip_levels;
             // TODO: limit to a max indent level too. It doesn't cause visual artifacts but it would avoid some
             // extra loops if the code is deeply nested.
 
-            for i in starting_indent..(indent_level / tab_width as u16) {
+            for i in starting_indent..(indent_level / tab_width) {
                 surface.set_string(
-                    viewport.x + (i * tab_width as u16) - offset.col as u16,
+                    (viewport.x as usize + (i * tab_width) - offset.col) as u16,
                     viewport.y + line,
                     &indent_guide_char,
                     indent_guide_style,
@@ -494,14 +493,14 @@ impl EditorView {
                     use helix_core::graphemes::{grapheme_width, RopeGraphemes};
 
                     for grapheme in RopeGraphemes::new(text) {
-                        let out_of_bounds = visual_x < offset.col as u16
-                            || visual_x >= viewport.width + offset.col as u16;
+                        let out_of_bounds = offset.col > (visual_x as usize)
+                            || (visual_x as usize) >= viewport.width as usize + offset.col;
 
                         if LineEnding::from_rope_slice(&grapheme).is_some() {
                             if !out_of_bounds {
                                 // we still want to render an empty cell with the style
                                 surface.set_string(
-                                    viewport.x + visual_x - offset.col as u16,
+                                    (viewport.x as usize + visual_x - offset.col) as u16,
                                     viewport.y + line,
                                     &newline,
                                     style.patch(whitespace_style),
@@ -549,7 +548,7 @@ impl EditorView {
                             if !out_of_bounds {
                                 // if we're offscreen just keep going until we hit a new line
                                 surface.set_string(
-                                    viewport.x + visual_x - offset.col as u16,
+                                    (viewport.x as usize + visual_x - offset.col) as u16,
                                     viewport.y + line,
                                     display_grapheme,
                                     if is_whitespace {
@@ -582,7 +581,7 @@ impl EditorView {
                                 last_line_indent_level = visual_x;
                             }
 
-                            visual_x = visual_x.saturating_add(width as u16);
+                            visual_x = visual_x.saturating_add(width);
                         }
                     }
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -23,7 +23,7 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-use std::{borrow::Cow, path::PathBuf};
+use std::{borrow::Cow, cmp::min, path::PathBuf};
 
 use tui::buffer::Buffer as Surface;
 
@@ -444,12 +444,18 @@ impl EditorView {
             let starting_indent =
                 (offset.col / tab_width) + config.indent_guides.skip_levels as usize;
 
-            for i in starting_indent..(indent_level / tab_width) {
+            // Don't draw indent guides outside of view
+            let end_indent = min(
+                indent_level,
+                // Add tab_width - 1 to round up, since the first visible
+                // indent might be a bit after offset.col
+                offset.col + viewport.width as usize + (tab_width - 1),
+            ) / tab_width;
+
+            for i in starting_indent..end_indent {
                 let x = (viewport.x as usize + (i * tab_width) - offset.col) as u16;
                 let y = viewport.y + line;
-                if !surface.in_bounds(x, y) {
-                    break;
-                }
+                debug_assert!(surface.in_bounds(x, y));
                 surface.set_string(x, y, &indent_guide_char, indent_guide_style);
             }
         };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -558,7 +558,7 @@ impl Default for WhitespaceCharacters {
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
-    pub skip_levels: u16,
+    pub skip_levels: usize,
 }
 
 impl Default for IndentGuidesConfig {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -558,7 +558,7 @@ impl Default for WhitespaceCharacters {
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
-    pub skip_levels: usize,
+    pub skip_levels: u8,
 }
 
 impl Default for IndentGuidesConfig {


### PR DESCRIPTION
Before things would be cast to u16 earlier than needed, which would cause problems for insanely long lines (longer than 2^16 ~ 65 thousand)
In order to reproduce:
 - Open file with _really long_ lines, for example <http://tom7.org/abc/paper.txt>
- `65500l` (go 65500 to the left)
- hold `l` for a bit

Before it would disappear when you reached 2^16 (65536), now it doesn't.

**Note:** currently moving around when the cursor is very far left is very slow, especially in debug mode, this is an unrelated issue.
