### PR TITLE
themes: Update bogster theme

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -1,97 +1,96 @@
 # Author : Wojciech Kępka <wojciech@wkepka.dev>
 
-"attribute" = "bogster0"
-"keyword" = { fg = "bogster1", modifiers = ["bold"] }
-"keyword.directive" = "bogster1"
-"namespace" = "bogster2"
-"punctuation" = "bogster0"
-"punctuation.delimiter" = "bogster0"
-"operator" = { fg = "bogster0", modifiers = ["bold"] }
-"special" = "bogster3"
-"variable.other.member" = "bogster4"
-"variable" = "bogster4"
-"variable.parameter" = "bogster4"
-"type" = "bogster5"
-"type.builtin" = { fg = "bogster2", modifiers = ["bold"] }
-"constructor" = "bogster5"
-"function" = "bogster6"
-"function.macro" = { fg = "bogster0", modifiers = ["bold"] }
-"function.builtin" = { fg = "bogster6", modifiers = ["bold"] }
-"comment" = "bogster7"
-"variable.builtin" = "bogster4"
-"constant" = "bogster8"
-"constant.builtin" = "bogster8"
-"string" = "bogster8"
-"constant.numeric" = "bogster9"
-"constant.character.escape" = { fg = "bogster3", modifiers = ["bold"] }
-"label" = "bogster9"
+"attribute" = "bogster-orange"
+"keyword" = { fg = "bogster-yellow", modifiers = ["bold"] }
+"keyword.directive" = "bogster-yellow"
+"namespace" = "bogster-red"
+"punctuation" = "bogster-orange"
+"punctuation.delimiter" = "bogster-orange"
+"operator" = { fg = "bogster-orange", modifiers = ["bold"] }
+"special" = "bogster-lgreen"
+"variable.other.member" = "bogster-fg0"
+"variable" = "bogster-fg0"
+"variable.parameter" = "bogster-fg0"
+"type" = "bogster-lred"
+"type.builtin" = { fg = "bogster-red", modifiers = ["bold"] }
+"constructor" = "bogster-lred"
+"function" = "bogster-lblue"
+"function.macro" = { fg = "bogster-orange", modifiers = ["bold"] }
+"function.builtin" = { fg = "bogster-lblue", modifiers = ["bold"] }
+"comment" = "bogster-base5"
+"variable.builtin" = "bogster-fg0"
+"constant" = "bogster-teal"
+"constant.builtin" = "bogster-teal"
+"string" = "bogster-teal"
+"constant.numeric" = "bogster-blue"
+"constant.character.escape" = { fg = "bogster-lgreen", modifiers = ["bold"] }
+"label" = "bogster-blue"
+"module" = "bogster-red"
 
-"module" = "bogster2"
+"markup.heading" = "bogster-blue"
+"markup.list" = "bogster-red"
+"markup.bold" = { fg = "bogster-yellow", modifiers = ["bold"] }
+"markup.italic" = { fg = "bogster-purp", modifiers = ["italic"] }
+"markup.link.url" = { fg = "bogster-yellow", modifiers = ["underlined"] }
+"markup.link.text" = "bogster-red"
+"markup.quote" = "bogster-teal"
+"markup.raw" = "bogster-lgreen"
 
-# TODO
-"markup.heading" = "blue"
-"markup.list" = "red"
-"markup.bold" = { fg = "yellow", modifiers = ["bold"] }
-"markup.italic" = { fg = "magenta", modifiers = ["italic"] }
-"markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
-"markup.link.text" = "red"
-"markup.quote" = "cyan"
-"markup.raw" = "green"
+"diff.plus" = "bogster-teal"
+"diff.delta" = "bogster-orange"
+"diff.minus" = "bogster-lred"
 
-"diff.plus" = "bogster8"
-"diff.delta" = "bogster0"
-"diff.minus" = "bogster5"
+"ui.background" = { bg = "bogster-base1" }
+"ui.linenr" = { fg = "bogster-base4" }
+"ui.linenr.selected" = { fg = "bogster-fg1" }
+"ui.cursorline" = { bg = "bogster-base0" }
+"ui.statusline" = { fg = "bogster-fg1", bg = "bogster-base2" }
+"ui.statusline.inactive" = { fg = "bogster-fg0", bg = "bogster-base2" }
+"ui.popup" = { bg = "bogster-base2" }
+"ui.window" = { bg = "bogster-base2" }
+"ui.help" = { bg = "bogster-base2", fg = "bogster-fg1" }
 
