### PR TITLE
Add command to select surrounding whitespace

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -136,6 +136,7 @@ though, we climb the syntax tree and then take the previous selection. So
 | `w`                    | Word                     |
 | `W`                    | WORD                     |
 | `p`                    | Paragraph                |
+| `s`                    | Whitespace               |
 | `(`, `[`, `'`, etc     | Specified surround pairs |
 | `m`                    | Closest surround pair    |
 | `f`                    | Function                 |

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -112,14 +112,17 @@ pub fn textobject_word(
     }
 }
 
+// `textobject` and `count` are unused for now, this textobject behaves the same
+// whether it is inside or around.
 pub fn textobject_whitespace(
     slice: RopeSlice,
     range: Range,
-    textobject: TextObject,
+    _textobject: TextObject,
     _count: usize,
 ) -> Range {
     let pos = range.cursor(slice);
 
+    // find the number of consecutive whitespace chars in front of the cursor
     let whitespace_start = pos
         - slice
             .chars_at(slice.len_chars())

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -128,14 +128,14 @@ pub fn textobject_whitespace(
             .chars_at(slice.len_chars())
             .reversed()
             .skip(slice.len_chars() - pos - 1)
-            .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+            .take_while(|c| c.is_whitespace())
             .count()
         + 1;
 
     let whitespace_end = pos
         + slice
             .chars_at(pos)
-            .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+            .take_while(|c| c.is_whitespace())
             .count();
 
     Range::new(whitespace_start, whitespace_end)

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -112,6 +112,37 @@ pub fn textobject_word(
     }
 }
 
+pub fn textobject_whitespace(
+    slice: RopeSlice,
+    range: Range,
+    textobject: TextObject,
+    _count: usize,
+) -> Range {
+    let pos = range.cursor(slice);
+
+    let whitespace_start = pos - slice
+        .chars_at(slice.len_chars())
+        .reversed()
+        .skip(slice.len_chars() - pos - 1)
+        .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+        .count() + 1;
+
+    let whitespace_end = pos + slice
+        .chars_at(pos)
+        .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+        .count();
+
+    if whitespace_start == whitespace_end {
+        return Range::new(whitespace_start, whitespace_end);
+    }
+
+    match textobject {
+        TextObject::Inside => Range::new(whitespace_start, whitespace_end),
+        TextObject::Around => Range::new(whitespace_start, whitespace_end),
+        TextObject::Movement => unreachable!(),
+    }
+}
+
 pub fn textobject_paragraph(
     slice: RopeSlice,
     range: Range,

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -120,27 +120,22 @@ pub fn textobject_whitespace(
 ) -> Range {
     let pos = range.cursor(slice);
 
-    let whitespace_start = pos - slice
-        .chars_at(slice.len_chars())
-        .reversed()
-        .skip(slice.len_chars() - pos - 1)
-        .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
-        .count() + 1;
+    let whitespace_start = pos
+        - slice
+            .chars_at(slice.len_chars())
+            .reversed()
+            .skip(slice.len_chars() - pos - 1)
+            .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+            .count()
+        + 1;
 
-    let whitespace_end = pos + slice
-        .chars_at(pos)
-        .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
-        .count();
+    let whitespace_end = pos
+        + slice
+            .chars_at(pos)
+            .take_while(|c| char_is_whitespace(*c) || *c == '\r' || *c == '\n')
+            .count();
 
-    if whitespace_start == whitespace_end {
-        return Range::new(whitespace_start, whitespace_end);
-    }
-
-    match textobject {
-        TextObject::Inside => Range::new(whitespace_start, whitespace_end),
-        TextObject::Around => Range::new(whitespace_start, whitespace_end),
-        TextObject::Movement => unreachable!(),
-    }
+    Range::new(whitespace_start, whitespace_end)
 }
 
 pub fn textobject_paragraph(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4452,6 +4452,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                     match ch {
                         'w' => textobject::textobject_word(text, range, objtype, count, false),
                         'W' => textobject::textobject_word(text, range, objtype, count, true),
+                        's' => textobject::textobject_whitespace(text, range, objtype, count),
                         'c' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),
@@ -4483,6 +4484,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     let help_text = [
         ("w", "Word"),
         ("W", "WORD"),
+        ("s", "Whitespace"),
         ("p", "Paragraph"),
         ("c", "Class (tree-sitter)"),
         ("f", "Function (tree-sitter)"),


### PR DESCRIPTION
Add `mis` and `mas` commands to select the whitespace surrounding the cursor.

If the cursor is on a whitespace character, the command will select all surrounding whitespace, including newlines and carriage returns. If the cursor is not on a whitespace character but adjacent to one, it will not select anything. This PR closes #4509.

https://user-images.githubusercontent.com/82178396/199630802-85261263-8844-4074-b1aa-d15a65f6aeb2.mp4

