### PR TITLE
Show keys required to enter each minor mode

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -170,9 +170,10 @@ These sub-modes are accessible from normal mode and typically switch back to nor
 Accessed by typing `z` in [normal mode](#normal-mode).
 
 View mode is intended for scrolling and manipulating the view without changing
-the selection. The "sticky" variant of this mode (accessed by typing `Z` in normal mode) is
-persistent; use the Escape key to return to normal mode after usage (useful when you're simply looking
-over text and not actively editing it).
+the selection. The "sticky" variant of this mode (accessed by typing `Z` in
+normal mode) is persistent; use the Escape key to return to normal mode after
+usage (useful when you're simply looking over text and not actively editing
+it).
 
 
 | Key                  | Description                                               | Command             |
@@ -219,8 +220,8 @@ Jumps to various locations.
 
 Accessed by typing `m` in [normal mode](#normal-mode).
 
-See the relevant section in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
-and [textobject](./usage.md#textobject) usage.
+See the relevant section in [Usage](./usage.md) for an explanation about
+[surround](./usage.md#surround) and [textobject](./usage.md#textobject) usage.
 
 | Key              | Description                                     | Command                    |
 | -----            | -----------                                     | -------                    |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -167,9 +167,11 @@ These sub-modes are accessible from normal mode and typically switch back to nor
 
 #### View mode
 
+Accessed by typing `z` in [normal mode](#normal-mode).
+
 View mode is intended for scrolling and manipulating the view without changing
-the selection. The "sticky" variant of this mode is persistent; use the Escape
-key to return to normal mode after usage (useful when you're simply looking
+the selection. The "sticky" variant of this mode (accessed by typing `Z` in normal mode) is
+persistent; use the Escape key to return to normal mode after usage (useful when you're simply looking
 over text and not actively editing it).
 
 
@@ -187,6 +189,8 @@ over text and not actively editing it).
 | `Ctrl-u`             | Move half page up                                         | `half_page_up`      |
 
 #### Goto mode
+
+Accessed by typing `g` in [normal mode](#normal-mode).
 
 Jumps to various locations.
 
@@ -213,8 +217,9 @@ Jumps to various locations.
 
 #### Match mode
 
-Enter this mode using `m` from normal mode. See the relevant section
-in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
+Accessed by typing `m` in [normal mode](#normal-mode).
+
+See the relevant section in [Usage](./usage.md) for an explanation about [surround](./usage.md#surround)
 and [textobject](./usage.md#textobject) usage.
 
 | Key              | Description                                     | Command                    |
@@ -229,6 +234,8 @@ and [textobject](./usage.md#textobject) usage.
 TODO: Mappings for selecting syntax nodes (a superset of `[`).
 
 #### Window mode
+
+Accessed by typing `Ctrl-w` in [normal mode](#normal-mode).
 
 This layer is similar to Vim keybindings as Kakoune does not support window.
 
@@ -252,8 +259,9 @@ This layer is similar to Vim keybindings as Kakoune does not support window.
 
 #### Space mode
 
-This layer is a kludge of mappings, mostly pickers.
+Accessed by typing `Space` in [normal mode](#normal-mode).
 
+This layer is a kludge of mappings, mostly pickers.
 
 | Key     | Description                                                             | Command                             |
 | -----   | -----------                                                             | -------                             |


### PR DESCRIPTION
Currently, the [minor mode sections of the book](https://docs.helix-editor.com/keymap.html#view-mode) don't actually contain the key needed to reach them.  Finding this requires an unpleasant amount of forward/backward searching.  So this PR adds a line to each of the sections with the corresponding key.

P.S.  Excellent editor, by the way :smiley: 