### PR TITLE
Fix `x` behavior on empty lines

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -54,6 +54,9 @@ pub struct Range {
     /// The head of the range, moved when extending.
     pub head: usize,
     pub horiz: Option<u32>,
+    /// True if range is intended to contain whole lines (e.g. after `line_extend_below`).
+    /// Useful to prevent first `line_extend_below` on an empty line selecting the next line.
+    pub line_mode: bool,
 }
 
 impl Range {
@@ -62,6 +65,7 @@ impl Range {
             anchor,
             head,
             horiz: None,
+            line_mode: false,
         }
     }
 
@@ -128,6 +132,7 @@ impl Range {
             anchor: self.head,
             head: self.anchor,
             horiz: self.horiz,
+            line_mode: self.line_mode,
         }
     }
 
@@ -186,6 +191,7 @@ impl Range {
             anchor,
             head,
             horiz: None,
+            line_mode: false,
         }
     }
 
@@ -199,12 +205,14 @@ impl Range {
                 anchor: self.anchor.min(from),
                 head: self.head.max(to),
                 horiz: None,
+                line_mode: self.line_mode,
             }
         } else {
             Self {
                 anchor: self.anchor.max(to),
                 head: self.head.min(from),
                 horiz: None,
+                line_mode: self.line_mode,
             }
         }
     }
@@ -220,12 +228,14 @@ impl Range {
                 anchor: self.anchor.max(other.anchor),
                 head: self.head.min(other.head),
                 horiz: None,
+                line_mode: self.line_mode || other.line_mode,
             }
         } else {
             Range {
                 anchor: self.from().min(other.from()),
                 head: self.to().max(other.to()),
                 horiz: None,
+                line_mode: self.line_mode || other.line_mode,
             }
         }
     }
@@ -284,6 +294,7 @@ impl Range {
             } else {
                 None
             },
+            line_mode: self.line_mode,
         }
     }
 
@@ -307,6 +318,7 @@ impl Range {
                 anchor: self.anchor,
                 head: next_grapheme_boundary(slice, self.head),
                 horiz: self.horiz,
+                line_mode: self.line_mode,
             }
         } else {
             *self
@@ -371,6 +383,11 @@ impl Range {
         let second = graphemes.next();
         first.is_some() && second.is_none()
     }
+
+    pub fn with_line_mode(mut self, line_mode: bool) -> Self {
+        self.line_mode = line_mode;
+        self
+    }
 }
 
 impl From<(usize, usize)> for Range {
@@ -379,6 +396,7 @@ impl From<(usize, usize)> for Range {
             anchor,
             head,
             horiz: None,
+            line_mode: false,
         }
     }
 }
@@ -482,7 +500,8 @@ impl Selection {
             ranges: smallvec![Range {
                 anchor,
                 head,
-                horiz: None
+                horiz: None,
+                line_mode: false,
             }],
             primary_index: 0,
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2060,7 +2060,7 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
         );
 
         // extend to previous/next line if current line is selected
-        let (anchor, head) = if range.from() == start && range.to() == end {
+        let (anchor, head) = if range.from() == start && range.to() == end && range.line_mode {
             match extend {
                 Extend::Above => (end, text.line_to_char(start_line.saturating_sub(count))),
                 Extend::Below => (
@@ -2078,7 +2078,7 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
             }
         };
 
-        Range::new(anchor, head)
+        Range::new(anchor, head).with_line_mode(true)
     });
 
     doc.set_selection(view.id, selection);
@@ -2096,7 +2096,9 @@ fn extend_to_line_bounds(cx: &mut Context) {
             let start = text.line_to_char(start_line);
             let end = text.line_to_char((end_line + 1).min(text.len_lines()));
 
-            Range::new(start, end).with_direction(range.direction())
+            Range::new(start, end)
+                .with_direction(range.direction())
+                .with_line_mode(true)
         }),
     );
 }


### PR DESCRIPTION
This is to address my personal issue with #356.

I'm not sure if this is an ideal implementation, or will it get merged, but was easy enough and it should be easy for me to use a personal fork, just like I used to for kakoune: https://github.com/dpc/kakoune-dpc/