### PR TITLE
Easier way to implement mouse action

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -9,6 +9,8 @@
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Force close all buffers but the currently focused one. |
 | `:buffer-close-all`, `:bca`, `:bcloseall` | Close all buffers without quitting. |
 | `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Force close all buffers ignoring unsaved changes without quitting. |
+| `:buffer-close-nth`, `:bcn`, `:bclosenth` | Close nth buffer without quitting. |
+| `:buffer-nth`, `:bnth` | Goto nth buffer. |
 | `:buffer-next`, `:bn`, `:bnext` | Goto next buffer. |
 | `:buffer-previous`, `:bp`, `:bprev` | Goto previous buffer. |
 | `:write`, `:w` | Write changes to disk. Accepts an optional path (:write some/path.txt) |
@@ -50,6 +52,7 @@
 | `:lsp-restart` | Restarts the Language Server that is in use by the current doc |
 | `:tree-sitter-scopes` | Display tree sitter scopes, primarily for theming and development. |
 | `:debug-start`, `:dbg` | Start a debug session from a given template with given parameters. |
+| `:dap-toggle-breakpoint-by-line` | Toggle dap breakpoint by line |
 | `:debug-remote`, `:dbg-tcp` | Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters. |
 | `:debug-eval` | Evaluate expression in current debug context. |
 | `:vsplit`, `:vs` | Open the file in a vertical split. |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -180,7 +180,8 @@ impl Application {
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
             &config.keys
         }));
-        let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
+        let mut editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
+        editor_view.mouse_enable(editor.config().mouse);
         compositor.push(editor_view);
 
         if args.load_tutor {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -371,6 +371,19 @@ pub fn dap_toggle_breakpoint(cx: &mut Context) {
     dap_toggle_breakpoint_impl(cx, path, line);
 }
 
+pub fn dap_toggle_breakpoint_by_line(cx: &mut Context, line: usize) {
+    let doc = doc!(cx.editor);
+    let path = match doc.path() {
+        Some(path) => path.clone(),
+        None => {
+            cx.editor
+                .set_error("Can't set breakpoint: document has no path");
+            return;
+        }
+    };
+    dap_toggle_breakpoint_impl(cx, path, line);
+}
+
 pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) {
     // TODO: need to map breakpoints over edits and update them?
     // we shouldn't really allow editing while debug is running though


### PR DESCRIPTION
Developed an easier way to implement mouse action.

```rust
mouse_actions: HashMap<MouseEventKind, Vec<(Rect, MappableCommand)>>

pub fn add_mouse_action(
        &mut self,
        mouse_event: MouseEventKind,
        area: Rect,
        action: MappableCommand,
    ) {
        if self.mosue_enable {
            match self.mouse_actions.get_mut(&mouse_event) {
                Some(commands) => commands.push((area, action)),
                None => {
                    self.mouse_actions.insert(mouse_event, vec![(area, action)]);
                }
            }
        }
    }

let has_click_action = |kind, row, column| match self.mouse_actions.get(kind) {
    Some(commands) => commands.iter().rev().find(|(area, _)| {
        if area.x <= column
            && area.x + area.width > column
            && area.y <= row
            && area.y + area.height > row
        {
            return true;
        }
        false
    }),
    None => None,
};

if let Some((_, cmd)) = has_click_action(&kind, row, column) {
    cmd.execute(cxt);
    return EventResult::Consumed(None);
}
```

