### PR TITLE
Add command to add word boundaries to search

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -247,6 +247,7 @@ impl MappableCommand {
         extend_search_next, "Add next search match to selection",
         extend_search_prev, "Add previous search match to selection",
         search_selection, "Use current selection as search pattern",
+        make_search_word_bounded, "Modify current search to make it word bounded",
         global_search, "Global search in workspace folder",
         extend_line, "Select current line, if already selected, extend to another line based on the anchor",
         extend_line_below, "Select current line, if already selected, extend to next line",
@@ -1789,6 +1790,29 @@ fn search_selection(cx: &mut Context) {
     let msg = format!("register '{}' set to '{}'", '/', &regex);
     cx.editor.registers.get_mut('/').push(regex);
     cx.editor.set_status(msg);
+}
+
+fn make_search_word_bounded(cx: &mut Context) {
+    let regex = match cx.editor.registers.last('/') {
+        Some(regex) => regex,
+        None => return,
+    };
+    let mut new_regex = String::new();
+    let mut modified = false;
+    if !regex.starts_with("\\b") {
+        new_regex.push_str("\\b");
+        modified = true;
+    }
+    new_regex.push_str(regex);
+    if !regex.ends_with("\\b") {
+        new_regex.push_str("\\b");
+        modified = true;
+    }
+    if modified {
+        let msg = format!("register '{}' set to '{}'", '/', &new_regex);
+        cx.editor.registers.get_mut('/').push(new_regex);
+        cx.editor.set_status(msg);
+    }
 }
 
 fn global_search(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1797,22 +1797,28 @@ fn make_search_word_bounded(cx: &mut Context) {
         Some(regex) => regex,
         None => return,
     };
-    let mut new_regex = String::new();
-    let mut modified = false;
-    if !regex.starts_with("\\b") {
+    let start_anchored = regex.starts_with("\\b");
+    let end_anchored = regex.ends_with("\\b");
+
+    if start_anchored && end_anchored {
+        return;
+    }
+
+    let mut new_regex = String::with_capacity(
+        regex.len() + if start_anchored { 0 } else { 2 } + if end_anchored { 0 } else { 2 },
+    );
+
+    if !start_anchored {
         new_regex.push_str("\\b");
-        modified = true;
     }
     new_regex.push_str(regex);
-    if !regex.ends_with("\\b") {
+    if !end_anchored {
         new_regex.push_str("\\b");
-        modified = true;
     }
-    if modified {
-        let msg = format!("register '{}' set to '{}'", '/', &new_regex);
-        cx.editor.registers.get_mut('/').push(new_regex);
-        cx.editor.set_status(msg);
-    }
+
+    let msg = format!("register '{}' set to '{}'", '/', &new_regex);
+    cx.editor.registers.get_mut('/').push(new_regex);
+    cx.editor.set_status(msg);
 }
 
 fn global_search(cx: &mut Context) {


### PR DESCRIPTION
This adds a command to rewrite the search register to add word boundaries to the regex that's there. This is an alternative to #4222.

```toml
[keys.normal]
"*" = ["move_prev_word_start", "move_next_word_end", "search_selection", "make_search_word_bounded", "search_next"]
```

This seems more complex but has the added benefit that it can be used independently. So for instance if one is already down the search of something and discovers that it's not specific enough, a hotkey can be hit to automatically add word boundaries and resubmit the search:

```toml
[keys.normal]
A-s = ["make_search_word_bounded", "search_next"]
```