### PR TITLE
Add config for default line ending

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -62,6 +62,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
+| `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -66,5 +66,5 @@ pub use syntax::Syntax;
 
 pub use diagnostic::Diagnostic;
 
-pub use line_ending::{LineEnding, DEFAULT_LINE_ENDING};
+pub use line_ending::{LineEnding, NATIVE_LINE_ENDING};
 pub use transaction::{Assoc, Change, ChangeSet, Deletion, Operation, Transaction};

--- a/helix-core/src/line_ending.rs
+++ b/helix-core/src/line_ending.rs
@@ -1,9 +1,9 @@
 use crate::{Rope, RopeSlice};
 
 #[cfg(target_os = "windows")]
-pub const DEFAULT_LINE_ENDING: LineEnding = LineEnding::Crlf;
+pub const NATIVE_LINE_ENDING: LineEnding = LineEnding::Crlf;
 #[cfg(not(target_os = "windows"))]
-pub const DEFAULT_LINE_ENDING: LineEnding = LineEnding::LF;
+pub const NATIVE_LINE_ENDING: LineEnding = LineEnding::LF;
 
 /// Represents one of the valid Unicode line endings.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]

--- a/helix-term/tests/test/auto_pairs.rs
+++ b/helix-term/tests/test/auto_pairs.rs
@@ -2,7 +2,7 @@ use helix_core::{auto_pairs::DEFAULT_PAIRS, hashmap};
 
 use super::*;
 
-const LINE_END: &str = helix_core::DEFAULT_LINE_ENDING.as_str();
+const LINE_END: &str = helix_core::NATIVE_LINE_ENDING.as_str();
 
 fn differing_pairs() -> impl Iterator<Item = &'static (char, char)> {
     DEFAULT_PAIRS.iter().filter(|(open, close)| open != close)

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -244,7 +244,7 @@ pub fn test_editor_config() -> helix_view::editor::Config {
 /// character, and if one doesn't exist already, appends the system's
 /// appropriate line ending to the end of a string.
 pub fn platform_line(input: &str) -> String {
-    let line_end = helix_core::DEFAULT_LINE_ENDING.as_str();
+    let line_end = helix_core::NATIVE_LINE_ENDING.as_str();
 
     // we can assume that the source files in this code base will always
     // be LF, so indoc strings will always insert LF

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -8,7 +8,6 @@ use helix_core::doc_formatter::TextFormat;
 use helix_core::encoding::Encoding;
 use helix_core::syntax::{Highlight, LanguageServerFeature};
 use helix_core::text_annotations::{InlineAnnotation, TextAnnotations};
-use helix_core::Range;
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
 
 use ::parking_lot::Mutex;
@@ -31,8 +30,8 @@ use helix_core::{
     indent::{auto_detect_indent_style, IndentStyle},
     line_ending::auto_detect_line_ending,
     syntax::{self, LanguageConfiguration},
-    ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, Selection, Syntax, Transaction,
-    DEFAULT_LINE_ENDING,
+    ChangeSet, Diagnostic, LineEnding, Range, Rope, RopeBuilder, Selection, Syntax, Transaction,
+    NATIVE_LINE_ENDING,
 };
 
 use crate::editor::{Config, RedrawHandle};
@@ -590,6 +589,7 @@ impl Document {
         config: Arc<dyn DynAccess<Config>>,
     ) -> Self {
         let (encoding, has_bom) = encoding_with_bom_info.unwrap_or((encoding::UTF_8, false));
+        let line_ending = config.load().default_line_ending.into();
         let changes = ChangeSet::new(&text);
         let old_state = None;
 
@@ -603,7 +603,7 @@ impl Document {
             inlay_hints: HashMap::default(),
             inlay_hints_oudated: false,
             indent_style: DEFAULT_INDENT,
-            line_ending: DEFAULT_LINE_ENDING,
+            line_ending,
             restore_cursor: false,
             syntax: None,
             language: None,
@@ -623,10 +623,12 @@ impl Document {
             focused_at: std::time::Instant::now(),
         }
     }
+
     pub fn default(config: Arc<dyn DynAccess<Config>>) -> Self {
-        let text = Rope::from(DEFAULT_LINE_ENDING.as_str());
+        let text = Rope::from(NATIVE_LINE_ENDING.as_str());
         Self::from(text, None, config)
     }
+
     // TODO: async fn?
     /// Create a new document from `path`. Encoding is auto-detected, but it can be manually
     /// overwritten with the `encoding` parameter.
@@ -643,7 +645,7 @@ impl Document {
             from_reader(&mut file, encoding)?
         } else {
             let encoding = encoding.unwrap_or(encoding::UTF_8);
-            (Rope::from(DEFAULT_LINE_ENDING.as_str()), encoding, false)
+            (Rope::from(NATIVE_LINE_ENDING.as_str()), encoding, false)
         };
 
         let mut doc = Self::from(rope, Some((encoding, has_bom)), config);
@@ -887,14 +889,16 @@ impl Document {
 
     /// Detect the indentation used in the file, or otherwise defaults to the language indentation
     /// configured in `languages.toml`, with a fallback to tabs if it isn't specified. Line ending
-    /// is likewise auto-detected, and will fallback to the default OS line ending.
+    /// is likewise auto-detected, and will remain unchanged if no line endings were detected.
     pub fn detect_indent_and_line_ending(&mut self) {
         self.indent_style = auto_detect_indent_style(&self.text).unwrap_or_else(|| {
             self.language_config()
                 .and_then(|config| config.indent.as_ref())
                 .map_or(DEFAULT_INDENT, |config| IndentStyle::from_str(&config.unit))
         });
-        self.line_ending = auto_detect_line_ending(&self.text).unwrap_or(DEFAULT_LINE_ENDING);
+        if let Some(line_ending) = auto_detect_line_ending(&self.text) {
+            self.line_ending = line_ending;
+        }
     }
 
     /// Reload the document from its path.
@@ -1921,7 +1925,7 @@ mod test {
             Document::default(Arc::new(ArcSwap::new(Arc::new(Config::default()))))
                 .text()
                 .to_string(),
-            DEFAULT_LINE_ENDING.as_str()
+            NATIVE_LINE_ENDING.as_str()
         );
     }
 


### PR DESCRIPTION
I've finally gotten around to giving this a shot.

This adds a key to the editor config that allows specifying the default line ending for new documents. I added variants for `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). The default is `native`, so the out-of-the-box behavior remains unchanged.

One thing I noticed is that the enum naming is a little odd - `Crlf` vs. `LF`. But I kept the existing variant names.

closes #4378