### PR TITLE
feat(lang): add kdl grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -60,6 +60,7 @@
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ |  |  | `julia` |
+| kdl | ✓ |  |  |  |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
 | latex | ✓ | ✓ |  | `texlab` |
 | lean | ✓ |  |  | `lean` |

--- a/languages.toml
+++ b/languages.toml
@@ -1849,3 +1849,15 @@ formatter = { command = "dfmt" }
 [[grammar]]
 name = "d"
 source = { git = "https://github.com/gdamore/tree-sitter-d", rev="601c4a1e8310fb2f3c43fa8a923d0d27497f3c04" }
+
+[[language]]
+name = "kdl"
+scope = "source.kdl"
+file-types = ["kdl"]
+roots = []
+comment-token = "//"
+injection-regex = "kdl"
+
+[[grammar]]
+name = "kdl"
+source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d15df6610484e1d4b5c987ecad52373" }

--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -3,7 +3,7 @@
 
 (node
     name: (identifier) @function)
-(prop (identifier) @property)
+(prop (identifier) @attribute)
 (type) @type
 
 (bare_identifier) @variable.other.member

--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -1,0 +1,22 @@
+(comment) @comment
+(single_line_comment) @comment
+
+(node
+    name: (identifier) @function)
+(prop (identifier) @property)
+(type) @type
+
+(bare_identifier) @variable.other.member
+
+(keyword) @keyword
+
+(string) @string
+(number) @number
+(boolean) @constant.builtin.boolean
+
+"." @punctuation.delimiter
+
+"=" @operator
+
+"{" @punctuation.bracket
+"}" @punctuation.bracket

--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -11,7 +11,7 @@
 (keyword) @keyword
 
 (string) @string
-(number) @number
+(number) @constant.numeric
 (boolean) @constant.builtin.boolean
 
 "." @punctuation.delimiter


### PR DESCRIPTION
Adds the KDL (a cuddly document language) grammar to the languages.

Website: https://kdl.dev/
Repo: https://github.com/kdl-org/kdl
Grammar: https://github.com/Unoqwy/tree-sitter-kdl