### PR TITLE
Use markdown language for hub pull-request files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1019,7 +1019,7 @@ source = { git = "https://github.com/Flakebi/tree-sitter-tablegen", rev = "568dd
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"
-file-types = ["md", "markdown"]
+file-types = ["md", "markdown", "PULLREQ_EDITMSG"]
 roots = [".marksman.toml"]
 language-server = { command = "marksman", args=["server"] }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Use markdown language for hub pull-request files
    
The hub[^1] command-line tool uses a file called `PULLREQ_EDITMSG`[^2].
This file is used to edit the text from of each commit being submitted
in a pull request, and the final content is rendered as markdown by
GitHub.
    
This commit adds `PULLREQ_EDITMSG` to the list of markdown file-types.
    
[^1]: https://github.com/github/hub
[^2]: https://github.com/github/hub/blob/c8e68d548a39ec0fab6f674a669c21b54d4eec61/commands/pull_request.go#L225
