### PR TITLE
Path remapping for LSP

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -201,6 +201,12 @@ impl<'de> Deserialize<'de> for FileType {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct PathMappingConfiguration {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct LanguageServerConfiguration {
     pub command: String,
@@ -212,6 +218,8 @@ pub struct LanguageServerConfiguration {
     #[serde(default = "default_timeout")]
     pub timeout: u64,
     pub language_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_mapping: Option<PathMappingConfiguration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1,5 +1,6 @@
 use crate::{
     jsonrpc,
+    remap::LSPRemap,
     transport::{Payload, Transport},
     Call, Error, OffsetEncoding, Result,
 };
@@ -9,13 +10,13 @@ use helix_loader::{self, VERSION_AND_GIT_HASH};
 use lsp_types as lsp;
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::future::Future;
 use std::process::Stdio;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
+use std::{collections::HashMap, path::Path};
+use std::{future::Future, path::PathBuf};
 use tokio::{
     io::{BufReader, BufWriter},
     process::{Child, Command},
@@ -38,6 +39,7 @@ pub struct Client {
     root_uri: Option<lsp::Url>,
     workspace_folders: Vec<lsp::WorkspaceFolder>,
     req_timeout: u64,
+    path_mapping: Option<(String, String)>,
 }
 
 impl Client {
@@ -52,6 +54,7 @@ impl Client {
         id: usize,
         req_timeout: u64,
         doc_path: Option<&std::path::PathBuf>,
+        path_mapping: Option<(String, String)>,
     ) -> Result<(Self, UnboundedReceiver<(usize, Call)>, Arc<Notify>)> {
         // Resolve path to the binary
         let cmd = which::which(cmd).map_err(|err| anyhow::anyhow!(err))?;
@@ -111,6 +114,7 @@ impl Client {
             root_path,
             root_uri,
             workspace_folders,
+            path_mapping,
         };
 
         Ok((client, server_rx, initialize_notify))
@@ -156,6 +160,10 @@ impl Client {
 
     pub fn workspace_folders(&self) -> &[lsp::WorkspaceFolder] {
         &self.workspace_folders
+    }
+
+    pub fn path_mapping(&self) -> Option<&(String, String)> {
+        self.path_mapping.as_ref()
     }
 
     /// Execute a RPC request on the language server.
@@ -280,14 +288,26 @@ impl Client {
             log::info!("Using custom LSP config: {}", config);
         }
 
+        let mut root_path = self.root_path.clone();
+        let mut root_uri = self.root_uri.clone();
+        let mut workspace_folders = self.workspace_folders.clone();
+
+        if let Some((from, to)) = &self.path_mapping {
+            root_path = replace_path(&root_path, &from, &to);
+            root_uri = root_uri.map(|p| p.remap(&from, &to));
+            workspace_folders.iter_mut().for_each(|wsf| {
+                wsf.uri = wsf.uri.remap(&from, &to);
+            });
+        }
+
         #[allow(deprecated)]
         let params = lsp::InitializeParams {
             process_id: Some(std::process::id()),
-            workspace_folders: Some(self.workspace_folders.clone()),
+            workspace_folders: Some(workspace_folders),
             // root_path is obsolete, but some clients like pyright still use it so we specify both.
             // clients will prefer _uri if possible
-            root_path: self.root_path.to_str().map(|path| path.to_owned()),
-            root_uri: self.root_uri.clone(),
+            root_path: root_path.to_str().map(|path| path.to_owned()),
+            root_uri,
             initialization_options: self.config.clone(),
             capabilities: lsp::ClientCapabilities {
                 workspace: Some(lsp::WorkspaceClientCapabilities {
@@ -434,6 +454,12 @@ impl Client {
         doc: &Rope,
         language_id: String,
     ) -> impl Future<Output = Result<()>> {
+        let mut uri = uri;
+
+        if let Some((from, to)) = &self.path_mapping {
+            uri = uri.remap(&from, &to);
+        }
+
         self.notify::<lsp::notification::DidOpenTextDocument>(lsp::DidOpenTextDocumentParams {
             text_document: lsp::TextDocumentItem {
                 uri,
@@ -567,6 +593,11 @@ impl Client {
             _ => return None,
         };
 
+        let mut text_document = text_document;
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let changes = match sync_capabilities {
             lsp::TextDocumentSyncKind::FULL => {
                 vec![lsp::TextDocumentContentChangeEvent {
@@ -644,6 +675,11 @@ impl Client {
         // Return early if the server does not support completion.
         capabilities.completion_provider.as_ref()?;
 
+        let mut text_document = text_document;
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::CompletionParams {
             text_document_position: lsp::TextDocumentPositionParams {
                 text_document,
@@ -690,6 +726,12 @@ impl Client {
         // Return early if the server does not support signature help.
         capabilities.signature_help_provider.as_ref()?;
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::SignatureHelpParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document,
@@ -718,6 +760,12 @@ impl Client {
                 | lsp::HoverProviderCapability::Options(_),
             ) => (),
             _ => return None,
+        }
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
         }
 
         let params = lsp::HoverParams {
@@ -766,6 +814,12 @@ impl Client {
             options
         };
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::DocumentFormattingParams {
             text_document,
             options,
@@ -795,6 +849,12 @@ impl Client {
             Some(lsp::OneOf::Left(true) | lsp::OneOf::Right(_)) => (),
             _ => return None,
         };
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
 
         let params = lsp::DocumentRangeFormattingParams {
             text_document,
@@ -826,6 +886,12 @@ impl Client {
             _ => return None,
         }
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::DocumentHighlightParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document,
@@ -851,6 +917,12 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> impl Future<Output = Result<Value>> {
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::GotoDefinitionParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document,
@@ -879,6 +951,12 @@ impl Client {
             _ => return None,
         }
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         Some(self.goto_request::<lsp::request::GotoDefinition>(
             text_document,
             position,
@@ -901,6 +979,12 @@ impl Client {
                 | lsp::TypeDefinitionProviderCapability::Options(_),
             ) => (),
             _ => return None,
+        }
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
         }
 
         Some(self.goto_request::<lsp::request::GotoTypeDefinition>(
@@ -927,6 +1011,12 @@ impl Client {
             _ => return None,
         }
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         Some(self.goto_request::<lsp::request::GotoImplementation>(
             text_document,
             position,
@@ -946,6 +1036,12 @@ impl Client {
         match capabilities.references_provider {
             Some(lsp::OneOf::Left(true) | lsp::OneOf::Right(_)) => (),
             _ => return None,
+        }
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
         }
 
         let params = lsp::ReferenceParams {
@@ -975,6 +1071,12 @@ impl Client {
         match capabilities.document_symbol_provider {
             Some(lsp::OneOf::Left(true) | lsp::OneOf::Right(_)) => (),
             _ => return None,
+        }
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
         }
 
         let params = lsp::DocumentSymbolParams {
@@ -1022,6 +1124,12 @@ impl Client {
             _ => return None,
         }
 
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
+
         let params = lsp::CodeActionParams {
             text_document,
             range,
@@ -1047,6 +1155,12 @@ impl Client {
             // None | Some(false)
             _ => return None,
         };
+
+        let mut text_document = text_document;
+
+        if let Some((from, to)) = &self.path_mapping {
+            text_document.uri = text_document.uri.remap(&from, &to);
+        }
 
         let params = lsp::RenameParams {
             text_document_position: lsp::TextDocumentPositionParams {
@@ -1084,4 +1198,10 @@ impl Client {
 
         Some(self.call::<lsp::request::ExecuteCommand>(params))
     }
+}
+
+pub fn replace_path(path: &PathBuf, old: &str, new: &str) -> PathBuf {
+    path.as_path()
+        .strip_prefix(old)
+        .map_or(path.clone(), |s| Path::new(new).join(s))
 }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -1,5 +1,6 @@
 mod client;
 pub mod jsonrpc;
+pub mod remap;
 mod transport;
 
 pub use client::Client;
@@ -555,6 +556,11 @@ fn start_client(
         id,
         ls_config.timeout,
         doc_path,
+        config.language_server.as_ref().and_then(|ls| {
+            ls.path_mapping
+                .as_ref()
+                .map(|pm| (pm.from.clone(), pm.to.clone()))
+        }),
     )?;
 
     let client = Arc::new(client);

--- a/helix-lsp/src/remap.rs
+++ b/helix-lsp/src/remap.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use lsp_types::Url;
+
+pub trait LSPRemap {
+    fn remap(&self, from: &str, to: &str) -> Self;
+}
+
+impl LSPRemap for Url {
+    fn remap(&self, from: &str, to: &str) -> Self {
+        let path = self.to_file_path().ok();
+
+        path.and_then(|p| {
+            let replaced = p
+                .strip_prefix(from)
+                .map_or(p.clone(), |stripped| Path::new(to).join(stripped));
+            Self::from_file_path(replaced).ok()
+        })
+        .unwrap_or(self.clone())
+    }
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -5,7 +5,7 @@ use helix_core::{
     path::get_relative_path,
     pos_at_coords, syntax, Selection,
 };
-use helix_lsp::{lsp, util::lsp_pos_to_pos, LspProgressMap};
+use helix_lsp::{lsp, remap::LSPRemap, util::lsp_pos_to_pos, LspProgressMap};
 use helix_view::{
     align_view,
     document::DocumentSavedEventResult,
@@ -675,6 +675,17 @@ impl Application {
                         }
                     }
                     Notification::PublishDiagnostics(mut params) => {
+                        match self.editor.language_servers.get_by_id(server_id) {
+                            Some(language_server) => {
+                                if let Some((to, from)) = language_server.path_mapping() {
+                                    params.uri = params.uri.remap(&from, &to)
+                                }
+                            }
+                            None => {
+                                warn!("can't perform path mapping because language server with id `{}` can not be found", server_id);
+                            }
+                        };
+
                         let path = params.uri.to_file_path().unwrap();
                         let doc = self.editor.document_by_path_mut(&path);
 
@@ -949,10 +960,17 @@ impl Application {
                         Ok(serde_json::Value::Null)
                     }
                     MethodCall::ApplyWorkspaceEdit(params) => {
+                        let language_server = self.editor.language_servers.get_by_id(server_id);
+                        let path_mapping = language_server
+                            .and_then(|ls| ls.path_mapping())
+                            .map(|a| a.clone())
+                            .map(|(a, b)| (b, a));
+
                         apply_workspace_edit(
                             &mut self.editor,
                             helix_lsp::OffsetEncoding::Utf8,
                             &params.edit,
+                            path_mapping.as_ref(),
                         );
 
                         Ok(json!(lsp::ApplyWorkspaceEditResponse {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -2,6 +2,7 @@ use futures_util::FutureExt;
 use helix_lsp::{
     block_on,
     lsp::{self, CodeAction, CodeActionOrCommand, DiagnosticSeverity, NumberOrString},
+    remap::LSPRemap,
     util::{diagnostic_to_lsp_diagnostic, lsp_pos_to_pos, lsp_range_to_range, range_to_lsp_range},
     OffsetEncoding,
 };
@@ -567,6 +568,11 @@ pub fn code_action(cx: &mut Context) {
         }
     };
 
+    let path_mapping = language_server
+        .path_mapping()
+        .map(|a| a.clone())
+        .map(|(a, b)| (b, a));
+
     cx.callback(
         future,
         move |editor, compositor, response: Option<lsp::CodeActionResponse>| {
@@ -641,7 +647,13 @@ pub fn code_action(cx: &mut Context) {
                         log::debug!("code action: {:?}", code_action);
                         if let Some(ref workspace_edit) = code_action.edit {
                             log::debug!("edit: {:?}", workspace_edit);
-                            apply_workspace_edit(editor, offset_encoding, workspace_edit);
+
+                            apply_workspace_edit(
+                                editor,
+                                offset_encoding,
+                                workspace_edit,
+                                path_mapping.as_ref(),
+                            );
                         }
 
                         // if code action provides both edit and command first the edit
@@ -751,9 +763,16 @@ pub fn apply_workspace_edit(
     editor: &mut Editor,
     offset_encoding: OffsetEncoding,
     workspace_edit: &lsp::WorkspaceEdit,
+    path_mapping: Option<&(String, String)>,
 ) {
     let mut apply_edits = |uri: &helix_lsp::Url, text_edits: Vec<lsp::TextEdit>| {
-        let path = match uri.to_file_path() {
+        let path = if let Some((from, to)) = path_mapping {
+            uri.remap(&from, &to).to_file_path()
+        } else {
+            uri.to_file_path()
+        };
+
+        let path = match path {
             Ok(path) => path,
             Err(_) => {
                 let err = format!("unable to convert URI to filepath: {}", uri);
@@ -871,8 +890,16 @@ fn goto_impl(
     compositor: &mut Compositor,
     locations: Vec<lsp::Location>,
     offset_encoding: OffsetEncoding,
+    path_mapping: Option<(String, String)>,
 ) {
     let cwdir = std::env::current_dir().unwrap_or_default();
+
+    let mut locations = locations;
+    if let Some((from, to)) = path_mapping {
+        locations.iter_mut().for_each(|l| {
+            l.uri = l.uri.remap(&from, &to);
+        });
+    }
 
     match locations.as_slice() {
         [location] => {
@@ -914,6 +941,9 @@ pub fn goto_definition(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
+    let path_mapping = language_server
+        .path_mapping()
+        .map(|(a, b)| (b.clone(), a.clone()));
 
     let pos = doc.position(view.id, offset_encoding);
 
@@ -930,7 +960,7 @@ pub fn goto_definition(cx: &mut Context) {
         future,
         move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
             let items = to_locations(response);
-            goto_impl(editor, compositor, items, offset_encoding);
+            goto_impl(editor, compositor, items, offset_encoding, path_mapping);
         },
     );
 }
@@ -939,6 +969,9 @@ pub fn goto_type_definition(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
+    let path_mapping = language_server
+        .path_mapping()
+        .map(|(a, b)| (b.clone(), a.clone()));
 
     let pos = doc.position(view.id, offset_encoding);
 
@@ -955,7 +988,7 @@ pub fn goto_type_definition(cx: &mut Context) {
         future,
         move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
             let items = to_locations(response);
-            goto_impl(editor, compositor, items, offset_encoding);
+            goto_impl(editor, compositor, items, offset_encoding, path_mapping);
         },
     );
 }
@@ -964,6 +997,9 @@ pub fn goto_implementation(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
+    let path_mapping = language_server
+        .path_mapping()
+        .map(|(a, b)| (b.clone(), a.clone()));
 
     let pos = doc.position(view.id, offset_encoding);
 
@@ -980,7 +1016,7 @@ pub fn goto_implementation(cx: &mut Context) {
         future,
         move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
             let items = to_locations(response);
-            goto_impl(editor, compositor, items, offset_encoding);
+            goto_impl(editor, compositor, items, offset_encoding, path_mapping);
         },
     );
 }
@@ -989,6 +1025,9 @@ pub fn goto_reference(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
+    let path_mapping = language_server
+        .path_mapping()
+        .map(|(a, b)| (b.clone(), a.clone()));
 
     let pos = doc.position(view.id, offset_encoding);
 
@@ -1005,7 +1044,7 @@ pub fn goto_reference(cx: &mut Context) {
         future,
         move |editor, compositor, response: Option<Vec<lsp::Location>>| {
             let items = response.unwrap_or_default();
-            goto_impl(editor, compositor, items, offset_encoding);
+            goto_impl(editor, compositor, items, offset_encoding, path_mapping);
         },
     );
 }
@@ -1222,6 +1261,10 @@ pub fn rename_symbol(cx: &mut Context) {
 
             let (view, doc) = current!(cx.editor);
             let language_server = language_server!(cx.editor, doc);
+            let path_mapping = language_server
+                .path_mapping()
+                .map(|a| a.clone())
+                .map(|(a, b)| (b, a));
             let offset_encoding = language_server.offset_encoding();
 
             let pos = doc.position(view.id, offset_encoding);
@@ -1235,8 +1278,11 @@ pub fn rename_symbol(cx: &mut Context) {
                         return;
                     }
                 };
+
             match block_on(future) {
-                Ok(edits) => apply_workspace_edit(cx.editor, offset_encoding, &edits),
+                Ok(edits) => {
+                    apply_workspace_edit(cx.editor, offset_encoding, &edits, path_mapping.as_ref())
+                }
                 Err(err) => cx.editor.set_error(err.to_string()),
             }
         },


### PR DESCRIPTION
# Path remapping for LSP

(See issue #3002 for more context)

Sometimes it is useful to have the language server running in a docker container with all the required dependencies for the project, whereas the editor is running on the developers local machine. In this case helix can use the docker executable to open a tty with the language server running in the container. However since the volume mapping of the container likely causes path mismatches the communication between the editor and the language server is not done correctly.

A simple approach to fix this would be to scan the strings going over the transport layers and map the paths accordingly, however this might mistakenly modify certain pieces of the communication that are not specifying paths to be used by the editor or the language server. One example could be a string literal in the source code containing one of the path prefixes.

## Solution implemented in this PR

In this PR an alternative approach is implemented where a remap method is added to the lsp::Url struct. Then everywhere where the editor sends something to the language server a mapping is performed to adjust the paths. Similarly whenever the editor uses a path it obtained from the LSP (for example in the diagnostics and the code actions) it maps it back to the correct paths.

The mapping is made configurable in the languages.toml file (and thus can be done on a project by project basis with different path mappings for each project in the $PROJECT_DIR/.helix/languages.toml file)

an example configuration could be as follows:
```toml
[[language]]
name="rust"
language-server = { command = "docker", args = ["start", "-i", "rust-analyzer"], path-mapping = { from = "/home/user/dev/some-project", to = "/app" } }
```