### PR TITLE
Automations for shared board

### DIFF
--- a/.github/workflows/add-item-to-project
+++ b/.github/workflows/add-item-to-project
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+if [[
+      -z "${CONTENT_ID}" ||
+      -z "${PROJECT_ID}" ||
+      (-z "${GH_TOKEN}" && -z "${GITHUB_TOKEN}")
+   ]]; then
+  echo "Please provide GITHUB_TOKEN, CONTENT_ID, and PROJECT_ID" >&2
+  exit 1
+fi
+
+item_id="$(gh api graphql \
+  -f "query=$(cat add-item-to-project.gql)" \
+  -f project="$PROJECT_ID" \
+  -f content="$CONTENT_ID" \
+  --jq '.data.addProjectV2ItemById.item.id')"
+
+echo 'ITEM_ID='"$item_id"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
   pull_request:
+    branches:
+      - '!nobuild-*'
   push:
     branches:
       - master

--- a/.github/workflows/fetch-project-data
+++ b/.github/workflows/fetch-project-data
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+if [[
+      -z "${ORGANIZATION}" ||
+      -z "${PROJECT_NUMBER}" ||
+      (-z "${GH_TOKEN}" && -z "${GITHUB_TOKEN}")
+   ]]; then
+  echo "Please provide GITHUB_TOKEN, ORGANIZATION, and PROJECT_NUMBER" >&2
+  exit 1
+fi
+
+project_data="$(gh api graphql \
+  -f "query=$(cat fetch-statuses.gql)" \
+  -f org="$ORGANIZATION" \
+  -F number="$PROJECT_NUMBER")"
+
+echo 'PROJECT_ID='"$(echo "${project_data}" | jq -r '.data.organization.projectV2.id')"
+echo 'STATUS_FIELD_ID='"$(echo "${project_data}" \
+  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id')"
+
+# Transform each status field name into camel case and track its id
+echo "${project_data}" | jq -r '.data.organization.projectV2.fields.nodes[]
+  | select(.name == "Status")
+  | .options[]
+  | {id: .id, name: .name | gsub("[^\\w\\s]\\s"; "")
+  | ascii_upcase
+  | gsub("[\\s-]"; "_")}
+  | "STATUS_ID_" + .name + "=" + .id'
+

--- a/.github/workflows/project-set-item-status.yml
+++ b/.github/workflows/project-set-item-status.yml
@@ -1,0 +1,110 @@
+name: Categorize new items
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  pull_request:
+    types:
+      - opened
+      - labeled
+  pull_request_review:
+    types:
+      - submitted
+jobs:
+  set-item-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          ORGANIZATION: helix-editor
+          PROJECT_NUMBER: '5'
+        run: ./ci/fetch-project-data >> $GITHUB_ENV
+
+      - name: Add item to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          CONTENT_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
+        run: ./ci/add-item-to-project >> $GITHUB_ENV
+
+      - name: Get date
+        run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+
+      - name: New PR
+        if: github.event.pull_request && github.event.action == 'opened'
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_INITIAL_REVIEW}" >> $GITHUB_ENV
+
+      - name: New issue
+        if: "github.event.issue && github.event.action == 'opened' && github.event.label.name != 'C-bug'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_NEW}" >> $GITHUB_ENV
+
+      - name: Bugs
+        if: "github.event.issue && github.event.action == 'labeled' && github.event.label.name == 'C-bug'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_BUGS}" >> $GITHUB_ENV
+
+      - name: Waiting on author from label
+        if: "github.event.action == 'labeled' && github.event.label.name == 'S-waiting-on-author'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_WAITING_ON_AUTHOR}" >> $GITHUB_ENV
+
+      - name: Waiting on author from review
+        if: "github.event.pull_request_review && github.event.action == 'submitted' && github.event.review.state == 'changes_requested'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_WAITING_ON_AUTHOR}" >> $GITHUB_ENV
+
+      - name: Needs review
+        if: "github.event.pull_request && github.event.action == 'labeled' && github.event.pull_request.review_comments == 0 && github.event.label.name == 'S-waiting-on-review'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_INITIAL_REVIEW}" >> $GITHUB_ENV
+
+      - name: Needs re-review from label
+        if: "github.event.pull_request && github.event.action == 'labeled' && github.event.pull_request.review_comments > 0 && github.event.label.name == 'S-waiting-on-review'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_RE_REVIEW}" >> $GITHUB_ENV
+
+      - name: Needs re-review from review
+        if: "github.event.pull_request_review && github.event.action == 'dismissed'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_RE_REVIEW}" >> $GITHUB_ENV
+
+      - name: Blocked
+        if: "github.event.action == 'labeled' && github.event.label.name == 'S-waiting-on-pr'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_BLOCKED}" >> $GITHUB_ENV
+
+      - name: Inactive
+        if: "github.event.action == 'labeled' && github.event.label.name == 'S-inactive'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_STALLED}" >> $GITHUB_ENV
+
+      - name: Approved
+        if: "github.event.pull_request_review && github.event.action == 'submitted' && github.event.review.state == 'approved'"
+        run: echo "TARGET_OPTION_ID=${STATUS_ID_APPROVED}" >> $GITHUB_ENV
+
+      - name: Set fields
+        if: env.TARGET_OPTION_ID != null
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: { 
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' \
+            -f project=$PROJECT_ID \
+            -f item=$ITEM_ID \
+            -f status_field=$STATUS_FIELD_ID \
+            -f status_value=${{ env.TARGET_OPTION_ID }} \
+            --silent

--- a/.github/workflows/project-set-item-status.yml
+++ b/.github/workflows/project-set-item-status.yml
@@ -75,7 +75,11 @@ jobs:
         run: echo "TARGET_OPTION_ID=${STATUS_ID_STALLED}" >> $GITHUB_ENV
 
       - name: Approved
-        if: "github.event.pull_request_review && github.event.action == 'submitted' && github.event.review.state == 'approved'"
+        if: >-
+          github.event.pull_request_review &&
+          github.event.action == 'submitted' &&
+          github.event.review.state == 'approved' &&
+          github.event.review.author_association == 'COLLABORATOR'
         run: echo "TARGET_OPTION_ID=${STATUS_ID_APPROVED}" >> $GITHUB_ENV
 
       - name: Set fields

--- a/.github/workflows/project-set-item-status.yml
+++ b/.github/workflows/project-set-item-status.yml
@@ -1,4 +1,4 @@
-name: Categorize new items
+name: Categorize items
 on:
   issues:
     types:
@@ -11,6 +11,7 @@ on:
   pull_request_review:
     types:
       - submitted
+      - dismissed
 jobs:
   set-item-status:
     runs-on: ubuntu-latest
@@ -51,7 +52,7 @@ jobs:
         run: echo "TARGET_OPTION_ID=${STATUS_ID_WAITING_ON_AUTHOR}" >> $GITHUB_ENV
 
       - name: Waiting on author from review
-        if: "github.event.pull_request_review && github.event.action == 'submitted' && github.event.review.state == 'changes_requested'"
+        if: "github.event.review && github.event.action == 'submitted' && github.event.review.state == 'changes_requested'"
         run: echo "TARGET_OPTION_ID=${STATUS_ID_WAITING_ON_AUTHOR}" >> $GITHUB_ENV
 
       - name: Needs review
@@ -63,7 +64,7 @@ jobs:
         run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_RE_REVIEW}" >> $GITHUB_ENV
 
       - name: Needs re-review from review
