### PR TITLE
fix(commands): extend_line to proper line when count and current line selected

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2053,16 +2053,10 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
     let selection = doc.selection(view.id).clone().transform(|range| {
         let (start_line, end_line) = range.line_range(text.slice(..));
 
-        let start = text.line_to_char(match extend {
-            Extend::Above => start_line.saturating_sub(count - 1),
-            Extend::Below => start_line,
-        });
+        let start = text.line_to_char(start_line);
         let end = text.line_to_char(
-            match extend {
-                Extend::Above => end_line + 1, // the start of next line
-                Extend::Below => end_line + count,
-            }
-            .min(text.len_lines()),
+            (end_line + 1) // newline of end_line
+                .min(text.len_lines()),
         );
 
         // extend to previous/next line if current line is selected
@@ -2076,8 +2070,11 @@ fn extend_line_impl(cx: &mut Context, extend: Extend) {
             }
         } else {
             match extend {
-                Extend::Above => (end, start),
-                Extend::Below => (start, end),
+                Extend::Above => (end, text.line_to_char(start_line.saturating_sub(count - 1))),
+                Extend::Below => (
+                    start,
+                    text.line_to_char((end_line + count).min(text.len_lines())),
+                ),
             }
         };
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -316,17 +316,39 @@ async fn test_undo_redo() -> anyhow::Result<()> {
 async fn test_extend_line() -> anyhow::Result<()> {
     // extend with line selected then count
     test((
-        platform_line("#[a|]#\na\na\n\n").as_str(),
+        platform_line(indoc! {"\
+            #[l|]#orem
+            ipsum
+            dolor
+            
+            "})
+        .as_str(),
         "x2x",
-        platform_line("#[a\na\na\n|]#\n").as_str(),
+        platform_line(indoc! {"\
+            #[lorem
+            ipsum
+            dolor
+            |]#
+            "})
+        .as_str(),
     ))
     .await?;
 
     // extend with count on partial selection
     test((
-        platform_line("#[a|]#\na\n\n").as_str(),
+        platform_line(indoc! {"\
+            #[l|]#orem
+            ipsum
+            
+            "})
+        .as_str(),
         "2x",
-        platform_line("#[a\na\n|]#\n").as_str(),
+        platform_line(indoc! {"\
+            #[lorem
+            ipsum
+            |]#
+            "})
+        .as_str(),
     ))
     .await?;
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -311,3 +311,24 @@ async fn test_undo_redo() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_extend_line() -> anyhow::Result<()> {
+    // extend with line selected then count
+    test((
+        platform_line("#[a|]#\na\na\n\n").as_str(),
+        "x2x",
+        platform_line("#[a\na\na\n|]#\n").as_str(),
+    ))
+    .await?;
+
+    // extend with count on partial selection
+    test((
+        platform_line("#[a|]#\na\n\n").as_str(),
+        "2x",
+        platform_line("#[a\na\n|]#\n").as_str(),
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
for both extend_line_(above/below) the check for if current line is selected now works if there is a count:

this now means if you select a line with ``x`` and then do ``2x`` 3 lines will be selected whereas before only 2 lines would be, this keeps ``2x`` on a not fully selected line only selecting 2 lines which is the desired functionality of ``extend_line``

fixes #5270 