### PR TITLE
feat(commands): add clear_registers command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -78,3 +78,4 @@
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh` | Run a shell command |
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
+| `:clear-register` | Clear given register. If no argument is provided, clear all registers. |

--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -78,4 +78,12 @@ impl Registers {
     pub fn inner(&self) -> &HashMap<char, Register> {
         &self.inner
     }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn remove(&mut self, name: char) -> Option<Register> {
+        self.inner.remove(&name)
+    }
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2165,6 +2165,38 @@ fn reset_diff_change(
     Ok(())
 }
 
+fn clear_register(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(args.len() <= 1, ":clear-register takes at most 1 argument");
+    if args.is_empty() {
+        cx.editor.registers.clear();
+        cx.editor.set_status("All registers cleared");
+        return Ok(());
+    }
+
+    ensure!(
+        args[0].chars().count() == 1,
+        format!("Invalid register {}", args[0])
+    );
+    let register = args[0].chars().next().unwrap_or_default();
+    match cx.editor.registers.remove(register) {
+        Some(_) => cx
+            .editor
+            .set_status(format!("Register {} cleared", register)),
+        None => cx
+            .editor
+            .set_error(format!("Register {} not found", register)),
+    }
+    Ok(())
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -2716,6 +2748,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &["diffget", "diffg"],
             doc: "Reset the diff change at the cursor position.",
             fun: reset_diff_change,
+            signature: CommandSignature::none(),
+        },
+        TypableCommand {
+            name: "clear-register",
+            aliases: &[],
+            doc: "Clear given register. If no argument is provided, clear all registers.",
+            fun: clear_register,
             signature: CommandSignature::none(),
         },
     ];


### PR DESCRIPTION
Closes #4256. This is a rework of closed https://github.com/helix-editor/helix/pull/4408. Summary of discussion from there:

 * clear registers by pressing `"` and then the key to clear the registers
 * the key to clear the registers is suggested to be `|`