### PR TITLE
Update `diagnostic.error` background for acme theme

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -18,7 +18,7 @@
 "ui.menu.selected" = {bg="selected"}
 "ui.window" = {bg="acme_bg"}
 "diagnostic.error" = {bg="red", fg="white", modifiers=["bold"]}
-"diagnostic.warning" = {bg="yellow", fg="black", modifiers=["bold"]}
+"diagnostic.warning" = {bg="orange", fg="black", modifiers=["bold"]}
 "diagnostic.hint" = {fg="gray", modifiers=["bold"]}
 "ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }
 "ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
@@ -37,5 +37,5 @@ cursor = "#444444"
 red = "#a0342f"
 green = "#065905"
 indent = "#aaaaaa"
-yellow = "#ffef4a"
+orange = "#f0ad4e"
 gray = "#777777"

--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -17,9 +17,9 @@
 "ui.menu" = {fg="black", bg="acme_bg"}
 "ui.menu.selected" = {bg="selected"}
 "ui.window" = {bg="acme_bg"}
-"diagnostic.error" = {bg="acme_bar_bg", modifiers=["bold"]}
-"diagnostic.warning" = {bg="white", modifiers=["bold"]}
-"diagnostic.hint" = {bg="white", modifiers=["bold"]}
+"diagnostic.error" = {bg="red", fg="white", modifiers=["bold"]}
+"diagnostic.warning" = {bg="yellow", fg="black", modifiers=["bold"]}
+"diagnostic.hint" = {fg="gray", modifiers=["bold"]}
 "ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }
 "ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
 "diff.plus" = {fg = "green"}
@@ -37,3 +37,5 @@ cursor = "#444444"
 red = "#a0342f"
 green = "#065905"
 indent = "#aaaaaa"
+yellow = "#ffef4a"
+gray = "#777777"

--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -17,7 +17,7 @@
 "ui.menu" = {fg="black", bg="acme_bg"}
 "ui.menu.selected" = {bg="selected"}
 "ui.window" = {bg="acme_bg"}
-"diagnostic.error" = {bg="white", modifiers=["bold"]}
+"diagnostic.error" = {bg="acme_bar_bg", modifiers=["bold"]}
 "diagnostic.warning" = {bg="white", modifiers=["bold"]}
 "diagnostic.hint" = {bg="white", modifiers=["bold"]}
 "ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }


### PR DESCRIPTION
Previously: 
![acme2](https://user-images.githubusercontent.com/92624829/205764462-8fd85165-82da-48ef-a9a1-8f399a791ab8.png)

After change:
![acme1](https://user-images.githubusercontent.com/92624829/205764481-2e006cb9-ef3f-4cd9-a819-426d038d9507.png)
