### PR TITLE
lsp: Resolve completion item asynchronously on idle-timeout

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -650,12 +650,11 @@ impl Client {
         self.call::<lsp::request::Completion>(params)
     }
 
-    pub async fn resolve_completion_item(
+    pub fn resolve_completion_item(
         &self,
         completion_item: lsp::CompletionItem,
-    ) -> Result<lsp::CompletionItem> {
-        self.request::<lsp::request::ResolveCompletionItem>(completion_item)
-            .await
+    ) -> impl Future<Output = Result<Value>> {
+        self.call::<lsp::request::ResolveCompletionItem>(completion_item)
     }
 
     pub fn text_document_signature_help(

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -224,6 +224,17 @@ impl<T: Item> Menu<T> {
     }
 }
 
+impl<T: Item + PartialEq> Menu<T> {
+    pub fn replace_option(&mut self, old_option: T, new_option: T) {
+        for option in &mut self.options {
+            if old_option == *option {
+                *option = new_option;
+                break;
+            }
+        }
+    }
+}
+
 use super::PromptEvent as MenuEvent;
 
 impl<T: Item + 'static> Component for Menu<T> {


### PR DESCRIPTION
#4406 resolves completion items on the idle-timeout event. The `Completion::resolve_completion_item` function blocks on the LSP request though, which blocks the compositor and in turn blocks the event loop. So until the language server returns the resolved completion item, Helix is unable to respond to keypresses or other LSP messages.

This is typically ok since the resolution request is fast but for some language servers this can be problematic, and ideally we shouldn't be blocking like this anyways.

When receiving a `completionItem/resolve` request, the Volar server sends a `workspace/configuration` request to Helix and blocks itself on the response, leading to a deadlock. Eventually the resolve request times out within Helix but Helix is locked up and unresponsive in that window.

This change resolves the completion item without blocking the compositor.

Closes #4714