### PR TITLE
Attempting to fix rulers/cursor highlighting

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -149,9 +149,9 @@ impl EditorView {
             Box::new(highlights)
         };
 
+        Self::render_rulers(editor, doc, view, inner, surface, theme);
         Self::render_text_highlights(doc, view.offset, inner, surface, theme, highlights, &config);
         Self::render_gutter(editor, doc, view, view.area, surface, theme, is_focused);
-        Self::render_rulers(editor, doc, view, inner, surface, theme);
 
         if is_focused {
             Self::render_focused_view_elements(view, doc, inner, theme, surface);


### PR DESCRIPTION
The issue: In #2060 a rulers options was added. This allows for both setting a traditional colorcolumn (background color) or highlighting the foreground at the column instead (text color). The two themes I’m using as example are the default Helix theme (colors foreground at ruler) and catppuccin_mocha (colors background at ruler). In the current state both versions work well, with the caveat/bug that the cursor at the colorcolumn has no visible background when setting the background color of the ruler. Following screenshots compare the current state and this draft:

original | fix
---|---
![default-original](https://user-images.githubusercontent.com/13988217/213129093-7b7a2354-a4ed-44ef-99ac-e8c326d302d6.png) | ![default-fix](https://user-images.githubusercontent.com/13988217/213129467-876d00b4-c89b-4fdc-b82a-e7b4f5936011.png)
![mocha-original](https://user-images.githubusercontent.com/13988217/213129568-c15dc0a4-62d8-46fc-a871-7fb44d278104.png) | ![mocha-fix](https://user-images.githubusercontent.com/13988217/213129611-fd60c338-781d-469d-92b7-c9c53b259fb8.png)

The default theme has a working ruler in the original, the fix breaks the ruler (characters at the column are no longer themed).
Catppuccin_mocha has a visible ruler in the original, but the cursor background is the background of the ruler and the character is unreadable. The fix themes the cursor again.

All I want to do is point out that the current implementation has problems for a majority of the themes, because most themes set the background color of the virtual ruler, not the foreground color. The only thing I did was switching it up and rendering rulers first. Apparently the text highlights are then able to overrule the ruler theming—which in turn breaks themes which set the foreground color of the ruler (a minority). I wonder whether there is a way to get both working properly.


