### PR TITLE
Trim quotes and braces from paths in goto_file_impl

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1036,9 +1036,10 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
     // Checks whether there is only one selection with a width of 1
     if selections.len() == 1 && primary.len() == 1 {
         let count = cx.count();
+        let text_slice = text.slice(..);
         // In this case it selects the WORD under the cursor
         let current_word = textobject::textobject_word(
-            text.slice(..),
+            text_slice,
             primary,
             textobject::TextObject::Inside,
             count,
@@ -1048,8 +1049,8 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         let surrounding_chars: &[_] = &['\'', '"', '(', ')'];
         paths.clear();
         paths.push(
-            text.slice(current_word.from()..current_word.to())
-                .to_string()
+            current_word
+                .fragment(text_slice)
                 .trim_matches(surrounding_chars)
                 .to_string(),
         );

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1033,16 +1033,20 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         .collect();
     let primary = selections.primary();
     if selections.len() == 1 && primary.to() - primary.from() == 1 {
-        let current_word = movement::move_prev_long_word_start(
-            text.slice(..),
-            movement::move_next_long_word_start(text.slice(..), primary, 1),
-            1,
-        );
-        paths.clear();
-        paths.push(
-            text.slice(current_word.from()..current_word.to())
-                .to_string(),
-        );
+        let count = cx.count();
+        let new_selection = selections.clone().transform(|range| {
+            textobject::textobject_word(
+                text.slice(..),
+                range,
+                textobject::TextObject::Inside,
+                count,
+                true,
+            )
+        });
+        paths = new_selection
+            .iter()
+            .map(|r| text.slice(r.from()..r.to()).to_string())
+            .collect();
     }
     for sel in paths {
         let surrounding_chars: &[_] = &['\'', '"', '(', ')'];

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1033,9 +1033,9 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         .collect();
     let primary = selections.primary();
     if selections.len() == 1 && primary.to() - primary.from() == 1 {
-        let current_word = movement::move_next_long_word_start(
+        let current_word = movement::move_prev_long_word_start(
             text.slice(..),
-            movement::move_prev_long_word_start(text.slice(..), primary, 1),
+            movement::move_next_long_word_start(text.slice(..), primary, 1),
             1,
         );
         paths.clear();
@@ -1045,7 +1045,8 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         );
     }
     for sel in paths {
-        let p = sel.trim();
+        let surrounding_chars: &[_] = &['\'', '"', '(', ')'];
+        let p = sel.trim().trim_matches(surrounding_chars);
         if !p.is_empty() {
             if let Err(e) = cx.editor.open(&PathBuf::from(p), action) {
                 cx.editor.set_error(format!("Open file failed: {:?}", e));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1032,21 +1032,25 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         .map(|r| text.slice(r.from()..r.to()).to_string())
         .collect();
     let primary = selections.primary();
-    if selections.len() == 1 && primary.to() - primary.from() == 1 {
+    if primary.len() == 1 {
         let count = cx.count();
-        let new_selection = selections.clone().transform(|range| {
-            textobject::textobject_word(
-                text.slice(..),
-                range,
-                textobject::TextObject::Inside,
-                count,
-                true,
-            )
-        });
-        paths = new_selection
-            .iter()
-            .map(|r| text.slice(r.from()..r.to()).to_string())
-            .collect();
+        let current_word = selections
+            .clone()
+            .transform(|range| {
+                textobject::textobject_word(
+                    text.slice(..),
+                    range,
+                    textobject::TextObject::Inside,
+                    count,
+                    true,
+                )
+            })
+            .primary();
+        paths.clear();
+        paths.push(
+            text.slice(current_word.from()..current_word.to())
+                .to_string(),
+        );
     }
     for sel in paths {
         let surrounding_chars: &[_] = &['\'', '"', '(', ')'];

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1033,10 +1033,10 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         .map(|r| text.slice(r.from()..r.to()).to_string())
         .collect();
     let primary = selections.primary();
-    // Checks whether the current selection is empty
+    // Checks whether there is only one selection with a width of 1
     if selections.len() == 1 && primary.len() == 1 {
         let count = cx.count();
-        // In this case it selects the long word under the cursor
+        // In this case it selects the WORD under the cursor
         let current_word = textobject::textobject_word(
             text.slice(..),
             primary,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1055,8 +1055,8 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         );
     }
     for sel in paths {
-        if !sel.is_empty() {
-            let p = sel.trim();
+        let p = sel.trim();
+        if !p.is_empty() {
             if let Err(e) = cx.editor.open(&PathBuf::from(p), action) {
                 cx.editor.set_error(format!("Open file failed: {:?}", e));
             }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -139,9 +139,10 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_goto_file_impl() -> anyhow::Result<()> {
     let file = tempfile::NamedTempFile::new()?;
-    
+
     fn match_paths(app: &Application, matches: Vec<&str>) -> usize {
-        app.editor.documents()
+        app.editor
+            .documents()
             .map(|d| d.path())
             .flatten()
             .map(|p| p.file_name())
@@ -149,7 +150,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
             .filter(|n| matches.iter().any(|m| &OsStr::new(m) == n))
             .count()
     }
-    
+
     // Single selection
     test_key_sequence(
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
@@ -160,7 +161,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         false,
     )
     .await?;
-    
+
     // Multiple selection
     test_key_sequence(
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
@@ -171,7 +172,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         false,
     )
     .await?;
-    
+
     // Cursor on first quote
     test_key_sequence(
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
@@ -182,7 +183,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         false,
     )
     .await?;
-    
+
     // Cursor on last quote
     test_key_sequence(
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
@@ -193,7 +194,6 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         false,
     )
     .await?;
-    
-    
+
     Ok(())
 }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -2,7 +2,6 @@ use std::ops::RangeInclusive;
 
 use helix_core::diagnostic::Severity;
 use helix_term::application::Application;
-use std::ffi::OsStr;
 
 use super::*;
 
@@ -143,11 +142,8 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
     fn match_paths(app: &Application, matches: Vec<&str>) -> usize {
         app.editor
             .documents()
-            .map(|d| d.path())
-            .flatten()
-            .map(|p| p.file_name())
-            .flatten()
-            .filter(|n| matches.iter().any(|m| &OsStr::new(m) == n))
+            .filter_map(|d| d.path()?.file_name())
+            .filter(|n| matches.iter().any(|m| *m == n.to_string_lossy()))
             .count()
     }
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -152,7 +152,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
         Some("ione.js<esc>%gf"),
         Some(&|app| {
-            assert_eq!(1, match_paths(app, ["one.js"].to_vec()));
+            assert_eq!(1, match_paths(app, vec!["one.js"]));
         }),
         false,
     )
@@ -163,7 +163,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
         Some("ione.js<ret>two.js<esc>%<A-s>gf"),
         Some(&|app| {
-            assert_eq!(2, match_paths(app, ["one.js", "two.js"].to_vec()));
+            assert_eq!(2, match_paths(app, vec!["one.js", "two.js"]));
         }),
         false,
     )
@@ -174,7 +174,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
         Some("iimport 'one.js'<esc>B;gf"),
         Some(&|app| {
-            assert_eq!(1, match_paths(app, ["one.js"].to_vec()));
+            assert_eq!(1, match_paths(app, vec!["one.js"]));
         }),
         false,
     )
@@ -185,7 +185,7 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
         &mut AppBuilder::new().with_file(file.path(), None).build()?,
         Some("iimport 'one.js'<esc>bgf"),
         Some(&|app| {
-            assert_eq!(1, match_paths(app, ["one.js"].to_vec()));
+            assert_eq!(1, match_paths(app, vec!["one.js"]));
         }),
         false,
     )


### PR DESCRIPTION
`goto_file_impl` now trims surrounding `'`, `"`, `(` and `)` before opening the path.

The `current_word` selection was inverted so that now it works from both the first and last characters of the word.

Fixes #4122
