### PR TITLE
Make mouse click extend selection in select mode

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1178,7 +1178,7 @@ impl EditorView {
 
                 let (view, doc) = current!(cxt.editor);
 
-                let should_yank = match cxt.editor.mouse_down_range {
+                let should_yank = match cxt.editor.mouse_down_range.take() {
                     Some(down_range) => doc.selection(view.id).primary() != down_range,
                     None => {
                         // This should not happen under normal cases. We fall back to the original
@@ -1190,8 +1190,6 @@ impl EditorView {
                             > 1
                     }
                 };
-
-                cxt.editor.mouse_down_range = None;
 
                 if should_yank {
                     commands::MappableCommand::yank_main_selection_to_primary_clipboard

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -41,7 +41,7 @@ pub use helix_core::diagnostic::Severity;
 use helix_core::{
     auto_pairs::AutoPairs,
     syntax::{self, AutoPairConfig, IndentationHeuristic, LanguageServerFeature, SoftWrap},
-    Change, LineEnding, Position, Selection, NATIVE_LINE_ENDING,
+    Change, LineEnding, Position, Range, Selection, NATIVE_LINE_ENDING,
 };
 use helix_dap as dap;
 use helix_lsp::lsp;
@@ -959,6 +959,8 @@ pub struct Editor {
     /// times during rendering and should not be set by other functions.
     pub cursor_cache: Cell<Option<Option<Position>>>,
     pub handlers: Handlers,
+
+    pub mouse_down_range: Option<Range>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1075,6 +1077,7 @@ impl Editor {
             needs_redraw: false,
             cursor_cache: Cell::new(None),
             handlers,
+            mouse_down_range: None,
         }
     }
 
@@ -1889,7 +1892,7 @@ impl Editor {
 
     /// Switches the editor into normal mode.
     pub fn enter_normal_mode(&mut self) {
-        use helix_core::{graphemes, Range};
+        use helix_core::graphemes;
 
         if self.mode == Mode::Normal {
             return;


### PR DESCRIPTION
Resolves #5425. Design rationale detailed in #5425 comments.

I'm not entirely sure whether this change is desired, but am still submitting this optimistically as I think it makes a lot of sense. I use Helix on a touch screen device (phone) sometimes and find this extremely useful for selecting code blocks as touches are easier to do than key strokes on such devices. It annoys me that currently the only way to extend a selection would be to use a keyboard.

This PR should improve the mouse UX. It's now possible to extend the primary selection with mouse clicks. The original drag-to-yank behavior is also retained.

With this PR, the editor no longer collapses all selections into a single point on mouse clicks unconditionally. Instead, it extends the primary selection to the point click when it's in select mode (secondary selections are still discarded for consistency). Normal mode behavior is left untouched.