### PR TITLE
chore(view): remove indent_unit helper fn

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3017,7 +3017,7 @@ pub mod insert {
         // TODO: round out to nearest indentation level (for example a line with 3 spaces should
         // indent by one to reach 4 spaces).
 
-        let indent = Tendril::from(doc.indent_unit());
+        let indent = Tendril::from(doc.indent_style.as_str());
         let transaction = Transaction::insert(
             doc.text(),
             &doc.selection(view.id).clone().cursors(doc.text().slice(..)),
@@ -3117,7 +3117,7 @@ pub mod insert {
         let count = cx.count();
         let (view, doc) = current_ref!(cx.editor);
         let text = doc.text().slice(..);
-        let indent_unit = doc.indent_unit();
+        let indent_unit = doc.indent_style.as_str();
         let tab_size = doc.tab_width();
         let auto_pairs = doc.auto_pairs(cx.editor);
 
@@ -3642,7 +3642,7 @@ fn indent(cx: &mut Context) {
     let lines = get_lines(doc, view.id);
 
     // Indent by one level
-    let indent = Tendril::from(doc.indent_unit().repeat(count));
+    let indent = Tendril::from(doc.indent_style.as_str().repeat(count));
 
     let transaction = Transaction::change(
         doc.text(),

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -999,14 +999,6 @@ impl Document {
             .map_or(4, |config| config.tab_width) // fallback to 4 columns
     }
 
-    /// Returns a string containing a single level of indentation.
-    ///
-    /// TODO: we might not need this function anymore, since the information
-    /// is conveniently available in `Document::indent_style` now.
-    pub fn indent_unit(&self) -> &'static str {
-        self.indent_style.as_str()
-    }
-
     pub fn changes(&self) -> &ChangeSet {
         &self.changes
     }


### PR DESCRIPTION
Remove indent_unit as the identation is conveniently available in `Document::indent_style`.