### PR TITLE
Fix whitespace handling in command-mode completion

### DIFF
--- a/helix-core/src/shellwords.rs
+++ b/helix-core/src/shellwords.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
 /// Auto escape for shellwords usage.
-pub fn escape(input: &str) -> Cow<'_, str> {
+pub fn escape(input: Cow<str>) -> Cow<str> {
     if !input.chars().any(|x| x.is_ascii_whitespace()) {
-        Cow::Borrowed(input)
+        input
     } else if cfg!(unix) {
         Cow::Owned(input.chars().fold(String::new(), |mut buf, c| {
             if c.is_ascii_whitespace() {
@@ -311,15 +311,15 @@ mod test {
     #[test]
     #[cfg(unix)]
     fn test_escaping_unix() {
-        assert_eq!(escape("foobar"), Cow::Borrowed("foobar"));
-        assert_eq!(escape("foo bar"), Cow::Borrowed("foo\\ bar"));
-        assert_eq!(escape("foo\tbar"), Cow::Borrowed("foo\\\tbar"));
+        assert_eq!(escape("foobar".into()), Cow::Borrowed("foobar"));
+        assert_eq!(escape("foo bar".into()), Cow::Borrowed("foo\\ bar"));
+        assert_eq!(escape("foo\tbar".into()), Cow::Borrowed("foo\\\tbar"));
     }
 
     #[test]
     #[cfg(windows)]
     fn test_escaping_windows() {
-        assert_eq!(escape("foobar"), Cow::Borrowed("foobar"));
-        assert_eq!(escape("foo bar"), Cow::Borrowed("\"foo bar\""));
+        assert_eq!(escape("foobar".into()), Cow::Borrowed("foobar"));
+        assert_eq!(escape("foo bar".into()), Cow::Borrowed("\"foo bar\""));
     }
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2216,12 +2216,15 @@ pub(super) fn command_mode(cx: &mut Context) {
                     ..
                 }) = typed::TYPABLE_COMMAND_MAP.get(&parts[0] as &str)
                 {
+                    let part_len = shellwords::escape(part.clone()).len();
+
                     completer(editor, part)
                         .into_iter()
                         .map(|(range, file)| {
                             let file = shellwords::escape(file);
+
                             // offset ranges to input
-                            let offset = input.len() - part.len();
+                            let offset = input.len() - part_len;
                             let range = (range.start + offset)..;
                             (range, file)
                         })

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2219,6 +2219,7 @@ pub(super) fn command_mode(cx: &mut Context) {
                     completer(editor, part)
                         .into_iter()
                         .map(|(range, file)| {
+                            let file = shellwords::escape(file);
                             // offset ranges to input
                             let offset = input.len() - part.len();
                             let range = (range.start + offset)..;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2183,10 +2183,11 @@ pub(super) fn command_mode(cx: &mut Context) {
             static FUZZY_MATCHER: Lazy<fuzzy_matcher::skim::SkimMatcherV2> =
                 Lazy::new(fuzzy_matcher::skim::SkimMatcherV2::default);
 
-            // simple heuristic: if there's no just one part, complete command name.
-            // if there's a space, per command completion kicks in.
-            // we use .this over split_whitespace() because we care about empty segments
-            if input.split(' ').count() <= 1 {
+            let parts = shellwords::shellwords(input);
+            let ends_with_whitespace = shellwords::ends_with_whitespace(input);
+
+            if parts.is_empty() || (parts.len() == 1 && !ends_with_whitespace) {
+                // If the command has not been finished yet, complete commands.
                 let mut matches: Vec<_> = typed::TYPABLE_COMMAND_LIST
                     .iter()
                     .filter_map(|command| {
@@ -2202,8 +2203,13 @@ pub(super) fn command_mode(cx: &mut Context) {
                     .map(|(name, _)| (0.., name.into()))
                     .collect()
             } else {
-                let parts = shellwords::shellwords(input);
-                let part = parts.last().unwrap();
+                // Otherwise, use the command's completer and the last shellword
+                // as completion input.
+                let part = if parts.len() == 1 {
+                    &Cow::Borrowed("")
+                } else {
+                    parts.last().unwrap()
+                };
 
                 if let Some(typed::TypableCommand {
                     completer: Some(completer),

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,6 +1,5 @@
 use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
-use helix_core::shellwords;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
 use std::{borrow::Cow, ops::RangeFrom};
@@ -336,10 +335,7 @@ impl Prompt {
 
         let (range, item) = &self.completion[index];
 
-        // since we are using shellwords to parse arguments, make sure
-        // that whitespace in files is properly escaped.
-        let item = shellwords::escape(item);
-        self.line.replace_range(range.clone(), &item);
+        self.line.replace_range(range.clone(), item);
 
         self.move_end();
     }


### PR DESCRIPTION
A few fixes/improvements here for shellwords-based completion in command_mode (`:`):

* Fix completion when the last item in the prompt is a space
* Fix a panic for the sequence `:<space>`
* Escape values in the completion list
* Fix an edge-case in completion when the input is escaped

Closes https://github.com/helix-editor/helix/issues/4586
Closes https://github.com/helix-editor/helix/issues/4563