### PR TITLE
Add save on idle 🚀

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -50,7 +50,8 @@ on unix operating systems.
 | `auto-completion` | Enable automatic pop up of auto-completion. | `true` |
 | `auto-format` | Enable automatic formatting on save. | `true` |
 | `auto-save` | Enable automatic saving on focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal. | `false` |
-| `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant. | `400` |
+| `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion and idle-save, set to 0 for instant. | `400` |
+| `idle-save` | Enable automatic saving on idle timer trigger. | `false` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `auto-info` | Whether to display infoboxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. | `false` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1429,7 +1429,15 @@ impl Component for EditorView {
             }
 
             Event::Mouse(event) => self.handle_mouse_event(event, &mut cx),
-            Event::IdleTimeout => self.handle_idle_timeout(&mut cx),
+            Event::IdleTimeout => {
+                let event_result = self.handle_idle_timeout(&mut cx);
+                if context.editor.config().idle_save {
+                    if let Err(e) = commands::typed::write_all_impl(context, false, false) {
+                        context.editor.set_error(format!("{}", e));
+                    }
+                }
+                event_result
+            }
             Event::FocusGained => EventResult::Ignored(None),
             Event::FocusLost => {
                 if context.editor.config().auto_save {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -147,12 +147,14 @@ pub struct Config {
     /// Automatic save on focus lost. Defaults to false.
     pub auto_save: bool,
     /// Time in milliseconds since last keypress before idle timers trigger.
-    /// Used for autocompletion, set to 0 for instant. Defaults to 400ms.
+    /// Used for autocompletion and idle-save, set to 0 for instant. Defaults to 400ms.
     #[serde(
         serialize_with = "serialize_duration_millis",
         deserialize_with = "deserialize_duration_millis"
     )]
     pub idle_timeout: Duration,
+    /// Automatic save on idle timeout trigger. Defaults to false.
+    pub idle_save: bool,
     pub completion_trigger_len: u8,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
@@ -616,6 +618,7 @@ impl Default for Config {
             auto_format: true,
             auto_save: false,
             idle_timeout: Duration::from_millis(400),
+            idle_save: false,
             completion_trigger_len: 2,
             auto_info: true,
             file_picker: FilePickerConfig::default(),


### PR DESCRIPTION
- Implements an `auto-save` like feature on idle timer trigger events.
- Useful for immediate feedback from `rust-analyzer` as most diagnostics are only refreshed on file save.
- Configured as a boolean `idle-save` in the `[editor]` section of the config file, `false` by default. 

Video showcasing the feature with `rust-analyzer` language server **(**`idle-timeout` is set to `0`**)**

https://user-images.githubusercontent.com/83179501/209581216-c29e581b-c17f-4e63-b2b8-6228e9cdff93.mp4

