### PR TITLE
Add `:pipe-to` typable command that ignores shell output

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -71,4 +71,5 @@
 | `:insert-output` | Run shell command, inserting output before each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
+| `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh` | Run a shell command |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1739,14 +1739,14 @@ fn pipe_to(
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
-    _pipe(cx, args, event, &ShellBehavior::Ignore)
+    pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
 
 fn pipe(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
-    _pipe(cx, args, event, &ShellBehavior::Replace)
+    pipe_impl(cx, args, event, &ShellBehavior::Replace)
 }
 
-fn _pipe(
+fn pipe_impl(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
     event: PromptEvent,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1734,13 +1734,30 @@ fn insert_output(
     Ok(())
 }
 
+fn pipe_to(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    _pipe(cx, args, event, &ShellBehavior::Ignore)
+}
+
 fn pipe(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+    _pipe(cx, args, event, &ShellBehavior::Replace)
+}
+
+fn _pipe(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+    behavior: &ShellBehavior,
+) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
     ensure!(!args.is_empty(), "Shell command required");
-    shell(cx, &args.join(" "), &ShellBehavior::Replace);
+    shell(cx, &args.join(" "), behavior);
     Ok(())
 }
 
@@ -2283,6 +2300,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Pipe each selection to the shell command.",
             fun: pipe,
+            completer: None,
+        },
+        TypableCommand {
+            name: "pipe-to",
+            aliases: &[],
+            doc: "Pipe each selection to the shell command, ignoring output.",
+            fun: pipe_to,
             completer: None,
         },
         TypableCommand {


### PR DESCRIPTION
I often use an editor in conjunction with a REPL open in another terminal.
To quickly send commands from my editor to the REPL I pipe the editor selection into kitty's remote control feature: `kitty @ send-text --match recent:1 --stdin`.

In kakoune I could set up a keybinding utilizing the `pipe-to` command <Alt-|> and pass the shell command directly.
For helix I can only pass the command to typed arguments, but there is currently no typed command to pipe selections to shell commands while ignoring the output.

My suggestion is this:
Add a `:pipe-to` command which is essentially a copy of the `:pipe` command, but uses `ShellBehavior::Ignore` instead of the hard-coded `ShellBehavior::Replace`.