### PR TITLE
Update the cargo installation instructions to include --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you would like to build from source:
 ```shell
 git clone https://github.com/helix-editor/helix
 cd helix
-cargo install --path helix-term
+cargo install --locked --path helix-term
 ```
 
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars in `./runtime/grammars`.
@@ -84,7 +84,7 @@ mklink /D runtime "<helix-repo>\runtime"
 
 The runtime location can be overridden via the `HELIX_RUNTIME` environment variable.
 
-> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --path helix-term`,
+> NOTE: if `HELIX_RUNTIME` is set prior to calling `cargo install --locked --path helix-term`,
 > tree-sitter grammars will be built in `$HELIX_RUNTIME/grammars`.
 
 If you plan on keeping the repo locally, an alternative to copying/symlinking


### PR DESCRIPTION
The ignore-0.4.19 package has a breaking change for the current build configuration as it requires Rust 1.63 or greater. The cargo install command ignores the lock file producing the following error: error[E0658]: use of unstable library feature 'scoped_threads'
    --> /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ignore-0.4.19/src/walk.rs:1285:9
The locked flag keeps the package pinned at 0.4.18.

See:
Cargo install lock issue: https://github.com/rust-lang/cargo/issues/7169
ignore commit: https://github.com/BurntSushi/ripgrep/commit/e95254a86f484eec663be4714924d91d3cf39cb8