### PR TITLE
Protect against overwriting external changes

### DIFF
--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -67,7 +67,7 @@ async fn test_buffer_close_concurrent() -> anyhow::Result<()> {
     const RANGE: RangeInclusive<i32> = 1..=1000;
 
     for i in RANGE {
-        let cmd = format!("%c{}<esc>:w<ret>", i);
+        let cmd = format!("%c{}<esc>:w!<ret>", i);
         command.push_str(&cmd);
     }
 

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -322,6 +322,12 @@ impl AppBuilder {
     }
 }
 
+pub async fn run_event_loop_to_idle(app: &mut Application) {
+    let (_, rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut rx_stream = UnboundedReceiverStream::new(rx);
+    app.event_loop_until_idle(&mut rx_stream).await;
+}
+
 pub fn assert_file_has_content(file: &mut File, content: &str) -> anyhow::Result<()> {
     file.flush()?;
     file.sync_all()?;

--- a/helix-term/tests/test/write.rs
+++ b/helix-term/tests/test/write.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{Read, Write},
+    io::{Read, Seek, SeekFrom, Write},
     ops::RangeInclusive,
 };
 
@@ -31,6 +31,38 @@ async fn test_write() -> anyhow::Result<()> {
 
     assert_eq!(
         helpers::platform_line("the gostak distims the doshes"),
+        file_content
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_overwrite_protection() -> anyhow::Result<()> {
+    let mut file = tempfile::NamedTempFile::new()?;
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file.path(), None)
+        .build()?;
+
+    helpers::run_event_loop_to_idle(&mut app).await;
+
+    file.as_file_mut()
+        .write_all(helpers::platform_line("extremely important content").as_bytes())?;
+
+    file.as_file_mut().flush()?;
+    file.as_file_mut().sync_all()?;
+
+    test_key_sequence(&mut app, Some(":x<ret>"), None, false).await?;
+
+    file.as_file_mut().flush()?;
+    file.as_file_mut().sync_all()?;
+
+    file.seek(SeekFrom::Start(0))?;
+    let mut file_content = String::new();
+    file.as_file_mut().read_to_string(&mut file_content)?;
+
+    assert_eq!(
+        helpers::platform_line("extremely important content"),
         file_content
     );
 
@@ -76,7 +108,7 @@ async fn test_write_concurrent() -> anyhow::Result<()> {
         .build()?;
 
     for i in RANGE {
-        let cmd = format!("%c{}<esc>:w<ret>", i);
+        let cmd = format!("%c{}<esc>:w!<ret>", i);
         command.push_str(&cmd);
     }
 


### PR DESCRIPTION
When saving, check that the file has not changed before our last known save before writing the file. Only overwrite external changes if asked to force.

I've almost lost a bunch of work because I did it on a separate instance of helix in another terminal window, but had the same file opened on an earlier instance and saved the file without realizing. Thankfully I had a backup (a cat in another tab xD)