### PR TITLE
New option in language config to use nearest `roots` match

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -41,11 +41,16 @@ pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
 /// Find project root.
 ///
 /// Order of detection:
-/// * Top-most folder containing a root marker in current git repository
+/// * Top-most folder containing a root marker in current git repository unless
+///   `match_nearest_root` is true in which case the nearest match is returned
 /// * Git repository root if no marker detected
 /// * Top-most folder containing a root marker if not git repository detected
 /// * Current working directory as fallback
-pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::PathBuf {
+pub fn find_root(
+    root: Option<&str>,
+    root_markers: &[String],
+    match_nearest_root: bool,
+) -> std::path::PathBuf {
     let current_dir = std::env::current_dir().expect("unable to determine current directory");
 
     let root = match root {
@@ -67,6 +72,9 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
             .any(|marker| ancestor.join(marker).exists())
         {
             top_marker = Some(ancestor);
+            if match_nearest_root {
+                break;
+            }
         }
 
         if ancestor.join(".git").exists() {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -126,6 +126,10 @@ pub struct LanguageConfiguration {
     pub auto_pairs: Option<AutoPairs>,
 
     pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+    /// Use the nearest directory that matches one of the options in `roots`
+    /// as the workspace root for the language server
+    #[serde(default)]
+    pub match_nearest_root: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -52,6 +52,7 @@ impl Client {
         id: usize,
         req_timeout: u64,
         doc_path: Option<&std::path::PathBuf>,
+        match_nearest_root: bool,
     ) -> Result<(Self, UnboundedReceiver<(usize, Call)>, Arc<Notify>)> {
         // Resolve path to the binary
         let cmd = which::which(cmd).map_err(|err| anyhow::anyhow!(err))?;
@@ -79,6 +80,7 @@ impl Client {
         let root_path = find_root(
             doc_path.and_then(|x| x.parent().and_then(|x| x.to_str())),
             root_markers,
+            match_nearest_root,
         );
 
         let root_uri = lsp::Url::from_file_path(root_path.clone()).ok();

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -555,6 +555,7 @@ fn start_client(
         id,
         ls_config.timeout,
         doc_path,
+        config.match_nearest_root,
     )?;
 
     let client = Arc::new(client);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2289,7 +2289,7 @@ fn append_mode(cx: &mut Context) {
 fn file_picker(cx: &mut Context) {
     // We don't specify language markers, root will be the root of the current
     // git repo or the current dir if we're not in a repo
-    let root = find_root(None, &[]);
+    let root = find_root(None, &[], false);
     let picker = ui::file_picker(root, &cx.editor.config());
     cx.push_layer(Box::new(overlayed(picker)));
 }


### PR DESCRIPTION
## Description
This PR adds a new boolean option to language config called `match-nearest-root` to use the nearest match for one of the patterns in `roots` as the LS workspace root. 

Without such an option the LS often returns error responses in languages like Golang/Java where projects can be nested and patterns such as `go.mod` or `pom.xml` can be reused in parent directories. 

## Examples
```toml
[[language]]
name = "go"
scope = "source.go"
injection-regex = "go"
file-types = ["go"]
roots = ["go.mod"]
auto-format = true
comment-token = "//"
language-server = { command = "gopls", args = ["-vv"] }
indent = { tab-width = 4, unit = "\t" }
match-nearest-root = true
```

With the above configuration the nearest directory that has `go.mod` will be picked as LS workspace root. 

Note that the file-picker workspace root is still going to use the old pattern of finding the nearest `.git` directory or else defaulting to the current directory. This option is also set to false by default which makes it backwards-compatible and an opt-in feature. 