### PR TITLE
Bump ropey to 1.5.1-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "ropey"
-version = "1.5.0"
+version = "1.5.1-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd22239fafefc42138ca5da064f3c17726a80d2379d817a3521240e78dd0064"
+checksum = "917e62c0dee8926492dd13164b3cefaad2b0e03ab49f48c0d41635797a7409b3"
 dependencies = [
  "smallvec",
  "str_indices",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -17,7 +17,7 @@ integration = []
 [dependencies]
 helix-loader = { version = "0.6", path = "../helix-loader" }
 
-ropey = { version = "1.5", default-features = false, features = ["simd"] }
+ropey = { version = "1.5.1-alpha", default-features = false, features = ["simd"] }
 smallvec = "1.10"
 smartstring = "1.0.1"
 unicode-segmentation = "1.10"


### PR DESCRIPTION
This `ropey` release contains multiple bugfixes and performance improvements for the line iterator.
Unblocks #4457 and #3890