### PR TITLE
highlight(scala): update to fix potential crash

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1065,7 +1065,7 @@ config = { "isHttpEnabled" = true }
 
 [[grammar]]
 name = "scala"
-source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "db1c8c23d7996476a791db85a0d292084c19c232" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "f6bbf35de41653b409ca9a3537a154f2b095ef64" }
 
 [[language]]
 name = "dockerfile"

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -112,6 +112,9 @@
 (generic_function
   function: (identifier) @function)
 
+(interpolated_string_expression
+  interpolator: (identifier) @function.call)
+
 (
   (identifier) @function.builtin
   (#match? @function.builtin "^super$")

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -113,7 +113,7 @@
   function: (identifier) @function)
 
 (interpolated_string_expression
-  interpolator: (identifier) @function.call)
+  interpolator: (identifier) @function)
 
 (
   (identifier) @function.builtin


### PR DESCRIPTION
Ref https://github.com/tree-sitter/tree-sitter-scala/pull/164

tree-sitter-scala has recently add a fix to workaround segv crashes in other editors. Not sure if it happens to Helix as well, but it's probably a good idea to use the latest.