### PR TITLE
Add build.gradle to list of java roots

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -652,7 +652,7 @@ name = "java"
 scope = "source.java"
 injection-regex = "java"
 file-types = ["java"]
-roots = ["pom.xml"]
+roots = ["pom.xml", "build.gradle"]
 language-server = { command = "jdtls" }
 indent = { tab-width = 4, unit = "    " }
 


### PR DESCRIPTION
After much pain and tribulation I finally found that what I needed to do was add build.gradle to my list of roots for java in order to get jdtls to not hate me. 

I figure this would be a good general addition