### PR TITLE
TS-rust move "macro_rules!" to "keyword.directive"

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -158,10 +158,13 @@
 
   "unsafe"
   "default"
-  "macro_rules!"
 
   "async"
 ] @keyword
+
+[
+ "macro_rules!"
+] @keyword.directive
 
 [
   "struct"


### PR DESCRIPTION
Changing queries for Rust macros.
```rust
macro_rules! name{}
name!()
```
as of now  `name` `name!()` both matched as `function.macro` and `macro_rules!` as `keyword`, however macros in Rust are direct analogue to the C's preproccessor directives, which have a dedicated scope `keyword.directive`.

These commits fixes that by making `macro_rules!` and macro-invocations to be matched to `keyword.directive`, so macro-invocations and macro-declarations can be highlighted differently.

> Update
`@keyword.directive` purpose is to match preprocessor-specific keywords like C's `#if`, `#define` 
`@function.macro` as of now serves both `macro declaration` and `macro invocation`