### PR TITLE
update tree sitter rust

### DIFF
--- a/.github/workflows/languages.toml
+++ b/.github/workflows/languages.toml
@@ -11,7 +11,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "a360da0a29a19c281d08295a35ecd0544d2da211" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "0431a2c60828731f27491ee9fdefe25e250ce9c9" }
 
 [[language]]
 name = "nix"

--- a/helix-core/tests/data/indent/languages.toml
+++ b/helix-core/tests/data/indent/languages.toml
@@ -10,4 +10,4 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "a360da0a29a19c281d08295a35ecd0544d2da211" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "0431a2c60828731f27491ee9fdefe25e250ce9c9" }

--- a/languages.toml
+++ b/languages.toml
@@ -50,7 +50,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "41e23b454f503e6fe63ec4b6d9f7f2cf7788ab8e" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "0431a2c60828731f27491ee9fdefe25e250ce9c9" }
 
 [[language]]
 name = "toml"

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -271,9 +271,9 @@
 ; ---
 ; Macros
 ; ---
-(meta_item
+(attribute
   (identifier) @function.macro)
-(attr_item
+(attribute
   [
     (identifier) @function.macro
     (scoped_identifier

--- a/runtime/queries/rust/indents.scm
+++ b/runtime/queries/rust/indents.scm
@@ -51,13 +51,14 @@
   .
   (_) @expr-start
   value: (_) @indent
+  alternative: (_)? @indent
   (#not-same-line? @indent @expr-start)
   (#set! "scope" "all")
 )
-(if_let_expression
+(if_expression
   .
   (_) @expr-start
-  value: (_) @indent
+  condition: (_) @indent
   (#not-same-line? @indent @expr-start)
   (#set! "scope" "all")
 )

--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -42,7 +42,7 @@
 
 (; #[test]
  (attribute_item
-   (meta_item
+   (attribute
      (identifier) @_test_attribute))
  ; allow other attributes like #[should_panic] and comments
  [


### PR DESCRIPTION
- deps: Update tree-sitter-rust (supports let-else && let-chains)
- fix: Outdated Rust queries after TS update

Refs:

- https://github.com/tree-sitter/tree-sitter-rust/commit/6ebdb1dc6cf4c19d8bae1d04f7bad44408e877d8
- https://github.com/tree-sitter/tree-sitter-rust/commit/63eba73c6e5923a6946c3e3a23582b5ecd496d79