### PR TITLE
Improve error message handling for theme loading failures

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -777,7 +777,7 @@ fn theme(
                     .editor
                     .theme_loader
                     .load(theme_name)
-                    .with_context(|| "Theme does not exist")?;
+                    .map_err(|err| anyhow::anyhow!("Could not load theme: {}", err))?;
                 if !(true_color || theme.is_16_color()) {
                     bail!("Unsupported theme: theme requires true color support");
                 }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -136,8 +136,9 @@ impl Loader {
     // Loads the theme data as `toml::Value` first from the user_dir then in default_dir
     fn load_toml(&self, path: PathBuf) -> Result<Value> {
         let data = std::fs::read(&path)?;
+        let value = toml::from_slice(data.as_slice())?;
 
-        toml::from_slice(data.as_slice()).context("Failed to deserialize theme")
+        Ok(value)
     }
 
     // Returns the path to the theme with the name


### PR DESCRIPTION
The error messages for a theme that failed to be deserialized (or otherwise failed to load) were covered up by the context/with_context calls:

* The log message for a bad theme configured in config.toml would only say "Failed to deserilaize theme"
* Selecting a bad theme via :theme would show "Theme does not exist"

With these changes, we let the TOML deserializer errors bubble up, so the error messages can now say the line number of a duplicated key - and that key's name - when a theme fails to load because of a duplicated key.

Providing a theme which does not exist to :theme still gives a helpful error message: "No such file or directory."

See #5043