-"ui.background" = { bg = "bogster10" }
-"ui.linenr" = { fg = "bogster11" }
-"ui.linenr.selected" = { fg = "bogster12" }  # TODO
-"ui.cursorline" = { bg = "bogster13" }
-"ui.statusline" = { fg = "bogster12", bg = "bogster14" }
-"ui.statusline.inactive" = { fg = "bogster4", bg = "bogster14" }
-"ui.popup" = { bg = "bogster14" }
-"ui.window" = { bg = "bogster14" }
-"ui.help" = { bg = "bogster14", fg = "bogster12" }
+"ui.statusline.normal" = { fg = "bogster-base1", bg = "bogster-blue", modifiers = [ "bold" ]}
+"ui.statusline.insert" = { fg = "bogster-base1", bg = "bogster-lgreen", modifiers = [ "bold" ]}
+"ui.statusline.select" = { fg = "bogster-base1", bg = "bogster-red", modifiers = [ "bold" ] }
 
-"ui.statusline.normal" = { fg = "bogster10", bg = "bogster9", modifiers = [ "bold" ]}
-"ui.statusline.insert" = { fg = "bogster10", bg = "bogster3", modifiers = [ "bold" ]}
-"ui.statusline.select" = { fg = "bogster10", bg = "bogster2", modifiers = [ "bold" ] }
+"ui.text" = { fg = "bogster-fg1" }
+"ui.text.focus" = { fg = "bogster-fg1", modifiers= ["bold"] }
+"ui.virtual.whitespace" = "bogster-base5"
+"ui.virtual.ruler" = { bg = "bogster-base0" }
 
-"ui.text" = { fg = "bogster12" }
-"ui.text.focus" = { fg = "bogster12", modifiers= ["bold"] }
-"ui.virtual.whitespace" = "bogster7"
-"ui.virtual.ruler" = { bg = "bogster13" }
+"ui.selection" = { bg = "bogster-base3" }
+"ui.cursor.match" = { fg = "bogster-base3", bg = "bogster-orange" }
+"ui.cursor" = { fg = "bogster-base5", modifiers = ["reversed"] }
 
-"ui.selection" = { bg = "bogster15" }
-# "ui.cursor.match"  # TODO might want to override this because dimmed is not widely supported
-"ui.cursor.match" = { fg = "bogster15", bg = "bogster0" }
-"ui.cursor" = { fg = "bogster16", modifiers = ["reversed"] }
+"ui.menu" = { fg = "bogster-fg1", bg = "bogster-base2" }
+"ui.menu.selected" = { bg = "bogster-base3" }
 
-"ui.menu" = { fg = "bogster12", bg = "bogster14" }
-"ui.menu.selected" = { bg = "bogster15" }
-
-"warning" = "bogster0"
-"error" = "bogster5"
-"info" = "bogster8"
-"hint" = "bogster9"
+"warning" = "bogster-orange"
+"error" = "bogster-lred"
+"info" = "bogster-teal"
+"hint" = "bogster-blue"
 
 # make diagnostic underlined, to distinguish with selection text.
 diagnostic = { modifiers = ["underlined"] }
 
 [palette]
-bogster0 = "#dc7759"
-bogster1 = "#dcb659"
-bogster2 = "#d32c5d"
-bogster3 = "#7fdc59"
-bogster4 = "#c6b8ad"
-bogster5 = "#dc597f"
-bogster6 = "#59dcd8"
-bogster7 = "#627d9d"
-bogster8 = "#59dcb7"
-bogster9 = "#59c0dc"
-bogster10 = "#161c23" 
-bogster11 = "#415367" 
-bogster12 = "#e5ded6"
-bogster13 = "#131920"
-bogster14 = "#232d38"
-bogster15 = "#313f4e" 
-bogster16 = "#ABB2BF"
+bogster-yellow = "#dcb659"
+bogster-lblue = "#59dcd8"
+bogster-teal = "#59dcb7"
+bogster-blue = "#36b2d4"
+bogster-orange = "#dc7759"
+bogster-red = "#d32c5d"
+bogster-lgreen = "#7fdc59"
+bogster-lred = "#dc597f"
+bogster-purp = "#b759dc"
+
+bogster-base0 = "#13181e"
+bogster-base1 = "#161c23" 
+bogster-base2 = "#232d38"
+bogster-base3 = "#313f4e" 
+bogster-base4 = "#415367" 
+bogster-base5 = "#abb2bf"
+
+bogster-fg0 = "#c6b8ad"
+bogster-fg1 = "#e5ded6"


### PR DESCRIPTION
This PR cleans up the bogster theme with names for specific colors and makes the palette match the original colors closer. 

![image](https://user-images.githubusercontent.com/46892771/195782030-b8ea659a-1d55-473c-a75b-6dd5bb008bfe.png)
