### PR TITLE
update(theme): adjust base16_transparent and dark_high_contrast

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -103,7 +103,7 @@ Some styles might not be supported by your terminal emulator.
 | `line`         |
 | `curl`         |
 | `dashed`       |
-| `dot`          |
+| `dotted`       |
 | `double_line`  |
 
 

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -65,7 +65,7 @@
 "warning" = "light-yellow"
 "error" = "light-red"
 
-"diagnostic.info" = { underline = { color = "light-blue", style = "dot" } }
+"diagnostic.info" = { underline = { color = "light-blue", style = "dotted" } }
 "diagnostic.hint" = { underline = { color = "light-gray", style = "double_line" } }
 "diagnostic.debug" = { underline ={ color ="light-gray", style = "dashed" } }
 "diagnostic.warning" = { underline = { color = "light-yellow", style = "curl" } }

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -1,27 +1,28 @@
 # Author: GreasySlug <9619abgoni@gmail.com>
+# This theme is base on base16_theme(Author: NNB <nnbnh@protonmail.com>)
 
 "ui.background" = { fg = "white"}
 "ui.background.separator" = { fg = "gray" }
-"ui.menu" = { fg = "gray" }
+"ui.menu" = { fg = "white" }
 "ui.menu.selected" = { modifiers = ["reversed"] }
 "ui.menu.scroll" = { fg = "light-gray" }
 "ui.linenr" = { fg = "light-gray" }
 "ui.linenr.selected" = { fg = "white",  modifiers = ["bold"] }
 "ui.popup" = { fg = "white" }
 "ui.window" = { fg = "white" }
-"ui.selection" = { modifiers = [ "reversed"] }
-"comment" = { fg = "gray", modifiers = ["italic"] }
+"ui.selection" = { bg = "gray" }
+"comment" = "light-gray"
 "ui.statusline" = { fg = "white" }
 "ui.statusline.inactive" = { fg = "gray" }
-"ui.statusline.normal" = { fg = "blue", modifiers = ["reversed"] }
-"ui.statusline.insert" = { fg = "green", modifiers = ["reversed"] }
-"ui.statusline.select" = { fg = "magenta", modifiers = ["reversed"] }
+"ui.statusline.normal" = { fg = "black", bg = "blue" }
+"ui.statusline.insert" = { fg = "black", bg = "green" }
+"ui.statusline.select" = { fg = "black", bg = "magenta" }
 "ui.help" = { fg = "light-gray" }
 "ui.cursor" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { fg = "light-yellow", underline = { color = "light-yellow", style = "line" } }
 "ui.cursor.primary" = { modifiers = ["reversed", "slow_blink"] }
 "ui.cursor.secondary" = { modifiers = ["reversed"] }
-"ui.virtual.ruler" = { fg = "gray", modifiers = ["reversed"] }
+"ui.virtual.ruler" = { bg = "gray" }
 "ui.virtual.whitespace" = "gray"
 "ui.virtual.indent-guide" = "gray"
 
@@ -53,15 +54,16 @@
 "markup.select" = { fg = "magenta" }
 
 "diff.plus" = "light-green"
-"diff.delta" = "yellow"
+"diff.delta" = "light-blue"
+"diff.delta.moved" = "blue"
 "diff.minus" = "light-red"
 
-"ui.gutter" = "gray" 
-"info" = "light-blue" 
-"hint" = "gray" 
-"debug" = "gray"  
-"warning" = "yellow" 
-"error" = "light-red" 
+"ui.gutter" = "gray"
+"info" = "light-blue"
+"hint" = "light-gray"
+"debug" = "light-gray"
+"warning" = "light-yellow"
+"error" = "light-red"
 
 "diagnostic.info" = { underline = { color = "light-blue", style = "dot" } }
 "diagnostic.hint" = { underline = { color = "light-gray", style = "double_line" } }

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -18,7 +18,7 @@
 "ui.statusline.select" = { fg = "magenta", modifiers = ["reversed"] }
 "ui.help" = { fg = "light-gray" }
 "ui.cursor" = { modifiers = ["reversed"] }
-"ui.cursor.match" = { fg = "light-yellow", modifiers = ["underlined"] }
+"ui.cursor.match" = { fg = "light-yellow", underline = { color = "light-yellow", style = "line" } }
 "ui.cursor.primary" = { modifiers = ["reversed", "slow_blink"] }
 "ui.cursor.secondary" = { modifiers = ["reversed"] }
 "ui.virtual.ruler" = { fg = "gray", modifiers = ["reversed"] }
