### PR TITLE
Re-request workspace symbols dynamically

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1,3 +1,4 @@
+use futures_util::FutureExt;
 use helix_lsp::{
     block_on,
     lsp::{self, CodeAction, CodeActionOrCommand, DiagnosticSeverity, NumberOrString},
@@ -14,7 +15,8 @@ use helix_view::{apply_transaction, document::Mode, editor::Action, theme::Style
 use crate::{
     compositor::{self, Compositor},
     ui::{
-        self, lsp::SignatureHelp, overlay::overlayed, FileLocation, FilePicker, Popup, PromptEvent,
+        self, lsp::SignatureHelp, overlay::overlayed, DynamicPicker, FileLocation, FilePicker,
+        Popup, PromptEvent,
     },
 };
 
@@ -384,10 +386,48 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     cx.callback(
         future,
         move |_editor, compositor, response: Option<Vec<lsp::SymbolInformation>>| {
-            if let Some(symbols) = response {
-                let picker = sym_picker(symbols, current_url, offset_encoding);
-                compositor.push(Box::new(overlayed(picker)))
-            }
+            let symbols = match response {
+                Some(s) => s,
+                None => return,
+            };
+            let picker = sym_picker(symbols, current_url, offset_encoding);
+            let get_symbols = |query: String, editor: &mut Editor| {
+                let doc = doc!(editor);
+                let language_server = match doc.language_server() {
+                    Some(s) => s,
+                    None => {
+                        // This should not generally happen since the picker will not
+                        // even open in the first place if there is no server.
+                        return async move { Err(anyhow::anyhow!("LSP not active")) }.boxed();
+                    }
+                };
+                let symbol_request = match language_server.workspace_symbols(query) {
+                    Some(future) => future,
+                    None => {
+                        // This should also not happen since the language server must have
+                        // supported workspace symbols before to reach this block.
+                        return async move {
+                            Err(anyhow::anyhow!(
+                                "Language server does not support workspace symbols"
+                            ))
+                        }
+                        .boxed();
+                    }
+                };
+
+                let future = async move {
+                    let json = symbol_request.await?;
+                    let response: Option<Vec<lsp::SymbolInformation>> =
+                        serde_json::from_value(json)?;
+
+                    response.ok_or_else(|| {
+                        anyhow::anyhow!("No response for workspace symbols from language server")
+                    })
+                };
+                future.boxed()
+            };
+            let dyn_picker = DynamicPicker::new(picker, Box::new(get_symbols));
+            compositor.push(Box::new(overlayed(dyn_picker)))
         },
     )
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -386,10 +386,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     cx.callback(
         future,
         move |_editor, compositor, response: Option<Vec<lsp::SymbolInformation>>| {
-            let symbols = match response {
-                Some(s) => s,
-                None => return,
-            };
+            let symbols = response.unwrap_or_default();
             let picker = sym_picker(symbols, current_url, offset_encoding);
             let get_symbols = |query: String, editor: &mut Editor| {
                 let doc = doc!(editor);
@@ -420,9 +417,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
                     let response: Option<Vec<lsp::SymbolInformation>> =
                         serde_json::from_value(json)?;
 
-                    response.ok_or_else(|| {
-                        anyhow::anyhow!("No response for workspace symbols from language server")
-                    })
+                    Ok(response.unwrap_or_default())
                 };
                 future.boxed()
             };

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -19,7 +19,7 @@ pub use completion::Completion;
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{FileLocation, FilePicker, Picker};
+pub use picker::{DynamicPicker, FileLocation, FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -69,4 +69,8 @@ impl<T: Component + 'static> Component for Overlay<T> {
         let dimensions = (self.calc_child_size)(area);
         self.content.cursor(dimensions, ctx)
     }
+
+    fn id(&self) -> Option<&'static str> {
+        self.content.id()
+    }
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -469,32 +469,39 @@ impl<T: Item> Picker<T> {
 
             self.matches.sort_unstable();
         } else {
-            let query = FuzzyQuery::new(pattern);
-            self.matches.clear();
-            self.matches.extend(
-                self.options
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, option)| {
-                        let text = option.filter_text(&self.editor_data);
-
-                        query
-                            .fuzzy_match(&text, &self.matcher)
-                            .map(|score| PickerMatch {
-                                index,
-                                score,
-                                len: text.chars().count(),
-                            })
-                    }),
-            );
-            self.matches.sort_unstable();
+            self.force_score();
         }
 
         log::debug!("picker score {:?}", Instant::now().duration_since(now));
 
         // reset cursor position
         self.cursor = 0;
