### PR TITLE
Add support for single-line comments to scss

### DIFF
--- a/runtime/queries/scss/highlights.scm
+++ b/runtime/queries/scss/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+[(comment) (single_line_comment)] @comment
 
 "~" @operator
 ">" @operator

--- a/runtime/queries/scss/injections.scm
+++ b/runtime/queries/scss/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
+([(comment) (single_line_comment)] @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Adds missing [single line comments](https://sass-lang.com/documentation/syntax/comments) support to SCSS queries.
