### PR TITLE
Adds a diagnostics severity marker to diagnostics picker

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -143,6 +143,19 @@ struct PickerDiagnostic {
     offset_encoding: OffsetEncoding,
 }
 
+impl PickerDiagnostic {
+    fn severity_marker(&self) -> &'static str {
+        let empty_space = "  ";
+        self.diag.severity.map_or(empty_space, |s| match s {
+            DiagnosticSeverity::HINT => "H ",
+            DiagnosticSeverity::INFORMATION => "I ",
+            DiagnosticSeverity::WARNING => "W ",
+            DiagnosticSeverity::ERROR => "E ",
+            _ => empty_space,
+        })
+    }
+}
+
 impl ui::menu::Item for PickerDiagnostic {
     type Data = (DiagnosticStyles, DiagnosticsFormat);
 
@@ -178,6 +191,7 @@ impl ui::menu::Item for PickerDiagnostic {
         };
 
         Spans::from(vec![
+            Span::raw(self.severity_marker()),
             Span::raw(path),
             Span::styled(&self.diag.message, style),
             Span::styled(code, style),


### PR DESCRIPTION
Diagnostics severity markers `E`, `W`, `I`, `H` in diagnostics picker.

As noted in the related issue comments, this allows filtering inside the picker by these markers.
This is also useful for people who have color blindness.

<img width="340" alt="Screenshot 2022-12-10 at 17 52 04" src="https://user-images.githubusercontent.com/3009258/206856381-1a61db01-88e1-4310-96b6-fdd695ce111b.png">
<img width="368" alt="Screenshot 2022-12-10 at 17 52 31" src="https://user-images.githubusercontent.com/3009258/206856382-7643a08c-04b5-4bee-92fb-b05047ee6160.png">
<img width="300" alt="Screenshot 2022-12-10 at 17 53 20" src="https://user-images.githubusercontent.com/3009258/206856383-f79fcb90-27d6-4549-af73-c606f8a54dd0.png">

I was trying different formats and styles. Format like `[E]` looks heavy and takes up a precious space. Styling markers with diagnostics color looks a little weird, especially with a file path in workspace diagnostics picker. In any case I'm open to any suggestions.

Closes #3543