### PR TITLE
Fix `delete_char_backward` for paired characters

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3198,6 +3198,7 @@ pub mod insert {
                         (Some(_x), Some(_y), Some(ap))
                             if range.is_single_grapheme(text)
                                 && ap.get(_x).is_some()
+                                && ap.get(_x).unwrap().open == _x
                                 && ap.get(_x).unwrap().close == _y =>
                         // delete both autopaired characters
                         {


### PR DESCRIPTION
When backward-deleting a character, if this character and the following character form a Pair, we want to delete both. However, there is a bug that deletes both characters also if both characters are closers of some Pair.

This PR fixes that by adding an additional check that the deleted character should be an opener in a Pair.

Closes https://github.com/helix-editor/helix/issues/4544.

Are any more tests needed?
