### PR TITLE
Accept +num flag for opening at line number

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
     pub files: Vec<(PathBuf, Position)>,
+    pub line_number: usize,
 }
 
 impl Args {
@@ -73,6 +74,16 @@ impl Args {
                         }
                     }
                 }
+                arg if arg.starts_with('+') => {
+                    let arg = arg.get(1..).unwrap();
+                    args.line_number = match arg.parse() {
+                        Ok(n) => n,
+                        _ => anyhow::bail!("bad line number after +"),
+                    };
+                    if args.line_number > 0 {
+                        args.line_number -= 1;
+                    }
+                }
                 arg => args.files.push(parse_file(arg)),
             }
         }
@@ -80,6 +91,10 @@ impl Args {
         // push the remaining args, if any to the files
         for arg in argv {
             args.files.push(parse_file(&arg));
+        }
+
+        if let Some(file) = args.files.first_mut() {
+            file.1.row = args.line_number;
         }
 
         Ok(args)

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -73,6 +73,7 @@ FLAGS:
     -V, --version                  Prints version information
     --vsplit                       Splits all given files vertically into different windows
     --hsplit                       Splits all given files horizontally into different windows
+    +N                             Goto line number N
 ",
         env!("CARGO_PKG_NAME"),
         VERSION_AND_GIT_HASH,


### PR DESCRIPTION
Resolves #5437 
Added basic logic for opening files with `+N` argument, where N is the line number.
Can be mentioned after each file. If mentioned several times, latest one will be taken.

This is a very basic implementation, since in Vim/NeoVim the `+` arguments runs a command in the editor.
With some help, I can try to change the implementation. Need to understand how I can use the `execute()` method upon startup. ([helix-term/src/commands.rs:164](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs#L164))

P.S: I'm new to Rust, so any comments about my code are more than welcome :)