### PR TITLE
theme: make dracula ui.virtual.whitespace less intrusive

### DIFF
--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -40,7 +40,7 @@
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
-"ui.virtual.whitespace" = { fg = "comment" }
+"ui.virtual.whitespace" = { fg = "subtle" }
 "ui.virtual.ruler" = { bg = "background_dark"}
 
 "error" = { fg = "red" }
@@ -63,6 +63,7 @@ background = "#282a36"
 background_dark = "#21222c"
 primary_highlight = "#800049"
 secondary_highlight = "#4d4f66"
+subtle = "#424450"
 foreground = "#f8f8f2"
 comment = "#6272a4"
 red = "#ff5555"
@@ -72,3 +73,4 @@ green = "#50fa7b"
 purple = "#bd93f9"
 cyan = "#8be9fd"
 pink = "#ff79c6"
+


### PR DESCRIPTION
Hi,
while using the editor I've notided that the colors for the invisible characters are the same as comments, and I find that really poping especcialy comming from `dracula/vim`. The PR simply adds a new highlight color (taken from the `dracula/vim` repo) and used that for the invisible characters.

**before**
<img width="438" alt="Screenshot 2023-01-21 at 23 01 28" src="https://user-images.githubusercontent.com/96259932/213888629-8832992a-7925-48cd-b081-cd915ae24e68.png">

**after**
<img width="433" alt="Screenshot 2023-01-21 at 23 01 54" src="https://user-images.githubusercontent.com/96259932/213888642-0e424a01-e2d7-46c6-976a-2b9595025249.png">
