### PR TITLE
Acme Theme - Change bufferline foreground color

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -20,7 +20,7 @@
 "diagnostic.error" = {bg="red", fg="white", modifiers=["bold"]}
 "diagnostic.warning" = {bg="orange", fg="black", modifiers=["bold"]}
 "diagnostic.hint" = {fg="gray", modifiers=["bold"]}
-"ui.bufferline" = { fg = "indent", bg = "acme_bar_bg" }
+"ui.bufferline" = { fg = "black", bg = "acme_bar_bg" }
 "ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
 "diff.plus" = {fg = "green"}
 "diff.delta" = {fg = "acme_bar_bg"}


### PR DESCRIPTION
Current configuration doesn't really fit this theme.

Previously:
![image](https://user-images.githubusercontent.com/92624829/211593089-a4f86aea-8175-4361-b47e-c1ca968684ec.png)

Now:
![image](https://user-images.githubusercontent.com/92624829/211593185-23bd2b06-dca9-423f-b256-9c0552b979d5.png)
