### PR TITLE
tutor: fix wording in recap for chapter 5

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -596,8 +596,8 @@ _________________________________________________________________
 =                        CHAPTER 5 RECAP                        =
 =================================================================
 
- * Type C to copy the current selection to below and Alt-C for
-   above.
+ * Type C to duplicate the cursor to the next suitable line
+   and Alt-C for previous suitable line.
 
  * Type s to select all instances of a regex pattern inside
    the current selection.


### PR DESCRIPTION
In recap for chapter 5.1 specify that the cursor is duplicted to the next suitable line instead of the next line.

Fixes #4598