### PR TITLE
Enable auto format for css and scss files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -422,6 +422,8 @@ injection-regex = "css"
 file-types = ["css", "scss"]
 roots = []
 language-server = { command = "vscode-css-language-server", args = ["--stdio"] }
+auto-format = true
+config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -435,6 +437,8 @@ injection-regex = "scss"
 file-types = ["scss"]
 roots = []
 language-server = { command = "vscode-css-language-server", args = ["--stdio"] }
+auto-format = true
+config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Took me a while to figure out why auto format doesn't work. I think these are sensible defaults.

`provideFormatter` enables capability in LS and `auto-format` performs format on save.