### PR TITLE
Update SSH client config grammar & highlight queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1518,7 +1518,7 @@ roots = []
 
 [[grammar]]
 name = "sshclientconfig"
-source = { git = "https://github.com/metio/tree-sitter-ssh-client-config", rev = "769d7a01a2e5493b4bb5a51096c6bf4be130b024" }
+source = { git = "https://github.com/metio/tree-sitter-ssh-client-config", rev = "e45c6d5c71657344d4ecaf87dafae7736f776c57" }
 
 [[language]]
 name = "scheme"

--- a/runtime/queries/sshclientconfig/highlights.scm
+++ b/runtime/queries/sshclientconfig/highlights.scm
@@ -1,17 +1,17 @@
-(host) @keyword
-(host_value) @identifier
+(host) @namespace
+(host_value) @string
 
-(match) @keyword
-(match_value) @identifier
+(match) @namespace
+(match_value) @string
 
 (add_keys_to_agent) @keyword
-(add_keys_to_agent_value) @boolean
+(add_keys_to_agent_value) @constant.builtin.boolean
 
 (address_family) @keyword
-(address_family_value) @type
+(address_family_value) @constant.builtin.string
 
 (batch_mode) @keyword
-(batch_mode_value) @boolean
+(batch_mode_value) @constant.builtin.boolean
 
 (bind_address) @keyword
 (bind_address_value) @string
@@ -20,165 +20,165 @@
 (bind_interface_value) @string
 
 (canonical_domains) @keyword
-(canonical_domains_value) @identifier
+(canonical_domains_value) @string
 
 (canonicalize_fallback_local) @keyword
-(canonicalize_fallback_local_value) @boolean
+(canonicalize_fallback_local_value) @constant.builtin.boolean
 
 (canonicalize_hostname) @keyword
-(canonicalize_hostname_value) @boolean
+(canonicalize_hostname_value) @constant.builtin.string
 
 (canonicalize_max_dots) @keyword
-(canonicalize_max_dots_value) @number
+(canonicalize_max_dots_value) @constant.numeric.integer
 
 (canonicalize_permitted_cnames) @keyword
-(canonicalize_permitted_cnames_value) @identifier
+(canonicalize_permitted_cnames_value) @string
 
 (ca_signature_algorithms) @keyword
-(ca_signature_algorithms_value) @identifier
+(ca_signature_algorithms_value) @constant.builtin.string
 
 (certificate_file) @keyword
-(certificate_file_value) @file
+(certificate_file_value) @string.special.path
 
 (challenge_response_authentication) @keyword
-(challenge_response_authentication_value) @boolean
+(challenge_response_authentication_value) @constant.builtin.boolean
 
 (check_host_ip) @keyword
-(check_host_ip_value) @boolean
+(check_host_ip_value) @constant.builtin.boolean
 
 (cipher) @keyword
-(cipher_value) @identifier
+(cipher_value) @constant.builtin.string
 
 (ciphers) @keyword
-(ciphers_value) @identifier
+(ciphers_value) @constant.builtin.string
 
 (clear_all_forwardings) @keyword
-(clear_all_forwardings_value) @boolean
+(clear_all_forwardings_value) @constant.builtin.boolean
 
 (comment) @comment
 
 (compression) @keyword
-(compression_value) @boolean
+(compression_value) @constant.builtin.boolean
 
 (connect_timeout) @keyword
-(connect_timeout_value) @number
+(connect_timeout_value) @constant.numeric.integer
 
 (connection_attempts) @keyword
-(connection_attempts_value) @number
+(connection_attempts_value) @constant.numeric.integer
 
 (control_master) @keyword
-(control_master_value) @type
+(control_master_value) @constant.builtin.string
 
 (control_path) @keyword
-(control_path_value) @file
+(control_path_value) @string.special.path
 
 (control_persist) @keyword
-(control_persist_value) @type
+(control_persist_value) @constant.builtin
 
 (dynamic_forward) @keyword
 (dynamic_forward_value) @string
 
 (enable_ssh_keysign) @keyword
-(enable_ssh_keysign_value) @boolean
+(enable_ssh_keysign_value) @constant.builtin.boolean
 
 (escape_char) @keyword
-(escape_char_value) @string
+(escape_char_value) @constant.character.escape
 
 (exit_on_forward_failure) @keyword
-(exit_on_forward_failure_value) @boolean
+(exit_on_forward_failure_value) @constant.builtin.boolean
 
 (fingerprint_hash) @keyword
