### PR TITLE
Print the binary required by the debug adapter

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -281,9 +281,9 @@ fn probe_protocol(protocol_name: &str, server_cmd: Option<String>) -> std::io::R
     writeln!(stdout, "Configured {}: {}", protocol_name, cmd_name)?;
 
     if let Some(cmd) = server_cmd {
-        let path = match which::which(cmd) {
+        let path = match which::which(&cmd) {
             Ok(path) => path.display().to_string().green(),
-            Err(_) => "Not found in $PATH".to_string().red(),
+            Err(_) => format!("'{}' not found in $PATH", cmd).red(),
         };
         writeln!(stdout, "Binary for {}: {}", protocol_name, path)?;
     }


### PR DESCRIPTION
This commit resolves #5193, where the author requested that the name of the binary needed is printed along with the rest of the health information.

This commit adds a `format!` macro which formats in the name of the binary and then it will be printed along with the rest of the debug information. The value in `cmd` is referenced to the call to which, and then consumed upon the call to `format!`.

This is my first issue in Helix, so please give feedback if this is not the kind of solution that you find optimal.