### PR TITLE
Fix: invalid file path if it contains commas/periods/semicolons

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1049,7 +1049,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             true,
         );
         // Trims some surrounding chars so that the actual file is opened.
-        let surrounding_chars: &[_] = &['\'', '"', '(', ')'];
+        let surrounding_chars: &[_] = &['\'', '"', '(', ')', ',', '.', ';'];
         paths.clear();
         paths.push(
             current_word


### PR DESCRIPTION
Closes #5533 

If a file contains one of these characters (",.;") , the program will open an invalid path.
For example: `"/path/to/file",`   would open as: `/path/to/file",` because the comma blocked deletion of the quote.
Now commas, periods and semicolons also truncate.

This covers 99% cases. However, there are still problems if you don't have space after delimiter.
`"/path/to/file","path/to/file2"`
It will be read as one long path, and the middle comma will not separate the path.

Also it's possible to go left and right from the current cursor position and find the first "not path related" chars and truncate the rest.
In any case, there will be cases where both algorithms won't be able to do anything. For example, if the path contains spaces in the naming (common on Windows).