-(fingerprint_hash_value) @identifier
+(fingerprint_hash_value) @constant.builtin.string
 
 (fork_after_authentication) @keyword
-(fork_after_authentication_value) @boolean
+(fork_after_authentication_value) @constant.builtin.boolean
 
 (forward_agent) @keyword
-(forward_agent_value) @boolean
+(forward_agent_value) @string
 
 (forward_x11) @keyword
-(forward_x11_value) @boolean
+(forward_x11_value) @constant.builtin.boolean
 
 (forward_x11_timeout) @keyword
-(forward_x11_timeout_value) @time
+(forward_x11_timeout_value) @string.special.time
 
 (forward_x11_trusted) @keyword
-(forward_x11_trusted_value) @boolean
+(forward_x11_trusted_value) @constant.builtin.boolean
 
 (gateway_ports) @keyword
-(gateway_ports_value) @boolean
+(gateway_ports_value) @constant.builtin.boolean
 
 (global_known_hosts_file) @keyword
-(global_known_hosts_file_value) @file
+(global_known_hosts_file_value) @string.special.path
 
 (gssapi_authentication) @keyword
-(gssapi_authentication_value) @boolean
+(gssapi_authentication_value) @constant.builtin.boolean
 
 (gssapi_client_identity) @keyword
 (gssapi_client_identity_value) @string
 
 (gssapi_delegate_credentials) @keyword
-(gssapi_delegate_credentials_value) @boolean
+(gssapi_delegate_credentials_value) @constant.builtin.boolean
 
 (gssapi_kex_algorithms) @keyword
-(gssapi_kex_algorithms_value) @identifier
+(gssapi_kex_algorithms_value) @constant.builtin.string
 
 (gssapi_key_exchange) @keyword
-(gssapi_key_exchange_value) @boolean
+(gssapi_key_exchange_value) @constant.builtin.boolean
 
 (gssapi_renewal_forces_rekey) @keyword
-(gssapi_renewal_forces_rekey_value) @boolean
+(gssapi_renewal_forces_rekey_value) @constant.builtin.boolean
 
 (gssapi_server_identity) @keyword
 (gssapi_server_identity_value) @string
 
 (gssapi_trust_dns) @keyword
-(gssapi_trust_dns_value) @boolean
+(gssapi_trust_dns_value) @constant.builtin.boolean
 
 (hash_known_hosts) @keyword
-(hash_known_hosts_value) @boolean
+(hash_known_hosts_value) @constant.builtin.boolean
 
 (host_key_algorithms) @keyword
-(host_key_algorithms_value) @identifier
+(host_key_algorithms_value) @constant.builtin.string
 
 (host_key_alias) @keyword
 (host_key_alias_value) @string
 
 (hostbased_accepted_algorithms) @keyword
-(hostbased_accepted_algorithms_value) @identifier
+(hostbased_accepted_algorithms_value) @constant.builtin.string
 
 (hostbased_authentication) @keyword
-(hostbased_authentication_value) @boolean
+(hostbased_authentication_value) @constant.builtin.boolean
 
 (hostname) @keyword
 (hostname_value) @string
 
 (identities_only) @keyword
-(identities_only_value) @boolean
+(identities_only_value) @constant.builtin.boolean
 
 (identity_agent) @keyword
 (identity_agent_value) @string
 
 (identity_file) @keyword
-(identity_file_value) @file
+(identity_file_value) @string.special.path
 
 (ignore_unknown) @keyword
 (ignore_unknown_value) @string
 
-(include) @keyword
-(include_value) @file
+(include) @function.macro
+(include_value) @string.special.path
 
 (ip_qos) @keyword
-(ip_qos_value) @type
+(ip_qos_value) @constant.builtin.string
 
 (kbd_interactive_authentication) @keyword
-(kbd_interactive_authentication_value) @boolean
+(kbd_interactive_authentication_value) @constant.builtin.boolean
 
 (kbd_interactive_devices) @keyword
-(kbd_interactive_devices_value) @type
+(kbd_interactive_devices_value) @constant.builtin.string
 
 (kex_algorithms) @keyword
-(kex_algorithms_value) @identifier
+(kex_algorithms_value) @constant.builtin.string
 
 (known_hosts_command) @keyword
 (known_hosts_command_value) @string
@@ -190,25 +190,25 @@
 (local_forward_value) @string
 
 (log_level) @keyword
-(log_level_value) @type
+(log_level_value) @constant.builtin.string
 
 (log_verbose) @keyword
 (log_verbose_value) @string
 
 (macs) @keyword
