### PR TITLE
update scala roots

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -997,7 +997,7 @@ source = { git = "https://github.com/UserNobody14/tree-sitter-dart", rev = "2d7f
 [[language]]
 name = "scala"
 scope = "source.scala"
-roots = ["build.sbt", "pom.xml"]
+roots = ["build.sbt", "build.sc", "build.gradle", "pom.xml", ".scala-build"]
 file-types = ["scala", "sbt", "sc"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
This adds in a couple more roots that are common in Scala.

- `build.sc` which is used in Mill
- `build.gradle` for Scala Gradle projects
- `.scala-build` for scala-cli projects
