### PR TITLE
feat(picker): add directory picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2344,6 +2344,8 @@ fn directory_picker(cx: &mut Context) {
         },
         |_editor, _path| None,
     );
+    picker.picker.show_preview = false;
+
     cx.push_layer(Box::new(overlayed(picker)));
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -210,6 +210,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "space" => { "Space"
             "f" => file_picker,
             "F" => file_picker_in_current_directory,
+            "c" => directory_picker,
             "b" => buffer_picker,
             "j" => jumplist_picker,
             "s" => symbol_picker,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -65,7 +65,7 @@ impl From<DocumentId> for PathOrId {
 pub type FileLocation = (PathOrId, Option<(usize, usize)>);
 
 pub struct FilePicker<T: Item> {
-    picker: Picker<T>,
+    pub picker: Picker<T>,
     pub truncate_start: bool,
     /// Caches paths to documents
     preview_cache: HashMap<PathBuf, CachedPreview>,
@@ -388,7 +388,7 @@ pub struct Picker<T: Item> {
     /// Whether to truncate the start (default true)
     pub truncate_start: bool,
     /// Whether to show the preview panel (default true)
-    show_preview: bool,
+    pub show_preview: bool,
     /// Constraints for tabular formatting
     widths: Vec<Constraint>,
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1147,6 +1147,19 @@ impl Editor {
         Ok(id)
     }
 
+    pub fn change_current_directory(&mut self, path: &Path) -> Result<(), Error> {
+        let dir = helix_core::path::get_canonicalized_path(path)?;
+        std::env::set_current_dir(dir)?;
+
+        let cwd = std::env::current_dir()?;
+        self.set_status(format!(
+            "Current working directory is now {}",
+            cwd.display()
+        ));
+
+        Ok(())
+    }
+
     pub fn close(&mut self, id: ViewId) {
         // Remove selections for the closed view on all documents.
         for doc in self.documents_mut() {


### PR DESCRIPTION
Add the directory picker into the space mode that changes the current working directory to the selected path.

Closes #4430