### PR TITLE
Select text inserted by shell or paste

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3458,6 +3458,8 @@ fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Pa
     let text = doc.text();
     let selection = doc.selection(view.id);
 
+    let mut ranges = SmallVec::with_capacity(selection.len());
+
     let transaction = Transaction::change_by_selection(text, selection, |range| {
         let pos = match (action, linewise) {
             // paste linewise before
@@ -3474,8 +3476,21 @@ fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Pa
             // paste at cursor
             (Paste::Cursor, _) => range.cursor(text.slice(..)),
         };
-        (pos, pos, values.next())
+
+        let value = values.next();
+
+        let value_len = value
+            .as_ref()
+            .map(|content| content.chars().count())
+            .unwrap_or_default();
+
+        ranges.push(Range::new(pos, pos + value_len));
+
+        (pos, pos, value)
     });
+
+    let transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
+
     apply_transaction(&transaction, doc, view);
 }
 
@@ -4714,6 +4729,7 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let selection = doc.selection(view.id);
 
     let mut changes = Vec::with_capacity(selection.len());
+    let mut ranges = SmallVec::with_capacity(selection.len());
     let text = doc.text().slice(..);
 
     for range in selection.ranges() {
@@ -4737,11 +4753,13 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
             ShellBehavior::Append => (range.to(), range.to()),
             _ => (range.from(), range.from()),
         };
+        ranges.push(Range::new(to, to + output.chars().count()));
         changes.push((from, to, Some(output)));
     }
 
     if behavior != &ShellBehavior::Ignore {
-        let transaction = Transaction::change(doc.text(), changes.into_iter());
+        let transaction = Transaction::change(doc.text(), changes.into_iter())
+            .with_selection(Selection::new(ranges, selection.primary_index()));
         apply_transaction(&transaction, doc, view);
         doc.append_changes_to_history(view.id);
     }


### PR DESCRIPTION
This follows changes in Kakoune to the same effects:

* `p`/`<space>p`: https://github.com/mawww/kakoune/commit/266d1c37d0d970a7eff747f5e6a5773a3cea39d8
* `!`/`<A-!>`: https://github.com/mawww/kakoune/commit/85b78dda2e29d70b620836b04224b104426bdbae

Selecting the new data inserted by shell or pasting is often more useful than retaining a selection of the pre-paste/insert content.

Closes https://github.com/helix-editor/helix/issues/3401