### PR TITLE
Fleetish: Adjustments to resemble official theme and reworked diagnostics to reduce subconjunctival hemorrhage

### DIFF
--- a/runtime/themes/fleetish.toml
+++ b/runtime/themes/fleetish.toml
@@ -1,11 +1,11 @@
 # Author: Kristoffer Flottorp <kr.fl@outlook.com>
-# Based on a few screenshots of Jetbrains Fleet
+# A take on the JetBrains Fleet theme sprinkled with some creative freedom
 
-"type" = { fg = "orange" } # .builtin
-"constructor" = { fg = "orange" }
-"constant" = { fg = "green" }
+"type" = { fg = "yellow" } # .builtin
+"constructor" = { fg = "yellow" }
+"constant" = { fg = "cyan" }
 # "constant.builtin" = {} # .boolean
-"constant.builtin.boolean" = { fg = "green" } # .boolean
+"constant.builtin.boolean" = { fg = "cyan" } # .boolean
 # "constant.character" = {} #.escape
 "constant.numeric" = { fg = "yellow" } # .integer / .float
 "string" = { fg = "pink" } # .regexp
@@ -16,31 +16,31 @@
 "variable" = { fg = "light" } # .builtin / .parameter
 # "variable.other" = {} # .member
 "variable.other.member" = { fg = "purple" }
-"label" = { fg = "orange" }
+"label" = { fg = "yellow" }
 # "punctuation" = {} # .delimiter / .bracket
-"keyword" = { fg = "green" } # .operator / .directive / .function
+"keyword" = { fg = "cyan" } # .operator / .directive / .function
 # "keyword.control" = { fg = "orange" } # .conditional / .repeat / .import / .return / .exception
 "operator" = { fg = "light" }
 "function" = { fg = "blue" } # .builtin / .method / .macro / .special
-"function.macro" = { fg = "yellow" }
-"function.special" = { fg = "yellow" }
-"tag" = { fg = "yellow" }
-"special" = { fg = "yellow" }
+"function.macro" = { fg = "green" }
+"function.special" = { fg = "green" }
+"tag" = { fg = "green"}
+"special" = { fg = "green" }
 "namespace" = { fg = "light" }
 "markup" = { fg = "purple" } # .bold / .italic / .quote
 "markup.heading" = { fg = "light" } # .marker / .1 / .2 / .3 / .4 / .5 / .6
-"markup.heading.1" = { fg = "orange" }
-"markup.heading.2" = { fg = "yellow" }
+"markup.heading.1" = { fg = "yellow" }
+"markup.heading.2" = { fg = "green" }
 "markup.heading.3" = { fg = "pink" }
 "markup.heading.4" = { fg = "purple" }
-"markup.heading.5" = { fg = "green" }
+"markup.heading.5" = { fg = "cyan" }
 "markup.heading.6" = { fg = "blue" }
-"markup.list" = { fg = "green" } # .unnumbered / .numbered
-"markup.link" = { fg = "yellow" } # .url / .label / .text
+"markup.list" = { fg = "cyan" } # .unnumbered / .numbered
+"markup.link" = { fg = "green" } # .url / .label / .text
 "markup.raw" = { fg = "pink" } # .inline / .block
 # "diff" = {} # .plus / .minus
-"diff.plus" = { fg = "green" }
-"diff.minus" = { fg = "orange" }
+"diff.plus" = { fg = "cyan" }
+"diff.minus" = { fg = "yellow" }
 "diff.delta" = { fg = "purple" } # .moved
 
 # used in theming
@@ -74,11 +74,11 @@
 "info" = { fg = "yellow_accent" }
 "warning" = { fg = "orange_accent" }
 "error" = { fg = "diff_red_accent" }
-"diagnostic" = { fg = "orange", bg = "darkest" } # .hint / .info / .warning / .error
-"diagnostic.hint" = { fg = "lightest", bg = "blue_accent" }
-"diagnostic.info" = { fg = "lightest", bg = "purple_accent" }
-"diagnostic.warning" = { fg = "lightest", bg = "yellow_accent" }
-"diagnostic.error" = { fg = "lightest", bg = "orange_accent" }
+"diagnostic" = { modifiers = ["underlined"], underline = { style = "curl" } } # .hint / .info / .warning / .error
+# "diagnostic.hint" = { modifiers = ["underlined"] }
+# "diagnostic.info" = { modifiers = ["underlined"] }
+# "diagnostic.warning" = { modifiers = ["underlined"] }
+# "diagnostic.error" = { modifiers = ["underlined"] }
 
 [palette]
 darkest = "#0F0F0F"
@@ -91,12 +91,13 @@ lightest = "#FFFFFF"
 
 dark_gray = "#5B5B5B"
 light_gray = "#757575"
-purple = "#A096F9"
-blue = "#52A7F6"
-pink = "#E878DE"
-green = "#78D0BD"
+purple = "#AC9CF9"
+blue = "#52A7F6" #"#94C1FA"
+pink = "#D898D8"
+green = "#AFCB85"
+cyan = "#78D0BD"
 orange = "#ECA775"
-yellow = "#F9CA6A"
+yellow = "#E5C995"
 
 purple_accent = "#6363EE"
 blue_accent = "#2197F3"

--- a/runtime/themes/fleetish.toml
+++ b/runtime/themes/fleetish.toml
@@ -74,11 +74,7 @@
 "info" = { fg = "yellow_accent" }
 "warning" = { fg = "orange_accent" }
 "error" = { fg = "diff_red_accent" }
-"diagnostic" = { modifiers = ["underlined"], underline = { style = "curl" } } # .hint / .info / .warning / .error
-# "diagnostic.hint" = { modifiers = ["underlined"] }
-# "diagnostic.info" = { modifiers = ["underlined"] }
-# "diagnostic.warning" = { modifiers = ["underlined"] }
-# "diagnostic.error" = { modifiers = ["underlined"] }
+"diagnostic". underline = { style = "curl"  } 
 
 [palette]
 darkest = "#0F0F0F"


### PR DESCRIPTION
- Small changes to more closely resemble the official fleet theme. 
- Some create freedom to fit my own preferences and to keep it interesting.
- Reworked diagnostics to reduce bleeding from the eyes :)


Themelint compliant.

Will update wiki when approved. 

<img width="1780" alt="fleetish" src="https://user-images.githubusercontent.com/2630397/198378986-c765822f-e086-4d2d-a18c-a589d02cd01b.png">

