### PR TITLE
[rust highlights] fix scoped attribute macro matching

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -274,7 +274,11 @@
 (meta_item
   (identifier) @function.macro)
 (attr_item
-  (identifier) @function.macro
+  [
+    (identifier) @function.macro
+    (scoped_identifier
+      name: (identifier) @function.macro)
+  ]
   (token_tree (identifier) @function.macro)?)
 
 (inner_attribute_item) @attribute


### PR DESCRIPTION
Without this scoped attribute macros are not matched as macros. Eg
```
  #[path::macro]
```