### PR TITLE
Find out comment style from file content as a fallback

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -612,7 +612,8 @@ impl Document {
         if let Some(path) = &self.path {
             let language_config = config_loader
                 .language_config_for_file_name(path)
-                .or_else(|| config_loader.language_config_for_shebang(self.text()));
+                .or_else(|| config_loader.language_config_for_shebang(self.text()))
+                .or_else(|| config_loader.language_config_from_text_head(self.text()));
             self.set_language(language_config, Some(config_loader));
         }
     }


### PR DESCRIPTION
Usually we find out the language based on file extension and use the comment style used for the language. This PR lets helix figure out the correct comment style by peeking the first few lines of the file. This is a fallback, when helix is unable to figure out the language for any reason.

fixes #5380