### PR TITLE
Better sorting in picker in case of ties

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -207,13 +207,14 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 
     // Cap the number of files if we aren't in a git project, preventing
     // hangs when using the picker in your home directory
-    let files: Vec<_> = if root.join(".git").exists() {
+    let mut files: Vec<PathBuf> = if root.join(".git").exists() {
         files.collect()
     } else {
         // const MAX: usize = 8192;
         const MAX: usize = 100_000;
         files.take(MAX).collect()
     };
+    files.sort();
 
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 


### PR DESCRIPTION
Before:
![old](https://user-images.githubusercontent.com/1711539/207885140-5e6abf9e-a944-4d94-acdc-2b344d1b5599.png)

After:
![new](https://user-images.githubusercontent.com/1711539/207885157-286e899f-1d3d-4a13-b33a-6bf1078ad685.png)

Wouldn't be opposed to writing a test here, but, given that this doesn't fail any existing test, also happy to let it pass :P