### PR TITLE
feat(lsp): LSP preselected items appear first in completion menu

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -92,19 +92,13 @@ impl Completion {
 
     pub fn new(
         editor: &Editor,
-        items: Vec<CompletionItem>,
+        mut items: Vec<CompletionItem>,
         offset_encoding: helix_lsp::OffsetEncoding,
         start_offset: usize,
         trigger_offset: usize,
     ) -> Self {
         // Sort completion items according to their preselect status (given by the LSP server)
-        let mut items = items;
-        items.sort_by(|item1, item2| {
-            item2
-                .preselect
-                .unwrap_or(false)
-                .cmp(&item1.preselect.unwrap_or(false))
-        });
+        items.sort_by_key(|item| !item.preselect.unwrap_or(false));
 
         // Then create the menu
         let menu = Menu::new(items, (), move |editor: &mut Editor, item, event| {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -97,6 +97,16 @@ impl Completion {
         start_offset: usize,
         trigger_offset: usize,
     ) -> Self {
+        // Sort completion items according to their preselect status (given by the LSP server)
+        let mut items = items;
+        items.sort_by(|item1, item2| {
+            item2
+                .preselect
+                .unwrap_or(false)
+                .cmp(&item1.preselect.unwrap_or(false))
+        });
+
+        // Then create the menu
         let menu = Menu::new(items, (), move |editor: &mut Editor, item, event| {
             fn item_to_transaction(
                 doc: &Document,

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -108,7 +108,8 @@ impl<T: Item> Menu<T> {
                         .map(|score| (index, score))
                 }),
         );
-        self.matches.sort_unstable_by_key(|(_, score)| -score);
+        // Order of equal elements needs to be preserved as LSP preselected items come in order of high to low priority
+        self.matches.sort_by_key(|(_, score)| -score);
 
         // reset cursor position
         self.cursor = None;


### PR DESCRIPTION
# Support LSP preselect completion items

In addition to suggesting completion, some **LSP servers can tell the client which suggestions would be the most probable fit**.

For instance, if you want to assign a value to a variable named `position`, rust-analyzer will preselect a method that is also named `position()` if it is part of the suggested items. The LSP server can mark multiple completion items as preselect, but in this case the order they are send back to the LSP client defines their order. This PR makes these preselected items appear at the top of the completion menu, in the same order as the LSP server intended.

This superseeds #3215 after the merge of #4134. It also partially superseeds #2705.

![image](https://user-images.githubusercontent.com/43273245/198136276-ebef09b6-5501-45ea-846c-e7cfed507e87.png)

