### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.66.0"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
Closes #5481 
Feature `scoped_threads` was stabilized in Rust version 1.63.0. Building from source using Rust version 1.61.0 fails.
Reference: https://doc.rust-lang.org/std/thread/fn.scope.html