### PR TITLE
set 'c++' as a recognised extension for cpp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -190,7 +190,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "7175a6dd
 name = "cpp"
 scope = "source.cpp"
 injection-regex = "cpp"
-file-types = ["cc", "hh", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino"]
+file-types = ["cc", "hh", "c++", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino"]
 roots = []
 comment-token = "//"
 language-server = { command = "clangd" }


### PR DESCRIPTION
used in, for instance, https://github.com/ifax/HylaFAX/tree/0aa97f2dfe7e71005c2406dcd7677f09691bf48b/faxd