### PR TITLE
Fix file-types declaration for racket

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -95,7 +95,7 @@
 | python | ✓ | ✓ | ✓ | `pylsp` |
 | qml | ✓ |  | ✓ | `qmlls` |
 | r | ✓ |  |  | `R` |
-| racket |  |  |  | `racket` |
+| racket | ✓ |  |  | `racket` |
 | regex | ✓ |  |  |  |
 | rescript | ✓ | ✓ |  | `rescript-language-server` |
 | rmarkdown | ✓ |  | ✓ | `R` |

--- a/languages.toml
+++ b/languages.toml
@@ -880,6 +880,7 @@ file-types = ["rkt"]
 shebangs = ["racket"]
 comment-token = ";"
 language-server = { command = "racket", args = ["-l", "racket-langserver"] }
+grammar = "scheme"
 
 [[language]]
 name = "comment"
@@ -1526,7 +1527,7 @@ source = { git = "https://github.com/metio/tree-sitter-ssh-client-config", rev =
 name = "scheme"
 scope = "source.scheme"
 injection-regex = "scheme"
-file-types = ["ss", "rkt"] # "scm",
+file-types = ["ss"] # "scm",
 roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }

--- a/runtime/queries/racket/highlights.scm
+++ b/runtime/queries/racket/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: scheme

--- a/runtime/queries/racket/injections.scm
+++ b/runtime/queries/racket/injections.scm
@@ -1,0 +1,1 @@
+; inherits: scheme


### PR DESCRIPTION
Both the racket and scheme entries used the rkt file-extension. This commit removes that entry for scheme and so that the racket entry takes precedence. We explicitly point to the scheme grammar now and setup queries that inherit from scheme. This should enable using the racket language server configuration.

Closes #4913 