### PR TITLE
match_brackets: add heuristic when matching starts with `$` char

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -51,7 +51,11 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
 
     loop {
         let (start_byte, end_byte) = surrounding_bytes(doc, &node)?;
-        let (start_char, end_char) = (doc.byte_to_char(start_byte), doc.byte_to_char(end_byte));
+        let (mut start_char, end_char) = (doc.byte_to_char(start_byte), doc.byte_to_char(end_byte));
+
+        if doc.char(start_char) == '$' && end_char > start_char {
+            start_char += 1
+        }
 
         if is_valid_pair(doc, start_char, end_char) {
             if end_byte == pos {


### PR DESCRIPTION
When editing a variety of different types of files (eg. YAML) there's usually support for variable interpolation, this usually comes in the form of `${var}`. For the case of YAML, this is not specially recognized since it's not part of the spec. Imagine the following YAML:

```yaml
key: ${value}
```

According to the YAML spec this is simply a string scalar node, which TreeSitter correctly recognizes. Users that try going to the matching bracket may find the behaviour confusing, because nothing happens.

This patch runs a small check, in which if the syntax node starts with `$` then it skips to the next character, worst-case scenario it's not a recognized bracket, and best case scenario a supported bracket.