### PR TITLE
allow LSP insert text to replace non-matching prefixes (#5469)

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -130,10 +130,6 @@ impl Completion {
                     )
                 } else {
                     let text = item.insert_text.as_ref().unwrap_or(&item.label);
-                    // Some LSPs just give you an insertText with no offset ¯\_(ツ)_/¯
-                    // in these cases we need to check for a common prefix and remove it
-                    let prefix = Cow::from(doc.text().slice(start_offset..trigger_offset));
-                    let text = text.trim_start_matches::<&str>(&prefix);
 
                     // TODO: this needs to be true for the numbers to work out correctly
                     // in the closure below. It's passed in to a callback as this same
@@ -146,10 +142,8 @@ impl Completion {
                             == trigger_offset
                     );
 
-                    Transaction::change_by_selection(doc.text(), doc.selection(view_id), |range| {
-                        let cursor = range.cursor(doc.text().slice(..));
-
-                        (cursor, cursor, Some(text.into()))
+                    Transaction::change_by_selection(doc.text(), doc.selection(view_id), |_| {
+                        (start_offset, trigger_offset, Some(text.into()))
                     })
                 };
 


### PR DESCRIPTION
closes #5469 

Most LSPs will complete case-insensitive matches, particularly from lowercase to uppercase.  In some cases, notably Pyright, this is given as a simple insert text instead of TextEdit.  When this happens, the prefix text was left unedited.

This change seems to fix it for me.  I'm not sure if there are other side effects to doing it this way, though.  If another LSP gave an insert text that was just the rest to be inserted, I imagine this would still cause problems.  But the previous method would also fail in that case with repeated text.  If you typed `su` and the suggestion was `surration`, it would be ambiguous in that case whether that was to be inserted (making `susurration`) or replaced entirely (making `surration`).