### PR TITLE
Fix Broken Attribute Highlights

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -140,6 +140,8 @@ We use a similar set of scopes as
 
 - `type` - Types
   - `builtin` - Primitive types provided by the language (`int`, `usize`)
+  - `enum`
+    - `variant`
 - `constructor`
 
 - `constant` (TODO: constant.other.placeholder for %v)
@@ -201,6 +203,8 @@ We use a similar set of scopes as
 - `tag` - Tags (e.g. `<body>` in HTML)
 
 - `namespace`
+
+- `special`
 
 - `markup`
   - `heading`

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -263,6 +263,12 @@
 ; ---
 
 (attribute
+  (identifier) @special
+  arguments: (token_tree (identifier) @type)
+  (#eq? @special "derive")
+)
+
+(attribute
   (identifier) @function.macro)
 (attribute
   [

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -231,13 +231,6 @@
 ((identifier) @type
   (#match? @type "^[A-Z]"))
 
-(attribute
-  (identifier) @_macro
-  arguments: (token_tree (identifier) @constant.numeric.integer)
-  (#eq? @_macro "derive")
-)
-@special
-
 ; -------
 ; Functions
 ; -------


### PR DESCRIPTION
The deleted code contained keys that aren't used by Helix's themes, caused inconsistent highlighting of punctuation, highlighted lowercase arguments as integers, and was in the wrong section of the file.

However it was also highlighting `derive` as `@special` instead of `function.macro`, so if we want to keep that behaviour then maybe something like this could be inserted at the top of the `Macros` section instead?
```scheme
(attribute
  (identifier) @special
  (#eq? @special "derive")
)
```