### PR TITLE
Improve indent queries for python

### DIFF
--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -29,6 +29,19 @@
   (class_definition)
 ] @indent
 
+; Workaround for the tree-sitter grammar creating large errors when a
+; try_statement is missing the except/finally clause
+(ERROR
+  "try"
+  .
+  ":" @indent @extend)
+(ERROR
+  .
+  "def") @indent @extend
+(ERROR
+  (block) @indent @extend
+  (#set! "scope" "all"))
+
 [
   (if_statement)
   (for_statement)


### PR DESCRIPTION
This is a workaround for the python tree-sitter grammar being very sensitive to incomplete code in some cases (an `try_statement` without an except/finally clause sometimes even prevents the surrounding function from being recognized). I simply added a few queries that improve the indentation in common situations. Since they only match `ERROR` nodes, this shouldn't break anything that works correctly right now.

Should fix  #763 and #5045. At least for the common scenario of writing down a `try_statement` with a missing `except_clause`/`finally_clause`, the indentation is now correct in all cases I tested,