### PR TITLE
Rework text rendering and integrate softwrap rendering

### DIFF
--- a/helix-core/src/doc_cursor.rs
+++ b/helix-core/src/doc_cursor.rs
@@ -1,0 +1,275 @@
+//! The `DocumentCursor` forms the bridge between the raw document text
+//! and onscreen rendering. It behaves similar to an iterator
+//! and transverses (part) of the document text. During that transversal it
+//! handles grapheme detection, softwrapping and annotation.
+//! The result are [`Word`]s which are chunks of graphemes placed at **visual**
+//! coordinates.
+//!
+//! The document cursor very flexible and be used to efficently map char positions in the document
+//! to visual coordinates (and back).
+
+use std::borrow::Cow;
+use std::mem::take;
+use std::vec;
+
+use crate::graphemes::{Grapheme, StyledGrapheme};
+use crate::{LineEnding, Position, RopeGraphemes, RopeSlice};
+
+pub trait AnnotationSource<'a> {
+    fn next_annotation_grapheme(&mut self, char_pos: usize) -> Option<Cow<'a, str>>;
+}
+
+impl<'a> AnnotationSource<'a> for () {
+    fn next_annotation_grapheme(&mut self, _char_pos: usize) -> Option<Cow<'a, str>> {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CursorConfig {
+    pub tab_width: u16,
+    pub max_wrap: usize,
+    pub max_indent_retain: usize,
+    pub wrap_indent: usize,
+    pub viewport_width: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LineBreak {
+    pub is_softwrap: bool,
+}
+
+enum WordBoundary {
+    /// Any line break
+    LineBreak,
+    /// a breaking space (' ' or \t)
+    Space,
+}
+
+#[derive(Debug)]
+pub struct Word<'d, 'a, S> {
+    pub visual_position: Position,
+    pub visual_width: usize,
+
+    pub terminating_linebreak: Option<LineBreak>,
+    pub graphmes: vec::Drain<'d, StyledGrapheme<'a, S>>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum IndentLevel {
+    /// Indentation is disabled for this line because it wrapped for too long
+    None,
+    /// Indentation level is not yet known for this line because no non-whitespace char has been reached
+    /// The previous indentation level is kept so that indentation guides are not interrupted by empty lines
+    Unkown,
+    /// Identation level is known for this line
+    Known(usize),
+}
+
+#[derive(Debug)]
+pub struct DocumentCursor<'a, S: Default, A: AnnotationSource<'a>> {
+    pub config: CursorConfig,
+
+    indent_level: IndentLevel,
+    char_pos: usize,
+    visual_pos: Position,
+    doc_line: usize,
+
+    graphemes: RopeGraphemes<'a>,
+    annotation_source: &'a mut A,
+
+    word_width: usize,
+    word_buf: Vec<StyledGrapheme<'a, S>>,
+}
+
+impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
+    pub fn new(
+        text: RopeSlice<'a>,
+        config: CursorConfig,
+        char_off: usize,
+        doc_line_off: usize,
+        annotation_source: &'a mut A,
+    ) -> Self {
+        DocumentCursor {
+            config,
+            indent_level: IndentLevel::Unkown,
+            char_pos: char_off,
+            visual_pos: Position { row: 0, col: 0 },
+            doc_line: doc_line_off,
+            word_width: 0,
+            graphemes: RopeGraphemes::new(text),
+            word_buf: Vec::with_capacity(64),
+            annotation_source,
+        }
+    }
+
+    /// Byte offset from the start of the document (annotations are not counted)
+    pub fn byte_pos(&self) -> usize {
+        self.graphemes.byte_pos()
+    }
+
+    /// Byte offset from the start of the document (annotations are not counted)
+    pub fn char_pos(&self) -> usize {
+        self.char_pos
+    }
+
+    /// line and (char) column in the document (annotations and softwrap are not counted)
+    pub fn visual_pos(&self) -> Position {
+        self.visual_pos
+    }
+
+    pub fn doc_line(&self) -> usize {
+        self.doc_line
+    }
+
+    pub fn advance<const SOFTWRAP: bool>(
+        &mut self,
+        highlight_scope: (usize, S),
+    ) -> Option<Word<'_, 'a, S>> {
+        loop {
+            if self.char_pos >= highlight_scope.0 {
+                debug_assert_eq!(
+                    self.char_pos, highlight_scope.0,
+                    "Highlight scope must be aligned to grapheme boundary"
+                );
+                return None;
+            }
+
+            if self.word_width + self.visual_pos.col >= self.config.viewport_width as usize {
+                break;
+            }
+
+            let grapheme = if let Some(annotation) = self
+                .annotation_source
+                .next_annotation_grapheme(self.char_pos)
+            {
+                annotation
+            } else if let Some(grapheme) = self.graphemes.next() {
+                let codepoints = grapheme.len_chars();
+                self.char_pos += codepoints;
+                Cow::from(grapheme)
+            } else {
+                return None;
+            };
+
+            match self.push_grapheme(grapheme, highlight_scope.1) {
+                Some(WordBoundary::LineBreak) => {
+                    self.indent_level = IndentLevel::Unkown;
+                    let word = self.take_word(Some(LineBreak { is_softwrap: false }));
+                    return Some(word);
+                }
+                Some(WordBoundary::Space) => {
+                    return Some(self.take_word(None));
+                }
+                _ => (),
+            }
+        }
+
+        if SOFTWRAP {
+            let indent_carry_over = if let IndentLevel::Known(indent) = self.indent_level {
+                if indent <= self.config.max_indent_retain {
+                    indent
+                } else {
+                    self.indent_level = IndentLevel::None;
+                    0
+                }
+            } else {
+                0
+            };
+            let new_visual_col = self.config.wrap_indent + indent_carry_over;
+
+            let mut taken_graphemes = 0;
+            let mut visual_width = 0;
+            if self.word_width > self.config.max_wrap {
+                taken_graphemes = self.word_buf.len();
+                visual_width = take(&mut self.word_width);
+
+                // Usually we stop accomulating graphemes as soon as softwrapping becomes necessary.
+                // However if the last grapheme is multiple columns wide it might extend beyond the EOL.
+                // The condition below ensures that this grapheme is not yielded yet and instead wrapped to the next line
+                if self.word_width + self.visual_pos.col != self.config.viewport_width as usize {
+                    taken_graphemes -= 1;
+                    let wrapped_grapheme = self.word_buf.last_mut().unwrap();
+
+                    wrapped_grapheme
+                        .grapheme
+                        .change_position(new_visual_col, self.config.tab_width);
+                    let wrapped_grapheme_width = wrapped_grapheme.width() as usize;
+                    visual_width -= wrapped_grapheme_width;
+                    self.word_width = wrapped_grapheme_width as usize;
+                }
+            }
+
+            let word = Word {
+                visual_width,
+                graphmes: self.word_buf.drain(..taken_graphemes),
+                terminating_linebreak: Some(LineBreak { is_softwrap: true }),
+                visual_position: self.visual_pos,
+            };
+            self.visual_pos.row += 1;
+            self.visual_pos.col = new_visual_col;
+
+            Some(word)
+        } else {
+            Some(self.take_word(None))
+        }
+    }
+
+    pub fn finish(&mut self) -> impl Iterator<Item = StyledGrapheme<'a, S>> + '_ {
+        self.word_buf.drain(..)
+    }
+
+    fn push_grapheme(&mut self, grapheme: Cow<'a, str>, style: S) -> Option<WordBoundary> {
+        if LineEnding::from_str(&grapheme).is_some() {
+            // we reached EOL reset column and advance the row
+            // do not push a grapheme for the line end, instead let the caller handle decide that
+            self.word_buf.push(StyledGrapheme {
+                grapheme: Grapheme::Newline,
+                style,
+            });
+            return Some(WordBoundary::LineBreak);
+        }
+
+        let grapheme = StyledGrapheme::new(
+            grapheme,
+            style,
+            self.visual_pos.col + self.word_width,
+            self.config.tab_width,
+        );
+
+        if self.indent_level == IndentLevel::Unkown && !grapheme.is_whitespace() {
+            self.indent_level = IndentLevel::Known(self.visual_pos.col);
+        }
+
+        self.word_width += grapheme.width() as usize;
+        let word_end = if grapheme.is_breaking_space() {
+            Some(WordBoundary::Space)
+        } else {
+            None
+        };
+
+        self.word_buf.push(grapheme);
+        word_end
+    }
+
+    fn take_word(&mut self, terminating_linebreak: Option<LineBreak>) -> Word<'_, 'a, S> {
+        let visual_position = self.visual_pos;
+        if let Some(line_break) = terminating_linebreak {
+            debug_assert!(
+                !line_break.is_softwrap,
+                "Softwrapped words are handeled seperatly"
+            );
+            self.doc_line += 1;
+            self.visual_pos.row += 1;
+            self.visual_pos.col = 0;
+        } else {
+            self.visual_pos.col += self.word_width;
+        }
+        Word {
+            visual_width: take(&mut self.word_width),
+            graphmes: self.word_buf.drain(..),
+            terminating_linebreak,
+            visual_position,
+        }
+    }
+}

--- a/helix-core/src/doc_cursor.rs
+++ b/helix-core/src/doc_cursor.rs
@@ -12,31 +12,113 @@ use std::borrow::Cow;
 use std::mem::take;
 use std::vec;
 
-use crate::graphemes::{Grapheme, StyledGrapheme};
+#[cfg(test)]
+mod test;
+
+use crate::graphemes::Grapheme;
 use crate::{LineEnding, Position, RopeGraphemes, RopeSlice};
 
-pub trait AnnotationSource<'a> {
-    fn next_annotation_grapheme(&mut self, char_pos: usize) -> Option<Cow<'a, str>>;
+/// A preprossed Grapheme that is ready for rendering
+/// with attachted styling data
+#[derive(Debug)]
+pub struct StyledGraphemes<'a, S> {
+    pub grapheme: Grapheme<'a>,
+    pub style: S,
+    // the number of chars in the document required by this grapheme
+    pub doc_chars: u16,
 }
 
