### PR TITLE
Implement simple indents.scm for Elixir

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -25,7 +25,7 @@
 | edoc | ✓ |  |  |  |
 | eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |
-| elixir | ✓ | ✓ |  | `elixir-ls` |
+| elixir | ✓ | ✓ | ✓ | `elixir-ls` |
 | elm | ✓ |  |  | `elm-language-server` |
 | elvish | ✓ |  |  | `elvish` |
 | env | ✓ |  |  |  |

--- a/runtime/queries/elixir/indents.scm
+++ b/runtime/queries/elixir/indents.scm
@@ -1,0 +1,13 @@
+[
+  (after_block)
+  (anonymous_function)
+  (catch_block)
+  (do_block)
+  (else_block)
+  (rescue_block)
+  "->"
+] @indent
+
+[
+  "end"
+] @outdent

--- a/runtime/queries/elixir/indents.scm
+++ b/runtime/queries/elixir/indents.scm
@@ -5,7 +5,7 @@
   (do_block)
   (else_block)
   (rescue_block)
-  "->"
+  (stab_clause)
 ] @indent
 
 [


### PR DESCRIPTION
Simple implementation of elixir indentations.

I am also not sure whether or not it is possible to do some kind of auto-pre outdent for "end", as it should be outdented before "end" and not after. 