### PR TITLE
Enabled keys for selecting previous lines, changed existing keymap;

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -86,8 +86,9 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "%" => select_all,
         "x" => extend_line_below,
-        "X" => extend_to_line_bounds,
-        "A-x" => shrink_to_line_bounds,
+        "X" => extend_line_above,
+        "A-x" => extend_to_line_bounds,
+        "A-X" => shrink_to_line_bounds,
 
         "m" => { "Match"
             "m" => match_brackets,

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -339,6 +339,12 @@ _________________________________________________________________
  3. Move to the fourth line.
  4. Type x twice or type 2x to select 2 lines, and d to delete.
 
+ This also works in reverse.
+
+ 1. Move the cursor to line labeled "7".
+ 2. Type X to select the current line.
+ 3. Type X again to select the previous line, and d to delete.
+
  --> 1) Roses are red,
  --> 2) Mud is fun,
  --> 3) Violets are blue,
@@ -347,8 +353,8 @@ _________________________________________________________________
  --> 6) Sugar is sweet,
  --> 7) And so are you.
 
- Note : X works similarly to x although it doesn't extend to
-      subsequent lines. X on an empty line does nothing.
+ Note : Alt-x works similarly to x although it doesn't extend to
+      subsequent lines.
 
 =================================================================
 =                   3.7 COLLAPSING SELECTIONS                   =


### PR DESCRIPTION
This does some changes to the default keybind to:
A) make use of an existing command
B)  align the Shift modifier and Alt modifier to align with usage. 
Before:
`x` => select current line if unselected, else extend to next line
`X` => extend current selection to end of line
`A-x` => trim current selection to new lines
Now:
`x` => unchanged
`X` => opposite of x... select current line otherwise extend to PREVIOUS line
`A-x` => extend current selection to end of lines
`A-X` => trim current selectiono to end of lines