-impl<'a> AnnotationSource<'a> for () {
-    fn next_annotation_grapheme(&mut self, _char_pos: usize) -> Option<Cow<'a, str>> {
+impl<'a, S: Default> StyledGraphemes<'a, S> {
+    pub fn placeholder() -> Self {
+        StyledGraphemes {
+            grapheme: Grapheme::Space,
+            style: S::default(),
+            doc_chars: 0,
+        }
+    }
+
+    pub fn new(
+        raw: Cow<'a, str>,
+        style: S,
+        visual_x: usize,
+        tab_width: u16,
+        chars: u16,
+    ) -> StyledGraphemes<'a, S> {
+        StyledGraphemes {
+            grapheme: Grapheme::new(raw, visual_x, tab_width),
+            style,
+            doc_chars: chars,
+        }
+    }
+
+    pub fn is_whitespace(&self) -> bool {
+        self.grapheme.is_whitespace()
+    }
+
+    pub fn is_breaking_space(&self) -> bool {
+        self.grapheme.is_breaking_space()
+    }
+
+    /// Returns the approximate visual width of this grapheme,
+    pub fn width(&self) -> u16 {
+        self.grapheme.width()
+    }
+}
+
+/// An annotation source allows inserting virtual text during rendering
+/// that is correctly considered by the positioning and rendering code
+/// The AnnotiationSource essentially fonctions as a cursor over annotations.
+/// To facilitate efficent implementation it is garunteed that all
+/// functions except `set_pos` are only called with increasing `char_pos`.
+///
+/// Further only `char_pos` correspoding to grapehme boundries are passed to `AnnotationSource`
+pub trait AnnotationSource<'t, S> {
+    /// Yield a grapeheme to insert at the current `char_pos`.
+    /// `char_pos` will not increase as long as this funciton yields `Some` grapheme.
+    fn next_annotation_grapheme(&mut self, char_pos: usize) -> Option<(Cow<'t, str>, S)>;
+    /// This function is usuully only called when a [`DocumentCursor`] is created.
+    /// It moves the annotation source to a random `char_pos` that might be before
+    /// other char_pos previously passed to this annotation source
+    fn set_pos(&mut self, char_pos: usize);
+}
+
+impl<'a, 't, S: Default, A> AnnotationSource<'t, S> for &'a mut A
+where
+    A: AnnotationSource<'t, S>,
+{
+    fn next_annotation_grapheme(&mut self, char_pos: usize) -> Option<(Cow<'t, str>, S)> {
+        A::next_annotation_grapheme(self, char_pos)
+    }
+
+    fn set_pos(&mut self, char_pos: usize) {
+        A::set_pos(self, char_pos);
+    }
+}
+
+impl<'t, S: Default> AnnotationSource<'t, S> for () {
+    fn next_annotation_grapheme(&mut self, _char_pos: usize) -> Option<(Cow<'t, str>, S)> {
         None
     }
+
+    fn set_pos(&mut self, _char_pos: usize) {}
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct CursorConfig {
+    pub soft_wrap: bool,
     pub tab_width: u16,
-    pub max_wrap: usize,
-    pub max_indent_retain: usize,
-    pub wrap_indent: usize,
+    pub max_wrap: u16,
+    pub max_indent_retain: u16,
+    pub wrap_indent: u16,
     pub viewport_width: u16,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct LineBreak {
+    /// wether this linebreak corresponds to a softwrap
     pub is_softwrap: bool,
+    /// Amount of additional indentation to insert before this line
+    pub indent: u16,
 }
 
 enum WordBoundary {
@@ -46,90 +128,171 @@ enum WordBoundary {
     Space,
 }
 
-#[derive(Debug)]
-pub struct Word<'d, 'a, S> {
-    pub visual_position: Position,
+#[derive(Debug, Clone)]
+pub struct Word {
     pub visual_width: usize,
-
+    pub doc_char_width: usize,
     pub terminating_linebreak: Option<LineBreak>,
-    pub graphmes: vec::Drain<'d, StyledGrapheme<'a, S>>,
+    /// The graphemes in this words
+    graphemes: Option<usize>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum IndentLevel {
-    /// Indentation is disabled for this line because it wrapped for too long
-    None,
-    /// Indentation level is not yet known for this line because no non-whitespace char has been reached
-    /// The previous indentation level is kept so that indentation guides are not interrupted by empty lines
-    Unkown,
-    /// Identation level is known for this line
-    Known(usize),
+impl Word {
+    pub fn consume_graphemes<'d, 't, S: Default, A: AnnotationSource<'t, S>>(
+        &mut self,
+        cursor: &'d mut DocumentCursor<'t, S, A>,
+    ) -> vec::Drain<'d, StyledGraphemes<'t, S>> {
+        let num_graphemes = self
+            .graphemes
+            .take()
+            .expect("finish_word can only be called once for a word");
+        cursor.word_buf.drain(..num_graphemes)
+    }
+}
+
+impl Drop for Word {
+    fn drop(&mut self) {
+        if self.graphemes.is_some() {
+            unreachable!("A words graphemes must be consumed with `Word::consume_graphemes`")
+        }
+    }
 }
 
 #[derive(Debug)]
-pub struct DocumentCursor<'a, S: Default, A: AnnotationSource<'a>> {
+pub struct DocumentCursor<'t, S: Default, A: AnnotationSource<'t, S>> {
     pub config: CursorConfig,
 
-    indent_level: IndentLevel,
-    char_pos: usize,
+    indent_level: Option<usize>,
+    /// The char index of the last yielded word boundary
+    doc_char_idx: usize,
+    /// The current line index inside the documnet
+    doc_line_idx: usize,
+    /// The visual position at the end of the last yielded word boundary
     visual_pos: Position,
-    doc_line: usize,
 
-    graphemes: RopeGraphemes<'a>,
-    annotation_source: &'a mut A,
+    graphemes: RopeGraphemes<'t>,
+    annotation_source: A,
 
+    /// The visual width of the word
     word_width: usize,
-    word_buf: Vec<StyledGrapheme<'a, S>>,
+    /// The number of codepoints (chars) in the current word
+    word_doc_chars: usize,
+    word_buf: Vec<StyledGraphemes<'t, S>>,
 }
 
-impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
+impl<'t, S: Default + Copy, A: AnnotationSource<'t, S>> DocumentCursor<'t, S, A> {
+    /// Create a new `DocumentCursor` that transveres `text`.
+    /// The char/document idx is offset by `doc_char_offset`
+    /// and `doc_line_offset`.
+    /// This has no effect on the cursor itself and only affects the char
+    /// indecies passed to the `annotation_source` and used to determine when the end of the `highlight_scope`
+    /// is reached
     pub fn new(
-        text: RopeSlice<'a>,
+        text: RopeSlice<'t>,
         config: CursorConfig,
-        char_off: usize,
-        doc_line_off: usize,
-        annotation_source: &'a mut A,
+        doc_char_offset: usize,
+        doc_line_offset: usize,
+        annotation_source: A,
     ) -> Self {
+        // // TODO implement blocks that force hardwraps at specific positions to avoid backtracing huge distances for large files here
+        // let doc_line = text.char_to_line(char_pos);
+        // let doc_line_start = text.line_to_char(doc_line);
         DocumentCursor {
             config,
-            indent_level: IndentLevel::Unkown,
-            char_pos: char_off,
+            indent_level: None,
+            doc_char_idx: doc_char_offset,
+            doc_line_idx: doc_line_offset,
             visual_pos: Position { row: 0, col: 0 },
-            doc_line: doc_line_off,
-            word_width: 0,
             graphemes: RopeGraphemes::new(text),
-            word_buf: Vec::with_capacity(64),
             annotation_source,
+            word_width: 0,
+            word_doc_chars: 0,
+            word_buf: Vec::with_capacity(64),
         }
     }
 
-    /// Byte offset from the start of the document (annotations are not counted)
-    pub fn byte_pos(&self) -> usize {
-        self.graphemes.byte_pos()
+    /// Returns the last checkpoint as (char_idx, line_idx) from which the `DocumentCursor` must be started
+    /// to find the first visual line.
+    ///
+    /// Right now only document lines are used as checkpoints
+    /// which leads to inefficent rendering for extremly large wrapped lines
+    /// In the future we want to mimic led and implement blocks to chunk extermly long lines
+    fn prev_checkpoint(text: RopeSlice, doc_char_idx: usize) -> (usize, usize) {
+        let line = text.char_to_line(doc_char_idx);
+        let line_start = text.line_to_char(line);
+        (line_start, line)
     }
 
-    /// Byte offset from the start of the document (annotations are not counted)
-    pub fn char_pos(&self) -> usize {
-        self.char_pos
+    /// Creates a new cursor at the visual line start that is closest to
+    pub fn new_at_prev_line(
+        text: RopeSlice<'t>,
+        config: CursorConfig,
+        char_idx: usize,
+        mut annotation_source: A,
+    ) -> Self {
+        let (mut checkpoint_char_idx, checkpoint_line_idx) = Self::prev_checkpoint(text, char_idx);
+        let mut line_off = 0;
+        let mut indent_level = None;
+
+        if config.soft_wrap {
+            annotation_source.set_pos(checkpoint_char_idx);
+            let mut cursor = DocumentCursor::new(
+                text.slice(checkpoint_char_idx..),
+                config,
+                checkpoint_char_idx,
+                checkpoint_line_idx,
+                &mut annotation_source,
+            );
+
+            while let Some(mut word) = cursor.advance() {
+                word.consume_graphemes(&mut cursor);
+                if cursor.doc_char_idx > char_idx {
+                    break;
+                }
+                if let Some(line_break) = word.terminating_linebreak {
+                    line_off = line_break.indent;
+                    checkpoint_char_idx = cursor.doc_char_idx;
+                    indent_level = Some((line_off - config.wrap_indent) as usize);
+                }
+            }
+        }
+
+        annotation_source.set_pos(checkpoint_char_idx);
+        let mut cursor = DocumentCursor::new(
+            text.slice(checkpoint_char_idx..),
+            config,
+            checkpoint_char_idx,
+            checkpoint_line_idx,
+            annotation_source,
+        );
+
+        cursor.indent_level = indent_level;
+        cursor.visual_pos.col = line_off as usize;
+        cursor
     }
 
-    /// line and (char) column in the document (annotations and softwrap are not counted)
+    pub fn doc_line_idx(&self) -> usize {
+        self.doc_line_idx
+    }
+
+    pub fn doc_char_idx(&self) -> usize {
+        self.doc_char_idx
+    }
+
     pub fn visual_pos(&self) -> Position {
         self.visual_pos
     }
 
-    pub fn doc_line(&self) -> usize {
-        self.doc_line
+    pub fn advance(&mut self) -> Option<Word> {
+        self.advance_with_highlight((usize::MAX, S::default()))
     }
 
-    pub fn advance<const SOFTWRAP: bool>(
-        &mut self,
-        highlight_scope: (usize, S),
-    ) -> Option<Word<'_, 'a, S>> {
+    pub fn advance_with_highlight(&mut self, highlight_scope: (usize, S)) -> Option<Word> {
         loop {
-            if self.char_pos >= highlight_scope.0 {
+            if self.doc_char_idx + self.word_doc_chars >= highlight_scope.0 {
                 debug_assert_eq!(
-                    self.char_pos, highlight_scope.0,
+                    self.doc_char_idx + self.word_doc_chars,
+                    highlight_scope.0,
                     "Highlight scope must be aligned to grapheme boundary"
                 );
                 return None;
@@ -139,23 +302,26 @@ impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
                 break;
             }
 
-            let grapheme = if let Some(annotation) = self
+            let (grapheme, style, doc_chars) = if let Some(annotation) = self
                 .annotation_source
-                .next_annotation_grapheme(self.char_pos)
+                .next_annotation_grapheme(self.doc_char_idx + self.word_doc_chars)
             {
-                annotation
+                (annotation.0, annotation.1, 0)
             } else if let Some(grapheme) = self.graphemes.next() {
                 let codepoints = grapheme.len_chars();
-                self.char_pos += codepoints;
-                Cow::from(grapheme)
+                self.word_doc_chars += codepoints;
+                (Cow::from(grapheme), highlight_scope.1, codepoints as u16)
             } else {
                 return None;
             };
 
-            match self.push_grapheme(grapheme, highlight_scope.1) {
+            match self.push_grapheme(grapheme, style, doc_chars) {
                 Some(WordBoundary::LineBreak) => {
-                    self.indent_level = IndentLevel::Unkown;
-                    let word = self.take_word(Some(LineBreak { is_softwrap: false }));
+                    self.indent_level = None;
+                    let word = self.take_word(Some(LineBreak {
+                        is_softwrap: false,
+                        indent: 0,
+                    }));
                     return Some(word);
                 }
                 Some(WordBoundary::Space) => {
@@ -165,49 +331,57 @@ impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
             }
         }
 
-        if SOFTWRAP {
-            let indent_carry_over = if let IndentLevel::Known(indent) = self.indent_level {
-                if indent <= self.config.max_indent_retain {
-                    indent
+        if self.config.soft_wrap {
+            let indent_carry_over = if let Some(indent) = self.indent_level {
+                if indent as u16 <= self.config.max_indent_retain {
+                    indent as u16
                 } else {
-                    self.indent_level = IndentLevel::None;
                     0
                 }
             } else {
                 0
             };
-            let new_visual_col = self.config.wrap_indent + indent_carry_over;
+            let line_indent = indent_carry_over + self.config.wrap_indent;
 
-            let mut taken_graphemes = 0;
+            let mut num_graphemes = 0;
             let mut visual_width = 0;
-            if self.word_width > self.config.max_wrap {
-                taken_graphemes = self.word_buf.len();
+            let mut doc_chars = 0;
+            if self.word_width > self.config.max_wrap as usize {
+                num_graphemes = self.word_buf.len();
                 visual_width = take(&mut self.word_width);
+                doc_chars = take(&mut self.word_doc_chars);
 
                 // Usually we stop accomulating graphemes as soon as softwrapping becomes necessary.
                 // However if the last grapheme is multiple columns wide it might extend beyond the EOL.
                 // The condition below ensures that this grapheme is not yielded yet and instead wrapped to the next line
-                if self.word_width + self.visual_pos.col != self.config.viewport_width as usize {
-                    taken_graphemes -= 1;
+                if self.word_buf.last().map_or(false, |last| last.width() != 1) {
+                    num_graphemes -= 1;
                     let wrapped_grapheme = self.word_buf.last_mut().unwrap();
 
                     wrapped_grapheme
                         .grapheme
-                        .change_position(new_visual_col, self.config.tab_width);
+                        .change_position(line_indent as usize, self.config.tab_width);
                     let wrapped_grapheme_width = wrapped_grapheme.width() as usize;
                     visual_width -= wrapped_grapheme_width;
                     self.word_width = wrapped_grapheme_width as usize;
+                    let wrapped_grapheme_chars = wrapped_grapheme.doc_chars as usize;
+                    self.word_doc_chars = wrapped_grapheme_chars;
+                    doc_chars -= wrapped_grapheme_chars;
                 }
             }
 
             let word = Word {
                 visual_width,
-                graphmes: self.word_buf.drain(..taken_graphemes),
-                terminating_linebreak: Some(LineBreak { is_softwrap: true }),
-                visual_position: self.visual_pos,
+                graphemes: Some(num_graphemes),
+                terminating_linebreak: Some(LineBreak {
+                    is_softwrap: true,
+                    indent: line_indent,
+                }),
+                doc_char_width: doc_chars,
             };
             self.visual_pos.row += 1;
-            self.visual_pos.col = new_visual_col;
+            self.visual_pos.col = line_indent as usize;
+            self.doc_char_idx += doc_chars;
 
             Some(word)
         } else {
@@ -215,30 +389,38 @@ impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
         }
     }
 
-    pub fn finish(&mut self) -> impl Iterator<Item = StyledGrapheme<'a, S>> + '_ {
-        self.word_buf.drain(..)
+    pub fn finish(&mut self) -> Word {
+        self.take_word(None)
     }
 
-    fn push_grapheme(&mut self, grapheme: Cow<'a, str>, style: S) -> Option<WordBoundary> {
+    fn push_grapheme(
+        &mut self,
+        grapheme: Cow<'t, str>,
+        style: S,
+        doc_chars: u16,
+    ) -> Option<WordBoundary> {
         if LineEnding::from_str(&grapheme).is_some() {
             // we reached EOL reset column and advance the row
             // do not push a grapheme for the line end, instead let the caller handle decide that
-            self.word_buf.push(StyledGrapheme {
+            self.word_buf.push(StyledGraphemes {
                 grapheme: Grapheme::Newline,
                 style,
+                doc_chars,
             });
+            self.word_width += 1;
             return Some(WordBoundary::LineBreak);
         }
 
-        let grapheme = StyledGrapheme::new(
+        let grapheme = StyledGraphemes::new(
             grapheme,
             style,
             self.visual_pos.col + self.word_width,
             self.config.tab_width,
+            doc_chars,
         );
 
-        if self.indent_level == IndentLevel::Unkown && !grapheme.is_whitespace() {
-            self.indent_level = IndentLevel::Known(self.visual_pos.col);
+        if self.indent_level.is_none() && !grapheme.is_whitespace() {
+            self.indent_level = Some(self.visual_pos.col);
         }
 
         self.word_width += grapheme.width() as usize;
@@ -252,24 +434,25 @@ impl<'a, S: Default + Copy, A: AnnotationSource<'a>> DocumentCursor<'a, S, A> {
         word_end
     }
 
-    fn take_word(&mut self, terminating_linebreak: Option<LineBreak>) -> Word<'_, 'a, S> {
-        let visual_position = self.visual_pos;
+    fn take_word(&mut self, terminating_linebreak: Option<LineBreak>) -> Word {
         if let Some(line_break) = terminating_linebreak {
             debug_assert!(
                 !line_break.is_softwrap,
                 "Softwrapped words are handeled seperatly"
             );
-            self.doc_line += 1;
+            self.doc_line_idx += 1;
             self.visual_pos.row += 1;
             self.visual_pos.col = 0;
         } else {
             self.visual_pos.col += self.word_width;
         }
+        let doc_char_width = take(&mut self.word_doc_chars);
+        self.doc_char_idx += doc_char_width;
         Word {
             visual_width: take(&mut self.word_width),
-            graphmes: self.word_buf.drain(..),
+            graphemes: Some(self.word_buf.len()),
             terminating_linebreak,
-            visual_position,
+            doc_char_width,
         }
     }
 }

--- a/helix-core/src/doc_cursor/test.rs
+++ b/helix-core/src/doc_cursor/test.rs
@@ -1,0 +1,144 @@
+use crate::doc_cursor::{CursorConfig, DocumentCursor};
+
+const WRAP_INDENT: u16 = 1;
+impl CursorConfig {
+    fn new_test(softwrap: bool) -> CursorConfig {
+        CursorConfig {
+            softwrap,
+            tab_width: 2,
+            max_wrap: 3,
+            max_indent_retain: 4,
+            wrap_indent: WRAP_INDENT,
+            // use a prime number to allow linging up too often with repear
+            viewport_width: 17,
+        }
+    }
+}
+
+impl<'t> DocumentCursor<'t, (), ()> {
+    fn new_test(text: &'t str, char_pos: usize, softwrap: bool) -> Self {
+        Self::new_at_prev_line(text.into(), CursorConfig::new_test(softwrap), char_pos, ())
+    }
+
+    fn collect_to_str(&mut self, res: &mut String) {
+        use std::fmt::Write;
+        let wrap_indent = self.config.wrap_indent;
+        let viewport_width = self.config.viewport_width;
+        let mut line_width = 0;
+
+        while let Some(mut word) = self.advance() {
+            let mut word_width_check = 0;
+            let word_width = word.visual_width;
+            for grapheme in word.consume_graphemes(self) {
+                word_width_check += grapheme.width() as usize;
+                write!(res, "{}", grapheme.grapheme).unwrap();
+            }
+            assert_eq!(word_width, word_width_check);
+            line_width += word.visual_width;
+
+            if let Some(line_break) = word.terminating_linebreak {
+                assert!(
+                    line_width <= viewport_width as usize,
+                    "softwrapped failed {line_width}<={viewport_width}"
+                );
+                res.push('\n');
+                if line_break.is_softwrap {
+                    for i in 0..line_break.indent {
+                        if i < wrap_indent {
+                            res.push('.');
+                        } else {
+                            res.push(' ')
+                        }
+                    }
+                } else {
+                    assert_eq!(line_break.indent, 0);
+                }
+                line_width = line_break.indent as usize;
+            }
+        }
+
+        for grapheme in self.finish().consume_graphemes(self) {
+            write!(res, "{}", grapheme.grapheme).unwrap();
+        }
+        assert!(
+            line_width <= viewport_width as usize,
+            "softwrapped failed {line_width}<={viewport_width}"
+        );
+    }
+}
+
+fn softwrap_text(text: &str, char_pos: usize) -> String {
+    let mut cursor = DocumentCursor::new_test(text, char_pos, true);
+    let mut res = String::new();
+    for i in 0..cursor.visual_pos().col {
+        if i < WRAP_INDENT as usize {
+            res.push('.');
+        } else {
+            res.push(' ')
+        }
+    }
+    cursor.collect_to_str(&mut res);
+    res
+}
+
+#[test]
+fn basic_softwrap() {
+    assert_eq!(
+        softwrap_text(&"foo ".repeat(10), 0),
+        "foo foo foo foo \n.foo foo foo foo \n.foo foo "
+    );
+    assert_eq!(
+        softwrap_text(&"fooo ".repeat(10), 0),
+        "fooo fooo fooo \n.fooo fooo fooo \n.fooo fooo fooo \n.fooo "
+    );
+
+    // check that we don't wrap unecessarly
+    assert_eq!(
+        softwrap_text("\t\txxxx1xxxx2xx\n", 0),
+        "    xxxx1xxxx2xx \n"
+    );
+}
+
+#[test]
+fn softwrap_indentation() {
+    assert_eq!(
+        softwrap_text("\t\tfoo1 foo2 foo3 foo4 foo5 foo6\n", 0),
+        "    foo1 foo2 \n.    foo3 foo4 \n.    foo5 foo6 \n"
+    );
+    assert_eq!(
+        softwrap_text("\t\t\tfoo1 foo2 foo3 foo4 foo5 foo6\n", 0),
+        "      foo1 foo2 \n.foo3 foo4 foo5 \n.foo6 \n"
+    );
+}
+
+#[test]
+fn long_word_softwrap() {
+    assert_eq!(
+        softwrap_text("\t\txxxx1xxxx2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n", 0),
+        "    xxxx1xxxx2xxx\n.    x3xxxx4xxxx5\n.    xxxx6xxxx7xx\n.    xx8xxxx9xxx \n"
+    );
+    assert_eq!(
+        softwrap_text("xxxxxxxx1xxxx2xxx\n", 0),
+        "xxxxxxxx1xxxx2xxx\n. \n"
+    );
+    assert_eq!(
+        softwrap_text("\t\txxxx1xxxx 2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n", 0),
+        "    xxxx1xxxx \n.    2xxxx3xxxx4x\n.    xxx5xxxx6xxx\n.    x7xxxx8xxxx9\n.    xxx \n"
+    );
+    assert_eq!(
+        softwrap_text("\t\txxxx1xxx 2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n", 0),
+        "    xxxx1xxx 2xxx\n.    x3xxxx4xxxx5\n.    xxxx6xxxx7xx\n.    xx8xxxx9xxx \n"
+    );
+}
+
+#[test]
+fn softwrap_checkpoint() {
+    assert_eq!(
+        softwrap_text(&"foo ".repeat(10), 4),
+        "foo foo foo foo \n.foo foo foo foo \n.foo foo "
+    );
+    let text = "foo ".repeat(10);
+    assert_eq!(softwrap_text(&text, 18), ".foo foo foo foo \n.foo foo ");
+    println!("{}", &text[32..]);
+    assert_eq!(softwrap_text(&"foo ".repeat(10), 32), ".foo foo ");
+}

--- a/helix-core/src/doc_cursor/test.rs
+++ b/helix-core/src/doc_cursor/test.rs
@@ -4,7 +4,7 @@ const WRAP_INDENT: u16 = 1;
 impl CursorConfig {
     fn new_test(softwrap: bool) -> CursorConfig {
         CursorConfig {
-            softwrap,
+            soft_wrap: softwrap,
             tab_width: 2,
             max_wrap: 3,
             max_indent_retain: 4,

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -8,7 +8,7 @@ use unicode_width::UnicodeWidthStr;
 use std::borrow::Cow;
 use std::fmt::{self, Display};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A preprossed Grapheme that is ready for rendering
 pub enum Grapheme<'a> {
     Space,

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod comment;
 pub mod config;
 pub mod diagnostic;
 pub mod diff;
+pub mod doc_cursor;
 pub mod graphemes;
 pub mod history;
 pub mod increment;

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod diagnostic;
 pub mod diff;
 pub mod doc_cursor;
+pub mod doc_formatter;
 pub mod graphemes;
 pub mod history;
 pub mod increment;

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -96,7 +96,8 @@ pub use {regex, tree_sitter};
 
 pub use graphemes::RopeGraphemes;
 pub use position::{
-    coords_at_pos, pos_at_coords, pos_at_visual_coords, visual_coords_at_pos, Position,
+    coords_at_pos, pos_at_coords, pos_at_visual_coords, pos_at_visual_coords_2,
+    visual_coords_at_pos, visual_coords_at_pos_2, Position,
 };
 pub use selection::{Range, Selection};
 pub use smallvec::{smallvec, SmallVec};

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -1,0 +1,362 @@
+use std::borrow::Cow;
+use std::cmp::min;
+
+use helix_core::doc_cursor::{AnnotationSource, DocumentCursor};
+use helix_core::graphemes::Grapheme;
+use helix_core::str_utils::char_to_byte_idx;
+use helix_core::syntax::Highlight;
+use helix_core::syntax::HighlightEvent;
+use helix_core::{Position, RopeSlice};
+use helix_view::editor::{WhitespaceConfig, WhitespaceRenderValue};
+use helix_view::graphics::Rect;
+use helix_view::theme::Style;
+use helix_view::Theme;
+use helix_view::{editor, Document};
+use tui::buffer::Buffer as Surface;
+
+pub struct DocumentRender<'a, H: Iterator<Item = HighlightEvent>, A: AnnotationSource<'a>> {
+    pub config: &'a editor::Config,
+    pub theme: &'a Theme,
+
+    text: RopeSlice<'a>,
+    pub cursor: DocumentCursor<'a, Style, A>,
+
+    highlights: H,
+    spans: Vec<Highlight>,
+    highlight_scope: (usize, Style),
+
+    is_finished: bool,
+}
+
+impl<'a, H: Iterator<Item = HighlightEvent>, A: AnnotationSource<'a>> DocumentRender<'a, H, A> {
+    pub fn new(
+        config: &'a editor::Config,
+        theme: &'a Theme,
+        text: RopeSlice<'a>,
+        cursor: DocumentCursor<'a, Style, A>,
+        highlights: H,
+        text_render: &mut TextRender,
+    ) -> Self {
+        let mut render = DocumentRender {
+            config,
+            theme,
+            highlights,
+            cursor,
+            // render: TextRender::new(surface, render_config, offset.col, viewport),
+            spans: Vec::with_capacity(64),
+            is_finished: false,
+            highlight_scope: (0, Style::default()),
+            text,
+        };
+
+        // advance to first highlight scope
+        render.advance_highlight_scope(text_render);
+        render
+    }
+
+    /// Advance to the next treesitter highlight range
+    /// if the last one is exhaused
+    fn advance_highlight_scope(&mut self, text_render: &mut TextRender) {
+        while let Some(event) = self.highlights.next() {
+            match event {
+                HighlightEvent::HighlightStart(span) => self.spans.push(span),
+                HighlightEvent::HighlightEnd => {
+                    self.spans.pop();
+                }
+                HighlightEvent::Source { start, end } => {
+                    if start == end {
+                        continue;
+                    }
+                    // TODO cursor end
+                    let style = self
+                        .spans
+                        .iter()
+                        .fold(text_render.config.text_style, |acc, span| {
+                            acc.patch(self.theme.highlight(span.0))
+                        });
+                    self.highlight_scope = (end, style);
+                    return;
+                }
+            }
+        }
+        self.is_finished = true;
+    }
+
+    /// Returns whether this document renderer finished rendering
+    /// either because the viewport end or EOF was reached
+    pub fn is_finished(&self) -> bool {
+        self.is_finished
+    }
+
+    /// Renders the next line of the document.
+    /// If softwrapping is enabled this may only correspond to rendering a part of the line
+    ///
+    /// # Returns
+    ///
+    /// Whether the rendered line was only partially rendered because the viewport end was reached
+    pub fn render_line<const SOFTWRAP: bool>(&mut self, text_render: &mut TextRender) {
+        if self.is_finished {
+            return;
+        }
+
+        loop {
+            while let Some(word) = self.cursor.advance::<SOFTWRAP>(self.highlight_scope) {
+                text_render.posititon = word.visual_position;
+                for grapheme in word.graphmes {
+                    text_render.draw_grapheme(grapheme);
+                }
+
+                let line_break = if let Some(line_break) = word.terminating_linebreak {
+                    line_break
+                } else {
+                    continue;
+                };
+
+                if self.config.indent_guides.render {
+                    text_render.draw_indent_guides();
+                }
+                if !line_break.is_softwrap {
+                    // render EOL space
+                    text_render.draw_grapheme(StyledGrapheme {
+                        grapheme: Grapheme::Space,
+                        style: self.highlight_scope.1,
+                    });
+                }
+
+                if self.config.indent_guides.render {
+                    text_render.draw_indent_guides()
+                }
+                text_render.posititon.row += 1;
+                self.is_finished = text_render.reached_viewport_end();
+                return;
+            }
+
+            self.advance_highlight_scope(text_render);
+
+            // we properly reached the text end, this is the end of the last line
+            // render remaining text
+            if self.is_finished {
+                // the last word is garunteed to fit on the last line
+                // and to not wrap (otherwise it would have been yielded before)
+                // render it
+                for grapheme in self.cursor.finish() {
+                    text_render.draw_grapheme(grapheme);
+                }
+
+                if self.highlight_scope.0 > self.text.len_chars() {
+                    // trailing cursor is rendered as a whitespace
+                    text_render.draw_grapheme(StyledGrapheme {
+                        grapheme: Grapheme::Space,
+                        style: self.highlight_scope.1,
+                    });
+                }
+
+                return;
+            }
+
+            // we reached the viewport end but the line was only partially rendered
+            if text_render.reached_viewport_end() {
+                if self.config.indent_guides.render {
+                    text_render.draw_indent_guides()
+                }
+                self.is_finished = true;
+                return;
+            }
+        }
+    }
+}
+
+pub type StyledGrapheme<'a> = helix_core::graphemes::StyledGrapheme<'a, Style>;
+
+/// A TextRender Basic grapheme rendering and visual position tracking
+#[derive(Debug)]
+pub struct TextRender<'a> {
+    /// Surface to render to
+    surface: &'a mut Surface,
+    /// Various constants required for rendering
+    pub config: &'a TextRenderConfig,
+    viewport: Rect,
+    col_offset: usize,
+    indent_known: bool,
+    indent_level: usize,
+    pub posititon: Position,
+}
+
+impl<'a> TextRender<'a> {
+    pub fn new(
+        surface: &'a mut Surface,
+        config: &'a TextRenderConfig,
+        col_offset: usize,
+        viewport: Rect,
+    ) -> TextRender<'a> {
+        TextRender {
+            surface,
+            config,
+            viewport,
+            col_offset,
+            posititon: Position { row: 0, col: 0 },
+            indent_level: 0,
+            indent_known: false,
+        }
+    }
+
+    /// Draws a single `grapheme` at the current render position with a specified `style`.
+    pub fn draw_grapheme(&mut self, styled_grapheme: StyledGrapheme) {
+        let cut_off_start = self.col_offset.saturating_sub(self.posititon.row as usize);
+        let is_whitespace = styled_grapheme.is_whitespace();
+
+        let style = if is_whitespace {
+            styled_grapheme.style.patch(self.config.whitespace_style)
+        } else {
+            styled_grapheme.style
+        };
+        let (width, grapheme) = match styled_grapheme.grapheme {
+            Grapheme::Tab { width } => {
+                let grapheme_tab_width = char_to_byte_idx(&self.config.tab, width as usize);
+                (width, Cow::from(&self.config.tab[..grapheme_tab_width]))
+            }
+
+            Grapheme::Space => (1, Cow::from(&self.config.space)),
+            Grapheme::Nbsp => (1, Cow::from(&self.config.nbsp)),
+            Grapheme::Other { width, raw: str } => (width, str),
+            Grapheme::Newline => (1, Cow::from(&self.config.newline)),
+        };
+
+        if self.in_bounds() {
+            self.surface.set_string(
+                self.viewport.x + (self.posititon.col - self.col_offset) as u16,
+                self.viewport.y + self.posititon.row as u16,
+                grapheme,
+                style,
+            );
+        } else if cut_off_start != 0 && cut_off_start < width as usize {
+            // partially on screen
+            let rect = Rect::new(
+                self.viewport.x as u16,
+                self.viewport.y + self.posititon.row as u16,
+                width - cut_off_start as u16,
+                1,
+            );
+            self.surface.set_style(rect, style);
+        }
+
+        if !is_whitespace && !self.indent_known {
+            self.indent_known = true;
+            self.indent_level = self.posititon.col;
+        }
+        self.posititon.col += width as usize;
+    }
+
+    /// Returns whether the current column is in bounds
+    fn in_bounds(&self) -> bool {
+        self.col_offset <= (self.posititon.col as usize)
+            && (self.posititon.col as usize) < self.viewport.width as usize + self.col_offset
+    }
+
+    /// Overlay indentation guides ontop of a rendered line
+    /// The indentation level is computed in `draw_lines`.
+    /// Therefore this function must always be called afterwards.
+    pub fn draw_indent_guides(&mut self) {
+        // Don't draw indent guides outside of view
+        let end_indent = min(
+            self.indent_level,
+            // Add tab_width - 1 to round up, since the first visible
+            // indent might be a bit after offset.col
+            self.col_offset + self.viewport.width as usize + (self.config.tab_width - 1) as usize,
+        ) / self.config.tab_width as usize;
+
+        for i in self.config.starting_indent..end_indent {
+            let x = (self.viewport.x as usize + (i * self.config.tab_width as usize)
+                - self.col_offset) as u16;
+            let y = self.viewport.y + self.posititon.row as u16;
+            debug_assert!(self.surface.in_bounds(x, y));
+            self.surface.set_string(
+                x,
+                y,
+                &self.config.indent_guide_char,
+                self.config.indent_guide_style,
+            );
+        }
+
+        // reset indentation level for next line
+        self.indent_known = false;
+    }
+
+    pub fn reached_viewport_end(&mut self) -> bool {
+        self.posititon.row as u16 >= self.viewport.height
+    }
+}
+
+#[derive(Debug)]
+/// Various constants required for text rendering.
+pub struct TextRenderConfig {
+    pub text_style: Style,
+    pub whitespace_style: Style,
+    pub indent_guide_char: String,
+    pub indent_guide_style: Style,
+    pub newline: String,
+    pub nbsp: String,
+    pub space: String,
+    pub tab: String,
+    pub tab_width: u16,
+    pub starting_indent: usize,
+}
+
+impl TextRenderConfig {
+    pub fn new(
+        doc: &Document,
+        editor_config: &editor::Config,
+        theme: &Theme,
+        offset: &Position,
+    ) -> TextRenderConfig {
+        let WhitespaceConfig {
+            render: ws_render,
+            characters: ws_chars,
+        } = &editor_config.whitespace;
+
+        let tab_width = doc.tab_width();
+        let tab = if ws_render.tab() == WhitespaceRenderValue::All {
+            std::iter::once(ws_chars.tab)
+                .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
+                .collect()
+        } else {
+            " ".repeat(tab_width)
+        };
+        let newline = if ws_render.newline() == WhitespaceRenderValue::All {
+            ws_chars.newline.into()
+        } else {
+            " ".to_owned()
+        };
+
+        let space = if ws_render.space() == WhitespaceRenderValue::All {
+            ws_chars.space.into()
+        } else {
+            " ".to_owned()
+        };
+        let nbsp = if ws_render.nbsp() == WhitespaceRenderValue::All {
+            ws_chars.nbsp.into()
+        } else {
+            " ".to_owned()
+        };
+
+        let text_style = theme.get("ui.text");
+
+        TextRenderConfig {
+            indent_guide_char: editor_config.indent_guides.character.into(),
+            newline,
+            nbsp,
+            space,
+            tab_width: tab_width as u16,
+            tab,
+            whitespace_style: theme.get("ui.virtual.whitespace"),
+            starting_indent: (offset.col / tab_width)
+                + editor_config.indent_guides.skip_levels as usize,
+            indent_guide_style: text_style.patch(
+                theme
+                    .try_get("ui.virtual.indent-guide")
+                    .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
+            ),
+            text_style,
+        }
+    }
+}

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -1,4 +1,5 @@
 mod completion;
+mod document;
 pub(crate) mod editor;
 mod fuzzy_match;
 mod info;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -193,18 +193,18 @@ pub struct SoftWrap {
     /// This is automatically hardlimited to a quarter of the viewport to ensure correct display on small views.
     ///
     /// Default to 5
-    pub max_wrap: usize,
+    pub max_wrap: u16,
     /// Maximum number of indentation that can be carried over from the previous line when softwrapping.
     /// If a line is indenten further then this limit it is rendered at the start of the viewport instead.
     ///
     /// This is automatically hardlimited to a quarter of the viewport to ensure correct display on small views.
     ///
     /// Default to 40
-    pub max_indent_retain: usize,
+    pub max_indent_retain: u16,
     /// Extra spaces inserted before rendeirng softwrapped lines.
     ///
     /// Default to 2
-    pub wrap_indent: usize,
+    pub wrap_indent: u16,
 }
 
 impl Default for SoftWrap {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -178,6 +178,44 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    pub soft_wrap: SoftWrap,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct SoftWrap {
+    /// Soft wrap lines that exceed viewport width. Default to off
+    pub enable: bool,
+    /// Maximum space that softwrapping may leave free at the end of the line when perfomring softwrapping
+    /// This space is used to wrap text at word boundries. If that is not possible within this limit
+    /// the word is simply split at the end of the line.
+    ///
+    /// This is automatically hardlimited to a quarter of the viewport to ensure correct display on small views.
+    ///
+    /// Default to 5
+    pub max_wrap: usize,
+    /// Maximum number of indentation that can be carried over from the previous line when softwrapping.
+    /// If a line is indenten further then this limit it is rendered at the start of the viewport instead.
+    ///
+    /// This is automatically hardlimited to a quarter of the viewport to ensure correct display on small views.
+    ///
+    /// Default to 40
+    pub max_indent_retain: usize,
+    /// Extra spaces inserted before rendeirng softwrapped lines.
+    ///
+    /// Default to 2
+    pub wrap_indent: usize,
+}
+
+impl Default for SoftWrap {
+    fn default() -> Self {
+        SoftWrap {
+            enable: true,
+            max_wrap: 5,
+            max_indent_retain: 80,
+            wrap_indent: 2,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -630,6 +668,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            soft_wrap: SoftWrap::default(),
         }
     }
 }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -185,8 +185,6 @@ impl View {
             .primary()
             .cursor(doc.text().slice(..));
 
-        let config = doc.cursor_config();
-
         let Position { col, row: line } =
             visual_coords_at_pos(doc.text().slice(..), cursor, doc.tab_width());
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -239,7 +239,7 @@ impl View {
     pub fn ensure_cursor_in_view(&mut self, doc: &Document, scrolloff: usize) {
         if let Some((row, col)) = self.offset_coords_to_in_view_center(doc, scrolloff, false) {
             self.offset.row = row;
-            self.offset.col = col;
+            self.offset.col = 0;
         }
     }
 


### PR DESCRIPTION
This PR implements a general rework of the text rendering system.
The main aim is to make the text rendering more flexible to easily allow implementation of various decorations or 
even new text-based views besides editor without hard-coding them into text rendering.
It also contains an implementation of soft-wrapping **rendering** (not actually usable right now see below).

While working on this PR I had the following features in mind:

* Virtual text #411
  * Inline LSP annotations
  * Overlays for jump mode #3791
  * (EOL annotations)
* Soft wrapping #136
* Side by side diffs #405 
* (Structural) search and replace (a better UI for #4381, also [ssr.nvim](https://github.com/cshuaimin/ssr.nvim))
* Better display for diagnostics (similar to [lsp_lines.nvim](https://git.sr.ht/~whynothugo/lsp_lines.nvim))

# Text Render System Desgin

This PR completely replaces the `render_text_highlights` function (but leaves the rest of the editor mostly untouched).
Although this new implementation looks quite different as it's structured it's not a complete rewrite and I heavily leaned on the old implementation.

My goal during the implementation was primarily separating different components of the text rendering.
The text rendering is now roughly split into three basic components:

* Basic grapheme rendering and visual position tracking (`TextRender`)
* Transversing the document efficiently and accumulating graphemes for rendering (`DocumentCursor`)
* Gluecode that handles syntax highlighting, soft-wrapping and integration of inline decorations (`DocumentRender`)

The primary interaction with the text rendering happens through the `DocumentRender` struct.
It allows the caller to render a single **visual** line (which could just be a part of a full line in case of soft-wrapping)
with the `reder_line` function.
It behaves similar to a rust iterator (lazy) so it only renders a line if this function is called.
This function requires a mutable reference to `TextRender` which tracks the actual onscreen position.

Thanks to this decoupling `TextRender` can be used to render other text in between lines.
For example a second `DocumentRender` could be used to interpose the removed lines of a second document (with syntax highlighting and soft-wrapping)
at hunks for a unified diff view.

Furthermore, `DocumentRender` yields after each **visual** line (instead of only after line break) to ensure other rendering components
can take soft wrapping into amount.
As the `DocumentCursor`/`DocumentRender` tracks the position within the document (both `line`/`col` and total `char_offset`/`byte_offset`) anyway
this can be used to track the exact beginning/end of wrapped lines (so the diagnostic gutter could be shown on the correct soft-wrapped line).
This information can also be used by custom views to interrupt the rendering to render other text with `TextRender` at line bounds.
In this PR I simply used this property to ensure gutters are displayed in the correct place when soft-wrapping is enabled.

Inline annotations/overlays can easily be integrated with a trait that would be called from within the `push_grapheme` function.

# Performance

Compared to the old text rendering the document transversal works very different now.
Previously `RopeSlice`s were created for each syntax range `text.slice(highlight_start..highlight_end)`.
For these slices a `RopeGraphemes` iterator was then created and rendered in a single continuous (non-interruptible) loop.

This approach does not work well for this PR because we need the iteration to be interruptible.
Therefore, the graphemes are collected into a temporary vector instead which is rendered at:

* Word boundaries
* Line breaks
* at the end of the visual line when soft-wrapping is enabled
* after a fixed chunk size when soft-wrapping is disabled (to avoid excessive memory consumption)

The overhead should be minimal as the buffer never exceeds a fixed size (viewport width with soft-warping, 64 without).

As both the `slice()` function and the creation of `RopeGraphemes` are `log(N)` operations.
The code now uses a single `RopeGraphemes` iterator for the entire text (so no more slicing at highlight boundaries)
which should be a nice performance boost.
Another advantage of this approach is that text rendering can now easily be refactored to use byte positions instead of char
positions (which avoids the costly `NlogN` `char` -> `byte` conversion currently performed for treesitter queries).
However, I left this as a followup PR for now as it requires some code outside the rendering system.

# Soft Wrapping

The PR implements soft-wrapping this is partly inspired by led (credit to @cessen here).
The text is wraps words that would exceed the line-width at their starting boundary (spaces) when possible.
When the text that would need to be wrapped exceeds a certain (configurable) width (5 by default) the word start
is instead broken exactly at the line end.
In practice this usually wraps text well while only causing minimal overhead (there are no pathological cases with this approach).

Right now only (breaking) spaces (so tabs and space) are treated as word boundaries.
To better wrap source code I am considering treating everything that is not `char::is_alphanumeric` as a word boundary instead.
This would wrap long paths in rust at `.` for example.

Wrapped lines are indented with a configurable amount of space (2 by default).
They furthermore retain the indentation (and indent guides) from the start of the line unless
this indentation exceeds as (configurable) limit (people that don't like this feature can set the limit to 0).

# Landing this

The rendering system in this PR works quite well, although more testing is obviously needed.
Rendering soft-wrapping behaves well and has all the features I personally except.
However, soft-wrapping is currently not handled well in the rest of the editor which excepts that.
`View::offset` corresponds to document lines/columns which is not the case anymore with this PR. 
To address this we need some.way to find wrapped line starts which is why I would probably move.some.of the softwrapping code into `DocumentCursor` which could then be moved to `helic-core` to provide that functionality everywhere in helix. 

Gutters also need further improvements (for example insert and modify diff gutters should be shown for all wrapped lines).

In interest of landing this PR faster and enable work on orthogonal features (like side-by-side diffs)
that could leverage the improved rendering system I propose to land this PR as is (with some minor improvements)
and disable soft-wrapping with a (off by default) feature flag (everywhere `config.soft_wrap.enable` is used simply add `&& cfg!(feature=softwrap)`).

This PR still has some rough edges to polish:
* [ ] Clean up code documentation/comments
* [ ] Maybe some tests, although I am not sure how to actually test this yet (maybe asserting the contest of a surface after render?)
* [ ] Add the feature flag mentioned above
* [ ] Adjust user facing documentation (better documentation for the soft wrap config options with a note that this is an in-development feature that is disabled)
* [ ] undo some changes to view positioning that were added to demo text wrapping



A big shoutout to @kirawi for reaching out to me about potential overlap between virtual text.
The initial design discussions with him heavily influenced this PR.
