### PR TITLE
feat: add 'file-abs-path' to statusline (#4434)

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -97,6 +97,7 @@ The following statusline elements can be configured:
 | `mode` | The current editor mode (`mode.normal`/`mode.insert`/`mode.select`) |
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
+| `file-abs-path` | The absolute path/name of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
 | `total-line-numbers` | The total line numbers of the opened file |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -137,6 +137,7 @@ where
         helix_view::editor::StatusLineElement::Mode => render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
+        helix_view::editor::StatusLineElement::FileAbsPath => render_file_abs_path,
         helix_view::editor::StatusLineElement::FileEncoding => render_file_encoding,
         helix_view::editor::StatusLineElement::FileLineEnding => render_file_line_ending,
         helix_view::editor::StatusLineElement::FileType => render_file_type,
@@ -342,6 +343,26 @@ where
     let file_type = context.doc.language_name().unwrap_or("text");
 
     write(context, format!(" {} ", file_type), None);
+}
+
+fn render_file_abs_path<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let title = {
+        let path = context.doc.canonicalized_path();
+        let path = path
+            .as_ref()
+            .map(|p| p.to_string_lossy())
+            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+        format!(
+            " {}{} ",
+            path,
+            if context.doc.is_modified() { "[+]" } else { "" }
+        )
+    };
+
+    write(context, title, None);
 }
 
 fn render_file_name<F>(context: &mut RenderContext, write: F)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1087,6 +1087,17 @@ impl Document {
             .map(helix_core::path::get_relative_path)
     }
 
+    pub fn canonicalized_path(&self) -> Option<PathBuf> {
+        if let Some(path) = self.path.as_deref() {
+            helix_core::path::get_canonicalized_path(path).ok()
+        } else {
+            None
+        }
+        // self.path
+        //     .as_deref()
+        //     .map(helix_core::path::get_canonicalized_path)
+    }
+
     pub fn display_name(&self) -> Cow<'static, str> {
         self.relative_path()
             .map(|path| path.to_string_lossy().to_string().into())

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -313,6 +313,9 @@ pub enum StatusLineElement {
     /// The file nane/path, including a dirty flag if it's unsaved
     FileName,
 
+    /// The file absolute path, including a dirty flag if it's unsaved
+    FileAbsPath,
+
     /// The file encoding
     FileEncoding,
 


### PR DESCRIPTION
Adds configuration option 'file-abs-path' for the status line that will allow the user to choose to show the full absolute path to the file rather than just the file name with 'file-name'.