### PR TITLE
Allow custom preprocessors for 'vue' injections

### DIFF
--- a/runtime/queries/vue/injections.scm
+++ b/runtime/queries/vue/injections.scm
@@ -8,13 +8,39 @@
   (raw_text) @injection.content)
  (#set! injection.language "javascript"))
 
+; <script>
 ((script_element
-  (raw_text) @injection.content)
- (#set! injection.language "javascript"))
+    (start_tag) @_no_lang
+    (raw_text) @injection.content)
+  (#not-match? @_no_lang "lang=")
+  (#set! injection.language "javascript"))
 
+; <script lang="js|javascript">
+((script_element
+    (start_tag (attribute (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @injection.content)
+    (#match? @_lang "^(js|javascript)$")
+    (#set! injection.language "javascript"))
+
+; <script lang="ts|typescript">
+((script_element
+    (start_tag (attribute (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @injection.content)
+    (#match? @_lang "^(ts|typescript)$")
+    (#set! injection.language "typescript"))
+
+; <style>
 ((style_element
-  (raw_text) @injection.content)
- (#set! injection.language "css"))
+    (start_tag) @_no_lang
+    (raw_text) @injection.content)
+  (#not-match? @_no_lang "lang=")
+  (#set! injection.language "css"))
+
+; <style lang="...">
+((style_element
+    (start_tag (attribute (quoted_attribute_value (attribute_value) @injection.language)))
+    (raw_text) @injection.content)
+    (#match? @injection.language "^(css|scss)$"))
 
 ((comment) @injection.content
  (#set! injection.language "comment"))

--- a/runtime/queries/vue/injections.scm
+++ b/runtime/queries/vue/injections.scm
@@ -15,19 +15,14 @@
   (#not-match? @_no_lang "lang=")
   (#set! injection.language "javascript"))
 
-; <script lang="js|javascript">
+; <script lang="...">
 ((script_element
-    (start_tag (attribute (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @injection.content)
-    (#match? @_lang "^(js|javascript)$")
-    (#set! injection.language "javascript"))
-
-; <script lang="ts|typescript">
-((script_element
-    (start_tag (attribute (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @injection.content)
-    (#match? @_lang "^(ts|typescript)$")
-    (#set! injection.language "typescript"))
+  (start_tag
+    (attribute
+    (attribute_name) @_attr_name
+    (quoted_attribute_value (attribute_value) @injection.language)))
+  (raw_text) @injection.content)
+  (#eq? @_attr_name "lang"))
 
 ; <style>
 ((style_element
@@ -38,9 +33,12 @@
 
 ; <style lang="...">
 ((style_element
-    (start_tag (attribute (quoted_attribute_value (attribute_value) @injection.language)))
-    (raw_text) @injection.content)
-    (#match? @injection.language "^(css|scss)$"))
+  (start_tag
+    (attribute
+      (attribute_name) @_attr_name
+      (quoted_attribute_value (attribute_value) @injection.language)))
+   (raw_text) @injection.content)
+ (#eq? @_attr_name "lang"))
 
 ((comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Changes the injections for *Vue* `script` and `style` tags to allow for custom preprocessors. Before they were hardcoded to  plain `javascript` and `css`.

*Vue* tooling can specify a preprocessor via the `lang` attribute.
This only adds injections for languages that helix already supports.

e.g.
```vue
<script lang="typescript">
```

or very commonly used
```vue
<style lang="scss">
```

