### PR TITLE
Update tree-sitter-java and add Java textobjects

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -55,7 +55,7 @@
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | ini | ✓ |  |  |  |
-| java | ✓ |  |  | `jdtls` |
+| java | ✓ | ✓ |  | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jsdoc | ✓ |  |  |  |
 | json | ✓ |  | ✓ | `vscode-json-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -617,7 +617,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "java"
-source = { git = "https://github.com/tree-sitter/tree-sitter-java", rev = "bd6186c24d5eb13b4623efac9d944dcc095c0dad" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-java", rev = "09d650def6cdf7f479f4b78f595e9ef5b58ce31e" }
 
 [[language]]
 name = "ledger"

--- a/runtime/queries/java/highlights.scm
+++ b/runtime/queries/java/highlights.scm
@@ -21,6 +21,8 @@
   name: (identifier) @type)
 (class_declaration
   name: (identifier) @type)
+(record_declaration
+  name: (identifier) @type)
 (enum_declaration
   name: (identifier) @type)
 
@@ -32,6 +34,8 @@
  (#match? @type "^[A-Z]"))
 
 (constructor_declaration
+  name: (identifier) @type)
+(compact_constructor_declaration
   name: (identifier) @type)
 
 (type_identifier) @type
@@ -59,6 +63,7 @@
   (hex_integer_literal)
   (decimal_integer_literal)
   (octal_integer_literal)
+  (binary_integer_literal)
 ] @constant.numeric.integer
 
 [
@@ -67,7 +72,11 @@
 ] @constant.numeric.float
 
 (character_literal) @constant.character
-(string_literal) @string
+
+[
+  (string_literal)
+  (text_block)
+] @string
 
 [
   (true)
@@ -75,7 +84,8 @@
   (null_literal)
 ] @constant.builtin
 
-(comment) @comment
+(line_comment) @comment
+(block_comment) @comment
 
 ; Keywords
 
@@ -104,15 +114,19 @@
   "module"
   "native"
   "new"
+  "non-sealed"
   "open"
   "opens"
   "package"
+  "permits"
   "private"
   "protected"
   "provides"
   "public"
   "requires"
+  "record"
   "return"
+  "sealed"
   "static"
   "strictfp"
   "switch"
@@ -127,4 +141,5 @@
   "volatile"
   "while"
   "with"
+  "yield"
 ] @keyword

--- a/runtime/queries/java/injections.scm
+++ b/runtime/queries/java/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
+([(line_comment) (block_comment)] @injection.content
  (#set! injection.language "comment"))

--- a/runtime/queries/java/textobjects.scm
+++ b/runtime/queries/java/textobjects.scm
@@ -1,0 +1,35 @@
+(method_declaration
+  body: (_) @function.inside) @function.around
+
+(interface_declaration
+  body: (_) @class.inside) @class.around
+
+(class_declaration
+  body: (_) @class.inside) @class.around
+
+(record_declaration
+  body: (_) @class.inside) @class.around
+
+(enum_declaration
+  body: (_) @class.inside) @class.around
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(type_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(type_arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(argument_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inside
+
+(line_comment)+ @comment.around
+
+(block_comment) @comment.around


### PR DESCRIPTION
tree-sitter-java [gained support](https://github.com/tree-sitter/tree-sitter-java/compare/bd6186c24d5eb13b4623efac9d944dcc095c0dad...09d650def6cdf7f479f4b78f595e9ef5b58ce31e) for Java """text blocks""", switch expressions, and records, so I figured it was time to update it.