### PR TITLE
Kanagawa: theme rulers and some miscellaneous fixes

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -30,7 +30,8 @@
 "ui.help" = { fg = "fujiWhite", bg = "sumiInk1" }
 "ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
-"ui.virtual" = "waveBlue1"
+"ui.virtual.whitespace" = "waveBlue1"
+"ui.virtual.ruler" = { bg = "sumiInk2" }
 
 "ui.cursor" = { fg = "waveBlue1", bg = "fujiWhite"}
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "seaFoam" }
@@ -107,7 +108,8 @@ fujiWhite     = "#DCD7BA" # default foreground
 oldWhite      = "#C8C093" # dark foreground, e.g. statuslines
 sumiInk0      = "#16161D" # dark background, e.g. statuslines, floating windows
 sumiInk1      = "#1F1F28" # default background
-sumiInk3      = "#363646" # lighter background, e.g. colorcolumns and folds
+sumiInk2      = "#2A2A37" # lighter background, e.g. colorcolumns, folds
+sumiInk3      = "#363646" # lighter background, e.g. cursorline
 sumiInk4      = "#54546D" # darker foreground, e.g. linenumbers, fold column
 waveBlue1     = "#223249" # popup background, visual selection background
 waveBlue2     = "#2D4F67" # popup selection background, search background

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -19,8 +19,8 @@
 "ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }
 "ui.statusline.normal" = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "sumiInk0", bg = "autumnGreen"  }
-"ui.statusline.select" = { fg = "sumiInk0", bg = "oniViolet" }
+"ui.statusline.insert" = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
 
 "ui.bufferline" = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.bufferline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -14,6 +14,8 @@
 "ui.linenr" = { fg = "sumiInk4" }
 "ui.linenr.selected" = { fg = "roninYellow" }
 
+"ui.virtual.ruler" = { bg = "sumiInk2" }
+"ui.virtual.whitespace" = "waveBlue1"
 "ui.virtual.indent-guide" = "sumiInk4"
 
 "ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
@@ -30,8 +32,6 @@
 "ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
-"ui.virtual.whitespace" = "waveBlue1"
-"ui.virtual.ruler" = { bg = "sumiInk2" }
 
 "ui.cursor" = { fg = "waveBlue1", bg = "fujiWhite"}
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "seaFoam" }

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -27,7 +27,7 @@
 
 "ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.window" = { fg = "fujiWhite" }
-"ui.help" = { fg = "fujiWhite", bg = "sumiInk1" }
+"ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "waveBlue1"
@@ -37,8 +37,8 @@
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "seaFoam" }
 "ui.cursor.match" = { fg = "seaFoam", modifiers = ["bold"] }
 "ui.highlight" = { fg = "fujiWhite", bg = "waveBlue2" }
-"ui.menu" = { fg = "fujiWhite", bg = "sumiInk1" }
-"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu" = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 
 "ui.cursorline.primary" = { bg = "sumiInk3"}
 

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -26,7 +26,7 @@
 "ui.bufferline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }
 
 "ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
-"ui.window" = { fg = "fujiWhite" }
+"ui.window" = { fg = "sumiInk0" }
 "ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }


### PR DESCRIPTION
This PR introduces following changes

* Add sumiInk2 color for theming rulers – at the moment only »virtual« is set, which themes both whitespace characters and rulers. This change themes the foreground for whitespace characters and the background for rulers.
* Dark background for menu and help – while the current version works for the command mode menu and help, these UI elements are also in use for auto-completion. Using the main background for such popups is a little confusing, because there is no border to separate menu content from main content.
* Bold modifier for insert and select mode in statusline – normal mode already uses bold and it is a matter of taste, but I’d say it looks more consistent this way.
* Dark foreground color for window separators – the original nvim theme seems to use a dark color, here the default foreground color is in use. Personally I think it looks best to set both foreground and background color of window separators to sumiInk0, so the separators meld with the statusline and there is no gap between statuslines of adjacent windows. But no other theme handles it this way so I didn’t do it either.

@zetashift and @leonqadirie please take a look. This is naturally all up for discussion and apart from theming the rulers none of it is addressing anything serious.