### PR TITLE
reset command register to update it

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -547,7 +547,7 @@ impl Component for Prompt {
                         if last_item != self.line {
                             // store in history
                             if let Some(register) = self.history_register {
-                                cx.editor.registers.push(register, self.line.clone());
+                                cx.editor.registers.write(register, vec![self.line.clone()]);
                             };
                         }
 


### PR DESCRIPTION
Fix the bug that `:` register always use the first command