### PR TITLE
Improvements to Meson syntax.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1508,7 +1508,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "meson"
-source = { git = "https://github.com/bearcove/tree-sitter-meson", rev = "feea83be9225842490066522ced2d13eb9cce0bd" }
+source = { git = "https://github.com/staysail/tree-sitter-meson", rev = "32a83e8f200c347232fa795636cfe60dde22957a" }
 
 [[language]]
 name = "sshclientconfig"

--- a/runtime/queries/meson/highlights.scm
+++ b/runtime/queries/meson/highlights.scm
@@ -1,62 +1,62 @@
-(string_literal) @string
+(comment) @comment
 
-(boolean_literal) @constant.builtin.boolean
-(integer_literal) @constant.numeric.integer
-
-(comment) @comment.line
-(function_id) @function
-(keyword_arg_key) @variable.other.member
-(id_expression) @variable
+; these are listed first, because they override keyword queries
+(function_expression (identifier) @function)
 
 [
-  "if"
-  "elif"
-  "else"
-  "endif"
-] @keyword.control.conditional
-
-[
-  "foreach"
-  "endforeach"
-] @keyword.control.repeat
-
-[
-  "break"
-  "continue"
-] @keyword.control
-
-[
-  "not"
-  "in"
-  "and"
-  "or"
-] @keyword.operator
-
-[
-  "!"
-  "+"
-  "-"
-  "*"
-  "/"
-  "%"
-  "=="
-  "!="
-  ">"
-  "<"
-  ">="
-  "<="
+    (assignment_operator)
+    (additive_operator)
+    (multiplicative_operator)
+    (equality_operator)
+    ">="
+    "<="
+    "<"
+    ">"
+    "+"
+    "-"
 ] @operator
 
 [
-  ":"
-  ","
+    (and)
+    (or)
+    (not)
+    (in)
+] @keyword.operator
+
+[
+    "(" ")" "[" "]" "{" "}"
+] @punctuation.bracket
+
+[
+    (if)
+    (elif)
+    (else)
+    (endif)
+] @keyword.control.conditional
+
+[
+    (foreach)
+    (endforeach)
+    (break)
+    (continue)
+] @keyword.control.repeat
+
+(boolean_literal) @constant.builtin.boolean
+(int_literal) @constant.numeric.integer
+
+(keyword_argument keyword: (identifier) @variable.parameter)
+(escape_sequence) @string.special
+(bad_escape) @warning
+
+[
+"."
+","
+":"
 ] @punctuation.delimiter
 
 [
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+    (string_literal)
+    (fstring_literal)
+] @string
+
+(identifier) @variable.other

--- a/runtime/queries/meson/indents.scm
+++ b/runtime/queries/meson/indents.scm
@@ -1,5 +1,4 @@
 [
-  (method_expression)
   (function_expression)
   (array_literal)
   (dictionary_literal)


### PR DESCRIPTION
This updates the Helix tree-sitter for meson to https://github.com/staysail/meson.  I believe that this grammar fixes at least one bug, and the queries are a bit richer with more idiomatic support for Helix.

(Admittedly I didn't know about the present meson tree-sitter before I created mine -- see the discussion with the author of the other tree-sitter here: https://github.com/bearcove/tree-sitter-meson/issues/7
