### PR TITLE
feat(statusline): if color_modes is enabled, color the file type as well

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -340,8 +340,21 @@ where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
     let file_type = context.doc.language_name().unwrap_or("text");
+    let visible = context.focused;
 
-    write(context, format!(" {} ", file_type), None);
+    write(
+        context,
+        format!(" {} ", file_type),
+        if visible && context.editor.config().color_modes {
+            match context.editor.mode() {
+                Mode::Insert => Some(context.editor.theme.get("ui.statusline.insert")),
+                Mode::Select => Some(context.editor.theme.get("ui.statusline.select")),
+                Mode::Normal => Some(context.editor.theme.get("ui.statusline.normal")),
+            }
+        } else {
+            None
+        },
+    );
 }
 
 fn render_file_name<F>(context: &mut RenderContext, write: F)


### PR DESCRIPTION
This is a little cosmetic improvement, which colors the file type in addition to the mode; ~~shamelessly copied from~~ inspired by [lualine](https://github.com/nvim-lualine/lualine.nvim).

In addition to the subjectively better look, I found that having only the mode colored made it *intuitively unclear* which buffer the mode belongs to, when working with a vertical split. When both the left and the right side of the focused statusline are highlighted, however, this ambiguity disappears:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/2804556/197288683-dd6299f7-9d37-4876-9520-a31573384643.png">