### PR TITLE
Add Ctrl-i alias for Windows

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -198,7 +198,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         // z family for save/restore/combine from/to sels from register
 
-        "tab" | "C-i" => jump_forward, // tab == <C-i> on Linux, <C-i> is for Windows
+        "C-i" | "tab" => jump_forward, // tab == <C-i>
         "C-o" => jump_backward,
         "C-s" => save_selection,
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -198,7 +198,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         // z family for save/restore/combine from/to sels from register
 
-        "tab" => jump_forward, // tab == <C-i>
+        "tab" | "C-i" => jump_forward, // tab == <C-i> on Linux, <C-i> is for Windows
         "C-o" => jump_backward,
         "C-s" => save_selection,
 

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -845,11 +845,11 @@ lines.
  Type q to repeat the macro from register @ (the default).
 
  1. Move the cursor to the first line marked '-->' below.
-    Ensure your cursor is on the > of the arrow.
+    Ensure your cursor is on the '>' of the arrow.
  2. Type Q to start recording.
  3. Edit the line to look like the bottom one.
  4. Exit insert and Type Q again to stop recording.
- 5. Move to the line below and put your cursor on the > again.
+ 5. Move to the line below and put your cursor on '>' again.
  6. Type q to repeat the macro.
 
  --> ... sentence doesn't have it's first and last ... .

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -671,8 +671,8 @@ _________________________________________________________________
     for instance.
 
  --> This is some text for you to repeat things. You can repeat
- --> insertions like changing words, or repeat selections like
- --> f / t.
+     insertions like changing words, or repeat selections like
+     f / t.
 
 
 
@@ -845,16 +845,16 @@ lines.
  Type q to repeat the macro from register @ (the default).
 
  1. Move the cursor to the first line marked '-->' below.
-    Ensure your cursor is on the '>' of the arrow.
+    Ensure your cursor is on the > of the arrow.
  2. Type Q to start recording.
  3. Edit the line to look like the bottom one.
  4. Exit insert and Type Q again to stop recording.
- 5. Move to the line below and put your cursor on '>' again.
+ 5. Move to the line below and put your cursor on the > again.
  6. Type q to repeat the macro.
 
- --> ... sentence doesn't have its first and last ... .
- --> ... sentence doesn't have its first and last ... .
-     This sentence doesn't have its first and last word.
+ --> ... sentence doesn't have it's first and last ... .
+ --> ... sentence doesn't have it's first and last ... .
+     This sentence doesn't have it's first and last word.
 
 =================================================================
 =                        CHAPTER 8 RECAP                        =

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -671,8 +671,8 @@ _________________________________________________________________
     for instance.
 
  --> This is some text for you to repeat things. You can repeat
-     insertions like changing words, or repeat selections like
-     f / t.
+ --> insertions like changing words, or repeat selections like
+ --> f / t.
 
 
 
@@ -852,9 +852,9 @@ lines.
  5. Move to the line below and put your cursor on '>' again.
  6. Type q to repeat the macro.
 
- --> ... sentence doesn't have it's first and last ... .
- --> ... sentence doesn't have it's first and last ... .
-     This sentence doesn't have it's first and last word.
+ --> ... sentence doesn't have its first and last ... .
+ --> ... sentence doesn't have its first and last ... .
+     This sentence doesn't have its first and last word.
 
 =================================================================
 =                        CHAPTER 8 RECAP                        =


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/4874, closes https://github.com/helix-editor/helix/issues/4864

Tested on both Linux and Windows, the aliases don't seem to conflict each other.

"tab" on Linux works as both tab and C-i and "C-i" itself doesn't do anything on gnome terminal.

While on Windows tab works as tab and "C-i" works as C-i.