### PR TITLE
tutor: Change "Type" to "Press" for specials keys and modifiers

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -48,13 +48,13 @@ _________________________________________________________________
 
  1. Type : to enter Command mode. Your cursor will
     move to the bottom of the screen.
- 2. Type q or quit and type Enter to exit Helix.
+ 2. Type q or quit and press Enter to exit Helix.
 
  Note: The quit command will fail if there are unsaved changes.
        To force quit and DISCARD these changes, type q! or quit!.
        You will learn how to save files later.
 
- To exit Command mode without entering a command, type Escape.
+ To exit Command mode without entering a command, press Escape.
 
  Now, move on to the next lesson.
 
@@ -96,7 +96,7 @@ _________________________________________________________________
  2. Move to a place in the line which is missing text and type
     i to enter Insert mode. Keys you type will now type text.
  3. Enter the missing text.
- 4. Type Escape to exit Insert mode and return to Normal mode.
+ 4. Press Escape to exit Insert mode and return to Normal mode.
  5. Repeat until the line matches the line below it.
 
  --> Th stce misg so.
@@ -119,7 +119,7 @@ _________________________________________________________________
  2. Open a file in Helix by running: hx FILENAME
  3. Make some edits to the file.
  4. Type : to enter Command mode.
- 5. Type w or write, and type Enter to save the file.
+ 5. Type w or write, and press Enter to save the file.
 
  You can also type wq or write-quit to save and exit.
 
@@ -145,7 +145,7 @@ _________________________________________________________________
 
  * Type d to delete the character at the cursor.
 
- * Type i to enter Insert mode and type text. Type Escape to
+ * Type i to enter Insert mode and type text. Press Escape to
    return to Normal mode.
 
 
@@ -469,7 +469,7 @@ _________________________________________________________________
  Type N to go to the previous search match.
 
  1. Type / and type in a common word, like 'banana'.
- 2. Type Enter to confirm the search.
+ 2. Press Enter to confirm the search.
  3. Use n and N to cycle through the matches.
 
  Searching uses regular expressions, allowing you to target more
@@ -524,7 +524,7 @@ _________________________________________________________________
  --> Fix th two nes at same ime.
      Fix these two lines at the same time.
 
- Note: Type Alt-C to do the same above the cursor.
+ Note: Press Alt-C to do the same above the cursor.
 
 =================================================================
 =                    5.2 THE SELECT COMMAND                     =
@@ -535,11 +535,11 @@ _________________________________________________________________
  1. Move the cursor to the line marked '-->' below.
  2. Type x to select the line.
  3. Type s. A prompt will appear.
- 4. Type 'apples' and type Enter. Both occurrences of
+ 4. Type 'apples' and press Enter. Both occurrences of
     'apples' in the line will be selected.
  5. You can now type c and change 'apples' to something else,
     like 'oranges'.
- 6. Type Escape to exit Insert mode.
+ 6. Press Escape to exit Insert mode.
  7. Type , to remove the second cursor.
 
  --> I like to eat apples since my favorite fruit is apples.
@@ -558,7 +558,7 @@ _________________________________________________________________
  1. Move the cursor to the line marked '-->' below.
  2. Select the line with x and then type s.
  3. Type '  +' to select any amount of consecutive spaces >1,
-    then type Enter.
+    then press Enter.
  4. Type c and change the matches to single spaces.
 
  --> This  sentence has   some      extra spaces.
@@ -596,11 +596,11 @@ _________________________________________________________________
 =                 5.5 SPLIT SELECTION INTO LINES                =
 =================================================================
 
- Type Alt-s to split the selection(s) on newlines.
+ Press Alt-s to split the selection(s) on newlines.
 
  1. Move the cursor to the first row of the table below.
  2. Select the entire table with 6x.
- 3. Type Alt-s to split into selections at each line.
+ 3. Press Alt-s to split into selections at each line.
  4. Align the table with &.
 
     | FRUIT   | AMOUNT |
@@ -626,7 +626,7 @@ _________________________________________________________________
 
  * Type & to align selections.
 
- * Type Alt-s to split the selection into lines.
+ * Press Alt-s to split the selection into lines.
 
 
 
@@ -685,7 +685,7 @@ _________________________________________________________________
 =================================================================
 
  Type . to repeat the last insert command.
- Type Alt-. to repeat the last f / t selection.
+ Press Alt-. to repeat the last f / t selection.
 
  1. Move the cursor to the line marked '-->' below.
  2. Make a change, insertion or appendage and repeat it with . .
@@ -712,7 +712,7 @@ _________________________________________________________________
  * Type r to replace selected characters.
 
  * Type . to repeat the last insertion.
-   * Type Alt-. to repeat the last f / t selection.
+   * Press Alt-. to repeat the last f / t selection.
 
 
 
@@ -794,13 +794,13 @@ lines.
 =               7.4 INCREMENTING AND DECREMENTING               =
 =================================================================
 
- Type Ctrl-a to increment the number under selection.
- Type Ctrl-x to decrement the number under selection.
+ Press Ctrl-a to increment the number under selection.
+ Press Ctrl-x to decrement the number under selection.
 
  1. Move the cursor to the third line marked '-->' below.
- 2. Type Ctrl-a to increment the second point marked 2.
+ 2. Press Ctrl-a to increment the second point marked 2.
  3. Repeat for the point marked 3.
