### PR TITLE
File-scrolling by moving the cursor -> enable scrolling all the way to file ends

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1385,9 +1385,6 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
     }
     // If cursor moved, reposition viewport and replace primary selection
     // clamp viewport around cursor
-    // view.offset.row = view.offset.row
-    //     .max(cursor.row.saturating_add(scrolloff).saturating_sub(height))
-    //     .min(doc_last_line.saturating_sub(height).min(cursor.row.saturating_sub(scrolloff)));
     view.offset.row = view
         .offset
         .row


### PR DESCRIPTION
This is an attempt to fix #4491. Previously, file scrolling was performed by scrolling the view of the doc and, then, repositioning the cursor accordingly. In this version, I implemented the opposite. Now, the cursor is the one moving the view. In other words, the view now clamps around the cursor based on the cursor's offset. The implementation still respects the `scolloff` setting.

**Not ready yet.** It requires some further testing.
**Note**: I recommend building with --profile=opt. Otherwise, scrolling with the mousewheel is laggy even with the previous code's version.