### PR TITLE
Increase default language server timeout for Julia

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -593,7 +593,7 @@ injection-regex = "julia"
 file-types = ["jl"]
 roots = ["Manifest.toml", "Project.toml"]
 comment-token = "#"
-language-server = { command = "julia", args = [
+language-server = { command = "julia", timeout = 60, args = [
     "--startup-file=no",
     "--history-file=no",
     "--quiet",


### PR DESCRIPTION
The Julia language server often needs more than the default 20 seconds to respond to the initial request, especially on slower computers. This increases the default timeout, one less potential issue to troubleshoot.

Can be removed once the Julia precompiling story improves.