### PR TITLE
nightfox theme: Use brighter colors for diff scopes

### DIFF
--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -140,10 +140,10 @@
 # Diff ==============================
 # Version control changes.
 
-"diff.plus" = "green-dim" # Additions.
-"diff.minus" = "red-dim" # Deletions.
-"diff.delta" = "blue-dim" # Modifications.
-"diff.delta.moved" = "cyan-dim" # Renamed or moved files.
+"diff.plus" = "green" # Additions.
+"diff.minus" = "red" # Deletions.
+"diff.delta" = "blue" # Modifications.
+"diff.delta.moved" = "cyan" # Renamed or moved files.
 
 # color palette
 [palette]


### PR DESCRIPTION
Hi, I just fix the  nightfox theme Diff sign color too dumb， so that can no see it in the code edit view.
Please take a moment to see this，Thanks！