### PR TITLE
Detect truecolor support in kmscon

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -15,7 +15,7 @@ pub use keymap::macros::*;
 #[cfg(not(windows))]
 fn true_color() -> bool {
     std::env::var("COLORTERM")
-        .map(|v| matches!(v.as_str(), "truecolor" | "24bit"))
+        .map(|v| matches!(v.as_str(), "truecolor" | "24bit" | "kmscon"))
         .unwrap_or(false)
 }
 #[cfg(windows)]


### PR DESCRIPTION
A patched version of kmscon for true color compatibility reports true color support by setting `COLORTERM` to `kmscon`. This PR allows helix to recognize it.