### PR TITLE
Fix deleting word from end of buffer

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2880,7 +2880,7 @@ pub mod insert {
 
     /// Exclude the cursor in range.
     fn exclude_cursor(text: RopeSlice, range: Range, cursor: Range) -> Range {
-        if range.to() == cursor.to() {
+        if range.to() == cursor.to() && text.len_chars() != cursor.to() {
             Range::new(
                 range.from(),
                 graphemes::prev_grapheme_boundary(text, cursor.to()),


### PR DESCRIPTION
Fixes #4327.

This PR skips the range adjustment for excluding the cursor if the cursor is at the very end of the buffer. Doing this fixes the "one extra character left" issue.

This is my first contribution to Helix that actually touches Rust code. Please kindly let me know if I'm doing anything wrong. Thanks!