### PR TITLE
fix(core): broken LSPs on monorepos

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -40,10 +40,15 @@ pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
 
 /// Find project root.
 ///
-/// Order of detection:
-/// * Top-most folder containing either a root marker or a git repository root
-/// * Current working directory as fallback
-pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::PathBuf {
+/// Order of detection is based on `match-closest-root` option:
+/// * If true, search for top-most folder containing either a root marker or a git repository root
+/// * If false, search for closest folder containing a root marker or a git a repository root
+/// * Use current working directory as fallback
+pub fn find_root(
+    root: Option<&str>,
+    root_markers: &[String],
+    match_closest_root: bool,
+) -> std::path::PathBuf {
     let current_dir = std::env::current_dir().expect("unable to determine current directory");
 
     let root = match root {
@@ -58,21 +63,34 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
         None => current_dir.clone(),
     };
 
-    // Return as soon as we find either:
-    // - The first ancestor that contains root files.
-    // - The first ancestor that is a git repo.
+    let mut found_marker = None;
+
     for ancestor in root.ancestors() {
         if root_markers
             .iter()
             .any(|marker| ancestor.join(marker).exists())
-            || ancestor.join(".git").is_dir()
         {
-            return ancestor.to_path_buf();
+            found_marker = Some(ancestor);
+
+            // If `match_closest_root` is set to true,
+            // stop looking for top level matches.
+            if match_closest_root {
+                break;
+            }
+        }
+
+        if ancestor.join(".git").is_dir() {
+            // Marker is repo root if no root marker was detected yet
+            if found_marker.is_none() {
+                found_marker = Some(ancestor);
+            }
+            // Don't go higher than repo if we're in one
+            break;
         }
     }
 
-    // If no root folder or git repo is found, return current_dir as fallback.
-    current_dir
+    // Return the found marker or the current_dir as fallback
+    found_marker.map_or(current_dir, |a| a.to_path_buf())
 }
 
 pub use ropey::{str_utils, Rope, RopeBuilder, RopeSlice};

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -72,7 +72,7 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
     }
 
     // If no root folder or git repo is found, return current_dir as fallback.
-    return current_dir.to_path_buf();
+    current_dir
 }
 
 pub use ropey::{str_utils, Rope, RopeBuilder, RopeSlice};

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -66,9 +66,8 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
             .iter()
             .any(|marker| ancestor.join(marker).exists())
         {
-            if top_marker.is_none() {
-                top_marker = Some(ancestor);
-            }
+            top_marker = Some(ancestor);
+            break;
         }
 
         if ancestor.join(".git").is_dir() {

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -41,8 +41,8 @@ pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
 /// Find project root.
 ///
 /// Order of detection is based on `match-closest-root` option:
-/// * If true, search for top-most folder containing either a root marker or a git repository root
-/// * If false, search for closest folder containing a root marker or a git a repository root
+/// * If false (default), search for top-most folder containing either a root marker or a git repository root
+/// * If true, search for closest folder containing a root marker or a git a repository root
 /// * Use current working directory as fallback
 pub fn find_root(
     root: Option<&str>,

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -66,7 +66,9 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
             .iter()
             .any(|marker| ancestor.join(marker).exists())
         {
-            top_marker = Some(ancestor);
+            if top_marker.is_none() {
+                top_marker = Some(ancestor);
+            }
         }
 
         if ancestor.join(".git").is_dir() {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -78,6 +78,8 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub shebangs: Vec<String>, // interpreter(s) associated with language
     pub roots: Vec<String>,        // these indicate project roots <.git, Cargo.toml>
+    #[serde(default)]
+    pub match_closest_root: bool, // match closest root instead of the top-level one
     pub comment_token: Option<String>,
     pub max_line_length: Option<usize>,
 

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -42,6 +42,7 @@ pub struct Client {
 
 impl Client {
     #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         cmd: &str,
         args: &[String],

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -47,6 +47,7 @@ impl Client {
         args: &[String],
         config: Option<Value>,
         root_markers: &[String],
+        match_closest_root: bool,
         id: usize,
         req_timeout: u64,
         doc_path: Option<&std::path::PathBuf>,
@@ -76,6 +77,7 @@ impl Client {
         let root_path = find_root(
             doc_path.and_then(|x| x.parent().and_then(|x| x.to_str())),
             root_markers,
+            match_closest_root,
         );
 
         let root_uri = lsp::Url::from_file_path(root_path.clone()).ok();

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -507,6 +507,7 @@ fn start_client(
         &ls_config.args,
         config.config.clone(),
         &config.roots,
+        config.match_closest_root,
         id,
         ls_config.timeout,
         doc_path,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2266,7 +2266,7 @@ fn append_mode(cx: &mut Context) {
 fn file_picker(cx: &mut Context) {
     // We don't specify language markers, root will be the root of the current
     // git repo or the current dir if we're not in a repo
-    let root = find_root(None, &[]);
+    let root = find_root(None, &[], false);
     let picker = ui::file_picker(root, &cx.editor.config());
     cx.push_layer(Box::new(overlayed(picker)));
 }

--- a/languages.toml
+++ b/languages.toml
@@ -1129,6 +1129,7 @@ scope = "source.elm"
 injection-regex = "elm"
 file-types = ["elm"]
 roots = ["elm.json"]
+match-closest-root = true
 auto-format = true
 comment-token = "--"
 language-server = { command = "elm-language-server" }


### PR DESCRIPTION
**Problem**

We're currently matching the top-most root for all projects and languages, but a few of them are not workspace oriented and the current behavior prevents the LSP from working in nested projects (a monorepo or a library with an example folder) when working in said languages.

e.g.

```
lib/
  elm.json
  example/
    elm.json
```

`lib/elm.json` would always be the root even if Helix was opened at `example` – that breaks LSP integrations, auto-formatting, etc.

**Solution**

For a non-breaking change solution that could be defined as the default for some languages and even configured case-by-case by the user (through a project `/.helix` folder), I propose adding a `match_closest_root` language option that is `false` by default (maintaining current behavior for all languages) but can be marked as `true` for languages like elm.

```toml
[[language]]
name = "elm"
match-closest-root = true
```
