### PR TITLE
Primary cursor colors by mode

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -248,10 +248,14 @@ These scopes are used for theming the editor interface.
 | `ui.background`             |                                                                                                |
 | `ui.background.separator`   | Picker separator below input line                                                              |
 | `ui.cursor`                 |                                                                                                |
+| `ui.cursor.normal`          |                                                                                                |
 | `ui.cursor.insert`          |                                                                                                |
 | `ui.cursor.select`          |                                                                                                |
 | `ui.cursor.match`           | Matching bracket etc.                                                                          |
 | `ui.cursor.primary`         | Cursor with primary selection                                                                  |
+| `ui.cursor.primary.normal`  |                                                                                                |
+| `ui.cursor.primary.insert`  |                                                                                                |
+| `ui.cursor.primary.select`  |                                                                                                |
 | `ui.gutter`                 | Gutter                                                                                         |
 | `ui.gutter.selected`        | Gutter for the line the cursor is on                                                           |
 | `ui.linenr`                 | Line numbers                                                                                   |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -342,23 +342,29 @@ impl EditorView {
         let selection_scope = theme
             .find_scope_index("ui.selection")
             .expect("could not find `ui.selection` scope in the theme!");
+        let primary_selection_scope = theme
+            .find_scope_index("ui.selection.primary")
+            .unwrap_or(selection_scope);
         let base_cursor_scope = theme
             .find_scope_index("ui.cursor")
             .unwrap_or(selection_scope);
+        let base_primary_cursor_scope = theme
+            .find_scope_index("ui.cursor.primary")
+            .unwrap_or(base_cursor_scope);
 
         let cursor_scope = match mode {
             Mode::Insert => theme.find_scope_index("ui.cursor.insert"),
             Mode::Select => theme.find_scope_index("ui.cursor.select"),
-            Mode::Normal => Some(base_cursor_scope),
+            Mode::Normal => theme.find_scope_index("ui.cursor.normal"),
         }
         .unwrap_or(base_cursor_scope);
 
-        let primary_cursor_scope = theme
-            .find_scope_index("ui.cursor.primary")
-            .unwrap_or(cursor_scope);
-        let primary_selection_scope = theme
-            .find_scope_index("ui.selection.primary")
-            .unwrap_or(selection_scope);
+        let primary_cursor_scope = match mode {
+            Mode::Insert => theme.find_scope_index("ui.cursor.primary.insert"),
+            Mode::Select => theme.find_scope_index("ui.cursor.primary.select"),
+            Mode::Normal => theme.find_scope_index("ui.cursor.primary.normal"),
+        }
+        .unwrap_or(base_primary_cursor_scope);
 
         let mut spans: Vec<(usize, std::ops::Range<usize>)> = Vec::new();
         for (i, range) in selection.iter().enumerate() {


### PR DESCRIPTION
This PR is the result of a discussion held in #4298. It's an alternative solution to #4298 and #2366, which in turn closes the issues in ~~#1833 and~~ #1337.

In short; it adds the possibility to set primary and non-primary (secondary) cursor colors for a given mode. Compared to the other presented solutions:

* The source change is smaller and IMO cleaner.
* Adds the possibility to set a primary for normal mode and a fallback for the other modes.
* Does not introduce any breaking changes to the themes and their current behavior.
* Is consistent with other fallback behavior for themes.

Example of something that was previously not possible to do:

https://imgur.com/a/JHxYuJm

Diagram for fallback behavior:

https://imgur.com/a/Kds3606