-(macs_value) @identifier
+(macs_value) @constant.builtin.string
 
 (no_host_authentication_for_localhost) @keyword
-(no_host_authentication_for_localhost_value) @boolean
+(no_host_authentication_for_localhost_value) @constant.builtin.boolean
 
 (number_of_password_prompts) @keyword
-(number_of_password_prompts_value) @number
+(number_of_password_prompts_value) @constant.numeric.integer
 
 (password_authentication) @keyword
-(password_authentication_value) @boolean
+(password_authentication_value) @constant.builtin.boolean
 
 (permit_local_command) @keyword
-(permit_local_command_value) @boolean
+(permit_local_command_value) @constant.builtin.boolean
 
 (permit_remote_open) @keyword
 (permit_remote_open_value) @string
@@ -217,13 +217,13 @@
 (pkcs11_provider_value) @string
 
 (port) @keyword
-(port_value) @number
+(port_value) @constant.numeric.integer
 
 (preferred_authentications) @keyword
-(preferred_authentications_value) @type
+(preferred_authentications_value) @constant.builtin.string
 
 (protocol) @keyword
-(protocol_value) @number
+(protocol_value) @constant.numeric.integer
 
 (proxy_command) @keyword
 (proxy_command_value) @string
@@ -232,16 +232,16 @@
 (proxy_jump_value) @string
 
 (proxy_use_fdpass) @keyword
-(proxy_use_fdpass_value) @boolean
+(proxy_use_fdpass_value) @constant.builtin.boolean
 
 (pubkey_accepted_algorithms) @keyword
-(pubkey_accepted_algorithms_value) @identifier
+(pubkey_accepted_algorithms_value) @constant.builtin.string
 
 (pubkey_accepted_key_types) @keyword
-(pubkey_accepted_key_types_value) @identifier
+(pubkey_accepted_key_types_value) @constant.builtin.string
 
 (pubkey_authentication) @keyword
-(pubkey_authentication_value) @boolean
+(pubkey_authentication_value) @constant.builtin.string
 
 (rekey_limit) @keyword
 (rekey_limit_value) @string
@@ -253,10 +253,10 @@
 (remote_forward_value) @string
 
 (request_tty) @keyword
-(request_tty_value) @type
+(request_tty_value) @constant.builtin.string
 
 (revoked_host_keys) @keyword
-(revoked_host_keys_value) @file
+(revoked_host_keys_value) @string.special.path
 
 (security_key_provider) @keyword
 (security_key_provider_value) @string
@@ -265,60 +265,60 @@
 (send_env_value) @string
 
 (server_alive_count_max) @keyword
-(server_alive_count_max_value) @number
+(server_alive_count_max_value) @constant.numeric.integer
 
 (server_alive_interval) @keyword
-(server_alive_interval_value) @number
+(server_alive_interval_value) @constant.numeric.integer
 
 (session_type) @keyword
-(session_type_value) @type
+(session_type_value) @constant.builtin.string
 
 (set_env) @keyword
 (set_env_value) @string
 
 (stdin_null) @keyword
-(stdin_null_value) @boolean
+(stdin_null_value) @constant.builtin.boolean
 
 (stream_local_bind_mask) @keyword
 (stream_local_bind_mask_value) @string
 
 (stream_local_bind_unlink) @keyword
-(stream_local_bind_unlink_value) @boolean
+(stream_local_bind_unlink_value) @constant.builtin.boolean
 
 (strict_host_key_checking) @keyword
-(strict_host_key_checking_value) @type
+(strict_host_key_checking_value) @constant.builtin.string
 
 (syslog_facility) @keyword
-(syslog_facility_value) @type
+(syslog_facility_value) @constant.builtin.string
 
 (tcp_keep_alive) @keyword
-(tcp_keep_alive_value) @boolean
+(tcp_keep_alive_value) @constant.builtin.boolean
 (keep_alive) @keyword
-(keep_alive_value) @boolean
+(keep_alive_value) @constant.builtin.boolean
 
 (tunnel) @keyword
-(tunnel_value) @type
+(tunnel_value) @constant.builtin.string
 
 (tunnel_device) @keyword
 (tunnel_device_value) @string
 
 (update_host_keys) @keyword
-(update_host_keys_value) @type
+(update_host_keys_value) @constant.builtin.string
 
 (use_keychain) @keyword
