### PR TITLE
feat(view): re-use align_view function

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,4 +1,5 @@
 use crate::{
+    align_view,
     clipboard::{get_clipboard_provider, ClipboardProvider},
     document::Mode,
     graphics::{CursorKind, Rect},
@@ -6,7 +7,7 @@ use crate::{
     input::KeyEvent,
     theme::{self, Theme},
     tree::{self, Tree},
-    Document, DocumentId, View, ViewId,
+    Align, Document, DocumentId, View, ViewId,
 };
 
 use futures_util::future;
@@ -929,13 +930,7 @@ impl Editor {
         let doc = doc_mut!(self, &doc_id);
         doc.ensure_view_init(view.id);
 
-        // TODO: reuse align_view
-        let pos = doc
-            .selection(view.id)
-            .primary()
-            .cursor(doc.text().slice(..));
-        let line = doc.text().char_to_line(pos);
-        view.offset.row = line.saturating_sub(view.inner_area().height as usize / 2);
+        align_view(doc, view, Align::Center);
     }
 
     pub fn switch(&mut self, id: DocumentId, action: Action) {


### PR DESCRIPTION
In replace_document_in_view re-use align_view function to align the newly viewed doc.