### PR TITLE
Optimize `ui::menu::Item::label()` implementations

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -597,13 +597,13 @@ impl Application {
 
                         // trigger textDocument/didOpen for docs that are already open
                         for doc in docs {
-                            let language_id =
-                                doc.language_id().map(ToOwned::to_owned).unwrap_or_default();
-
                             let url = match doc.url() {
                                 Some(url) => url,
                                 None => continue, // skip documents with no path
                             };
+
+                            let language_id =
+                                doc.language_id().map(ToOwned::to_owned).unwrap_or_default();
 
                             tokio::spawn(language_server.text_document_did_open(
                                 url,


### PR DESCRIPTION
- nit: move an allocation to happen after a `continue`, making sure it's not done for nothing
- nit: Do less allocations in `ui::menu::Item::label` implementations, often dividing by two or more
  the number of allocations in a call
