### PR TITLE
Provide option to completely disable LSP

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -115,6 +115,7 @@ The following statusline elements can be configured:
 
 | Key                   | Description                                                 | Default |
 | ---                   | -----------                                                 | ------- |
+| `enable`              | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.| `true` |
 | `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |

--- a/helix-term/tests/test/auto_indent.rs
+++ b/helix-term/tests/test/auto_indent.rs
@@ -7,7 +7,7 @@ async fn auto_indent_c() -> anyhow::Result<()> {
             files: vec![(PathBuf::from("foo.c"), Position::default())],
             ..Default::default()
         },
-        Config::default(),
+        helpers::test_config(),
         helpers::test_syntax_conf(None),
         // switches to append mode?
         (

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -41,7 +41,7 @@ macro_rules! command_provider {
      primary_paste => $pr_get_prg:literal $( , $pr_get_arg:literal )* ;
      primary_copy => $pr_set_prg:literal $( , $pr_set_arg:literal )* ;
     ) => {{
-        log::info!(
+        log::debug!(
             "Using {} to interact with the system and selection (primary) clipboard",
             if $set_prg != $get_prg { format!("{}+{}", $set_prg, $get_prg)} else { $set_prg.to_string() }
         );
@@ -381,7 +381,7 @@ mod provider {
 
     impl ClipboardProvider for WindowsProvider {
         fn name(&self) -> Cow<str> {
-            log::info!("Using clipboard-win to interact with the system clipboard");
+            log::debug!("Using clipboard-win to interact with the system clipboard");
             Cow::Borrowed("clipboard-win")
         }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -366,6 +366,8 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
+    /// Enables LSP
+    pub enable: bool,
     /// Display LSP progress messages below statusline
     pub display_messages: bool,
     /// Enable automatic pop up of signature help (parameter hints)
@@ -377,6 +379,7 @@ pub struct LspConfig {
 impl Default for LspConfig {
     fn default() -> Self {
         Self {
+            enable: true,
             display_messages: false,
             auto_signature_help: true,
             display_signature_help_docs: true,
@@ -1074,18 +1077,25 @@ impl Editor {
 
     /// Refreshes the language server for a given document
     pub fn refresh_language_server(&mut self, doc_id: DocumentId) -> Option<()> {
-        let doc = self.documents.get_mut(&doc_id)?;
-        Self::launch_language_server(&mut self.language_servers, doc)
+        self.launch_language_server(doc_id)
     }
 
     /// Launch a language server for a given document
-    fn launch_language_server(ls: &mut helix_lsp::Registry, doc: &mut Document) -> Option<()> {
+    fn launch_language_server(&mut self, doc_id: DocumentId) -> Option<()> {
+        if !self.config().lsp.enable {
+            return None;
+        }
+
         // if doc doesn't have a URL it's a scratch buffer, ignore it
-        let doc_url = doc.url()?;
+        let (lang, path) = {
+            let doc = self.document(doc_id)?;
+            (doc.language.clone(), doc.path().cloned())
+        };
 
         // try to find a language server based on the language name
-        let language_server = doc.language.as_ref().and_then(|language| {
-            ls.get(language, doc.path())
+        let language_server = lang.as_ref().and_then(|language| {
+            self.language_servers
+                .get(language, path.as_ref())
                 .map_err(|e| {
                     log::error!(
                         "Failed to initialize the LSP for `{}` {{ {} }}",
@@ -1096,6 +1106,10 @@ impl Editor {
                 .ok()
                 .flatten()
         });
+
+        let doc = self.document_mut(doc_id)?;
+        let doc_url = doc.url()?;
+
         if let Some(language_server) = language_server {
             // only spawn a new lang server if the servers aren't the same
             if Some(language_server.id()) != doc.language_server().map(|server| server.id()) {
@@ -1285,11 +1299,14 @@ impl Editor {
                 self.config.clone(),
             )?;
 
-            let _ = Self::launch_language_server(&mut self.language_servers, &mut doc);
             if let Some(diff_base) = self.diff_providers.get_diff_base(&path) {
                 doc.set_diff_base(diff_base, self.redraw_handle.clone());
             }
-            self.new_document(doc)
+
+            let id = self.new_document(doc);
+            let _ = self.launch_language_server(id);
+
+            id
         };
 
         self.switch(id, action);


### PR DESCRIPTION
I had had this code sitting around in a branch I'm working on already before #4391 became necessary in order to turn off LSP for the integration tests. It slows them down and is totally unnecessary until we figure out a good way to do integration tests with real language servers.

I'm making this PR as a proposed different way to approach this, where this is generalized into a user config option exposed to the user. I figure that while my motivation for this was reducing noise in the integration tests, this could conceivably be desirable by some users without having to e.g. compile out LSP integration with a feature flag.

Another benefit is that when we do get to integration tests around LSP, we won't need to manually specify a language config; we'll just need to set this one boolean config setting in the test invocation, which is a lot less tedious, and allows always testing the same default configs that ship to users.

With that said, I don't actually have any strong feelings about keeping this, I just thought it was worth proposing and seeing what everyone thinks since I had already done it. I'm perfectly content leaving it the way it is now.