### PR TITLE
Implement Vim like movement commands

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -131,7 +131,7 @@ pub fn move_vertically_anchored(
     // cases we take advantage that anchored movement sets the horizontal column
     // to the largest possible integer.
     let newline_move_mode = pos == line_end_char_index(&slice, line)
-        && (horiz == !0 || !rope_is_line_ending(slice.line(line)));
+        && (horiz == u32::MAX || !rope_is_line_ending(slice.line(line)));
 
     // Compute the new position.
     let new_row = match dir {
@@ -153,7 +153,7 @@ pub fn move_vertically_anchored(
 
         // when in newline_move_mode we set the horizontal column to the largest
         // possible integer to be able to disambiugate movements across empty lines.
-        (new_pos, !0)
+        (new_pos, u32::MAX)
 
     // otherwise move up and down like normal but ensure to never place the
     // cursor on the newline character.

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -104,11 +104,13 @@ pub fn move_vertically(
 
 /// Implements anchored vertical movement.
 ///
-/// Anchored movement behaves differently depending on where the cursor is placed.  If
-/// the cursor is currently on the end of the line (the newline character) then when it
-/// is moving up and down, it stays anchored to the newline as it moves up and down.
+/// Anchored movement behaves differently depending on where the cursor is placed with
+/// regards to newlines.  If the cursor is currently on a newline, then moving up and
+/// down will place you again on the newline of that line.
 ///
-/// Otherwise when it moves up and down it will not move unto the newline character.
+/// If you are not on the newline, then moving up and down will move you to the same
+/// column except if that column is further to the left from where you are.  In that case
+/// it places you on the rightmost column that is not a newline.
 pub fn move_vertically_anchored(
     slice: RopeSlice,
     range: Range,

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -48,6 +48,31 @@ pub fn move_horizontally(
     range.put_cursor(slice, new_pos, behaviour == Movement::Extend)
 }
 
+pub fn move_horizontally_line_bounded(
+    slice: RopeSlice,
+    range: Range,
+    dir: Direction,
+    count: usize,
+    behaviour: Movement,
+    tab_width: usize,
+) -> Range {
+    let pos = range.cursor(slice);
+    let new_pos = match dir {
+        Direction::Forward => nth_next_grapheme_boundary(slice, pos, count),
+        Direction::Backward => nth_prev_grapheme_boundary(slice, pos, count),
+    };
+
+    let old_coords = visual_coords_at_pos(slice, pos, tab_width);
+    let new_coords = visual_coords_at_pos(slice, new_pos, tab_width);
+
+    // only allow moves within the same line.
+    if old_coords.row == new_coords.row {
+        range.put_cursor(slice, new_pos, behaviour == Movement::Extend)
+    } else {
+        range
+    }
+}
+
 pub fn move_vertically(
     slice: RopeSlice,
     range: Range,

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -6,7 +6,7 @@ use tree_sitter::{Node, QueryCursor};
 use crate::{
     chars::{categorize_char, char_is_line_ending, CharCategory},
     graphemes::{
-        self, next_grapheme_boundary, nth_next_grapheme_boundary, nth_prev_grapheme_boundary,
+        next_grapheme_boundary, nth_next_grapheme_boundary, nth_prev_grapheme_boundary,
         prev_grapheme_boundary,
     },
     line_ending::{line_end_char_index, rope_is_line_ending},
@@ -167,7 +167,7 @@ pub fn move_vertically_anchored(
         // Move away from the newline character.
         let end_index = line_end_char_index(&slice, new_row);
         if new_pos == end_index && slice.line(new_row).len_chars() != 1 {
-            new_pos = graphemes::prev_grapheme_boundary(slice, end_index);
+            new_pos = prev_grapheme_boundary(slice, end_index);
         }
 
         (new_pos, horiz)

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -131,7 +131,7 @@ pub fn move_vertically_anchored(
     // cases we take advantage that anchored movement sets the horizontal column
     // to the largest possible integer.
     let newline_move_mode = pos == line_end_char_index(&slice, line)
-        && (horiz == !0 || slice.line(line).len_chars() != 1);
+        && (horiz == !0 || !rope_is_line_ending(slice.line(line)));
 
     // Compute the new position.
     let new_row = match dir {
@@ -168,7 +168,7 @@ pub fn move_vertically_anchored(
 
         // Move away from the newline character.
         let end_index = line_end_char_index(&slice, new_row);
-        if new_pos == end_index && slice.line(new_row).len_chars() != 1 {
+        if new_pos == end_index && !rope_is_line_ending(slice.line(new_row)) {
             new_pos = prev_grapheme_boundary(slice, end_index);
         }
 

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -54,7 +54,7 @@ pub fn move_horizontally_same_line(
     dir: Direction,
     count: usize,
     behaviour: Movement,
-    tab_width: usize,
+    _: usize,
 ) -> Range {
     let pos = range.cursor(slice);
     let new_pos = match dir {
@@ -62,11 +62,8 @@ pub fn move_horizontally_same_line(
         Direction::Backward => nth_prev_grapheme_boundary(slice, pos, count),
     };
 
-    let old_coords = visual_coords_at_pos(slice, pos, tab_width);
-    let new_coords = visual_coords_at_pos(slice, new_pos, tab_width);
-
     // only allow moves within the same line.
-    if old_coords.row == new_coords.row {
+    if slice.char_to_line(pos) == slice.char_to_line(new_pos) {
         range.put_cursor(slice, new_pos, behaviour == Movement::Extend)
     } else {
         range
@@ -155,6 +152,9 @@ pub fn move_vertically_anchored(
         // when in newline_move_mode we set the horizontal column to the largest
         // possible integer to be able to disambiugate movements across empty lines.
         (new_pos, !0)
+
+    // otherwise move up and down like normal but ensure to never place the
+    // cursor on the newline character.
     } else {
         let new_col = col.max(horiz as usize);
         let mut new_pos = pos_at_visual_coords(slice, Position::new(new_row, new_col), tab_width);

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -48,7 +48,7 @@ pub fn move_horizontally(
     range.put_cursor(slice, new_pos, behaviour == Movement::Extend)
 }
 
-pub fn move_horizontally_line_bounded(
+pub fn move_horizontally_same_line(
     slice: RopeSlice,
     range: Range,
     dir: Direction,

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -53,7 +53,6 @@ pub struct Range {
     pub anchor: usize,
     /// The head of the range, moved when extending.
     pub head: usize,
-    /// Retains the information about the horizontal column we were on
     pub horiz: Option<u32>,
 }
 
@@ -483,7 +482,7 @@ impl Selection {
             ranges: smallvec![Range {
                 anchor,
                 head,
-                horiz: None,
+                horiz: None
             }],
             primary_index: 0,
         }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -55,10 +55,6 @@ pub struct Range {
     pub head: usize,
     /// Retains the information about the horizontal column we were on
     pub horiz: Option<u32>,
-    /// Disambiugation state for movement across empty lines for anchored
-    /// newline movement.  If this flag is `true` it means that we came
-    /// from the newline character rather than a character in the line.
-    pub newline_move_mode: bool,
 }
 
 impl Range {
@@ -67,7 +63,6 @@ impl Range {
             anchor,
             head,
             horiz: None,
-            newline_move_mode: false,
         }
     }
 
@@ -134,7 +129,6 @@ impl Range {
             anchor: self.head,
             head: self.anchor,
             horiz: self.horiz,
-            newline_move_mode: self.newline_move_mode,
         }
     }
 
@@ -193,7 +187,6 @@ impl Range {
             anchor,
             head,
             horiz: None,
-            newline_move_mode: false,
         }
     }
 
@@ -207,14 +200,12 @@ impl Range {
                 anchor: self.anchor.min(from),
                 head: self.head.max(to),
                 horiz: None,
-                newline_move_mode: false,
             }
         } else {
             Self {
                 anchor: self.anchor.max(to),
                 head: self.head.min(from),
                 horiz: None,
-                newline_move_mode: false,
             }
         }
     }
@@ -230,14 +221,12 @@ impl Range {
                 anchor: self.anchor.max(other.anchor),
                 head: self.head.min(other.head),
                 horiz: None,
-                newline_move_mode: false,
             }
         } else {
             Range {
                 anchor: self.from().min(other.from()),
                 head: self.to().max(other.to()),
                 horiz: None,
-                newline_move_mode: false,
             }
         }
     }
@@ -296,11 +285,6 @@ impl Range {
             } else {
                 None
             },
-            newline_move_mode: if new_anchor == self.anchor {
-                self.newline_move_mode
-            } else {
-                false
-            },
         }
     }
 
@@ -324,7 +308,6 @@ impl Range {
                 anchor: self.anchor,
                 head: next_grapheme_boundary(slice, self.head),
                 horiz: self.horiz,
-                newline_move_mode: self.newline_move_mode,
             }
         } else {
             *self
@@ -397,7 +380,6 @@ impl From<(usize, usize)> for Range {
             anchor,
             head,
             horiz: None,
-            newline_move_mode: false,
         }
     }
 }
@@ -502,7 +484,6 @@ impl Selection {
                 anchor,
                 head,
                 horiz: None,
-                newline_move_mode: false,
             }],
             primary_index: 0,
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -539,7 +539,7 @@ where
 }
 
 use helix_core::movement::{
-    move_horizontally, move_horizontally_line_bounded, move_vertically, move_vertically_anchored,
+    move_horizontally, move_horizontally_same_line, move_vertically, move_vertically_anchored,
 };
 
 fn move_char_left(cx: &mut Context) {
@@ -549,7 +549,7 @@ fn move_char_left(cx: &mut Context) {
 fn move_char_left_same_line(cx: &mut Context) {
     move_impl(
         cx,
-        move_horizontally_line_bounded,
+        move_horizontally_same_line,
         Direction::Backward,
         Movement::Move,
     )
@@ -562,7 +562,7 @@ fn move_char_right(cx: &mut Context) {
 fn move_char_right_same_line(cx: &mut Context) {
     move_impl(
         cx,
-        move_horizontally_line_bounded,
+        move_horizontally_same_line,
         Direction::Forward,
         Movement::Move,
     )

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -201,7 +201,9 @@ impl MappableCommand {
         move_char_right, "Move right",
         move_char_right_same_line, "Move right within same line only",
         move_line_up, "Move up",
+        move_line_up_anchored, "Move up with newline anchoring behavior",
         move_line_down, "Move down",
+        move_line_down_anchored, "Move down with newline anchoring behavior",
         move_from_line_end, "Move left from line end",
         extend_char_left, "Extend left",
         extend_char_right, "Extend right",
@@ -537,7 +539,9 @@ where
     doc.set_selection(view.id, selection);
 }
 
-use helix_core::movement::{move_horizontally, move_horizontally_line_bounded, move_vertically};
+use helix_core::movement::{
+    move_horizontally, move_horizontally_line_bounded, move_vertically, move_vertically_anchored,
+};
 
 fn move_char_left(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Backward, Movement::Move)
@@ -569,8 +573,26 @@ fn move_line_up(cx: &mut Context) {
     move_impl(cx, move_vertically, Direction::Backward, Movement::Move)
 }
 
+fn move_line_up_anchored(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_vertically_anchored,
+        Direction::Backward,
+        Movement::Move,
+    )
+}
+
 fn move_line_down(cx: &mut Context) {
     move_impl(cx, move_vertically, Direction::Forward, Movement::Move)
+}
+
+fn move_line_down_anchored(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_vertically_anchored,
+        Direction::Forward,
+        Movement::Move,
+    )
 }
 
 fn move_from_line_end(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -204,7 +204,6 @@ impl MappableCommand {
         move_line_up_anchored, "Move up with newline anchoring behavior",
         move_line_down, "Move down",
         move_line_down_anchored, "Move down with newline anchoring behavior",
-        move_from_line_end, "Move left from line end",
         extend_char_left, "Extend left",
         extend_char_right, "Extend right",
         extend_line_up, "Extend up",
@@ -593,29 +592,6 @@ fn move_line_down_anchored(cx: &mut Context) {
         Direction::Forward,
         Movement::Move,
     )
-}
-
-fn move_from_line_end(cx: &mut Context) {
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        let line = range.cursor_line(text);
-        let line_start = text.line_to_char(line);
-
-        let pos = range.cursor(text);
-
-        let last_line_char =
-            graphemes::prev_grapheme_boundary(text, line_end_char_index(&text, line))
-                .max(line_start);
-        if pos == last_line_char + 1 {
-            range.put_cursor(text, last_line_char, false)
-        } else {
-            range
-        }
-    });
-
-    doc.set_selection(view.id, selection);
 }
 
 fn extend_char_left(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -205,9 +205,13 @@ impl MappableCommand {
         move_line_down, "Move down",
         move_line_down_anchored, "Move down with newline anchoring behavior",
         extend_char_left, "Extend left",
+        extend_char_left_same_line, "Extend left within same line only",
         extend_char_right, "Extend right",
+        extend_char_right_same_line, "Extend left within same line only",
         extend_line_up, "Extend up",
+        extend_line_up_anchored, "Extend up with newline anchoring behavior",
         extend_line_down, "Extend down",
+        extend_line_down_anchored, "Extend down with newline anchoring behavior",
         copy_selection_on_next_line, "Copy selection on next line",
         copy_selection_on_prev_line, "Copy selection on previous line",
         move_next_word_start, "Move to start of next word",
@@ -598,16 +602,52 @@ fn extend_char_left(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Backward, Movement::Extend)
 }
 
+fn extend_char_left_same_line(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally_same_line,
+        Direction::Backward,
+        Movement::Extend,
+    )
+}
+
 fn extend_char_right(cx: &mut Context) {
     move_impl(cx, move_horizontally, Direction::Forward, Movement::Extend)
+}
+
+fn extend_char_right_same_line(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_horizontally_same_line,
+        Direction::Forward,
+        Movement::Extend,
+    )
 }
 
 fn extend_line_up(cx: &mut Context) {
     move_impl(cx, move_vertically, Direction::Backward, Movement::Extend)
 }
 
+fn extend_line_up_anchored(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_vertically_anchored,
+        Direction::Backward,
+        Movement::Extend,
+    )
+}
+
 fn extend_line_down(cx: &mut Context) {
     move_impl(cx, move_vertically, Direction::Forward, Movement::Extend)
+}
+
+fn extend_line_down_anchored(cx: &mut Context) {
+    move_impl(
+        cx,
+        move_vertically_anchored,
+        Direction::Forward,
+        Movement::Extend,
+    )
 }
 
 fn goto_line_end_impl(view: &mut View, doc: &mut Document, movement: Movement) {


### PR DESCRIPTION
This adds a few new movement commands to allow `hjkl` to be rebound so that they follow more the movement of vim. left/right movement cannot move between lines and up/down either follows newline or does not accidentally move onto the newline character. See #4268 for motivation. This however does not emulate vim, it just has some vim inspired movements. In particular it retains the entire behavior of Helix with regards to how newlines are otherwise handled (they stay selectable, and these alternative movement commands to not interfere with other commands in use or change their assumptions).

![vim-movement mov](https://user-images.githubusercontent.com/7396/195949926-ad74756f-901b-4afa-b995-b907c0f469b6.gif)

The following commands are added:

* `move_line_up_anchored` (bind to `k`): implements anchored movement up
* `move_line_down_anchored` (bind to `j`): implements anchored movement down
* `move_char_left_same_line` (bind to `h`): implements same-line movement left
* `move_char_right_same_line` (bind to `l`): implements same-line movement right
* `extend_line_up_anchored` (bind to `k`): implements anchored selection extension up
* `extend_line_down_anchored` (bind to `j`): implements anchored selection extension down
* `extend_char_left_same_line` (bind to `h`): implements same-line selection extension left
* `extend_char_right_same_line` (bind to `l`): implements same-line selection extension right

## Bindings

```toml
[keys.normal]
j = ["move_line_down_anchored"]
k = ["move_line_up_anchored"]
h = ["move_char_left_same_line"]
l = ["move_char_right_same_line"]

[keys.select]
j = ["extend_line_down_anchored"]
k = ["extend_line_up_anchored"]
h = ["extend_char_left_same_line"]
l = ["extend_char_right_same_line"]
```

## Same Line Movement

The default movement behavior of helix will happily place you in the next line. Vim users are not used to that and are likely to prefer the cursor not to move into the next line (that is at least my expectation). This is what `move_char_left_same_line` and `move_char_right_same_line` do. They will however let you move to the rightmost character (the newline) which is not what vim does (except of `virtualedit=oneline` is used). However this pairs up nicely with the anchored movement (see next).

## Anchored Vertical Movements

The two commands `move_line_up_anchored` and `move_line_down_anchored` implement what I would call anchored movement. If you are on the newline character (eg: one to the right of where `goto_line_end` would place you) then as you move up and down you end up on the newline of the target line again.  This emulates the behavior of vim of what happens if you move to the line end with `$`. If however you are placed to the left of the newline, as you move up and down you will not move onto the newline.

The main difference is that in vim if you use `$` and go up/down you stay anchored to the line end. In Helix with this change you need to do `gll` to stay anchored to the newline. I do however have to say that I prefer this actually because in Vim you do not actually know if you are newline anchored visually. That is as far as I can tell an internal state.

I played around with this a bit now and I really like the combination of the two. It stays true to the helix character model, but it also feels very natural for vim users.

**Limitation:** Movements across empty lines are ambiguous. To help with this I put the horizontal column to the largest possible integer on the range to tell these cases apart. From what I can tell this does not create negative impact and avoids extra complication on the range.

## Notes on Mixed Use

I think these move/extend commands are interesting to use independent of each other. For instance I find the anchored newline movement functionality useful even if one does not like restricting the movements within a line. For instance line based selection works really nice as once the visual selection is on the newline, any further moving down will continue to capture entire lines. That means for instance `vx` will continue to move downwards which I think also addresses some points of #1638 as it basically keeps you in line mode for as long as you don't move left.