### PR TITLE
Fix Sonokai theme to better match original

### DIFF
--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -6,24 +6,22 @@
 # License: MIT License
 
 "type" = "blue"
-"constant" = "purple"
+"constant" = "fg"
 "constant.numeric" = "purple"
 "constant.character.escape" = "orange"
 "string" = "yellow"
 "comment" = "grey"
 "variable" = "fg"
-"variable.builtin" = "orange"
+"variable.builtin" = "purple"
 "variable.parameter" = "fg"
-"variable.other.member" = "fg"
-"label" = "orange"
+"variable.other.member" = "orange"
+"label" = "red"
 "punctuation" = "grey"
-"punctuation.delimiter" = "grey"
-"punctuation.bracket" = "fg"
 "keyword" = "red"
-"operator" = "orange"
+"operator" = "red"
 "function" = "green"
-"function.builtin" = "blue"
-"function.macro" = "purple"
+"function.builtin" = "green"
+"function.macro" = "green"
 "tag" = "yellow"
 "namespace" = "blue"
 "attribute" = "purple"
@@ -48,12 +46,12 @@
 "markup.raw" = "green"
 
 "diff.plus" = "green"
-"diff.delta" = "orange"
+"diff.delta" = "blue"
 "diff.minus" = "red"
 
 "ui.background" = { bg = "bg0" }
 "ui.cursor" = { modifiers = ['reversed'] }
-"ui.cursor.match" = { fg = "orange", bg = "diff_yellow" }
+"ui.cursor.match" = { bg = "bg4" }
 "ui.cursor.insert" = { fg = "black", bg = "grey" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
 "ui.selection" = { bg = "bg5" }
@@ -73,7 +71,7 @@
 "ui.text.focus" = "green"
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
-"ui.virtual.whitespace" = { fg = "grey_dim" }
+"ui.virtual.whitespace" = "bg4" 
 "ui.virtual.ruler" = { bg = "bg3" }
 "ui.virtual.inlay-hint" = { fg = "grey_dim" }
 

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -92,11 +92,12 @@ error = { fg = 'red', bg = 'bg2', modifiers = ['bold'] }
 [palette]
 
 black = "#181819"
+bg_dim = "#222327"
 bg0 = "#2c2e34"
 bg1 = "#33353f"
 bg2 = "#363944"
 bg3 = "#3b3e48"
-bg4 = "#5C606A"
+bg4 = "#414550"
 bg5 = "#444852"
 bg_red = "#ff6077"
 diff_red = "#55393d"

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -17,6 +17,7 @@
 "variable.other.member" = "orange"
 "label" = "red"
 "punctuation" = "grey"
+"punctuation.special" = "yellow"
 "keyword" = "red"
 "operator" = "red"
 "function" = "green"


### PR DESCRIPTION
The Sonokai theme had some inconsistencies, so I fixed some of them.

* Copied the palette exactly from https://github.com/sainnhe/sonokai/blob/master/autoload/sonokai.vim
* Used the following two resources to pick correct colors for different scopes:

1. https://www.sainnhe.dev/post/contributing-guide/#sonokai
2. https://github.com/sainnhe/sonokai/blob/master/colors/sonokai.vim

Edit: Changes I made as listed in the git commit:
* Make constants white (1)
* Make builtin variables purple (1)
* Make members orange (1)
* Make labels red (2)
* Make operators red (1)
* Make all punctuation grey (2)
* Make builtin functions and macros green (2)
* Make diff delta blue (2)
* Make cursor match bg4 (2)
* Make visible whitespace bg4 (2)