### PR TITLE
Run cachix workflow for x86_64-darwin

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -7,8 +7,11 @@ on:
 
 jobs:
   publish:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     name: Publish Flake
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -19,11 +19,16 @@ jobs:
     - name: Install nix
       uses: cachix/install-nix-action@v18
 
+    - name: Print toolchain regex
+      id: print-toolchain-regex
+      run: echo "TOOLCHAIN_REGEX=$(nix show-derivation .#default.rustToolchain.cargo < /dev/null | jq -r '.[].env.paths' | tr ' ' '|')" >> "$GITHUB_OUTPUT"
+
     - name: Authenticate with Cachix
       uses: cachix/cachix-action@v12
       with:
         name: helix
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        pushFilter: ^(${{ steps.print-toolchain-regex.outputs.TOOLCHAIN_REGEX }}|.*-source|.*nixpkgs\.tar\.gz)$
 
     - name: Build nix flake
       run: nix build -L


### PR DESCRIPTION
This merge request updates the Cachix workflow so it also runs on macOS. This will allow Nix users to avoid having to build Helix themselves on `x86_64-darwin` when they have configured the Helix Cachix as a binary cache.

**I have not tested these changes.** I don't have a Cachix cache set up myself, and I don't have permissions for the Helix one. I am as confident as I can be without having tested them that these changes are correct, since they're copied directly from [cachix-action's test workflow](https://github.com/cachix/cachix-action/blob/6a9a34cdd93d0ae4b4b59fd678660efb08109f2f/.github/workflows/test.yml#L10-L13), but someone else should definitely also take a careful look at them before this gets merged.

This partially addresses [my comment on #1720](https://github.com/helix-editor/helix/issues/1720#issuecomment-1306618514).