### PR TITLE
Fix panic from two windows editing the same document

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -236,7 +236,7 @@ impl EditorView {
                 .saturating_sub(1)
                 .min(last_line);
             let start = text.line_to_byte(offset.row.min(last_line));
-            let end = text.line_to_byte(last_visible_line.min(last_line) + 1);
+            let end = text.line_to_byte(last_visible_line + 1);
 
             start..end
         };

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -227,16 +227,16 @@ impl EditorView {
         _theme: &Theme,
     ) -> Box<dyn Iterator<Item = HighlightEvent> + 'doc> {
         let text = doc.text().slice(..);
-        let last_line = std::cmp::min(
-            // Saturating subs to make it inclusive zero indexing.
-            (offset.row + height as usize).saturating_sub(1),
-            doc.text().len_lines().saturating_sub(1),
-        );
 
         let range = {
-            // calculate viewport byte ranges
-            let start = text.line_to_byte(offset.row);
-            let end = text.line_to_byte(last_line + 1);
+            // Calculate viewport byte ranges:
+            // Saturating subs to make it inclusive zero indexing.
+            let last_line = doc.text().len_lines().saturating_sub(1);
+            let last_visible_line = (offset.row + height as usize)
+                .saturating_sub(1)
+                .min(last_line);
+            let start = text.line_to_byte(offset.row.min(last_line));
+            let end = text.line_to_byte(last_visible_line.min(last_line) + 1);
 
             start..end
         };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1223,9 +1223,11 @@ impl Editor {
     pub fn focus(&mut self, view_id: ViewId) {
         let prev_id = std::mem::replace(&mut self.tree.focus, view_id);
 
-        // if leaving the view: mode should reset
+        // if leaving the view: mode should reset and the cursor should be
+        // within view
         if prev_id != view_id {
             self.mode = Mode::Normal;
+            self.ensure_cursor_in_view(view_id);
         }
     }
 
@@ -1234,9 +1236,11 @@ impl Editor {
         self.tree.focus_next();
         let id = self.tree.focus;
 
-        // if leaving the view: mode should reset
+        // if leaving the view: mode should reset and the cursor should be
+        // within view
         if prev_id != id {
             self.mode = Mode::Normal;
+            self.ensure_cursor_in_view(id);
         }
     }
 


### PR DESCRIPTION
This change has two fixes for a scenario that can come up if you use multiple windows to edit/view the same document.

The first fixes the panic in #3978 by clamping the syntax highlighting range to always be within the length of the document. The second fixes a minor UX issue where if you delete enough of a document, one window may be looking past the end of the document - in this case we ensure that the cursor is within view upon switching windows.

Closes #3978