### PR TITLE
Configurable lsp shutdown timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 helix-term/rustfmt.toml
 result
 runtime/grammars
+.DS_Store

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -117,6 +117,7 @@ The following statusline elements can be configured:
 | `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
+| `shutdown-timeout`    | Time in milliseconds to wait for lsp to shutdown before closing editor, set to 0 to close instantly. | `3000`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1087,7 +1087,8 @@ impl Application {
             errs.push(err);
         }
 
-        if self.editor.close_language_servers(None).await.is_err() {
+        let timeout = self.editor.config().lsp.shutdown_timeout;
+        if self.editor.close_language_servers(timeout).await.is_err() && !timeout.is_zero() {
             log::error!("Timed out waiting for language servers to shutdown");
             errs.push(anyhow::format_err!(
                 "Timed out waiting for language servers to shutdown"


### PR DESCRIPTION
## What
Makes the lsp shutdown timeout configurable but retains the default of `3s`,

## Why
I use a proxy server: https://github.com/pr2502/ra-multiplex so I can have multiple instances of helix open via a multiplexer using the same instance of `rust-analyzer`, every time I want to close a window gracefully it takes 3s and is a little painful, this allows me to set it to 0 via the option:
```
[editor.lsp]
shutdown-timeout = 0
```