### PR TITLE
Update LaTex grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -570,7 +570,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "latex"
-source = { git = "https://github.com/latex-lsp/tree-sitter-latex", rev = "b3b2cf27f33e71438ebe46934900b1153901c6f2" }
+source = { git = "https://github.com/latex-lsp/tree-sitter-latex", rev = "8c75e93cd08ccb7ce1ccab22c1fbd6360e3bcea6" }
 
 [[language]]
 name = "lean"

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -29,6 +29,12 @@
   (#eq? @punctuation.delimiter "&"))
 
 ["[" "]" "{" "}"] @punctuation.bracket ; "(" ")" has no syntactical meaning in LaTeX
+(math_delimiter
+  left_command: _ @punctuation.delimiter
+  left_delimiter: _ @punctuation.delimiter
+  right_command: _ @punctuation.delimiter
+  right_delimiter: _ @punctuation.delimiter
+)
 
 ;; General environments
 (begin

--- a/runtime/queries/latex/injections.scm
+++ b/runtime/queries/latex/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
+((line_comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Update the LaTex grammar. I also noticed that the comment injection has been broken for a while and math delimiters were not highlighted, so I fixed that too.