### PR TITLE
Enable http server by default in Metals config

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1061,6 +1061,7 @@ file-types = ["scala", "sbt", "sc"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "metals" }
+config = { "isHttpEnabled" = true }
 
 [[grammar]]
 name = "scala"


### PR DESCRIPTION
This is required to make commands like [doctor-run](https://scalameta.org/metals/docs/integrations/new-editor#run-doctor) work. It simply opens a browser to get general information about the build.

[isHttpEnabled](https://scalameta.org/metals/docs/integrations/new-editor/#ishttpenabled)