### PR TITLE
docs/book: map `esc` key in config.toml to escape multi-cursor and non-normal modes to help new users

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -23,6 +23,15 @@ select = "underline"
 
 [editor.file-picker]
 hidden = false
+
+[keys.insert]
+esc = ["collapse_selection", "normal_mode"]
+
+[keys.normal]
+esc = ["collapse_selection", "keep_primary_selection"]
+
+[keys.select]
+esc = ["collapse_selection", "keep_primary_selection", "normal_mode"]
 ```
 
 You may also specify a file to use for configuration with the `-c` or

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -16,6 +16,9 @@ theme = "onedark"
 line-number = "relative"
 mouse = false
 
+# Uncomment true-color to fix false positive "Unsupported theme: theme requires true color support."
+# true-color = true
+
 [editor.cursor-shape]
 insert = "bar"
 normal = "block"
@@ -24,14 +27,21 @@ select = "underline"
 [editor.file-picker]
 hidden = false
 
+# Mapping a key is easy.  E.g. Vim users can map 0 to go to start of line.
+# Experienced Helix users prefer that collapsing and keeping the primary
+# selection be explicit operations and distinct from changing modes.
+# However, beginners can map esc key to reset Helix to fully default state of
+# normal mode, single cursor, and not having multiple chars or words selected.
 [keys.insert]
 esc = ["collapse_selection", "normal_mode"]
 
 [keys.normal]
 esc = ["collapse_selection", "keep_primary_selection"]
+0   = "goto_line_start"
 
 [keys.select]
 esc = ["collapse_selection", "keep_primary_selection", "normal_mode"]
+0   = "goto_line_start"
 ```
 
 You may also specify a file to use for configuration with the `-c` or


### PR DESCRIPTION
PR was updated after reading comments by @gibbz00 and @the-mikedavis.

The example config.toml embedded in docs will be most useful to new users and reviewers who don't know how to map a key .  At that level of experience, their frustration will be from:
- not knowing how to map keys in config.toml
- not having `esc` key reset Helix to fully default state of normal mode, single cursor, etc.
- getting false positive error about lack of true color support (e.g. Linux distros in WSL2 on Windows 11)

This PR resolves all of the above in a simple update to the example config embedded in the docs.  This PR does not promote this config for use by non-beginners.  It's just an example showing how use config.toml to map a key and resolve early challenges.

Non-beginners are unlikely to even look at the example config embedded in the docs, so this config can safely be ignored by everyone already familiar with Helix and it won't affect them.

I'm not the only new user to initially wonder why `esc` key doesn't reset to fully default state in Helix.  See "Taking a look at the Helix editor" video at around [14m37s (youtube)](https://www.youtube.com/watch?v=8L308PdmhMY&t=877s).

Here's what is added to the example config in the docs:

```toml
# Uncomment true-color to fix false positive "Unsupported theme: theme requires true color support."
# true-color = true

# Mapping a key is easy.  E.g. Vim users can map 0 to go to start of line.
# Experienced Helix users prefer that collapsing and keeping the primary
# selection be explicit operations and distinct from changing modes.
# However, beginners can map esc key to reset Helix to fully default state of
# normal mode, single cursor, and not having multiple chars or words selected.
[keys.insert]
esc = ["collapse_selection", "normal_mode"]

[keys.normal]
esc = ["collapse_selection", "keep_primary_selection"]
0   = "goto_line_start"

[keys.select]
esc = ["collapse_selection", "keep_primary_selection", "normal_mode"]
0   = "goto_line_start"
```
Again, this update to docs won't affect existing users and will only reduce problems for new users and reviewers.  It should improve positive reviews and increase conversion rate of new users trying Helix for the first time by creating a better first impression.
