### PR TITLE
Match `.hs-boot` files to Haskell

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -732,7 +732,7 @@ source = { git = "https://github.com/ikatyang/tree-sitter-yaml", rev = "0e36bed1
 name = "haskell"
 scope = "source.haskell"
 injection-regex = "haskell"
-file-types = ["hs"]
+file-types = ["hs", "hs-boot"]
 roots = ["Setup.hs", "stack.yaml", "*.cabal"]
 comment-token = "--"
 language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }


### PR DESCRIPTION
Haskell source files are now either `.hs` (as before) or `.hs-boot`, which is a type of Haskell file that only contains type declarations (https://downloads.haskell.org/ghc/latest/docs/users_guide/separate_compilation.html#how-to-compile-mutually-recursive-modules)