### PR TITLE
feat(find_root): add `$ROOT` environment variable detection

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -42,12 +42,17 @@ pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
 /// Find project root.
 ///
 /// Order of detection:
+/// * `ROOT` environment variable
 /// * Top-most folder containing a root marker in current git repository
 /// * Git repository root if no marker detected
 /// * Top-most folder containing a root marker if not git repository detected
 /// * Current working directory as fallback
 pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::PathBuf {
-    let current_dir = std::env::current_dir().expect("unable to determine current directory");
+    use std::env;
+    if let Ok(path) = env::var("ROOT") {
+        return path.into();
+    }
+    let current_dir = env::current_dir().expect("unable to determine current directory");
 
     let root = match root {
         Some(root) => {

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -77,6 +77,7 @@ impl Client {
             doc_path.and_then(|x| x.parent().and_then(|x| x.to_str())),
             root_markers,
         );
+        log::info!("root_path: {root_path:?}");
 
         let root_uri = lsp::Url::from_file_path(root_path.clone()).ok();
 


### PR DESCRIPTION
fix https://github.com/helix-editor/helix/issues/4342

You can use `ROOT=$PWD hx src/main.rs` to specify the project root if helix is failed to detect the unusual project structure.