### PR TITLE
theme: monkai_aqua variant

### DIFF
--- a/runtime/themes/monokai_aqua.toml
+++ b/runtime/themes/monokai_aqua.toml
@@ -1,0 +1,17 @@
+inherits = "monokai"
+
+"keyword.control.import" = { fg = "cyan", modifiers = ["italic"] }
+"keyword.function" = { fg = "cyan", modifiers = ["italic"] }
+"keyword.storage.type" = { fg = "cyan", modifiers = ["italic"] }
+
+"namespace" = { fg = "text" }
+
+"type" = { fg = "type", modifiers = ["bold"] }
+
+"ui.statusline.normal" = { fg = "light-black", bg = "cyan" }
+"ui.statusline.insert" = { fg = "light-black", bg = "green" }
+"ui.statusline.select" = { fg = "light-black", bg = "purple" }
+
+[palette]
+cyan = "#66D9EF"
+type = "#66D9EF"


### PR DESCRIPTION
Problem
-------
Current monokai (pro or otherwise) seems too red and green, missingthe bright aqua / cyan color found in Sublime's Monokai.

Solution
--------
This adds a variant of monokai, which I named monokai_aqua.

### monokai
<img width="841" alt="monokai_baseline" src="https://user-images.githubusercontent.com/184683/213247075-e279c4d1-3e6f-41bc-8a6f-ca6e2a6c0c14.png">

### monokai_aqua
<img width="832" alt="monokai_aqua_after" src="https://user-images.githubusercontent.com/184683/213247101-2f89a14d-06a5-4a75-936d-fd118dab238b.png">
