### PR TITLE
Add syntax highlighting and indentation for Python pattern matching expressions

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -2,7 +2,7 @@
 
 (dotted_name
   (identifier)* @namespace)
-  
+
 (aliased_import
   alias: (identifier) @namespace)
 
@@ -67,7 +67,7 @@
 (parameters
   (dictionary_splat_pattern ; **kwargs
     (identifier) @variable.parameter))
-    
+
 (lambda_parameters
   (identifier) @variable.parameter)
 
@@ -97,7 +97,7 @@
  (#match? @constant "^[A-Z_]{2,}$"))
 
 ((identifier) @type
- (#match? @type "^[A-Z]")) 
+ (#match? @type "^[A-Z]"))
 
 (attribute attribute: (identifier) @variable.other.member)
 (identifier) @variable
@@ -168,6 +168,8 @@
   "if"
   "elif"
   "else"
+  "match"
+  "case"
 ] @keyword.control.conditional
 
 [

--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -9,6 +9,8 @@
   (while_statement)
   (with_statement)
   (try_statement)
+  (match_statement)
+  (case_clause)
   (import_from_statement)
 
   (parenthesized_expression)
@@ -33,6 +35,8 @@
   (while_statement)
   (with_statement)
   (try_statement)
+  (match_statement)
+  (case_clause)
 
   (function_definition)
   (class_definition)


### PR DESCRIPTION
- Add syntax highlighting for Python pattern matching
- Add indentation for Python pattern matching

Closes https://github.com/helix-editor/helix/issues/4526
