### PR TITLE
improve performance of tree sitter query captures (for text object motions in particular)

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -356,10 +356,10 @@ impl<'a> CapturedNode<'a> {
 
 /// The number of matches a TS cursor can at once to avoid performance problems for medium to large files.
 /// Set with `set_match_limit`.
-/// Using such a limit means that we loose valid captures in, so there is fundamentally a tradeoff here.
+/// Using such a limit means that we lose valid captures in, so there is fundamentally a tradeoff here.
 ///
 ///
-/// Old tree sitter versions used a limit of 32 by default until this limit was removed in version `0.19.5` (must now best set manually).
+/// Old tree sitter versions used a limit of 32 by default until this limit was removed in version `0.19.5` (must now be set manually).
 /// However, this causes performance issues for medium to large files.
 /// In helix, this problem caused treesitter motions to take multiple seconds to complete in medium-sized rust files (3k loc).
 /// Neovim also encountered this problem and reintroduced this limit after it was removed upstream
@@ -371,7 +371,6 @@ impl<'a> CapturedNode<'a> {
 /// Neovim chose this value somewhat arbitrarily (<https://github.com/neovim/neovim/pull/18397>) adjusting it whenever issues occur in practice.
 /// However this value has been in use for a long time and due to the large userbase of neovim it is probably a good choice.
 /// If this limit causes problems for a grammar in the future, it could be increased.
-
 const TREE_SITTER_MATCH_LIMIT: u32 = 64;
 
 impl TextObjectQuery {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -354,6 +354,26 @@ impl<'a> CapturedNode<'a> {
     }
 }
 
+/// The number of matches a TS cursor can at once to avoid performance problems for medium to large files.
+/// Set with `set_match_limit`.
+/// Using such a limit means that we loose valid captures in, so there is fundamentally a tradeoff here.
+///
+///
+/// Old tree sitter versions used a limit of 32 by default until this limit was removed in version `0.19.5` (must now best set manually).
+/// However, this causes performance issues for medium to large files.
+/// In helix, this problem caused treesitter motions to take multiple seconds to complete in medium-sized rust files (3k loc).
+/// Neovim also encountered this problem and reintroduced this limit after it was removed upstream
+/// (see <https://github.com/neovim/neovim/issues/14897> and <https://github.com/neovim/neovim/pull/14915>).
+/// The number used here is fundamentally a tradeoff between breaking some obscure edge cases and performance.
+///
+///
+/// A value of 64 was chosen because neovim uses that value.
+/// Neovim chose this value somewhat arbitrarily (<https://github.com/neovim/neovim/pull/18397>) adjusting it whenever issues occur in practice.
+/// However this value has been in use for a long time and due to the large userbase of neovim it is probably a good choice.
+/// If this limit causes problems for a grammar in the future, it could be increased.
+
+const TREE_SITTER_MATCH_LIMIT: u32 = 64;
+
 impl TextObjectQuery {
     /// Run the query on the given node and return sub nodes which match given
     /// capture ("function.inside", "class.around", etc).
@@ -393,6 +413,8 @@ impl TextObjectQuery {
         let capture_idx = capture_names
             .iter()
             .find_map(|cap| self.query.capture_index_for_name(cap))?;
+
+        cursor.set_match_limit(TREE_SITTER_MATCH_LIMIT);
 
         let nodes = cursor
             .captures(&self.query, node, RopeProvider(slice))
@@ -843,6 +865,7 @@ impl Syntax {
             let mut cursor = ts_parser.cursors.pop().unwrap_or_else(QueryCursor::new);
             // TODO: might need to set cursor range
             cursor.set_byte_range(0..usize::MAX);
+            cursor.set_match_limit(TREE_SITTER_MATCH_LIMIT);
 
             let source_slice = source.slice(..);
 
@@ -1032,6 +1055,7 @@ impl Syntax {
 
                 // if reusing cursors & no range this resets to whole range
                 cursor_ref.set_byte_range(range.clone().unwrap_or(0..usize::MAX));
+                cursor_ref.set_match_limit(TREE_SITTER_MATCH_LIMIT);
 
                 let mut captures = cursor_ref
                     .captures(


### PR DESCRIPTION
Helix sometimes freezes when performing treesitter motions on medium to large files.
The problem only occurs in very particular cases and depends highly on the grammar, specific capture and file content.
I was able to reproduce the problem consistently by using any treesitter motion in the `iter.rs` file of ropey.
But @dead10ck also noted that the same problem sometimes occurs for him in the matrix chat.

Looking at the flamegraph almost all time is spent in treesitter itself:

![image](https://user-images.githubusercontent.com/61850714/201235618-8c1e8899-4575-41e6-8615-412a017a8a37.png)


After a bit of digging I found the problem:
Since treesitter version `19.5` treesitter does not set any limit for the amount of in-progress captures any more (used to be 32).
Because advancing the `QueryCursor` requires comparing every new capture to all in-progress captures, this can become `O(N^2)` in pathalogical cases and freeze the editor.
The issue is solved by setting a match limit.
I discovered this fix while browsing the neovim treesitter code (as it does not suffer from this problem) where a limit was introduced after the `19.5` release
to fix similar issues. I have added more details (and pointers to neovim) in comments.

To avoid similar problems I also made sure this limit is set in all other places a `QueryCursor` is created (in the syntax highlighting).
I tried out a few large files where I had performance problems with tree sitter highlighting in the past, but this fix doesn't help much there.
However, neovim did introduce this limit to fix performance issues with syntax highlighting, so I think it's good to add the limit to syntax highlighting just in case.

While investigating this problem I found a few other ways to slightly improve the performance of the treesitter movements.
I bundled these here as they are too small to really warrant a seperate PR.
