### PR TITLE
Add goto_url (gu) command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "helix-tui",
  "log",
  "once_cell",
+ "open",
  "serde",
  "serde_json",
  "slotmap",
@@ -737,6 +738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "open"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
+dependencies = [
+ "pathdiff",
+ "windows-sys",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +769,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -195,6 +195,7 @@ Jumps to various locations.
 | `g`   | Go to line number `<n>` else start of file       | `goto_file_start`          |
 | `e`   | Go to the end of the file                        | `goto_last_line`           |
 | `f`   | Go to files in the selection                     | `goto_file`                |
+| `u`   | Go to url in the selection                       | `goto_url`                 |
 | `h`   | Go to the start of the line                      | `goto_line_start`          |
 | `l`   | Go to the end of the line                        | `goto_line_end`            |
 | `s`   | Go to first non-whitespace character of the line | `goto_first_nonwhitespace` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -291,6 +291,7 @@ impl MappableCommand {
         goto_file, "Goto files in selection",
         goto_file_hsplit, "Goto files in selection (hsplit)",
         goto_file_vsplit, "Goto files in selection (vsplit)",
+        goto_url, "Goto url in selection",
         goto_reference, "Goto references",
         goto_window_top, "Goto window top",
         goto_window_center, "Goto window center",
@@ -1048,6 +1049,27 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             if let Err(e) = cx.editor.open(&PathBuf::from(p), action) {
                 cx.editor.set_error(format!("Open file failed: {:?}", e));
             }
+        }
+    }
+}
+
+fn goto_url(cx: &mut Context) {
+    use helix_lsp::Url;
+
+    let (view, doc) = current_ref!(cx.editor);
+    let selection = doc.selection(view.id).primary();
+    let text = doc
+        .text()
+        .slice(selection.from()..selection.to())
+        .to_string();
+
+    match Url::parse(&text) {
+        Ok(url) => {
+            cx.editor.open_url(url);
+        }
+        Err(e) => {
+            cx.editor
+                .set_error(format!("Failed to parse url '{}': {}", text, e.to_string()));
         }
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1058,10 +1058,19 @@ fn goto_url(cx: &mut Context) {
 
     let (view, doc) = current_ref!(cx.editor);
     let selection = doc.selection(view.id).primary();
-    let text = doc
-        .text()
-        .slice(selection.from()..selection.to())
-        .to_string();
+    let text = doc.text();
+
+    let text = if selection.to() - selection.from() == 1 {
+        let current_word = movement::move_next_long_word_start(
+            text.slice(..),
+            movement::move_prev_long_word_start(text.slice(..), selection, 1),
+            1,
+        );
+        text.slice(current_word.from()..current_word.to())
+            .to_string()
+    } else {
+        text.slice(selection.from()..selection.to()).to_string()
+    };
 
     match Url::parse(&text) {
         Ok(url) => {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -40,6 +40,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "g" => goto_file_start,
             "e" => goto_last_line,
             "f" => goto_file,
+            "u" => goto_url,
             "h" => goto_line_start,
             "l" => goto_line_end,
             "s" => goto_first_nonwhitespace,

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -43,6 +43,8 @@ log = "~0.4"
 
 which = "4.2"
 
+open = "3"
+
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "4.4", features = ["std"] }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1079,6 +1079,12 @@ impl Editor {
         self._refresh();
     }
 
+    pub fn open_url(&mut self, url: lsp::Url) {
+        if let Err(e) = open::that(url.as_str()) {
+            self.set_error(format!("Failed to open url '{}': {:?}", url.as_str(), e));
+        }
+    }
+
     pub fn close_document(&mut self, doc_id: DocumentId, force: bool) -> Result<(), CloseError> {
         let doc = match self.documents.get(&doc_id) {
             Some(doc) => doc,


### PR DESCRIPTION
This PR adds `gu` command which opens URL (either selected or hovered).

Closes #1472 