### PR TITLE
Remove Statement in Zig indentation query

### DIFF
--- a/runtime/queries/zig/indents.scm
+++ b/runtime/queries/zig/indents.scm
@@ -6,7 +6,6 @@
   (ContainerDecl)
   (ErrorUnionExpr)
   (InitList)
-  (Statement)
   (SwitchExpr)
   (TestDecl)
 ] @indent


### PR DESCRIPTION
This additional statement caused constructs such as 
`} else if (...) {` to have 1 too many indents.

The drawbacks of removing `Statement` from the Indent queries is so far only to my knowledge, that the first line of multi-line string assignments aren't properly indented.

I am the one to blame for this as well.

Introduced with #4281 