### PR TITLE
Sonokai theme: style secondary selections differently

### DIFF
--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -55,7 +55,8 @@
 "ui.cursor.match" = { fg = "orange", bg = "diff_yellow" }
 "ui.cursor.insert" = { fg = "black", bg = "grey" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
-"ui.selection" = { bg = "bg4" }
+"ui.selection" = { bg = "bg5" }
+"ui.selection.primary" = { bg = "bg4" }
 "ui.linenr" = "grey"
 "ui.linenr.selected" = "fg"
 "ui.cursorline.primary" = { bg = "bg1" }
@@ -86,7 +87,8 @@ bg0 = "#2c2e34"
 bg1 = "#33353f"
 bg2 = "#363944"
 bg3 = "#3b3e48"
-bg4 = "#545862"
+bg4 = "#5C606A"
+bg5 = "#444852"
 bg_red = "#ff6077"
 diff_red = "#55393d"
 bg_green = "#a7df78"


### PR DESCRIPTION
Without styling the primary and secondary selections differently, it's
impossible to tell them apart when cycling through selections.

Make the primary selection slightly brighter and secondary selections
slightly paler.