### PR TITLE
feat(view): global status line option

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -19,7 +19,7 @@ use helix_core::{
 use helix_view::{
     apply_transaction,
     document::{Mode, SCRATCH_BUFFER_NAME},
-    editor::{CompleteAction, CursorShapeConfig},
+    editor::{CompleteAction, CursorShapeConfig, StatusLineRenderConfig},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
@@ -80,7 +80,10 @@ impl EditorView {
         is_focused: bool,
     ) {
         let inner = view.inner_area(doc);
-        let area = view.area;
+        let area = match editor.config().statusline.render {
+            StatusLineRenderConfig::Single => view.area.clip_bottom(1),
+            StatusLineRenderConfig::PerView => view.area,
+        };
         let theme = &editor.theme;
         let config = editor.config();
 
@@ -164,22 +167,37 @@ impl EditorView {
             for y in area.top()..area.bottom() {
                 surface[(x, y)]
                     .set_symbol(tui::symbols::line::VERTICAL)
-                    //.set_symbol(" ")
                     .set_style(border_style);
             }
         }
 
         Self::render_diagnostics(doc, view, inner, surface, theme);
 
-        let statusline_area = view
-            .area
-            .clip_top(view.area.height.saturating_sub(1))
-            .clip_bottom(1); // -1 from bottom to remove commandline
+        match editor.config().statusline.render {
+            StatusLineRenderConfig::PerView => {
+                let statusline_area = view
+                    .area
+                    .clip_top(view.area.height.saturating_sub(1))
+                    .clip_bottom(1); // -1 from bottom to remove commandline
 
-        let mut context =
-            statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
+                let mut context =
+                    statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
 
-        statusline::render(&mut context, statusline_area, surface);
+                statusline::render(&mut context, statusline_area, surface);
+            }
+            StatusLineRenderConfig::Single => {
+                // -1 for command line
+                if viewport.bottom() - 1 != view.area.bottom() {
+                    let y = area.bottom();
+                    let border_style = theme.get("ui.window");
+                    for x in area.left()..area.right() {
+                        surface[(x, y)]
+                            .set_symbol(tui::symbols::line::HORIZONTAL)
+                            .set_style(border_style);
+                    }
+                }
+            }
+        };
     }
 
     pub fn render_rulers(
@@ -1468,6 +1486,23 @@ impl Component for EditorView {
         for (view, is_focused) in cx.editor.tree.views() {
             let doc = cx.editor.document(view.doc).unwrap();
             self.render_view(cx.editor, doc, view, area, surface, is_focused);
+        }
+
+        if config.statusline.render == StatusLineRenderConfig::Single {
+            if let Some((view, is_focused)) =
+                cx.editor.tree.views().find(|&(_, is_focused)| is_focused)
+            {
+                let doc = cx.editor.document(view.doc).unwrap();
+                let mut context = statusline::RenderContext::new(
+                    cx.editor,
+                    doc,
+                    view,
+                    is_focused,
+                    &self.spinners,
+                );
+                let statusline_area = area.clip_top(area.height.saturating_sub(2)).clip_bottom(1); // -1 from bottom to remove commandline
+                statusline::render(&mut context, statusline_area, surface);
+            }
         }
 
         if config.auto_info {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -271,6 +271,7 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub render: StatusLineRenderConfig,
 }
 
 impl Default for StatusLineConfig {
@@ -283,6 +284,7 @@ impl Default for StatusLineConfig {
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            render: StatusLineRenderConfig::PerView,
         }
     }
 }
@@ -303,6 +305,13 @@ impl Default for ModeConfig {
             select: String::from("SEL"),
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StatusLineRenderConfig {
+    Single,
+    PerView,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Add option to render single global status line instead of rendering status line per view.

With
```
[editor.statusline]
render = "per_view"
```
(default)

<img width="1440" alt="Screenshot 2022-10-23 at 21 52 52" src="https://user-images.githubusercontent.com/15747583/197415289-398c187c-c823-4141-b97a-68327a4186a1.png">

with

```
[editor.statusline]
render = "single"
```

<img width="1440" alt="Screenshot 2022-10-23 at 21 50 04" src="https://user-images.githubusercontent.com/15747583/197415284-3ce0a453-0bd7-4c59-8ad5-a20b766e282a.png">


Fixes: https://github.com/helix-editor/helix/issues/2254