### PR TITLE
reset idle timeout when pushing a new compositor layer

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -181,7 +181,7 @@ impl Application {
             &config.keys
         }));
         let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
-        compositor.push(editor_view);
+        compositor.push(editor_view, &mut editor);
 
         if args.load_tutor {
             let path = helix_loader::runtime_dir().join("tutor");
@@ -194,7 +194,7 @@ impl Application {
                 std::env::set_current_dir(first).context("set current dir")?;
                 editor.new_file(Action::VerticalSplit);
                 let picker = ui::file_picker(".".into(), &config.load().editor);
-                compositor.push(Box::new(overlayed(picker)));
+                compositor.push(Box::new(overlayed(picker)), &mut editor);
             } else {
                 let nr_of_files = args.files.len();
                 for (i, (file, pos)) in args.files.into_iter().enumerate() {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -81,8 +81,8 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Push a new component onto the compositor.
     pub fn push_layer(&mut self, component: Box<dyn Component>) {
-        self.callback = Some(Box::new(|compositor: &mut Compositor, _| {
-            compositor.push(component)
+        self.callback = Some(Box::new(|compositor: &mut Compositor, cx| {
+            compositor.push(component, cx.editor)
         }));
     }
 
@@ -2013,7 +2013,7 @@ fn global_search(cx: &mut Context) {
                         Some((path.clone().into(), Some((*line_num, *line_num))))
                     },
                 );
-                compositor.push(Box::new(overlayed(picker)));
+                compositor.push(Box::new(overlayed(picker)), editor);
             },
         ));
         Ok(call)
@@ -2521,7 +2521,7 @@ pub fn command_palette(cx: &mut Context) {
                     }
                 }
             });
-            compositor.push(Box::new(overlayed(picker)));
+            compositor.push(Box::new(overlayed(picker)), cx.editor);
         },
     ));
 }
@@ -2530,7 +2530,7 @@ fn last_picker(cx: &mut Context) {
     // TODO: last picker does not seem to work well with buffer_picker
     cx.callback = Some(Box::new(|compositor, cx| {
         if let Some(picker) = compositor.last_picker.take() {
-            compositor.push(picker);
+            compositor.push(picker, cx.editor);
         } else {
             cx.editor.set_error("no last picker")
         }

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -88,7 +88,7 @@ fn thread_picker(
                     Some((path.into(), pos))
                 },
             );
-            compositor.push(Box::new(picker));
+            compositor.push(Box::new(picker), editor);
         },
     );
 }
@@ -278,9 +278,9 @@ pub fn dap_launch(cx: &mut Context) {
             let name = template.name.clone();
             let callback = Box::pin(async move {
                 let call: Callback =
-                    Callback::EditorCompositor(Box::new(move |_editor, compositor| {
+                    Callback::EditorCompositor(Box::new(move |editor, compositor| {
                         let prompt = debug_parameter_prompt(completions, name, Vec::new());
-                        compositor.push(Box::new(prompt));
+                        compositor.push(Box::new(prompt), editor);
                     }));
                 Ok(call)
             });
@@ -337,9 +337,9 @@ fn debug_parameter_prompt(
                 let params = params.clone();
                 let callback = Box::pin(async move {
                     let call: Callback =
-                        Callback::EditorCompositor(Box::new(move |_editor, compositor| {
+                        Callback::EditorCompositor(Box::new(move |editor, compositor| {
                             let prompt = debug_parameter_prompt(completions, config_name, params);
-                            compositor.push(Box::new(prompt));
+                            compositor.push(Box::new(prompt), editor);
                         }));
                     Ok(call)
                 });
@@ -614,7 +614,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
                 if let Some(condition) = breakpoint.condition {
                     prompt.insert_str(&condition, editor)
                 }
-                compositor.push(Box::new(prompt));
+                compositor.push(Box::new(prompt), editor);
             }));
             Ok(call)
         });
@@ -655,7 +655,7 @@ pub fn dap_edit_log(cx: &mut Context) {
                 if let Some(log_message) = breakpoint.log_message {
                     prompt.insert_str(&log_message, editor);
                 }
-                compositor.push(Box::new(prompt));
+                compositor.push(Box::new(prompt), editor);
             }));
             Ok(call)
         });

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -367,7 +367,7 @@ pub fn symbol_picker(cx: &mut Context) {
                 };
 
                 let picker = sym_picker(symbols, current_url, offset_encoding);
-                compositor.push(Box::new(overlayed(picker)))
+                compositor.push(Box::new(overlayed(picker)), editor)
             }
         },
     )
@@ -389,7 +389,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
 
     cx.callback(
         future,
-        move |_editor, compositor, response: Option<Vec<lsp::SymbolInformation>>| {
+        move |editor, compositor, response: Option<Vec<lsp::SymbolInformation>>| {
             let symbols = response.unwrap_or_default();
             let picker = sym_picker(symbols, current_url, offset_encoding);
             let get_symbols = |query: String, editor: &mut Editor| {
@@ -426,7 +426,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
                 future.boxed()
             };
             let dyn_picker = DynamicPicker::new(picker, Box::new(get_symbols));
-            compositor.push(Box::new(overlayed(dyn_picker)))
+            compositor.push(Box::new(overlayed(dyn_picker)), editor)
         },
     )
 }
