### PR TITLE
Use OSC 52 for tmux copy

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -136,7 +136,7 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
     } else if env_var_is_set("TMUX") && binary_exists("tmux") {
         command_provider! {
             paste => "tmux", "save-buffer", "-";
-            copy => "tmux", "load-buffer", "-";
+            copy => "tmux", "load-buffer", "-w", "-";
         }
     } else {
         Box::new(provider::FallbackProvider::new())


### PR DESCRIPTION
Currently the tmux clipboard provider does not make use of OSC 52 when yanking content to clipboard, which results in the content only going into the tmux buffer but not the actual system clipboard.

This PR adds `-w` to the argument list, which according to the man page:

```doc
If -w is given, the buffer is also sent to the clipboard for target-client using the xterm(1) escape sequence, if possible.
```