### PR TITLE
doc: add build instructions for musl-libc

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -99,6 +99,14 @@ cargo install --path helix-term --locked
 
 This will install the `hx` binary to `$HOME/.cargo/bin` and build tree-sitter grammars in `./runtime/grammars`.
 
+If you are using the musl-libc instead of glibc the following environment variable must be set during the build
+to ensure tree sitter grammars can be loaded correctly:
+
+```
+RUSTFLAGS="-C target-feature=-crt-static"
+```
+
+
 Helix also needs its runtime files so make sure to copy/symlink the `runtime/` directory into the
 config directory (for example `~/.config/helix/runtime` on Linux/macOS). This location can be overridden
 via the `HELIX_RUNTIME` environment variable.


### PR DESCRIPTION
Adds build instructions for musl to the installation section of the book.
See https://github.com/helix-editor/helix/issues/1028#issuecomment-1387251890 for reference.
I tested this on the official docker image without this flag tree-sitter
grammars do not load but with this flag they do load.