### PR TITLE
theme(zenburn): separate theme for selection.ui.primary

### DIFF
--- a/runtime/themes/zenburn.toml
+++ b/runtime/themes/zenburn.toml
@@ -6,7 +6,8 @@
 "ui.linenr" = { fg = "#9fafaf", bg = "#262626"}
 "ui.linenr.selected" = { modifiers = ["bold"]}
 "ui.popup" = { bg = "uibg" }
-"ui.selection" = { bg = "#2f2f2f" }
+"ui.selection" = { bg = "#304a3d" }
+"ui.selection.primary" = { bg = "#2f2f2f" }
 "comment" = { fg = "#7f9f7f" }
 "comment.block.documentation" = { fg = "black", modifiers = ["bold"] }
 "ui.statusline" = { bg = "statusbg", fg = "#ccdc90" }


### PR DESCRIPTION
Add a separate theme for `selection.ui.primary`. To stay consistent, I took the `Visual` value of the `alternate_visual` variant (https://github.com/jnurmine/Zenburn/blob/master/colors/zenburn.vim#L421)

See #3842

![2023-01-18-164559_429x184_scrot](https://user-images.githubusercontent.com/173299/213218809-d7f099b3-3621-4aac-8742-29043385aa66.png)
