### PR TITLE
significantly improve treesitter performance while editing large files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,18 +412,29 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.2",
 ]
 
 [[package]]
 name = "helix-core"
 version = "0.6.0"
 dependencies = [
+ "ahash 0.8.2",
  "arc-swap",
  "bitflags",
  "chrono",
  "encoding_rs",
  "etcetera",
+ "hashbrown 0.13.1",
  "helix-loader",
  "log",
  "once_cell",
@@ -1288,7 +1311,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -30,6 +30,8 @@ once_cell = "1.16"
 arc-swap = "1"
 regex = "1"
 bitflags = "1.3"
+ahash = "0.8.2"
+hashbrown = { version = "0.13.1", features = ["raw"] }
 
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -719,7 +719,7 @@ pub struct Syntax {
 
 impl fmt::Debug for Syntax {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // skip the layer_lut and layer_lut hasher here as they
+        // skip the layer_lut and layer_lut hasher here as they do not implement Debug
         f.debug_struct("Syntax")
             .field("layers", &self.layers)
             .field("root", &self.root)
@@ -806,7 +806,7 @@ impl Syntax {
             // Ensure lut is large enough to hold all layers.
             // The lut should always be empty at this point because it is only
             // kept to avoid realloctions so rehashing is never requied (hence unreachable).
-            assert_eq!(self.layers_lut.len(), 0);
+            assert!(self.layers_lut.is_empty());
             self.layers_lut
                 .reserve(self.layers.len(), |_| unreachable!());
 
@@ -1190,7 +1190,7 @@ fn hash_injection_layer(
     let mut state = state.build_hasher();
     depth.hash(&mut state);
     // The transmute is necessary here because tree_sitter::Language does not derive Hash at the moment.
-    // However it does use #[repr] transpraerent so the transmute here is save
+    // However it does use #[repr] transparent so the transmute here is safe
     // as `Language` (which `Grammar` is an alias for) is just a newtype wrapper around a (thin) pointer.
     // This is also compatible with the PartialEq implementation of language
     // as that is just a pointer comparison.


### PR DESCRIPTION
While working on an unrelated PR related to treesitter performance I noticed that editing text is extremely slow for large files with loads of injections.
The testcase I was looking at during testing is the largest file in the Linux kernel: `drivers/gpu/drm/amd/include/asic_reg/dcn/dcn_3_2_0_sh_mask.h`

From the flamegraph (see below) I noticed that most of the time is actually spent inside helix comparing language layers.

![image](https://user-images.githubusercontent.com/61850714/201428369-49c1eeca-a4c6-465b-9ff6-ed339567a798.png)

After some digging I found that helix checks if an injection layer is already present (and hence can be incrementally updated) by iterating the entire list of injections. This has worst-case performance of `O(N^2)`.
For example the Linux kernel header I was investigating contains 27859 injections (comments) all inside the top layer, so about 776 million comparisons are performed (on every edit).

This PR fixes this problem by replacing the linear search with a Hashtable that is built at the beginning of the update function.
The Hashtable allows replacing the linear search with `O(1)` lookups, so the time complexity is decreased to `O(N)`.

I am using a `RawTable` from `hashbrown` here because I did not want to change the collection of `layers` (the closes substitute is a `IndexMap`, but that does not allow reusing indices like the `HopeSlotMap`). 

After this change there is still some delay in the huge Linux kernel header while typing but now typing a single latter takes maybe 0.4s compared to 2s previously (very unscientifically benchmarked).
Looking at the flamegraph (see below) now the bottleneck is treesitter itself (which might be potentially speedup in the future by setting a byte range on the query cursor although that will be more challenging).
While the file provided here was an extreme case, this should be a win (or not matter) for all languages/files.

![image](https://user-images.githubusercontent.com/61850714/201427733-f1debf55-0503-45bd-ab9f-9c870c29b8ba.png)