### PR TITLE
Added --print-path flag to print common paths

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -9,6 +9,7 @@ pub struct Args {
     pub display_version: bool,
     pub health: bool,
     pub health_arg: Option<String>,
+    pub print_path: Option<String>,
     pub load_tutor: bool,
     pub fetch_grammars: bool,
     pub build_grammars: bool,
@@ -44,6 +45,10 @@ impl Args {
                     args.health = true;
                     args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));
                 }
+                "--print-path" => match argv.next().as_deref() {
+                    Some(path) => args.print_path = Some(path.into()),
+                    None => anyhow::bail!("--print-path must specify a kind"),
+                },
                 "-g" | "--grammar" => match argv.next().as_deref() {
                     Some("fetch") => args.fetch_grammars = true,
                     Some("build") => args.build_grammars = true,

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use crossterm::event::EventStream;
 use helix_term::application::Application;
 use helix_term::args::Args;
@@ -64,6 +64,8 @@ FLAGS:
     --health [CATEGORY]            Checks for potential errors in editor setup
                                    CATEGORY can be a language or one of 'clipboard', 'languages'
                                    or 'all'. 'all' is the default if not specified.
+    --print-path [KIND]            Prints the path of a specific kind ('config-dir', 'config-file',
+                                   'runtime-dir', 'cache-dir', 'log-file', or 'lang-config-file').
     -g, --grammar {{fetch|build}}    Fetches or builds tree-sitter grammars listed in languages.toml
     -c, --config <file>            Specifies a file to use for configuration
     -v                             Increases logging verbosity each use for up to 3 times
@@ -112,6 +114,19 @@ FLAGS:
 
     if args.build_grammars {
         helix_loader::grammar::build_grammars(None)?;
+        return Ok(0);
+    }
+
+    if let Some(ref kind) = args.print_path {
+        match kind.as_str() {
+            "config-dir" => println!("{}", helix_loader::config_dir().display()),
+            "config-file" => println!("{}", helix_loader::config_file().display()),
+            "runtime-dir" => println!("{}", helix_loader::runtime_dir().display()),
+            "cache-dir" => println!("{}", helix_loader::cache_dir().display()),
+            "log-file" => println!("{}", helix_loader::log_file().display()),
+            "lang-config-file" => println!("{}", helix_loader::lang_config_file().display()),
+            _ => return Err(anyhow!("unknown path kind {}", kind)),
+        }
         return Ok(0);
     }
 


### PR DESCRIPTION
I was trying to debug why stuff was not loading on my windows machine and learned in the process that the paths are quite different. Since I was trying to rewrite the config file for a test automatically I needed to add platform specific logic. That might be something people need to do more commonly so this adds a `--print-path` argument that can be used for scripting.

Example:

```
$ hx --print-path config-file
/Users/mitsuhiko/.config/helix/config.toml
```

Feel free to close this down. This seems valuable to me, but it might be too specific.