### PR TITLE
Include unnamed children for html injected into inline markdown

### DIFF
--- a/runtime/queries/markdown.inline/injections.scm
+++ b/runtime/queries/markdown.inline/injections.scm
@@ -1,2 +1,2 @@
 
-((html_tag) @injection.content (#set! injection.language "html"))
+((html_tag) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))


### PR DESCRIPTION
Simple fix for html tags in inline markdown not working sometimes.