### PR TITLE
Make clippy happy on Windows

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -296,10 +296,10 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
         });
     }
 
-    return Some(TerminalConfig {
+    Some(TerminalConfig {
         command: "conhost".to_string(),
         args: vec!["cmd".to_string(), "/C".to_string()],
-    });
+    })
 }
 
 #[cfg(not(any(windows, target_os = "wasm32")))]


### PR DESCRIPTION
There's a clippy warning on Windows. This PR fixes it.