### PR TITLE
Fix erroneous indent between closers of auto-pairs

### DIFF
--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_PAIRS: &[(char, char)] = &[
 ];
 
 /// The type that represents the collection of auto pairs,
-/// keyed by the opener.
+/// keyed by both opener and closer.
 #[derive(Debug, Clone)]
 pub struct AutoPairs(HashMap<char, Pair>);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3173,8 +3173,7 @@ pub mod insert {
                 let on_auto_pair = doc
                     .auto_pairs(cx.editor)
                     .and_then(|pairs| pairs.get(prev))
-                    .and_then(|pair| if pair.close == curr { Some(pair) } else { None })
-                    .is_some();
+                    .map_or(false, |pair| pair.open == prev && pair.close == curr);
 
                 let local_offs = if on_auto_pair {
                     let inner_indent = indent.clone() + doc.indent_style.as_str();


### PR DESCRIPTION
Currently, inserting a newline sometimes creates an additional indent (and an additional line) even if the cursor is not between matching auto-pairs:
````
))
````
Pressing enter when the cursor is on the second closing bracket results in the following text and indented cursor:
````
)
    |
)
````
This commit fixes that issue (which occured whenever the cursor was between 2 closers of some auto-pair) and the wrong documentation that probably caused this in the first place.