### PR TITLE
flake: Fix devshell for darwin hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,8 @@
           packages = with common.pkgs;
             [lld_13 cargo-flamegraph rust-analyzer]
             ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
-            ++ (lib.optional stdenv.isLinux lldb);
+            ++ (lib.optional stdenv.isLinux lldb)
+            ++ (lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation);
           env = [
             {
               name = "HELIX_RUNTIME";
@@ -94,10 +95,10 @@
             }
             {
               name = "RUSTFLAGS";
-              value =
+              eval =
                 if common.pkgs.stdenv.isLinux
-                then "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment"
-                else "";
+                then "$RUSTFLAGS\" -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment\""
+                else "$RUSTFLAGS";
             }
           ];
         };


### PR DESCRIPTION
Runs of `cargo build` would fail with `ld: framework not found CoreFoundation` inside a devshell (`nix develop`) on a Darwin host.

This is fixed with two changes:

* Including the `CoreFoundation` package within the devshell's derivation.
* Switching from `value` to `eval` so that we append to the `RUSTFLAGS` environment variable rather than overwriting it. `numtide/devshell` already exposes the `Library/Frameworks` path within the devshell derivation but it was being overwritten by the manual setting of `RUSTFLAGS` in `env`.