### PR TITLE
Acme Theme - Add `ui.linenr` configuration

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -2,6 +2,8 @@
 
 "ui.background" = {bg="acme_bg"}
 "ui.text" = "black"
+"ui.linenr" = {bg="acme_bg", fg="black"}
+"ui.linenr.selected" = {bg="acme_bg", fg="black"}
 "ui.selection" = {bg="selected"}
 "ui.cursorline" = {bg="acme_bar_bg"}
 "ui.statusline" = {fg="black", bg="acme_bar_bg"}


### PR DESCRIPTION
Current configuration doesn't have `ui.linenr` set up which leads to showing line numbers in an unpredictable way, like in an example below:
![image](https://user-images.githubusercontent.com/92624829/211659294-353c970e-b436-418b-9cf3-ce1e76d68c08.png)

After change:
![image](https://user-images.githubusercontent.com/92624829/211659374-23e984da-ea94-42ba-b93b-caed5b70174a.png)
