### PR TITLE
Exit select mode on surround commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4582,6 +4582,7 @@ fn surround_add(cx: &mut Context) {
         let transaction = Transaction::change(doc.text(), changes.into_iter())
             .with_selection(Selection::new(ranges, selection.primary_index()));
         apply_transaction(&transaction, doc, view);
+        exit_select_mode(cx);
     })
 }
 
@@ -4621,6 +4622,7 @@ fn surround_replace(cx: &mut Context) {
                 }),
             );
             apply_transaction(&transaction, doc, view);
+            exit_select_mode(cx);
         });
     })
 }
@@ -4648,6 +4650,7 @@ fn surround_delete(cx: &mut Context) {
         let transaction =
             Transaction::change(doc.text(), change_pos.into_iter().map(|p| (p, p + 1, None)));
         apply_transaction(&transaction, doc, view);
+        exit_select_mode(cx);
     })
 }
 


### PR DESCRIPTION
Similar to #4554, this PR fixes the bug where the editor doesn't exit select mode after performing a surround command. The following commands are affected:

- `surround_add` (`ms`)
- `surround_replace` (`mr`)
- `surround_delete` (`md`)

Sending this patch with @archseer's confirmation on Matrix, quoting here:

> Anything that does an action on the selection should exit select mode