### PR TITLE
Add scrolling down past the scroll-off height at the bottom of the buffer

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1380,7 +1380,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
     let last_line = view.last_line(doc);
 
     if direction == Backward && view.offset.row == 0
-        || direction == Forward && last_line == doc_last_line
+        || !config.scroll_past_bottom && direction == Forward && last_line == doc_last_line
     {
         return;
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -122,6 +122,8 @@ pub struct Config {
     pub scrolloff: usize,
     /// Number of lines to scroll at once. Defaults to 3
     pub scroll_lines: isize,
+    /// Allow scrolling down past half the buffer height. Defaults to false.
+    pub scroll_past_bottom: bool,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
     /// Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
@@ -594,6 +596,7 @@ impl Default for Config {
         Self {
             scrolloff: 5,
             scroll_lines: 3,
+            scroll_past_bottom: false,
             mouse: true,
             shell: if cfg!(windows) {
                 vec!["cmd".to_owned(), "/C".to_owned()]


### PR DESCRIPTION
When using scroll via page_down this lets the buffer go beyond just the distance set by scroll off. This is what I expected from vim and is useful because I often use page_down to position the screen to my liking including when I am at the bottom of the buffer. I've currently set this as a configuration feature that defaults to false

If this really should be a configuration feature how should it be named?