### PR TITLE
Limit the amount of vertical splits

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4266,11 +4266,15 @@ fn hsplit_new(cx: &mut Context) {
 }
 
 fn vsplit(cx: &mut Context) {
-    split(cx, Action::VerticalSplit);
+    if typed::can_do_vsplit(cx.editor) {
+        split(cx, Action::VerticalSplit);
+    }
 }
 
 fn vsplit_new(cx: &mut Context) {
-    cx.editor.new_file(Action::VerticalSplit);
+    if typed::can_do_vsplit(cx.editor) {
+        cx.editor.new_file(Action::VerticalSplit);
+    }
 }
 
 fn wclose(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1177,6 +1177,7 @@ fn vsplit_new(
     if can_do_vsplit(cx.editor) {
         cx.editor.new_file(Action::VerticalSplit);
     }
+
     Ok(())
 }
 
@@ -1188,7 +1189,6 @@ fn hsplit_new(
     if event != PromptEvent::Validate {
         return Ok(());
     }
-
     cx.editor.new_file(Action::HorizontalSplit);
 
     Ok(())
@@ -1200,7 +1200,7 @@ pub fn can_do_vsplit(editor: &mut Editor) -> bool {
     if editor
         .tree
         .views()
-        .any(|(view, _focused)| view.inner_area().width == 1)
+        .any(|(view, _focused)| view.inner_area().width == 1 && editor.tree.is_child(&view.id))
     {
         editor.set_error("Max number of splits reached");
         false

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1127,15 +1127,16 @@ fn vsplit(
     if event != PromptEvent::Validate {
         return Ok(());
     }
+    if can_do_vsplit(cx.editor) {
+        let id = view!(cx.editor).doc;
 
-    let id = view!(cx.editor).doc;
-
-    if args.is_empty() {
-        cx.editor.switch(id, Action::VerticalSplit);
-    } else {
-        for arg in args {
-            cx.editor
-                .open(&PathBuf::from(arg.as_ref()), Action::VerticalSplit)?;
+        if args.is_empty() {
+            cx.editor.switch(id, Action::VerticalSplit);
+        } else {
+            for arg in args {
+                cx.editor
+                    .open(&PathBuf::from(arg.as_ref()), Action::VerticalSplit)?;
+            }
         }
     }
 
@@ -1173,9 +1174,9 @@ fn vsplit_new(
     if event != PromptEvent::Validate {
         return Ok(());
     }
-
-    cx.editor.new_file(Action::VerticalSplit);
-
+    if can_do_vsplit(cx.editor) {
+        cx.editor.new_file(Action::VerticalSplit);
+    }
     Ok(())
 }
 
@@ -1191,6 +1192,21 @@ fn hsplit_new(
     cx.editor.new_file(Action::HorizontalSplit);
 
     Ok(())
+}
+
+pub fn can_do_vsplit(editor: &mut Editor) -> bool {
+    // check if there are views with an inner area of 1 (1 character per line gets drawn)
+    // if there are, it's not feasible to create any more vertical splits
+    if editor
+        .tree
+        .views()
+        .any(|(view, _focused)| view.inner_area().width == 1)
+    {
+        editor.set_error("Max number of splits reached");
+        false
+    } else {
+        true
+    }
 }
 
 fn debug_eval(

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -385,11 +385,9 @@ impl Tree {
                         }
                         Layout::Vertical => {
                             let len = container.children.len();
+                            let inner_gap = 1u16;
 
                             let width = area.width / len as u16;
-
-                            let inner_gap = 1u16;
-                            // let total_gap = inner_gap * (len as u16 - 1);
 
                             let mut child_x = area.x;
 
@@ -397,10 +395,11 @@ impl Tree {
                                 let mut area = Rect::new(
                                     child_x,
                                     container.area.y,
-                                    width,
+                                    // we subtract inner gap here to accommodate for the width that inner gaps take
+                                    width - inner_gap,
                                     container.area.height,
                                 );
-                                child_x += width + inner_gap;
+                                child_x += width;
 
                                 // last child takes the remaining width because we can get uneven
                                 // space from rounding

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -214,6 +214,24 @@ impl Tree {
         node
     }
 
+    pub fn is_child(&self, child_id: &ViewId) -> bool {
+        let focus = self.focus;
+        let parent = self.nodes[focus].parent;
+
+        let container_children: Vec<ViewId> = match &self.nodes[parent] {
+            Node {
+                content: Content::Container(container),
+                ..
+            } => container.children.clone(),
+            _ => unimplemented!(),
+        };
+        if container_children.contains(child_id) {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn remove(&mut self, index: ViewId) {
         let mut stack = Vec::new();
 


### PR DESCRIPTION
This would fix #1083.
Right now there's this error happening: https://github.com/helix-editor/helix/pull/2773#issuecomment-1162007131, when you do an appropriate amount of vertical splits.
This is the line that causes the crash: https://github.com/helix-editor/helix/blob/fd585c1ee4ae0ac541f99b5e69a40833f5e3246d/helix-view/src/tree.rs#L408
I think recalculate() here doesn't take into consideration that inner gaps decrease area width, so I changed that.
I also added a function in typed.rs that checks if a child view of the focused view has a width of 1. If it does, then we can't make any more vertical splits.