### PR TITLE
Add missing comment injection for nix

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
 ; mark arbitary languages with a comment
 ((((comment) @injection.language) .
   (indented_string_expression (string_fragment) @injection.content))


### PR DESCRIPTION
`comment` lang injection was missing for `nix`

adding it doesn't seem to interfer with the marking of multiline strings.
so this still works...

```
# NOTE: can still mark language of multi-line strings with a comment
foo = /*rust*/''
  pub fn bar() {}
''
```