### PR TITLE
Make editor remember the latest search register

### DIFF
--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -29,6 +29,7 @@ pub struct Registers {
     /// efficiently prepend new values in `Registers::push`.
     inner: HashMap<char, Vec<String>>,
     clipboard_provider: Box<dyn ClipboardProvider>,
+    pub last_search_register: char,
 }
 
 impl Default for Registers {
@@ -36,6 +37,7 @@ impl Default for Registers {
         Self {
             inner: Default::default(),
             clipboard_provider: get_clipboard_provider(),
+            last_search_register: '/',
         }
     }
 }


### PR DESCRIPTION
Resolves #5112.

This PR makes changes to the behavior of search commands:

- The editor now remembers the _search register_ used to kick start a `search`/`rsearch`/`global_search` command;
- `search_next`, `search_prev`, `extend_search_next`, and `extend_search_prev` now uses the _search register_ to continue the search;
- `search_selection` now uses the selected register. It also updates the _search register_;
- `make_search_word_bounded` defaults to using the _search register_ to make the `search_selection`-`make_search_word_bounded` flow more ergonomic, while also accepting register selection.

Overall, this PR should make the whole family of search commands play more nicely with register selection.