### PR TITLE
add explicit formatter for cue

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1778,6 +1778,7 @@ auto-format = true
 comment-token = "//"
 language-server = { command = "cuelsp" }
 indent = { tab-width = 4, unit = "\t" }
+formatter = { command = "cue", args = ["fmt", "-"] }
 
 [[grammar]]
 name = "cue"


### PR DESCRIPTION
cuelsp does not support formatting.

Cue language support was added to Helix before "formatter" was available.

References:
https://github.com/helix-editor/helix/pull/3262
https://github.com/dagger/cuelsp/issues/44