### PR TITLE
Add command to rotate view backward

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -386,6 +386,7 @@ impl MappableCommand {
         swap_view_down, "Swap with split below",
         transpose_view, "Transpose splits",
         rotate_view, "Goto next window",
+        rotate_view_reverse, "Goto previous window",
         hsplit, "Horizontal bottom split",
         hsplit_new, "Horizontal bottom split scratch buffer",
         vsplit, "Vertical right split",
@@ -4302,6 +4303,10 @@ fn save_selection(cx: &mut Context) {
 
 fn rotate_view(cx: &mut Context) {
     cx.editor.focus_next()
+}
+
+fn rotate_view_reverse(cx: &mut Context) {
+    cx.editor.focus_prev()
 }
 
 fn jump_view_right(cx: &mut Context) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1285,6 +1285,10 @@ impl Editor {
         self.focus(self.tree.next());
     }
 
+    pub fn focus_prev(&mut self) {
+        self.focus(self.tree.prev());
+    }
+
     pub fn focus_direction(&mut self, direction: tree::Direction) {
         let current_view = self.tree.focus;
         if let Some(id) = self.tree.find_split_in_direction(current_view, direction) {


### PR DESCRIPTION
Adds command 'rotate_view_backward' and changes 'rotate_view' to 'rotate_view_forward' to stay consistent.