### PR TITLE
feat(dap): send Disconnect if Terminated event received

### DIFF
--- a/helix-dap/src/lib.rs
+++ b/helix-dap/src/lib.rs
@@ -2,7 +2,7 @@ mod client;
 mod transport;
 mod types;
 
-pub use client::Client;
+pub use client::{Client, ConnectionType};
 pub use events::Event;
 pub use transport::{Payload, Response, Transport};
 pub use types::*;

--- a/helix-dap/src/types.rs
+++ b/helix-dap/src/types.rs
@@ -391,11 +391,22 @@ pub mod requests {
         const COMMAND: &'static str = "attach";
     }
 
+    #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DisconnectArguments {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub restart: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub terminate_debuggee: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub suspend_debuggee: Option<bool>,
+    }
+
     #[derive(Debug)]
     pub enum Disconnect {}
 
     impl Request for Disconnect {
-        type Arguments = ();
+        type Arguments = Option<DisconnectArguments>;
         type Result = ();
         const COMMAND: &'static str = "disconnect";
     }

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -539,7 +539,7 @@ pub fn dap_variables(cx: &mut Context) {
 pub fn dap_terminate(cx: &mut Context) {
     let debugger = debugger!(cx.editor);
 
-    let request = debugger.disconnect();
+    let request = debugger.disconnect(None);
     dap_callback(cx.jobs, request, |editor, _compositor, _response: ()| {
         // editor.set_error(format!("Failed to disconnect: {}", e));
         editor.debugger = None;

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -1,7 +1,8 @@
 use crate::editor::{Action, Breakpoint};
 use crate::{align_view, Align, Editor};
+use dap::requests::DisconnectArguments;
 use helix_core::Selection;
-use helix_dap::{self as dap, Client, Payload, Request, ThreadId};
+use helix_dap::{self as dap, Client, ConnectionType, Payload, Request, ThreadId};
 use helix_lsp::block_on;
 use log::warn;
 use std::fmt::Write;
@@ -273,6 +274,66 @@ impl Editor {
                     if debugger.configuration_done().await.is_ok() {
                         self.set_status("Debugged application started");
                     }; // TODO: do we need to handle error?
+                }
+                Event::Terminated(terminated) => {
+                    let restart_args = if let Some(terminated) = terminated {
+                        terminated.restart
+                    } else {
+                        None
+                    };
+
+                    let disconnect_args = Some(DisconnectArguments {
+                        restart: Some(restart_args.is_some()),
+                        terminate_debuggee: None,
+                        suspend_debuggee: None,
+                    });
+
+                    if let Err(err) = debugger.disconnect(disconnect_args).await {
+                        self.set_error(format!(
+                            "Cannot disconnect debugger upon terminated event receival {:?}",
+                            err
+                        ));
+                        return false;
+                    }
+
+                    match restart_args {
+                        Some(restart_args) => {
+                            log::info!("Attempting to restart debug session.");
+                            let connection_type = match debugger.connection_type() {
+                                Some(connection_type) => connection_type,
+                                None => {
+                                    self.set_error("No starting request found, to be used in restarting the debugging session.");
+                                    return false;
+                                }
+                            };
+
+                            let relaunch_resp = if let ConnectionType::Launch = connection_type {
+                                debugger.launch(restart_args).await
+                            } else {
+                                debugger.attach(restart_args).await
+                            };
+
+                            if let Err(err) = relaunch_resp {
+                                self.set_error(format!(
+                                    "Failed to restart debugging session: {:?}",
+                                    err
+                                ));
+                            }
+                        }
+                        None => {
+                            self.set_status(
+                                "Terminated debugging session and disconnected debugger.",
+                            );
+                        }
+                    }
+                }
+                Event::Exited(resp) => {
+                    let exit_code = resp.exit_code;
+                    if exit_code != 0 {
+                        self.set_error(format!(
+                            "Debuggee failed to exit successfully (exit code: {exit_code})."
+                        ));
+                    }
                 }
                 ev => {
                     log::warn!("Unhandled event {:?}", ev);


### PR DESCRIPTION
Send a `Disconnect` DAP request if the `Terminated` event is received. According to the specification, if the debugging session was started by as `launch`, the debuggee should be terminated alongside the session. If instead the session was started as `attach`, it should not be disposed of.

This default behaviour can be overriden if the `supportTerminateDebuggee` capability is supported by the adapter, through the `Disconnect` request `terminateDebuggee` argument, as described in
[the specification][discon-spec].

This also implies saving the starting command for a debug sessions, in order to decide which behaviour should be used, as well as validating the capabilities of the adapter, in order to decide what the disconnect should do.

An additional change made is handling of the `Exited` event, showing a message if the exit code is different than `0`, for the user to be aware off the termination failure.

[discon-spec]: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect

Closes: #4674
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>