### PR TITLE
C# syntax highlight tweaks

### DIFF
--- a/runtime/queries/c-sharp/highlights.scm
+++ b/runtime/queries/c-sharp/highlights.scm
@@ -109,8 +109,8 @@
 (comment) @comment
 
 ;; Tokens
-(type_argument_list (["<" ">"] @punctuation.bracket))
-(type_parameter_list (["<" ">"] @punctuation.bracket))
+(type_argument_list ["<" ">"] @punctuation.bracket)
+(type_parameter_list ["<" ">"] @punctuation.bracket)
 
 [
   ";"

--- a/runtime/queries/c-sharp/highlights.scm
+++ b/runtime/queries/c-sharp/highlights.scm
@@ -109,6 +109,9 @@
 (comment) @comment
 
 ;; Tokens
+(type_argument_list (["<" ">"] @punctuation.bracket))
+(type_parameter_list (["<" ">"] @punctuation.bracket))
+
 [
   ";"
   "."
@@ -159,14 +162,7 @@
   "??="
 ] @operator
 
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-]  @punctuation.bracket
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 ;; Keywords
 (modifier) @keyword.storage.modifier
@@ -175,36 +171,32 @@
 
 [
   "as"
+  "await"
   "base"
-  "catch"
   "checked"
-  "finally"
+  "from"
+  "get"
+  "in"
+  "init"
   "is"
+  "let"
   "lock"
+  "new"
   "operator"
+  "out"
   "params"
+  "ref"
+  "select"
+  "set"
   "sizeof"
   "stackalloc"
-  "throw"
-  "try"
   "typeof"
   "unchecked"
   "using"
-  "new"
-  "await"
-  "in"
-  "yield"
-  "get"
-  "set"
   "when"
-  "out"
-  "ref"
-  "from"
   "where"
-  "select"
-  "init"
   "with"
-  "let"
+  "yield"
 ] @keyword
 
 [
@@ -225,21 +217,31 @@
 ] @keyword.storage.modifier
 
 [
-  "for"
-  "foreach"
-  "do"
-  "while"
   "break"
   "continue"
+  "goto"
+] @keyword.control
+
+[
+  "catch"
+  "finally"
+  "throw"
+  "try"
+] @keyword.control.exception
+
+[
+  "do"
+  "for"
+  "foreach"
+  "while"
 ] @keyword.control.repeat
 
 [
-  "goto"
-  "if"
-  "else"
-  "switch"
   "case"
   "default"
+  "else"
+  "if"
+  "switch"
 ] @keyword.control.conditional
 
 "return" @keyword.control.return


### PR DESCRIPTION
- Angle brackets are now highlighted as `@punctuation.bracket` when not used as operators
- `break`, `continue`, and `goto` are moved to `@keyword.control`
- `catch`, `finally`, `throw`, and `try` are moved to `@keyword.control.exception`
- The rest of the keywords are arranged in alphabetical order so they're easier to read

Before:
![before](https://user-images.githubusercontent.com/6290295/195969256-a6186b7f-eb8c-4332-8939-2f1dfe86cdc3.png)

After:
![after](https://user-images.githubusercontent.com/6290295/195969263-b5518e98-e4a2-4eae-aade-04801b601860.png)

