### PR TITLE
Add command to open user's language.toml file

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -67,6 +67,7 @@
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
+| `:config-language-open`, `:config-lang-open` | Open the user config.toml file. |
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output before each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1703,6 +1703,20 @@ fn open_config(
     Ok(())
 }
 
+fn open_language_config(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .open(&helix_loader::lang_config_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_log(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -2295,6 +2309,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Open the user config.toml file.",
             fun: open_config,
+            completer: None,
+        },
+        TypableCommand {
+            name: "config-language-open",
+            aliases: &["config-lang-open"],
+            doc: "Open the user config.toml file.",
+            fun: open_language_config,
             completer: None,
         },
         TypableCommand {


### PR DESCRIPTION
Added "open-language-config". It also has an alias "config-lang-open".

![image](https://user-images.githubusercontent.com/28984877/209447946-934384f2-67a6-47b8-a91a-e542cd749cf5.png)

I'd like to request suggestions in case the names are not clear enough.