### PR TITLE
fix(grammar): Add `block_comment` and `comment_environment` injection for latex comments

### DIFF
--- a/runtime/queries/latex/injections.scm
+++ b/runtime/queries/latex/injections.scm
@@ -1,2 +1,6 @@
-((line_comment) @injection.content
- (#set! injection.language "comment"))
+([
+   (comment)
+   (line_comment)
+   (block_comment)
+   (comment_environment)
+ ] @injection.content (#set! injection.language "comment"))


### PR DESCRIPTION
This adds the remaining comment injections to `latex/injections.scm`.
I've looked at the rust grammar to find out how I should add those.

Fixes #4921.