### PR TITLE
Improved jumplist push dedup

### DIFF
--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -28,7 +28,7 @@ impl JumpList {
     pub fn push(&mut self, jump: Jump) {
         self.jumps.truncate(self.current);
         // don't push duplicates
-        if self.jumps.last() != Some(&jump) {
+        if !self.jumps.contains(&jump) {
             self.jumps.push(jump);
             self.current = self.jumps.len();
         }


### PR DESCRIPTION
To address #4488 

The jumplist `push()` function only prevents duplicate entries if they're at the end of the vector. While this dedup check is less efficient, even with a jumplist of 100 entries shouldn't be noticeably slower.