### PR TITLE
feat(themes): fleetish highlight for diffs

### DIFF
--- a/runtime/themes/fleetish.toml
+++ b/runtime/themes/fleetish.toml
@@ -54,9 +54,9 @@
 "markup.raw" = "pink" # .inline
 "markup.raw.block" = "orange"
 
-"diff.plus" = "cyan"
-"diff.minus" = "yellow"
-"diff.delta" = "purple"
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "blue"
 
 # ui specific
 "ui.background" = { bg = "#0d0d0d" } # .separator

--- a/runtime/themes/fleetish.toml
+++ b/runtime/themes/fleetish.toml
@@ -54,9 +54,9 @@
 "markup.raw" = "pink" # .inline
 "markup.raw.block" = "orange"
 
-"diff.plus" = "green"
-"diff.minus" = "red"
-"diff.delta" = "blue"
+"diff.plus" = "#afcb85"
+"diff.minus" = "#f44747"
+"diff.delta" = "#52a7f6"
 
 # ui specific
 "ui.background" = { bg = "#0d0d0d" } # .separator


### PR DESCRIPTION
(tiny PR) Improve colors for diff highlighting for fleetish theme. Previously used colors work nicely for text but have (in my opinion) too low contrast to work well with the gutter git signs as well as non-standard color coding that might make it confusing. This PR re-uses already defined colors for red, green, and blue for diff highligting.

**before**:

<img width="587" alt="Screenshot 2022-12-02 at 18 37 45" src="https://user-images.githubusercontent.com/15747583/205352383-5f414511-9843-48df-8c6e-21aa3ce239d6.png">

**after**:

<img width="555" alt="Screenshot 2022-12-02 at 18 37 10" src="https://user-images.githubusercontent.com/15747583/205352422-a3a39d93-7643-4999-9632-efed23efb786.png">
