### PR TITLE
Bump tree-sitter pattern matching limit to 256

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -354,24 +354,25 @@ impl<'a> CapturedNode<'a> {
     }
 }
 
-/// The number of matches a TS cursor can at once to avoid performance problems for medium to large files.
-/// Set with `set_match_limit`.
-/// Using such a limit means that we lose valid captures in, so there is fundamentally a tradeoff here.
+/// The maximum number of in-progress matches a TS cursor can consider at once.
+/// This is set to a constant in order to avoid performance problems for medium to large files. Set with `set_match_limit`.
+/// Using such a limit means that we lose valid captures, so there is fundamentally a tradeoff here.
 ///
 ///
 /// Old tree sitter versions used a limit of 32 by default until this limit was removed in version `0.19.5` (must now be set manually).
 /// However, this causes performance issues for medium to large files.
 /// In helix, this problem caused treesitter motions to take multiple seconds to complete in medium-sized rust files (3k loc).
+///
+///
 /// Neovim also encountered this problem and reintroduced this limit after it was removed upstream
 /// (see <https://github.com/neovim/neovim/issues/14897> and <https://github.com/neovim/neovim/pull/14915>).
 /// The number used here is fundamentally a tradeoff between breaking some obscure edge cases and performance.
 ///
 ///
-/// A value of 64 was chosen because neovim uses that value.
-/// Neovim chose this value somewhat arbitrarily (<https://github.com/neovim/neovim/pull/18397>) adjusting it whenever issues occur in practice.
-/// However this value has been in use for a long time and due to the large userbase of neovim it is probably a good choice.
-/// If this limit causes problems for a grammar in the future, it could be increased.
-const TREE_SITTER_MATCH_LIMIT: u32 = 64;
+/// Neovim chose 64 for this value somewhat arbitrarily (<https://github.com/neovim/neovim/pull/18397>).
+/// 64 is too low for some languages though. In particular, it breaks some highlighting for record fields in Erlang record definitions.
+/// This number can be increased if new syntax highlight breakages are found, as long as the performance penalty is not too high.
+const TREE_SITTER_MATCH_LIMIT: u32 = 256;
 
 impl TextObjectQuery {
     /// Run the query on the given node and return sub nodes which match given


### PR DESCRIPTION
The limit of 64 breaks some highlighting in Erlang files with complicated record definitions. Bumping to 256  seems to work on all files I have seen.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/202921390-4a79d2ad-6ef4-4697-a042-2bc7997d12df.png) | ![after](https://user-images.githubusercontent.com/21230295/202921398-89d80c7f-a881-477b-bfdc-76d2540080d5.png) |
