### PR TITLE
Add `markup.strikethrough` theme keys

### DIFF
--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -51,7 +51,8 @@
 "markup.heading" = "my_yellow1"
 "markup.list" = "my_white2"
 "markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = {  modifiers = ["italic"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "my_turquoise2"
 "markup.link.text" = "my_white2"
 "markup.quote" = "my_brown"

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -37,6 +37,7 @@
 "markup.list" = "base08"
 "markup.bold" = { fg = "base0A", modifiers = ["bold"] }
 "markup.italic" = { fg = "base0E", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "base09", modifiers = ["underlined"] }
 "markup.link.text" = "base08"
 "markup.quote" = "base0C"

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -37,6 +37,7 @@
 "markup.list" = "base08"
 "markup.bold" = { fg = "base0A", modifiers = ["bold"] }
 "markup.italic" = { fg = "base0E", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "base09", modifiers = ["underlined"] }
 "markup.link.text" = "base08"
 "markup.quote" = "base0C"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -34,6 +34,7 @@
 "markup.list" = "light-red"
 "markup.bold" = { fg = "light-yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "light-magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
 "markup.link.text" = "light-red"
 "markup.quote" = "light-cyan"

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -45,6 +45,7 @@
 "markup.list" = "light-red"
 "markup.bold" = { fg = "light-yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "light-magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", underline = { color = "yellow", style = "line"} }
 "markup.link.text" = "light-red"
 "markup.quote" = "light-cyan"

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -31,6 +31,7 @@
 "markup.list" = "bogster-red"
 "markup.bold" = { fg = "bogster-yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "bogster-purp", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "bogster-yellow", modifiers = ["underlined"] }
 "markup.link.text" = "bogster-red"
 "markup.quote" = "bogster-teal"

--- a/runtime/themes/bogster_light.toml
+++ b/runtime/themes/bogster_light.toml
@@ -31,6 +31,7 @@
 "markup.list" = "bogster-red"
 "markup.bold" = { fg = "bogster-yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "bogster-yellow", modifiers = ["underlined"] }
 "markup.link.text" = "bogster-red"
 "markup.quote" = "bogster-lblue"

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -22,6 +22,7 @@
 "markup.list" = { fg = "bubblegum" }
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "violet", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "violet" }
 "markup.quote" = { fg = "berry_desaturated" }

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -50,6 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "rosewater", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -56,6 +56,7 @@
 "markup.list" = "white"
 "markup.bold" = { fg = "white", modifiers = ["bold"] }
 "markup.italic" = { fg = "white", modifiers = ["italic"] }
+"markup.strikethrough" = { fg = "white", modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "lightblue", modifiers = ["underlined"] }
 "markup.link.text" = "white"
 "markup.quote" = "darkgreen"

--- a/runtime/themes/dark_high_contrast.toml
+++ b/runtime/themes/dark_high_contrast.toml
@@ -84,6 +84,7 @@
 "markup.list" = "pink"
 "markup.bold" = { fg = "emerald_green", modifiers = ["bold"] }
 "markup.italic" = { fg = "blue", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue", underline = { color = "blue", style = "line" } }
 "markup.link.text" = "pink"
 "markup.quote" = "yellow"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -44,6 +44,7 @@
 "markup.list" = "blue3"
 "markup.bold" = { fg = "blue2", modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { modifiers = ["underlined"] }
 "markup.link.text" = "orange"
 "markup.quote" = "dark_green"

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -29,6 +29,7 @@
 
 'markup.bold' = { fg = 'orange', modifiers = ['bold'] }
 'markup.italic' = { fg = 'magenta', modifiers = ['italic'] }
+'markup.strikethrough' = { modifiers = ['crossed_out'] }
 'markup.heading' = { fg = 'red' }
 'markup.link' = { fg = 'orange' }
 'markup.link.url' = { fg = 'magenta' }

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -50,6 +50,7 @@
 "markup.list" = "cyan"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "pink"
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -50,6 +50,7 @@
 "markup.list" = "cyan"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "pink"
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/runtime/themes/emacs.toml
+++ b/runtime/themes/emacs.toml
@@ -37,6 +37,7 @@
 "markup.list" = { fg = "black" }
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "royalblue3", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "royalblue3" }
 "markup.quote" = { fg = "gray60" }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -46,6 +46,7 @@
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "purple"
 "markup.quote" = "grey2"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -46,6 +46,7 @@
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "purple"
 "markup.quote" = "grey2"

--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -37,14 +37,15 @@
 "markup.raw" = { fg = "orange_text", bg = "orange_bg" }
 "markup.raw.inline" = { fg = "orange_text", bg = "orange_bg" }
 "markup.raw.block" = { fg = "orange_text", bg = "orange_bg" }
+"markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue_text", bg = "blue_bg", modifiers = [
   "underlined",
 ] }
 "markup.link.label" = { fg = "blue_text", bg = "blue_bg" }
 "markup.link.text" = { fg = "blue_text", bg = "blue_bg" }
 "markup.quote" = { fg = "teal_text", bg = "teal_bg" }
-"markup.bold" = { modifiers = ["bold"] }
 "markup.list" = { fg = "purple_text", bg = "purple_bg" }
 
 "ui.background" = { fg = "base1", bg = "base7" }

--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -46,6 +46,7 @@
 # "markup.normal" = {} # .completion / .hover
 "markup.bold" = { fg = "lightest", modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.heading" = { fg = "cyan", modifiers = ["bold"] } # .marker / .1 / .2 / .3 / .4 / .5 / .6
 "markup.list" = "pink" # .unnumbered / .numbered
 "markup.list.numbered" = "cyan"

--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -33,6 +33,7 @@ label = "scale.red.3"
 "markup.heading" = "scale.blue.2"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { modifiers = ["underlined"] }
 "markup.link.text" = { fg = "scale.blue.1", modifiers = ["underlined"] }
 "markup.raw" = "scale.blue.2"

--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -33,6 +33,7 @@ label = "scale.red.5"
 "markup.heading" = "scale.blue.6"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { modifiers = ["underlined"] }
 "markup.link.text" = { fg = "scale.blue.8", modifiers = ["underlined"] }
 "markup.raw" = "scale.blue.6"

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -69,6 +69,7 @@
 "markup.heading" = "aqua1"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
 "markup.link.text" = "red1"
 "markup.raw" = "red1"

--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -70,6 +70,7 @@
 "markup.heading" = "aqua1"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
 "markup.link.text" = "red1"
 "markup.raw" = "red1"

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -70,6 +70,7 @@
 "markup.heading" = "aqua1"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "green1", modifiers = ["underlined"] }
 "markup.link.text" = "red1"
 "markup.raw" = "red1"

--- a/runtime/themes/hex_steel.toml
+++ b/runtime/themes/hex_steel.toml
@@ -75,6 +75,7 @@
 "markup.list" = { fg = "t4" }
 "markup.bold" = { fg = "t4" }
 "markup.italic" = { fg = "t4" }
+"markup.strikethrough" = { fg = "t4", modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "t4", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "t4" }
 "markup.quote" = { fg = "t4" }

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -33,6 +33,7 @@
 "markup.list" = "red"
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
 "markup.link.text" = "red"
 "markup.quote" = "cyan"

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -97,6 +97,7 @@ hint = "dragonBlue"
 "markup.list" = "oniViolet"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "springBlue", modifiers = ["underlined"] }
 "markup.link.text" = "crystalBlue"
 "markup.quote" = "seaFoam"

--- a/runtime/themes/meliora.toml
+++ b/runtime/themes/meliora.toml
@@ -67,8 +67,9 @@
 
 "markup.heading" = { fg = "orange" }
 "markup.list" = { fg = "blue" }
-"markup.bold" = { fg = "magenta" }
-"markup.italic" = { fg = "blue" }
+"markup.bold" = { fg = "magenta", modifiers = ["bold"] }
+"markup.italic" = { fg = "blue", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "comment" , modifiers = ["underlined"] }
 "markup.link.text" = { fg = "comment" }
 "markup.quote" = { fg = "yellow" }

--- a/runtime/themes/mellow.toml
+++ b/runtime/themes/mellow.toml
@@ -50,6 +50,7 @@
 "markup.list" = "gray06"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "green", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "blue", modifiers = ["italic"] }
 "markup.raw" = "yellow"

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -46,6 +46,7 @@
 "markup.list" = "red"
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
 "markup.link.text" = "red"
 "markup.quote" = "cyan"

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -99,6 +99,7 @@
 "markup.heading" = "green"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.quote" = "green"

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -96,6 +96,7 @@
 "markup.heading" = "green"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.quote" = "green"

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -99,6 +99,7 @@
 "markup.heading" = "green"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.quote" = "green"

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -96,6 +96,7 @@
 "markup.heading" = "green"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.quote" = "green"

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -96,6 +96,7 @@
 "markup.heading" = "green"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "orange", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.quote" = "green"

--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -80,6 +80,7 @@
 'markup.list' = { fg = 'pink' }
 'markup.bold' = { fg = 'foreground', modifiers = ['bold'] }
 'markup.italic' = { fg = 'foreground', modifiers = ['italic'] }
+'markup.strikethrough' = { fg = 'foreground', modifiers = ['crossed_out'] }
 'markup.link' = { fg = 'pink', modifiers = ['underlined'] }
 'markup.link.url' = { fg = 'slate', modifiers = ['underlined'] }
 'markup.quote' = { fg = 'green', modifiers = ['italic'] }

--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -55,6 +55,7 @@
 "markup.list" = { fg = "magenta", modifiers = ["bold"] }
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "pink" }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link" = { fg = "yellow-bright", modifiers = ["bold"] }
 "markup.quote" = { fg = "blue" }
 

