### PR TITLE
Fix indents for Zig's else constructs on same line

### DIFF
--- a/runtime/queries/zig/indents.scm
+++ b/runtime/queries/zig/indents.scm
@@ -16,3 +16,11 @@
   "]"
   ")"
 ] @outdent
+
+(IfExpression
+  .
+  (_) @expr-start
+  condition: (_) @indent
+  (#not-same-line? @indent @expr-start)
+  (#set! "scope" "all")
+)

--- a/runtime/queries/zig/indents.scm
+++ b/runtime/queries/zig/indents.scm
@@ -17,10 +17,10 @@
   ")"
 ] @outdent
 
-(IfExpression
+(IfStatement
   .
   (_) @expr-start
-  condition: (_) @indent
+  (_) @indent
   (#not-same-line? @indent @expr-start)
   (#set! "scope" "all")
 )


### PR DESCRIPTION
The recent behaviour was, that the `outdent` was ignored (causing to double indent per `IfPrefix` and `Else`).

This fixes this issue.