### PR TITLE
Update tree-sitter-cpp, support injections in tagged rawstrings

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -221,7 +221,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "cpp"
-source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "d5e90fba898f320db48d81ddedd78d52c67c1fed" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "2d2c4aee8672af4c7c8edff68e7dd4c07e88d2b1" }
 
 [[language]]
 name = "crystal"

--- a/runtime/queries/cpp/injections.scm
+++ b/runtime/queries/cpp/injections.scm
@@ -1,1 +1,4 @@
 ; inherits: c
+(raw_string_literal
+  delimiter: (raw_string_delimiter) @injection.language
+  (raw_string_content) @injection.content)


### PR DESCRIPTION
The grammar now exposes the delimiter of raw-strings. We can now inject the inner grammar in cases like:

    const char* script = R"js(
      alert('hello world!');
    )js";