### PR TITLE
Fix link to textobjects usage from keymap documentation

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -221,7 +221,7 @@ Jumps to various locations.
 Accessed by typing `m` in [normal mode](#normal-mode).
 
 See the relevant section in [Usage](./usage.md) for an explanation about
-[surround](./usage.md#surround) and [textobject](./usage.md#textobject) usage.
+[surround](./usage.md#surround) and [textobject](./usage.md#textobjects) usage.
 
 | Key              | Description                                     | Command                    |
 | -----            | -----------                                     | -------                    |


### PR DESCRIPTION
Minor thing I figured I'd fix after coming across it: the anchor "#textobject" wasn't correctly linking to the section in Usage "#textobjects".