### PR TITLE
Update file change history before calling MappableCommand

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -172,6 +172,11 @@ impl MappableCommand {
                         jobs: cx.jobs,
                         scroll: None,
                     };
+
+                    // We update any changes to history before calling the command
+                    let (view, doc) = current!(cx.editor);
+                    doc.append_changes_to_history(view.id);
+
                     if let Err(e) = (command.fun)(&mut cx, &args[..], PromptEvent::Validate) {
                         cx.editor.set_error(format!("{}", e));
                     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -167,16 +167,12 @@ impl MappableCommand {
             Self::Typable { name, args, doc: _ } => {
                 let args: Vec<Cow<str>> = args.iter().map(Cow::from).collect();
                 if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
+                    commit_undo_checkpoint(cx);
                     let mut cx = compositor::Context {
                         editor: cx.editor,
                         jobs: cx.jobs,
                         scroll: None,
                     };
-
-                    // We update any changes to history before calling the command
-                    let (view, doc) = current!(cx.editor);
-                    doc.append_changes_to_history(view.id);
-
                     if let Err(e) = (command.fun)(&mut cx, &args[..], PromptEvent::Validate) {
                         cx.editor.set_error(format!("{}", e));
                     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -167,7 +167,10 @@ impl MappableCommand {
             Self::Typable { name, args, doc: _ } => {
                 let args: Vec<Cow<str>> = args.iter().map(Cow::from).collect();
                 if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
-                    commit_undo_checkpoint(cx);
+                    // #4719 - Fix for checkpoint issues when calling commands in INSERT mode
+                    if cx.editor.mode == Mode::Insert {
+                        commit_undo_checkpoint(cx);
+                    }
                     let mut cx = compositor::Context {
                         editor: cx.editor,
                         jobs: cx.jobs,


### PR DESCRIPTION
 Before we run a mappable command we should update the current changes to history.

 This fixes #4719