### PR TITLE
Only write newlines in menu selection popup if the lsp returns detail

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -394,7 +394,7 @@ impl Component for Completion {
                             "```{}\n{}\n```\n{}",
                             language,
                             option.detail.as_deref().unwrap_or_default(),
-                            contents.clone()
+                            contents
                         ),
                         cx.editor.syn_loader.clone(),
                     )
@@ -404,15 +404,14 @@ impl Component for Completion {
                     value: contents,
                 })) => {
                     // TODO: set language based on doc scope
-                    Markdown::new(
-                        format!(
-                            "```{}\n{}\n```\n{}",
-                            language,
-                            option.detail.as_deref().unwrap_or_default(),
-                            contents.clone()
-                        ),
-                        cx.editor.syn_loader.clone(),
-                    )
+                    if let Some(detail) = &option.detail.as_deref() {
+                        Markdown::new(
+                            format!("```{}\n{}\n```\n{}", language, detail, contents),
+                            cx.editor.syn_loader.clone(),
+                        )
+                    } else {
+                        Markdown::new(contents.to_string(), cx.editor.syn_loader.clone())
+                    }
                 }
                 None if option.detail.is_some() => {
                     // TODO: copied from above


### PR DESCRIPTION
Before:
![menu_selection_popup_before](https://user-images.githubusercontent.com/45574139/204097935-b3fe5d5f-e53e-4d86-bb5d-bd34ac521578.png)

After:
![menu_selection_popup_after](https://user-images.githubusercontent.com/45574139/204097952-43ae5683-ba98-4aea-a740-a1935bde9e0c.png)
