### PR TITLE
feat(csharp,debug): add C# debugger support

### DIFF
--- a/helix-dap/src/types.rs
+++ b/helix-dap/src/types.rs
@@ -726,7 +726,7 @@ pub mod events {
     #[serde(tag = "event", content = "body")]
     // seq is omitted as unused and is not sent by some implementations
     pub enum Event {
-        Initialized,
+        Initialized(Option<DebuggerCapabilities>),
         Stopped(Stopped),
         Continued(Continued),
         Exited(Exited),

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -262,7 +262,7 @@ impl Editor {
                     log::info!("{}", output);
                     self.set_status(format!("{} {}", prefix, output));
                 }
-                Event::Initialized => {
+                Event::Initialized(_) => {
                     // send existing breakpoints
                     for (path, breakpoints) in &mut self.breakpoints {
                         // TODO: call futures in parallel, await all

--- a/languages.toml
+++ b/languages.toml
@@ -233,6 +233,25 @@ comment-token = "//"
 indent = { tab-width = 4, unit = "\t" }
 language-server = { command = "OmniSharp", args = [ "--languageserver" ] }
 
+[language.debugger]
+name = "netcoredbg"
+transport = "tcp"
+command = "netcoredbg"
+args = [ "--interpreter=vscode" ]
+port-arg = "--server={}"
+
+[[language.debugger.templates]]
+name = "launch"
+request = "launch"
+completion = [ { name = "path to dll", completion = "filename" } ]
+args = { type="coreclr", console = "internalConsole", internalConsoleOptions = "openOnSessionStart", program = "{0}" }
+
+[[language.debugger.templates]]
+name = "attach"
+request = "attach"
+completion = [ "pid" ]
+args = { processId = "{0}" }
+
 [[grammar]]
 name = "c-sharp"
 source = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp", rev = "5b60f99545fea00a33bbfae5be956f684c4c69e2" }

--- a/languages.toml
+++ b/languages.toml
@@ -244,7 +244,7 @@ port-arg = "--server={}"
 name = "launch"
 request = "launch"
 completion = [ { name = "path to dll", completion = "filename" } ]
-args = { type="coreclr", console = "internalConsole", internalConsoleOptions = "openOnSessionStart", program = "{0}" }
+args = { type = "coreclr", console = "internalConsole", internalConsoleOptions = "openOnSessionStart", program = "{0}" }
 
 [[language.debugger.templates]]
 name = "attach"


### PR DESCRIPTION
Add C# debugger support in the `languages.toml` file. This includes "launch" and "attach" configurations that employ [netcoredbg][netdbg].

In order to make it work with the aforementioned debugger, the `Initialized` DAP event response is changed to include an optional `DebuggerCapabilities` response, as per the specification.

[netdbg]: https://github.com/Samsung/netcoredbg

Closes: #4212
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>