### PR TITLE
Fix kanagawa theme lint and added git gutter colors

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -12,6 +12,9 @@
 "ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
 "ui.linenr" = { fg = "sumiInk4" }
+"ui.linenr.selected" = { fg = "roninYellow" }
+
+"ui.virtual.indent-guide" = "sumiInk4"
 
 "ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -7,7 +7,8 @@
 # because of some theming differences, it's not an exact copy of the original.
 
 ## User interface
-"ui.selection" = { bg = "waveBlue1" }
+"ui.selection" = { bg = "waveBlue2" }
+"ui.selection.primary" = { bg = "waveBlue1" }
 "ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
 "ui.linenr" = { fg = "sumiInk4" }
@@ -28,10 +29,14 @@
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 "ui.virtual" = "waveBlue1"
 
-"ui.cursor" = { fg = "fujiWhite", bg = "waveBlue1"}
-"ui.cursor.primary" = { fg = "seaFoam", bg = "waveBlue1" }
+"ui.cursor" = { fg = "waveBlue1", bg = "fujiWhite"}
+"ui.cursor.primary" = { fg = "waveBlue1", bg = "seaFoam" }
 "ui.cursor.match" = { fg = "seaFoam", modifiers = ["bold"] }
 "ui.highlight" = { fg = "fujiWhite", bg = "waveBlue2" }
+"ui.menu" = { fg = "fujiWhite", bg = "sumiInk1" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue1" }
+
+"ui.cursorline.primary" = { bg = "sumiInk3"}
 
 diagnostic = { modifiers = ["underlined"] }
 
@@ -54,8 +59,8 @@ hint = "dragonBlue"
 "variable.other.member" = "carpYellow"
 "label" = "springBlue"
 "punctuation" = "springViolet2"
-"punctuation.delimiter" = "springViolet2" 
-"punctuation.bracket" = "springViolet2" 
+"punctuation.delimiter" = "springViolet2"
+"punctuation.bracket" = "springViolet2"
 "keyword" = "oniViolet"
 "keyword.directive" = "peachRed"
 "operator" = "boatYellow2"

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -27,7 +27,7 @@
 
 "ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.window" = { fg = "fujiWhite" }
-"ui.help" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.help" = { fg = "fujiWhite", bg = "sumiInk1" }
 "ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 "ui.virtual" = "waveBlue1"

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -45,6 +45,11 @@ warning = "roninYellow"
 info = "waveAqua1"
 hint = "dragonBlue"
 
+## Git gutter
+"diff.plus" = "autumnGreen"
+"diff.minus" = "autumnRed"
+"diff.delta" = "autumnYellow"
+
 ## Syntax highlighting
 "type" = "waveAqua2"
 "constant" = "surimiOrange"


### PR DESCRIPTION
This comprises 4 changes:

1. added "sumiInk3" as ui.cursorline.primary bg color (in line with original)
2. swapped the cursor bg and fg colors (to maintain readability with cursorline; now in line with original)
3. added ui.menu and ui.menu.selected colors (should be close to original)
4. separated ui.selection and ui.selection.primary

@zetashift please take a look; especially regarding my choice of color for change 4.

--
Edit: now 8 changes:
5. added the theme's official git gutter colors to address kanagawa's share of #4972 
6. added "sumiInk4" as ui.virtual.indent-guide
7. added "roninYellow" as ui.linenr.selected
8. set ui.help bg to "sumiInk1"