### PR TITLE
search buffer contents during global search

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -41,7 +41,9 @@ pub use helix_loader::find_workspace;
 pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
     line.chars().position(|ch| !ch.is_whitespace())
 }
+mod rope_reader;
 
+pub use rope_reader::RopeReader;
 pub use ropey::{self, str_utils, Rope, RopeBuilder, RopeSlice};
 
 // pub use tendril::StrTendril as Tendril;

--- a/helix-core/src/rope_reader.rs
+++ b/helix-core/src/rope_reader.rs
@@ -1,0 +1,37 @@
+use std::io;
+
+use ropey::iter::Chunks;
+use ropey::RopeSlice;
+
+pub struct RopeReader<'a> {
+    current_chunk: &'a [u8],
+    chunks: Chunks<'a>,
+}
+
+impl<'a> RopeReader<'a> {
+    pub fn new(rope: RopeSlice<'a>) -> RopeReader<'a> {
+        RopeReader {
+            current_chunk: &[],
+            chunks: rope.chunks(),
+        }
+    }
+}
+
+impl io::Read for RopeReader<'_> {
+    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
+        let buf_len = buf.len();
+        loop {
+            let read_bytes = self.current_chunk.read(buf)?;
+            buf = &mut buf[read_bytes..];
+            if buf.is_empty() {
+                return Ok(buf_len);
+            }
+
+            if let Some(next_chunk) = self.chunks.next() {
+                self.current_chunk = next_chunk.as_bytes();
+            } else {
+                return Ok(buf_len - buf.len());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Followup to #5639, addresses https://github.com/helix-editor/helix/issues/5604#issuecomment-1399674583

Currently, helix always queries the FS when performing global search.
However, when previewing and opening a file helix automatically uses the buffer if it's already open.
That means that the search would report incorrect results for unsaved buffers (which lead to crashes prior to #5639).

This PR creates am implementation of `std::io::Read` for `Rope`, so we can easily reuse the existing API in `grep_searcher`.

This change has the nice side effect of avoiding IO for already open buffers for global search. The performance difference will rarely matter in practice, but it's a nice boost when a huge file is already open in helix.
A similar mechanism can be used for #5645 so that files that are changed but unsaved also get reported as changed.