@@ -44,7 +44,7 @@
 "markup.list" = "light-red"
 "markup.bold" = { fg = "light-yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "light-magenta", modifiers = ["italic"] }
-"markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "yellow", underline = { color = "yellow", style = "line"} }
 "markup.link.text" = "light-red"
 "markup.quote" = "light-cyan"
 "markup.raw" = "green"
@@ -63,9 +63,8 @@
 "warning" = "yellow" 
 "error" = "light-red" 
 
-"diagnostic" = { modifiers = ["underlined"] }
-"diagnostic.info" = { fg = "light-blue", modifiers = ["underlined"] }
-"diagnostic.hint" = { fg = "gray", modifiers = ["underlined"] }
-"diagnostic.debug" ={ fg ="gray",  modifiers = ["underlined"] }
-"diagnostic.warning" = { fg = "yellow", modifiers = ["underlined"] }
-"diagnostic.error" = { fg ="light-red", modifiers = ["underlined"] }
+"diagnostic.info" = { underline = { color = "light-blue", style = "dot" } }
+"diagnostic.hint" = { underline = { color = "light-gray", style = "double_line" } }
+"diagnostic.debug" = { underline ={ color ="light-gray", style = "dashed" } }
+"diagnostic.warning" = { underline = { color = "light-yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color ="light-red", style = "curl" } }

--- a/runtime/themes/dark_high_contrast.toml
+++ b/runtime/themes/dark_high_contrast.toml
@@ -26,9 +26,8 @@
 "ui.cursor.primary" = { fg = "black", bg = "white", modifiers = ["slow_blink"] }
 
 "ui.cursor.secondary" = "white"
-"ui.cursorline.primary" = { fg = "orange", modifiers = ["underlined"] }
-"ui.cursorline.secondary" = { fg = "orange", modifiers = ["underlined"] }
-"ui.selection" = { fg = "deep_blue", bg = "white" }
+"ui.cursorline.primary" = { bg = "deep_blue", underline = { color = "orange", style = "double_line" } }
+"ui.cursorline.secondary" = { bg = "dark_blue", underline = { color = "white", style = "line" } }
 
 "ui.menu" = { fg = "white", bg = "deep_blue" }
 "ui.menu.selected" = { fg = "orange", modifiers = ["underlined"] }
@@ -44,10 +43,10 @@
 
 # Diagnostic
 "diagnostic" = "white"
-"diagnostic.info" = { bg = "white", modifiers = ["underlined"] }
-"diagnostic.hint" = { fg = "yellow", modifiers = ["underlined"] }
-"diagnostic.warning" = { fg = "orange", modifiers = ["underlined"] }
-"diagnostic.error" = { fg = "red", modifiers = ["underlined"] }
+"diagnostic.info" = { underline = { color = "white", style = "dotted" } }
+"diagnostic.hint" = { underline = { color = "yellow", style = "dashed" } }
+"diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "info" = "white" 
 "hint" = "yellow"
 "warning" = "orange"
@@ -79,11 +78,11 @@
 "label" = "blue"
 
 # Markup 
-"markup.heading" = { fg = "yellow", modifiers = ["bold", "underlined"] }
+"markup.heading" = { fg = "yellow", modifiers = ["bold"], underline = { color = "yellow", style = "double_line"} }
 "markup.list" = { fg = "pink" }
 "markup.bold" = { fg = "emerald_green", modifiers = ["bold"] }
 "markup.italic" = { fg = "blue", modifiers = ["italic"] }
-"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "blue", underline = { color = "blue", style = "line" } }
 "markup.link.text" = "pink"
 "markup.quote" = "yellow"
 "markup.raw" = "brown"

--- a/runtime/themes/dark_high_contrast.toml
+++ b/runtime/themes/dark_high_contrast.toml
@@ -9,28 +9,29 @@
 "ui.text.focus" = { modifiers = ["reversed"] } # file picker selected
 
 "ui.virtual.whitespace" = "gray"
-"ui.virtual.ruler" = { fg = "gray", bg = "white", modifiers = ["reversed"] }
+"ui.virtual.ruler" = { fg = "white", bg = "gray" }
 "ui.virtual.indent-guide" = "white"
 
 "ui.statusline" = { fg = "white", bg = "deep_blue" }
-"ui.statusline.inactive" = { fg = "gray" }
+"ui.statusline.inactive" = { fg = "gray", bg = "deep_blue" }
 "ui.statusline.normal" = { fg = "black", bg = "aqua" }
 "ui.statusline.insert" = { fg = "black", bg = "orange" }
 "ui.statusline.select" = { fg = "black", bg = "purple" }
-# "ui.statusline.separator" = { fg = "aqua", bg = "white" }
+"ui.statusline.separator" = { fg = "aqua", bg = "white" }
 
 "ui.cursor" = { fg = "black", bg = "white" }
 "ui.cursor.insert" = { fg = "black", bg = "white" }
 "ui.cursor.select" = { fg = "black", bg = "white" }
 "ui.cursor.match" = { bg = "white", modifiers = ["dim"] }
 "ui.cursor.primary" = { fg = "black", bg = "white", modifiers = ["slow_blink"] }
-
 "ui.cursor.secondary" = "white"
 "ui.cursorline.primary" = { bg = "deep_blue", underline = { color = "orange", style = "double_line" } }
 "ui.cursorline.secondary" = { bg = "dark_blue", underline = { color = "white", style = "line" } }
+"ui.selection" = { fg = "dark_blue", bg = "white" }
+"ui.selection.primary" = { fg = "deep_blue", bg = "white" }
 
 "ui.menu" = { fg = "white", bg = "deep_blue" }
-"ui.menu.selected" = { fg = "orange", modifiers = ["underlined"] }
+"ui.menu.selected" = { fg = "orange", underline = { style = "line" } }
 "ui.menu.scroll" = { fg = "aqua", bg = "black" }
 "ui.help" = { fg = "white", bg = "deep_blue" }
 
@@ -38,11 +39,12 @@
 "ui.popup.info" = { fg = "white", bg = "deep_blue" }
 
 "ui.gutter" = { bg = "black" }
+"ui.gutter.selected" = { bg = "black" }
 "ui.linenr" = { fg = "white", bg = "black" }
 "ui.linenr.selected" = { fg = "orange", bg = "black", modifiers = ["bold"] }
 
 # Diagnostic
-"diagnostic" = "white"
+"diagnostic" = { fg = "white" }
 "diagnostic.info" = { underline = { color = "white", style = "dotted" } }
 "diagnostic.hint" = { underline = { color = "yellow", style = "dashed" } }
 "diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
@@ -58,28 +60,28 @@
 "diff.minus" = "pink"
 
 # Syntax high light
-"type" = { fg = "emerald_green" }
+"type" = "emerald_green"
 "type.buildin" = "emerald_green"
-"comment" = { fg = "white" }
+"comment" = "white"
 "operator" = "white"
-"variable" = { fg = "aqua" }
+"variable" = "aqua"
 "variable.other.member" = "brown"
 "constant" = "aqua"
 "constant.numeric" = "emerald_green"
-"attributes" = { fg = "blue" }
+"attributes" = "blue"
 "namespace" = "blue"
 "string" = "brown"
-"string.special.url" = { fg = "brown", modifiers =["underlined"]}
+"string.special.url" = "brown"
 "constant.character.escape" = "yellow"
 "constructor" = "aqua"
-"keyword" = { fg = "blue", modifiers = ["underlined"] }
+"keyword" = "blue"
 "keyword.control" = "purple"
 "function" = "yellow"
 "label" = "blue"
 
 # Markup 
 "markup.heading" = { fg = "yellow", modifiers = ["bold"], underline = { color = "yellow", style = "double_line"} }
-"markup.list" = { fg = "pink" }
+"markup.list" = "pink"
 "markup.bold" = { fg = "emerald_green", modifiers = ["bold"] }
 "markup.italic" = { fg = "blue", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", underline = { color = "blue", style = "line" } }
@@ -93,6 +95,7 @@ gray = "#585858"
 white = "#ffffff"
 blue = "#66a4ff"
 deep_blue = "#142743"
+dark_blue = "#0d1a2d"
 aqua = "#6fc3df"
 purple = "#c586c0"
 red = "#b65f5f"


### PR DESCRIPTION
- Use `underline` instead of `modifier = ["underlined"]`
- Add base theme author sign
- Adjust some colors

![base16_transparent](https://user-images.githubusercontent.com/106496265/206849282-59868283-aa59-4c5a-9482-a6b450138015.png)
