### PR TITLE
Make `r<tab>` and `f<tab>` work

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1135,6 +1135,10 @@ where
             }
 
             KeyEvent {
+                code: KeyCode::Tab, ..
+            } => '\t',
+
+            KeyEvent {
                 code: KeyCode::Char(ch),
                 ..
             } => ch,
@@ -1280,6 +1284,9 @@ fn replace(cx: &mut Context) {
                 code: KeyCode::Enter,
                 ..
             } => Some(doc.line_ending.as_str()),
+            KeyEvent {
+                code: KeyCode::Tab, ..
+            } => Some("\t"),
             _ => None,
         };
 


### PR DESCRIPTION
Currently, commands such as `r<tab>` (replace with tab) or `t<tab>` (select till tab) have no effect. I consider this a bug because these commands work in Kakoune and I sometimes try to use them. Also, both `r<ret>` and `t<ret>` already work in Helix.