### PR TITLE
build(deps): bump toml from 0.6.0 to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
+checksum = "2f560bc7fb3eb31f5eee1340c68a2160cad39605b7b9c9ec32045ddbdee13b85"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2204,18 +2204,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+checksum = "886f31a9b85b6182cabd4d8b07df3b451afcc216563748201490940d2a28ed36"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "233d8716cdc5d20ec88a18a839edaf545edc71efa4a5ff700ef4a102c26cd8fa"
 dependencies = [
  "indexmap",
  "nom8",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -36,7 +36,7 @@ hashbrown = { version = "0.13.2", features = ["raw"] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.6"
+toml = "0.7"
 
 imara-diff = "0.1.0"
 

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.6"
+toml = "0.7"
 etcetera = "0.4"
 tree-sitter = "0.20"
 once_cell = "1.17"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -61,7 +61,7 @@ pulldown-cmark = { version = "0.9", default-features = false }
 content_inspector = "0.2.4"
 
 # config
-toml = "0.6"
+toml = "0.7"
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -39,7 +39,7 @@ chardetng = "0.1"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.6"
+toml = "0.7"
 log = "~0.4"
 
 which = "4.4"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,4 +10,4 @@ helix-term = { version = "0.6", path = "../helix-term" }
 helix-core = { version = "0.6", path = "../helix-core" }
 helix-view = { version = "0.6", path = "../helix-view" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
-toml = "0.6"
+toml = "0.7"


### PR DESCRIPTION
[breaking changes](https://github.com/toml-rs/toml/blob/57c9bb07f45303626fc44bdb9a8721d27591123e/crates/toml/CHANGELOG.md#070---2023-01-27) don't seem to have any effect for helix