@@ -659,7 +659,7 @@ pub fn code_action(cx: &mut Context) {
             picker.move_down(); // pre-select the first item
 
             let popup = Popup::new("code-action", picker).with_scrollbar(false);
-            compositor.replace_or_push("code-action", popup);
+            compositor.replace_or_push("code-action", popup, editor);
         },
     )
 }
@@ -894,7 +894,7 @@ fn goto_impl(
                 },
                 move |_editor, location| Some(location_to_file_location(location)),
             );
-            compositor.push(Box::new(overlayed(picker)));
+            compositor.push(Box::new(overlayed(picker)), editor);
         }
     }
 }
@@ -1139,7 +1139,7 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
                 .position(old_popup.and_then(|p| p.get_position()))
                 .position_bias(Open::Above)
                 .ignore_escape_key(true);
-            compositor.replace_or_push(SignatureHelp::ID, popup);
+            compositor.replace_or_push(SignatureHelp::ID, popup, editor);
         },
     );
 }
@@ -1195,7 +1195,7 @@ pub fn hover(cx: &mut Context) {
 
                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                 let popup = Popup::new("hover", contents).auto_close(true);
-                compositor.replace_or_push("hover", popup);
+                compositor.replace_or_push("hover", popup, editor);
             }
         },
     );

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -70,7 +70,7 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
                 let call: job::Callback = job::Callback::EditorCompositor(Box::new(
                     move |editor: &mut Editor, compositor: &mut Compositor| {
                         let picker = ui::file_picker(path, &editor.config());
-                        compositor.push(Box::new(overlayed(picker)));
+                        compositor.push(Box::new(overlayed(picker)), editor);
                     },
                 ));
                 Ok(call)
@@ -1158,11 +1158,11 @@ fn lsp_workspace_command(
             .collect::<Vec<_>>();
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
-                move |_editor: &mut Editor, compositor: &mut Compositor| {
+                move |editor: &mut Editor, compositor: &mut Compositor| {
                     let picker = ui::Picker::new(commands, (), |cx, command, _action| {
                         execute_lsp_command(cx.editor, command.clone());
                     });
-                    compositor.push(Box::new(overlayed(picker)))
+                    compositor.push(Box::new(overlayed(picker)), editor)
                 },
             ));
             Ok(call)
@@ -1245,7 +1245,7 @@ fn tree_sitter_scopes(
             move |editor: &mut Editor, compositor: &mut Compositor| {
                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                 let popup = Popup::new("hover", contents).auto_close(true);
-                compositor.replace_or_push("hover", popup);
+                compositor.replace_or_push("hover", popup, editor);
             },
         ));
         Ok(call)
@@ -1674,7 +1674,7 @@ fn tree_sitter_subtree(
                     move |editor: &mut Editor, compositor: &mut Compositor| {
                         let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
                         let popup = Popup::new("hover", contents).auto_close(true);
-                        compositor.replace_or_push("hover", popup);
+                        compositor.replace_or_push("hover", popup, editor);
                     },
                 ));
                 Ok(call)
@@ -1810,7 +1810,7 @@ fn run_shell_command(
                     let popup = Popup::new("shell", contents).position(Some(
                         helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
                     ));
-                    compositor.replace_or_push("shell", popup);
+                    compositor.replace_or_push("shell", popup, editor);
                 },
             ));
             Ok(call)

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -98,7 +98,8 @@ impl Compositor {
     }
 
     /// Add a layer to be rendered in front of all existing layers.
-    pub fn push(&mut self, mut layer: Box<dyn Component>) {
+    pub fn push(&mut self, mut layer: Box<dyn Component>, editor: &mut Editor) {
+        editor.reset_idle_timer();
         let size = self.size();
         // trigger required_size on init
         layer.required_size((size.width, size.height));
@@ -107,11 +108,16 @@ impl Compositor {
 
     /// Replace a component that has the given `id` with the new layer and if
     /// no component is found, push the layer normally.
-    pub fn replace_or_push<T: Component>(&mut self, id: &'static str, layer: T) {
+    pub fn replace_or_push<T: Component>(
+        &mut self,
+        id: &'static str,
+        layer: T,
+        editor: &mut Editor,
+    ) {
         if let Some(component) = self.find_id(id) {
             *component = layer;
         } else {
-            self.push(Box::new(layer))
+            self.push(Box::new(layer), editor)
         }
     }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -122,7 +122,7 @@ pub fn regex_prompt(
                             if event == PromptEvent::Validate {
                                 let callback = async move {
                                     let call: job::Callback = Callback::EditorCompositor(Box::new(
-                                        move |_editor: &mut Editor, compositor: &mut Compositor| {
+                                        move |editor: &mut Editor, compositor: &mut Compositor| {
                                             let contents = Text::new(format!("{}", err));
                                             let size = compositor.size();
                                             let mut popup = Popup::new("invalid-regex", contents)
@@ -133,7 +133,11 @@ pub fn regex_prompt(
                                                 .auto_close(true);
                                             popup.required_size((size.width, size.height));
 
-                                            compositor.replace_or_push("invalid-regex", popup);
+                                            compositor.replace_or_push(
+                                                "invalid-regex",
+                                                popup,
+                                                editor,
+                                            );
                                         },
                                     ));
                                     Ok(call)


### PR DESCRIPTION
Fixes #4956

As suggested in https://github.com/helix-editor/helix/issues/4956#issuecomment-1335540871 the right fix is to
reset the idle timer when pushing new layers into the compositor.
