### PR TITLE
Allow ANSI colors in themes

### DIFF
--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -351,8 +351,23 @@ impl ThemePalette {
         Self { palette: default }
     }
 
-    pub fn hex_string_to_rgb(s: &str) -> Result<Color, String> {
-        if s.starts_with('#') && s.len() >= 7 {
+    pub fn string_to_rgb(s: &str) -> Result<Color, String> {
+        if s.starts_with('#') {
+            Self::hex_string_to_rgb(s)
+        } else {
+            Self::ansi_string_to_rgb(s)
+        }
+    }
+
+    fn ansi_string_to_rgb(s: &str) -> Result<Color, String> {
+        if let Ok(index) = s.parse::<u8>() {
+            return Ok(Color::Indexed(index));
+        }
+        Err(format!("Theme: malformed ANSI: {}", s))
+    }
+
+    fn hex_string_to_rgb(s: &str) -> Result<Color, String> {
+        if s.len() >= 7 {
             if let (Ok(red), Ok(green), Ok(blue)) = (
                 u8::from_str_radix(&s[1..3], 16),
                 u8::from_str_radix(&s[3..5], 16),
@@ -378,7 +393,7 @@ impl ThemePalette {
             .get(value)
             .copied()
             .ok_or("")
-            .or_else(|_| Self::hex_string_to_rgb(value))
+            .or_else(|_| Self::string_to_rgb(value))
     }
 
     pub fn parse_modifier(value: &Value) -> Result<Modifier, String> {
@@ -454,7 +469,7 @@ impl TryFrom<Value> for ThemePalette {
         let mut palette = HashMap::with_capacity(map.len());
         for (name, value) in map {
             let value = Self::parse_value_as_str(&value)?;
-            let color = Self::hex_string_to_rgb(value)?;
+            let color = Self::string_to_rgb(value)?;
             palette.insert(name, color);
         }
 


### PR DESCRIPTION
My current vim theme doesn't use rgb colors but instead uses the ANSI color (150, 174, etc). 

Is this something Helix want to be able to do? It seems it already supports some colors (black, etc) but not all the ANSI colors.
