### PR TITLE
fix(xml): XML highlighting fails with comment of certain length in doc root

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1981,7 +1981,7 @@ roots = []
 
 [[grammar]]
 name = "xml"
-source = { git = "https://github.com/RenjiSann/tree-sitter-xml", rev = "422528a43630db6dcc1e222d1c5ee3babd559473" }
+source = { git = "https://github.com/RenjiSann/tree-sitter-xml", rev = "48a7c2b6fb9d515577e115e6788937e837815651" }
 
 [[language]]
 name = "wit"


### PR DESCRIPTION
Fixes #5470

Upstream changes: https://github.com/RenjiSann/tree-sitter-xml/compare/422528a43630db6dcc1e222d1c5ee3babd559473...48a7c2b6fb9d515577e115e6788937e837815651 

# Before

![image](https://user-images.githubusercontent.com/22329650/214729717-acf761f1-1f08-44c4-930b-d49cdb3b11b9.png)

# After

![image](https://user-images.githubusercontent.com/22329650/214729829-1d485527-4218-40fb-a5c5-cf049ee8c65c.png)
