### PR TITLE
Fix diagnostic indicator background for gruvbox themes

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -33,10 +33,10 @@
 "diff.delta" = "orange1"
 "diff.minus" = "red1"
 
-"warning" = { fg = "orange1", bg = "bg1" }
-"error" = { fg = "red1", bg = "bg1" }
-"info" = { fg = "aqua1", bg = "bg1" }
-"hint" = { fg = "blue1", bg = "bg1" }
+"warning" = "orange1"
+"error" = "red1"
+"info" = "aqua1"
+"hint" = "blue1"
 
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg4" }

--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -34,10 +34,10 @@
 "diff.delta" = "orange1"
 "diff.minus" = "red1"
 
-"warning" = { fg = "orange1", bg = "bg1" }
-"error" = { fg = "red1", bg = "bg1" }
-"info" = { fg = "aqua1", bg = "bg1" }
-"hint" = { fg = "blue1", bg = "bg1" }
+"warning" = "orange1"
+"error" = "red1"
+"info" = "aqua1"
+"hint" = "blue1"
 
 "diagnostic.error" = { underline = { style = "curl", color = "red0" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "orange1" } }

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -34,10 +34,10 @@
 "diff.delta" = "orange1"
 "diff.minus" = "red1"
 
-"warning" = { fg = "orange1", bg = "bg1" }
-"error" = { fg = "red1", bg = "bg1" }
-"info" = { fg = "aqua1", bg = "bg1" }
-"hint" = { fg = "blue1", bg = "bg1" }
+"warning" = "orange1"
+"error" = "red1"
+"info" = "aqua1"
+"hint" = "blue1"
 
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "bg4" }


### PR DESCRIPTION
The diagnostic indicator background did not match the column or row's background colour as this was context specific, and the background for the indicator was being explicitly set.

This commit removes the explicit value for the indicators background allowing it to adapt to the context. This aligns it with other themes, and resolves the issue.

Before:
<img width="912" alt="Screenshot 2023-01-15 at 13 10 49" src="https://user-images.githubusercontent.com/8218521/212544001-6eb81e42-7593-4490-8207-8684b1158ae0.png">
After:
<img width="912" alt="Screenshot 2023-01-15 at 13 11 05" src="https://user-images.githubusercontent.com/8218521/212544008-d9f5e324-0e80-4835-b97d-f219cc090a0c.png">