### PR TITLE
Remove selections for closed views on all documents

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1116,9 +1116,10 @@ impl Editor {
     }
 
     pub fn close(&mut self, id: ViewId) {
-        let (_view, doc) = current!(self);
-        // remove selection
-        doc.remove_view(id);
+        // Remove selections for the closed view on all documents.
+        for doc in self.documents_mut() {
+            doc.remove_view(id);
+        }
         self.tree.remove(id);
         self._refresh();
     }


### PR DESCRIPTION
Previously we removed selections for a closed view on only the currently focused document. A view might have selections in other documents though, so the view needs to be removed from all documents.

Closes #4878