### PR TITLE
Resolve conflicts between insert mode and completion menu bindings

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -256,12 +256,12 @@ impl<T: Item + 'static> Component for Menu<T> {
                 return EventResult::Consumed(close_fn);
             }
             // arrow up/ctrl-p/shift-tab prev completion choice (including updating the doc)
-            shift!(Tab) | key!(Up) | ctrl!('p') | ctrl!('k') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') => {
                 self.move_up();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') | ctrl!('j') => {
+            key!(Tab) | key!(Down) | ctrl!('n') => {
                 // arrow down/ctrl-n/tab advances completion choice (including updating the doc)
                 self.move_down();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);


### PR DESCRIPTION
Related to issue https://github.com/helix-editor/helix/issues/4963

When in insert mode, when a completion menu is up, `C-k` (kill to end of line) and `C-j` (insert newline) are overwritten by navigation within completion menu. I see that something similar was the case for pickers at one point, https://github.com/helix-editor/helix/pull/1792, and the solution was to remove said bindings. 

This PR will help to resolve these conflicts as well as making navigation within pickers and completion menus more similar. 