### PR TITLE
Select diagnostic range in goto_*_diag commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2822,35 +2822,28 @@ fn exit_select_mode(cx: &mut Context) {
     }
 }
 
-fn goto_pos(editor: &mut Editor, pos: usize) {
-    let (view, doc) = current!(editor);
-
-    push_jump(view, doc);
-    doc.set_selection(view.id, Selection::point(pos));
+fn goto_first_diag(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let selection = match doc.diagnostics().first() {
+        Some(diag) => Selection::single(diag.range.start, diag.range.end),
+        None => return,
+    };
+    doc.set_selection(view.id, selection);
     align_view(doc, view, Align::Center);
 }
 
-fn goto_first_diag(cx: &mut Context) {
-    let doc = doc!(cx.editor);
-    let pos = match doc.diagnostics().first() {
-        Some(diag) => diag.range.start,
-        None => return,
-    };
-    goto_pos(cx.editor, pos);
-}
-
 fn goto_last_diag(cx: &mut Context) {
-    let doc = doc!(cx.editor);
-    let pos = match doc.diagnostics().last() {
-        Some(diag) => diag.range.start,
+    let (view, doc) = current!(cx.editor);
+    let selection = match doc.diagnostics().last() {
+        Some(diag) => Selection::single(diag.range.start, diag.range.end),
         None => return,
     };
-    goto_pos(cx.editor, pos);
+    doc.set_selection(view.id, selection);
+    align_view(doc, view, Align::Center);
 }
 
 fn goto_next_diag(cx: &mut Context) {
-    let editor = &mut cx.editor;
-    let (view, doc) = current!(editor);
+    let (view, doc) = current!(cx.editor);
 
     let cursor_pos = doc
         .selection(view.id)
@@ -2863,17 +2856,16 @@ fn goto_next_diag(cx: &mut Context) {
         .find(|diag| diag.range.start > cursor_pos)
         .or_else(|| doc.diagnostics().first());
 
-    let pos = match diag {
-        Some(diag) => diag.range.start,
+    let selection = match diag {
+        Some(diag) => Selection::single(diag.range.start, diag.range.end),
         None => return,
     };
-
-    goto_pos(editor, pos);
+    doc.set_selection(view.id, selection);
+    align_view(doc, view, Align::Center);
 }
 
 fn goto_prev_diag(cx: &mut Context) {
-    let editor = &mut cx.editor;
-    let (view, doc) = current!(editor);
+    let (view, doc) = current!(cx.editor);
 
     let cursor_pos = doc
         .selection(view.id)
@@ -2887,12 +2879,14 @@ fn goto_prev_diag(cx: &mut Context) {
         .find(|diag| diag.range.start < cursor_pos)
         .or_else(|| doc.diagnostics().last());
 
-    let pos = match diag {
-        Some(diag) => diag.range.start,
+    let selection = match diag {
+        // NOTE: the selection is reversed because we're jumping to the
+        // previous diagnostic.
+        Some(diag) => Selection::single(diag.range.end, diag.range.start),
         None => return,
     };
-
-    goto_pos(editor, pos);
+    doc.set_selection(view.id, selection);
+    align_view(doc, view, Align::Center);
 }
 
 pub mod insert {


### PR DESCRIPTION
This roughly matches the behavior of the diagnostic picker: when jumping to a diagnostic with `[d`/`]d`/`[D`/`]D`, the range of the diagnostic is selected instead of the start point.