### PR TITLE
feat(lang): add xml

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -127,5 +127,6 @@
 | wat | ✓ |  |  |  |
 | wgsl | ✓ |  |  | `wgsl_analyzer` |
 | xit | ✓ |  |  |  |
+| xml | ✓ |  | ✓ |  |
 | yaml | ✓ |  | ✓ | `yaml-language-server` |
 | zig | ✓ | ✓ | ✓ | `zls` |

--- a/languages.toml
+++ b/languages.toml
@@ -1897,3 +1897,23 @@ injection-regex = "kdl"
 [[grammar]]
 name = "kdl"
 source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d15df6610484e1d4b5c987ecad52373" }
+
+[[language]]
+name = "xml"
+scope = "source.xml"
+injection-regex = "xml"
+file-types = ["xml"]
+indent = { tab-width = 2, unit = "  " }
+roots = []
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+"'" = "'"
+"<" = ">"
+
+[[grammar]]
+name = "xml"
+source = { git = "https://github.com/RenjiSann/tree-sitter-xml", rev = "422528a43630db6dcc1e222d1c5ee3babd559473" }

--- a/runtime/queries/xml/highlights.scm
+++ b/runtime/queries/xml/highlights.scm
@@ -1,0 +1,42 @@
+(comment) @comment
+
+[
+    "DOCTYPE"
+    "ELEMENT"
+    "ATTLIST"
+] @keyword
+
+[
+    "#REQUIRED"
+    "#IMPLIED"
+    "#FIXED"
+    "#PCDATA"
+] @keyword.directive
+
+[
+    "EMPTY"
+    "ANY"
+    "SYSTEM"
+    "PUBLIC"
+] @constant
+
+(doctype) @variable
+(element_name) @variable
+
+"xml" @tag
+(tag_name) @tag
+
+[
+    "encoding"
+    "version"
+    "standalone"
+] @attribute
+(attribute_name) @attribute
+
+(system_literal) @string
+(pubid_literal) @string
+(attribute_value) @string
+
+[
+    "<" ">" "</" "/>" "<?" "?>" "<!"
+] @punctuation.bracket

--- a/runtime/queries/xml/indents.scm
+++ b/runtime/queries/xml/indents.scm
@@ -1,0 +1,1 @@
+(element) @indent

--- a/runtime/queries/xml/injections.scm
+++ b/runtime/queries/xml/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
There have been two issues opened about this (#3479 and #4331) so I think it would be good for us to include something in the default configuration that handles XML.

The solution in this pull request adds a new grammar. This same grammar was added to lapace in https://github.com/lapce/lapce/pull/1554, and it seems to handle things well. The highlight queries were copied from the grammar's repository. Here's a screenshot with the Darcula theme:

![2022-10-29T14:19:26,733205436-04:00](https://user-images.githubusercontent.com/36740602/198847059-c364c5a3-eef3-4b78-ac20-a473fcec8d59.png)

There was also [a suggestion](https://github.com/helix-editor/helix/issues/3479#issuecomment-1221323100) on one of the XML-related issues that we could re-use the HTML grammar. If we'd prefer to avoid adding another grammar, let me know and I can update this pull request. The XML grammar is pretty small though (only 97K), so I think the small size increase might be worth it.

Also, I haven't included a language server in the configuration, since I don't use one myself. [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) has instructions for [lemminx](https://github.com/eclipse/lemminx), but it looks like it will take a bit of work to get running on NixOS, so I haven't been able to test it yet. Would it be fine if we just left it without a language server right now? I'm thinking that it should probably be added by someone who actually uses an XML language server and has tested it with Helix for a little bit.