### PR TITLE
Enable elixir-ls for heex language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -50,7 +50,7 @@
 | hare | ✓ |  |  |  |
 | haskell | ✓ |  |  | `haskell-language-server-wrapper` |
 | hcl | ✓ |  | ✓ | `terraform-ls` |
-| heex | ✓ | ✓ |  |  |
+| heex | ✓ | ✓ |  | `elixir-ls` |
 | html | ✓ |  |  | `vscode-html-language-server` |
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1356,6 +1356,7 @@ file-types = ["heex"]
 roots = ["mix.exs", "mix.lock"]
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "elixir-ls" }
+config = { elixirLS.dialyzerEnabled = false }
 
 [[grammar]]
 name = "heex"

--- a/languages.toml
+++ b/languages.toml
@@ -1355,6 +1355,7 @@ injection-regex = "heex"
 file-types = ["heex"]
 roots = ["mix.exs", "mix.lock"]
 indent = { tab-width = 2, unit = "  " }
+language-server = { command = "elixir-ls" }
 
 [[grammar]]
 name = "heex"


### PR DESCRIPTION
Elixir-LS is also supported for `.heex`-files.
Not sure if we should also add `config = { elixirLS.dialyzerEnabled = false }` like we have in the `elixir` configuration.