### PR TITLE
Switch from toml::from_slice to toml::from_str

### DIFF
--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -1,6 +1,9 @@
+use std::str::from_utf8;
+
 /// Default built-in languages.toml.
 pub fn default_lang_config() -> toml::Value {
-    toml::from_slice(include_bytes!("../../languages.toml"))
+    let default_config = include_bytes!("../../languages.toml");
+    toml::from_str(from_utf8(default_config).unwrap())
         .expect("Could not parse built-in languages.toml to valid toml")
 }
 
@@ -11,8 +14,8 @@ pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
         .chain([crate::config_dir()].into_iter())
         .map(|path| path.join("languages.toml"))
         .filter_map(|file| {
-            std::fs::read(&file)
-                .map(|config| toml::from_slice(&config))
+            std::fs::read_to_string(&file)
+                .map(|config| toml::from_str(&config))
                 .ok()
         })
         .collect::<Result<Vec<_>, _>>()?

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -179,6 +179,8 @@ pub fn merge_toml_values(left: toml::Value, right: toml::Value, merge_depth: usi
 
 #[cfg(test)]
 mod merge_toml_tests {
+    use std::str;
+
     use super::merge_toml_values;
     use toml::Value;
 
@@ -191,8 +193,9 @@ mod merge_toml_tests {
         indent = { tab-width = 4, unit = "    ", test = "aaa" }
         "#;
 
-        let base: Value = toml::from_slice(include_bytes!("../../languages.toml"))
-            .expect("Couldn't parse built-in languages config");
+        let base = include_bytes!("../../languages.toml");
+        let base = str::from_utf8(base).expect("Couldn't parse built-in languages config");
+        let base: Value = toml::from_str(base).expect("Couldn't parse built-in languages config");
         let user: Value = toml::from_str(USER).unwrap();
 
         let merged = merge_toml_values(base, user, 3);
@@ -224,8 +227,9 @@ mod merge_toml_tests {
         language-server = { command = "deno", args = ["lsp"] }
         "#;
 
-        let base: Value = toml::from_slice(include_bytes!("../../languages.toml"))
-            .expect("Couldn't parse built-in languages config");
+        let base = include_bytes!("../../languages.toml");
+        let base = str::from_utf8(base).expect("Couldn't parse built-in languages config");
+        let base: Value = toml::from_str(base).expect("Couldn't parse built-in languages config");
         let user: Value = toml::from_str(USER).unwrap();
 
         let merged = merge_toml_values(base, user, 3);

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    str,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -15,12 +16,13 @@ use crate::graphics::UnderlineStyle;
 pub use crate::graphics::{Color, Modifier, Style};
 
 pub static DEFAULT_THEME_DATA: Lazy<Value> = Lazy::new(|| {
-    toml::from_slice(include_bytes!("../../theme.toml")).expect("Failed to parse default theme")
+    let bytes = include_bytes!("../../theme.toml");
+    toml::from_str(str::from_utf8(bytes).unwrap()).expect("Failed to parse base default theme")
 });
 
 pub static BASE16_DEFAULT_THEME_DATA: Lazy<Value> = Lazy::new(|| {
-    toml::from_slice(include_bytes!("../../base16_theme.toml"))
-        .expect("Failed to parse base 16 default theme")
+    let bytes = include_bytes!("../../base16_theme.toml");
+    toml::from_str(str::from_utf8(bytes).unwrap()).expect("Failed to parse base 16 default theme")
 });
 
 pub static DEFAULT_THEME: Lazy<Theme> = Lazy::new(|| Theme {
@@ -148,8 +150,8 @@ impl Loader {
 
     // Loads the theme data as `toml::Value` first from the user_dir then in default_dir
     fn load_toml(&self, path: PathBuf) -> Result<Value> {
-        let data = std::fs::read(&path)?;
-        let value = toml::from_slice(data.as_slice())?;
+        let data = std::fs::read_to_string(&path)?;
+        let value = toml::from_str(&data)?;
 
         Ok(value)
     }

--- a/xtask/src/helpers.rs
+++ b/xtask/src/helpers.rs
@@ -39,6 +39,6 @@ pub fn find_files(dir: &Path, filename: &str) -> Vec<PathBuf> {
 }
 
 pub fn lang_config() -> LangConfig {
-    let bytes = std::fs::read(path::lang_config()).unwrap();
-    toml::from_slice(&bytes).unwrap()
+    let text = std::fs::read_to_string(path::lang_config()).unwrap();
+    toml::from_str(&text).unwrap()
 }

--- a/xtask/src/themelint.rs
+++ b/xtask/src/themelint.rs
@@ -156,8 +156,8 @@ pub fn lint(file: String) -> Result<(), DynError> {
         return Ok(());
     }
     let path = path::themes().join(file.clone() + ".toml");
-    let theme = std::fs::read(&path).unwrap();
-    let theme: Theme = toml::from_slice(&theme).expect("Failed to parse theme");
+    let theme = std::fs::read_to_string(&path).unwrap();
+    let theme: Theme = toml::from_str(&theme).expect("Failed to parse theme");
 
     let mut messages: Vec<String> = vec![];
     get_rules().iter().for_each(|lint| match lint {


### PR DESCRIPTION
Unblocks #5656

Just a small fix since that function was removed.
I found the usage of `std::fs::read` instead of `std::fs::read_to_string` odd anyway.
Sadly there is no `include_str!` macro so we have the conversion ourselves (not a big deal regardless).