### PR TITLE
Use curl underlines in the rose_pine theme

### DIFF
--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -1,5 +1,6 @@
 # Author: RayGervais<raygervais@hotmail.ca>
 # Author: ChrisHa<chunghha@users.noreply.github.com>
+# Diagnostics patch author: cor<cor@pruijs.dev>
 
 "ui.background" = { bg = "base" }
 "ui.menu" = { fg = "text", bg = "overlay" }
@@ -45,11 +46,17 @@
 "diff.delta" = "rose"
 "diff.minus" = "love"
 
-"info" = "gold"
-"hint" = "gold"
+"info" = "foam"
+"hint" = "iris"
 "debug" = "rose"
-"diagnostic" = "rose"
+"warning" = "gold"
 "error" = "love"
+
+"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic.error" = { underline = { style = "curl", color = "love" } }
+"diagnostic.warning" = { underline = { style = "curl", color = "gold" } }
+"diagnostic.info" = { underline = { style = "curl", color = "foam" } }
+"diagnostic.hint" = { underline = { style = "curl", color = "iris" } }
 
 "markup.heading.marker" = "subtle"
 "markup.heading.1" = { fg = "love", modifiers = ["bold"] }


### PR DESCRIPTION
Apply the new curl underline diagnostics to the `rose_pine` theme. Also fixes the color "gold" being used for too many kinds of diagnostics, now there's a more conventional choice of diagnostics colors (redish = error, yellowish = warning, blueish = hint).

Before
<img width="442" alt="rose_pine_before" src="https://user-images.githubusercontent.com/4728062/209342929-e3303cb4-95bd-4dcb-aefe-9c2b6442c6ba.png">

After
<img width="397" alt="rose_pine_after" src="https://user-images.githubusercontent.com/4728062/209342974-0377d602-7b51-4d01-bcb3-f09e98f4a7cd.png">


I've updated the authors section above as it seemed to be some sort of list of people who contributed to the theme, but I'm not sure if this is correct. If it isn't, then please let me know :)