### PR TITLE
Language support for dhall

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -22,6 +22,7 @@
 | d | ✓ | ✓ | ✓ | `serve-d` |
 | dart | ✓ |  | ✓ | `dart` |
 | devicetree | ✓ |  |  |  |
+| dhall | ✓ | ✓ |  | `dhall-lsp-server` |
 | diff | ✓ |  |  |  |
 | dockerfile | ✓ |  |  | `docker-langserver` |
 | dot | ✓ |  |  | `dot-language-server` |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -35,7 +35,7 @@ Each language is configured by adding a `[[language]]` section to a
 [[language]]
 name = "mylang"
 scope = "source.mylang"
-injection-regex = "^mylang$"
+injection-regex = "mylang"
 file-types = ["mylang", "myl"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }

--- a/languages.toml
+++ b/languages.toml
@@ -2092,3 +2092,18 @@ comment-token = "//"
 [[grammar]]
 name = "ponylang"
 source = { git = "https://github.com/mfelsche/tree-sitter-ponylang", rev = "ef66b151bc2604f431b5668fcec4747db4290e11" }
+
+[[language]]
+name = "dhall"
+scope = "source.dhall"
+injection-regex = "dhall"
+file-types = ["dhall"]
+roots = []
+comment-token = "--"
+indent = { tab-width = 2, unit = "  " }
+language-server = { command = "dhall-lsp-server" }
+formatter = { command = "dhall" , args = ["format"] }
+
+[[grammar]]
+name = "dhall"
+source = { git = "https://github.com/jbellerb/tree-sitter-dhall", rev = "affb6ee38d629c9296749767ab832d69bb0d9ea8" }

--- a/runtime/queries/dhall/highlights.scm
+++ b/runtime/queries/dhall/highlights.scm
@@ -1,0 +1,52 @@
+;; Literals
+
+(integer_literal) @constant.numeric.integer
+(natural_literal) @constant.numeric.integer
+(double_literal) @constant.numeric.float
+(boolean_literal) @constant.builtin.boolean
+(text_literal) @string
+(local_import) @string.special.path
+(http_import) @string.special.url
+(import_hash) @string
+
+;; Comments
+[
+  (line_comment)
+  (block_comment)
+] @comment
+
+;; Keywords
+[
+  ("let")
+  ("in")
+  (assign_operator)
+  (type_operator)
+  (lambda_operator)
+  (arrow_operator)
+  (infix_operator)
+  (completion_operator)
+  ("using")
+  ("assert")
+  (assert_operator)
+  ("as")
+  (forall_operator)
+  ("with")
+] @keyword
+
+;; Builtins
+[
+  (builtin_function)
+  (missing_import)
+] @function.builtin
+
+[ 
+  (builtin)
+  (import_as_text)
+] @type.builtin
+
+;; Conditionals
+[
+  ("if")
+  ("then")
+  ("else")
+] @keyword.control.conditional

--- a/runtime/queries/dhall/textobjects.scm
+++ b/runtime/queries/dhall/textobjects.scm
@@ -1,0 +1,23 @@
+(lambda_expression
+  (label) @parameter.inside
+  (expression) @function.inside
+) @function.around
+
+(forall_expression
+  (label) @parameter.inside
+  (expression) @function.inside
+) @function.around
+
+(assert_expression
+  (expression) @test.inside
+) @test.around
+
+[
+  (block_comment_content)
+  (line_comment_content)
+] @comment.inside
+
+[
+  (block_comment)
+  (line_comment)
+] @comment.around


### PR DESCRIPTION
This adds language configuration for the [dhall language](https://dhall-lang.org/).

# LSP & formatting

I chose to add configuration for the command line formatter even though the LSP implementation handles formatting, since the formatter is part of the `dhall` CLI and is more widely available.

# Textobject queries

- The class queries don't apply to dhall.
- Dhall does not have unit tests per se, but does have assert expressions.
- dhall does not have named functions, but has lambdas (term and type-level)