### PR TITLE
Pretty print `tree-sitter-subtree` expression

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2024,18 +2024,18 @@ impl<I: Iterator<Item = HighlightEvent>> Iterator for Merge<I> {
     }
 }
 
-pub fn pretty_print_tree<W: fmt::Write>(fmt: &mut W, node: Node<'_>) -> fmt::Result {
+pub fn pretty_print_tree<W: fmt::Write>(fmt: &mut W, node: Node) -> fmt::Result {
     pretty_print_tree_impl(fmt, node, true, None, 0)
 }
 
 fn pretty_print_tree_impl<W: fmt::Write>(
     fmt: &mut W,
-    node: Node<'_>,
+    node: Node,
     is_root: bool,
     field_name: Option<&str>,
     depth: usize,
 ) -> fmt::Result {
-    fn is_visible(node: Node<'_>) -> bool {
+    fn is_visible(node: Node) -> bool {
         node.is_missing()
             || (node.is_named() && node.language().node_kind_is_visible(node.kind_id()))
     }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2024,6 +2024,57 @@ impl<I: Iterator<Item = HighlightEvent>> Iterator for Merge<I> {
     }
 }
 
+pub fn pretty_print_tree<W: fmt::Write>(fmt: &mut W, node: Node<'_>) -> fmt::Result {
+    pretty_print_tree_impl(fmt, node, true, None, 0)
+}
+
+fn pretty_print_tree_impl<W: fmt::Write>(
+    fmt: &mut W,
+    node: Node<'_>,
+    is_root: bool,
+    field_name: Option<&str>,
+    depth: usize,
+) -> fmt::Result {
+    fn is_visible(node: Node<'_>) -> bool {
+        node.is_missing()
+            || (node.is_named() && node.language().node_kind_is_visible(node.kind_id()))
+    }
+
+    if is_visible(node) {
+        let indentation_columns = depth * 2;
+        write!(fmt, "{:indentation_columns$}", "")?;
+
+        if let Some(field_name) = field_name {
+            write!(fmt, "{}: ", field_name)?;
+        }
+
+        write!(fmt, "({}", node.kind())?;
+    } else if is_root {
+        write!(fmt, "(\"{}\")", node.kind())?;
+    }
+
+    for child_idx in 0..node.child_count() {
+        if let Some(child) = node.child(child_idx) {
+            if is_visible(child) {
+                fmt.write_char('\n')?;
+            }
+
+            pretty_print_tree_impl(
+                fmt,
+                child,
+                false,
+                node.field_name_for_child(child_idx as u32),
+                depth + 1,
+            )?;
+        }
+    }
+
+    if is_visible(node) {
+        write!(fmt, ")")?;
+    }
+
+    Ok(())
+}
 #[cfg(test)]
 mod test {
     use super::*;
@@ -2193,6 +2244,63 @@ mod test {
                 new_end_position: Point { row: 0, column: 14 }
             }]
         );
+    }
+
+    #[track_caller]
+    fn assert_pretty_print(source: &str, expected: &str, start: usize, end: usize) {
+        let source = Rope::from_str(source);
+
+        let loader = Loader::new(Configuration { language: vec![] });
+        let language = get_language("Rust").unwrap();
+
+        let config = HighlightConfiguration::new(language, "", "", "").unwrap();
+        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader));
+
+        let root = syntax
+            .tree()
+            .root_node()
+            .descendant_for_byte_range(start, end)
+            .unwrap();
+
+        let mut output = String::new();
+        pretty_print_tree(&mut output, root).unwrap();
+
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_pretty_print() {
+        let source = r#"/// Hello"#;
+        assert_pretty_print(source, "(line_comment)", 0, source.len());
+
+        // A large tree should be indented with fields:
+        let source = r#"fn main() {
+            println!("Hello, World!");
+        }"#;
+        assert_pretty_print(
+            source,
+            concat!(
+                "(function_item\n",
+                "  name: (identifier)\n",
+                "  parameters: (parameters)\n",
+                "  body: (block\n",
+                "    (expression_statement\n",
+                "      (macro_invocation\n",
+                "        macro: (identifier)\n",
+                "        (token_tree\n",
+                "          (string_literal))))))",
+            ),
+            0,
+            source.len(),
+        );
+
+        // Selecting a token should print just that token:
+        let source = r#"fn main() {}"#;
+        assert_pretty_print(source, r#"("fn")"#, 0, 1);
+
+        // Error nodes are printed as errors:
+        let source = r#"}{"#;
+        assert_pretty_print(source, "(ERROR)", 0, source.len());
     }
 
     #[test]

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2,7 +2,6 @@ use std::ops::Deref;
 
 use super::*;
 
-use helix_core::syntax::pretty_print_tree;
 use helix_view::{
     apply_transaction,
     editor::{Action, CloseError, ConfigEvent},
@@ -1475,7 +1474,7 @@ fn tree_sitter_subtree(
             .descendant_for_byte_range(from, to)
         {
             let mut contents = String::from("```tsq\n");
-            pretty_print_tree(&mut contents, selected_node)?;
+            helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
             contents.push_str("\n```");
 
             let callback = async move {


### PR DESCRIPTION
Closes #2880

This PR indents and line-breaks the expression displayed for `:tree-sitter-subtree`. For short sexprs it might be a little annoying. Maybe we should generate the sexpr and if it's longer than ~40 chars, manually format it?

I didn't know where to put the formatting function, so I just put it inside the command itself.

Before:
<img width="871" alt="Screen Shot 2022-10-15 at 3 36 02 PM" src="https://user-images.githubusercontent.com/14206675/195989738-445f4068-312e-4c8a-bd84-5aa2dc162dd2.png">

After:
<img width="456" alt="Screen Shot 2022-10-15 at 3 36 48 PM" src="https://user-images.githubusercontent.com/14206675/195989742-d339db30-5f1f-402a-aa42-f073c99e9273.png">

With named fields:
<img width="668" alt="Screen Shot 2022-10-15 at 3 51 13 PM" src="https://user-images.githubusercontent.com/14206675/195990106-a4377216-c3e8-4b40-b0ba-70ba8d34a27b.png">

