### PR TITLE
Docs: Put default theme to a light theme

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -7,6 +7,6 @@ edit-url-template = "https://github.com/helix-editor/helix/tree/master/book/{pat
 
 [output.html]
 cname = "docs.helix-editor.com"
-default-theme = "colibri"
+default-theme = "rust"
 preferred-dark-theme = "colibri"
 git-repository-url = "https://github.com/helix-editor/helix"


### PR DESCRIPTION
Until this patch, the docs always loaded with the "Colibri" theme, a dark theme, even for light theme users. This PR switches it to be  the "Rust" theme, a light but not all white theme.
MdBook will still switch to the "Colibri" theme if the reader's browsers is set to prefer dark themes (`prefers-color-scheme: dark`)