### PR TITLE
Add error upon tutor requested without runtime dir

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -72,3 +72,4 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:help`, `:h` | Get help for a specific feature. |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -185,6 +185,11 @@ impl Application {
 
         if args.load_tutor {
             let path = helix_loader::runtime_dir().join("tutor");
+            if !path.exists() {
+                return Err(anyhow::anyhow!(
+                    "No path to the tutor found. Is the runtime directory linked?"
+                ));
+            }
             editor.open(&path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None)?;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -186,9 +186,7 @@ impl Application {
         if args.load_tutor {
             let path = helix_loader::runtime_dir().join("tutor");
             if !path.exists() {
-                return Err(anyhow::anyhow!(
-                    "No path to the tutor found. Is the runtime directory linked?"
-                ));
+                anyhow::bail!("No path to the tutor found. Is the runtime directory linked?");
             }
             editor.open(&path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -186,7 +186,7 @@ impl Application {
         if args.load_tutor {
             let path = helix_loader::runtime_dir().join("tutor");
             if !path.exists() {
-                anyhow::bail!("No path to the tutor found. Is the runtime directory linked?");
+                anyhow::bail!("No path to the tutor found. For further help use :help runtime");
             }
             editor.open(&path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1390,6 +1390,9 @@ fn tutor(
     }
 
     let path = helix_loader::runtime_dir().join("tutor");
+    if !path.exists() {
+        bail!("No path to the tutor found. Is the runtime directory linked?");
+    }
     cx.editor.open(&path, Action::Replace)?;
     // Unset path to prevent accidentally saving to the original tutor file.
     doc_mut!(cx.editor).set_path(None)?;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1391,7 +1391,7 @@ fn tutor(
 
     let path = helix_loader::runtime_dir().join("tutor");
     if !path.exists() {
-        bail!("No path to the tutor found. Is the runtime directory linked?");
+        bail!("No path to the tutor found. Use :help runtime to receive further help.");
     }
     cx.editor.open(&path, Action::Replace)?;
     // Unset path to prevent accidentally saving to the original tutor file.
@@ -1700,6 +1700,21 @@ fn open_log(
     }
 
     cx.editor.open(&helix_loader::log_file(), Action::Replace)?;
+    Ok(())
+}
+
+fn help(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let status = match args.first().unwrap_or(&Cow::from("")).trim() {
+        "runtime" => 
+            "There has to exist a symlink to the runtime folder in the folder of your config.",
+        _ => "Please check the documentation at the helix webpage for further info, or open an issue on Github.",
+    };
+
+    cx.editor.set_status(status);
     Ok(())
 }
 
@@ -2301,6 +2316,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             doc: "Run a shell command",
             fun: run_shell_command,
             completer: Some(completers::directory),
+        },
+        TypableCommand {
+            name: "help",
+            aliases: &["h"],
+            doc: "Get help for a specific feature.",
+            fun: help,
+            completer: Some(completers::help_command),
         },
     ];
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -441,6 +441,24 @@ pub mod completers {
         })
     }
 
+    pub fn help_command(_: &Editor, input: &str) -> Vec<Completion> {
+        let matcher = Matcher::default();
+        let mut help: Vec<_> = vec!["runtime", ""]
+            .iter()
+            .map(|str| str.to_owned())
+            .map(|name| ((0..), Cow::from(name)))
+            .filter_map(|(_range, name)| {
+                matcher.fuzzy_match(&name, input).map(|score| (name, score))
+            })
+            .collect();
+
+        help.sort_unstable_by(|(name1, score1), (name2, score2)| {
+            (Reverse(*score1), name1).cmp(&(Reverse(*score2), name2))
+        });
+
+        help.into_iter().map(|(name, _)| ((0..), name)).collect()
+    }
+
     #[derive(Copy, Clone, PartialEq, Eq)]
     enum FileMatch {
         /// Entry should be ignored


### PR DESCRIPTION
As mentioned in #5050 it would be great to let the user immediately know whether or not the runtime directory is linked.

Might be beneficial especially for new users. 