### PR TITLE
highlight non-bar cursors

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -386,7 +386,14 @@ impl EditorView {
             if range.head > range.anchor {
                 // Standard case.
                 let cursor_start = prev_grapheme_boundary(text, range.head);
-                spans.push((selection_scope, range.anchor..cursor_start));
+                // non block cursors look like they exclude the cursor
+                let selection_end =
+                    if selection_is_primary && !cursor_is_block && mode != Mode::Insert {
+                        range.head
+                    } else {
+                        cursor_start
+                    };
+                spans.push((selection_scope, range.anchor..selection_end));
                 if !selection_is_primary || cursor_is_block {
                     spans.push((cursor_scope, cursor_start..range.head));
                 }
@@ -396,7 +403,16 @@ impl EditorView {
                 if !selection_is_primary || cursor_is_block {
                     spans.push((cursor_scope, range.head..cursor_end));
                 }
-                spans.push((selection_scope, cursor_end..range.anchor));
+                // non block cursors look like they exclude the cursor
+                let selection_start = if selection_is_primary
+                    && !cursor_is_block
+                    && !(mode == Mode::Insert && cursor_end == range.anchor)
+                {
+                    range.head
+                } else {
+                    cursor_end
+                };
+                spans.push((selection_scope, selection_start..range.anchor));
             }
         }
 


### PR DESCRIPTION
Fixes #1568

The logic is a bit more complicated than originally described in the issue. I think all non-block cursors don't show well that the cursor is part of the selection. Therefore, the cursor is always highlighted as a selection now. To avoid weird looking regressions in insert mode I added two special cases so that `a` (and `i` with just a single grapheme selected) don't regress.