### PR TITLE
Handle language server termination

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -282,6 +282,8 @@ impl MethodCall {
 pub enum Notification {
     // we inject this notification to signal the LSP is ready
     Initialized,
+    // and this notification to signal that the LSP exited
+    Exit,
     PublishDiagnostics(lsp::PublishDiagnosticsParams),
     ShowMessage(lsp::ShowMessageParams),
     LogMessage(lsp::LogMessageParams),
@@ -294,6 +296,7 @@ impl Notification {
 
         let notification = match method {
             lsp::notification::Initialized::METHOD => Self::Initialized,
+            lsp::notification::Exit::METHOD => Self::Exit,
             lsp::notification::PublishDiagnostics::METHOD => {
                 let params: lsp::PublishDiagnosticsParams = params.parse()?;
                 Self::PublishDiagnostics(params)
@@ -348,6 +351,10 @@ impl Registry {
             .values()
             .find(|(client_id, _)| client_id == &id)
             .map(|(_, client)| client.as_ref())
+    }
+
+    pub fn remove_by_id(&mut self, id: usize) {
+        self.inner.retain(|_, (client_id, _)| client_id != &id)
     }
 
     pub fn restart(


### PR DESCRIPTION
This change handles a language server exiting. This was a UX sore-spot: if a language server crashed, Helix did not recognize the exit and continued to send requests to it. All requests would timeout since they would not receive responses. This would also hold-up Helix closing itself down since it would try to gracefully shutdown the server which is implemented in the LSP spec as a request.

We could attempt to automatically restart the language server on crash. I left this for future work since that change will need to be slightly complicated: it will need to cover the case of a language server repeatedly crashing.