### PR TITLE
Fix panic on paste from blackhole register

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3434,7 +3434,12 @@ enum Paste {
 }
 
 fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Paste, count: usize) {
+    if values.is_empty() {
+        return;
+    }
+
     let repeat = std::iter::repeat(
+        // `values` is asserted to have at least one entry above.
         values
             .last()
             .map(|value| Tendril::from(value.repeat(count)))


### PR DESCRIPTION
The sequence `"_y"_p` panics because the blackhole register contains an empty values vec. This causes a panic when pasting since it unwraps a `slice::last`.