### PR TITLE
Exit select mode on replace commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1304,6 +1304,7 @@ fn replace(cx: &mut Context) {
             });
 
             apply_transaction(&transaction, doc, view);
+            exit_select_mode(cx);
         }
     })
 }
@@ -3580,18 +3581,19 @@ fn replace_with_yanked(cx: &mut Context) {
             });
 
             apply_transaction(&transaction, doc, view);
+            exit_select_mode(cx);
         }
     }
 }
 
 fn replace_selections_with_clipboard_impl(
-    editor: &mut Editor,
+    cx: &mut Context,
     clipboard_type: ClipboardType,
-    count: usize,
 ) -> anyhow::Result<()> {
-    let (view, doc) = current!(editor);
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
 
-    match editor.clipboard_provider.get_contents(clipboard_type) {
+    match cx.editor.clipboard_provider.get_contents(clipboard_type) {
         Ok(contents) => {
             let selection = doc.selection(view.id);
             let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
@@ -3604,18 +3606,20 @@ fn replace_selections_with_clipboard_impl(
 
             apply_transaction(&transaction, doc, view);
             doc.append_changes_to_history(view.id);
-            Ok(())
         }
-        Err(e) => Err(e.context("Couldn't get system clipboard contents")),
+        Err(e) => return Err(e.context("Couldn't get system clipboard contents")),
     }
+
+    exit_select_mode(cx);
+    Ok(())
 }
 
 fn replace_selections_with_clipboard(cx: &mut Context) {
-    let _ = replace_selections_with_clipboard_impl(cx.editor, ClipboardType::Clipboard, cx.count());
+    let _ = replace_selections_with_clipboard_impl(cx, ClipboardType::Clipboard);
 }
 
 fn replace_selections_with_primary_clipboard(cx: &mut Context) {
-    let _ = replace_selections_with_clipboard_impl(cx.editor, ClipboardType::Selection, cx.count());
+    let _ = replace_selections_with_clipboard_impl(cx, ClipboardType::Selection);
 }
 
 fn paste(cx: &mut Context, pos: Paste) {


### PR DESCRIPTION
Currently Helix doesn't exit select mode when replace commands are used, which is inconsistent with yank commands.

Confirmed in Matrix with @archseer that this is a bug, though I wasn't very clear about _which_ replace command I was talking about (there are 4). But I think it makes sense to exit select mode on them all. Please let me know if that's not the case. Thanks!

This PR makes the editor exit select mode on the follow commands:

- `replace`
- `replace_with_yanked`
- `replace_selections_with_clipboard`
- `replace_selections_with_primary_clipboard`