### PR TITLE
Add command to merge consecutive ranges in selection

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -111,6 +111,7 @@
 | `s`                   | Select all regex matches inside selections                        | `select_regex`                       |
 | `S`                   | Split selection into subselections on regex matches               | `split_selection`                    |
 | `Alt-s`               | Split selection on newlines                                       | `split_selection_on_newline`         |
+| `Alt-_ `              | Merge consecutive selections                                      | `merge_consecutive_selections`       |
 | `&`                   | Align selection in columns                                        | `align_selections`                   |
 | `_`                   | Trim whitespace from the selection                                | `trim_selections`                    |
 | `;`                   | Collapse selection onto a single cursor                           | `collapse_selection`                 |

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -499,7 +499,7 @@ impl Selection {
         self.ranges.sort_unstable_by_key(Range::from);
 
         self.ranges.dedup_by(|curr_range, prev_range| {
-            if prev_range.overlaps(&curr_range) {
+            if prev_range.overlaps(curr_range) {
                 let new_range = curr_range.merge(*prev_range);
                 if prev_range == &primary || curr_range == &primary {
                     primary = new_range;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -244,7 +244,7 @@ impl MappableCommand {
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
         split_selection_on_newline, "Split selection on newlines",
-        merge_consecutive_ranges, "Merge consecutive ranges",
+        merge_consecutive_selections, "Merge consecutive selections",
         search, "Search for regex pattern",
         rsearch, "Reverse search for regex pattern",
         search_next, "Select next search match",
@@ -1590,7 +1590,7 @@ fn split_selection_on_newline(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
-fn merge_consecutive_ranges(cx: &mut Context) {
+fn merge_consecutive_selections(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let selection = doc.selection(view.id).clone().merge_consecutive_ranges();
     doc.set_selection(view.id, selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -244,6 +244,7 @@ impl MappableCommand {
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
         split_selection_on_newline, "Split selection on newlines",
+        merge_consecutive_ranges, "Merge consecutive ranges",
         search, "Search for regex pattern",
         rsearch, "Reverse search for regex pattern",
         search_next, "Select next search match",
@@ -1586,6 +1587,12 @@ fn split_selection_on_newline(cx: &mut Context) {
     static REGEX: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\r\n|[\n\r\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}]").unwrap());
     let selection = selection::split_on_matches(text, doc.selection(view.id), &REGEX);
+    doc.set_selection(view.id, selection);
+}
+
+fn merge_consecutive_ranges(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let selection = doc.selection(view.id).clone().merge_consecutive_ranges();
     doc.set_selection(view.id, selection);
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -76,7 +76,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "s" => select_regex,
         "A-s" => split_selection_on_newline,
-        "A-_" => merge_consecutive_ranges,
+        "A-_" => merge_consecutive_selections,
         "S" => split_selection,
         ";" => collapse_selection,
         "A-;" => flip_selections,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -76,6 +76,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "s" => select_regex,
         "A-s" => split_selection_on_newline,
+        "A-_" => merge_consecutive_ranges,
         "S" => split_selection,
         ";" => collapse_selection,
         "A-;" => flip_selections,


### PR DESCRIPTION
My attempt at https://github.com/helix-editor/helix/issues/4914 

Adds command that will merge consecutive ranges in the selection, bound to `Alt-_` for now.