### PR TITLE
feat: add sc to filetypes for Scala

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -998,7 +998,7 @@ source = { git = "https://github.com/UserNobody14/tree-sitter-dart", rev = "2d7f
 name = "scala"
 scope = "source.scala"
 roots = ["build.sbt", "pom.xml"]
-file-types = ["scala", "sbt"]
+file-types = ["scala", "sbt", "sc"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "metals" }


### PR DESCRIPTION
Files ending in `.sc` are known as "Scala Scripts". The scalac compiler
knows how to handle these, popular tools like
[Ammonite](https://github.com/com-lihaoyi/Ammonite) and
[scala-cli](https://github.com/Virtuslab/scala-cli) use them, and even
some Scala build tools like [mill](https://github.com/com-lihaoyi/mill)
use them as their build files (`build.sc`). This change just makes sure
that they are treated as Scala files so Metals kicks in.