+        let pattern = self.prompt.line();
         self.previous_pattern.clone_from(pattern);
+    }
+
+    pub fn force_score(&mut self) {
+        let pattern = self.prompt.line();
+
+        let query = FuzzyQuery::new(pattern);
+        self.matches.clear();
+        self.matches.extend(
+            self.options
+                .iter()
+                .enumerate()
+                .filter_map(|(index, option)| {
+                    let text = option.filter_text(&self.editor_data);
+
+                    query
+                        .fuzzy_match(&text, &self.matcher)
+                        .map(|score| PickerMatch {
+                            index,
+                            score,
+                            len: text.chars().count(),
+                        })
+                }),
+        );
+        self.matches.sort_unstable();
     }
 
     /// Move the cursor by a number of lines, either down (`Forward`) or up (`Backward`)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -798,7 +798,7 @@ impl<T: Item + Send + 'static> Component for DynamicPicker<T> {
         cx.jobs.callback(async move {
             let new_options = new_options.await?;
             let callback =
-                crate::job::Callback::EditorCompositor(Box::new(move |_editor, compositor| {
+                crate::job::Callback::EditorCompositor(Box::new(move |editor, compositor| {
                     // Wrapping of pickers in overlay is done outside the picker code,
                     // so this is fragile and will break if wrapped in some other widget.
                     let picker = match compositor.find_id::<Overlay<DynamicPicker<T>>>(Self::ID) {
@@ -808,6 +808,7 @@ impl<T: Item + Send + 'static> Component for DynamicPicker<T> {
                     picker.options = new_options;
                     picker.cursor = 0;
                     picker.force_score();
+                    editor.reset_idle_timer();
                 }));
             anyhow::Ok(callback)
         });

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -763,6 +763,7 @@ pub type DynQueryCallback<T> =
 pub struct DynamicPicker<T: ui::menu::Item + Send> {
     file_picker: FilePicker<T>,
     query_callback: DynQueryCallback<T>,
+    query: String,
 }
 
 impl<T: ui::menu::Item + Send> DynamicPicker<T> {
@@ -772,6 +773,7 @@ impl<T: ui::menu::Item + Send> DynamicPicker<T> {
         Self {
             file_picker,
             query_callback,
+            query: String::new(),
         }
     }
 }
@@ -782,13 +784,14 @@ impl<T: Item + Send + 'static> Component for DynamicPicker<T> {
     }
 
     fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
-        let prev_query = self.file_picker.picker.prompt.line().to_owned();
         let event_result = self.file_picker.handle_event(event, cx);
         let current_query = self.file_picker.picker.prompt.line();
 
-        if *current_query == prev_query || matches!(event_result, EventResult::Ignored(_)) {
+        if !matches!(event, Event::IdleTimeout) || self.query == *current_query {
             return event_result;
         }
+
+        self.query.clone_from(current_query);
 
         let new_options = (self.query_callback)(current_query.to_owned(), cx.editor);
 


### PR DESCRIPTION
Supersedes #3110. Many language servers don't send all symbols when the client sends an empty query (typically for performance reasons). This change adds a DynamicPicker component that re-requests workspace symbols when the query changes.

See sudormrfbin's before & after gifs:

| Before | After |
| ---- | ---- |
| ![helix-old-workspace-symbols](https://user-images.githubusercontent.com/23398472/179821244-0d82aa7d-c941-49a5-9c48-b92e5d5b01c2.gif) | ![helix-dynamic-workspace-symbols](https://user-images.githubusercontent.com/23398472/179821259-408a4d3d-c5a3-4e01-b370-e933cf4cee59.gif) |

This version uses the idle-timeout event as a sort of debounce which prevents querying the language server too aggressively.

Fixes #1437
Fixes #3619
Fixes #4910
Closes #3110