### PR TITLE
fix: make `scroll` aware of tabs and wide characters

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1360,7 +1360,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
     let range = doc.selection(view.id).primary();
     let text = doc.text().slice(..);
 
-    let cursor = coords_at_pos(text, range.cursor(text));
+    let cursor = visual_coords_at_pos(text, range.cursor(text), doc.tab_width());
     let doc_last_line = doc.text().len_lines().saturating_sub(1);
 
     let last_line = view.last_line(doc);
@@ -1392,7 +1392,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
 
     // If cursor needs moving, replace primary selection
     if line != cursor.row {
-        let head = pos_at_coords(text, Position::new(line, cursor.col), true); // this func will properly truncate to line end
+        let head = pos_at_visual_coords(text, Position::new(line, cursor.col), doc.tab_width()); // this func will properly truncate to line end
 
         let anchor = if cx.editor.mode == Mode::Select {
             range.anchor


### PR DESCRIPTION
This pull request fixes the same issue as #2620, except for `scroll` instead of `move_vertically`.

The issue is kind of complicated to explain in text, so here's a video of the before and after:

![out](https://user-images.githubusercontent.com/36740602/198850926-a522b4de-adbc-43d4-a40b-d4b5290edd98.gif)

I believe the comment on line 1395 about things getting truncated properly should still be accurate, but I wouldn't mind a second opinion on that.

Also, do we have tests for scrolling anywhere? Is there somewhere that I could add a unit test for this behaviour?