### PR TITLE
Add support for color modes with Monokai Pro

### DIFF
--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -18,6 +18,9 @@
 # status bars, panels, modals, autocompletion
 "ui.statusline" = { fg = "base8", bg = "base4" }
 "ui.statusline.inactive" = { fg = "base8", bg = "base8x0c" }
+"ui.statusline.normal" = { fg = "base4", bg = "blue" }
+"ui.statusline.insert" = { fg = "base4", bg = "green" }
+"ui.statusline.select" = { fg = "base4", bg = "purple" }
 "ui.popup" = { bg = "base3" }
 "ui.window" = { bg = "base3" }
 "ui.help" = { fg = "base8", bg = "base3" }


### PR DESCRIPTION
This basically follows the pattern found in

https://github.com/helix-editor/helix/blob/9cb5aed9c723df118df95a5206257a9425460835/runtime/themes/monokai_pro_octagon.toml#L21-L23