### PR TITLE
Select surrounding characters when using match/surround (m) mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4530,7 +4530,8 @@ fn surround_add(cx: &mut Context) {
         let (view, doc) = current!(cx.editor);
         let selection = doc.selection(view.id);
         let (open, close) = surround::get_pair(ch);
-        let surround_len = open.len_utf8() + close.len_utf8();
+        // The number of chars in get_pair
+        let surround_len = 2;
 
         let mut changes = Vec::with_capacity(selection.len() * 2);
         let mut ranges = SmallVec::with_capacity(selection.len());

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4529,7 +4529,6 @@ fn surround_add(cx: &mut Context) {
         };
         let (view, doc) = current!(cx.editor);
         let selection = doc.selection(view.id);
-        let index = selection.primary_index();
         let (open, close) = surround::get_pair(ch);
 
         let mut changes = Vec::with_capacity(selection.len() * 2);
@@ -4551,11 +4550,9 @@ fn surround_add(cx: &mut Context) {
             });
         }
 
-        let transaction = Transaction::change(doc.text(), changes.into_iter());
+        let transaction = Transaction::change(doc.text(), changes.into_iter())
+            .with_selection(Selection::new(ranges, selection.primary_index()));
         apply_transaction(&transaction, doc, view);
-
-        // Extend the selections to include the surrounding character
-        doc.set_selection(view.id, Selection::new(ranges, index));
     })
 }
 


### PR DESCRIPTION
When doing a `surround add` operation, the original selection is kept in place, which makes it difficult to chain surrounds and does not feel idiomatic. 

It might feel more natural when chaining surround operations. For example, quoting something, then wrapping parenthesis, then prepending `Box::new` might look like a selection of `someStringContent` then `ms"ms(iBox::new`

This PR/MR changes the behavior of the editor. 

`ms"` before:

![2022-11-14_23:19:57](https://user-images.githubusercontent.com/7482347/201825496-30070233-df98-41ef-927e-5f04cbeefed1.png)
![2022-11-14_23:20:20](https://user-images.githubusercontent.com/7482347/201825511-6fcbb1b9-78d8-4dca-97ff-a345617c9c1a.png)

`ms"` after this commit:

![2022-11-14_23:20:36](https://user-images.githubusercontent.com/7482347/201825543-8e5799c1-93f5-42f3-b49a-6dc566a04bf3.png)
![2022-11-14_23:20:47](https://user-images.githubusercontent.com/7482347/201825561-6beaf621-88f4-4082-9880-52ec3fde7f71.png)
