### PR TITLE
Add new theme scope `ui.text.inactive` for prompt suggestions

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -7,6 +7,7 @@
 "ui.linenr.selected" = { fg = "white", bg = "black", modifiers = ["bold"] }
 "ui.selection" = { fg = "black", bg = "blue" }
 "ui.selection.primary" = { fg = "white", bg = "blue" }
+"ui.text.inactive" = { fg = "gray" }
 "comment" = { fg = "gray" }
 "ui.statusline" = { fg = "black", bg = "white" }
 "ui.statusline.inactive" = { fg = "gray", bg = "white" }

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -268,6 +268,7 @@ These scopes are used for theming the editor interface.
 | `ui.help`                   | Description box for commands                                                                   |
 | `ui.text`                   | Command prompts, popup text, etc.                                                              |
 | `ui.text.focus`             |                                                                                                |
+| `ui.text.inactive`          | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`              | The key: command text in `ui.popup.info` boxes                                                 |
 | `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`     | Visible whitespace characters                                                                 |

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -352,6 +352,7 @@ impl Prompt {
         let prompt_color = theme.get("ui.text");
         let completion_color = theme.get("ui.menu");
         let selected_color = theme.get("ui.menu.selected");
+        let suggestion_color = theme.get("ui.text.inactive");
         // completion
 
         let max_len = self
@@ -450,21 +451,29 @@ impl Prompt {
         // render buffer text
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
-        let input: Cow<str> = if self.line.is_empty() {
+        let (input, is_suggestion): (Cow<str>, bool) = if self.line.is_empty() {
             // latest value in the register list
-            self.history_register
+            match self
+                .history_register
                 .and_then(|reg| cx.editor.registers.last(reg))
                 .map(|entry| entry.into())
-                .unwrap_or_else(|| Cow::from(""))
+            {
+                Some(value) => (value, true),
+                None => (Cow::from(""), false),
+            }
         } else {
-            self.line.as_str().into()
+            (self.line.as_str().into(), false)
         };
 
         surface.set_string(
             area.x + self.prompt.len() as u16,
             area.y + line,
             &input,
-            prompt_color,
+            if is_suggestion {
+                suggestion_color
+            } else {
+                prompt_color
+            },
         );
     }
 }

--- a/theme.toml
+++ b/theme.toml
@@ -54,6 +54,7 @@ label = "honey"
 
 "ui.text" = { fg = "lavender" }
 "ui.text.focus" = { fg = "white" }
+"ui.text.inactive" = "sirocco"
 "ui.virtual" = { fg = "comet" }
 
 "ui.virtual.indent-guide" = { fg = "comet" }


### PR DESCRIPTION
Resolves #4920.

This PR adds a new theme key `ui.text.inactive`, and sets the value in the default themes (`theme` and `base16_theme`) to be the same value as the `comment` key.

Themes from external contributors are left untouched, in the hope that maintainers of those themes will support this new key themselves.