### PR TITLE
feat(lang): bump tree-sitter-go

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -301,7 +301,7 @@ args = { mode = "local", processId = "{0}" }
 
 [[grammar]]
 name = "go"
-source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "05900faa3cdb5d2d8c8bd5e77ee698487e0a8611" }
 
 [[language]]
 name = "gomod"

--- a/runtime/queries/go/indents.scm
+++ b/runtime/queries/go/indents.scm
@@ -5,7 +5,7 @@
   (type_spec)
   (func_literal)
   (literal_value)
-  (element)
+  (literal_element)
   (keyed_element)
   (expression_case)
   (default_case)


### PR DESCRIPTION
Update tree-sitter-go to latest with updated support for generics.

See: https://github.com/tree-sitter/tree-sitter-go/compare/0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75..05900faa3cdb5d2d8c8bd5e77ee698487e0a8611 for full diff.