-(use_keychain_value) @boolean
+(use_keychain_value) @constant.builtin.boolean
 
 (user) @keyword
 (user_value) @string
 
 (user_known_hosts_file) @keyword
-(user_known_hosts_file_value) @file
+(user_known_hosts_file_value) @string.special.path
 
 (verify_host_key_dns) @keyword
-(verify_host_key_dns_value) @type
+(verify_host_key_dns_value) @constant.builtin.string
 
 (visual_host_key) @keyword
-(visual_host_key_value) @boolean
+(visual_host_key_value) @constant.builtin.boolean
 
 (xauth_location) @keyword
-(xauth_location_value) @file
+(xauth_location_value) @string.special.path

--- a/runtime/queries/sshclientconfig/highlights.scm
+++ b/runtime/queries/sshclientconfig/highlights.scm
@@ -8,7 +8,7 @@
 (add_keys_to_agent_value) @constant.builtin.boolean
 
 (address_family) @keyword
-(address_family_value) @constant.builtin.string
+(address_family_value) @constant.builtin
 
 (batch_mode) @keyword
 (batch_mode_value) @constant.builtin.boolean
@@ -26,7 +26,7 @@
 (canonicalize_fallback_local_value) @constant.builtin.boolean
 
 (canonicalize_hostname) @keyword
-(canonicalize_hostname_value) @constant.builtin.string
+(canonicalize_hostname_value) @constant.builtin
 
 (canonicalize_max_dots) @keyword
 (canonicalize_max_dots_value) @constant.numeric.integer
@@ -35,7 +35,7 @@
 (canonicalize_permitted_cnames_value) @string
 
 (ca_signature_algorithms) @keyword
-(ca_signature_algorithms_value) @constant.builtin.string
+(ca_signature_algorithms_value) @string
 
 (certificate_file) @keyword
 (certificate_file_value) @string.special.path
@@ -47,10 +47,10 @@
 (check_host_ip_value) @constant.builtin.boolean
 
 (cipher) @keyword
-(cipher_value) @constant.builtin.string
+(cipher_value) @string
 
 (ciphers) @keyword
-(ciphers_value) @constant.builtin.string
+(ciphers_value) @string
 
 (clear_all_forwardings) @keyword
 (clear_all_forwardings_value) @constant.builtin.boolean
@@ -67,7 +67,7 @@
 (connection_attempts_value) @constant.numeric.integer
 
 (control_master) @keyword
-(control_master_value) @constant.builtin.string
+(control_master_value) @constant.builtin
 
 (control_path) @keyword
 (control_path_value) @string.special.path
@@ -88,7 +88,7 @@
 (exit_on_forward_failure_value) @constant.builtin.boolean
 
 (fingerprint_hash) @keyword
-(fingerprint_hash_value) @constant.builtin.string
+(fingerprint_hash_value) @constant.builtin
 
 (fork_after_authentication) @keyword
 (fork_after_authentication_value) @constant.builtin.boolean
@@ -100,7 +100,7 @@
 (forward_x11_value) @constant.builtin.boolean
 
 (forward_x11_timeout) @keyword
-(forward_x11_timeout_value) @string.special.time
+(forward_x11_timeout_value) @constant.numeric.integer
 
 (forward_x11_trusted) @keyword
 (forward_x11_trusted_value) @constant.builtin.boolean
@@ -121,7 +121,7 @@
 (gssapi_delegate_credentials_value) @constant.builtin.boolean
 
 (gssapi_kex_algorithms) @keyword
-(gssapi_kex_algorithms_value) @constant.builtin.string
+(gssapi_kex_algorithms_value) @string
 
 (gssapi_key_exchange) @keyword
 (gssapi_key_exchange_value) @constant.builtin.boolean
@@ -139,13 +139,13 @@
 (hash_known_hosts_value) @constant.builtin.boolean
 
 (host_key_algorithms) @keyword
-(host_key_algorithms_value) @constant.builtin.string
+(host_key_algorithms_value) @string
 
 (host_key_alias) @keyword
 (host_key_alias_value) @string
 
 (hostbased_accepted_algorithms) @keyword
-(hostbased_accepted_algorithms_value) @constant.builtin.string
+(hostbased_accepted_algorithms_value) @string
 
 (hostbased_authentication) @keyword
 (hostbased_authentication_value) @constant.builtin.boolean
@@ -169,16 +169,16 @@
 (include_value) @string.special.path
 
 (ip_qos) @keyword
