### PR TITLE
Fix language config reload logic

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -403,6 +403,7 @@ impl Application {
             .map_err(|err| anyhow::anyhow!("Failed to load language config: {}", err))?;
 
         self.syn_loader = std::sync::Arc::new(syntax::Loader::new(syntax_config));
+        self.editor.syn_loader = self.syn_loader.clone();
         for document in self.editor.documents.values_mut() {
             document.detect_language(self.syn_loader.clone());
         }
@@ -438,8 +439,13 @@ impl Application {
             Ok(())
         };
 
-        if let Err(err) = refresh_config() {
-            self.editor.set_error(err.to_string());
+        match refresh_config() {
+            Ok(_) => {
+                self.editor.set_status("Config refreshed");
+            }
+            Err(err) => {
+                self.editor.set_error(err.to_string());
+            }
         }
     }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1797,7 +1797,7 @@ fn run_shell_command(
     let shell = &cx.editor.config().shell;
     let (output, success) = shell_impl(shell, &args.join(" "), None)?;
     if success {
-        cx.editor.set_status("Command succeed");
+        cx.editor.set_status("Command succeeded");
     } else {
         cx.editor.set_error("Command failed");
     }


### PR DESCRIPTION
Fixes  https://github.com/helix-editor/helix/issues/5377.

I think the bug https://github.com/helix-editor/helix/issues/5377 stemmed from not updating the reference to the syntax loader in the `editor` as well.

Hence, it probably was the case that before, the old reference was in fact actually never dropped, and that the `editor` was still pointing to the old syntax loader.

Took the chance to improve some status messages too.

