### PR TITLE
Differentiate between duplicate names in bufferline

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -683,11 +683,7 @@ impl EditorView {
                 .to_str()
                 .unwrap_or_default();
 
-            if names_map.contains_key(fname) {
-                names_map.insert(fname, names_map.get(fname).unwrap() + 1);
-            } else {
-                names_map.insert(fname, 1);
-            }
+            *names_map.entry(fname).or_insert(0) += 1;
         }
 
         for doc in editor.documents() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -671,6 +671,9 @@ impl EditorView {
         let mut x = viewport.x;
         let current_doc = view!(editor).doc;
 
+        use std::collections::HashMap;
+        let mut names_map: HashMap<&str, usize> = HashMap::new();
+
         for doc in editor.documents() {
             let fname = doc
                 .path()
@@ -679,6 +682,28 @@ impl EditorView {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default();
+
+            if names_map.contains_key(fname) {
+                names_map.insert(fname, names_map.get(fname).unwrap() + 1);
+            } else {
+                names_map.insert(fname, 1);
+            }
+        }
+
+        for doc in editor.documents() {
+            let mut fname = doc
+                .path()
+                .unwrap_or(&scratch)
+                .file_name()
+                .unwrap_or_default()
+                .to_str()
+                .unwrap_or_default();
+
+            let rel_path = doc.relative_path().unwrap_or_default();
+
+            if *names_map.get(fname).unwrap() > 1 {
+                fname = rel_path.to_str().unwrap_or_default();
+            }
 
             let style = if current_doc == doc.id() {
                 bufferline_active


### PR DESCRIPTION
Currently, if there are multiple buffers with the same name, the bufferline does not differentiate these names (https://github.com/helix-editor/helix/issues/5040). This PR should fix that; if there are two open buffers with the same name, the relative path will be displayed in the bufferline instead of just the file name. 