### PR TITLE
fix(theme): Replace invalid `cyan` by `blue` in line with original theme

### DIFF
--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -53,7 +53,7 @@
 "constructor" = "blue"
 "function" = "green"
 "function.macro" = { fg = "blue" }
-"function.builtin" = { fg = "cyan" }
+"function.builtin" = { fg = "blue" }
 
 # operator, tags, units, punctuations
 "operator" = "red"


### PR DESCRIPTION
This is a partial fix for https://github.com/helix-editor/helix/issues/5249 - notably the comment https://github.com/helix-editor/helix/issues/5249#issuecomment-1361571312 

The theme `monokai_pro_spectrum` uses a non-hex-coded color `"cyan"`.

`"cyan"` should be `#5ad4e6` according to the screenshot at https://www.vscolors.com/themes/f5d7ffda-c1d6-4070-ba80-803c705a1ee6-3ed72ace, which is in fact the palette color `"blue"`.