### PR TITLE
Improve Ruby TextObjects

### DIFF
--- a/runtime/queries/ruby/textobjects.scm
+++ b/runtime/queries/ruby/textobjects.scm
@@ -24,6 +24,17 @@
 (method (identifier) (method_parameters)
   (_)+ @function.inside)
   
+(method (identifier) !parameters
+  (_)+  @function.inside)
+
+(singleton_method) @function.around
+
+(singleton_method (identifier) (method_parameters)
+  (_)+ @function.inside)
+  
+(singleton_method (identifier) !parameters
+  (_)+  @function.inside)
+
 (do_block !parameters
   (_)+ @function.inside)
   
@@ -35,9 +46,6 @@
       
 (block !parameters
   (_)+ @function.inside)
-      
-(method (identifier) !parameters
-  (_)+  @function.inside)
 
 ; Parameters      
 (method_parameters

--- a/runtime/queries/ruby/textobjects.scm
+++ b/runtime/queries/ruby/textobjects.scm
@@ -1,11 +1,6 @@
-; Class
-(class) @class.around
-
-(class [(constant) (scope_resolution)] !superclass
-  (_)+ @class.inside) 
-
-(class [(constant) (scope_resolution)] (superclass)
-  (_)+ @class.inside) 
+; Class and Modules
+(class
+  body: (_)? @class.inside) @class.around
 
 (singleton_class
   value: (_)
@@ -17,45 +12,32 @@
   (#match? @class_const "Class")
   (#match? @class_method "new")
   (do_block (_)+ @class.inside)) @class.around
-
-; Functions
-(method) @function.around
-
-(method (identifier) (method_parameters)
-  (_)+ @function.inside)
   
-(method (identifier) !parameters
-  (_)+  @function.inside)
+(module
+  body: (_)? @class.inside) @class.around
 
-(singleton_method) @function.around
+; Functions and Blocks
+(singleton_method
+  body: (_)? @function.inside) @function.around
 
-(singleton_method (identifier) (method_parameters)
-  (_)+ @function.inside)
-  
-(singleton_method (identifier) !parameters
-  (_)+  @function.inside)
+(method
+  body: (_)? @function.inside) @function.around
 
-(do_block !parameters
-  (_)+ @function.inside)
-  
-(do_block (block_parameters)
-  (_)+ @function.inside)
-    
-(block (block_parameters)
-  (_)+ @function.inside)
-      
-(block !parameters
-  (_)+ @function.inside)
+(do_block
+  body: (_)? @function.inside) @function.around
+
+(block
+  body: (_)? @function.inside) @function.around
 
 ; Parameters      
 (method_parameters
-  (_) @parameter.inside)
+  (_) @parameter.inside) @parameter.around
         
 (block_parameters 
-  (_) @parameter.inside)
+  (_) @parameter.inside) @parameter.around
         
 (lambda_parameters 
-  (_) @parameter.inside)
+  (_) @parameter.inside) @parameter.around
 
 ; Comments
 (comment) @comment.inside 


### PR DESCRIPTION
This PR Refactor current TextObjects and improves it adding:

- Adds Singleton Methods
- Adds Module
- Adds `@parameter.around`