### PR TITLE
 Popup scrollbar

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -598,7 +598,7 @@ pub fn code_action(cx: &mut Context) {
             });
             picker.move_down(); // pre-select the first item
 
-            let popup = Popup::new("code-action", picker);
+            let popup = Popup::new("code-action", picker).with_scrollbar(false);
             compositor.replace_or_push("code-action", popup);
         },
     )

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -219,7 +219,7 @@ impl Completion {
                 }
             };
         });
-        let popup = Popup::new(Self::ID, menu);
+        let popup = Popup::new(Self::ID, menu).with_scrollbar(false);
         let mut completion = Self {
             popup,
             start_offset,

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -356,19 +356,12 @@ impl<T: Item + 'static> Component for Menu<T> {
         let fits = len <= win_height;
 
         let scroll_style = theme.get("ui.menu.scroll");
-        for (i, _) in (scroll..(scroll + win_height).min(len)).enumerate() {
-            let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
+        if !fits {
+            // Draw scroll thumb
+            for i in scroll_line..(scroll_line + scroll_height) {
+                let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
 
-            if !fits {
-                // Draw scroll track
                 cell.set_symbol("▐"); // right half block
-                cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
-            }
-
-            let is_marked = i >= scroll_line && i < scroll_line + scroll_height;
-
-            if !fits && is_marked {
-                // Draw scroll thumb
                 cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
             }
         }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -356,13 +356,20 @@ impl<T: Item + 'static> Component for Menu<T> {
         let fits = len <= win_height;
 
         let scroll_style = theme.get("ui.menu.scroll");
+        let mut cell;
         if !fits {
-            // Draw scroll thumb
-            for i in scroll_line..(scroll_line + scroll_height) {
-                let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
+            for i in 0..win_height {
+                cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
 
                 cell.set_symbol("▐"); // right half block
-                cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+
+                if scroll_line <= i && i < scroll_line + scroll_height {
+                    // Draw scroll thumb
+                    cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+                } else {
+                    // Draw scroll track
+                    cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
+                }
             }
         }
     }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -319,7 +319,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             (a + b - 1) / b
         }
 
-        let scroll_height = std::cmp::min(div_ceil(win_height.pow(2), len), win_height as usize);
+        let scroll_height = std::cmp::min(div_ceil(win_height.pow(2), len), win_height);
 
         let scroll_line = (win_height - scroll_height) * scroll
             / std::cmp::max(1, len.saturating_sub(win_height));

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -319,11 +319,6 @@ impl<T: Item + 'static> Component for Menu<T> {
             (a + b - 1) / b
         }
 
-        let scroll_height = std::cmp::min(div_ceil(win_height.pow(2), len), win_height);
-
-        let scroll_line = (win_height - scroll_height) * scroll
-            / std::cmp::max(1, len.saturating_sub(win_height));
-
         let rows = options.iter().map(|option| option.row(&self.editor_data));
         let table = Table::new(rows)
             .style(style)
@@ -356,8 +351,12 @@ impl<T: Item + 'static> Component for Menu<T> {
         let fits = len <= win_height;
 
         let scroll_style = theme.get("ui.menu.scroll");
-        let mut cell;
         if !fits {
+            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
+            let scroll_line = (win_height - scroll_height) * scroll
+                / std::cmp::max(1, len.saturating_sub(win_height));
+
+            let mut cell;
             for i in 0..win_height {
                 cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -129,9 +129,9 @@ impl<T: Component> Popup<T> {
             self.scroll = self.scroll.saturating_sub(offset);
         }
     }
-    
+
     /// Enables the Popup's scrollbar.
-    /// Consider disabling the scrollbar in case the child 
+    /// Consider disabling the scrollbar in case the child
     /// already has its own.
     pub fn with_scrollbar(mut self, enable_scrollbar: bool) -> Self {
         self.has_scrollbar = enable_scrollbar;
@@ -239,7 +239,7 @@ impl<T: Component> Component for Popup<T> {
         let inner = area.inner(&self.margin);
         self.contents.render(inner, surface, cx);
 
-        // render scrollbar if contents do not fit 
+        // render scrollbar if contents do not fit
         if self.has_scrollbar {
             let win_height = inner.height as usize;
             let len = self.child_size.1 as usize;

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -251,7 +251,7 @@ impl<T: Component> Component for Popup<T> {
                 (a + b - 1) / b
             }
 
-            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height as usize);
+            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
             let scroll_line = (win_height - scroll_height) * scroll
                 / std::cmp::max(1, len.saturating_sub(win_height));
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -258,7 +258,7 @@ impl<T: Component> Component for Popup<T> {
 
                 let mut cell;
                 for i in 0..win_height {
-                    cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
+                    cell = &mut surface[(inner.right() - 1, inner.top() + i as u16)];
 
                     cell.set_symbol("▐"); // right half block
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -244,20 +244,19 @@ impl<T: Component> Component for Popup<T> {
             let win_height = inner.height as usize;
             let len = self.child_size.1 as usize;
             let fits = len <= win_height;
-            let theme = &cx.editor.theme;
             let scroll = self.scroll;
+            let scroll_style = cx.editor.theme.get("ui.menu.scroll");
 
             const fn div_ceil(a: usize, b: usize) -> usize {
                 (a + b - 1) / b
             }
 
-            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
-            let scroll_line = (win_height - scroll_height) * scroll
-                / std::cmp::max(1, len.saturating_sub(win_height));
-
-            let scroll_style = theme.get("ui.menu.scroll");
-            let mut cell;
             if !fits {
+                let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
+                let scroll_line = (win_height - scroll_height) * scroll
+                    / std::cmp::max(1, len.saturating_sub(win_height));
+
+                let mut cell;
                 for i in 0..win_height {
                     cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -256,13 +256,20 @@ impl<T: Component> Component for Popup<T> {
                 / std::cmp::max(1, len.saturating_sub(win_height));
 
             let scroll_style = theme.get("ui.menu.scroll");
+            let mut cell;
             if !fits {
-                // Draw scroll thumb
-                for i in scroll_line..(scroll_line + scroll_height) {
-                    let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
+                for i in 0..win_height {
+                    cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
 
                     cell.set_symbol("▐"); // right half block
-                    cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+
+                    if scroll_line <= i && i < scroll_line + scroll_height {
+                        // Draw scroll thumb
+                        cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+                    } else {
+                        // Draw scroll track
+                        cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
+                    }
                 }
             }
         }

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -130,7 +130,7 @@ impl<T: Component> Popup<T> {
         }
     }
 
-    /// Enables the Popup's scrollbar.
+    /// Toggles the Popup's scrollbar.
     /// Consider disabling the scrollbar in case the child
     /// already has its own.
     pub fn with_scrollbar(mut self, enable_scrollbar: bool) -> Self {
@@ -256,19 +256,12 @@ impl<T: Component> Component for Popup<T> {
                 / std::cmp::max(1, len.saturating_sub(win_height));
 
             let scroll_style = theme.get("ui.menu.scroll");
-            for (i, _) in (scroll..(scroll + win_height).min(len)).enumerate() {
-                let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
+            if !fits {
+                // Draw scroll thumb
+                for i in scroll_line..(scroll_line + scroll_height) {
+                    let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
 
-                if !fits {
-                    // Draw scroll track
                     cell.set_symbol("▐"); // right half block
-                    cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
-                }
-
-                let is_marked = i >= scroll_line && i < scroll_line + scroll_height;
-
-                if !fits && is_marked {
-                    // Draw scroll thumb
                     cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
                 }
             }

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -22,6 +22,7 @@ pub struct Popup<T: Component> {
     auto_close: bool,
     ignore_escape_key: bool,
     id: &'static str,
+    has_scrollbar: bool,
 }
 
 impl<T: Component> Popup<T> {
@@ -37,6 +38,7 @@ impl<T: Component> Popup<T> {
             auto_close: false,
             ignore_escape_key: false,
             id,
+            has_scrollbar: true,
         }
     }
 
@@ -126,6 +128,14 @@ impl<T: Component> Popup<T> {
         } else {
             self.scroll = self.scroll.saturating_sub(offset);
         }
+    }
+    
+    /// Enables the Popup's scrollbar.
+    /// Consider disabling the scrollbar in case the child 
+    /// already has its own.
+    pub fn with_scrollbar(mut self, enable_scrollbar: bool) -> Self {
+        self.has_scrollbar = enable_scrollbar;
+        self
     }
 
     pub fn contents(&self) -> &T {
@@ -228,6 +238,41 @@ impl<T: Component> Component for Popup<T> {
 
         let inner = area.inner(&self.margin);
         self.contents.render(inner, surface, cx);
+
+        // render scrollbar if contents do not fit 
+        if self.has_scrollbar {
+            let win_height = inner.height as usize;
+            let len = self.child_size.1 as usize;
+            let fits = len <= win_height;
+            let theme = &cx.editor.theme;
+            let scroll = self.scroll;
+
+            const fn div_ceil(a: usize, b: usize) -> usize {
+                (a + b - 1) / b
+            }
+
+            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height as usize);
+            let scroll_line = (win_height - scroll_height) * scroll
+                / std::cmp::max(1, len.saturating_sub(win_height));
+
+            let scroll_style = theme.get("ui.menu.scroll");
+            for (i, _) in (scroll..(scroll + win_height).min(len)).enumerate() {
+                let cell = &mut surface[(area.x + area.width - 1, area.y + i as u16)];
+
+                if !fits {
+                    // Draw scroll track
+                    cell.set_symbol("▐"); // right half block
+                    cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
+                }
+
+                let is_marked = i >= scroll_line && i < scroll_line + scroll_height;
+
+                if !fits && is_marked {
+                    // Draw scroll thumb
+                    cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+                }
+            }
+        }
     }
 
     fn id(&self) -> Option<&'static str> {


### PR DESCRIPTION
Closes #1248 by implementing a scrollbar as the required hint. As mentioned by @the-mikedavis in #4364. This is a simple copy of the scrollbar functionality from `Menu`. The scrollbar is enabled by default and `Popup::with_scrollbar()` can be used to toggle it on/off.