### PR TITLE
Only render the auto-complete menu if it intersects with signature help

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4233,7 +4233,8 @@ pub fn completion(cx: &mut Context) {
                     trigger_offset,
                     size,
                 )
-                .and_then(|area| Some(area.intersects(signature_help_area?)))
+                .zip(signature_help_area)
+                .filter(|(a, b)| a.intersects(*b))
                 .is_some()
             {
                 compositor.remove(SignatureHelp::ID);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4225,7 +4225,6 @@ pub fn completion(cx: &mut Context) {
 
             // Delete the signature help popup if they intersect.
             if ui.set_completion(
-                // compositor,
                 signature_help_area,
                 editor,
                 items,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4220,8 +4220,7 @@ pub fn completion(cx: &mut Context) {
             let size = compositor.size();
             let signature_help_area = compositor
                 .find_id::<Popup<SignatureHelp>>(SignatureHelp::ID)
-                .and_then(|signature_help| signature_help.area(size, editor))
-                .unwrap();
+                .map(|signature_help| signature_help.area(size, editor));
             let ui = compositor.find::<ui::EditorView>().unwrap();
 
             // Delete the signature help popup if they intersect.
@@ -4234,7 +4233,7 @@ pub fn completion(cx: &mut Context) {
                     trigger_offset,
                     size,
                 )
-                .filter(|area| area.intersects(signature_help_area))
+                .and_then(|area| Some(area.intersects(signature_help_area?)))
                 .is_some()
             {
                 compositor.remove(SignatureHelp::ID);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -52,7 +52,10 @@ use crate::{
     filter_picker_entry,
     job::Callback,
     keymap::ReverseKeymap,
-    ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent},
+    ui::{
+        self, lsp::SignatureHelp, overlay::overlayed, FilePicker, Picker, Popup, Prompt,
+        PromptEvent,
+    },
 };
 
 use crate::job::{self, Jobs};
@@ -4215,15 +4218,24 @@ pub fn completion(cx: &mut Context) {
                 return;
             }
             let size = compositor.size();
+            let signature_help_area = compositor
+                .find_id::<Popup<SignatureHelp>>(SignatureHelp::ID)
+                .and_then(|signature_help| signature_help.area(size, editor));
             let ui = compositor.find::<ui::EditorView>().unwrap();
-            ui.set_completion(
+
+            // Delete the signature help popup if they intersect.
+            if ui.set_completion(
+                // compositor,
+                signature_help_area,
                 editor,
                 items,
                 offset_encoding,
                 start_offset,
                 trigger_offset,
                 size,
-            );
+            ) {
+                compositor.remove(SignatureHelp::ID);
+            }
         },
     );
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4220,19 +4220,23 @@ pub fn completion(cx: &mut Context) {
             let size = compositor.size();
             let signature_help_area = compositor
                 .find_id::<Popup<SignatureHelp>>(SignatureHelp::ID)
-                .and_then(|signature_help| signature_help.area(size, editor));
+                .and_then(|signature_help| signature_help.area(size, editor))
+                .unwrap();
             let ui = compositor.find::<ui::EditorView>().unwrap();
 
             // Delete the signature help popup if they intersect.
-            if ui.set_completion(
-                signature_help_area,
-                editor,
-                items,
-                offset_encoding,
-                start_offset,
-                trigger_offset,
-                size,
-            ) {
+            if ui
+                .set_completion(
+                    editor,
+                    items,
+                    offset_encoding,
+                    start_offset,
+                    trigger_offset,
+                    size,
+                )
+                .filter(|area| area.intersects(signature_help_area))
+                .is_some()
+            {
                 compositor.remove(SignatureHelp::ID);
             }
         },

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -19,7 +19,7 @@ use helix_core::{path, Selection};
 use helix_view::{document::Mode, editor::Action, theme::Style};
 
 use crate::{
-    compositor::{self, Compositor},
+    compositor::{self, Component, Compositor},
     ui::{
         self, lsp::SignatureHelp, overlay::overlayed, DynamicPicker, FileLocation, FilePicker,
         Popup, PromptEvent,
@@ -1164,10 +1164,25 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
             contents.set_active_param_range(active_param_range());
 
             let old_popup = compositor.find_id::<Popup<SignatureHelp>>(SignatureHelp::ID);
-            let popup = Popup::new(SignatureHelp::ID, contents)
+            let mut popup = Popup::new(SignatureHelp::ID, contents)
                 .position(old_popup.and_then(|p| p.get_position()))
                 .position_bias(Open::Above)
                 .ignore_escape_key(true);
+
+            // Don't create a popup if it intersects the auto-complete menu.
+            let size = compositor.size();
+            if compositor
+                .find::<ui::EditorView>()
+                .unwrap()
+                .completion
+                .as_mut()
+                .and_then(|completion| completion.area(size, editor))
+                .filter(|area| area.intersects(popup.area(size, editor).unwrap()))
+                .is_some()
+            {
+                return;
+            }
+
             compositor.replace_or_push(SignatureHelp::ID, popup);
         },
     );

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -19,7 +19,7 @@ use helix_core::{path, Selection};
 use helix_view::{document::Mode, editor::Action, theme::Style};
 
 use crate::{
-    compositor::{self, Component, Compositor},
+    compositor::{self, Compositor},
     ui::{
         self, lsp::SignatureHelp, overlay::overlayed, DynamicPicker, FileLocation, FilePicker,
         Popup, PromptEvent,
@@ -1176,8 +1176,8 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
                 .unwrap()
                 .completion
                 .as_mut()
-                .and_then(|completion| completion.area(size, editor))
-                .filter(|area| area.intersects(popup.area(size, editor).unwrap()))
+                .map(|completion| completion.area(size, editor))
+                .filter(|area| area.intersects(popup.area(size, editor)))
                 .is_some()
             {
                 return;

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -72,6 +72,10 @@ pub trait Component: Any + AnyComponent {
     fn id(&self) -> Option<&'static str> {
         None
     }
+
+    fn area(&mut self, _viewport: Rect, _editor: &Editor) -> Option<Rect> {
+        None
+    }
 }
 
 pub struct Compositor {

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -72,10 +72,6 @@ pub trait Component: Any + AnyComponent {
     fn id(&self) -> Option<&'static str> {
         None
     }
-
-    fn area(&mut self, _viewport: Rect, _editor: &Editor) -> Option<Rect> {
-        None
-    }
 }
 
 pub struct Compositor {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -433,7 +433,7 @@ impl Component for Completion {
         };
 
         let popup_area = {
-            let (popup_x, popup_y) = self.popup.get_rel_position(area, cx);
+            let (popup_x, popup_y) = self.popup.get_rel_position(area, cx.editor);
             let (popup_width, popup_height) = self.popup.get_size();
             Rect::new(popup_x, popup_y, popup_width, popup_height)
         };
@@ -478,5 +478,9 @@ impl Component for Completion {
         let background = cx.editor.theme.get("ui.popup");
         surface.clear_with(doc_area, background);
         markdown_doc.render(doc_area, surface, cx);
+    }
+
+    fn area(&mut self, viewport: Rect, editor: &Editor) -> Option<Rect> {
+        self.popup.area(viewport, editor)
     }
 }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -359,6 +359,10 @@ impl Completion {
 
         true
     }
+
+    pub fn area(&mut self, viewport: Rect, editor: &Editor) -> Rect {
+        self.popup.area(viewport, editor)
+    }
 }
 
 impl Component for Completion {
@@ -478,9 +482,5 @@ impl Component for Completion {
         let background = cx.editor.theme.get("ui.popup");
         surface.clear_with(doc_area, background);
         markdown_doc.render(doc_area, surface, cx);
-    }
-
-    fn area(&mut self, viewport: Rect, editor: &Editor) -> Option<Rect> {
-        self.popup.area(viewport, editor)
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1260,7 +1260,7 @@ impl Component for EditorView {
                                         // assume close_fn
                                         self.clear_completion(cx.editor);
 
-                                        // In case the popup was deleted beacuse of an intersection w/ the auto-complete menu.
+                                        // In case the popup was deleted because of an intersection w/ the auto-complete menu.
                                         commands::signature_help_impl(
                                             &mut cx,
                                             commands::SignatureHelpInvoked::Automatic,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -940,7 +940,6 @@ impl EditorView {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn set_completion(
         &mut self,
         editor: &mut Editor,
@@ -969,7 +968,7 @@ impl EditorView {
         // TODO : propagate required size on resize to completion too
         completion.required_size((size.width, size.height));
         self.completion = Some(completion);
-        area
+        Some(area)
     }
 
     pub fn clear_completion(&mut self, editor: &mut Editor) {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -158,6 +158,16 @@ impl<T: Component> Popup<T> {
     pub fn contents_mut(&mut self) -> &mut T {
         &mut self.contents
     }
+
+    pub fn area(&mut self, viewport: Rect, editor: &Editor) -> Rect {
+        // trigger required_size so we recalculate if the child changed
+        self.required_size((viewport.width, viewport.height));
+
+        let (rel_x, rel_y) = self.get_rel_position(viewport, editor);
+
+        // clip to viewport
+        viewport.intersection(Rect::new(rel_x, rel_y, self.size.0, self.size.1))
+    }
 }
 
 impl<T: Component> Component for Popup<T> {
@@ -235,7 +245,7 @@ impl<T: Component> Component for Popup<T> {
     }
 
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
-        let area = self.area(viewport, cx.editor).unwrap();
+        let area = self.area(viewport, cx.editor);
         cx.scroll = Some(self.scroll);
 
         // clear area
@@ -282,16 +292,5 @@ impl<T: Component> Component for Popup<T> {
 
     fn id(&self) -> Option<&'static str> {
         Some(self.id)
-    }
-
-    fn area(&mut self, viewport: Rect, editor: &Editor) -> Option<Rect> {
-        // trigger required_size so we recalculate if the child changed
-        self.required_size((viewport.width, viewport.height));
-
-        let (rel_x, rel_y) = self.get_rel_position(viewport, editor);
-
-        // clip to viewport
-        let area = viewport.intersection(Rect::new(rel_x, rel_y, self.size.0, self.size.1));
-        Some(area)
     }
 }


### PR DESCRIPTION
Supersedes #5495 because it required moving `Completion` into its own layer in the compositor. This one simply checks if the two intersect, and will always defer to the auto-complete menu if they do.

Closes #3821