### PR TITLE
Fixup Zig Indent Queries

### DIFF
--- a/runtime/queries/zig/indents.scm
+++ b/runtime/queries/zig/indents.scm
@@ -1,12 +1,14 @@
 [
+  (AsmExpr)
+  (AssignExpr)
   (Block)
   (BlockExpr)
   (ContainerDecl)
-  (SwitchExpr)
-  (AssignExpr)
   (ErrorUnionExpr)
-  (Statement)
   (InitList)
+  (Statement)
+  (SwitchExpr)
+  (TestDecl)
 ] @indent
 
 [


### PR DESCRIPTION
Some indent queries for Zig were missing (which are obv. typically indented).

I also sorted the queries alphabetically.