### PR TITLE
Update tree-sitter-cairo with support for 0.10

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1413,7 +1413,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "cairo"
-source = { git = "https://github.com/archseer/tree-sitter-cairo", rev = "5155c6eb40db6d437f4fa41b8bcd8890a1c91716" }
+source = { git = "https://github.com/archseer/tree-sitter-cairo", rev = "e2f9b3d75f483fcfda03cf07e4176869357bfb52" }
 
 [[language]]
 name = "cpon"

--- a/languages.toml
+++ b/languages.toml
@@ -1413,7 +1413,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "cairo"
-source = { git = "https://github.com/archseer/tree-sitter-cairo", rev = "e2f9b3d75f483fcfda03cf07e4176869357bfb52" }
+source = { git = "https://github.com/archseer/tree-sitter-cairo", rev = "b249662a1eefeb4d71c9529cdd971e74fecc10fe" }
 
 [[language]]
 name = "cpon"

--- a/languages.toml
+++ b/languages.toml
@@ -1408,7 +1408,7 @@ scope = "source.cairo"
 injection-regex = "cairo"
 file-types = ["cairo"]
 roots = []
-comment-token = "#"
+comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]

--- a/runtime/queries/cairo/highlights.scm
+++ b/runtime/queries/cairo/highlights.scm
@@ -36,7 +36,6 @@
 [
   "if"
   "else"
-  "end"
   "assert"
   "with"
   "with_attr"
@@ -54,7 +53,6 @@
   "const"
   "local"
   "struct"
-  "member"
   "alloc_locals"
   "tempvar"
 ] @keyword


### PR DESCRIPTION
In [Cairo 0.10.0](https://github.com/starkware-libs/cairo-lang/releases/tag/v0.10.0) the comment token has been changed from the Pythonic style `#` to the more C-like `//`:

> Change comment to use `//` instead of `#`

The PR fixes the comment token used in Helix for Cairo.

There are also many other changes, including the introduction of curly brackets, but those need changes in the tree-sitter grammar, so it's probably better to deal with those in a future PR.