### PR TITLE
Saving macros

### DIFF
--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -88,15 +88,10 @@ impl Registers {
             return Ok(deserialized);
         }
 
-        println!("Loading");
-
         // todo: log results
         match _read_data(name) {
             Ok(content) => match _string_to_register(content) {
-                Ok(register) => {
-                    println!("INSERTED");
-                    self.inner.insert(name, register)
-                }
+                Ok(register) => self.inner.insert(name, register),
                 Err(_error) => None,
             },
             Err(_error) => None,

--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -73,18 +73,15 @@ impl Registers {
     }
 
     pub fn load(&mut self) -> std::io::Result<()> {
-        println!("Loading.. ");
-        let mut file = File::open("foo.txt")?;
+        let mut file = File::open("foo.macro")?;
         let mut buf_reader = BufReader::new(file);
         let mut content = String::new();
 
         buf_reader.read_to_string(&mut content)?;
 
-        let deserialized: HashMap<char, Register> = serde_json::from_str(&content).unwrap();
-        dbg!(self.inner = deserialized);
+        let deserialized: Register = serde_json::from_str(&content).unwrap();
 
-        eprintln!("loaded");
-        println!("loaded");
+        self.inner.insert('@', deserialized);
 
         Ok(())
     }
@@ -96,10 +93,6 @@ impl Registers {
 
         let mut file = File::create(&file_name)?;
         file.write_all(&content.as_bytes());
-
-        println!("Saved");
-
-        eprintln!("Saved!");
 
         Ok(())
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5015,14 +5015,20 @@ fn save_macro(cx: &mut Context) {
                 return;
             }
         }
-        None => println!("blub"),
+        None => (),
     }
 
-    cx.editor.registers.save(reg, Path::new("foo.macro"));
+    cx.editor.registers.save(reg);
+
+    cx.editor
+        .set_status(format!("Saved macro in register [{}]", reg));
 }
 
 fn load_macro(cx: &mut Context) {
-    cx.editor.registers.load();
+    let reg = '@';
+    cx.editor.registers.load(reg);
+    cx.editor
+        .set_status(format!("Loaded macro in register [{}]", reg));
 }
 
 fn replay_macro(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5018,17 +5018,28 @@ fn save_macro(cx: &mut Context) {
         None => (),
     }
 
-    cx.editor.registers.save(reg);
-
-    cx.editor
-        .set_status(format!("Saved macro in register [{}]", reg));
+    match cx.editor.registers.save(reg) {
+        Ok(_) => cx
+            .editor
+            .set_status(format!("Saved macro in register [{}]", reg)),
+        Err(error) => cx.editor.set_error(format!(
+            "Saving macro in register [{}] failed: {}",
+            reg, error
+        )),
+    }
 }
 
 fn load_macro(cx: &mut Context) {
     let reg = '@';
-    cx.editor.registers.load(reg);
-    cx.editor
-        .set_status(format!("Loaded macro in register [{}]", reg));
+    match cx.editor.registers.load(reg) {
+        Ok(()) => cx
+            .editor
+            .set_status(format!("Loaded macro in register [{}]", reg)),
+        Err(error) => cx.editor.set_error(format!(
+            "Loading macro in register [{}] failed: {}",
+            reg, error
+        )),
+    }
 }
 
 fn replay_macro(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -437,6 +437,7 @@ impl MappableCommand {
         decrement, "Decrement item under cursor",
         record_macro, "Record macro",
         replay_macro, "Replay macro",
+        save_macro, "Save macro",
         command_palette, "Open command palette",
     );
 }
@@ -5000,7 +5001,28 @@ fn record_macro(cx: &mut Context) {
     }
 }
 
+fn save_macro(cx: &mut Context) {
+    let reg = cx.register.unwrap_or('@');
+
+    match &cx.editor.macro_recording {
+        Some(val) => {
+            if val.0 == reg {
+                cx.editor.set_error(format!(
+                    "Cannot save from register [{}] because currently recording at the same register",
+                reg
+                ));
+                return;
+            }
+        }
+        None => println!("blub"),
+    }
+
+    cx.editor.registers.save(reg, Path::new("foo.macro"));
+}
+
 fn replay_macro(cx: &mut Context) {
+    println!("fun");
+    cx.editor.registers.load();
     let reg = cx.register.unwrap_or('@');
 
     if cx.editor.macro_replaying.contains(&reg) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -438,6 +438,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         save_macro, "Save macro",
+        load_macro, "Load macro",
         command_palette, "Open command palette",
     );
 }
@@ -5020,9 +5021,11 @@ fn save_macro(cx: &mut Context) {
     cx.editor.registers.save(reg, Path::new("foo.macro"));
 }
 
-fn replay_macro(cx: &mut Context) {
-    println!("fun");
+fn load_macro(cx: &mut Context) {
     cx.editor.registers.load();
+}
+
+fn replay_macro(cx: &mut Context) {
     let reg = cx.register.unwrap_or('@');
 
     if cx.editor.macro_replaying.contains(&reg) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -17,7 +17,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "F" => find_prev_char,
         "r" => replace,
         "R" => replace_with_yanked,
-        "A-." =>  repeat_last_motion,
+        "A-." => repeat_last_motion,
 
         "~" => switch_case,
         "`" => switch_to_lowercase,
@@ -137,10 +137,12 @@ pub fn default() -> HashMap<Mode, Keymap> {
         // paste_all
         "P" => paste_before,
 
-        "Q" => record_macro,
-        "q" => replay_macro,
-        "ö" => save_macro,
-        "Ö" => load_macro,
+        "q" => { "Macro"
+            "r" => record_macro,
+            "p" => replay_macro,
+            "s" => save_macro,
+            "l" => load_macro,
+        },
 
         ">" => indent,
         "<" => unindent,
@@ -152,9 +154,6 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "," => keep_primary_selection,
         "A-," => remove_primary_selection,
-
-        // "q" => record_macro,
-        // "Q" => replay_macro,
 
         "&" => align_selections,
         "_" => trim_selections,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -139,6 +139,8 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "Q" => record_macro,
         "q" => replay_macro,
+        "ö" => save_macro,
+        "Ö" => load_macro,
 
         ">" => indent,
         "<" => unindent,


### PR DESCRIPTION
This adds the feature to save a macro in the current working directory.

I didn't want to always re-record macros whenever I restarted helix so I thought about adding the option to store and load macros.

The way it works:
```q``` opens the macro menu.
|-- ```r``` records a new macro.
|-- ```p``` replays a recorded or loaded macro
|-- ```s``` saves a macro (in the working directory)
|-- ```l``` loads a macro (from the working directory)

Limitations: 
- Loading currently works only for macros that were originally stored in the default register at '@'