### PR TITLE
Fix panic from indenting on tree with errors

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -511,8 +511,12 @@ fn extend_nodes<'a>(
             *node = deepest_preceding;
             break;
         }
-        // This parent always exists since node is an ancestor of deepest_preceding
-        deepest_preceding = deepest_preceding.parent().unwrap();
+        // If the tree contains a syntax error, `deepest_preceding` may not
+        // have a parent despite being a descendant of `node`.
+        deepest_preceding = match deepest_preceding.parent() {
+            Some(parent) => parent,
+            None => return,
+        }
     }
 }
 


### PR DESCRIPTION
`deepest_preceding` is known to be a descendant of `node`. Repeated calls of `Node::parent` _should_ eventually turn `deepest_preceding` into `node`, but when the node is errored (the tree contains a syntax error), `Node::parent` returns None.

<details><summary>In the typescript case...</summary>

```typescript
if(true) &&true
//      ^ press enter here
```

The tree is:

```
(program [0, 0] - [1, 0]
  (if_statement [0, 0] - [0, 15]
    condition: (parenthesized_expression [0, 2] - [0, 8]
      (true [0, 3] - [0, 7]))
    consequence: (expression_statement [0, 8] - [0, 15]
      (binary_expression [0, 8] - [0, 15]
        left: (identifier [0, 8] - [0, 8])
        right: (true [0, 11] - [0, 15])))))
```

`node` is the `program` node and `deepest_preceding` is the
`binary_expression`. The tree is errored on the `binary_expression`
node with `(MISSING identifier [0, 8] - [0, 8])`.

<br></details>

<details><summary>In the C++ case...</summary>

```cpp
; <<
// press enter after the ';'
```

The tree is:

```
(translation_unit [0, 0] - [1, 0]
  (expression_statement [0, 0] - [0, 1])
  (ERROR [0, 1] - [0, 4]
    (identifier [0, 1] - [0, 1])))
```

`node` is the `translation_unit` and `deepest_preceding` is the `ERROR`
node.

</details>

In both cases, `Node::parent` on the errored node returns None.

Closes #4579
Closes #4664