### PR TITLE
Allow max number of files seen by file_picker to be configurable

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -138,11 +138,10 @@ Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
 
 ### `[editor.file-picker]` Section
 
-Sets options for file picker and global search. All but the last key listed in
-the default file-picker configuration below are IgnoreOptions: whether hidden
-files and files listed within ignore files are ignored by (not visible in) the
-helix file picker and global search. There is also one other key, `max-depth`
-available, which is not defined by default.
+Sets options for file picker and global search. Except `max-depth` and `max-
+files`, all keys listed in the default file-picker configuration below are
+IgnoreOptions: whether hidden files and files listed within ignore files are
+ignored by (not visible in) the helix file picker and global search.
 
 All git related options are only enabled in a git repository.
 
@@ -155,6 +154,7 @@ All git related options are only enabled in a git repository.
 |`git-global` | Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option. | true
 |`git-exclude` | Enables reading `.git/info/exclude` files. | true
 |`max-depth` | Set with an integer value for maximum depth to recurse. | Defaults to `None`.
+|`max-files` | Cap on number of files to consider. Ignored in a git repository. | Defaults to `100_000`.
 
 ### `[editor.auto-pairs]` Section
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -210,9 +210,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     let mut files: Vec<PathBuf> = if root.join(".git").exists() {
         files.collect()
     } else {
-        // const MAX: usize = 8192;
-        const MAX: usize = 100_000;
-        files.take(MAX).collect()
+        files.take(config.file_picker.max_files).collect()
     };
     files.sort();
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -98,6 +98,8 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
+    /// Cap on number of files to consider. Default is 100_000. Ignored in a git repository.
+    pub max_files: usize,
 }
 
 impl Default for FilePickerConfig {
@@ -111,6 +113,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            max_files: 100_000,
         }
     }
 }


### PR DESCRIPTION
Fixes #5157.
Follow up on #5165.