### PR TITLE
Reset idle timeout on job completion

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -348,10 +348,12 @@ impl Application {
                 Some(callback) = self.jobs.futures.next() => {
                     self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
                     self.render().await;
+                    self.editor.reset_idle_timer();
                 }
                 Some(callback) = self.jobs.wait_futures.next() => {
                     self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
                     self.render().await;
+                    self.editor.reset_idle_timer();
                 }
                 event = self.editor.wait_event() => {
                     let _idle_handled = self.handle_editor_event(event).await;


### PR DESCRIPTION
Fixes #4956

I originally fixed this by resetting the idle timeout when pushing to the compositor as suggested by @archseer .
However, this polluted a bunch of call sites with extra `editor` arguments.
Furthermore, it seemed like a special cased fix for a more general issue that might occur again in the future:

Asynchronous jobs caused by commands (usually) modify the editor state in some way as a delayed response to user input
and therefore should reset the idle-timeout.

To solve this more generally I reset the `idle_timer` after every call to `handle_callback` instead.
