### PR TITLE
Fixed disorienting selection palette on Gruvbox theme

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -52,9 +52,9 @@
 "ui.help" = { bg = "bg1", fg = "fg1" }
 "ui.text" = { fg = "fg1" }
 "ui.text.focus" = { fg = "fg1" }
-"ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
-"ui.cursor.primary" = { modifiers = ["reversed"] }
-"ui.cursor.match" = { bg = "bg2" }
+"ui.selection" = { bg = "bg2" }
+"ui.cursor.primary" = { bg = "fg4", fg = "bg1" }
+"ui.cursor.match" = { bg = "bg3" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"


### PR DESCRIPTION
Details from https://github.com/helix-editor/helix/issues/4625

<img width="997" alt="Screen Shot 2022-11-06 at 8 37 22 PM" src="https://user-images.githubusercontent.com/18314366/200229543-59c46cda-7c4c-434e-b96e-39730d556882.png">

Top part of the screenshot above is the OOTB Gruvbox theme. As you can see, it's quite offensive to the eyes and makes it hard to see exactly where the selected region begins and ends at a glance. The bottom part of the screenshot is the theme after a couple tweaks to the palette.

Not sure if anyone actually prefers the way it is now, but it seems untenable to me.

Here's the modified settings from the screenshot:

```toml
"ui.selection" = { bg = "bg2" }
"ui.cursor.primary" = { bg = "fg4", fg = "bg1" }
"ui.cursor.match" = { bg = "bg3" }
```