### PR TITLE
Add config option for clear whitespace line on `<ret>`

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -217,6 +217,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 |-----|-------------|---------|
 | `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `tab`, and `newline`. | `"none"` |
 | `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad` | See example below |
+| `clear-whitespace-line-on-ret` | If current line is only whitespace, whether to clear it when `<ret>` is pressed | `true`
 
 Example
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3131,17 +3131,24 @@ pub mod insert {
             let curr = contents.get_char(pos).unwrap_or(' ');
 
             let current_line = text.char_to_line(pos);
+
             let line_is_only_whitespace = text
                 .line(current_line)
                 .chars()
                 .all(|char| char.is_ascii_whitespace());
 
+            let ws_cfg = &cx.editor.config().whitespace;
+
+            let clear_line = ws_cfg.clear_whitespace_line_on_ret &&
+                line_is_only_whitespace;
+
             let mut new_text = String::new();
 
-            // If the current line is all whitespace, insert a line ending at the beginning of
-            // the current line. This makes the current line empty and the new line contain the
-            // indentation of the old line.
-            let (from, to, local_offs) = if line_is_only_whitespace {
+            let (from, to, local_offs) = if clear_line {
+                // If the current line is all whitespace, insert a line ending at
+                // the beginning of the current line. This makes the current
+                // line empty and the new line contain the indentation of the
+                // old line.
                 let line_start = text.line_to_char(current_line);
                 new_text.push_str(doc.line_ending.as_str());
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -477,8 +477,9 @@ impl std::str::FromStr for GutterType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct WhitespaceConfig {
+    pub clear_whitespace_line_on_ret: bool,
     pub render: WhitespaceRender,
     pub characters: WhitespaceCharacters,
 }
@@ -486,6 +487,7 @@ pub struct WhitespaceConfig {
 impl Default for WhitespaceConfig {
     fn default() -> Self {
         Self {
+            clear_whitespace_line_on_ret: true,
             render: WhitespaceRender::Basic(WhitespaceRenderValue::None),
             characters: WhitespaceCharacters::default(),
         }


### PR DESCRIPTION
I was unpleasantly surprised this morning to discover that #4854 had been merged in the last release with no discussion.

I find this behavior incredibly frustrating, and most editors don't provide a way to configure it. I have a really nasty regex that *works* for (n)vim. I've been using `kak` a bit recently and unfortunately there it's included in the syntax regexes for each language, so I ended up hacking my own versions of those for the languages I use. That's obviously not sustainable. Based on how easy it was to add this config option, I guess this is the "right" way to do it.

I'm not attached to the name for the option, I just really want a way to turn off the behavior introduced in #4854 . I'm happy to figure out how to write a test if that's needed.