### PR TITLE
Multi cursor increment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "based"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37133bf6cd50777365d7aec7263348cc98af90d0120ea7934e858d056e9b2246"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1176,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "based",
  "chrono",
  "content_inspector",
  "crossterm",
@@ -1191,6 +1198,7 @@ dependencies = [
  "log",
  "once_cell",
  "pulldown-cmark",
+ "septem",
  "serde",
  "serde_json",
  "signal-hook",
@@ -1799,6 +1807,12 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "septem"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bdcf1faee4966686e4545ccb1441ccf81f27a97fe16ad280a405a2f371aebc"
 
 [[package]]
 name = "serde"

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -580,6 +580,14 @@ impl Transaction {
         )
     }
 
+    /// Generate a transaction with a change per selection range enumerated.
+    pub fn change_by_enumerated_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
+    where
+        F: FnMut((usize, &Range)) -> Change,
+    {
+        Self::change(doc, selection.iter().enumerate().map(f))
+    }
+
     /// Insert text at each selection head.
     pub fn insert(doc: &Rope, selection: &Selection, text: Tendril) -> Self {
         Self::change_by_selection(doc, selection, |range| {

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -66,6 +66,10 @@ serde = { version = "1.0", features = ["derive"] }
 grep-regex = "0.1.11"
 grep-searcher = "0.1.11"
 
+# For Renumbering
+based = "1.0.0"
+septem = "1.1.0"
+
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 libc = "0.2.141"

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3888,7 +3888,7 @@ fn replace_with_count_converter(cx: &mut Context, converter: fn(usize) -> String
             }
         });
 
-    apply_transaction(&transaction, doc, view);
+    doc.apply(&transaction, view.id);
     exit_select_mode(cx);
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -369,6 +369,7 @@ impl MappableCommand {
         yank_joined_to_primary_clipboard, "Join and yank selections to primary clipboard",
         yank_main_selection_to_primary_clipboard, "Yank main selection to primary clipboard",
         replace_with_yanked, "Replace with yanked text",
+        replace_with_count, "Replace with count",
         replace_selections_with_clipboard, "Replace selections by clipboard content",
         replace_selections_with_primary_clipboard, "Replace selections by primary clipboard",
         paste_after, "Paste after selection",
@@ -3860,6 +3861,28 @@ fn replace_with_yanked(cx: &mut Context) {
             exit_select_mode(cx);
         }
     }
+}
+
+fn replace_with_count(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let selection = doc.selection(view.id);
+    let transaction =
+        Transaction::change_by_enumerated_selection(doc.text(), selection, |enum_range| {
+            let val = count + enum_range.0;
+            if !enum_range.1.is_empty() {
+                (
+                    enum_range.1.from(),
+                    enum_range.1.to(),
+                    Some(Tendril::from(val.to_string())),
+                )
+            } else {
+                (enum_range.1.from(), enum_range.1.to(), None)
+            }
+        });
+
+    apply_transaction(&transaction, doc, view);
+    exit_select_mode(cx);
 }
 
 fn replace_selections_with_clipboard_impl(

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -17,6 +17,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "F" => find_prev_char,
         "r" => replace,
         "R" => replace_with_yanked,
+        "A-R" => replace_with_count,
         "A-." =>  repeat_last_motion,
 
         "~" => switch_case,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -17,7 +17,14 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "F" => find_prev_char,
         "r" => replace,
         "R" => replace_with_yanked,
-        "A-R" => replace_with_count,
+        "A-R" => { "Replace with incrementing"
+            "n" => replace_with_number,
+            "z" => replace_with_zero_index,
+            "a" => replace_with_alpha_lower,
+            "A" => replace_with_alpha_upper,
+            "i" => replace_with_roman_lower,
+            "I" => replace_with_roman_upper,
+        },
         "A-." =>  repeat_last_motion,
 
         "~" => switch_case,


### PR DESCRIPTION
This feature lets you replace a multi-cursor selection with an incrementing value.

- numeric (starting with 1)
- numeric (starting with 0)
- ascii alphabet incrementing the same way excel columns do
- roman numerals

The starting value can be changed with the repeat count for the command.

https://youtu.be/-mSc2fB35Cg