### PR TITLE
Add Bash indents

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | --- | --- |
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
-| bash | ✓ |  |  | `bash-language-server` |
+| bash | ✓ |  | ✓ | `bash-language-server` |
 | bass | ✓ |  |  | `bass` |
 | beancount | ✓ |  |  |  |
 | bibtex | ✓ |  |  | `texlab` |

--- a/runtime/queries/bash/indents.scm
+++ b/runtime/queries/bash/indents.scm
@@ -1,0 +1,11 @@
+[
+  (function_definition)
+  (if_statement)
+  (for_statement)
+  (case_statement)
+  (pipeline)
+] @indent
+
+[
+  "}"
+] @outdent


### PR DESCRIPTION
Resolves #5087 

Adds indents for pipelines, if statements, case statements, and functions, which was mentioned in the original issue. I'm sure there's more indents that would be applicable here, so if anyone catches any that should be added, let me know :-)