### PR TITLE
[WIP] View based refactoring in workspace

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2165,6 +2165,7 @@ fn reset_diff_change(
     Ok(())
 }
 
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -533,13 +533,19 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = doc
-                .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let fname = match &doc.document_type {
+                helix_view::document::DocumentType::File => doc
+                    .path()
+                    .unwrap_or(&scratch)
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default(),
+                helix_view::document::DocumentType::Refactor {
+                    matches: _,
+                    line_map: _,
+                } => helix_view::document::REFACTOR_BUFFER_NAME,
+            };
 
             let style = if current_doc == doc.id() {
                 bufferline_active

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -2,7 +2,7 @@ use helix_core::{coords_at_pos, encoding, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
-    document::{Mode, SCRATCH_BUFFER_NAME},
+    document::{Mode, REFACTOR_BUFFER_NAME, SCRATCH_BUFFER_NAME},
     graphics::Rect,
     theme::Style,
     Document, Editor, View,
@@ -417,12 +417,20 @@ where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
     let title = {
-        let rel_path = context.doc.relative_path();
-        let path = rel_path
-            .as_ref()
-            .map(|p| p.to_string_lossy())
-            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
-        format!(" {} ", path)
+        match &context.doc.document_type {
+            helix_view::document::DocumentType::File => {
+                let rel_path = context.doc.relative_path();
+                let path = rel_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy())
+                    .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+                format!(" {} ", path)
+            }
+            helix_view::document::DocumentType::Refactor {
+                matches: _,
+                line_map: _,
+            } => REFACTOR_BUFFER_NAME.into(),
+        }
     };
 
     write(context, title, None);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1285,7 +1285,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
This implements a new command: global_refactor, where one inputs a search regex and a new window shows up with all the lines in different files matching the search.

One can then do edits on the lines and afterwards apply those changes to the documents.
If a file was not opened in the editor from before it will be opened and the change added as a transaction.
This means that the refactoring can be undone in their respective documents.
* Demo:

https://user-images.githubusercontent.com/114359560/196932067-dda9118c-dcfe-416d-971a-d8612349ef01.mp4

There is still a lot of work to be done but I opened a draft pr to get some feedback:
* Is this something you want in core?
* What should be the default keybind for this?
* Suggestions / Ideas / Something that should be done different?
