### PR TITLE
properly handle LSP position encoding

### DIFF
--- a/helix-core/src/line_ending.rs
+++ b/helix-core/src/line_ending.rs
@@ -203,6 +203,13 @@ pub fn line_end_char_index(slice: &RopeSlice, line: usize) -> usize {
             .unwrap_or(0)
 }
 
+pub fn line_end_byte_index(slice: &RopeSlice, line: usize) -> usize {
+    slice.line_to_byte(line + 1)
+        - get_line_ending(&slice.line(line))
+            .map(|le| le.as_str().len())
+            .unwrap_or(0)
+}
+
 /// Fetches line `line_idx` from the passed rope slice, sans any line ending.
 pub fn line_without_line_ending<'a>(slice: &'a RopeSlice, line_idx: usize) -> RopeSlice<'a> {
     let start = slice.line_to_char(line_idx);

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -481,6 +481,11 @@ impl Transaction {
         for (from, to, tendril) in changes {
             // Verify ranges are ordered and not overlapping
             debug_assert!(last <= from);
+            // Verify ranges are correct
+            debug_assert!(
+                from <= to,
+                "Edit end must end before it starts (should {from} <= {to})"
+            );
 
             // Retain from last "to" to current "from"
             changeset.retain(from - last);

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -104,7 +104,7 @@ impl Client {
             server_tx,
             request_counter: AtomicU64::new(0),
             capabilities: OnceCell::new(),
-            offset_encoding: OffsetEncoding::Utf8,
+            offset_encoding: OffsetEncoding::Utf16,
             config,
             req_timeout,
 

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -147,10 +147,10 @@ pub mod util {
         // Note that the end of the line here is **before** the line terminator
         // so we must use `line_end_char_index` istead of `doc.line_to_char(pos_line + 1)`
         //
-        // FIXME: Helix does not fully compley with the LSP spec for line terminators.
+        // FIXME: Helix does not fully comply with the LSP spec for line terminators.
         // The LSP standard requires that line terminators are ['\n', '\r\n', '\r'].
-        // Without the unicode-linbreak feature disabeled, the `\r` terminator is not handeled by helix.
-        // With the unicode-linbreak feature, helix recognized multiple extra line break chars
+        // Without the unicode-linebreak feature disabled, the `\r` terminator is not handled by helix.
+        // With the unicode-linebreak feature, helix recognizes multiple extra line break chars
         // which means that positions will be decoded/encoded incorrectly in their presence
 
         let line = match offset_encoding {
@@ -177,7 +177,7 @@ pub mod util {
             .unwrap_or(line.end)
             .min(line.end);
 
-        // TODO prefer UTF32/char indecies to avoid this step
+        // TODO prefer UTF32/char indices to avoid this step
         match offset_encoding {
             OffsetEncoding::Utf8 => doc.try_byte_to_char(pos).ok(),
             OffsetEncoding::Utf16 => doc.try_utf16_cu_to_char(pos).ok(),

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -57,6 +57,7 @@ pub enum OffsetEncoding {
 
 pub mod util {
     use super::*;
+    use helix_core::line_ending::{line_end_byte_index, line_end_char_index};
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
 
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
@@ -117,7 +118,7 @@ pub mod util {
 
     /// Converts [`lsp::Position`] to a position in the document.
     ///
-    /// Returns `None` if position exceeds document length or an operation overflows.
+    /// Returns `None` if position.line is out of bounds or an overflow occurs
     pub fn lsp_pos_to_pos(
         doc: &Rope,
         pos: lsp::Position,
@@ -128,22 +129,58 @@ pub mod util {
             return None;
         }
 
-        match offset_encoding {
+        // We need to be careful here to fully comply ith the LSP spec.
+        // Two relevant quotes from the spec:
+        //
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
+        // > If the character value is greater than the line length it defaults back
+        // >  to the line length.
+        //
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments
+        // > To ensure that both client and server split the string into the same
+        // > line representation the protocol specifies the following end-of-line sequences:
+        // > ‘\n’, ‘\r\n’ and ‘\r’. Positions are line end character agnostic.
+        // > So you can not specify a position that denotes \r|\n or \n| where | represents the character offset.
+        //
+        // This means that while the line must be in bounds the `charater`
+        // must be capped to the end of the line.
+        // Note that the end of the line here is **before** the line terminator
+        // so we must use `line_end_char_index` istead of `doc.line_to_char(pos_line + 1)`
+        //
+        // FIXME: Helix does not fully compley with the LSP spec for line terminators.
+        // The LSP standard requires that line terminators are ['\n', '\r\n', '\r'].
+        // Without the unicode-linbreak feature disabeled, the `\r` terminator is not handeled by helix.
+        // With the unicode-linbreak feature, helix recognized multiple extra line break chars
+        // which means that positions will be decoded/encoded incorrectly in their presence
+
+        let line = match offset_encoding {
             OffsetEncoding::Utf8 => {
-                let line = doc.line_to_char(pos_line);
-                let pos = line.checked_add(pos.character as usize)?;
-                if pos <= doc.len_chars() {
-                    Some(pos)
-                } else {
-                    None
-                }
+                let line_start = doc.line_to_byte(pos_line);
+                let line_end = line_end_byte_index(&doc.slice(..), pos_line);
+                line_start..line_end
             }
             OffsetEncoding::Utf16 => {
-                let line = doc.line_to_char(pos_line);
-                let line_start = doc.char_to_utf16_cu(line);
-                let pos = line_start.checked_add(pos.character as usize)?;
-                doc.try_utf16_cu_to_char(pos).ok()
+                // TODO directly translate line index to char-idx
+                // ropey can do this just as easily as utf-8 byte translation
+                // but the functions are just missing.
+                // Translate to char first and then utf-16 as a workaround
+                let line_start = doc.line_to_char(pos_line);
+                let line_end = line_end_char_index(&doc.slice(..), pos_line);
+                doc.char_to_utf16_cu(line_start)..doc.char_to_utf16_cu(line_end)
             }
+        };
+
+        // The LSP spec demands that the offset is capped to the end of the line
+        let pos = line
+            .start
+            .checked_add(pos.character as usize)
+            .unwrap_or(line.end)
+            .min(line.end);
+
+        // TODO prefer UTF32/char indecies to avoid this step
+        match offset_encoding {
+            OffsetEncoding::Utf8 => doc.try_byte_to_char(pos).ok(),
+            OffsetEncoding::Utf16 => doc.try_utf16_cu_to_char(pos).ok(),
         }
     }
 
@@ -158,8 +195,8 @@ pub mod util {
         match offset_encoding {
             OffsetEncoding::Utf8 => {
                 let line = doc.char_to_line(pos);
-                let line_start = doc.line_to_char(line);
-                let col = pos - line_start;
+                let line_start = doc.line_to_byte(line);
+                let col = doc.char_to_byte(pos) - line_start;
 
                 lsp::Position::new(line as u32, col as u32)
             }
@@ -606,16 +643,55 @@ mod tests {
         }
 
         test_case!("", (0, 0) => Some(0));
-        test_case!("", (0, 1) => None);
+        test_case!("", (0, 1) => Some(0));
         test_case!("", (1, 0) => None);
         test_case!("\n\n", (0, 0) => Some(0));
         test_case!("\n\n", (1, 0) => Some(1));
-        test_case!("\n\n", (1, 1) => Some(2));
+        test_case!("\n\n", (1, 1) => Some(1));
         test_case!("\n\n", (2, 0) => Some(2));
         test_case!("\n\n", (3, 0) => None);
         test_case!("test\n\n\n\ncase", (4, 3) => Some(11));
         test_case!("test\n\n\n\ncase", (4, 4) => Some(12));
-        test_case!("test\n\n\n\ncase", (4, 5) => None);
+        test_case!("test\n\n\n\ncase", (4, 5) => Some(12));
         test_case!("", (u32::MAX, u32::MAX) => None);
+    }
+
+    #[test]
+    fn emoji_format_gh_4791() {
+        use lsp_types::{Position, Range, TextEdit};
+
+        let edits = vec![
+            TextEdit {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 1,
+                    },
+                    end: Position {
+                        line: 1,
+                        character: 0,
+                    },
+                },
+                new_text: "\n  ".to_string(),
+            },
+            TextEdit {
+                range: Range {
+                    start: Position {
+                        line: 1,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 0,
+                    },
+                },
+                new_text: "\n  ".to_string(),
+            },
+        ];
+
+        let mut source = Rope::from_str("[\n\"🇺🇸\",\n\"🎄\",\n]");
+
+        let transaction = generate_transaction_from_edits(&source, edits, OffsetEncoding::Utf8);
+        assert!(transaction.apply(&mut source));
     }
 }


### PR DESCRIPTION
Fixes #4791
Fixes #3286
Fixes #2547 
Fixes #5809

I started to thoroughly investigate the char_pos <-> lsp_pos conversion in an effort to fix #4791. Initially I just started with the suggestion by @the-mikdavis of capping the `character` offset to the line length. While this is only mentioned offhand in the LSP standard, it's still part of the standard and seems a good precaution against crashing from broken LSPs.

This fixed the original panic but caused panics and weird formatting bugs for slightly different json files. So I investigated further and found a pretty mayor bug: Helix implemented the `UTF-8` encoding incorrectly:

Currently, helix treat the `Position::character` field as a char offset in `Utf-8` mode and as `utf16` offset in UTF-16 mode. This is incorrect, the `Position::character` field corresponds to `UTF-8` byte, what we had really implemented was `UTF-32`.

From the LSP spec:

> When describing positions the protocol needs to specify how offsets (specifically character offsets) should be interpreted. The corresponding PositionEncodingKind is negotiated between the client and the server during initialization.

> ```
> /**
> * A type indicating how positions are encoded,
> * specifically what column offsets mean.
> *
> * @since 3.17.0
> */
> export type PositionEncodingKind = string;
> 
> /**
> * A set of predefined position encoding kinds.
> *
> * @since 3.17.0
> */
> export namespace PositionEncodingKind {
> 
> /**
> * Character offsets count UTF-8 code units (e.g bytes).
> */
> export const UTF8: PositionEncodingKind = 'utf-8';
> 
> /**
> * Character offsets count UTF-16 code units.
> *
> * This is the default and must always be supported
> * by servers
> */
> export const UTF16: PositionEncodingKind = 'utf-16';
> 
> /**
> * Character offsets count UTF-32 code units.
> *
> * Implementation note: these are the same as Unicode code points,
> * so this `PositionEncodingKind` may also be used for an
> * encoding-agnostic representation of character offsets.
> */
> export const UTF32: PositionEncodingKind = 'utf-32';
> }
> ```

Fixing the UTF-8 encoding however only made the problems worse. The reason was simply that it was incorrect for us to use UTF-8 encoding at all. The `lsp-types` crate and helix (and many LSP servers) don't support LSP `3.17` yet so this option is not available to us. Instead we just hardcoded the encoding to `UTF-8`. However, we should be hard-coding helix to use utf-16 instead. To quote the standard:

> Prior to 3.17 the offsets were always based on a UTF-16 string representation. So in a string of the form a𐐀b the character offset of the character a is 0, the character offset of 𐐀 is 1 and the character offset of b is 3 since 𐐀 is represented using two code units in UTF-16. Since 3.17 clients and servers can agree on a different string encoding representation (e.g. UTF-8). The client announces it’s supported encoding via the client capability general.positionEncodings. The value is an array of position encodings the client supports, with decreasing preference (e.g. the encoding at index 0 is the most preferred one). To stay backwards compatible the only mandatory encoding is UTF-16 represented via the string utf-16. The server can pick one of the encodings offered by the client and signals that encoding back to the client via the initialize result’s property capabilities.positionEncoding. If the string value utf-16 is missing from the client’s capability general.positionEncodings servers can safely assume that the client supports UTF-16. If the server omits the position encoding in its initialize result the encoding defaults to the string value utf-16.

The only reason this hasn't caused much more problems yet is that these two bugs somewhat cancel out. Specifically we treated `UTF-8` like `UTF-32`. Characters that require 2 `UTF-16` codepoints instead of just 1 are rare and therefore problems were rare and these bugs essentially canceled out.

TLDR:
* Helix uses UTF-8 encoding for LSP offsets
* It should be using UTF-16 (first bug fixed here)
* The UTF-8 encoding was accidently a UTF-32 encoding (second bug fixed here), which is the same as UTF-16 for commonly used chars
* Added some minor cleanups and comments to be closer to the LSP spec
