### PR TITLE
Sort diagnostics by severity in diagnostics picker

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -272,6 +272,8 @@ fn diag_picker(
         }
     }
 
+    flat_diag.sort_by(severity_ordering);
+
     let styles = DiagnosticStyles {
         hint: cx.editor.theme.get("hint"),
         info: cx.editor.theme.get("info"),
@@ -306,6 +308,14 @@ fn diag_picker(
         },
     )
     .truncate_start(false)
+}
+
+fn severity_ordering(a: &PickerDiagnostic, b: &PickerDiagnostic) -> std::cmp::Ordering {
+    let severity_hint = lsp::DiagnosticSeverity::HINT;
+    a.diag
+        .severity
+        .unwrap_or(severity_hint)
+        .cmp(&b.diag.severity.unwrap_or(severity_hint))
 }
 
 pub fn symbol_picker(cx: &mut Context) {


### PR DESCRIPTION
Usually as a developer you want to fix errors first and then warnings, so let's show errors first in diagnostic picker.

When sorting I use `lsp::DiagnosticSeverity::HINT` as a default value in case a diagnostic doesn't have a severity. Initially I was trying to make the lowest severity possible using `lsp::DiagnosticSeverity`'s constructor but it's private.

While preparing a PR I thought that behaviour of `[d` and `]d` must also be consistent with that in the picker. Currently this is not the case. Therefore I'll make this PR as a draft to gather feedback.

Closes #3543