### PR TITLE
Expand `~` when parsing file paths in `:open`

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -88,7 +88,12 @@ impl Args {
 
 /// Parse arg into [`PathBuf`] and position.
 pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
-    let def = || (PathBuf::from(s), Position::default());
+    let def = || {
+        (
+            helix_core::path::expand_tilde(Path::new(s)),
+            Position::default(),
+        )
+    };
     if Path::new(s).exists() {
         return def();
     }

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -88,12 +88,7 @@ impl Args {
 
 /// Parse arg into [`PathBuf`] and position.
 pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
-    let def = || {
-        (
-            helix_core::path::expand_tilde(Path::new(s)),
-            Position::default(),
-        )
-    };
+    let def = || (PathBuf::from(s), Position::default());
     if Path::new(s).exists() {
         return def();
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -65,6 +65,7 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
     ensure!(!args.is_empty(), "wrong argument count");
     for arg in args {
         let (path, pos) = args::parse_file(arg);
+        let path = helix_core::path::expand_tilde(&path);
         // If the path is a directory, open a file picker on that directory and update the status
         // message
         if let Ok(true) = std::fs::canonicalize(&path).map(|p| p.is_dir()) {


### PR DESCRIPTION
Addresses #5322.

## Expected

- `:open` should work on directories with `~` in the filepath (i.e. file picker dialog opens)

https://user-images.githubusercontent.com/59901837/209839820-7887b399-07f7-4213-b98f-9d1c575012be.mov

