### PR TITLE
Add Appstream metadata file

### DIFF
--- a/contrib/Helix.appdata.xml
+++ b/contrib/Helix.appdata.xml
@@ -8,9 +8,8 @@
 
   <description>
     <p>
-      Helix is a terminal-based text editor inspired by Kakoune / Neovim, written in Rust.
+      Helix is a terminal-based text editor inspired by Kakoune / Neovim and written in Rust.
     </p>
-    <p>Features: </p>
     <ul>
       <li>Vim-like modal editing</li>
       <li>Multiple selections</li>
@@ -19,7 +18,7 @@
     </ul>
   </description>
 
-  <launchable type="desktop-id">com.helix_editor.Helix.desktop</launchable>
+  <launchable type="desktop-id">Helix.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">
@@ -29,12 +28,32 @@
   </screenshots>
 
   <url type="homepage">https://helix-editor.com/</url>
+  <url type="donation">https://opencollective.com/helix-editor</url>
+  <url type="help">https://docs.helix-editor.com/</url>
+  <url type="vcs-browser">https://github.com/helix-editor/helix</url>
+  <url type="bugtracker">https://github.com/helix-editor/helix/issues</url>
 
   <content_rating type="oars-1.1" />
 
   <releases>
     <release version="22.12" date="2022-12-7" />
   </releases>
+
+  <requires>
+    <control>keyboard</control>
+  </requires>
+
+  <categories>
+    <category>Utility</category>
+    <category>TextEditor</category>
+  </categories>
+
+  <keywords>
+    <keyword>text</keyword>
+    <keyword>editor</keyword>
+    <keyword>development</keyword>
+    <keyword>programming</keyword>
+  </keywords>
 
   <provides>
     <binary>hx</binary>

--- a/contrib/Helix.appdata.xml
+++ b/contrib/Helix.appdata.xml
@@ -36,7 +36,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="22.12" date="2022-12-7" />
+    <release version="22.12" date="2022-12-6" />
   </releases>
 
   <requires>

--- a/contrib/Helix.appdata.xml
+++ b/contrib/Helix.appdata.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.helix_editor.Helix</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  <name>Helix</name>
+  <summary>A post-modern text editor</summary>
+
+  <description>
+    <p>
+      Helix is a terminal-based text editor inspired by Kakoune / Neovim, written in Rust.
+    </p>
+    <p>Features: </p>
+    <ul>
+      <li>Vim-like modal editing</li>
+      <li>Multiple selections</li>
+      <li>Built-in language server support</li>
+      <li>Smart, incremental syntax highlighting and code editing via tree-sitter</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.helix_editor.Helix.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Helix with default theme</caption>
+      <image>https://github.com/helix-editor/helix/raw/d4565b4404cabc522bd60822abd374755581d751/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://helix-editor.com/</url>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="22.12" date="2022-12-7" />
+  </releases>
+
+  <provides>
+    <binary>hx</binary>
+    <mediatype>text/english</mediatype>
+    <mediatype>text/plain</mediatype>
+    <mediatype>text/x-makefile</mediatype>
+    <mediatype>text/x-c++hdr</mediatype>
+    <mediatype>text/x-c++src</mediatype>
+    <mediatype>text/x-chdr</mediatype>
+    <mediatype>text/x-csrc</mediatype>
+    <mediatype>text/x-java</mediatype>
+    <mediatype>text/x-moc</mediatype>
+    <mediatype>text/x-pascal</mediatype>
+    <mediatype>text/x-tcl</mediatype>
+    <mediatype>text/x-tex</mediatype>
+    <mediatype>application/x-shellscript</mediatype>
+    <mediatype>text/x-c</mediatype>
+    <mediatype>text/x-c++</mediatype>
+  </provides>
+</component>

--- a/contrib/Helix.appdata.xml
+++ b/contrib/Helix.appdata.xml
@@ -36,7 +36,18 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="22.12" date="2022-12-6" />
+    <release version="22.12" date="2022-12-6">
+      <url>https://helix-editor.com/news/release-22-12-highlights/</url>
+    </release>
+    <release version="22.08" date="2022-8-31">
+      <url>https://helix-editor.com/news/release-22-08-highlights/</url>
+    </release>
+    <release version="22.05" date="2022-5-28">
+      <url>https://helix-editor.com/news/release-22-05-highlights/</url>
+    </release>
+    <release version="22.03" date="2022-3-28">
+      <url>https://helix-editor.com/news/release-22-03-highlights/</url>
+    </release>
   </releases>
 
   <requires>

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,7 +5,7 @@ Helix releases are versioned in the Calendar Versioning scheme:
 we'll use `<tag>` as a placeholder for the tag being published.
 
 * Merge the changelog PR
-* Add new `<release>` entry in `contrib/Helix.appdata.xml` with release information 
+* Add new `<release>` entry in `contrib/Helix.appdata.xml` with release information according to the [AppStream spec](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html)
 * Tag and push
     * `git tag -s -m "<tag>" -a <tag> && git push`
     * Make sure to switch to master and pull first

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,6 +5,7 @@ Helix releases are versioned in the Calendar Versioning scheme:
 we'll use `<tag>` as a placeholder for the tag being published.
 
 * Merge the changelog PR
+* Add new `<release>` entry in `contrib/Helix.appdata.xml` with release information 
 * Tag and push
     * `git tag -s -m "<tag>" -a <tag> && git push`
     * Make sure to switch to master and pull first


### PR DESCRIPTION
For #5624.

In the future when new release is out we should add 
```xml
<release version="23.12" date="2004-12-07" />
```
or maybe even something like
```xml
<release version="23.12" date="2004-12-07">
  <description>
    <p>"X = 'extend_line_above'" is now the default!</p>
  </description>
  <url>https://helix-editor.com/news/release-23-12-highlights/</url>
</release>
```
