### PR TITLE
Correctly handle escaping in completion

### DIFF
--- a/helix-core/src/shellwords.rs
+++ b/helix-core/src/shellwords.rs
@@ -1,5 +1,22 @@
 use std::borrow::Cow;
 
+/// Auto escape for shellwords usage.
+pub fn escape(input: &str) -> Cow<'_, str> {
+    if !input.chars().any(|x| x.is_ascii_whitespace()) {
+        Cow::Borrowed(input)
+    } else if cfg!(unix) {
+        Cow::Owned(input.chars().fold(String::new(), |mut buf, c| {
+            if c.is_ascii_whitespace() {
+                buf.push('\\');
+            }
+            buf.push(c);
+            buf
+        }))
+    } else {
+        Cow::Owned(format!("\"{}\"", input))
+    }
+}
+
 /// Get the vec of escaped / quoted / doublequoted filenames from the input str
 pub fn shellwords(input: &str) -> Vec<Cow<'_, str>> {
     enum State {

--- a/helix-core/src/shellwords.rs
+++ b/helix-core/src/shellwords.rs
@@ -243,4 +243,18 @@ mod test {
         ];
         assert_eq!(expected, result);
     }
+
+    #[cfg(unix)]
+    fn test_escaping_unix() {
+        assert_eq!(escape("foobar"), Cow::Borrowed("foobar"));
+        assert_eq!(escape("foo bar"), Cow::Borrowed("foo\\ bar"));
+        assert_eq!(escape("foo\tbar"), Cow::Borrowed("foo\\\tbar"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_escaping_windows() {
+        assert_eq!(escape("foobar"), Cow::Borrowed("foobar"));
+        assert_eq!(escape("foo bar"), Cow::Borrowed("\"foo bar\""));
+    }
 }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,5 +1,6 @@
 use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
+use helix_core::shellwords;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
 use std::{borrow::Cow, ops::RangeFrom};
@@ -335,7 +336,10 @@ impl Prompt {
 
         let (range, item) = &self.completion[index];
 
-        self.line.replace_range(range.clone(), item);
+        // since we are using shellwords to parse arguments, make sure
+        // that whitespace in files is properly escaped.
+        let item = shellwords::escape(item);
+        self.line.replace_range(range.clone(), &item);
 
         self.move_end();
     }


### PR DESCRIPTION
This fixes two issues with spaces handling in file names for auto completion:

1. the code so far did not use `shellworlds::shellwords` for handling completion. This is now corrected so that the logic for completion matches that of parsing
2. when auto completing it did not correctly apply escaping which is now happening.

Fixes #4266 on unix.

This however does not really fix the issue on Windows. This is because `shellwords` behaves differently on windows. I'm not sure how to properly fix this, but basically it requires double quoting there and from what I can tell it does not support escapes there. It might be that it results in a better user experience if the behavior actually changes there? I'm not sure. At the very least the code requires double quotes there and the completion code does not properly work with double quotes at all yet.