### PR TITLE
Adding '--locked'

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -127,7 +127,7 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`,
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term --locked`,
 > tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -94,7 +94,7 @@ pacman -S mingw-w64-ucrt-x86_64-helix
 ```
 git clone https://github.com/helix-editor/helix
 cd helix
-cargo install --path helix-term
+cargo install --path helix-term --locked
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars in `./runtime/grammars`.


### PR DESCRIPTION
By default `cargo install` ignores `Cargo.lock` file.
This lead to a problem where ignore 0.4.19 didn't compile (was using unstable feature of Rust 1.61)
This change make an update in the 'Install from source'  forcing cargo to respect the aforementioned file.