### PR TITLE
Improved Completion

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -50,6 +50,7 @@ signal to the Helix process on Unix operating systems, such as by using the comm
 | `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant | `400` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
+| `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
 | `auto-info` | Whether to display info boxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -661,6 +661,15 @@ impl<'a> IntoIterator for &'a Selection {
     }
 }
 
+impl IntoIterator for Selection {
+    type Item = Range;
+    type IntoIter = smallvec::IntoIter<[Range; 1]>;
+
+    fn into_iter(self) -> smallvec::IntoIter<[Range; 1]> {
+        self.ranges.into_iter()
+    }
+}
+
 // TODO: checkSelection -> check if valid for doc length && sorted
 
 pub fn keep_or_remove_matches(

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -1,3 +1,5 @@
+use smallvec::SmallVec;
+
 use crate::{Range, Rope, Selection, Tendril};
 use std::borrow::Cow;
 
@@ -466,6 +468,33 @@ impl Transaction {
         self
     }
 
+    /// Generate a transaction from a set of potentially overlapping changes. The `change_ranges`
+    /// iterator yield the range (of removed text) in the old document for each edit. If any change
+    /// overlaps with a range overlaps with a previous range then that range is ignored.
+    ///
+    /// The `process_change` callback is called for each edit that is not ignored (in the order
+    /// yielded by `changes`) and should return the new text that the associated range will be
+    /// replaced with.
+    ///
+    /// To make this function more flexible the iterator can yield additional data for each change
+    /// that is passed to `process_change`
+    pub fn change_ignore_overlapping<T>(
+        doc: &Rope,
+        change_ranges: impl Iterator<Item = (usize, usize, T)>,
+        mut process_change: impl FnMut(usize, usize, T) -> Option<Tendril>,
+    ) -> Self {
+        let mut last = 0;
+        let changes = change_ranges.filter_map(|(from, to, data)| {
+            if from < last {
+                return None;
+            }
+            let tendril = process_change(from, to, data);
+            last = to;
+            Some((from, to, tendril))
+        });
+        Self::change(doc, changes)
+    }
+
     /// Generate a transaction from a set of changes.
     pub fn change<I>(doc: &Rope, changes: I) -> Self
     where
@@ -511,6 +540,44 @@ impl Transaction {
         F: FnMut(&Range) -> Change,
     {
         Self::change(doc, selection.iter().map(f))
+    }
+
+    pub fn change_by_selection_ignore_overlapping(
+        doc: &Rope,
+        selection: &Selection,
+        mut change_range: impl FnMut(&Range) -> (usize, usize),
+        mut create_tendril: impl FnMut(usize, usize) -> Option<Tendril>,
+    ) -> (Transaction, Selection) {
+        let mut last_selection_idx = None;
+        let mut new_primary_idx = None;
+        let mut ranges: SmallVec<[Range; 1]> = SmallVec::new();
+        let process_change = |change_start, change_end, (idx, range): (usize, &Range)| {
+            // update the primary idx
+            if idx == selection.primary_index() {
+                new_primary_idx = Some(idx);
+            } else if new_primary_idx.is_none() {
+                if idx > selection.primary_index() {
+                    new_primary_idx = last_selection_idx;
+                } else {
+                    last_selection_idx = Some(idx);
+                }
+            }
+            ranges.push(*range);
+            create_tendril(change_start, change_end)
+        };
+        let transaction = Self::change_ignore_overlapping(
+            doc,
+            selection.iter().enumerate().map(|range| {
+                let (change_start, change_end) = change_range(range.1);
+                (change_start, change_end, range)
+            }),
+            process_change,
+        );
+
+        (
+            transaction,
+            Selection::new(ranges, new_primary_idx.unwrap_or(0)),
+        )
     }
 
     /// Insert text at each selection head.

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -59,8 +59,8 @@ pub enum OffsetEncoding {
 pub mod util {
     use super::*;
     use helix_core::line_ending::{line_end_byte_index, line_end_char_index};
+    use helix_core::{chars, RopeSlice, SmallVec};
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
-    use helix_core::{smallvec, SmallVec};
 
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
     ///
@@ -247,13 +247,46 @@ pub mod util {
         Some(Range::new(start, end))
     }
 
+    /// If the LS did not provide a range for the completion or the range of the
+    /// primary cursor can not be used for the secondary cursor, this function
+    /// can be used to find the completion range for a cursor
+    fn find_completion_range(text: RopeSlice, cursor: usize) -> (usize, usize) {
+        let start = cursor
+            - text
+                .chars_at(cursor)
+                .reversed()
+                .take_while(|ch| chars::char_is_word(*ch))
+                .count();
+        (start, cursor)
+    }
+    fn completion_range(
+        text: RopeSlice,
+        edit_offset: Option<(i128, i128)>,
+        cursor: usize,
+    ) -> Option<(usize, usize)> {
+        let res = match edit_offset {
+            Some((start_offset, end_offset)) => {
+                let start_offset = cursor as i128 + start_offset;
+                if start_offset < 0 {
+                    return None;
+                }
+                let end_offset = cursor as i128 + end_offset;
+                if end_offset > text.len_chars() as i128 {
+                    return None;
+                }
+                (start_offset as usize, end_offset as usize)
+            }
+            None => find_completion_range(text, cursor),
+        };
+        Some(res)
+    }
+
     /// Creates a [Transaction] from the [lsp::TextEdit] in a completion response.
     /// The transaction applies the edit to all cursors.
     pub fn generate_transaction_from_completion_edit(
         doc: &Rope,
         selection: &Selection,
-        start_offset: i128,
-        end_offset: i128,
+        edit_offset: Option<(i128, i128)>,
         new_text: String,
     ) -> Transaction {
         let replacement: Option<Tendril> = if new_text.is_empty() {
@@ -263,83 +296,163 @@ pub mod util {
         };
 
         let text = doc.slice(..);
+        let (removed_start, removed_end) =
+            completion_range(text, edit_offset, selection.primary().cursor(text))
+                .expect("transaction must be valid for primary selection");
+        let removed_text = text.slice(removed_start..removed_end);
 
-        Transaction::change_by_selection(doc, selection, |range| {
-            let cursor = range.cursor(text);
-            (
-                (cursor as i128 + start_offset) as usize,
-                (cursor as i128 + end_offset) as usize,
-                replacement.clone(),
-            )
-        })
+        let (transaction, mut selection) = Transaction::change_by_selection_ignore_overlapping(
+            doc,
+            selection,
+            |range| {
+                let cursor = range.cursor(text);
+                completion_range(text, edit_offset, cursor)
+                    .filter(|(start, end)| text.slice(start..end) == removed_text)
+                    .unwrap_or_else(|| find_completion_range(text, cursor))
+            },
+            |_, _| replacement.clone(),
+        );
+        if transaction.changes().is_empty() {
+            return transaction;
+        }
+        selection = selection.map(transaction.changes());
+        transaction.with_selection(selection)
     }
 
     /// Creates a [Transaction] from the [snippet::Snippet] in a completion response.
     /// The transaction applies the edit to all cursors.
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_transaction_from_snippet(
         doc: &Rope,
         selection: &Selection,
-        start_offset: i128,
-        end_offset: i128,
+        edit_offset: Option<(i128, i128)>,
         snippet: snippet::Snippet,
         line_ending: &str,
         include_placeholder: bool,
+        tab_width: usize,
     ) -> Transaction {
         let text = doc.slice(..);
 
-        // For each cursor store offsets for the first tabstop
-        let mut cursor_tabstop_offsets = Vec::<SmallVec<[(i128, i128); 1]>>::new();
-        let transaction = Transaction::change_by_selection(doc, selection, |range| {
-            let cursor = range.cursor(text);
-            let replacement_start = (cursor as i128 + start_offset) as usize;
-            let replacement_end = (cursor as i128 + end_offset) as usize;
-            let newline_with_offset = format!(
-                "{line_ending}{blank:width$}",
-                line_ending = line_ending,
-                width = replacement_start - doc.line_to_char(doc.char_to_line(replacement_start)),
-                blank = ""
-            );
+        let mut off = 0i128;
+        let mut mapped_doc = doc.clone();
+        let mut selection_tabstops: SmallVec<[_; 1]> = SmallVec::new();
+        let (removed_start, removed_end) =
+            completion_range(text, edit_offset, selection.primary().cursor(text))
+                .expect("transaction must be valid for primary selection");
+        let removed_text = text.slice(removed_start..removed_end);
 
-            let (replacement, tabstops) =
-                snippet::render(&snippet, newline_with_offset, include_placeholder);
+        let (transaction, selection) = Transaction::change_by_selection_ignore_overlapping(
+            doc,
+            selection,
+            |range| {
+                let cursor = range.cursor(text);
+                completion_range(text, edit_offset, cursor)
+                    .filter(|(start, end)| text.slice(start..end) == removed_text)
+                    .unwrap_or_else(|| find_completion_range(text, cursor))
+            },
+            |replacement_start, replacement_end| {
+                let mapped_replacement_start = (replacement_start as i128 + off) as usize;
+                let mapped_replacement_end = (replacement_end as i128 + off) as usize;
 
-            let replacement_len = replacement.chars().count();
-            cursor_tabstop_offsets.push(
-                tabstops
-                    .first()
-                    .unwrap_or(&smallvec![(replacement_len, replacement_len)])
-                    .iter()
-                    .map(|(from, to)| -> (i128, i128) {
-                        (
-                            *from as i128 - replacement_len as i128,
-                            *to as i128 - replacement_len as i128,
-                        )
-                    })
-                    .collect(),
-            );
+                let line_idx = mapped_doc.char_to_line(mapped_replacement_start);
+                let pos_on_line = mapped_replacement_start - mapped_doc.line_to_char(line_idx);
 
-            (replacement_start, replacement_end, Some(replacement.into()))
-        });
+                // we only care about the actual offset here (not virtual text/softwrap)
+                // so it's ok to use the deprecated function here
+                #[allow(deprecated)]
+                let width = helix_core::visual_coords_at_pos(
+                    mapped_doc.line(line_idx),
+                    pos_on_line,
+                    tab_width,
+                )
+                .col;
+                let newline_with_offset = format!(
+                    "{line_ending}{blank:width$}",
+                    line_ending = line_ending,
+                    blank = ""
+                );
 
-        // Create new selection based on the cursor tabstop from above
-        let mut cursor_tabstop_offsets_iter = cursor_tabstop_offsets.iter();
-        let selection = selection
-            .clone()
-            .map(transaction.changes())
-            .transform_iter(|range| {
-                cursor_tabstop_offsets_iter
-                    .next()
-                    .unwrap()
-                    .iter()
-                    .map(move |(from, to)| {
-                        Range::new(
-                            (range.anchor as i128 + *from) as usize,
-                            (range.anchor as i128 + *to) as usize,
-                        )
-                    })
-            });
+                let (replacement, tabstops) =
+                    snippet::render(&snippet, &newline_with_offset, include_placeholder);
+                selection_tabstops.push((mapped_replacement_start, tabstops));
+                mapped_doc.remove(mapped_replacement_start..mapped_replacement_end);
+                mapped_doc.insert(mapped_replacement_start, &replacement);
+                off +=
+                    replacement_start as i128 - replacement_end as i128 + replacement.len() as i128;
 
-        transaction.with_selection(selection)
+                Some(replacement)
+            },
+        );
+
+        let changes = transaction.changes();
+        if changes.is_empty() {
+            return transaction;
+        }
+
+        let mut mapped_selection = SmallVec::with_capacity(selection.len());
+        let mut mapped_primary_idx = 0;
+        let primary_range = selection.primary();
+        for (range, (tabstop_anchor, tabstops)) in selection.into_iter().zip(selection_tabstops) {
+            if range == primary_range {
+                mapped_primary_idx = mapped_selection.len()
+            }
+
+            let range = range.map(changes);
+            let tabstops = tabstops.first().filter(|tabstops| !tabstops.is_empty());
+            let Some(tabstops) = tabstops else{
+                // no tabstop normal mapping
+                mapped_selection.push(range);
+                continue;
+            };
+
+            // expand the selection to cover the tabstop to retain the helix selection semantic
+            // the tabstop closest to the range simply replaces `head` while anchor remains in place
+            // the remaining tabstops receive their own single-width cursor
+            if range.head < range.anchor {
+                let first_tabstop = tabstop_anchor + tabstops[0].1;
+
+                // if selection is forward but was moved to the right it is
+                // contained entirely in the replacement text, just do a point
+                // selection (fallback below)
+                if range.anchor >= first_tabstop {
+                    let range = Range::new(range.anchor, first_tabstop);
+                    mapped_selection.push(range);
+                    let rem_tabstops = tabstops[1..]
+                        .iter()
+                        .map(|tabstop| Range::point(tabstop_anchor + tabstop.1));
+                    mapped_selection.extend(rem_tabstops);
+                    continue;
+                }
+            } else {
+                let last_idx = tabstops.len() - 1;
+                let last_tabstop = tabstop_anchor + tabstops[last_idx].1;
+
+                // if selection is forward but was moved to the right it is
+                // contained entirely in the replacement text, just do a point
+                // selection (fallback below)
+                if range.anchor <= last_tabstop {
+                    // we can't properly compute the the next grapheme
+                    // here because the transaction hasn't been applied yet
+                    // that is not a problem because the range gets grapheme aligned anyway
+                    // tough so just adding one will always cause head to be grapheme
+                    // aligned correctly when applied to the document
+                    let range = Range::new(range.anchor, last_tabstop + 1);
+                    mapped_selection.push(range);
+                    let rem_tabstops = tabstops[..last_idx]
+                        .iter()
+                        .map(|tabstop| Range::point(tabstop_anchor + tabstop.0));
+                    mapped_selection.extend(rem_tabstops);
+                    continue;
+                }
+            };
+
+            let tabstops = tabstops
+                .iter()
+                .map(|tabstop| Range::point(tabstop_anchor + tabstop.0));
+            mapped_selection.extend(tabstops);
+        }
+
+        transaction.with_selection(Selection::new(mapped_selection, mapped_primary_idx))
     }
 
     pub fn generate_transaction_from_edits(

--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::{anyhow, Result};
-use helix_core::{smallvec, SmallVec};
+use helix_core::{smallvec, SmallVec, Tendril};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CaseChange {
@@ -57,10 +57,10 @@ pub fn parse(s: &str) -> Result<Snippet<'_>> {
 
 fn render_elements(
     snippet_elements: &[SnippetElement<'_>],
-    insert: &mut String,
+    insert: &mut Tendril,
     offset: &mut usize,
     tabstops: &mut Vec<(usize, (usize, usize))>,
-    newline_with_offset: &String,
+    newline_with_offset: &str,
     include_placeholer: bool,
 ) {
     use SnippetElement::*;
@@ -121,10 +121,10 @@ fn render_elements(
 #[allow(clippy::type_complexity)] // only used one time
 pub fn render(
     snippet: &Snippet<'_>,
-    newline_with_offset: String,
+    newline_with_offset: &str,
     include_placeholer: bool,
-) -> (String, Vec<SmallVec<[(usize, usize); 1]>>) {
-    let mut insert = String::new();
+) -> (Tendril, Vec<SmallVec<[(usize, usize); 1]>>) {
+    let mut insert = Tendril::new();
     let mut tabstops = Vec::new();
     let mut offset = 0;
 
@@ -133,7 +133,7 @@ pub fn render(
         &mut insert,
         &mut offset,
         &mut tabstops,
-        &newline_with_offset,
+        newline_with_offset,
         include_placeholer,
     );
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -251,6 +251,9 @@ pub struct Config {
     )]
     pub idle_timeout: Duration,
     pub completion_trigger_len: u8,
+    /// Whether to instruct the LSP to replace the entire word when applying a completion
+    /// or to only insert new text
+    pub completion_replace: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
@@ -738,6 +741,7 @@ impl Default for Config {
             color_modes: false,
             soft_wrap: SoftWrap::default(),
             text_width: 80,
+            completion_replace: false,
         }
     }
 }


### PR DESCRIPTION
Fixes #4380 
Fixes #5469

This PR improves the completions in helix in multiple subtle ways. These fixes were lumped together as they all interact. 

The core change of this PR is a fix for #4380: Adding an option so that helix completions only insert text and don't replace the rest of the word (using `item.insert` instead of `item.replace`). I believe this to be the better default, so I changed the default behavior to use `item.insert`. This not only feels more appropriate for an *insert* mode action in a modal editor, but I feel that the replace mode has some issues that don't make it as suitable for a default setting (see below).

While working on this I noticed that in cases where a LSP does not supply a TextEdit, and we have to determine the range based on word boundaries ourself helix already behaves this way: We only insert the sent text but don't replace the rest of the word. I changed that behavior there to respect the new setting. Here is another reason why I think insert completions are a better default: There is a third option for sending completions (which is commonly used) where the LS does send a `TextEdit` but only a single edit (not two separate replace/insert edits). These edits are always insert edits so for many LSPs helix is already inserting by default.

To avoid conflicts with the change above, I also pulled in #5487 (commit remains to credit @Taywee). I discovered that #5487 doesn't respect multi cursors (so the edit was only applied to a single cursor), so I fixed that regression too.

In the process I noticed that completions with multiple cursors can cause overlapping ranges which can cause panics (always a panic in debug mode thanks to debug assertions). For example in helix in `document.rs` you can select `History` in the `use` statement type `s[iy]<ret>` start a completion and as soon as History is selected the editor instantly crashes in debug mode.I fixed the problem by adding a variant of `Selection::change` that ignores overlapping edits. This problem rarely occurs in practice and there are some odd edge cases that are not handled 100% right now (the cursor can be moved by the applied transactions which means the preview only applies the edit at once cursor but on hitting enter the cursor has moved and the edit is applied a both cursors) but I doubt people actually run into this problem as there was no bug report about the crash I could find. For now just fixing the crash seems good enough to me. This Problem is also more likely to occur in replace mode (as the rest of the word could contain another cursor) so yet another point for that.
