### PR TITLE
Fix panic for noop selecting join

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3938,6 +3938,11 @@ fn join_selections_impl(cx: &mut Context, select_space: bool) {
         }
     }
 
+    // nothing to do, bail out early to avoid crashes later
+    if changes.is_empty() {
+        return;
+    }
+
     changes.sort_unstable_by_key(|(from, _to, _text)| *from);
     changes.dedup();
 


### PR DESCRIPTION
Fixes #5423

This change simply makes `join_selections` and `join_selections_space` command return early when there is nothing to join (hence they have no effect anyway). This prevents setting an empty selection for `join_selections_space` (which would lead to a crash).
