### PR TITLE
Use language=bash when shebang line uses zsh

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -522,7 +522,7 @@ name = "bash"
 scope = "source.bash"
 injection-regex = "(shell|bash|zsh|sh)"
 file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild", "bazelrc"]
-shebangs = ["sh", "bash", "dash"]
+shebangs = ["sh", "bash", "dash", "zsh"]
 roots = []
 comment-token = "#"
 language-server = { command = "bash-language-server", args = ["start"] }


### PR DESCRIPTION
This PR makes the editor use language=bash when the shebang line uses zsh. We already use language=bash for zsh related files (~/.zshrc, ~/.zshenv etc.), so it's expected for the same to be true for shebang lines as well.