### PR TITLE
feat(commands): io and ao aliases

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -65,7 +65,7 @@
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
 | `:log-open` | Open the helix log file. |
-| `:insert-output` | Run shell command, inserting output before each selection. |
-| `:append-output` | Run shell command, appending output after each selection. |
+| `:insert-output`, `:io` | Run shell command, inserting output before each selection. |
+| `:append-output`, `:ao` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2106,14 +2106,14 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         },
         TypableCommand {
             name: "insert-output",
-            aliases: &[],
+            aliases: &["io"],
             doc: "Run shell command, inserting output before each selection.",
             fun: insert_output,
             completer: None,
         },
         TypableCommand {
             name: "append-output",
-            aliases: &[],
+            aliases: &["ao"],
             doc: "Run shell command, appending output after each selection.",
             fun: append_output,
             completer: None,


### PR DESCRIPTION
Adds aliases to `insert-output` and `append-output`. As mentioned in #4407.

Are there any integration tests that are needed for a small edition like this one?