### PR TITLE
Apply transactions to all views

### DIFF
--- a/helix-core/src/history.rs
+++ b/helix-core/src/history.rs
@@ -119,6 +119,24 @@ impl History {
         self.current == 0
     }
 
+    /// Returns the changes since the given revision composed into a transaction.
+    /// Returns None if there are no changes between the current and given revisions.
+    pub fn changes_since(&self, revision: usize) -> Option<Transaction> {
+        if self.at_root() || self.current >= revision {
+            return None;
+        }
+
+        let mut transaction = self.revisions[revision].transaction.clone();
+
+        // The bounds are checked in the if condition above:
+        // `revision + 1` is known to be `<= self.current`.
+        for revision in &self.revisions[revision + 1..self.current] {
+            transaction = transaction.compose(revision.transaction.clone());
+        }
+
+        Some(transaction)
+    }
+
     /// Undo the last edit.
     pub fn undo(&mut self) -> Option<&Transaction> {
         if self.at_root() {

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -71,12 +71,10 @@ pub fn align_view(doc: &Document, view: &mut View, align: Align) {
 pub fn apply_transaction(
     transaction: &helix_core::Transaction,
     doc: &mut Document,
-    view: &mut View,
+    view: &View,
 ) -> bool {
-    // This is a short function but it's easy to call `Document::apply`
-    // without calling `View::apply` or in the wrong order. The transaction
-    // must be applied to the document before the view.
-    doc.apply(transaction, view.id) && view.apply(transaction, doc)
+    // TODO remove this helper function. Just call Document::apply everywhere directly.
+    doc.apply(transaction, view.id)
 }
 
 pub use document::Document;

--- a/helix-view/src/macros.rs
+++ b/helix-view/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! view {
 #[macro_export]
 macro_rules! doc {
     ($editor:expr, $id:expr) => {{
-        $editor.documents[$id]
+        &$editor.documents[$id]
     }};
     ($editor:expr) => {{
         $crate::current_ref!($editor).1

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -345,6 +345,7 @@ impl View {
     /// which applies a transaction to the [`Document`] and view together.
     pub fn apply(&mut self, transaction: &Transaction, doc: &Document) -> bool {
         self.jumps.apply(transaction, doc);
+        // TODO: remove the boolean return. This is unused.
         true
     }
 }


### PR DESCRIPTION
Previously, transactions were only applied to the currently focused view. This could lead to jumplist selections not being updated or panics if a jumplist selection pointed past the end of the document.

Closes #4732
Closes #4600
Closes #4841