### PR TITLE
Added missing keywords to wat (wasm) hightlights

### DIFF
--- a/runtime/queries/wat/highlights.scm
+++ b/runtime/queries/wat/highlights.scm
@@ -1,4 +1,7 @@
-["module" "func" "param" "result" "type" "memory" "elem" "data" "table" "global"] @keyword
+[
+  "module" "func" "param" "result" "type" "memory" "elem" "data" "table" "global"
+  "if" "then" "else" "block" "loop" "end" "mut"
+] @keyword
 
 ["import" "export"] @keyword.control.import
 


### PR DESCRIPTION
added "if", "then", "else", "block", "loop", "end" and "mut" to the wat keyword highlights.