### PR TITLE
add cursor movement in insert mode

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -356,14 +356,14 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "C-j" | "ret" => insert_newline,
         "tab" => insert_tab,
 
-        "up" => move_line_up,
-        "down" => move_line_down,
-        "left" => move_char_left,
-        "right" => move_char_right,
+        "C-p" | "up" => move_line_up,
+        "C-n" | "down" => move_line_down,
+        "C-b" | "left" => move_char_left,
+        "C-f" | "right" => move_char_right,
         "pageup" => page_up,
         "pagedown" => page_down,
-        "home" => goto_line_start,
-        "end" => goto_line_end_newline,
+        "C-a" | "home" => goto_line_start,
+        "C-e" | "end" => goto_line_end_newline,
     });
     hashmap!(
         Mode::Normal => Keymap::new(normal),


### PR DESCRIPTION
I've added shortcuts for moving the cursor in insert mode for Helix, which I think will make them feel at home for users who frequently edit on **iPad/Mac/Emacs**.
`C-p` -> `Up`
`C-n` -> `Down`
`C-b` -> `Left`
`C-f` -> `Right`
`C-a` -> `Home`
`C-e` -> `End`