### PR TITLE
Add a maximum file size for highlighting with an editor setting

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -57,6 +57,7 @@ on unix operating systems.
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `syntax-max-file-size` | Specify the maximum file size in bytes to enable syntax highlighting | `157286400` |
 
 ### `[editor.statusline]` Section
 

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -62,7 +62,6 @@ These configuration keys are available:
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `max-line-length`     | Maximum line length. Used for the `:reflow` command           |
-| `hl-max-size`         | Maximum file size in bytes for syntax highlighting            |
 
 ### File-type detection and the `file-types` key
 

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -62,6 +62,7 @@ These configuration keys are available:
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `max-line-length`     | Maximum line length. Used for the `:reflow` command           |
+| `hl-max-size`         | Maximum file size in bytes for syntax highlighting            |
 
 ### File-type detection and the `file-types` key
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -122,8 +122,7 @@ pub struct LanguageConfiguration {
     #[serde(default, skip_serializing, deserialize_with = "deserialize_auto_pairs")]
     pub auto_pairs: Option<AutoPairs>,
 
-    pub rulers: Option<Vec<u16>>,   // if set, override editor's rulers
-    pub hl_max_size: Option<usize>, // maximum file size in bytes for highlighting
+    pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -551,7 +550,6 @@ pub struct Loader {
     language_config_ids_by_extension: HashMap<String, usize>, // Vec<usize>
     language_config_ids_by_suffix: HashMap<String, usize>,
     language_config_ids_by_shebang: HashMap<String, usize>,
-
     scopes: ArcSwap<Vec<String>>,
 }
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -122,7 +122,8 @@ pub struct LanguageConfiguration {
     #[serde(default, skip_serializing, deserialize_with = "deserialize_auto_pairs")]
     pub auto_pairs: Option<AutoPairs>,
 
-    pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+    pub rulers: Option<Vec<u16>>,   // if set, override editor's rulers
+    pub hl_max_size: Option<usize>, // maximum file size in bytes for highlighting
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -176,7 +176,7 @@ impl Application {
                 &config.editor
             })),
         );
-
+        let mut enable_syntax_highlighting = true;
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
             &config.keys
         }));
@@ -223,11 +223,19 @@ impl Application {
                         // opened last is focused on.
                         let view_id = editor.tree.focus;
                         let doc = doc_mut!(editor, &doc_id);
+                        enable_syntax_highlighting = doc.enable_syntax_highlighting;
                         let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
                         doc.set_selection(view_id, pos);
                     }
                 }
-                editor.set_status(format!("Loaded {} files.", nr_of_files));
+                if !enable_syntax_highlighting {
+                    editor.set_error(
+                        "Warning: Syntax highlighting is disabled due to exceeding the size limit"
+                            .to_string(),
+                    );
+                } else {
+                    editor.set_status(format!("Loaded {} files.", nr_of_files));
+                }
                 // align the view to center after all files are loaded,
                 // does not affect views without pos since it is at the top
                 let (view, doc) = current!(editor);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -150,7 +150,7 @@ impl<T: Item> FilePicker<T> {
                     (size, _) if size > MAX_FILE_SIZE_FOR_PREVIEW => CachedPreview::LargeFile,
                     _ => {
                         // TODO: enable syntax highlighting; blocked by async rendering
-                        Document::open(path, None, None)
+                        Document::open(path, None, None, 0)
                             .map(|doc| CachedPreview::Document(Box::new(doc)))
                             .unwrap_or(CachedPreview::NotFound)
                     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -681,6 +681,13 @@ impl Document {
         loader: Option<Arc<helix_core::syntax::Loader>>,
     ) {
         if let (Some(language_config), Some(loader)) = (language_config, loader) {
+            if let Some(max_size) = language_config.hl_max_size {
+                if self.text.len_bytes() > max_size {
+                    self.syntax = None;
+                    self.language = Some(language_config);
+                    return;
+                }
+            }
             if let Some(highlight_config) = language_config.highlight_config(&loader.scopes()) {
                 let syntax = Syntax::new(&self.text, highlight_config, loader);
                 self.syntax = Some(syntax);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -174,6 +174,8 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// Maximum file size to trigger syntax highlighting
+    pub syntax_max_file_size: usize,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -615,6 +617,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            syntax_max_file_size: 157286400,
         }
     }
 }
@@ -1098,8 +1101,12 @@ impl Editor {
         let id = if let Some(id) = id {
             id
         } else {
-            let mut doc = Document::open(&path, None, Some(self.syn_loader.clone()))?;
-
+            let mut doc = Document::open(
+                &path,
+                None,
+                Some(self.syn_loader.clone()),
+                self.config().syntax_max_file_size,
+            )?;
             let _ = Self::launch_language_server(&mut self.language_servers, &mut doc);
 
             self.new_document(doc)


### PR DESCRIPTION
### Problem

syntax highlighting can take so much resources to fire up especially with large files. Trying to open a very large file (100 mb file for example) will takes very long time for helix and will be very slow to navigate through.

 
##
This PR adds a language specific settings for the users to specify their desired maximum file size in bytes.

for example, 
```toml
[[language]]
name = "c"
hl-max-size = 1000000
```
will stop the highlighting for any C files larger than 1mb. 

Another option is making this a global settings, but I feel like making it a language specific provides more flexibility.