### PR TITLE
fix(theme): Replace non-palette color "magenta" with palette color "red" in `monokai_pro_spectrum`

### DIFF
--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -65,7 +65,7 @@
 "variable.parameter" = "#f59762"
 
 # error
-"error" = { bg = "red", fg = "yellow" }
+"error" = { fg = "red", modifiers = ["bold"] }
 
 # annotations, decorators
 "special" = "#f59762"

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -65,7 +65,7 @@
 "variable.parameter" = "#f59762"
 
 # error
-"error" = { bg = "magenta", fg = "yellow" }
+"error" = { bg = "red", fg = "yellow" }
 
 # annotations, decorators
 "special" = "#f59762"
@@ -88,7 +88,7 @@
 
 # make diagnostic underlined, to distinguish with selection text.
 "diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
-"diagnostic.error" = { underline = { color = "magenta", style = "curl" } } # maybe should be red?
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
 


### PR DESCRIPTION
Fixes #5249

# 1f0a76fe6dd2968cc183bdb7b08132a4836153ad

`"magenta"` is not defined as hex code in the theme's palette and thus depends on the terminal emulator color theme.

This commit replaces the color with `"red"`, which is defined.

# a6eb461d0f312d530aafd523514468430ed009cc

After 1f0a76fe6dd2968cc183bdb7b08132a4836153ad, a remaining issue mentioned in https://github.com/helix-editor/helix/issues/5249 is:

> Arguably, yellow on magenta has low contrast by definition (even if it was hex-coded) and thus is bound to be more or less hard to read.
> 
> The root cause is that unlike others, this theme uses red as color for builtin types, keywords and operators. Therefore, red is not a good error color. (See https://github.com/helix-editor/helix/pull/2433)

Note that https://github.com/helix-editor/helix/pull/2433 should no longer be a problem, since https://github.com/helix-editor/helix/pull/5419 was merged.

The second uses red + bold for `"error"`, like a range of other themes:
ayu_dark, onelight, solarized_light, solarized_dark, onedarker, heisenberg, ayu_mirage, hex_steel, ayu_light, onedark

Example rust-analyzer error:
![grafik](https://user-images.githubusercontent.com/22329650/213576304-b203316c-67b6-4c32-8bb3-0380de9b16b7.png)
