### PR TITLE
Run clippy on workspace in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets -- -D warnings
+          args: --workspace --all-targets -- -D warnings
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -148,6 +148,7 @@ pub fn plain(s: &str, selection: Selection) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod test {
     use super::*;
 

--- a/xtask/src/querycheck.rs
+++ b/xtask/src/querycheck.rs
@@ -17,8 +17,8 @@ pub fn query_check() -> Result<(), DynError> {
         let language_name = &language.language_id;
         let grammar_name = language.grammar.as_ref().unwrap_or(language_name);
         for query_file in query_files {
-            let language = get_language(&grammar_name);
-            let query_text = read_query(&language_name, query_file);
+            let language = get_language(grammar_name);
+            let query_text = read_query(language_name, query_file);
             if let Ok(lang) = language {
                 if !query_text.is_empty() {
                     if let Err(reason) = Query::new(lang, &query_text) {


### PR DESCRIPTION
Currently CI runs clippy as `cargo clippy --all-targets` without the `--all` flag, causing some code to be ignored. This PR enforces the `--all` flag and resolves some warnings from the addition of the flag.