### PR TITLE
Add more informational description to goto_line_end_newline

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -308,7 +308,7 @@ impl MappableCommand {
         goto_line_end, "Goto line end",
         goto_next_buffer, "Goto next buffer",
         goto_previous_buffer, "Goto previous buffer",
-        goto_line_end_newline, "Goto line end and add a new line",
+        goto_line_end_newline, "Goto newline after line end",
         goto_first_nonwhitespace, "Goto first non-blank in line",
         trim_selections, "Trim whitespace from selections",
         extend_to_line_start, "Extend to line start",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -308,8 +308,7 @@ impl MappableCommand {
         goto_line_end, "Goto line end",
         goto_next_buffer, "Goto next buffer",
         goto_previous_buffer, "Goto previous buffer",
-        // TODO: different description ?
-        goto_line_end_newline, "Goto line end",
+        goto_line_end_newline, "Goto line end and add a new line",
         goto_first_nonwhitespace, "Goto first non-blank in line",
         trim_selections, "Trim whitespace from selections",
         extend_to_line_start, "Extend to line start",


### PR DESCRIPTION
This should help distinguish `goto_line_end` and `goto_line_end_newline`.