### PR TITLE
Fix & Tweak Rust's Syntax Highlighting

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -169,6 +169,9 @@
 
 (mutable_specifier) @keyword.storage.modifier.mut
 
+(reference_type "&" @keyword.storage.modifier.ref)
+(self_parameter "&" @keyword.storage.modifier.ref)
+
 [
   "static"
   "const"

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -45,7 +45,8 @@
   "'" @label
   (identifier) @label)
 (loop_label
-  (identifier) @type)
+  "'" @label
+  (identifier) @label)
 
 ; ---
 ; Punctuation
@@ -102,8 +103,6 @@
 (closure_parameters
 	(identifier) @variable.parameter)
 
-
-
 ; -------
 ; Keywords
 ; -------
@@ -129,9 +128,7 @@
 [
   "break"
   "continue"
-
   "return"
-
   "await"
 ] @keyword.control.return
 
@@ -154,10 +151,7 @@
   "trait"
   "for"
 
-  "unsafe"
   "default"
-  "macro_rules!"
-
   "async"
 ] @keyword
 
@@ -165,18 +159,15 @@
   "struct"
   "enum"
   "union"
-
   "type"
 ] @keyword.storage.type
 
 "let" @keyword.storage
-
 "fn" @keyword.function
+"unsafe" @keyword.special
+"macro_rules!" @function.macro
 
 (mutable_specifier) @keyword.storage.modifier.mut
-
-(reference_type "&" @keyword.storage.modifier.ref)
-(self_parameter "&" @keyword.storage.modifier.ref)
 
 [
   "static"
@@ -202,11 +193,11 @@
 
 (call_expression
   function: [
-    ((identifier) @type.variant
-      (#match? @type.variant "^[A-Z]"))
+    ((identifier) @type.enum.variant
+      (#match? @type.enum.variant "^[A-Z]"))
     (scoped_identifier
-      name: ((identifier) @type.variant
-        (#match? @type.variant "^[A-Z]")))
+      name: ((identifier) @type.enum.variant
+        (#match? @type.enum.variant "^[A-Z]")))
   ])
 
 ; ---
@@ -237,15 +228,12 @@
 ((identifier) @type
   (#match? @type "^[A-Z]"))
 
-
-
 (attribute
   (identifier) @_macro
   arguments: (token_tree (identifier) @constant.numeric.integer)
   (#eq? @_macro "derive")
 )
 @special
-
 
 ; -------
 ; Functions
@@ -303,8 +291,6 @@
 (metavariable) @variable.parameter
 (fragment_specifier) @type
 
-
-
 ; -------
 ; Operators
 ; -------
@@ -350,8 +336,6 @@
   "'"
 ] @operator
 
-
-
 ; -------
 ; Paths
 ; -------
@@ -381,8 +365,6 @@
   name: (identifier) @namespace)
 (scoped_type_identifier
   path: (identifier) @namespace)
-
-
 
 ; -------
 ; Remaining Identifiers


### PR DESCRIPTION
- Loop labels are now highlighted as `@label` instead of `@type`
- `unsafe` is now `@keyword.special`
- `macro_rules!` is now `@function.macro`
- `@type.variant` is replaced with `@type.enum.variant` so enum constructors are highlighted correctly
- Some newlines were removed for consistency