### PR TITLE
Fix split startup

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -33,11 +33,11 @@ impl Args {
                 "--help" => args.display_help = true,
                 "--tutor" => args.load_tutor = true,
                 "--vsplit" => match args.split {
-                    Some(_) => anyhow::bail!("Can only set a split once of a specific type"),
+                    Some(_) => anyhow::bail!("can only set a split once of a specific type"),
                     None => args.split = Some(Layout::Vertical),
                 },
                 "--hsplit" => match args.split {
-                    Some(_) => anyhow::bail!("Can only set a split once of a specific type"),
+                    Some(_) => anyhow::bail!("can only set a split once of a specific type"),
                     None => args.split = Some(Layout::Horizontal),
                 },
                 "--health" => {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -32,8 +32,14 @@ impl Args {
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,
                 "--tutor" => args.load_tutor = true,
-                "--vsplit" => args.split = Some(Layout::Vertical),
-                "--hsplit" => args.split = Some(Layout::Horizontal),
+                "--vsplit" => match args.split {
+                    Some(_) => anyhow::bail!("Can only set a split once of a specific type"),
+                    None => args.split = Some(Layout::Vertical),
+                },
+                "--hsplit" => match args.split {
+                    Some(_) => anyhow::bail!("Can only set a split once of a specific type"),
+                    None => args.split = Some(Layout::Horizontal),
+                },
                 "--health" => {
                     args.health = true;
                     args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));


### PR DESCRIPTION
Noticed that --hsplit and --vsplit was implemented for this [issue](https://github.com/helix-editor/helix/issues/2709).
But passing `--hsplit --vsplit` resulted in using the later split type selected which user might not have intended.
So this PR makes them have to select one or the other explicitly.