### PR TITLE
Allow the editor area to be bigger than u16 (width and height remain u16)

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -120,7 +120,7 @@ impl Buffer {
 
     /// Returns a Buffer with all cells initialized with the attributes of the given Cell
     pub fn filled(area: Rect, cell: &Cell) -> Buffer {
-        let size = area.area() as usize;
+        let size = area.area();
         let mut content = Vec::with_capacity(size);
         for _ in 0..size {
             content.push(cell.clone());
@@ -222,7 +222,7 @@ impl Buffer {
             y,
             self.area
         );
-        ((y - self.area.y) * self.area.width + (x - self.area.x)) as usize
+        ((y - self.area.y) as usize) * (self.area.width as usize) + ((x - self.area.x) as usize)
     }
 
     /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates,
@@ -261,8 +261,8 @@ impl Buffer {
             self.content.len()
         );
         (
-            self.area.x + i as u16 % self.area.width,
-            self.area.y + i as u16 / self.area.width,
+            (self.area.x as usize + (i % self.area.width as usize)) as u16,
+            (self.area.y as usize + (i / self.area.width as usize)) as u16,
         )
     }
 
@@ -463,7 +463,7 @@ impl Buffer {
     /// Resize the buffer so that the mapped area matches the given area and that the buffer
     /// length is equal to area.width * area.height
     pub fn resize(&mut self, area: Rect) {
-        let length = area.area() as usize;
+        let length = area.area();
         if self.content.len() > length {
             self.content.truncate(length);
         } else {
@@ -570,8 +570,8 @@ impl Buffer {
         let mut to_skip: usize = 0;
         for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
             if (current != previous || invalidated > 0) && to_skip == 0 {
-                let x = i as u16 % width;
-                let y = i as u16 / width;
+                let x = (i % width as usize) as u16;
+                let y = (i / width as usize) as u16;
                 updates.push((x, y, &next_buffer[i]));
             }
 

--- a/helix-tui/tests/terminal.rs
+++ b/helix-tui/tests/terminal.rs
@@ -4,12 +4,12 @@ use helix_tui::{
 };
 
 #[test]
-fn terminal_buffer_size_should_be_limited() {
+fn terminal_buffer_size_should_not_be_limited() {
     let backend = TestBackend::new(400, 400);
     let terminal = Terminal::new(backend).unwrap();
     let size = terminal.backend().size().unwrap();
-    assert_eq!(size.width, 255);
-    assert_eq!(size.height, 255);
+    assert_eq!(size.width, 400);
+    assert_eq!(size.height, 400);
 }
 
 // #[test]

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -95,31 +95,19 @@ pub struct Rect {
 }
 
 impl Rect {
-    /// Creates a new rect, with width and height limited to keep the area under max u16.
-    /// If clipped, aspect ratio will be preserved.
+    /// Creates a new rect, with width and height
     pub fn new(x: u16, y: u16, width: u16, height: u16) -> Rect {
-        let max_area = u16::max_value();
-        let (clipped_width, clipped_height) =
-            if u32::from(width) * u32::from(height) > u32::from(max_area) {
-                let aspect_ratio = f64::from(width) / f64::from(height);
-                let max_area_f = f64::from(max_area);
-                let height_f = (max_area_f / aspect_ratio).sqrt();
-                let width_f = height_f * aspect_ratio;
-                (width_f as u16, height_f as u16)
-            } else {
-                (width, height)
-            };
         Rect {
             x,
             y,
-            width: clipped_width,
-            height: clipped_height,
+            width,
+            height,
         }
     }
 
     #[inline]
-    pub fn area(self) -> u16 {
-        self.width * self.height
+    pub fn area(self) -> usize {
+        (self.width as usize) * (self.height as usize)
     }
 
     #[inline]
@@ -551,33 +539,6 @@ impl Style {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_rect_size_truncation() {
-        for width in 256u16..300u16 {
-            for height in 256u16..300u16 {
-                let rect = Rect::new(0, 0, width, height);
-                rect.area(); // Should not panic.
-                assert!(rect.width < width || rect.height < height);
-                // The target dimensions are rounded down so the math will not be too precise
-                // but let's make sure the ratios don't diverge crazily.
-                assert!(
-                    (f64::from(rect.width) / f64::from(rect.height)
-                        - f64::from(width) / f64::from(height))
-                    .abs()
-                        < 1.0
-                )
-            }
-        }
-
-        // One dimension below 255, one above. Area above max u16.
-        let width = 900;
-        let height = 100;
-        let rect = Rect::new(0, 0, width, height);
-        assert_ne!(rect.width, 900);
-        assert_ne!(rect.height, 100);
-        assert!(rect.width < width || rect.height < height);
-    }
 
     #[test]
     fn test_rect_size_preservation() {


### PR DESCRIPTION
Now the editor can fill **very** large terminals.
Changed/removed tests which check the truncating behavior.

Closes #4283