### PR TITLE
Adds optional bottom border

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -157,15 +157,28 @@ impl EditorView {
             Self::render_focused_view_elements(view, doc, inner, theme, surface);
         }
 
+        let border_style = theme.get("ui.window");
         // if we're not at the edge of the screen, draw a right border
         if viewport.right() != view.area.right() {
             let x = area.right();
-            let border_style = theme.get("ui.window");
             for y in area.top()..area.bottom() {
                 surface[(x, y)]
                     .set_symbol(tui::symbols::line::VERTICAL)
                     //.set_symbol(" ")
                     .set_style(border_style);
+            }
+        }
+
+        // Draw a bottom border if needed
+        if editor.tree.bottom_border {
+            if area.bottom() != viewport.bottom() - 1 {
+                // -1 for the commandline
+                let y = area.bottom();
+                for x in area.left()..area.right() {
+                    surface[(x, y)]
+                        .set_symbol(tui::symbols::line::HORIZONTAL)
+                        .set_style(border_style);
+                }
             }
         }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -178,6 +178,8 @@ pub struct Config {
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
+    /// Whether to draw a bottom border for views
+    pub bottom_border: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -633,6 +635,7 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
+            bottom_border: false,
         }
     }
 }
@@ -792,7 +795,7 @@ impl Editor {
 
         Self {
             mode: Mode::Normal,
-            tree: Tree::new(area),
+            tree: Tree::new(area, conf.bottom_border),
             next_document_id: DocumentId::default(),
             documents: BTreeMap::new(),
             saves: HashMap::new(),

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -15,6 +15,8 @@ pub struct Tree {
 
     // used for traversals
     stack: Vec<(ViewId, Rect)>,
+    // Whether to draw  a bottom border in horizontal split
+    pub bottom_border: bool,
 }
 
 #[derive(Debug)]
@@ -84,7 +86,7 @@ impl Default for Container {
 }
 
 impl Tree {
-    pub fn new(area: Rect) -> Self {
+    pub fn new(area: Rect, bottom_border: bool) -> Self {
         let root = Node::container(Layout::Vertical);
 
         let mut nodes = HopSlotMap::with_key();
@@ -100,6 +102,7 @@ impl Tree {
             area,
             nodes,
             stack: Vec::new(),
+            bottom_border,
         }
     }
 
@@ -362,7 +365,7 @@ impl Tree {
                             let len = container.children.len();
 
                             let height = area.height / len as u16;
-
+                            let inner_gap = if self.bottom_border { 1 } else { 0 };
                             let mut child_y = area.y;
 
                             for (i, child) in container.children.iter().enumerate() {
@@ -372,9 +375,9 @@ impl Tree {
                                     container.area.width,
                                     height,
                                 );
-                                child_y += height;
 
-                                // last child takes the remaining width because we can get uneven
+                                child_y += height + inner_gap;
+                                // last child takes the remaining height because we can get uneven
                                 // space from rounding
                                 if i == len - 1 {
                                     area.height = container.area.y + container.area.height - area.y;
@@ -706,12 +709,16 @@ mod test {
 
     #[test]
     fn find_split_in_direction() {
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: 180,
-            height: 80,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 180,
+                height: 80,
+            },
+            false,
+        );
+
         let mut view = View::new(
             DocumentId::default(),
             vec![GutterType::Diagnostics, GutterType::LineNumbers],
@@ -773,12 +780,15 @@ mod test {
 
     #[test]
     fn swap_split_in_direction() {
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: 180,
-            height: 80,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 180,
+                height: 80,
+            },
+            false,
+        );
 
         let doc_l0 = DocumentId::default();
         let mut view = View::new(


### PR DESCRIPTION
Adds a config parameter to draw a horizontal border between splits. This can be helpful when the status line uses the same background color as the editor, since horizontal splits become hard to tell apart, especially when they are showing documents of the same type.