### PR TITLE
support multiple selections for pickers

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -392,19 +392,22 @@ you to selectively add search terms to your selections.
 
 Keys to use within picker. Remapping currently not supported.
 
-| Key                          | Description       |
-| -----                        | -------------     |
-| `Shift-Tab`, `Up`, `Ctrl-p`  | Previous entry    |
-| `Tab`, `Down`, `Ctrl-n`      | Next entry        |
-| `PageUp`, `Ctrl-u`           | Page up           |
-| `PageDown`, `Ctrl-d`         | Page down         |
-| `Home`                       | Go to first entry |
-| `End`                        | Go to last entry  |
-| `Enter`                      | Open selected     |
-| `Ctrl-s`                     | Open horizontally |
-| `Ctrl-v`                     | Open vertically   |
-| `Ctrl-t`                     | Toggle preview    |
-| `Escape`, `Ctrl-c`           | Close picker      |
+| Key                          | Description          |
+| -----                        | -------------        |
+| `Shift-Tab`, `Up`, `Ctrl-p`  | Previous entry       |
+| `Tab`, `Down`, `Ctrl-n`      | Next entry           |
+| `PageUp`, `Ctrl-u`           | Page up              |
+| `PageDown`, `Ctrl-d`         | Page down            |
+| `Home`                       | Go to first entry    |
+| `End`                        | Go to last entry     |
+| `Enter`                      | Open selected        |
+| `Ctrl-s`                     | Open horizontally    |
+| `Ctrl-v`                     | Open vertically      |
+| `Ctrl-t`                     | Toggle preview       |
+| `Ctrl-Space`                 | Toggle selection     |
+| `Alt-a`                      | Select all matches   |
+| `Alt-d`                      | Unselect all matches |
+| `Escape`, `Ctrl-c`           | Close picker         |
 
 ## Prompt
 


### PR DESCRIPTION
Support multiple selections like skim -m, so that we can open many files at once or delete all buffers or clear the jumplist.