### PR TITLE
Update CSS syntax highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -426,7 +426,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "css"
-source = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "94e10230939e702b4fa3fa2cb5c3bc7173b95d07" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
 
 [[language]]
 name = "scss"

--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -1,6 +1,12 @@
 (comment) @comment
 
 [
+ (tag_name)
+ (nesting_selector)
+ (universal_selector)
+] @tag
+
+[
  "~"
  ">"
  "+"
@@ -22,24 +28,16 @@
  "or"
 ] @keyword.operator
 
-((universal_selector) "*") @tag
-
-[
- (tag_name)
- (nesting_selector)
- (universal_selector)
-] @tag
-
 ((property_name) @variable
  (#match? @variable "^--"))
 ((plain_value) @variable
  (#match? @variable "^--"))
 
 (attribute_name) @attribute
-(class_name) @type
+(class_name) @label
 (feature_name) @variable.other.member
 (function_name) @function
-(id_name) @attribute
+(id_name) @label
 (namespace_name) @namespace
 (property_name) @variable.other.member
 

--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -1,64 +1,88 @@
 (comment) @comment
 
-(tag_name) @tag
-(nesting_selector) @tag
-(universal_selector) @tag
+[
+ "~"
+ ">"
+ "+"
+ "-"
+ "*"
+ "/"
+ "="
+ "^="
+ "|="
+ "~="
+ "$="
+ "*="
+] @operator
 
-"~" @operator
-">" @operator
-"+" @operator
-"-" @operator
-"*" @operator
-"/" @operator
-"=" @operator
-"^=" @operator
-"|=" @operator
-"~=" @operator
-"$=" @operator
-"*=" @operator
+[
+ "and"
+ "not"
+ "only"
+ "or"
+] @keyword.operator
 
-"and" @operator
-"or" @operator
-"not" @operator
-"only" @operator
+((universal_selector) "*") @tag
 
-(attribute_selector (plain_value) @string)
-(pseudo_element_selector (tag_name) @attribute)
-(pseudo_class_selector (class_name) @attribute)
-
-(class_name) @variable.other.member
-(id_name) @variable.other.member
-(namespace_name) @variable.other.member
-(property_name) @variable.other.member
-(feature_name) @variable.other.member
-
-(attribute_name) @attribute
-
-(function_name) @function
+[
+ (tag_name)
+ (nesting_selector)
+ (universal_selector)
+] @tag
 
 ((property_name) @variable
  (#match? @variable "^--"))
 ((plain_value) @variable
  (#match? @variable "^--"))
 
-"@media" @keyword
-"@import" @keyword
-"@charset" @keyword
-"@namespace" @keyword
-"@supports" @keyword
-"@keyframes" @keyword
-(at_keyword) @keyword
-(to) @keyword
-(from) @keyword
-(important) @keyword
+(attribute_name) @attribute
+(class_name) @type
+(feature_name) @variable.other.member
+(function_name) @function
+(id_name) @attribute
+(namespace_name) @namespace
+(property_name) @variable.other.member
+
+[
+ "@charset"
+ "@import"
+ "@keyframes"
+ "@media"
+ "@namespace"
+ "@supports"
+ (at_keyword)
+ (from)
+ (important)
+ (to)
+] @keyword
+
+[
+ "#"
+ "."
+] @punctuation
 
 (string_value) @string
+((color_value) "#") @string.special
 (color_value) @string.special
 
 (integer_value) @constant.numeric.integer
 (float_value) @constant.numeric.float
 (unit) @type
 
-"#" @punctuation.delimiter
-"," @punctuation.delimiter
-":" @punctuation.delimiter
+[
+ ")"
+ "("
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ ","
+ ";"
+ ":"
+ "::"
+] @punctuation.delimiter
+
+(plain_value) @constant

--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -65,7 +65,7 @@
 
 (integer_value) @constant.numeric.integer
 (float_value) @constant.numeric.float
-(unit) @type
+(unit) @constant.numeric
 
 [
  ")"

--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -65,7 +65,6 @@
 
 (integer_value) @constant.numeric.integer
 (float_value) @constant.numeric.float
-(unit) @constant.numeric
 
 [
  ")"


### PR DESCRIPTION
Bump the tree-sitter-css version to fix issues with spaces before colons, adds missing highlights, attempts to make other highlights more consistent, and organises the rest.