### PR TITLE
refactor(helix-view): remove cfg_attr references a nonexistent feature

### DIFF
--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -251,7 +251,6 @@ impl Rect {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Color {
     Reset,
     Black,
@@ -353,7 +352,6 @@ bitflags! {
     ///
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Modifier: u16 {
         const BOLD              = 0b0000_0000_0001;
         const DIM               = 0b0000_0000_0010;
@@ -450,7 +448,6 @@ impl FromStr for Modifier {
 /// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Style {
     pub fg: Option<Color>,
     pub bg: Option<Color>,

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -2,7 +2,6 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Represents key modifiers (shift, control, alt).
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct KeyModifiers: u8 {
         const SHIFT = 0b0000_0001;
         const CONTROL = 0b0000_0010;


### PR DESCRIPTION
remove `#[cfg_attr(feature = "serde")]` from helix-view crate.
`serde` feature is not currently being used in helix-view crate

Fixes https://github.com/helix-editor/helix/issues/5615