### PR TITLE
Fix: white color headers of `hx --health` command on light background.

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -159,8 +159,13 @@ pub fn languages_all() -> std::io::Result<()> {
     };
 
     for heading in headings {
-        column(heading, Color::White);
+        column(heading, Color::Reset);
     }
+    writeln!(stdout)?;
+
+    // Creates a dashed line between headings and body information
+    let dashes = "-".repeat(terminal_cols as usize);
+    let _ = crossterm::execute!(std::io::stdout(), Print(dashes));
     writeln!(stdout)?;
 
     syn_loader_conf


### PR DESCRIPTION
Closes #5516 

As said in issue on a light backgrounds white headers (table created with `hx --health`) are almost invisible. Especially with a light theme on _gnome-terminal_.

https://github.com/helix-editor/helix/blob/b6331394a3f341ad21f8fad3e6e0b93becda9ce5/helix-term/src/health.rs#L161-L164

I thought of 3 possible solutions:
1. Make the color `Color::Reset`. Then the headings will be the same as the `language name` color:
![image](https://user-images.githubusercontent.com/97038258/212555685-a60b4d1c-51a3-4d54-adb1-53b4192f602b.png)

1. First solution + add dashed line after the headings to make it clearer:
![image](https://user-images.githubusercontent.com/97038258/212555616-17864a8b-db6b-48a8-be02-a0259abb1827.png)

1. Use another color from this list: 
![image](https://user-images.githubusercontent.com/97038258/212555567-93409dac-1c9b-4bfe-832c-23759e0cbfb9.png)
But in this case, there is also a possibility that the user is using a background with this color.

#### What would you recommend?