### PR TITLE
Update tree-sitter-json that supports comments, add jsonc as file-type for json format (#5452)

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -138,7 +138,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 scope = "source.json"
 injection-regex = "json"
-file-types = ["json"]
+file-types = ["json", "jsonc"]
 roots = []
 language-server = { command = "vscode-json-language-server", args = ["--stdio"] }
 auto-format = true
@@ -147,7 +147,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "json"
-source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "65bceef69c3b0f24c0b19ce67d79f57c96e90fcb" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "73076754005a460947cafe8e03a8cf5fa4fa2938" }
 
 [[language]]
 name = "c"


### PR DESCRIPTION
Helix uses old tree-sitter-json git revision. Not too long ago new [version](https://github.com/tree-sitter/tree-sitter-json/commit/124edff33adfa209247c03119285feec8c4aca43) came out that supports comments. Also I added _jsonc_ format as alias for _json_. In todays world they're equal, all uses _json_ with comments and I very rarely see _jsonc_ format. There is no needs to distinct this formats.


Both formats look like this:
![image](https://user-images.githubusercontent.com/97038258/211904230-63767cad-ad55-4e29-bfa5-b32230d31850.png)

Previously json:
![image](https://user-images.githubusercontent.com/97038258/211906456-28a93965-66f1-4b5f-b696-6c28b4d7400a.png)

