### PR TITLE
Support goto-declaration LSP command

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -886,6 +886,31 @@ impl Client {
         ))
     }
 
+    pub fn goto_declaration(
+        &self,
+        text_document: lsp::TextDocumentIdentifier,
+        position: lsp::Position,
+        work_done_token: Option<lsp::ProgressToken>,
+    ) -> Option<impl Future<Output = Result<Value>>> {
+        let capabilities = self.capabilities.get().unwrap();
+
+        // Return early if the server does not support goto-declaration.
+        match capabilities.declaration_provider {
+            Some(
+                lsp::DeclarationCapability::Simple(true)
+                | lsp::DeclarationCapability::RegistrationOptions(_)
+                | lsp::DeclarationCapability::Options(_),
+            ) => (),
+            _ => return None,
+        }
+
+        Some(self.goto_request::<lsp::request::GotoDeclaration>(
+            text_document,
+            position,
+            work_done_token,
+        ))
+    }
+
     pub fn goto_type_definition(
         &self,
         text_document: lsp::TextDocumentIdentifier,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -285,6 +285,7 @@ impl MappableCommand {
         select_mode, "Enter selection extend mode",
         exit_select_mode, "Exit selection mode",
         goto_definition, "Goto definition",
+        goto_declaration, "Goto declaration",
         add_newline_above, "Add newline above",
         add_newline_below, "Add newline below",
         goto_type_definition, "Goto type definition",

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -44,6 +44,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "l" => goto_line_end,
             "s" => goto_first_nonwhitespace,
             "d" => goto_definition,
+            "D" => goto_declaration,
             "y" => goto_type_definition,
             "r" => goto_reference,
             "i" => goto_implementation,


### PR DESCRIPTION
Adds "goto declaration" support in the LSP client and defines a command to invoke it which is by default bound to `g D`.