### PR TITLE
Fix selecting pop dark theme

### DIFF
--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -43,7 +43,6 @@ module = { bg = 'orangeL' }
 special = { fg = 'orangeW' }
 operator = { fg = 'orangeY' }
 attribute = { fg = 'orangeL' }
-attribute = { fg = 'orangeL' }
 namespace = { fg = 'orangeL' }
 'type' = { fg = 'redH' }
 'type.builtin' = { fg = 'orangeL' }


### PR DESCRIPTION
**Reproduction**
1. Type in `:theme pop-dark`
2. No theme preview appears, pressing enter results in `Theme does not exist` error

**Cause**
- toml deserialization error due to duplicate keys

Out of scope for this PR but I think there's room for improvement for how this is handled. I feel like built in themes failing to deserialize should result in build/CI errors.

Also the error message is not the greatest specifically in the `:theme pop-dark` command scenario. If setting it in your config and then doing a `:config-reload`, the error message will instead be ``failed to load theme `pop-dark` - Failed to deserialize theme`` which is much better. After having saved the config value and upon re-opening helix, that same improved error message will logged as a warning.