### PR TITLE
properly handle detachted git worktrees

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -69,7 +69,7 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
             top_marker = Some(ancestor);
         }
 
-        if ancestor.join(".git").is_dir() {
+        if ancestor.join(".git").exists() {
             // Top marker is repo root if not root marker was detected yet
             if top_marker.is_none() {
                 top_marker = Some(ancestor);

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -263,7 +263,7 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<FetchStatus> {
         ))?;
 
         // create the grammar dir contains a git directory
-        if !grammar_dir.join(".git").is_dir() {
+        if !grammar_dir.join(".git").exists() {
             git(&grammar_dir, ["init"])?;
         }
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -97,7 +97,7 @@ pub fn find_local_config_dirs() -> Vec<PathBuf> {
     let mut directories = Vec::new();
 
     for ancestor in current_dir.ancestors() {
-        if ancestor.join(".git").is_dir() {
+        if ancestor.join(".git").exists() {
             directories.push(ancestor.to_path_buf());
             // Don't go higher than repo if we're in one
             break;

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -207,7 +207,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 
     // Cap the number of files if we aren't in a git project, preventing
     // hangs when using the picker in your home directory
-    let files: Vec<_> = if root.join(".git").is_dir() {
+    let files: Vec<_> = if root.join(".git").exists() {
         files.collect()
     } else {
         // const MAX: usize = 8192;


### PR DESCRIPTION
Right now we check if `.git` exists and is a directory to detect a git repo root.
This does not work well for git repos with multiple/detached work-tree where `.git`
is a file which contains the location of the folder that contains files that would normally be located in `.git`.

This PR changes all checks for `.git` to use `.exists()` instead of `.is_dir()`, so it also works for files.
Since the `git` cli uses the same detection mechanism (try `tough .git && git status` in an empty directory)
this seems more inline with the intended behavior.

Furthermore, workflows with multiple worktrees become much nicer with this (I use one for each branch to quickly context switch)
as the file picker now stops at the correct location. 
Fixing this will also be important for getting repo caching to work correctly in the future.

This change is technically a breaking for repos that contain random `.git` files but as this messes with 
the `git` cli as well, so I think those cases can be ignored and I did not mark it as a breaking change.
