### PR TITLE
tutor: Add a content cycling section

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -986,7 +986,9 @@ lines.
  --> if a wouldchuck could chuck would?
 
  Note: Additionally, Alt-( and Alt-) cycle the *contents* of the
-       selections as well.
+       selections as well. To see this in action, first select
+       different contents, like the words "would" and "much"
+       of the first line.
 
 =================================================================
 =                     10.2 CHANGING CASE                        =

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -985,11 +985,33 @@ lines.
  --> How much would would a wouldchuck chuck
  --> if a wouldchuck could chuck would?
 
- Note: Additionally, Alt-( and Alt-) cycle the *contents* of the
-       selections as well.
+
+
 
 =================================================================
-=                     10.2 CHANGING CASE                        =
+=             10.2 CYCLING THE CONTENT OF SELECTIONS            =
+=================================================================
+
+ Type Alt-) and Alt-( to cycle the content of the selections
+ forward and backward respectively.
+
+ 1. Move the cursor to the line marked '-->' below.
+ 2. Select both lines with xx or 2x.
+ 3. Type s to select, type "through|water|know" and enter.
+ 4. Use Alt-( and Alt-) to cycle the content of the selections.
+
+ --> Jumping through the water,
+ --> daring to know.
+
+
+
+
+
+
+
+
+=================================================================
+=                     10.3 CHANGING CASE                        =
 =================================================================
 
  Type ~ to switch the case of all selected letters.
@@ -1011,7 +1033,7 @@ lines.
  --> THIS sentence should ALL BE IN uppercase!
 
 =================================================================
-=                   10.3 SPLITTING SELECTIONS                   =
+=                   10.4 SPLITTING SELECTIONS                   =
 =================================================================
 
  Type S to split each selection on a regex pattern.
@@ -1039,13 +1061,13 @@ letters! that is not good grammar. you can fix this.
  * Use ) and ( to cycle the primary selection back and forward
    through selections respectively.
    * Type Alt-, to remove the primary selection.
+   * Type Alt-) and Alt-( to cycle the content of the selections.
 
  * Type ~ to alternate case of selected letters.
    * Use ` and Alt-` to set the case of selected letters to
      upper and lower respectively.
 
  * Type S to split selections on regex.
-
 
 
 

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -986,9 +986,7 @@ lines.
  --> if a wouldchuck could chuck would?
 
  Note: Additionally, Alt-( and Alt-) cycle the *contents* of the
-       selections as well. To see this in action, first select
-       different contents, like the words "would" and "much"
-       of the first line.
+       selections as well.
 
 =================================================================
 =                     10.2 CHANGING CASE                        =


### PR DESCRIPTION
Efforts towards [#506](https://github.com/helix-editor/helix/issues/506).

The tutor section `10.1` tells you to select `would`, which causes later cycling of content make no visible changes with `Alt-(` and `Alt-)`.

Instructions are added to the note, so that the user selects different contents before attempting to cycle them.