### PR TITLE
add buffer command so that we can bind key to switch buffers

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -3,6 +3,7 @@
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o` | Open a file from disk into the current view. |
+| `:buffer`, `:b` | Go to a buffer |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -147,6 +147,33 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<Docum
     document_ids
 }
 
+fn buffer(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate || args.len() < 1 {
+        return Ok(());
+    }
+
+    let name = args.first().unwrap().as_ref();
+    let arg_path = Some(Path::new(name));
+    let doc_id = cx.editor.documents().find_map(|doc| {
+        if doc.path().map(|p| p.as_path()) == arg_path
+            || doc.relative_path().as_deref() == arg_path
+            || doc.display_name() == name
+        {
+            Some(doc.id())
+        } else {
+            None
+        }
+    });
+    if let Some(document_id) = doc_id {
+        cx.editor.switch(document_id, Action::Replace);
+    }
+    Ok(())
+}
+
 fn buffer_close(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -1760,6 +1787,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             doc: "Open a file from disk into the current view.",
             fun: open,
             completer: Some(completers::filename),
+        },
+        TypableCommand {
+            name: "buffer",
+            aliases: &["b"],
+            doc: "Go to a buffer",
+            fun: buffer,
+            completer: Some(completers::buffer),
         },
         TypableCommand {
             name: "buffer-close",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -152,7 +152,7 @@ fn buffer(
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
-    if event != PromptEvent::Validate || args.len() < 1 {
+    if event != PromptEvent::Validate || args.is_empty() {
         return Ok(());
     }
 
@@ -162,6 +162,7 @@ fn buffer(
         if doc.path().map(|p| p.as_path()) == arg_path
             || doc.relative_path().as_deref() == arg_path
             || doc.display_name() == name
+            || format!("{}", doc.id()) == name
         {
             Some(doc.id())
         } else {


### PR DESCRIPTION
would like something like "space".t = ":buffer [scratch]"

this would be helpful if we support script in future