### PR TITLE
Add 'alphanumeric sort' commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alphanumeric-sort"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e9c9abb82613923ec78d7a461595d52491ba7240f3c64c0bbe0e6d98e0fce0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +471,7 @@ dependencies = [
 name = "helix-term"
 version = "0.6.0"
 dependencies = [
+ "alphanumeric-sort",
  "anyhow",
  "arc-swap",
  "chrono",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -66,6 +66,7 @@ serde = { version = "1.0", features = ["derive"] }
 # ripgrep for global search
 grep-regex = "0.1.10"
 grep-searcher = "0.1.10"
+alphanumeric-sort = "1.4.4"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }


### PR DESCRIPTION
Implements #4153 with the crate mentioned in the discussion of the issue.

This adds 2 new commands, `sortn` and `rsortn`, corresponding to the existing ones (`sort` and `rsort`), and they sort according to https://docs.rs/alphanumeric-sort/1.4.4/alphanumeric_sort/fn.compare_str.html 