### PR TITLE
Fix autocompletion for paths with period 

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -462,14 +462,13 @@ pub mod completers {
         use ignore::WalkBuilder;
         use std::path::Path;
 
-        let is_tilde = input.starts_with('~') && input.len() == 1;
+        let is_tilde = input == "~";
         let path = helix_core::path::expand_tilde(Path::new(input));
 
         let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
             (path, None)
         } else {
-            let is_period = (input.ends_with("/.") && input.len() > 2)
-                || (input.starts_with('.') && input.len() == 1);
+            let is_period = (input.ends_with("/.") && input.len() > 2) || input == ".";
             let file_name = if is_period {
                 Some(String::from("."))
             } else {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -468,7 +468,9 @@ pub mod completers {
         let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
             (path, None)
         } else {
-            let is_period = (input.ends_with("/.") && input.len() > 2) || input == ".";
+            let is_period = (input.ends_with((format!("{}.", std::path::MAIN_SEPARATOR)).as_str())
+                && input.len() > 2)
+                || input == ".";
             let file_name = if is_period {
                 Some(String::from("."))
             } else {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -468,14 +468,23 @@ pub mod completers {
         let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
             (path, None)
         } else {
-            let file_name = path
-                .file_name()
-                .and_then(|file| file.to_str().map(|path| path.to_owned()));
+            let is_period = (input.ends_with("/.") && input.len() > 2)
+                || (input.starts_with('.') && input.len() == 1);
+            let file_name = if is_period {
+                Some(String::from("."))
+            } else {
+                path.file_name()
+                    .and_then(|file| file.to_str().map(|path| path.to_owned()))
+            };
 
-            let path = match path.parent() {
-                Some(path) if !path.as_os_str().is_empty() => path.to_path_buf(),
-                // Path::new("h")'s parent is Some("")...
-                _ => std::env::current_dir().expect("couldn't determine current directory"),
+            let path = if is_period {
+                path
+            } else {
+                match path.parent() {
+                    Some(path) if !path.as_os_str().is_empty() => path.to_path_buf(),
+                    // Path::new("h")'s parent is Some("")...
+                    _ => std::env::current_dir().expect("couldn't determine current directory"),
+                }
             };
 
             (path, file_name)


### PR DESCRIPTION
Fix for https://github.com/helix-editor/helix/issues/5136

Bug has to do with how the `file_name` method deals with paths ending in `.` or `/.`. I hardcoded the value for `file_name` for paths ending in `/.` and paths that only consist of a single period, and updated the logic for `path`.