### PR TITLE
Add support for clangd's switchSourceHeader

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -445,6 +445,7 @@ impl MappableCommand {
         record_macro, "Record macro",
         replay_macro, "Replay macro",
         command_palette, "Open command palette",
+        switch_source_header, "Switch source/header",
     );
 }
 


### PR DESCRIPTION
Depends on https://github.com/gluon-lang/lsp-types/pull/254.

clangd supports several extensions outside the Language Server Protocol specification.
One of them is the functionality to determine the corresponding source/header file from another file: https://clangd.llvm.org/extensions#switch-between-sourceheader.

Unfortunately clangd does not explicitly mention this command in its capabilities list, i.e.
```
2022-12-26T10:43:40.798 helix_lsp::transport [INFO] <- {"id":0,"jsonrpc":"2.0","result":{"capabilities":{"astProvider":true,"callHierarchyProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","refactor","info"]},"compilationDatabase":{"automaticReload":true},"completionProvider":{"allCommitCharacters":[" ","\t","(",")","[","]","{","}","<",">",":",";",",","+","-","/","*","%","^","&","#","?",".","=","\"","'","|"],"resolveProvider":false,"triggerCharacters":[".","<",">",":","\"","/","*"]},"declarationProvider":true,"definitionProvider":true,"documentFormattingProvider":true,"documentHighlightProvider":true,"documentLinkProvider":{"resolveProvider":false},"documentOnTypeFormattingProvider":{"firstTriggerCharacter":"\n","moreTriggerCharacter":[]},"documentRangeFormattingProvider":true,"documentSymbolProvider":true,"executeCommandProvider":{"commands":["clangd.applyFix","clangd.applyTweak"]},"hoverProvider":true,"implementationProvider":true,"memoryUsageProvider":true,"referencesProvider":true,"renameProvider":true,"selectionRangeProvider":true,"semanticTokensProvider":{"full":{"delta":true},"legend":{"tokenModifiers":["declaration","deprecated","deduced","readonly","static","abstract","virtual","dependentName","defaultLibrary","usedAsMutableReference","functionScope","classScope","fileScope","globalScope"],"tokenTypes":["variable","variable","parameter","function","method","function","property","variable","class","interface","enum","enumMember","type","type","unknown","namespace","typeParameter","concept","type","macro","comment"]},"range":false},"signatureHelpProvider":{"triggerCharacters":["(",","]},"textDocumentSync":{"change":2,"openClose":true,"save":true},"typeHierarchyProvider":true,"workspaceSymbolProvider":true},"serverInfo":{"name":"clangd","version":"Apple clangd version 14.0.0 (clang-1400.0.29.202) mac+xpc x86_64-apple-darwin22.2.0; target=arm64-apple-darwin22.2.0"}}}
```

so I opted to check for the server_info name instead. We could instead send the request regardless, but from testing with some other language servers, there was no response for this request. And that meant the user never got an error message about it, which felt like a bad UX.

Tested:
- [x] cargo integration-test
- [x] Verified functionality with clangd (for missing and existing source/headers)
- [x] Verified this is a noop with rls and an error message is displayed