### PR TITLE
Optimizes View::screen_coords_at_pos by not computing char_to_line two times

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -95,7 +95,8 @@ pub use {regex, tree_sitter};
 
 pub use graphemes::RopeGraphemes;
 pub use position::{
-    coords_at_pos, pos_at_coords, pos_at_visual_coords, visual_coords_at_pos, Position,
+    coords_at_pos, pos_at_coords, pos_at_visual_coords, visual_col_position, visual_coords_at_pos,
+    Position,
 };
 pub use selection::{Range, Selection};
 pub use smallvec::{smallvec, SmallVec};


### PR DESCRIPTION
This solves a todo  in `View::screen_coords_at_pos` method to not compute `char_to_line` two times. 

I've introduced a new function `core::visual_col_position` which additionally accepts a row index. Also I've made corresponding changes in `core::position` module to remove some code duplication.