### PR TITLE
Avoid trailing `s` in message when only 1 file is opened

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -230,7 +230,7 @@ impl Application {
                 editor.set_status(format!(
                     "Loaded {} file{}.",
                     nr_of_files,
-                    "s".repeat((nr_of_files != 1).into()) // avoid "Loaded 1 files." grammo
+                    if nr_of_files == 1 { "" } else { "s" } // avoid "Loaded 1 files." grammo
                 ));
                 // align the view to center after all files are loaded,
                 // does not affect views without pos since it is at the top

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -227,7 +227,11 @@ impl Application {
                         doc.set_selection(view_id, pos);
                     }
                 }
-                editor.set_status(format!("Loaded {} files.", nr_of_files));
+                editor.set_status(format!(
+                    "Loaded {} file{}.",
+                    nr_of_files,
+                    "s".repeat((nr_of_files != 1).into()) // avoid "Loaded 1 files." grammo
+                ));
                 // align the view to center after all files are loaded,
                 // does not affect views without pos since it is at the top
                 let (view, doc) = current!(editor);


### PR DESCRIPTION
Fixes a minor grammar error with "Loaded 1 files" message. Only adds the `s` character when the number of files opened is not 1.