### PR TITLE
`error!` on unknown `CompletionItemKind`

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -66,7 +66,10 @@ impl menu::Item for CompletionItem {
                 Some(lsp::CompletionItemKind::EVENT) => "event",
                 Some(lsp::CompletionItemKind::OPERATOR) => "operator",
                 Some(lsp::CompletionItemKind::TYPE_PARAMETER) => "type_param",
-                Some(kind) => unimplemented!("{:?}", kind),
+                Some(kind) => {
+                    log::error!("Received unknown CompletionItemKind({:?})", kind);
+                    ""
+                },
                 None => "",
             }),
             // self.detail.as_deref().unwrap_or("")


### PR DESCRIPTION
Instead of panicking on an unknown CompletionItemKind, `error!` it instead and return `""`.

Would be a (temporary?) fix for [#4657](https://github.com/helix-editor/helix/issues/4657) as per [the-mikedavis'](https://github.com/helix-editor/helix/issues/4657#issuecomment-1307579186) instructions in the thread.