### PR TITLE
Reload language config with `:config-reload`

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -418,9 +418,7 @@ impl Application {
             if true_color || theme.is_16_color() {
                 self.editor.set_theme(theme);
             } else {
-                return Err(anyhow::anyhow!(
-                    "theme requires truecolor support, which is not available"
-                ));
+                anyhow::bail!("theme requires truecolor support, which is not available")
             }
         }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -394,7 +394,7 @@ impl Application {
     }
 
     /// refresh language config after config change
-    fn refresh_language(&mut self) {
+    fn refresh_language_config(&mut self) {
         match helix_core::config::user_syntax_loader() {
             Ok(syntax_config) => {
                 self.syn_loader = std::sync::Arc::new(syntax::Loader::new(syntax_config));
@@ -415,7 +415,7 @@ impl Application {
             let true_color = self.true_color();
             match self.theme_loader.load(&theme) {
                 Ok(theme) => {
-                    self.refresh_language();
+                    self.refresh_language_config();
                     if true_color || theme.is_16_color() {
                         self.editor.set_theme(theme);
                     } else {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -415,7 +415,6 @@ impl Application {
             let true_color = self.true_color();
             match self.theme_loader.load(&theme) {
                 Ok(theme) => {
-                    self.refresh_language_config();
                     if true_color || theme.is_16_color() {
                         self.editor.set_theme(theme);
                     } else {
@@ -434,6 +433,7 @@ impl Application {
     fn refresh_config(&mut self) {
         match Config::load_default() {
             Ok(config) => {
+                self.refresh_language_config();
                 self.refresh_theme(&config);
 
                 // Store new config

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -394,54 +394,50 @@ impl Application {
     }
 
     /// refresh language config after config change
-    fn refresh_language_config(&mut self) {
-        match helix_core::config::user_syntax_loader() {
-            Ok(syntax_config) => {
-                self.syn_loader = std::sync::Arc::new(syntax::Loader::new(syntax_config));
-                for document in self.editor.documents.values_mut() {
-                    document.detect_language(self.syn_loader.clone());
-                }
-            }
-            Err(err) => {
-                let err_string = format!("failed to reload language config: {}", err);
-                self.editor.set_error(err_string);
-            }
+    fn refresh_language_config(&mut self) -> Result<(), Error> {
+        let syntax_config = helix_core::config::user_syntax_loader()
+            .map_err(|err| anyhow::anyhow!("Failed to load language config: {}", err))?;
+
+        self.syn_loader = std::sync::Arc::new(syntax::Loader::new(syntax_config));
+        for document in self.editor.documents.values_mut() {
+            document.detect_language(self.syn_loader.clone());
         }
+
+        Ok(())
     }
 
     /// Refresh theme after config change
-    fn refresh_theme(&mut self, config: &Config) {
+    fn refresh_theme(&mut self, config: &Config) -> Result<(), Error> {
         if let Some(theme) = config.theme.clone() {
             let true_color = self.true_color();
-            match self.theme_loader.load(&theme) {
-                Ok(theme) => {
-                    if true_color || theme.is_16_color() {
-                        self.editor.set_theme(theme);
-                    } else {
-                        self.editor
-                            .set_error("theme requires truecolor support, which is not available");
-                    }
-                }
-                Err(err) => {
-                    let err_string = format!("failed to load theme `{}` - {}", theme, err);
-                    self.editor.set_error(err_string);
-                }
+            let theme = self
+                .theme_loader
+                .load(&theme)
+                .map_err(|err| anyhow::anyhow!("Failed to load theme `{}`: {}", theme, err))?;
+
+            if true_color || theme.is_16_color() {
+                self.editor.set_theme(theme);
+            } else {
+                return Err(anyhow::anyhow!(
+                    "theme requires truecolor support, which is not available"
+                ));
             }
         }
+
+        Ok(())
     }
 
     fn refresh_config(&mut self) {
-        match Config::load_default() {
-            Ok(config) => {
-                self.refresh_language_config();
-                self.refresh_theme(&config);
+        let mut refresh_config = || -> Result<(), Error> {
+            let default_config = Config::load_default()
+                .map_err(|err| anyhow::anyhow!("Failed to load config: {}", err))?;
+            self.refresh_language_config()?;
+            self.refresh_theme(&default_config)?;
+            Ok(())
+        };
 
-                // Store new config
-                self.config.store(Arc::new(config));
-            }
-            Err(err) => {
-                self.editor.set_error(err.to_string());
-            }
+        if let Err(err) = refresh_config() {
+            self.editor.set_error(err.to_string());
         }
     }
 


### PR DESCRIPTION
Just had a go at implementing this

Not quite sure where to make test or what tests to make, but I tried it and it seems to be able to reload auto formatting, at least

https://user-images.githubusercontent.com/30967965/208830221-40562d71-cec4-4c2d-9f31-e6a056360fa4.mp4