### PR TITLE
Add mode separator to statusline

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -200,18 +200,17 @@ where
                 let mut c = s.clone();
                 c.fg = s.bg;
                 c.bg = s.fg;
-                return c;
+                c
             });
 
-            let mode_separator_string = match config.statusline.mode_separator {
+            let mode_separator = match config.statusline.mode_separator {
                 ModeSeparator::Angled => "",
                 ModeSeparator::Slanted => "",
-                ModeSeparator::Rounded => "",
+                ModeSeparator::Round => "",
                 ModeSeparator::Flat => unreachable!(),
-            }
-            .to_string();
+            };
 
-            write(context, mode_separator_string, mode_separator_style);
+            write(context, mode_separator.to_string(), mode_separator_style);
         }
     };
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -271,6 +271,16 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub mode_separator: ModeSeparator,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModeSeparator {
+    Flat,
+    Angled,
+    Rounded,
+    Slanted,
 }
 
 impl Default for StatusLineConfig {
@@ -283,6 +293,7 @@ impl Default for StatusLineConfig {
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            mode_separator: ModeSeparator::Flat,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -279,7 +279,7 @@ pub struct StatusLineConfig {
 pub enum ModeSeparator {
     Flat,
     Angled,
-    Rounded,
+    Round,
     Slanted,
 }
 


### PR DESCRIPTION
Add a purely stylistic and configurable Unicode separator after the mode in the statusline.