### PR TITLE
feat(core): add plaintext matching fallback to tree-sitter matching

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -15,11 +15,13 @@ const PAIRS: &[(char, char)] = &[
 
 // Returns the position of the matching bracket under cursor.
 //
-// If the cursor is one the opening bracket, the position of
-// the closing bracket is returned. If the cursor in the closing
+// If the cursor is on the opening bracket, the position of
+// the closing bracket is returned. If the cursor on the closing
 // bracket, the position of the opening bracket is returned.
 //
 // If the cursor is not on a bracket, `None` is returned.
+//
+// If no matching bracket is found, `None` is returned.
 #[must_use]
 pub fn find_matching_bracket(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
     if pos >= doc.len_chars() || !is_valid_bracket(doc.char(pos)) {
@@ -70,10 +72,17 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
     }
 }
 
-// Returns the position of the bracket that is closing.
-// This function only searches on the current line, either forwards or backwards.
-// This function matches plain text, it ignores tree-sitter grammar.
-// Returns None when no matching bracket is found.
+// Returns the position of the matching bracket under cursor, the search
+// is limited to the current line. This function works on plain text, it
+// ignores tree-sitter grammar.
+//
+// If the cursor is on the opening bracket, the position of
+// the closing bracket is returned. If the cursor on the closing
+// bracket, the position of the opening bracket is returned.
+//
+// If the cursor is not on a bracket, `None` is returned.
+//
+// If no matching bracket is found, `None` is returned.
 #[must_use]
 pub fn find_matching_bracket_current_line_plaintext(
     doc: &Rope,

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -2,6 +2,9 @@ use tree_sitter::Node;
 
 use crate::{Rope, Syntax};
 
+const MAX_PLAINTEXT_SCAN: usize = 10000;
+
+// Limit matching pairs to only ( ) { } [ ] < > ' ' " "
 const PAIRS: &[(char, char)] = &[
     ('(', ')'),
     ('{', '}'),
@@ -10,8 +13,6 @@ const PAIRS: &[(char, char)] = &[
     ('\'', '\''),
     ('\"', '\"'),
 ];
-
-// limit matching pairs to only ( ) { } [ ] < > ' ' " "
 
 /// Returns the position of the matching bracket under cursor.
 ///
@@ -104,7 +105,7 @@ pub fn find_matching_bracket_current_line_plaintext(
 
     let mut open_cnt = 1;
 
-    for (i, candidate) in chars_iter.enumerate() {
+    for (i, candidate) in chars_iter.take(MAX_PLAINTEXT_SCAN).enumerate() {
         if candidate == bracket {
             open_cnt += 1;
         } else if is_valid_pair(

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -94,7 +94,7 @@ pub fn find_matching_bracket_current_line_plaintext(
         return None;
     }
 
-    // Determine the direction of the matching
+    // Determine the direction of the matching.
     let is_fwd = is_forward_bracket(bracket);
     let line = doc.byte_to_line(cursor_pos);
     let end = doc.line_to_byte(if is_fwd { line + 1 } else { line });
@@ -114,12 +114,11 @@ pub fn find_matching_bracket_current_line_plaintext(
             if is_fwd { cursor_pos } else { pos },
             if is_fwd { pos } else { cursor_pos },
         ) {
-            open_cnt -= 1;
-
             // Return when all pending brackets have been closed.
-            if open_cnt == 0 {
+            if open_cnt == 1 {
                 return Some(pos);
             }
+            open_cnt -= 1;
         }
     }
 

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -13,15 +13,15 @@ const PAIRS: &[(char, char)] = &[
 
 // limit matching pairs to only ( ) { } [ ] < > ' ' " "
 
-// Returns the position of the matching bracket under cursor.
-//
-// If the cursor is on the opening bracket, the position of
-// the closing bracket is returned. If the cursor on the closing
-// bracket, the position of the opening bracket is returned.
-//
-// If the cursor is not on a bracket, `None` is returned.
-//
-// If no matching bracket is found, `None` is returned.
+/// Returns the position of the matching bracket under cursor.
+///
+/// If the cursor is on the opening bracket, the position of
+/// the closing bracket is returned. If the cursor on the closing
+/// bracket, the position of the opening bracket is returned.
+///
+/// If the cursor is not on a bracket, `None` is returned.
+///
+/// If no matching bracket is found, `None` is returned.
 #[must_use]
 pub fn find_matching_bracket(syntax: &Syntax, doc: &Rope, pos: usize) -> Option<usize> {
     if pos >= doc.len_chars() || !is_valid_bracket(doc.char(pos)) {
@@ -72,17 +72,17 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
     }
 }
 
-// Returns the position of the matching bracket under cursor, the search
-// is limited to the current line. This function works on plain text, it
-// ignores tree-sitter grammar.
-//
-// If the cursor is on the opening bracket, the position of
-// the closing bracket is returned. If the cursor on the closing
-// bracket, the position of the opening bracket is returned.
-//
-// If the cursor is not on a bracket, `None` is returned.
-//
-// If no matching bracket is found, `None` is returned.
+/// Returns the position of the matching bracket under cursor, the search
+/// is limited to the current line. This function works on plain text, it
+/// ignores tree-sitter grammar.
+///
+/// If the cursor is on the opening bracket, the position of
+/// the closing bracket is returned. If the cursor on the closing
+/// bracket, the position of the opening bracket is returned.
+///
+/// If the cursor is not on a bracket, `None` is returned.
+///
+/// If no matching bracket is found, `None` is returned.
 #[must_use]
 pub fn find_matching_bracket_current_line_plaintext(
     doc: &Rope,

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -73,9 +73,9 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
     }
 }
 
-/// Returns the position of the matching bracket under cursor, the search
-/// is limited to the current line. This function works on plain text, it
-/// ignores tree-sitter grammar.
+/// Returns the position of the matching bracket under cursor.
+/// This function works on plain text and ignores tree-sitter grammar.
+/// The search is limited to `MAX_PLAINTEXT_SCAN` characters
 ///
 /// If the cursor is on the opening bracket, the position of
 /// the closing bracket is returned. If the cursor on the closing

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -109,8 +109,16 @@ pub fn find_matching_bracket_current_line_plaintext(
             open_cnt += 1;
         } else if is_valid_pair(
             doc,
-            if is_fwd { cursor_pos } else { cursor_pos - i - 1 },
-            if is_fwd { cursor_pos + i + 1 } else { cursor_pos },
+            if is_fwd {
+                cursor_pos
+            } else {
+                cursor_pos - i - 1
+            },
+            if is_fwd {
+                cursor_pos + i + 1
+            } else {
+                cursor_pos
+            },
         ) {
             // Return when all pending brackets have been closed.
             if open_cnt == 1 {

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -175,12 +175,6 @@ mod tests {
             assert_eq!(pos, actual.unwrap(), "expected symmetrical behaviour");
         };
 
-        let assert_no_match = |input: &str, pos| {
-            let input = &Rope::from(input);
-            let actual = find_matching_bracket_current_line_plaintext(input, pos);
-            assert!(actual.is_none(), "expected no match");
-        };
-
         assert("(hello)", 0, 6);
         assert("((hello))", 0, 8);
         assert("((hello))", 1, 7);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4537,7 +4537,14 @@ fn match_brackets(cx: &mut Context) {
             {
                 range.put_cursor(text, pos, cx.editor.mode == Mode::Select)
             } else {
-                range
+                if let Some(pos) = match_brackets::find_matching_bracket_current_line_plaintext(
+                    doc.text(),
+                    range.cursor(text),
+                ) {
+                    range.put_cursor(text, pos, cx.editor.mode == Mode::Select)
+                } else {
+                    range
+                }
             }
         });
         doc.set_selection(view.id, selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4528,23 +4528,24 @@ fn select_prev_sibling(cx: &mut Context) {
 
 fn match_brackets(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
+    let is_select = cx.editor.mode == Mode::Select;
+    let text = doc.text();
+    let text_slice = text.slice(..);
 
-    if let Some(syntax) = doc.syntax() {
-        let text = doc.text();
-        let text_slice = text.slice(..);
-        let is_select = cx.editor.mode == Mode::Select;
-        let selection = doc.selection(view.id).clone().transform(|range| {
-            let pos = range.cursor(text_slice);
-            if let Some(pos) = match_brackets::find_matching_bracket_fuzzy(syntax, text, pos)
-                .or_else(|| match_brackets::find_matching_bracket_current_line_plaintext(text, pos))
-            {
-                range.put_cursor(text_slice, pos, is_select)
-            } else {
-                range
-            }
-        });
-        doc.set_selection(view.id, selection);
-    }
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let pos = range.cursor(text_slice);
+        if let Some(matched_pos) = doc
+            .syntax()
+            .and_then(|syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text, pos))
+            .or_else(|| match_brackets::find_matching_bracket_current_line_plaintext(text, pos))
+        {
+            range.put_cursor(text_slice, matched_pos, is_select)
+        } else {
+            range
+        }
+    });
+
+    doc.set_selection(view.id, selection);
 }
 
 //

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4534,11 +4534,10 @@ fn match_brackets(cx: &mut Context) {
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         let pos = range.cursor(text_slice);
-        if let Some(matched_pos) = doc
-            .syntax()
-            .and_then(|syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text, pos))
-            .or_else(|| match_brackets::find_matching_bracket_current_line_plaintext(text, pos))
-        {
+        if let Some(matched_pos) = doc.syntax().map_or_else(
+            || match_brackets::find_matching_bracket_current_line_plaintext(text, pos),
+            |syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text, pos),
+        ) {
             range.put_cursor(text_slice, matched_pos, is_select)
         } else {
             range

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4535,10 +4535,8 @@ fn match_brackets(cx: &mut Context) {
         let is_select = cx.editor.mode == Mode::Select;
         let selection = doc.selection(view.id).clone().transform(|range| {
             let pos = range.cursor(text_slice);
-            if let Some(pos) = match_brackets::find_matching_bracket_fuzzy(syntax, text, pos) {
-                range.put_cursor(text_slice, pos, is_select)
-            } else if let Some(pos) =
-                match_brackets::find_matching_bracket_current_line_plaintext(text, pos)
+            if let Some(pos) = match_brackets::find_matching_bracket_fuzzy(syntax, text, pos)
+                .or_else(|| match_brackets::find_matching_bracket_current_line_plaintext(text, pos))
             {
                 range.put_cursor(text_slice, pos, is_select)
             } else {


### PR DESCRIPTION
This patch introduces bracket matching independent of tree-sitter grammar. This matching is introduced as a fallback in cases where the tree-sitter matcher does not match any bracket. The fallback should provide a better experience in cases like the ones reported in #3614

Relates to #3584 as well