### PR TITLE
Add statusline option: `filename-display-mode`

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -2,6 +2,7 @@ use helix_core::{coords_at_pos, encoding, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
+    editor::FilenameDisplayMode,
     graphics::Rect,
     theme::Style,
     Document, Editor, View,
@@ -414,7 +415,14 @@ where
         let rel_path = context.doc.relative_path();
         let path = rel_path
             .as_ref()
-            .map(|p| p.to_string_lossy())
+            .and_then(
+                |p| match context.editor.config().statusline.filename_display_mode {
+                    FilenameDisplayMode::Relative => Some(p.to_string_lossy()),
+                    FilenameDisplayMode::Leaf => {
+                        p.as_path().file_name().map(|s| s.to_string_lossy())
+                    }
+                },
+            )
             .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
         format!(
             " {}{} ",

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -264,6 +264,21 @@ pub struct SearchConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FilenameDisplayMode {
+    /// Show only the filename
+    Leaf,
+    /// Show the relative path of the file (absolute if the file is not in the current working dir)
+    Relative,
+}
+
+impl Default for FilenameDisplayMode {
+    fn default() -> Self {
+        Self::Relative
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct StatusLineConfig {
     pub left: Vec<StatusLineElement>,
@@ -271,6 +286,7 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub filename_display_mode: FilenameDisplayMode,
 }
 
 impl Default for StatusLineConfig {
@@ -283,6 +299,7 @@ impl Default for StatusLineConfig {
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            filename_display_mode: FilenameDisplayMode::default(),
         }
     }
 }


### PR DESCRIPTION
Allows for showing only the filename instead of the path which can sometimes be long.