### PR TITLE
Enable progressive keyboard enhancement protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -350,7 +350,7 @@ experience.
 | `Alt-d`, `Alt-Delete`                       | Delete next word            | `delete_word_forward`    |
 | `Ctrl-u`                                    | Delete to start of line     | `kill_to_line_start`     |
 | `Ctrl-k`                                    | Delete to end of line       | `kill_to_line_end`       |
-| `Ctrl-h`, `Backspace`                       | Delete previous char        | `delete_char_backward`   |
+| `Ctrl-h`, `Backspace`, `Shift-Backspace`    | Delete previous char        | `delete_char_backward`   |
 | `Ctrl-d`, `Delete`                          | Delete next char            | `delete_char_forward`    |
 | `Ctrl-j`, `Enter`                           | Insert new line             | `insert_newline`         |
 
@@ -431,7 +431,7 @@ Keys to use within prompt, Remapping currently not supported.
 | `Alt-d`, `Alt-Delete`, `Ctrl-Delete`        | Delete next word                                                        |
 | `Ctrl-u`                                    | Delete to start of line                                                 |
 | `Ctrl-k`                                    | Delete to end of line                                                   |
-| `Backspace`, `Ctrl-h`                       | Delete previous char                                                    |
+| `Backspace`, `Ctrl-h`, `Shift-Backspace`    | Delete previous char                                                    |
 | `Delete`, `Ctrl-d`                          | Delete next char                                                        |
 | `Ctrl-s`                                    | Insert a word under doc cursor, may be changed to Ctrl-r Ctrl-w later   |
 | `Ctrl-p`, `Up`                              | Select previous history                                                 |

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -41,7 +41,7 @@ which = "4.4"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.25", features = ["event-stream"] }
+crossterm = { version = "0.26", features = ["event-stream"] }
 signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -40,7 +40,8 @@ use anyhow::{Context, Error};
 use crossterm::{
     event::{
         DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
-        EnableFocusChange, EnableMouseCapture, Event as CrosstermEvent,
+        EnableFocusChange, EnableMouseCapture, Event as CrosstermEvent, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute, terminal,
     tty::IsTty,
@@ -111,6 +112,9 @@ fn restore_term() -> Result<(), Error> {
     let mut stdout = stdout();
     // reset cursor shape
     write!(stdout, "\x1B[0 q")?;
+    if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
+        execute!(stdout, PopKeyboardEnhancementFlags)?;
+    }
     // Ignore errors on disabling, this might trigger on windows if we call
     // disable without calling enable previously
     let _ = execute!(stdout, DisableMouseCapture);
@@ -1056,6 +1060,19 @@ impl Application {
         if self.config.load().editor.mouse {
             execute!(stdout, EnableMouseCapture)?;
         }
+        if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
+            log::debug!("The enhanced keyboard protocol is supported on this terminal");
+            execute!(
+                stdout,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+                )
+            )?;
+        } else {
+            log::debug!("The enhanced keyboard protocol is not supported on this terminal");
+        }
+
         Ok(())
     }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -363,7 +363,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "A-d" | "A-del" => delete_word_forward,
         "C-u" => kill_to_line_start,
         "C-k" => kill_to_line_end,
-        "C-h" | "backspace" => delete_char_backward,
+        "C-h" | "backspace" | "S-backspace" => delete_char_backward,
         "C-d" | "del" => delete_char_forward,
         "C-j" | "ret" => insert_newline,
         "tab" => insert_tab,

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -516,7 +516,7 @@ impl Component for Prompt {
             alt!('d') | alt!(Delete) | ctrl!(Delete) => self.delete_word_forwards(cx.editor),
             ctrl!('k') => self.kill_to_end_of_line(cx.editor),
             ctrl!('u') => self.kill_to_start_of_line(cx.editor),
-            ctrl!('h') | key!(Backspace) => {
+            ctrl!('h') | key!(Backspace) | shift!(Backspace) => {
                 self.delete_char_backwards(cx.editor);
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -19,7 +19,7 @@ default = ["crossterm"]
 bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.10"
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.26", optional = true }
 termini = "0.1"
 serde = { version = "1", "optional" = true, features = ["derive"]}
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -1,6 +1,6 @@
 use crate::{backend::Backend, buffer::Cell};
 use crossterm::{
-    cursor::{CursorShape, Hide, MoveTo, SetCursorShape, Show},
+    cursor::{Hide, MoveTo, SetCursorStyle, Show},
     execute, queue,
     style::{
         Attribute as CAttribute, Color as CColor, Print, SetAttribute, SetBackgroundColor,
@@ -156,12 +156,12 @@ where
 
     fn show_cursor(&mut self, kind: CursorKind) -> io::Result<()> {
         let shape = match kind {
-            CursorKind::Block => CursorShape::Block,
-            CursorKind::Bar => CursorShape::Line,
-            CursorKind::Underline => CursorShape::UnderScore,
+            CursorKind::Block => SetCursorStyle::SteadyBlock,
+            CursorKind::Bar => SetCursorStyle::SteadyBar,
+            CursorKind::Underline => SetCursorStyle::SteadyUnderScore,
             CursorKind::Hidden => unreachable!(),
         };
-        map_error(execute!(self.buffer, Show, SetCursorShape(shape)))
+        map_error(execute!(self.buffer, Show, shape))
     }
 
     fn get_cursor(&mut self) -> io::Result<(u16, u16)> {

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -20,7 +20,7 @@ helix-core = { version = "0.6", path = "../helix-core" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
 helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.26", optional = true }
 helix-vcs = { version = "0.6", path = "../helix-vcs" }
 
 # Conversion traits


### PR DESCRIPTION
See the Kitty documentation on this: https://sw.kovidgoyal.net/kitty/keyboard-protocol/

Key events given by the terminal are limited by default: the terminal confuses keycodes like C-i and tab and can't tell the difference between backspace and S-backspace or ret and S-ret. We can detect support for an enhanced keyboard protocol and enable that protocol to be able to disambiguate these keys on terminals which support the protocol.

Closes https://github.com/helix-editor/helix/issues/3725
Closes https://github.com/helix-editor/helix/issues/3210
Closes https://github.com/helix-editor/helix/issues/1085
Closes https://github.com/helix-editor/helix/issues/5765