### PR TITLE
multiple commands now shown in view

### DIFF
--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -55,7 +55,7 @@ impl Info {
         }
     }
 
-    pub fn from_keymap(title: &str, body: Vec<(&str, BTreeSet<KeyEvent>)>) -> Self {
+    pub fn from_keymap(title: &str, body: Vec<(String, BTreeSet<KeyEvent>)>) -> Self {
         let body: Vec<_> = body
             .into_iter()
             .map(|(desc, events)| {


### PR DESCRIPTION
**Problem** Once you start having multiple commands bind to a certain key int the `config.toml` they all appear get the _Multiple commands description_
<img width="327" alt="imagen" src="https://user-images.githubusercontent.com/6558089/208293989-f4429128-9be0-4005-b348-1faa209d3d88.png">

```toml
# config.toml

[keys.normal.backspace]
b = ":sh cargo build"
c = [":config-open"]
s = [":w",":config-reload"]
```


That's ok but wouldn't it be better to see the real commands being executed?

**This pr** solves that.
<img width="307" alt="imagen" src="https://user-images.githubusercontent.com/6558089/208294001-9da81a8d-7e2b-457f-bf8f-06835a8111e5.png">
