### PR TITLE
c/c++ highlights: *& are @type or @operator based on context

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -51,6 +51,9 @@
   (preproc_directive)
 ] @keyword.directive
 
+(pointer_declarator "*" @type.builtin)
+(abstract_pointer_declarator "*" @type.builtin)
+
 [
   "+"
   "-"

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -34,6 +34,10 @@
 (auto) @type
 "decltype" @type
 
+(ref_qualifier (["&" "&&"]) @type.builtin)
+(reference_declarator (["&" "&&"]) @type.builtin)
+(abstract_reference_declarator (["&" "&&"]) @type.builtin)
+
 ; Constants
 
 (this) @variable.builtin

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -34,9 +34,9 @@
 (auto) @type
 "decltype" @type
 
-(ref_qualifier (["&" "&&"]) @type.builtin)
-(reference_declarator (["&" "&&"]) @type.builtin)
-(abstract_reference_declarator (["&" "&&"]) @type.builtin)
+(ref_qualifier ["&" "&&"] @type.builtin)
+(reference_declarator ["&" "&&"] @type.builtin)
+(abstract_reference_declarator ["&" "&&"] @type.builtin)
 
 ; Constants
 


### PR DESCRIPTION
C gave us the infamous declaration-follows-use syntax for pointers, which can make it hard to tell at a glance whether a `*` is dereferencing a pointer or declaring one.
C++ copied the syntax for references, despite the logic not applying.

This patch highlights */& as (builtin) types when they're used to declare pointers/refs, and continues to treat them as operators in other contexts.

This is more formally correct, but also practically useful (at least for me), particularly with pointer-binds-right code styles. The potential downside is reduced contrast within type declarations.

Before: 
![image](https://user-images.githubusercontent.com/548993/195947290-8ca9d27e-66c3-4fdf-8e28-a2e8c3477393.png)
After:
![image](https://user-images.githubusercontent.com/548993/195947348-0280c777-db31-4bcc-b176-21ae04e6c696.png)
