### PR TITLE
Fix Go variable indentation

### DIFF
--- a/runtime/queries/go/indents.scm
+++ b/runtime/queries/go/indents.scm
@@ -16,6 +16,7 @@
   (block)
   (type_switch_statement)
   (expression_switch_statement)
+  (var_declaration)
 ] @indent
 
 [


### PR DESCRIPTION
Fixes #4877 
This fix correctly indents factored variable declarations.