### PR TITLE
Fix for lost clipboard contents (#5424)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "helix-lsp",
  "helix-tui",
  "helix-vcs",
+ "libc",
  "log",
  "once_cell",
  "serde",

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -22,7 +22,6 @@ helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
 crossterm = { version = "0.25", optional = true }
 helix-vcs = { version = "0.6", path = "../helix-vcs" }
-libc = "0.2"
 
 # Conversion traits
 once_cell = "1.17"
@@ -48,6 +47,9 @@ which = "4.2"
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "4.5", features = ["std"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 helix-tui = { path = "../helix-tui" }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -22,6 +22,7 @@ helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
 crossterm = { version = "0.25", optional = true }
 helix-vcs = { version = "0.6", path = "../helix-vcs" }
+libc = "0.2"
 
 # Conversion traits
 once_cell = "1.17"

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -276,12 +276,27 @@ pub mod provider {
                 let stdin = input.map(|_| Stdio::piped()).unwrap_or_else(Stdio::null);
                 let stdout = pipe_output.then(Stdio::piped).unwrap_or_else(Stdio::null);
 
-                let mut child = Command::new(self.prg)
+                let mut command: Command = Command::new(self.prg);
+
+                let mut command_mut: &mut Command = command
                     .args(self.args)
                     .stdin(stdin)
                     .stdout(stdout)
-                    .stderr(Stdio::null())
-                    .spawn()?;
+                    .stderr(Stdio::null());
+
+                // Fix for https://github.com/helix-editor/helix/issues/5424
+                if cfg!(not(any(windows, target_os = "wasm32", target_os = "macos"))) {
+                    use std::os::unix::process::CommandExt;
+
+                    unsafe {
+                        command_mut = command_mut.pre_exec(|| match libc::setsid() {
+                            -1 => Err(std::io::Error::last_os_error()),
+                            _ => Ok(()),
+                        });
+                    }
+                }
+
+                let mut child = command_mut.spawn()?;
 
                 if let Some(input) = input {
                     let mut stdin = child.stdin.take().context("stdin is missing")?;

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -285,7 +285,7 @@ pub mod provider {
                     .stderr(Stdio::null());
 
                 // Fix for https://github.com/helix-editor/helix/issues/5424
-                if cfg!(not(any(windows, target_os = "wasm32", target_os = "macos"))) {
+                if cfg!(unix) {
                     use std::os::unix::process::CommandExt;
 
                     unsafe {


### PR DESCRIPTION
Fixes the issue described in #5424 

The code has been changed so that for unix type platforms a call is made to `libc::setsid` using the unix specific CommandExt [pre_exec](https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.pre_exec).

The `setsid` call happens just after `fork` has been called and before `execve` is called. This means it runs in the context of the child process.

The call is necessary to ensure that spawned child processes related to the clipboard (e.g. `xclip`) have a distinct process session ID and process group ID.

Without this change when the parent process exits, the child (i.e. `xclip`), can be erroneously killed leading to copy/paste breaking in some specific circumstances such as those detailed in #5424 