### PR TITLE
Add a status line element that shows just the basename of the file

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -97,7 +97,7 @@ The following statusline elements can be configured:
 | `mode` | The current editor mode (`mode.normal`/`mode.insert`/`mode.select`) |
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
-| `file-base-name` | The basename of the the opened file |
+| `file-base-name` | The basename of the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
 | `total-line-numbers` | The total line numbers of the opened file |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -97,6 +97,7 @@ The following statusline elements can be configured:
 | `mode` | The current editor mode (`mode.normal`/`mode.insert`/`mode.select`) |
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
+| `file-base-name` | The basename of the the opened file |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
 | `total-line-numbers` | The total line numbers of the opened file |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -139,8 +139,8 @@ where
     match element_id {
         helix_view::editor::StatusLineElement::Mode => render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
+        helix_view::editor::StatusLineElement::FileBaseName => render_file_base_name,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
-        helix_view::editor::StatusLineElement::FilePath => render_file_path,
         helix_view::editor::StatusLineElement::FileEncoding => render_file_encoding,
         helix_view::editor::StatusLineElement::FileLineEnding => render_file_line_ending,
         helix_view::editor::StatusLineElement::FileType => render_file_type,
@@ -407,7 +407,7 @@ where
     write(context, format!(" {} ", file_type), None);
 }
 
-fn render_file_path<F>(context: &mut RenderContext, write: F)
+fn render_file_name<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
@@ -427,7 +427,7 @@ where
     write(context, title, None);
 }
 
-fn render_file_name<F>(context: &mut RenderContext, write: F)
+fn render_file_base_name<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -140,6 +140,7 @@ where
         helix_view::editor::StatusLineElement::Mode => render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
         helix_view::editor::StatusLineElement::FileName => render_file_name,
+        helix_view::editor::StatusLineElement::FilePath => render_file_path,
         helix_view::editor::StatusLineElement::FileEncoding => render_file_encoding,
         helix_view::editor::StatusLineElement::FileLineEnding => render_file_line_ending,
         helix_view::editor::StatusLineElement::FileType => render_file_type,
@@ -406,7 +407,7 @@ where
     write(context, format!(" {} ", file_type), None);
 }
 
-fn render_file_name<F>(context: &mut RenderContext, write: F)
+fn render_file_path<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
@@ -415,6 +416,26 @@ where
         let path = rel_path
             .as_ref()
             .map(|p| p.to_string_lossy())
+            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+        format!(
+            " {}{} ",
+            path,
+            if context.doc.is_modified() { "[+]" } else { "" }
+        )
+    };
+
+    write(context, title, None);
+}
+
+fn render_file_name<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let title = {
+        let rel_path = context.doc.relative_path();
+        let path = rel_path
+            .as_ref()
+            .and_then(|p| p.as_path().file_name().map(|s| s.to_string_lossy()))
             .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
         format!(
             " {}{} ",

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -278,7 +278,7 @@ impl Default for StatusLineConfig {
         use StatusLineElement as E;
 
         Self {
-            left: vec![E::Mode, E::Spinner, E::FileName],
+            left: vec![E::Mode, E::Spinner, E::FilePath],
             center: vec![],
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
             separator: String::from("│"),
@@ -314,8 +314,11 @@ pub enum StatusLineElement {
     /// The LSP activity spinner
     Spinner,
 
-    /// The file nane/path, including a dirty flag if it's unsaved
+    /// The base file name, including a dirty flag if it's unsaved
     FileName,
+
+    /// The file path, including a dirty flag if it's unsaved
+    FilePath,
 
     /// The file encoding
     FileEncoding,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -278,7 +278,7 @@ impl Default for StatusLineConfig {
         use StatusLineElement as E;
 
         Self {
-            left: vec![E::Mode, E::Spinner, E::FilePath],
+            left: vec![E::Mode, E::Spinner, E::FileName],
             center: vec![],
             right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
             separator: String::from("│"),
@@ -315,10 +315,10 @@ pub enum StatusLineElement {
     Spinner,
 
     /// The base file name, including a dirty flag if it's unsaved
-    FileName,
+    FileBaseName,
 
-    /// The file path, including a dirty flag if it's unsaved
-    FilePath,
+    /// The relative file path, including a dirty flag if it's unsaved
+    FileName,
 
     /// The file encoding
     FileEncoding,


### PR DESCRIPTION
Makes the `FileName` status line element render just the `basename` of the open file. The existing variant that renders the relative path of the open file is renamed to `FilePath` (render functions are also renamed accordingly).

# Configuration Snippets

```toml
[editor.statusline]
left = ["mode", "spinner", "file-name"]
```

![image](https://user-images.githubusercontent.com/64728420/209690411-b3847e5a-2c18-40b2-a1ee-66096df2df69.png)

```toml
[editor.statusline]
left = ["mode", "spinner", "file-path"]
```

![image](https://user-images.githubusercontent.com/64728420/209690497-fee6982d-1f26-4aa2-a4a6-51be4655800e.png)