### PR TITLE
feat: adapt status line separator style to focused or not

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -432,10 +432,15 @@ where
 {
     let sep = &context.editor.config().statusline.separator;
 
+    let style_key = match context.focused {
+        true => "ui.statusline.separator",
+        false => "ui.statusline.inactive",
+    };
+
     write(
         context,
         sep.to_string(),
-        Some(context.editor.theme.get("ui.statusline.separator")),
+        Some(context.editor.theme.get(style_key)),
     );
 }
 


### PR DESCRIPTION
Before this change:

![Screenshot 2022-12-03 at 16 29 55](https://user-images.githubusercontent.com/7951708/205448781-2a09d4ef-4f48-4a07-b4ba-eac80029d26a.png)

After this change:

![Screenshot 2022-12-03 at 16 30 20](https://user-images.githubusercontent.com/7951708/205448800-c048b291-9c84-4e26-a8a7-98ce6dacee8d.png)

It can be a little hard to spot: look on the right of the screenshots, at the separator character `|`