### PR TITLE
Add more file-types for python

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -473,7 +473,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "29f53
 name = "python"
 scope = "source.python"
 injection-regex = "python"
-file-types = ["py"]
+file-types = ["py","pyi","py3","pyw","ptl",".pythonstartup",".pythonrc","SConstruct"]
 shebangs = ["python"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
Add more file-types for Python. Based on https://stackoverflow.com/a/18032741/14986231 and https://github.com/neovim/neovim/blob/nightly/runtime/lua/vim/filetype.lua#L816