--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -150,6 +150,7 @@
 
 'markup.bold' = { modifiers = ["bold"] } # Bold text.
 'markup.italic' = { modifiers = ["italic"] } # Italicised text.
+"markup.strikethrough" = { modifiers = ["crossed_out"] } # Crossed out text.
 
 'markup.link' = { fg = "light-blue", modifiers = ["underlined"] }
 'markup.link.url' = { } # Urls pointed to by links.

--- a/runtime/themes/noctis_bordo.toml
+++ b/runtime/themes/noctis_bordo.toml
@@ -49,6 +49,7 @@
 "markup.list" = "base08"
 "markup.quote" = "base0C"
 "markup.raw" = "base0B"
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 
 "diff.delta" = "base09"
 "diff.plus" = "base0B"

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -95,6 +95,7 @@
 "markup.list" = "nord9"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.text" = "nord8"
 "markup.raw" = "nord7"
 

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -30,6 +30,7 @@
 "markup.raw.inline" = { fg = "green" }
 "markup.bold" = { fg = "gold", modifiers = ["bold"] }
 "markup.italic" = { fg = "purple", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.list" = { fg = "red" }
 "markup.quote" = { fg = "yellow" }
 "markup.link.url" = { fg = "cyan", modifiers = ["underlined"]}

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -31,6 +31,7 @@
 "markup.raw.block" = { fg = "white" }
 "markup.bold" = { fg = "gold", modifiers = ["bold"] }
 "markup.italic" = { fg = "purple", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.list" = { fg = "red" }
 "markup.quote" = { fg = "yellow" }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"]}

--- a/runtime/themes/onelight.toml
+++ b/runtime/themes/onelight.toml
@@ -48,6 +48,7 @@
 "markup.raw.inline" = { fg = "green", bg = "grey-200" }
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "purple", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.list" = { fg = "light-blue" }
 "markup.quote" = { fg = "gray" }
 "markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }

--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -31,6 +31,7 @@
 "markup.list" = "bright3"
 "markup.bold" = { fg = "foreground", modifiers = ["bold"] }
 "markup.italic" = { fg = "bright0", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "bright6", modifiers = ["underlined"] }
 "markup.link.text" = "bright2"
 "markup.link.label" = { fg = "regular2", modifiers = ["bold"] }

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -32,6 +32,7 @@
 "markup.list" = "regular4"
 "markup.bold" = { fg = "foreground", modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "regular4", modifiers = ["underlined"] }
 "markup.link.text" = "bright2"
 "markup.link.label" = { fg = "regular7", modifiers = ["bold"] }

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -95,6 +95,7 @@ error = "red"
 "markup.list" = "sky"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { modifiers = ["underlined"] }
 "markup.link.text" = "magenta"
 "markup.quote" = "green"

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -103,6 +103,7 @@ namespace = { fg = 'orangeL' }
 'markup.list.unnumbered' = { fg = 'greenN' }
 'markup.bold' = { modifiers = ['bold'] }
 'markup.italic' = { modifiers = ['italic'] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 'markup.link' = { fg = 'blueD' }
 'markup.link.url' = { fg = 'blueL' }
 'markup.link.label' = { fg = 'blueH' }

--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -55,6 +55,7 @@
 "markup.list" = "gray07"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "yellow"

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -143,6 +143,7 @@
 # "markup.list.numbered" = ""
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link" = "iris"
 "markup.link.url" = { fg = "iris",  underline = { color = "iris", style = "line" } } 
 "markup.link.label" = "subtle"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -71,6 +71,7 @@
 "markup.list" = "cyan"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "pink"
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -71,6 +71,7 @@
 "markup.list" = "cyan"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "pink"
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -84,6 +84,7 @@
 "markup.list" = "cyan"
 "markup.bold" = { fg = "blue", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "magenta"
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -27,6 +27,7 @@
 "markup.list" = "red"
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
 "markup.link.text" = "red"
 "markup.quote" = "cyan"

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -27,6 +27,7 @@
 "markup.list" = "red"
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "yellow", modifiers = ["underlined"] }
 "markup.link.text" = "red"
 "markup.quote" = "cyan"

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -41,6 +41,7 @@
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "purple"
 "markup.quote" = "grey"

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -34,6 +34,7 @@
 "markup.list" = "theme_red"
 "markup.bold" = { fg = "theme_yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "theme_magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "theme_yellow", modifiers = ["underlined"] }
 "markup.link.text" = "theme_red"
 "markup.quote" = "theme_cyan"

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -64,6 +64,7 @@
 "markup.list" = { fg = "cyan" }
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }
 "markup.italic" = { fg = "yellow", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "green" }
 "markup.link.text" = { fg = "light-gray" }
 "markup.quote" = { fg = "yellow", modifiers = ["italic"] }

--- a/theme.toml
+++ b/theme.toml
@@ -31,6 +31,7 @@ label = "honey"
 "markup.heading" = "lilac"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "silver", modifiers = ["underlined"] }
 "markup.link.text" = "almond"
 "markup.raw" = "almond"


### PR DESCRIPTION
This PR adds `markup.strikethrough` to all themes that specify `markup.italic`/`markup.bold`.

I tried to adhere to the themes where possible (`"`/`'` quotes, key order and comments).

closes #5595