### PR TITLE
Fix range offsets in multi-selection paste

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3476,6 +3476,7 @@ fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Pa
     let text = doc.text();
     let selection = doc.selection(view.id);
 
+    let mut offset = 0;
     let mut ranges = SmallVec::with_capacity(selection.len());
 
     let transaction = Transaction::change_by_selection(text, selection, |range| {
@@ -3501,8 +3502,10 @@ fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Pa
             .as_ref()
             .map(|content| content.chars().count())
             .unwrap_or_default();
+        let anchor = offset + pos;
 
-        ranges.push(Range::new(pos, pos + value_len));
+        ranges.push(Range::new(anchor, anchor + value_len));
+        offset += value_len;
 
         (pos, pos, value)
     });

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3504,7 +3504,8 @@ fn paste_impl(values: &[String], doc: &mut Document, view: &mut View, action: Pa
             .unwrap_or_default();
         let anchor = offset + pos;
 
-        ranges.push(Range::new(anchor, anchor + value_len));
+        let new_range = Range::new(anchor, anchor + value_len).with_direction(range.direction());
+        ranges.push(new_range);
         offset += value_len;
 
         (pos, pos, value)

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -193,3 +193,25 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_selection_paste() -> anyhow::Result<()> {
+    test((
+        platform_line(indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "})
+        .as_str(),
+        "yp",
+        platform_line(indoc! {"\
+            lorem#[|lorem]#
+            ipsum#(|ipsum)#
+            dolor#(|dolor)#
+            "})
+        .as_str(),
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
#4458 introduced a regression with multi-selection paste where pasting would not adjust the ranges correctly. To fix it, we need to track the total number of characters inserted in each changed selection and use that offset to slide each new range forwards.