### PR TITLE
Fix complilation on cargo 1.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["named-profiles"]
+
 [workspace]
 members = [
   "helix-core",


### PR DESCRIPTION
This commit fix the following error:

```
$ cargo --version
cargo 1.56.0
$ cargo install --path helix-term
error: failed to parse manifest at `/home/jvoisin/Applications/helix/Cargo.toml`

Caused by:
  feature `named-profiles` is required

  The package requires the Cargo feature called `named-profiles`, but that feature is not stabilized in this version of Cargo (1.56.0).
  Consider adding `cargo-features = ["named-profiles"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#custom-named-profiles for more information about the status of this feature.
[101]
```