### PR TITLE
Add runtime queries for `tfvars` (based on `hcl`)

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -120,7 +120,7 @@
 | swift | ✓ |  |  | `sourcekit-lsp` |
 | tablegen | ✓ | ✓ | ✓ |  |
 | task | ✓ |  |  |  |
-| tfvars |  |  |  | `terraform-ls` |
+| tfvars | ✓ |  | ✓ | `terraform-ls` |
 | toml | ✓ |  |  | `taplo` |
 | tsq | ✓ |  |  |  |
 | tsx | ✓ | ✓ | ✓ | `typescript-language-server` |

--- a/runtime/queries/tfvars/folds.scm
+++ b/runtime/queries/tfvars/folds.scm
@@ -1,0 +1,1 @@
+; inherits: hcl

--- a/runtime/queries/tfvars/highlights.scm
+++ b/runtime/queries/tfvars/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: hcl

--- a/runtime/queries/tfvars/indents.scm
+++ b/runtime/queries/tfvars/indents.scm
@@ -1,0 +1,1 @@
+; inherits: hcl

--- a/runtime/queries/tfvars/injections.scm
+++ b/runtime/queries/tfvars/injections.scm
@@ -1,0 +1,1 @@
+; inherits: hcl


### PR DESCRIPTION
I noticed that the `.tfvars` files in my Terraform projects don't get syntax highlighting unless I manually run `:set-language hcl`. 

The `tfvars` language is already configured to use the `hcl` grammar (since it was separated from `hcl` in #2244):

https://github.com/helix-editor/helix/blob/0dbee9590baed10bef3c6c32420b8a5802204657/languages.toml#L1279-L1288

So this small PR adds the `tfvars` files into `runtime/queries/`, with each simply inheriting from `hcl` (as advised on Matrix by @archseer).

I've added files to inherit everything from `hcl` (`folds`, `highlights`, `indents` and `injections`), though I'm unsure if all are necessary, or if perhaps only `highlights.scm` should be added. Please let me know if anything needs to be changed. 

Thanks!