### PR TITLE
bash completion: use builtin filenames option

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -19,5 +19,5 @@ _hx() {
 		COMPREPLY=($(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- $2))
 		;;
 	esac
-} && complete -F _hx hx
+} && complete -o filenames -F _hx hx
 


### PR DESCRIPTION
Use a builtin bash option which detects filenames in completion outputs and reflects this in sensible <tab> completion behaviour.

Fixes https://github.com/helix-editor/helix/issues/3606.

Solution taken from https://stackoverflow.com/a/57385447/470509