### PR TITLE
fix(theme): serika toml syntax valid

### DIFF
--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -59,7 +59,7 @@
 "error" = "nasty-red"
 "diagnostic" = { fg = "nasty-red", modifiers = ["underlined"] }
 
-"diff.plus" = { fg = "bg_green"
+"diff.plus" = { fg = "bg_green" }
 "diff.delta" = { fg = "bg_blue" }
 "diff.minus" = { fg = "nasty-red" }
 


### PR DESCRIPTION
While developing lints for `diff` key, I found that `serika` did not parse.
This is a quickfix for that.
Originiated from https://github.com/helix-editor/helix/issues/4972 and https://github.com/helix-editor/helix/pull/5037