### PR TITLE
Fix some commands not showing names in palette

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2426,11 +2426,11 @@ impl ui::menu::Item for MappableCommand {
         match self {
             MappableCommand::Typable { doc, name, .. } => match keymap.get(name as &String) {
                 Some(bindings) => format!("{} ({}) [{}]", doc, fmt_binding(bindings), name).into(),
-                None => doc.as_str().into(),
+                None => format!("{} [{}]", doc, name).into(),
             },
             MappableCommand::Static { doc, name, .. } => match keymap.get(*name) {
                 Some(bindings) => format!("{} ({}) [{}]", doc, fmt_binding(bindings), name).into(),
-                None => (*doc).into(),
+                None => format!("{} [{}]", doc, name).into(),
             },
         }
     }


### PR DESCRIPTION
This fixes the code added in #4071 to also show the names for commands without a binding. Before only commands with a binding would show the name.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/7396/195314006-af857d24-d9d4-4624-955a-8d001ae291bd.png">
