### PR TITLE
Commit to history after executing a command from the palette

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2509,8 +2509,7 @@ pub fn command_palette(cx: &mut Context) {
                     on_next_key_callback: None,
                     jobs: cx.jobs,
                 };
-                let (view, _) = current!(ctx.editor);
-                let focus = view.id;
+                let focus = view!(ctx.editor).id;
 
                 command.execute(&mut ctx);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2509,7 +2509,23 @@ pub fn command_palette(cx: &mut Context) {
                     on_next_key_callback: None,
                     jobs: cx.jobs,
                 };
+                let (view, _) = current!(ctx.editor);
+                let focus = view.id;
+
                 command.execute(&mut ctx);
+
+                if ctx.editor.tree.contains(focus) {
+                    let config = ctx.editor.config();
+                    let mode = ctx.editor.mode();
+                    let view = view_mut!(ctx.editor, focus);
+                    let doc = doc_mut!(ctx.editor, &view.doc);
+
+                    view.ensure_cursor_in_view(doc, config.scrolloff);
+
+                    if mode != Mode::Insert {
+                        doc.append_changes_to_history(view);
+                    }
+                }
             });
             compositor.push(Box::new(overlayed(picker)));
         },


### PR DESCRIPTION
Fixes #5261

While this does fix the underlying issue of that bug, which was that appending to history only happened in [editor.rs:1424](https://github.com/helix-editor/helix/blob/1af76b738dd5bdae14b025d07d3001c4ad23e071/helix-term/src/ui/editor.rs#L1424) which meant that undo-ing after executing a command from the palette would call `undo` before the change was committed, it does not address the bigger issue - that it's way too easy to mutate a document and have document and history desync.
I'm opening this PR not necessairly to have this fix merged (although we could do it to fix the issue temporarily) but to document and highlight the root cause and possibly discuss a long-term fix, which I'd gladly take on implementing.

Discussion from the matrix channel about this issue:
> Pascal Kuthe
> Generally any transaction should be appended immidietly to the history. We had quite a few bugs caused from missing that. You would need to find out how a history entry is normally created for a command and why its not happening from the picker. 
> 
> I do not know the commands area of the editor aswell as I would like (I usually focus more on the render system with what I work on). Therefore I can't tell you how it works off the top of my head without looking at the source (and I am at a Christmas party rn :D) but looking around a bit could be a good way to get into the codebase a bit.
> The interesting part here is that the same commands append to history when called normally but not when called trough the picker, if I understood the issue correctly
> So I taught it would be some generic mechanism

> niko (me)
> Yeah the problem here is that we append to history after handling event in the Component impl, but that doesn’t get executed for the picker callback so there’s a couple options for solving this issue:
> • Adding the code for appending history changes to command picker
> • Adding the code for appending history changes to MappableCommand::execute
> • Adding the code for appending history changes somewhere else entirely? 
> Ideally we wouldn’t want to repeat the same code multiple times in multiple places which is why I feel reluctant to just pasting that code into command palette handler but maybe that is the way forward

> gabydd
> Some commands like format make changes to the document asynchronously so they have to manually append that to the history
> If I remember correctly we don't want to append to history if we are still in insert mode only on change to normal mode but that might be able to be checked not sure, Micheal Davis or archseer would probably have know what the best way to do this is

> archseer
> yeah that's how it works, I also was thinking commands/keybinds could return an `Option<Transaction>` that would get auto applied, but that's slightly more code in commands that don't do anything
> and you wouldn't be able to apply multiple in a row then