- 4. Move to the last point and type Ctrl-x to decrement the 6.
+ 4. Move to the last point and press Ctrl-x to decrement the 6.
 
  --> 1) First point.
  --> 2) Added point.
@@ -822,8 +822,8 @@ lines.
 
  * Type < and > to indent / outdent lines.
 
- * Type Ctrl-a to increment the selected number.
-   * Type Ctrl-x to decrement the selected number.
+ * Press Ctrl-a to increment the selected number.
+   * Press Ctrl-x to decrement the selected number.
 
 
 
@@ -952,15 +952,15 @@ lines.
  searching or jumping to the definition of a function in code. It
  stores these in what's called the jumplist.
 
- Type Ctrl-s to manually save your current position to
+ Press Ctrl-s to manually save your current position to
  the jumplist.
 
- Type Ctrl-i ("in") and Ctrl-o ("out") to move forward and
+ Press Ctrl-i ("in") and Ctrl-o ("out") to move forward and
  backwards in the jumplist respectively.
 
- 1. Type Ctrl-s somewhere.
+ 1. Press Ctrl-s somewhere.
  2. Move far away in the file.
- 3. Type Ctrl-o (just once!) to come back to where you saved.
+ 3. Press Ctrl-o (just once!) to come back to where you saved.
 
 
 
@@ -975,8 +975,8 @@ lines.
  * Type n / N in Visual mode to add selections on each search
    match.
 
- * Type Ctrl-s to save position to the jumplist.
-   * Type Ctrl-i and Ctrl-o to go forward and backward in the
+ * Press Ctrl-s to save position to the jumplist.
+   * Press Ctrl-i and Ctrl-o to go forward and backward in the
      jumplist.
 
 
@@ -995,7 +995,7 @@ lines.
  Type ) and ( to cycle the primary selection forward and backward
  through selections respectively.
 
- Type Alt-, to remove the primary selection.
+ Press Alt-, to remove the primary selection.
 
  1. Move the cursor to the line marked '-->' below.
  2. Select both lines with xx or 2x.
@@ -1014,7 +1014,7 @@ lines.
 =             10.2 CYCLING THE CONTENT OF SELECTIONS            =
 =================================================================
 
- Type Alt-) and Alt-( to cycle the content of the selections
+ Press Alt-) and Alt-( to cycle the content of the selections
  forward and backward respectively.
 
  1. Move the cursor to the line marked '-->' below.
@@ -1038,7 +1038,7 @@ lines.
 
  Type ~ to switch the case of all selected letters.
  Type ` to set all selected letters to lowercase.
- Type Alt-` to set all selected letters to uppercase.
+ Press Alt-` to set all selected letters to uppercase.
 
  1. Move the cursor to the first line marked '-->' below.
  2. Select each wrongly capitalised or lowercase letter
@@ -1048,7 +1048,7 @@ lines.
  5. Type ` to change the line to lowercase.
  6. Move to the third line marked '-->'.
  7. Type x to select the line.
- 8. Type Alt-` to change the line to uppercase.
+ 8. Press Alt-` to change the line to uppercase.
 
  --> thIs sENtencE hAs MIS-cApitalIsed leTTerS.
  --> this SENTENCE SHOULD all be in LOWERCASE.
@@ -1065,10 +1065,10 @@ lines.
  3. Type S then \. |! Enter (note the spaces after . and !).
     This effectively splits the selection into sentences at each
     dot or exclamation mark.
- 4. Type Alt-; to reverse the selections.
+ 4. Press Alt-; to reverse the selections.
  5. Type ; to reduce selections to a single character - the first
     letter of each sentence.
- 6. Type Alt-` to convert all selected letters to uppercase.
+ 6. Press Alt-` to convert all selected letters to uppercase.
 
 ---
 these are sentences. some sentences don't start with uppercase
@@ -1082,8 +1082,8 @@ letters! that is not good grammar. you can fix this.
 
  * Use ) and ( to cycle the primary selection back and forward
    through selections respectively.
-   * Type Alt-, to remove the primary selection.
-   * Type Alt-) and Alt-( to cycle the content of the selections.
+   * Press Alt-, to remove the primary selection.
+   * Press Alt-) and Alt-( to cycle the content of the selections.
 
  * Type ~ to alternate case of selected letters.
    * Use ` and Alt-` to set the case of selected letters to
@@ -1102,7 +1102,7 @@ letters! that is not good grammar. you can fix this.
 =                     11.1 COMMENTING A LINE                    =
 =================================================================
 
-Type Ctrl-c to comment the line under your cursor.
+Press Ctrl-c to comment the line under your cursor.
 To uncomment the line, press Ctrl-c again.
 
 1. Move your cursor to the line marked '-->' below.
@@ -1146,7 +1146,7 @@ multiple cursors, they won't be uncommented but commented again.
 =                       CHAPTER 11 RECAP                        =
 =================================================================
 
- * Use Ctrl-c to comment a line under your cursor. Type Ctrl-c
+ * Use Ctrl-c to comment a line under your cursor. Press Ctrl-c
    again to uncomment.
  * To comment multiple lines, use the selections 
    and multi-cursors before typing Ctrl-c.


### PR DESCRIPTION
“Type Escape” makes it seem one has press <kbd>e</kbd><kbd>s</kbd><kbd>c</kbd><kbd>a</kbd><kbd>p</kbd><kbd>e</kbd> instead of pressing the key. This may be even better as “Press the esc key” but it’s wordier.