### PR TITLE
fix(build): don't statically link against the "musl" C standard library

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,16 @@
 xtask = "run --package xtask --"
 integration-test = "test --features integration --profile integration --workspace --test integration"
 
-[target.aarch64-unknown-linux-musl]
 # By default, on musl linux, statically linked binaries are produced.
 # But such binaries do not support loading libraries using `dlopen()` ("libloading" crate),
 # which is required for loading treesitter grammars.
+[target.arm-unknown-linux-musleabihf]
+rustflags = ["-C", "target-feature=-crt-static"]
+[target.armv7-unknown-linux-musleabihf]
+rustflags = ["-C", "target-feature=-crt-static"]
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+[target.i686-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+[target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 xtask = "run --package xtask --"
 integration-test = "test --features integration --profile integration --workspace --test integration"
 
-[build]
+[target.aarch64-unknown-linux-musl]
 # By default, on musl linux, statically linked binaries are produced.
 # But such binaries do not support loading libraries using `dlopen()` ("libloading" crate),
 # which is required for loading treesitter grammars.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@ integration-test = "test --features integration --profile integration --workspac
 # But such binaries do not support loading libraries using `dlopen()` ("libloading" crate),
 # which is required for loading treesitter grammars.
 [target.'cfg(target_env = "musl")']
-rustflags = ["-C", "target-feature=-crt-static"]
+rustflags = "-C target-feature=-crt-static"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,13 +5,5 @@ integration-test = "test --features integration --profile integration --workspac
 # By default, on musl linux, statically linked binaries are produced.
 # But such binaries do not support loading libraries using `dlopen()` ("libloading" crate),
 # which is required for loading treesitter grammars.
-[target.arm-unknown-linux-musleabihf]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.armv7-unknown-linux-musleabihf]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.i686-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.x86_64-unknown-linux-musl]
+[target.'cfg(target_env = "musl")']
 rustflags = ["-C", "target-feature=-crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
 [alias]
 xtask = "run --package xtask --"
 integration-test = "test --features integration --profile integration --workspace --test integration"
+
+[build]
+# By default, on musl linux, statically linked binaries are produced.
+# But such binaries do not support loading libraries using `dlopen()` ("libloading" crate),
+# which is required for loading treesitter grammars.
+rustflags = ["-C", "target-feature=-crt-static"]


### PR DESCRIPTION
By default, rustc always statically links against musl (*), unlike on glibc systems where the resulting binary is dynamically linked against glibc.

This has a very problematic side effect: Binaries which statically link against musl do not support the `dlopen()` call (which we do through the "libloading" crate) (**). **This in turn makes it impossible to load treesitter grammars.**

The result is an error in the log and the user is left without syntax highlighting, among others:
```
helix_core::syntax [ERROR] Failed to load tree-sitter parser for language "toml": Error opening dynamic library "/opt/helix-src/runtime/grammars/toml.so"
```

This PR ensures the resulting binary is never statically linked against a C standard library. This configuration should have no impact in environments where the resulting binary would be dynamically linked by default.

---

(*) Tested with v1.65.0. See also: https://github.com/rust-lang/rust/issues/34987 / https://github.com/rust-lang/compiler-team/issues/422

(**) I found it out by testing a call to `Library::new(...).unwrap()` in a statically and dynamically linked application. I couldn't find much information regarding my claim, but I found these:
https://www.openwall.com/lists/musl/2012/12/08/4
https://www.openwall.com/lists/musl/2014/08/27/14

I tested it with the following code:
```rust
use libloading::Library;

fn main() {
    let name = "/opt/helix-src/runtime/grammars/toml.so";

    println!("Loading: {}", name);
    let lib = unsafe { Library::new(name).unwrap() };

    println!("Unloading: {}", name);
    lib.close().unwrap();

    println!("Done");
}
```
Output (when built on musl with default options):
```
Loading: /opt/helix-src/runtime/grammars/toml.so
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: DlOpen { desc: "Dynamic loading not supported" }', src/main.rs:8:4
```