### PR TITLE
Support sagemath language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -109,6 +109,7 @@
 | ron | ✓ |  | ✓ |  |
 | ruby | ✓ | ✓ | ✓ | `solargraph` |
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |
+| sage | ✓ | ✓ |  |  |
 | scala | ✓ |  | ✓ | `metals` |
 | scheme | ✓ |  |  |  |
 | scss | ✓ |  |  | `vscode-css-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2109,3 +2109,13 @@ formatter = { command = "dhall" , args = ["format"] }
 [[grammar]]
 name = "dhall"
 source = { git = "https://github.com/jbellerb/tree-sitter-dhall", rev = "affb6ee38d629c9296749767ab832d69bb0d9ea8" }
+
+[[language]]
+name = "sage"
+scope = "source.sage"
+file-types = ["sage"]
+injection-regex = "sage"
+roots = []
+comment-token = "#"
+indent = { tab-width = 4, unit = "    " }
+grammar = "python"

--- a/runtime/queries/sage/highlights.scm
+++ b/runtime/queries/sage/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/runtime/queries/sage/injections.scm
+++ b/runtime/queries/sage/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/sage/textobjects.scm
+++ b/runtime/queries/sage/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: python


### PR DESCRIPTION
Hi this is my first contribution to this project. I copied the structure from: https://github.com/helix-editor/helix/pull/2903

The goal of this PR is to add support for the [sagemath](https://www.sagemath.org/) language. 
- The syntax is based on python.
- I didn't succeed at running the python language server by default with `.sage` files.
- It would be nice if  the syntax highlighting supported sage's docstrings:  In a comment, the lines starting with `sage: ` contain sage code. It would be nice if its syntax were highlighted. For an example of a docstring, see: https://doc.sagemath.org/html/en/developer/coding_basics.html#template