### PR TITLE
Clarify use of `HELIX_RUNTIME`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd helix
 cargo install --path helix-term
 ```
 
-This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars.
+This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars in `./runtime/grammars`.
 
 Helix needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS, or `%AppData%/helix/runtime` on Windows).
@@ -68,7 +68,14 @@ cd %appdata%\helix
 mklink /D runtime "<helix-repo>\runtime"
 ```
 
-This location can be overridden via the `HELIX_RUNTIME` environment variable.
+The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
+
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-
+> term`, tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+
+If you plan on keeping the repo locally, an alternative to copying/symlinking
+runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`
+(`HELIX_RUNTIME=$PWD/runtime` if you're in the helix repo directory).
 
 Packages already solve this for you by wrapping the `hx` binary with a wrapper
 that sets the variable to the install dir.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-
-> term`, tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`
+> , tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking
 runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`
-> , tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`,
+> tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking
 runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -105,8 +105,8 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`
-> , tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`,
+> tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking
 runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -75,7 +75,7 @@ cd helix
 cargo install --path helix-term
 ```
 
-This will install the `hx` binary to `$HOME/.cargo/bin`.
+This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars in `./runtime/grammars`.
 
 Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overridden
@@ -102,6 +102,15 @@ New-Item -ItemType SymbolicLink -Target "runtime" -Path "$Env:AppData\helix\runt
 cd %appdata%\helix
 mklink /D runtime "<helix-repo>\runtime"
 ```
+
+The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
+
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-
+> term`, tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+
+If you plan on keeping the repo locally, an alternative to copying/symlinking
+runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`
+(`HELIX_RUNTIME=$PWD/runtime` if you're in the helix repo directory).
 
 To use Helix in desktop environments that supports [XDG desktop menu](https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html), including Gnome and KDE, copy the provided `.desktop` file to the correct folder:
 

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -105,8 +105,8 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-
-> term`, tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`
+> , tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking
 runtime files is to set `HELIX_RUNTIME=/path/to/helix/runtime`


### PR DESCRIPTION
This adds some documentation to clarify that:

1. Having `HELIX_RUNTIME` set prior to building the project will generate tree-sitter grammars in `$HELIX_RUNTIME/grammars`.
2. If keeping the repo locally, an alternative copying/symlinking runtime files is to simply set `HELIX_RUNTIME`.

See issue https://github.com/helix-editor/helix/issues/4336 for discussion.