### PR TITLE
Simplify change/delete selection, remove blckhole register

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -23,10 +23,8 @@ If there is a selected register before invoking a change or delete command, the 
 | `/`                | Last search           |
 | `:`                | Last executed command |
 | `"`                | Last yanked text      |
-| `_`                | Black hole            |
 
 > There is no special register for copying to system clipboard, instead special commands and keybindings are provided. See the [keymap](keymap.md#space-mode) for the specifics.
-> The black hole register works as a no-op register, meaning no data will be written to / read from it.
 
 ## Surround
 

--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -15,11 +15,7 @@ impl Register {
     }
 
     pub fn new_with_values(name: char, values: Vec<String>) -> Self {
-        if name == '_' {
-            Self::new(name)
-        } else {
-            Self { name, values }
-        }
+        Self { name, values }
     }
 
     pub const fn name(&self) -> char {
@@ -31,15 +27,11 @@ impl Register {
     }
 
     pub fn write(&mut self, values: Vec<String>) {
-        if self.name != '_' {
-            self.values = values;
-        }
+        self.values = values;
     }
 
     pub fn push(&mut self, value: String) {
-        if self.name != '_' {
-            self.values.push(value);
-        }
+        self.values.push(value);
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3317,7 +3317,7 @@ fn yank_impl(cx: &mut Context) -> usize {
         .fragments(text)
         .map(Cow::into_owned)
         .collect();
-    
+
     let length = values.len();
 
     cx.editor


### PR DESCRIPTION
From my understanding blackhole `'_'` register is used only in `delete_selection_noyank` and `change_selection_noyank`.

Blackhole `'_'` register also significantly changes logic in otherwise very simple `Record` struct.

This PR tries to remove blackhole register altogether, also unifying `yank` logic where applicable.