### PR TITLE
Templatized global search as a typable command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -11,6 +11,8 @@
 | `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Force close all buffers ignoring unsaved changes without quitting. |
 | `:buffer-next`, `:bn`, `:bnext` | Goto next buffer. |
 | `:buffer-previous`, `:bp`, `:bprev` | Goto previous buffer. |
+| `:template_global_search_selection`, `:tgs` | Templatable global search as a typable command. Accepts one mandatory regex argument that can have `{}` placeholders and an optional delimiter argument. The current selection in the document is split by the delimiter if present, and is used to fill the placeholders. |
+| `:global_search`, `:gs` | Global search as a typable command. |
 | `:write`, `:w` | Write changes to disk. Accepts an optional path (:write some/path.txt) |
 | `:write!`, `:w!` | Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write some/path.txt) |
 | `:new`, `:n` | Create a new scratch buffer. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -19,7 +19,7 @@ use helix_core::{
     match_brackets,
     movement::{self, Direction},
     object, pos_at_coords, pos_at_visual_coords,
-    regex::{self, Regex, RegexBuilder},
+    regex::{Regex, RegexBuilder},
     search::{self, CharMatcher},
     selection, shellwords, surround, textobject,
     tree_sitter::Node,
@@ -54,7 +54,6 @@ use crate::{
 };
 
 use crate::job::{self, Jobs};
-use futures_util::StreamExt;
 use std::{collections::HashMap, fmt, future::Future};
 use std::{collections::HashSet, num::NonZeroUsize};
 
@@ -65,11 +64,6 @@ use std::{
 
 use once_cell::sync::Lazy;
 use serde::de::{self, Deserialize, Deserializer};
-
-use grep_regex::RegexMatcherBuilder;
-use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
-use ignore::{DirEntry, WalkBuilder, WalkState};
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub struct Context<'a> {
     pub register: Option<char>,
@@ -1850,7 +1844,11 @@ fn global_search(cx: &mut Context) {
                 return;
             }
 
-            global_search::launch_search_walkers(editor, regex.as_str(), all_matches_sx.clone());
+            if global_search::launch_search_walkers(editor, regex.as_str(), all_matches_sx.clone())
+                .is_err()
+            {
+                // Nothing special to do here on error
+            }
         },
     );
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1790,7 +1790,7 @@ fn extend_search_prev(cx: &mut Context) {
 }
 
 fn search_selection(cx: &mut Context) {
-    let regex = search_utils::escaped_current_selection(cx.editor);
+    let regex = search_utils::regex_escaped_current_selection(cx.editor);
 
     let msg = format!("register '{}' set to '{}'", '/', &regex);
     cx.editor.registers.push('/', regex);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1683,15 +1683,6 @@ fn search_impl(
     };
 }
 
-fn search_completions(cx: &mut Context, reg: Option<char>) -> Vec<String> {
-    let mut items = reg
-        .and_then(|reg| cx.editor.registers.get(reg))
-        .map_or(Vec::new(), |reg| reg.read().iter().take(200).collect());
-    items.sort_unstable();
-    items.dedup();
-    items.into_iter().cloned().collect()
-}
-
 fn search(cx: &mut Context) {
     searcher(cx, Direction::Forward)
 }
@@ -1713,7 +1704,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
     // HAXX: sadly we can't avoid allocating a single string for the whole buffer since we can't
     // feed chunks into the regex yet
     let contents = doc.text().slice(..).to_string();
-    let completions = search_completions(cx, Some(reg));
+    let completions = search_utils::search_completions(cx.editor, Some(reg));
 
     ui::regex_prompt(
         cx,
@@ -1799,17 +1790,7 @@ fn extend_search_prev(cx: &mut Context) {
 }
 
 fn search_selection(cx: &mut Context) {
-    let (view, doc) = current!(cx.editor);
-    let contents = doc.text().slice(..);
-
-    let regex = doc
-        .selection(view.id)
-        .iter()
-        .map(|selection| regex::escape(&selection.fragment(contents)))
-        .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join("|");
+    let regex = search_utils::escaped_current_selection(cx.editor);
 
     let msg = format!("register '{}' set to '{}'", '/', &regex);
     cx.editor.registers.push('/', regex);
@@ -1846,49 +1827,13 @@ fn make_search_word_bounded(cx: &mut Context) {
 }
 
 fn global_search(cx: &mut Context) {
-    #[derive(Debug)]
-    struct FileResult {
-        path: PathBuf,
-        /// 0 indexed lines
-        line_num: usize,
-    }
-
-    impl FileResult {
-        fn new(path: &Path, line_num: usize) -> Self {
-            Self {
-                path: path.to_path_buf(),
-                line_num,
-            }
-        }
-    }
-
-    impl ui::menu::Item for FileResult {
-        type Data = Option<PathBuf>;
-
-        fn label(&self, current_path: &Self::Data) -> Spans {
-            let relative_path = helix_core::path::get_relative_path(&self.path)
-                .to_string_lossy()
-                .into_owned();
-            if current_path
-                .as_ref()
-                .map(|p| p == &self.path)
-                .unwrap_or(false)
-            {
-                format!("{} (*)", relative_path).into()
-            } else {
-                relative_path.into()
-            }
-        }
-    }
-
-    let (all_matches_sx, all_matches_rx) = tokio::sync::mpsc::unbounded_channel::<FileResult>();
-    let config = cx.editor.config();
-    let smart_case = config.search.smart_case;
-    let file_picker_config = config.file_picker.clone();
+    let (all_matches_sx, all_matches_rx) =
+        tokio::sync::mpsc::unbounded_channel::<global_search::FileResult>();
 
     let reg = cx.register.unwrap_or('/');
+    log::debug!("global_search reg: {reg}");
 
-    let completions = search_completions(cx, Some(reg));
+    let completions = search_utils::search_completions(cx.editor, Some(reg));
     ui::regex_prompt(
         cx,
         "global-search:".into(),
@@ -1900,127 +1845,16 @@ fn global_search(cx: &mut Context) {
                 .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone())))
                 .collect()
         },
-        move |_editor, regex, event| {
+        move |editor, regex, event| {
             if event != PromptEvent::Validate {
                 return;
             }
 
-            if let Ok(matcher) = RegexMatcherBuilder::new()
-                .case_smart(smart_case)
-                .build(regex.as_str())
-            {
-                let searcher = SearcherBuilder::new()
-                    .binary_detection(BinaryDetection::quit(b'\x00'))
-                    .build();
-
-                let search_root = std::env::current_dir()
-                    .expect("Global search error: Failed to get current dir");
-                WalkBuilder::new(search_root)
-                    .hidden(file_picker_config.hidden)
-                    .parents(file_picker_config.parents)
-                    .ignore(file_picker_config.ignore)
-                    .follow_links(file_picker_config.follow_symlinks)
-                    .git_ignore(file_picker_config.git_ignore)
-                    .git_global(file_picker_config.git_global)
-                    .git_exclude(file_picker_config.git_exclude)
-                    .max_depth(file_picker_config.max_depth)
-                    // We always want to ignore the .git directory, otherwise if
-                    // `ignore` is turned off above, we end up with a lot of noise
-                    // in our picker.
-                    .filter_entry(|entry| entry.file_name() != ".git")
-                    .build_parallel()
-                    .run(|| {
-                        let mut searcher = searcher.clone();
-                        let matcher = matcher.clone();
-                        let all_matches_sx = all_matches_sx.clone();
-                        Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
-                            let entry = match entry {
-                                Ok(entry) => entry,
-                                Err(_) => return WalkState::Continue,
-                            };
-
-                            match entry.file_type() {
-                                Some(entry) if entry.is_file() => {}
-                                // skip everything else
-                                _ => return WalkState::Continue,
-                            };
-
-                            let result = searcher.search_path(
-                                &matcher,
-                                entry.path(),
-                                sinks::UTF8(|line_num, _| {
-                                    all_matches_sx
-                                        .send(FileResult::new(entry.path(), line_num as usize - 1))
-                                        .unwrap();
-
-                                    Ok(true)
-                                }),
-                            );
-
-                            if let Err(err) = result {
-                                log::error!(
-                                    "Global search error: {}, {}",
-                                    entry.path().display(),
-                                    err
-                                );
-                            }
-                            WalkState::Continue
-                        })
-                    });
-            } else {
-                // Otherwise do nothing
-                // log::warn!("Global Search Invalid Pattern")
-            }
+            global_search::launch_search_walkers(editor, regex.as_str(), all_matches_sx.clone());
         },
     );
 
-    let current_path = doc_mut!(cx.editor).path().cloned();
-
-    let show_picker = async move {
-        let all_matches: Vec<FileResult> =
-            UnboundedReceiverStream::new(all_matches_rx).collect().await;
-        let call: job::Callback = Callback::EditorCompositor(Box::new(
-            move |editor: &mut Editor, compositor: &mut Compositor| {
-                if all_matches.is_empty() {
-                    editor.set_status("No matches found");
-                    return;
-                }
-
-                let picker = FilePicker::new(
-                    all_matches,
-                    current_path,
-                    move |cx, FileResult { path, line_num }, action| {
-                        match cx.editor.open(path, action) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                cx.editor.set_error(format!(
-                                    "Failed to open file '{}': {}",
-                                    path.display(),
-                                    e
-                                ));
-                                return;
-                            }
-                        }
-
-                        let line_num = *line_num;
-                        let (view, doc) = current!(cx.editor);
-                        let text = doc.text();
-                        let start = text.line_to_char(line_num);
-                        let end = text.line_to_char((line_num + 1).min(text.len_lines()));
-
-                        doc.set_selection(view.id, Selection::single(start, end));
-                        align_view(doc, view, Align::Center);
-                    },
-                    |_editor, FileResult { path, line_num }| {
-                        Some((path.clone().into(), Some((*line_num, *line_num))))
-                    },
-                );
-                compositor.push(Box::new(overlayed(picker)));
-            },
-        ));
-        Ok(call)
-    };
-    cx.jobs.callback(show_picker);
+    global_search::collect_file_results(cx.editor, cx.jobs, all_matches_rx);
 }
 
 enum Extend {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -628,7 +628,7 @@ fn global_search_cmd(
         return Ok(());
     }
 
-    global_search::global_search_cmd_impl(cx.editor, cx.jobs, args.join(" "))
+    global_search::global_search_cmd_impl(cx.editor, cx.jobs, args.join("\\s+"))
 }
 
 fn template_global_search_selection_cmd(
@@ -648,11 +648,12 @@ fn template_global_search_selection_cmd(
 
     let current_selection = search_utils::escaped_current_selection(cx.editor);
 
-    let sep = args.get(2);
+    let sep = args.get(1);
     let template_args = sep
         .map(|sep| {
             current_selection
                 .split(sep.as_ref())
+                .map(&str::trim)
                 .map(ToOwned::to_owned)
                 .collect::<Vec<_>>()
         })

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -522,14 +522,12 @@ pub mod search_utils {
     use crate::commands::Context;
 
     pub fn search_completions(editor: &Editor, reg: Option<char>) -> Vec<String> {
-        log::debug!("using reg: {reg:?}");
         let mut items = reg
             .and_then(|reg| editor.registers.get(reg))
             .map_or(Vec::new(), |reg| reg.read().iter().take(200).collect());
         items.sort_unstable();
         items.dedup();
         let completions = items.into_iter().cloned().collect();
-        log::debug!("{completions:?}");
         completions
     }
 
@@ -2761,7 +2759,6 @@ pub(super) fn command_mode(cx: &mut Context) {
         ":".into(),
         Some(':'),
         |editor: &Editor, input: &str| {
-            log::debug!("command mode input: {input}");
             static FUZZY_MATCHER: Lazy<fuzzy_matcher::skim::SkimMatcherV2> =
                 Lazy::new(fuzzy_matcher::skim::SkimMatcherV2::default);
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -93,7 +93,6 @@ pub fn regex_prompt(
                         false
                     };
 
-                    log::debug!("regex prompt input: {input}");
                     match RegexBuilder::new(input)
                         .case_insensitive(case_insensitive)
                         .multi_line(true)
@@ -369,7 +368,6 @@ pub mod completers {
         input: &str,
         register: Option<char>,
     ) -> Vec<Completion> {
-        log::debug!("regex completer input: {input}");
         search_utils::search_completions(editor, register)
             .iter()
             .filter(|prev_search| prev_search.starts_with(input))
@@ -378,12 +376,10 @@ pub mod completers {
     }
 
     pub fn regex(editor: &Editor, input: &str) -> Vec<Completion> {
-        log::debug!("regex completer input: {input}");
         regex_completer_impl(editor, input, Some('/'))
     }
 
     pub fn regex_template(editor: &Editor, input: &str) -> Vec<Completion> {
-        log::debug!("regex template completer input: {input}");
         regex_completer_impl(editor, input, Some('?'))
     }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -93,6 +93,7 @@ pub fn regex_prompt(
                         false
                     };
 
+                    log::debug!("regex prompt input: {input}");
                     match RegexBuilder::new(input)
                         .case_insensitive(case_insensitive)
                         .multi_line(true)
@@ -236,6 +237,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 }
 
 pub mod completers {
+    use crate::commands::search_utils;
     use crate::ui::prompt::Completion;
     use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
     use fuzzy_matcher::FuzzyMatcher;
@@ -360,6 +362,29 @@ pub mod completers {
                 FileMatch::Accept
             }
         })
+    }
+
+    pub fn regex_completer_impl(
+        editor: &Editor,
+        input: &str,
+        register: Option<char>,
+    ) -> Vec<Completion> {
+        log::debug!("regex completer input: {input}");
+        search_utils::search_completions(editor, register)
+            .iter()
+            .filter(|prev_search| prev_search.starts_with(input))
+            .map(|prev_search| (0.., Cow::Owned(prev_search.clone())))
+            .collect()
+    }
+
+    pub fn regex(editor: &Editor, input: &str) -> Vec<Completion> {
+        log::debug!("regex completer input: {input}");
+        regex_completer_impl(editor, input, Some('/'))
+    }
+
+    pub fn regex_template(editor: &Editor, input: &str) -> Vec<Completion> {
+        log::debug!("regex template completer input: {input}");
+        regex_completer_impl(editor, input, Some('?'))
     }
 
     pub fn language(editor: &Editor, input: &str) -> Vec<Completion> {


### PR DESCRIPTION
## Description
This PR adds two new typable commands: one for global search and the other for a templatized global search using the current doc selection. These are made typable for enabling key remappings to further ease the pain of globally searching with complex regex surrounding the symbols that are currently selected.

### Motivation
During visual debugging, whenever the LS is unable to go to definition, especially if the definition lies in a separate file, or if it is in a separate language like with protobuf, I often find myself repeating the same boilerplate regex to get to the definitions of these symbols. This can become painful when forced to repeat this hundreds of times each week. I believe that having a typable global search that can accept a regex template as an argument, which can be filled by the current doc selection will greatly improve the search experience. 

For example, today if a Python class cannot be found by the LS I'd have to go to `global_search` mode first and then type something like `class\s+XYZ` with no way to remap the prefix `class\s+` to a key. While this does work, it is much more convenient if we have a templatized search method in typable command mode that can then be remapped.

## Use
The templatized global search (`:tgs`) takes in up to two arguments: the first argument is a templatized regex, with empty `{}` placeholders like with the rust `format!` macro, the optional second argument is for a delimiter, and on execution, the current document selection is split with the delimiter if it is present, and the results are used as parameters to format the template into a regex expression to search in the current workspace.

The global search `:gs` is pretty much the same as the `global_search` command but it is typable, allowing for key remaps to supply a constant regex argument to use. This does not use the current document selection in any way.

## Examples
![demo optimized](https://user-images.githubusercontent.com/14972559/210464547-41d5a92b-e137-47f4-88c5-a02ebbc07cf6.gif)

There could be more advanced use cases for more complex pattern matching that requires multiple inputs to be filled in. Right now this implementation uses a delimiter to split the current selection to pass in as arguments to fill the regex template. Say we have a comma-separated list of test class names that we want to search for: `TestABC, TestDEF, TestXYZ`, we can search for all these classes at once with `:tgs class\s+\({}|{}|{}\) ,`. Granted, this extended use case appears more esoteric and specialized, but implementing a generalized template model with support for an arbitrary number of arguments made more sense than just having one parameter for just the current selection. 

By adding something like the following to my config file, I can now search for classes, structs, or protobuf message definitions in a couple of keystrokes: 
```toml
[keys.normal.space]
"/" = { "/" = "global_search", "c" = ":tgs (struct|class|message)\\s+{}", "f" = ":tgs (def|fn|func)\\s+{}" }
```

## Caveats
- Right now the regex supplied to the template command cannot have whitespace in them and will instead have to use `\s` to represent whitespace pattern.
- The templates are added to the `?` register for auto-complete and the filled-in regexes are added to the `/` register as it does not make sense for the regular search functions to have the incomplete template with `{}` placeholders (which is invalid regex anyway) and further clutter the search history. As far as I am aware, the `?` register is used for auto-complete only by the template global search command right now. 
