### PR TITLE
Change primary selection color...

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -65,7 +65,8 @@ label = "honey"
 "ui.cursor.select" = { bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }
 "ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
-"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor" = { fg = "#756FDC", modifiers = ["reversed"] }
+"ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursorline.primary" = { bg = "bossanova" }
 "ui.highlight" = { bg = "bossanova" }
 

--- a/theme.toml
+++ b/theme.toml
@@ -60,13 +60,13 @@ label = "honey"
 "ui.virtual.indent-guide" = { fg = "comet" }
 
 "ui.selection" = { bg = "#540099" }
-"ui.selection.primary" = { bg = "#8700F5" }
+"ui.selection.primary" = { bg = "#1212CE" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
+"ui.cursor" = { fg = "#8984E1", modifiers = ["reversed"] }
+"ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.select" = { bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }
 "ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
-"ui.cursor" = { fg = "#756FDC", modifiers = ["reversed"] }
-"ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursorline.primary" = { bg = "bossanova" }
 "ui.highlight" = { bg = "bossanova" }
 

--- a/theme.toml
+++ b/theme.toml
@@ -60,7 +60,7 @@ label = "honey"
 "ui.virtual.indent-guide" = { fg = "comet" }
 
 "ui.selection" = { bg = "#540099" }
-"ui.selection.primary" = { bg = "#540099" }
+"ui.selection.primary" = { bg = "#7900DB" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
 "ui.cursor.select" = { bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }

--- a/theme.toml
+++ b/theme.toml
@@ -60,9 +60,9 @@ label = "honey"
 "ui.virtual.indent-guide" = { fg = "comet" }
 
 "ui.selection" = { bg = "#540099" }
-"ui.selection.primary" = { bg = "#1212CE" }
+"ui.selection.primary" = { bg = "#1313BE" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
-"ui.cursor" = { fg = "#8984E1", modifiers = ["reversed"] }
+"ui.cursor" = { fg = "#8E89E6", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.select" = { bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }

--- a/theme.toml
+++ b/theme.toml
@@ -60,7 +60,7 @@ label = "honey"
 "ui.virtual.indent-guide" = { fg = "comet" }
 
 "ui.selection" = { bg = "#540099" }
-"ui.selection.primary" = { bg = "#7900DB" }
+"ui.selection.primary" = { bg = "#8700F5" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
 "ui.cursor.select" = { bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }


### PR DESCRIPTION
Fix https://github.com/helix-editor/helix/issues/5314 
in continuation (or maybe now in precession) of https://github.com/helix-editor/helix/pull/5309/

Please squash the commits


### Sample text 
(for myself as i don't have latest tutor)

<details>

```
=================================================================
=             10.1 CYCLING AND REMOVING SELECTIONS              =
=================================================================

 Type ) and ( to cycle the primary selection forward and backward
 through selections respectively.

 Type Alt-, to remove the primary selection.

 1. Move the cursor to the line marked '-->' below.
 2. Select both lines with xx or 2x.
 3. Type s to select, type "would" and enter.
 4. Use ( and ) to cycle the primary selection and remove the
    very second "would" with Alt-, .
 5. Type c "wood" to change the remaining "would"s to "wood".

 --> How much would would a wouldchuck chuck
 --> if a wouldchuck could chuck would?

 ```
</details>


### Screenshots:

<img src="https://user-images.githubusercontent.com/19423063/209864244-b8dc2bc6-0d43-4bc3-ae96-ec996bff75b2.png" width="700px"/>


<br/><br/>


https://user-images.githubusercontent.com/19423063/209864081-6f7fb324-e7ce-4749-8687-2ec6d4153b9a.mp4


### The colors in this pr are

key = value | color (hsl) | comment | contrast |
-- | -- | -- | :--: |
`"ui.background" = { bg = "midnight" }` | `#3b224c` = `hsl(276, 38%, 22%)` | default | 
`"ui.text" = { fg = "lavender" }` | `#a4a0e8` = `hsl(243, 61%, 77%)` | default | 5.77
`"ui.selection" = { bg = "` `#540099` `" }` | `hsl(273, 100%, 30%)` | default | 4.77
`"ui.cursor" = { fg = "` `#8E89E6` <br/> `", modifiers = ["reversed"] }` | `hsl(243, 65%, 72%)` | proposed | 4.52
`"ui.selection.primary" = { bg = "` `#1313BE` `" }` | `hsl(240, 82%, 41%)` | proposed | 4.71
`"ui.cursor.primary" = { modifiers = ["reversed"] }` |  | default-ish | 5.77


https://user-images.githubusercontent.com/19423063/209863091-e4e05789-4c64-416c-8847-56efccfcba2d.mp4


### Constrast scale used

* Higher is better
* It is a ratio of some sorts between the two colors, 
* so, naturally, 1:1 means both are equal i.e. same color, i.e. no contrast
* it measures `21:1` for `black` on `white`
* WCAG 2.0 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text. ref: [WebAIM]

### Contrast Constraints

* So many constraints, oh god. Selection should contrast with background, with other selections, and most importantly with text while matching the color scheme harmonically.
* I wanted to keep the currently used selection/cursor colors, and add only two more (rather than tweaking all 4).
* I preferred to maintain contrast with text and background; while sacrificing inter-element contrast (i.e. with other selections).

This was the best i could do. It's noticeable when you know it, and when cycling between; may not be so in a new static screenshot - i ain't sure.

Following colors (now rejected) were chosen before this readability consideration:

* `#1212CE` = `hsl(240, 84%, 44%)` or `#8700F5` = `hsl(273, 100%, 48%)` for selection.primary
*  `#8984E1` = `hsl(243, 61%, 70%)` or `#756FDC` = `hsl(243, 61%, 65%)` for ui.cursor



### How this color is obtained:

* > _"The default theme.toml can be found [here](https://github.com/helix-editor/helix/blob/master/theme.toml), ..."_
\- https://docs.helix-editor.com/themes.html
<!-- * Using [paletton] with base color `#3b224c` and then with chromium inspect element/developer tools, changing colors to match the theme, then tweaking colors (in HSL space). -->
* Inspired from [paletton] site's preview widget, I made a small local browser page (html/css) for live testing how t'd look.
* Contrast with text was maximised manually in hsl space using this cool [contrast-checker] from coolors. It wouldn't have been possible without it, as the [WebAIM] were too limited with their color picking sliders.


[paletton]: https://paletton.com/#uid=14E0u0kiQef7FhobfeDpWd4-ybE
[github lingo]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#supported-color-models "Markdown color models"
[contrast-checker]: https://coolors.co/contrast-checker/3b224c-8984e1
[WebAIM]: https://webaim.org/resources/contrastchecker/


<!--
* `#540099` in hsl is: `hsl(273deg 100% 30%)` i.e. `hsl(273,100%,30%)` in [github lingo]
* increase `L` from 30% to 48% ~43%~: `hsl(273deg 100% 48%)`
(while monitoring the preview in paletton site as mentioned above)
* convert back to hex: `#8700f5` ~`#7900db`~
-->