### PR TITLE
Fix HTML injection within markdown

### DIFF
--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -5,7 +5,10 @@
     (language) @injection.language)
   (code_fence_content) @injection.content (#set! injection.include-unnamed-children))
 
-((html_block) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
+((html_block) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.include-unnamed-children)
+ (#set! injection.combined))
 
 ((pipe_table_cell) @injection.content (#set! injection.language "markdown.inline") (#set! injection.include-unnamed-children))
 


### PR DESCRIPTION
HTML nodes should be combined injections in the markdown block grammar. When nodes are together the highlighting works properly but when there is markdown content between HTML nodes like in a `<details>` tag, the highlighting of the closing tag breaks since tree-sitter-html looks for opening and closing tags.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/21230295/209239556-53824ed3-2918-406a-b9c0-9dec4e2fd879.png) | ![after](https://user-images.githubusercontent.com/21230295/209239567-6a0d0cbd-ffae-4076-a98a-1e74eef42dc0.png) |

(See that closing `</div>` tag on L17.)