### PR TITLE
Render diagnostics in the file picker preview

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -248,8 +248,14 @@ impl<T: Item + 'static> Component for FilePicker<T> {
 
             let offset = Position::new(first_line, 0);
 
-            let highlights =
+            let mut highlights =
                 EditorView::doc_syntax_highlights(doc, offset, area.height, &cx.editor.theme);
+            for spans in EditorView::doc_diagnostics_highlights(doc, &cx.editor.theme) {
+                if spans.is_empty() {
+                    continue;
+                }
+                highlights = Box::new(helix_core::syntax::merge(highlights, spans));
+            }
             EditorView::render_text_highlights(
                 doc,
                 offset,


### PR DESCRIPTION
This is mostly for the sake of the diagnostics pickers: without rendering the diagnostic styles, it's hard to tell where the entries in the picker are pointing to.