### PR TITLE
Fix broken html doctype highlighting

### DIFF
--- a/runtime/queries/html/highlights.scm
+++ b/runtime/queries/html/highlights.scm
@@ -14,6 +14,7 @@
   ">"
   "</"
   "/>"
+  "<!"
 ] @punctuation.bracket
 
 "=" @punctuation.delimiter


### PR DESCRIPTION
Adds the missing `<!` to the html highlights.scm to fix the incorrect highlighting of `DOCTYPE` declarations.

Before:
![broken doctype highlight](https://user-images.githubusercontent.com/6290295/202919638-4eea58e5-9e9c-439c-ab41-93ef3b3c0726.png)

After:
![fixed doctype highlight](https://user-images.githubusercontent.com/6290295/202919646-fcab9bdb-5ab1-462f-b56f-8a95d13eb4b3.png)