### PR TITLE
feat(dap): implement Restart request

### DIFF
--- a/helix-dap/src/types.rs
+++ b/helix-dap/src/types.rs
@@ -378,7 +378,7 @@ pub mod requests {
 
     impl Request for Launch {
         type Arguments = Value;
-        type Result = Value;
+        type Result = ();
         const COMMAND: &'static str = "launch";
     }
 
@@ -387,7 +387,7 @@ pub mod requests {
 
     impl Request for Attach {
         type Arguments = Value;
-        type Result = Value;
+        type Result = ();
         const COMMAND: &'static str = "attach";
     }
 
@@ -400,6 +400,15 @@ pub mod requests {
         pub terminate_debuggee: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub suspend_debuggee: Option<bool>,
+    }
+
+    #[derive(Debug)]
+    pub enum Restart {}
+
+    impl Request for Restart {
+        type Arguments = Value;
+        type Result = ();
+        const COMMAND: &'static str = "restart";
     }
 
     #[derive(Debug)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -430,6 +430,7 @@ impl MappableCommand {
         goto_next_paragraph, "Goto next paragraph",
         goto_prev_paragraph, "Goto previous paragraph",
         dap_launch, "Launch debug target",
+        dap_restart, "Restart debugging session",
         dap_toggle_breakpoint, "Toggle breakpoint",
         dap_continue, "Continue program execution",
         dap_pause, "Pause program execution",

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -289,6 +289,36 @@ pub fn dap_launch(cx: &mut Context) {
     ))));
 }
 
+pub fn dap_restart(cx: &mut Context) {
+    let debugger = match &cx.editor.debugger {
+        Some(debugger) => debugger,
+        None => {
+            cx.editor.set_error("Debugger is not running");
+            return;
+        }
+    };
+    if !debugger
+        .capabilities()
+        .supports_restart_request
+        .unwrap_or(false)
+    {
+        cx.editor
+            .set_error("Debugger does not support session restarts");
+        return;
+    }
+    if debugger.starting_request_args().is_none() {
+        cx.editor
+            .set_error("No arguments found with which to restart the sessions");
+        return;
+    }
+
+    dap_callback(
+        cx.jobs,
+        debugger.restart(),
+        |editor, _compositor, _resp: ()| editor.set_status("Debugging session restarted"),
+    );
+}
+
 fn debug_parameter_prompt(
     completions: Vec<DebugConfigCompletion>,
     config_name: String,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -223,6 +223,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "'" => last_picker,
             "g" => { "Debug (experimental)" sticky=true
                 "l" => dap_launch,
+                "r" => dap_restart,
                 "b" => dap_toggle_breakpoint,
                 "c" => dap_continue,
                 "h" => dap_pause,


### PR DESCRIPTION
Add a restart debug session command, which would issue a [Restart Request][1], if the debugger supports it and a session is running. It uses the same arguments and requests used to start the initial session, when recreating it.

It builds upon #5532, making use of the changes to the termination workflow of a session.

[1]: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Restart

Closes: #5594
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>