### PR TITLE
Fix opening new files

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -67,7 +67,7 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
         let (path, pos) = args::parse_file(arg);
         // If the path is a directory, open a file picker on that directory and update the status
         // message
-        if std::fs::canonicalize(&path)?.is_dir() {
+        if let Ok(true) = std::fs::canonicalize(&path).map(|p| p.is_dir()) {
             let callback = async move {
                 let call: job::Callback = job::Callback::EditorCompositor(Box::new(
                     move |editor: &mut Editor, compositor: &mut Compositor| {


### PR DESCRIPTION
Commit 1b89d3e5350f83b2ffb86a86326bd2714308ee53 introduced a regression where opening a new file would no longer work, because attempting to canonicalize its path would lead to a "No such file or directory" error. Fall back to opening a new file when encountering an error to fix this case.