### PR TITLE
Log failures to load tree-sitter parsers as error

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -368,7 +368,13 @@ impl LanguageConfiguration {
             None
         } else {
             let language = get_language(self.grammar.as_deref().unwrap_or(&self.language_id))
-                .map_err(|e| log::info!("{}", e))
+                .map_err(|err| {
+                    log::error!(
+                        "Failed to load tree-sitter parser for language {:?}: {}",
+                        self.language_id,
+                        err
+                    )
+                })
                 .ok()?;
             let config = HighlightConfiguration::new(
                 language,


### PR DESCRIPTION
Info logs don't show up in the log file by default, but this line should: failures to load tree-sitter parser objects are useful errors. A parser might fail to load it is misconfigured (https://github.com/helix-editor/helix/pull/4303#discussion_r996448543) or if the file does not exist.