### PR TITLE
Fix integration test flakes in CI

### DIFF
--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -286,6 +286,8 @@ impl AppBuilder {
         self
     }
 
+    // Remove this attribute once `with_config` is used in a test:
+    #[allow(dead_code)]
     pub fn with_config(mut self, config: Config) -> Self {
         self.config = config;
         self

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -125,13 +125,12 @@ pub async fn test_key_sequence_with_input_text<T: Into<TestCase>>(
     let sel = doc.selection(view.id).clone();
 
     // replace the initial text with the input text
-    doc.apply(
-        &Transaction::change_by_selection(doc.text(), &sel, |_| {
-            (0, doc.text().len_chars(), Some((&test_case.in_text).into()))
-        })
-        .with_selection(test_case.in_selection.clone()),
-        view.id,
-    );
+    let transaction = Transaction::change_by_selection(doc.text(), &sel, |_| {
+        (0, doc.text().len_chars(), Some((&test_case.in_text).into()))
+    })
+    .with_selection(test_case.in_selection.clone());
+
+    helix_view::apply_transaction(&transaction, doc, view);
 
     test_key_sequence(
         &mut app,
@@ -286,7 +285,7 @@ impl AppBuilder {
             .with_selection(selection);
 
             // replace the initial text with the input text
-            doc.apply(&trans, view.id);
+            helix_view::apply_transaction(&trans, doc, view);
         }
 
         Ok(app)


### PR DESCRIPTION
Write path fixes (#2267) introduced some flaky behavior in the integration test suite that happens when running within GitHub Actions.

The Windows runner has `clangd` installed, but it sometimes takes too long to shutdown which causes false-positive test failures. All runners have the `R` binary installed but not the language server package. This causes a flake whenever `tempfile::NamedTempFile` creates a file which is mistaken as R (this happens surprisingly often in practice). The R binary starts but immediately crashes because the language server package is not installed. Then the language server cannot be shutdown in the expected timeframe, resulting in a false-positive failure.

Here I've removed all language server configuration for the integration tests by default with the ability to add back the configuration explicitly. This fixes the flakes as far as I've tested and silences some unnecessary output when running locally (from `rust-analyzer`).

I've also added some small fixes to...

* use `helix_view::apply_transaction` instead of `Document::apply` (see #4186)
* silence the dead_code warning on `AppBuilder::with_config`