### PR TITLE
Move diff before line numbers by default

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -46,7 +46,7 @@ on unix operating systems.
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. | `absolute` |
 | `cursorline` | Highlight all lines with a cursor. | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor. | `false` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "diff", "spacer", "line-numbers", "spacer"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |
 | `auto-save` | Enable automatic saving on focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal. | `false` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -471,7 +471,9 @@ impl std::str::FromStr for GutterType {
             "spacer" => Ok(Self::Spacer),
             "line-numbers" => Ok(Self::LineNumbers),
             "diff" => Ok(Self::Diff),
-            _ => anyhow::bail!("Gutter type can only be `diagnostics` or `line-numbers`."),
+            _ => anyhow::bail!(
+                "Gutter type can only be `diagnostics`, `line-numbers`, `diff`, or `spacer`."
+            ),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -606,9 +606,10 @@ impl Default for Config {
             gutters: vec![
                 GutterType::Diagnostics,
                 GutterType::Spacer,
+                GutterType::Diff,
+                GutterType::Spacer,
                 GutterType::LineNumbers,
                 GutterType::Spacer,
-                GutterType::Diff,
             ],
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),


### PR DESCRIPTION
Hey, thanks for the awesome project. I'm really enjoying using Helix as my editor.

When using the latest git diff gutters feature I found it great but generally
noticed it looked a tiny bit strange and not what I was used to.

I believe most of the other software that implements this feature, for example:

* https://github.com/lewis6991/gitsigns.nvim
* https://github.com/airblade/vim-gitgutter

place the git diff signs behind the line numbers which (in my opinion) looks a
bit better.

This PR changes the defaults to what I would (personally) expect.

Feel free to close this PR if you believe that the defaults are correct. It's
easy enough to configure but thought it would be nice to have these as the
defaults, since I presume this is what most people will want (I may be totally
wrong though).

This is what the proposed defaults look like:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/42545625/205907402-f56a6e60-9248-46de-97df-ca54f767f53e.png">
