### PR TITLE
Update tree-sitter grammars for beam languages

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1360,7 +1360,7 @@ config = { elixirLS.dialyzerEnabled = false }
 
 [[grammar]]
 name = "heex"
-source = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "881f1c805f51485a26ecd7865d15c9ef8d606a78" }
+source = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 
 [[language]]
 name = "sql"

--- a/languages.toml
+++ b/languages.toml
@@ -1184,7 +1184,7 @@ language-server = { command = "erlang_ls" }
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "0e7d677d11a7379686c53c616825714ccb728059" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "ce0ed253d72c199ab93caba7542b6f62075339c4" }
 
 [[language]]
 name = "kotlin"
@@ -1574,7 +1574,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "edoc"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-edoc", rev = "1691ec0aa7ad1ed9fa295590545f27e570d12d60" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-edoc", rev = "74774af7b45dd9cefbf9510328fc6ff2374afc50" }
 
 [[language]]
 name = "jsdoc"

--- a/languages.toml
+++ b/languages.toml
@@ -1263,7 +1263,7 @@ language-server = { command = "gleam", args = ["lsp"] }
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "d7861b2a4b4d594c58bb4f1be5f1f4ee4c67e5c3" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "d6cbdf3477fcdb0b4d811518a356f9b5cd1795ed" }
 
 [[language]]
 name = "ron"

--- a/runtime/queries/edoc/highlights.scm
+++ b/runtime/queries/edoc/highlights.scm
@@ -48,3 +48,5 @@
   (language_identifier)
   (quote_content)
 ] @markup.raw.block
+
+(parameter) @variable.parameter

--- a/runtime/queries/edoc/injections.scm
+++ b/runtime/queries/edoc/injections.scm
@@ -16,5 +16,5 @@
    (tag) @_tag
    (argument) @injection.content)
  (#eq? @_tag "@type")
- (#set injection.language "erlang")
- (#set injection.include-children))
+ (#set! injection.language "erlang")
+ (#set! injection.include-children))

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -65,6 +65,37 @@
 (function_capture module: (atom) @namespace)
 (function_capture function: (atom) @function)
 
+; Ignored variables
+((variable) @comment.discard
+ (#match? @comment.discard "^_"))
+
+; Parameters
+; specs
+((attribute
+   name: (atom) @keyword
+   (stab_clause
+     pattern: (arguments (variable) @variable.parameter)
+     body: (variable)? @variable.parameter))
+ (#match? @keyword "(spec|callback)"))
+; functions
+(function_clause pattern: (arguments (variable) @variable.parameter))
+; anonymous functions
+(stab_clause pattern: (arguments (variable) @variable.parameter))
+; parametric types
+((attribute
+    name: (atom) @keyword
+    (arguments
+      (binary_operator
+        left: (call (arguments (variable) @variable.parameter))
+        operator: "::")))
+ (#match? @keyword "(type|opaque)"))
+; macros
+((attribute
+   name: (atom) @keyword
+   (arguments
+     (call (arguments (variable) @variable.parameter))))
+ (#eq? @keyword "define"))
+
 ; Records
 (record_content
   (binary_operator
@@ -105,9 +136,6 @@
   name: (_) @keyword.directive)
 
 ; Comments
-((variable) @comment.discard
- (#match? @comment.discard "^_"))
-
 (tripledot) @comment.discard
 
 [(comment) (line_comment) (shebang)] @comment

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -94,10 +94,6 @@
 (unary_operator operator: _ @operator)
 ["/" ":" "->"] @operator
 
-(tripledot) @comment.discard
-
-(comment) @comment
-
 ; Macros
 (macro
   "?"+ @constant
@@ -112,8 +108,14 @@
 ((variable) @comment.discard
  (#match? @comment.discard "^_"))
 
+(tripledot) @comment.discard
+
+[(comment) (line_comment) (shebang)] @comment
+
 ; Basic types
 (variable) @variable
+((atom) @constant.builtin.boolean
+ (#match? @constant.builtin.boolean "^(true|false)$"))
 (atom) @string.special.symbol
 (string) @string
 (character) @constant.character

--- a/runtime/queries/erlang/injections.scm
+++ b/runtime/queries/erlang/injections.scm
@@ -1,2 +1,7 @@
-((comment_content) @injection.content
- (#set! injection.language "edoc"))
+((line_comment (comment_content) @injection.content)
+ (#set! injection.language "edoc")
+ (#set! injection.include-children)
+ (#set! injection.combined))
+
+((comment (comment_content) @injection.content)
+ (#set! injection.language "comment"))

--- a/runtime/queries/erlang/locals.scm
+++ b/runtime/queries/erlang/locals.scm
@@ -1,0 +1,30 @@
+; Specs and Callbacks
+(attribute
+  (stab_clause
+    pattern: (arguments (variable) @local.definition)
+    ; If a spec uses a variable as the return type (and later a `when` clause to type it):
+    body: (variable)? @local.definition)) @local.scope
+
+; parametric `-type`s
+((attribute
+    name: (atom) @_type
+    (arguments
+      (binary_operator
+        left: (call (arguments (variable) @local.definition))
+        operator: "::") @local.scope))
+ (#match? @_type "(type|opaque)"))
+
+; macros
+((attribute
+   name: (atom) @_define
+   (arguments
+     (call (arguments (variable) @local.definition)))) @local.scope
+ (#eq? @_define "define"))
+
+; `fun`s
+(anonymous_function (stab_clause pattern: (arguments (variable) @local.definition))) @local.scope
+
+; Ordinary functions
+(function_clause pattern: (arguments (variable) @local.definition)) @local.scope
+
+(variable) @local.reference

--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -80,6 +80,7 @@
   "todo"
   "try"
   "type"
+  "use"
 ] @keyword
 
 ; Punctuation
@@ -103,4 +104,5 @@
   "->"
   ".."
   "-"
+  "<-"
 ] @punctuation.delimiter

--- a/runtime/queries/heex/injections.scm
+++ b/runtime/queries/heex/injections.scm
@@ -6,7 +6,11 @@
 ;     <%= if true do %>
 ;       <p>hello, tree-sitter!</p>
 ;     <% end %>
-((directive (partial_expression_value) @injection.content)
+((directive
+    [
+      (partial_expression_value)
+      (ending_expression_value)
+    ] @injection.content)
  (#set! injection.language "elixir")
  (#set! injection.include-children)
  (#set! injection.combined))


### PR DESCRIPTION
This PR has a few updates for BEAM language (Erlang, Gleam, HEEx, EDoc) tree-sitter grammars and queries.

The main improvement is in Erlang where EDoc can now be injected into inline-comments and line breaks are handled correctly. This enables highlighting things like code-fences within function doc comments, and fixes some highlights when they are broken across comment lines:

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/203657865-32f85c7a-fac7-4a58-a458-24323e31ba14.gif) | ![after](https://user-images.githubusercontent.com/21230295/203657890-65492b50-8b1a-43bf-867d-26c97167f053.gif) |

The trick was to parse the newline characters as a part of the comment node in the Erlang grammar and then inject comments together as `injection.combined` (along with `injection.include-children` to ensure that everything is re-parsed). (I know something similar is desired for rust doc comments and markdown. Maybe the same technique would work there too?)