-        if: "github.event.pull_request_review && github.event.action == 'dismissed'"
+        if: "github.event.review && github.event.action == 'dismissed'"
         run: echo "TARGET_OPTION_ID=${STATUS_ID_NEEDS_RE_REVIEW}" >> $GITHUB_ENV
 
       - name: Blocked
@@ -76,7 +77,7 @@ jobs:
 
       - name: Approved
         if: >-
-          github.event.pull_request_review &&
+          github.event.review &&
           github.event.action == 'submitted' &&
           github.event.review.state == 'approved' &&
           github.event.review.author_association == 'COLLABORATOR'

--- a/ci/add-item-to-project
+++ b/ci/add-item-to-project
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+if [[
+      -z "${CONTENT_ID}" ||
+      -z "${PROJECT_ID}" ||
+      (-z "${GH_TOKEN}" && -z "${GITHUB_TOKEN}")
+   ]]; then
+  echo "Please provide GITHUB_TOKEN, CONTENT_ID, and PROJECT_ID" >&2
+  exit 1
+fi
+
+item_id="$(gh api graphql \
+  -f "query=$(cat add-item-to-project.gql)" \
+  -f project="$PROJECT_ID" \
+  -f content="$CONTENT_ID" \
+  --jq '.data.addProjectV2ItemById.item.id')"
+
+echo 'ITEM_ID='"$item_id"

--- a/ci/add-item-to-project.gql
+++ b/ci/add-item-to-project.gql
@@ -1,0 +1,7 @@
+mutation($project:ID!, $content:ID!) {
+  addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
+    item {
+      id
+    }
+  }
+}

--- a/ci/fetch-project-data
+++ b/ci/fetch-project-data
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+if [[
+      -z "${ORGANIZATION}" ||
+      -z "${PROJECT_NUMBER}" ||
+      (-z "${GH_TOKEN}" && -z "${GITHUB_TOKEN}")
+   ]]; then
+  echo "Please provide GITHUB_TOKEN, ORGANIZATION, and PROJECT_NUMBER" >&2
+  exit 1
+fi
+
+project_data="$(gh api graphql \
+  -f "query=$(cat fetch-statuses.gql)" \
+  -f org="$ORGANIZATION" \
+  -F number="$PROJECT_NUMBER")"
+
+echo 'PROJECT_ID='"$(echo "${project_data}" | jq -r '.data.organization.projectV2.id')"
+echo 'STATUS_FIELD_ID='"$(echo "${project_data}" \
+  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id')"
+
+# Transform each status field name into camel case and track its id
+echo "${project_data}" | jq -r '.data.organization.projectV2.fields.nodes[]
+  | select(.name == "Status")
+  | .options[]
+  | {id: .id, name: .name | gsub("[^\\w\\s]\\s"; "")
+  | ascii_upcase
+  | gsub("[\\s-]"; "_")}
+  | "STATUS_ID_" + .name + "=" + .id'

--- a/ci/fetch-statuses.gql
+++ b/ci/fetch-statuses.gql
@@ -1,0 +1,23 @@
+query($org: String!, $number: Int!) {
+  organization(login: $org){
+    projectV2(number: $number) {
+      id
+      fields(first:50) {
+        nodes {
+          ... on ProjectV2Field {
+            id
+            name
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a first pass at a shared board with automations. The guiding principle for the main board is that things shouldn't stay on the board for "too long", whatever that means for us. Things that are not likely to make progress in the near future, such as a PR that had changes requested, but the author has gone silent for some period of time, should be in "Backlog" or "Stalled".

This way, the board remains focused and easier to see all the concrete tasks in motion, and we can have separate views for looking over items that are not immediately actionable.

Only thing I'm unsure of is the authentication. I set up my own personal access token for testing, but I'm not sure if just the standard `GITHUB_TOKEN` will work when it's in the same repo, or if a separate access token will need to be set up.