### PR TITLE
doc: add a note about nested bindings in key remapping

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -216,7 +216,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `tab`, and `newline`. | `"none"` |
+| `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `nbsp`, `tab`, and `newline`. | `"none"` |
 | `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad` | See example below |
 
 Example

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -25,6 +25,9 @@ j = { k = "normal_mode" } # Maps `jk` to exit insert mode
 ```
 > NOTE: Typable commands can also be remapped, remember to keep the `:` prefix to indicate it's a typable command.
 
+> NOTE: Bindings can be nested, to create (or edit) minor modes: `g = { a = "code_action"}` adds a new entry to
+> the `goto` mode.
+
 Ctrl, Shift and Alt modifiers are encoded respectively with the prefixes
 `C-`, `S-` and `A-`. Special keys are encoded as follows:
 


### PR DESCRIPTION
It was not clear (to me) that minor modes were configurable in the keymap configuration (it can be inferred from the `ga` mapping in the example, but it's easy to overlook).