### PR TITLE
Use filename completer on run-shell-command

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2335,7 +2335,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &["sh"],
             doc: "Run a shell command",
             fun: run_shell_command,
-            completer: Some(completers::directory),
+            completer: Some(completers::filename),
         },
     ];
 


### PR DESCRIPTION
This PR changes to use the `filename` completer on the `run-shell-command` typed command. With the current completer:

- I find myself having to type out the filename myself most of the time anyways when using `sh` for file operations like `chmod` and `rm`; 
- One would have to manually append `/` to get new completions for the next directory level, which is sub-optimal.

Switching to use `filename` conveniently solves both issues.