### PR TITLE
c/c++ highlighting: various tweaks

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -8,11 +8,9 @@
 ] @keyword.storage.type
 
 [
-  "const"
   "extern"
-  "inline"
   "register"
-  "volatile"
+  (type_qualifier)
   (storage_class_specifier)
 ] @keyword.storage.modifier
 
@@ -104,7 +102,7 @@
 (system_lib_string) @string
 
 (null) @constant
-(number_literal) @constant.numeric.integer
+(number_literal) @constant.numeric
 (char_literal) @constant.character
 
 (call_expression
@@ -130,7 +128,7 @@
 (statement_identifier) @label
 (type_identifier) @type
 (primitive_type) @type.builtin
-(sized_type_specifier) @type
+(sized_type_specifier) @type.builtin
 
 ((identifier) @constant
   (#match? @constant "^[A-Z][A-Z\\d_]*$"))

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -1,5 +1,11 @@
 ; Functions
 
+; These casts are parsed as function calls, but are not.
+((identifier) @keyword (#eq? @keyword "static_cast"))
+((identifier) @keyword (#eq? @keyword "dynamic_cast"))
+((identifier) @keyword (#eq? @keyword "reinterpret_cast"))
+((identifier) @keyword (#eq? @keyword "const_cast"))
+
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
@@ -59,7 +65,6 @@
   "co_yield"
   "concept"
   "delete"
-  "final"
   "new"
   "operator"
   "requires"
@@ -91,22 +96,27 @@
   "class"  
   "namespace"
   "typename"
+  "template"
 ] @keyword.storage.type
 
 [
   "constexpr"
   "constinit"
   "consteval"
+  "mutable"
+] @keyword.storage.modifier
+
+; Modifiers that aren't plausibly type/storage related.
+[
   "explicit"
   "friend"
-  "mutable"
+  "virtual"
+  (virtual_specifier) ; override/final
   "private"
   "protected"
   "public"
-  "override"
-  "template"
-  "virtual"
-] @keyword.storage.modifier
+  "inline" ; C++ meaning differs from C!
+] @keyword
 
 ; Strings
 


### PR DESCRIPTION
- treat `restrict`/`_Atomic` like `const`/`volatile` => @keyword.storage.modifier
- highlight `unsigned int` as builtin => @type.builtin
- recognize `static_cast` and friends => @keyword
- `template` is a kind of entity like `typename` => @keyword.storage.type
- many declaration modifiers have nothing to do with storage/types (explicit, friend, access specifiers, inline in C++) => @keyword
- fix floats highlighted as integer => @constant.numeric

Before: 
![image](https://user-images.githubusercontent.com/548993/195956982-3cf2f9a8-34b4-4269-9e51-6da18aaae6f1.png)
After:
![image](https://user-images.githubusercontent.com/548993/195957001-b1ce5ccf-3097-4005-a94a-8038ac2af7ce.png)

(OK, the difference in number highlighting is just for this patch :-))