### PR TITLE
bump up LhKipp/tree-sitter-nu's version to latest

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1414,7 +1414,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nu"
-source = { git = "https://github.com/LhKipp/tree-sitter-nu", rev = "db4e990b78824c8abef3618e0f93b7fe1e8f4c0d" }
+source = { git = "https://github.com/LhKipp/tree-sitter-nu", rev = "eb95bdac3abd73ef47e53f19c63e74a31405ebd2" }
 
 [[language]]
 name = "vala"


### PR DESCRIPTION
This PR bumps the version of `LhKipp/tree-sitter-nu` up for `nushell` syntax highlighting support.

this has been tested locally, as stated in #4577, by applying
```diff
diff --git a/.config/helix/languages.toml b/.config/helix/languages.toml
index 94313dc..f4b0775 100644
--- a/.config/helix/languages.toml
+++ b/.config/helix/languages.toml
@@ -7,3 +7,7 @@ roots = []
 comment-token = "(*"
 indent = { tab-width = 4, unit = "  " }
 grammar = "pascal"
+
+[[grammar]]
+name = "nu"
+source = { git = "https://github.com/LhKipp/tree-sitter-nu", rev = "eb95bdac3abd73ef47e53f19c63e74a31405ebd2" }
\ No newline at end of file
```
and then running
```bash
> hx --grammar fetch
Fetching 114 grammars
113 up to date git grammars
1 updated grammars
	nu now on eb95bdac3abd73ef47e53f19c63e74a31405ebd2
> hx --grammar build
Building 114 grammars
113 grammars already built
1 grammars built now
	["nu"]
```
close #4577 