### PR TITLE
feat(format): current file in formatter args

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -96,7 +96,7 @@ The `language-server` field takes the following keys:
 | Key           | Description                                                           |
 | ---           | -----------                                                           |
 | `command`     | The name of the language server binary to execute. Binaries must be in `$PATH` |
-| `args`        | A list of arguments to pass to the language server binary             |
+| `args`        | A list of arguments to pass to the language server binary. Those can have `"{}"` as a placeholder for the current file path. |
 | `timeout`     | The maximum time a request to the language server may take, in seconds. Defaults to `20` |
 | `language-id` | The language name to pass to the language server. Some language servers support multiple languages and use this field to determine which one is being served in a buffer |
 | `environment` | Any environment variables that will be used when starting the language server `{ "KEY1" = "Value1", "KEY2" = "Value2" }` |


### PR DESCRIPTION
Add support for a current file placeholder in formatter arguments. This should make it possible to run custom formatters, such as `rome` (Typescript), `rustfmt` (Rust) and more.

The changes take inspiration from f7ecf9c and acdce30, but instead of adding a new field to the formatter struct, it works by looking for a predefined placeholder (`{}`), which should be replaced, if found. This should allow for better control over arguments of formatters, allowing both giving it as a standalone arg (`"{}"`) and as part of one (ie `"--src-file={}"`). The placeholder, `{}`, is used since it is common, Rust using it frequently.

Closes: #3596
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>