-(ip_qos_value) @constant.builtin.string
+(ip_qos_value) @constant.builtin
 
 (kbd_interactive_authentication) @keyword
 (kbd_interactive_authentication_value) @constant.builtin.boolean
 
 (kbd_interactive_devices) @keyword
-(kbd_interactive_devices_value) @constant.builtin.string
+(kbd_interactive_devices_value) @string
 
 (kex_algorithms) @keyword
-(kex_algorithms_value) @constant.builtin.string
+(kex_algorithms_value) @string
 
 (known_hosts_command) @keyword
 (known_hosts_command_value) @string
@@ -190,13 +190,13 @@
 (local_forward_value) @string
 
 (log_level) @keyword
-(log_level_value) @constant.builtin.string
+(log_level_value) @constant.builtin
 
 (log_verbose) @keyword
 (log_verbose_value) @string
 
 (macs) @keyword
-(macs_value) @constant.builtin.string
+(macs_value) @string
 
 (no_host_authentication_for_localhost) @keyword
 (no_host_authentication_for_localhost_value) @constant.builtin.boolean
@@ -220,7 +220,7 @@
 (port_value) @constant.numeric.integer
 
 (preferred_authentications) @keyword
-(preferred_authentications_value) @constant.builtin.string
+(preferred_authentications_value) @string
 
 (protocol) @keyword
 (protocol_value) @constant.numeric.integer
@@ -235,13 +235,13 @@
 (proxy_use_fdpass_value) @constant.builtin.boolean
 
 (pubkey_accepted_algorithms) @keyword
-(pubkey_accepted_algorithms_value) @constant.builtin.string
+(pubkey_accepted_algorithms_value) @string
 
 (pubkey_accepted_key_types) @keyword
-(pubkey_accepted_key_types_value) @constant.builtin.string
+(pubkey_accepted_key_types_value) @string
 
 (pubkey_authentication) @keyword
-(pubkey_authentication_value) @constant.builtin.string
+(pubkey_authentication_value) @constant.builtin
 
 (rekey_limit) @keyword
 (rekey_limit_value) @string
@@ -253,7 +253,7 @@
 (remote_forward_value) @string
 
 (request_tty) @keyword
-(request_tty_value) @constant.builtin.string
+(request_tty_value) @constant.builtin
 
 (revoked_host_keys) @keyword
 (revoked_host_keys_value) @string.special.path
@@ -271,7 +271,7 @@
 (server_alive_interval_value) @constant.numeric.integer
 
 (session_type) @keyword
-(session_type_value) @constant.builtin.string
+(session_type_value) @constant.builtin
 
 (set_env) @keyword
 (set_env_value) @string
@@ -286,10 +286,10 @@
 (stream_local_bind_unlink_value) @constant.builtin.boolean
 
 (strict_host_key_checking) @keyword
-(strict_host_key_checking_value) @constant.builtin.string
+(strict_host_key_checking_value) @constant.builtin
 
 (syslog_facility) @keyword
-(syslog_facility_value) @constant.builtin.string
+(syslog_facility_value) @constant.builtin
 
 (tcp_keep_alive) @keyword
 (tcp_keep_alive_value) @constant.builtin.boolean
@@ -297,13 +297,13 @@
 (keep_alive_value) @constant.builtin.boolean
 
 (tunnel) @keyword
-(tunnel_value) @constant.builtin.string
+(tunnel_value) @constant.builtin
 
 (tunnel_device) @keyword
 (tunnel_device_value) @string
 
 (update_host_keys) @keyword
-(update_host_keys_value) @constant.builtin.string
+(update_host_keys_value) @constant.builtin
 
 (use_keychain) @keyword
 (use_keychain_value) @constant.builtin.boolean
@@ -315,7 +315,7 @@
 (user_known_hosts_file_value) @string.special.path
 
 (verify_host_key_dns) @keyword
-(verify_host_key_dns_value) @constant.builtin.string
+(verify_host_key_dns_value) @constant.builtin
 
 (visual_host_key) @keyword
 (visual_host_key_value) @constant.builtin.boolean


### PR DESCRIPTION
This updates the highlight queries for SSH client configs to be more closely aligned with what helix themes expect and it fetches the latest upstream source which fixes some grammar related issues as well.

Before:
![before](https://user-images.githubusercontent.com/44168/198954740-9d9763b0-ee4a-4c88-8188-40839a98ab3b.png)

After:
![after](https://user-images.githubusercontent.com/44168/198954757-1a99c6fd-b0e7-44db-8d4b-83c42b3fca76.png)
