### PR TITLE
Reduce log message about diff timeout from warn to info

### DIFF
--- a/helix-vcs/src/diff/worker.rs
+++ b/helix-vcs/src/diff/worker.rs
@@ -185,7 +185,7 @@ impl<'a> EventAccumulator {
                     }
                     // Diff failed to complete in time log the event
                     // and wait until the diff occurs to trigger an async redraw
-                    log::warn!("Diff computation timed out, update of diffs might appear delayed");
+                    log::info!("Diff computation timed out, update of diffs might appear delayed");
                     diff_finished_notify.notified().await;
                     redraw_notify.notify_one();
                 });


### PR DESCRIPTION
This log message is not that important and can occur very frequently when editing large files.
To avoid excessive IO/polluting the log file the log level is reduced to `info` which is not written to disk by default.