### PR TITLE
Fix comment token for sshclientconfig

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1579,6 +1579,7 @@ name = "sshclientconfig"
 scope = "source.sshclientconfig"
 file-types = [{ suffix = ".ssh/config" }, { suffix = "/etc/ssh/ssh_config" }]
 roots = []
+comment-token = "#"
 
 [[grammar]]
 name = "sshclientconfig"


### PR DESCRIPTION
Currently the `sshclientconfig` language uses the default comment token `//` instead of the correct `#`. This PR fixes it.