### PR TITLE
Specify primary selection colour for Gruvbox themes

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -53,6 +53,7 @@
 "ui.text" = { fg = "fg1" }
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg2" }
+"ui.selection.primary" = { bg = "bg3" }
 "ui.cursor.primary" = { bg = "fg4", fg = "bg1" }
 "ui.cursor.match" = { bg = "bg3" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }

--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -60,6 +60,7 @@
 "ui.text" = { fg = "fg1" }
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
+"ui.selection.primary" = { bg = "bg4", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -54,6 +54,7 @@
 "ui.text" = { fg = "fg1" }
 "ui.text.focus" = { fg = "fg1" }
 "ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
+"ui.selection.primary" = { bg = "bg4", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { bg = "bg2" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }


### PR DESCRIPTION
Set a different `ui.selection.primary` colour for the Gruvbox family of themes so that the active selection is visually distinct when there are multiple selections.