### PR TITLE
Update `emacs` theme diff colors

### DIFF
--- a/runtime/themes/emacs.toml
+++ b/runtime/themes/emacs.toml
@@ -72,9 +72,9 @@
 "ui.cursorline.primary" = { bg = "darkseagreen2" }
 "ui.cursorline.secondary" = { bg = "darkseagreen2" }
 
-"diff.plus" = { fg = "#22aa22", bg = "#eeffee" }
-"diff.delta" = { fg = "#aaaa22", bg = "#ffffcc" }
-"diff.minus" = { fg = "#aa2222", bg = "#ffdddd" }
+"diff.plus" = { fg = "green3" }
+"diff.delta" = { fg = "orange2" }
+"diff.minus" = { fg = "red2" }
 
 "error" = { fg = "red1" }
 "warning" = { fg = "dark_orange" }


### PR DESCRIPTION
Screenshot:

<img width="353" alt="Screenshot 2022-12-29 at 10 17 52" src="https://user-images.githubusercontent.com/16749790/209894675-7d3b4106-9650-4dbf-aab6-48fb1721c6fb.png">

This PR fixes #4972. CC @David-Else 