### PR TITLE
Remove lower-case requirement for language/grammar

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -67,7 +67,6 @@ pub fn get_language(name: &str) -> Result<Language> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn get_language(name: &str) -> Result<Language> {
     use libloading::{Library, Symbol};
-    let name = name.to_ascii_lowercase();
     let mut library_path = crate::runtime_dir().join("grammars").join(&name);
     library_path.set_extension(DYLIB_EXTENSION);
 

--- a/xtask/src/querycheck.rs
+++ b/xtask/src/querycheck.rs
@@ -14,8 +14,8 @@ pub fn query_check() -> Result<(), DynError> {
     ];
 
     for language in lang_config().language {
-        let language_name = language.language_id.to_ascii_lowercase();
-        let grammar_name = language.grammar.unwrap_or(language.language_id);
+        let language_name = &language.language_id;
+        let grammar_name = language.grammar.as_ref().unwrap_or(language_name);
         for query_file in query_files {
             let language = get_language(&grammar_name);
             let query_text = read_query(&language_name, query_file);


### PR DESCRIPTION
As described in #4346 both language and grammar names are sometimes lower-cased. For grammars this is incompatible with ones using uppercase names. And for languages this can be a bit surprising. (At least I stumbled across helix ignoring my queries because of this).

Note that the syntax part is  not strictly necessary to get grammars as described in the issue to work.

Closes #4346 