### PR TITLE
Change default language server for 'v' from 'vls' to 'v ls'

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -130,7 +130,7 @@
 | twig | ✓ |  |  |  |
 | typescript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | ungrammar | ✓ |  |  |  |
-| v | ✓ |  |  | `vls` |
+| v | ✓ |  |  | `v` |
 | vala | ✓ |  |  | `vala-language-server` |
 | verilog | ✓ | ✓ |  | `svlangserver` |
 | vhs | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1603,7 +1603,7 @@ scope = "source.v"
 file-types = ["v", "vv"]
 shebangs = ["v run"]
 roots = ["v.mod"]
-language-server = { command = "vls", args = [] }
+language-server = { command = "v", args = ["ls"] }
 auto-format = true
 comment-token = "//"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
According to the [V Language Server Repository README](https://github.com/vlang/vls#via-v-cli-recommended), the recommended way to install the V Language Server is via the `v` CLI. Therefore, the default config should expect it to be called by using `v ls` not `vls`.