### PR TITLE
Gutter character configuration.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -284,7 +284,7 @@ layout = ["diff", "diagnostics", "line-numbers", "spacer"]
 
 #### `[editor.gutters.line-numbers]` Section
 
-Options for the line number gutter
+Options for the line number gutter.
 
 | Key         | Description                             | Default |
 | ---         | ---                                     | ---     |
@@ -297,13 +297,36 @@ Example:
 min-width = 1
 ```
 
-#### `[editor.gutters.diagnotics]` Section
+#### `[editor.gutters.diagnostics]` Section
 
-Currently unused
+Options for the diagnostics gutter.
+
+| Key          | Description                                | Default |
+| ---          | ---                                        | ---     |
+| `characters` | Characters to be used in the gutter column | `"●"`   |
+
+#### `[editor.gutters.breakpoints]` Section
+
+Options for the breakpoints gutter.
+
+| Key                   | Description                                                         | Default |
+| ---                   | ---                                                                 | ---     |
+| `characters.verified` | Characters to be used in the gutter column for verified breakpoints | `"▲"`   |
+| `characters.other`    | Characters to be used in the gutter column for other breakpoints    | `"⊚"`   |
+
+Alternatively, you can use the `[editor.gutters.breakpoints.characters]` section 
+and use the `verified` and `other` keys.
 
 #### `[editor.gutters.diff]` Section
 
-Currently unused
+| Key                 | Description                                                   | Default |
+| ---                 | ---                                                           | ---     |
+| `characters.add`    | Characters to be used in the gutter column for code additions | `"▍"`   |
+| `characters.remove` | Characters to be used in the gutter column for code deletions | `"▔"`   |
+| `characters.change` | Characters to be used in the gutter column for code changes   | `"▍"`   |
+
+Alternatively, you can use the `[editor.gutters.diff.characters]` section 
+and use the `add`, `remove` and `change` keys.
 
 #### `[editor.gutters.spacer]` Section
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -78,6 +78,12 @@ pub struct GutterConfig {
     pub layout: Vec<GutterType>,
     /// Options specific to the "line-numbers" gutter
     pub line_numbers: GutterLineNumbersConfig,
+    /// Options specific to the "diagnostics" gutter.
+    pub diagnostics: DiagnosticsGutterConfig,
+    /// Options specific to the “breakpoints” gutter.
+    pub breakpoints: BreakpointsGutterConfig,
+    /// Options specific to the “diff” gutter.
+    pub diff: DiffGutterConfig,
 }
 
 impl Default for GutterConfig {
@@ -91,6 +97,9 @@ impl Default for GutterConfig {
                 GutterType::Diff,
             ],
             line_numbers: GutterLineNumbersConfig::default(),
+            diagnostics: DiagnosticsGutterConfig::default(),
+            breakpoints: BreakpointsGutterConfig::default(),
+            diff: DiffGutterConfig::default(),
         }
     }
 }
@@ -565,6 +574,66 @@ impl std::str::FromStr for GutterType {
             "line-numbers" => Ok(Self::LineNumbers),
             "diff" => Ok(Self::Diff),
             _ => anyhow::bail!("Gutter type can only be `diagnostics` or `line-numbers`."),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiagnosticsGutterConfig {
+    pub characters: String,
+}
+
+impl Default for DiagnosticsGutterConfig {
+    fn default() -> Self {
+        Self {
+            characters: "●".to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BreakpointsGutterConfig {
+    pub characters: BreakpointsGutterCharacters,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BreakpointsGutterCharacters {
+    pub verified: String,
+    pub other: String,
+}
+
+impl Default for BreakpointsGutterCharacters {
+    fn default() -> Self {
+        Self {
+            verified: "▲".to_owned(),
+            other: "⊚".to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiffGutterConfig {
+    pub characters: DiffGutterCharacters,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiffGutterCharacters {
+    pub add: String,
+    pub remove: String,
+    pub change: String,
+}
+
+impl Default for DiffGutterCharacters {
+    fn default() -> Self {
+        Self {
+            add: "▍".to_owned(),
+            remove: "▔".to_owned(),
+            change: "▍".to_owned(),
         }
     }
 }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -484,6 +484,7 @@ mod tests {
             GutterConfig {
                 layout: vec![GutterType::Diagnostics],
                 line_numbers: GutterLineNumbersConfig::default(),
+                ..GutterConfig::default()
             },
         );
         view.area = Rect::new(40, 40, 40, 40);
@@ -507,6 +508,7 @@ mod tests {
             GutterConfig {
                 layout: vec![],
                 line_numbers: GutterLineNumbersConfig::default(),
+                ..GutterConfig::default()
             },
         );
         view.area = Rect::new(40, 40, 40, 40);


### PR DESCRIPTION
This commit adds support for configuring the gutter characters. Currently, three flavours are supported:

- Diagnostics, with a string.
- Breakpoints, with two strings (one for verified and one for non-verified breakpoints).
- And diffs, with three strings (add, remove, change).