### PR TITLE
highlight(scala): update the Scala highlight queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1064,7 +1064,7 @@ language-server = { command = "metals" }
 
 [[grammar]]
 name = "scala"
-source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "140c96cf398693189d4e50f76d19ddfcd8a018f8" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "db1c8c23d7996476a791db85a0d292084c19c232" }
 
 [[language]]
 name = "dockerfile"

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -33,6 +33,26 @@
 (type_definition
   name: (type_identifier) @type)
 
+(full_enum_case
+  name: (identifier) @type)
+
+(simple_enum_case
+  name: (identifier) @type)
+
+;; val/var definitions/declarations
+
+(val_definition
+  pattern: (identifier) @variable)
+
+(var_definition
+  pattern: (identifier) @variable)
+
+(val_declaration
+  name: (identifier) @variable)
+
+(var_declaration
+  name: (identifier) @variable)
+
 ; method definition
 
 (class_definition
@@ -48,7 +68,7 @@
     (function_definition
       name: (identifier) @function.method)))
 
-; imports
+; imports/exports
 
 (import_declaration
   path: (identifier) @namespace)
@@ -58,7 +78,15 @@
   path: (identifier) @type) (#match? @type "^[A-Z]"))
 ((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
 
-((import_selectors (identifier) @type) (#match? @type "^[A-Z]"))
+(export_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((export_declaration
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
+
+((namespace_selectors (identifier) @type) (#match? @type "^[A-Z]"))
 
 ; method invocation
 
@@ -67,8 +95,15 @@
   function: (identifier) @function)
 
 (call_expression
+  function: (operator_identifier) @function)
+
+(call_expression
   function: (field_expression
     field: (identifier) @function.method))
+
+(call_expression
+  function: (field_expression
+    field: (operator_identifier) @function.method))
 
 ((call_expression
    function: (identifier) @variable.other.member)
@@ -87,7 +122,13 @@
 (function_definition
   name: (identifier) @function)
 
+(function_definition
+  name: (operator_identifier) @function)
+
 (parameter
+  name: (identifier) @variable.parameter)
+
+(binding
   name: (identifier) @variable.parameter)
 
 ; expressions
@@ -109,7 +150,7 @@
 
 
 (symbol_literal) @string.special.symbol
- 
+
 [
 (string)
 (character_literal)
@@ -118,29 +159,50 @@
 
 (interpolation "$" @punctuation.special)
 
+; annotations
+
+(annotation) @attribute
+
 ;; keywords
 
+;; storage in TextMate scope lingo means field or type
 [
+  (opaque_modifier)
+  (infix_modifier)
+  (transparent_modifier)
+  (open_modifier)
   "abstract"
-  "case"
-  "class"
-  "extends"
   "final"
-  "finally"
-;; `forSome` existential types not implemented yet
   "implicit"
   "lazy"
-;; `macro` not implemented yet
-  "object"
   "override"
-  "package"
   "private"
   "protected"
   "sealed"
+] @keyword.storage.modifier
+
+[
+  "class"
+  "enum"
+  "extension"
+  "given"
+  "object"
+  "package"
   "trait"
   "type"
   "val"
   "var"
+] @keyword.storage.type
+
+[
+  "as"
+  "derives"
+  "end"
+  "extends"
+;; `forSome` existential types not implemented yet
+;; `macro` not implemented yet
+;; `throws`
+  "using"
   "with"
 ] @keyword
 
@@ -152,33 +214,36 @@
 "new" @keyword.operator
 
 [
- "else"
- "if"
- "match"
- "try"
- "catch"
- "throw"
+  "case"
+  "catch"
+  "else"
+  "finally"
+  "if"
+  "match"
+  "then"
+  "throw"
+  "try"
 ] @keyword.control.conditional
 
 [
- "("
- ")"
- "["
- "]"
- "{"
- "}"
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
 ] @punctuation.bracket
 
 [
- "."
- ","
+  "."
+  ","
 ] @punctuation.delimiter
 
 [
- "do"
- "for"
- "while"
- "yield"
+  "do"
+  "for"
+  "while"
+  "yield"
 ] @keyword.control.repeat
 
 "def" @keyword.function
@@ -191,6 +256,8 @@
 
 "import" @keyword.control.import
 
+"export" @keyword.control.import
+
 "return" @keyword.control.return
 
 (comment) @comment
@@ -201,3 +268,5 @@
   (case_clause ("case") @keyword.control.conditional))
 
 (identifier) @variable
+
+(operator_identifier) @operator


### PR DESCRIPTION
There have been a lot of changes in tree-sitter/tree-sitter-scala, including partial support for Scala 3 syntax and breaking changes in some of the nodes.

This bumps up the grammar to the latest, and adjusts the queries.

### before

<img width="921" alt="baseline_helix" src="https://user-images.githubusercontent.com/184683/212566924-49ee9c92-d7bb-4509-a1a3-1f5e00a128b2.png">

### after

<img width="989" alt="helix_1" src="https://user-images.githubusercontent.com/184683/212566884-7f3c5078-ab71-4a32-b441-0791757a9d1c.png">

Co-authored-by: Anton Sviridov <keynmol@gmail.com>
Co-authored-by: Chris Kipp <ckipp@pm.me>