### PR TITLE
Esc aborts completions reverting any changes

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -363,14 +363,16 @@ impl Completion {
 
 impl Component for Completion {
     fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
-        // let the Editor handle Esc instead
-        if let Event::Key(KeyEvent {
-            code: KeyCode::Esc, ..
-        }) = event
-        {
-            return EventResult::Ignored(None);
+        // Escape needs to get handled by the popup so that completions can
+        // be properly reverted and it needs to bubble up so that helix
+        // will go into normal mode.
+        let event_result = self.popup.handle_event(event, cx);
+        match event {
+            Event::Key(KeyEvent {
+                code: KeyCode::Esc, ..
+            }) => EventResult::Ignored(None),
+            _ => event_result,
         }
-        self.popup.handle_event(event, cx)
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {


### PR DESCRIPTION
Currently if you have some completions open and you hit the `Esc` key, the completion picker will get closed but the changes will still be applied to you code. This seems incorrect for 2 reasons:

 - The docs say that `Escape` will close the completions the same way `Ctrl-c` will. https://docs.helix-editor.com/master/keymap.html#picker (Admittedly I don't know if the picker this is referring to is the completion picker)
 - The imports for the change aren't properly inserted as they would be had the user pressed `Enter`

Here's some recordings, note you can't see that I'm pressing `Esc`, you'll just have to trust me or try it out:

Before this PR:
https://asciinema.org/a/yQed8bXSB3mJOHp4IqE5sld4B

After this PR:
https://asciinema.org/a/rTj3yfQbUWmU1VjSenY1ImsJb

I do not know that this is the best way to do this, and I don't know why this code originally deliberately ignored the Esc key but looked like a quick fix.