### PR TITLE
Restore deleted goto_pos function

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2789,6 +2789,14 @@ fn exit_select_mode(cx: &mut Context) {
     }
 }
 
+fn goto_pos(editor: &mut Editor, pos: usize) {
+    let (view, doc) = current!(editor);
+
+    push_jump(view, doc);
+    doc.set_selection(view.id, Selection::point(pos));
+    align_view(doc, view, Align::Center);
+}
+
 fn goto_first_diag(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let selection = match doc.diagnostics().first() {


### PR DESCRIPTION
This function appears to have been deleted by mistake in https://github.com/helix-editor/helix/commit/42ad1a9e043e2e0fb148924ff79b9abbe06907ae.