### PR TITLE
display tree sitter scopes in a popup

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1060,7 +1060,21 @@ fn tree_sitter_scopes(
 
     let pos = doc.selection(view.id).primary().cursor(text);
     let scopes = indent::get_scopes(doc.syntax(), text, pos);
-    cx.editor.set_status(format!("scopes: {:?}", &scopes));
+
+    let contents = format!("```json\n{:?}\n````", scopes);
+
+    let callback = async move {
+        let call: job::Callback =
+            Box::new(move |editor: &mut Editor, compositor: &mut Compositor| {
+                let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
+                let popup = Popup::new("hover", contents).auto_close(true);
+                compositor.replace_or_push("hover", popup);
+            });
+        Ok(call)
+    };
+
+    cx.jobs.callback(callback);
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/4325

![Screenshot from 2022-10-17 22-47-47](https://user-images.githubusercontent.com/1636604/196280255-e96ca5c8-4d38-4508-aa30-eeb1dd0a8db8.png)

