### PR TITLE
Store new config on application in :config-reload

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -436,6 +436,8 @@ impl Application {
                 .map_err(|err| anyhow::anyhow!("Failed to load config: {}", err))?;
             self.refresh_language_config()?;
             self.refresh_theme(&default_config)?;
+            // Store new config
+            self.config.store(Arc::new(default_config));
             Ok(())
         };
 


### PR DESCRIPTION
After changes in #5239, the loaded configuration wasn't stored, resulting in a success message even if the instance kept the previous configuration values.