### PR TITLE
Add command for resetting diff hunks

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -74,3 +74,4 @@
 | `:pipe` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh` | Run a shell command |
+| `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3009,13 +3009,13 @@ fn goto_first_change_impl(cx: &mut Context, reverse: bool) {
     let (view, doc) = current!(editor);
     if let Some(handle) = doc.diff_handle() {
         let hunk = {
-            let hunks = handle.hunks();
+            let diff = handle.load();
             let idx = if reverse {
-                hunks.len().saturating_sub(1)
+                diff.len().saturating_sub(1)
             } else {
                 0
             };
-            hunks.nth_hunk(idx)
+            diff.nth_hunk(idx)
         };
         if hunk != Hunk::NONE {
             let range = hunk_range(hunk, doc.text().slice(..));
@@ -3047,12 +3047,12 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
         let selection = doc.selection(view.id).clone().transform(|range| {
             let cursor_line = range.cursor_line(doc_text) as u32;
 
-            let hunks = diff_handle.hunks();
+            let diff = diff_handle.load();
             let hunk_idx = match direction {
-                Direction::Forward => hunks
+                Direction::Forward => diff
                     .next_hunk(cursor_line)
-                    .map(|idx| (idx + count).min(hunks.len() - 1)),
-                Direction::Backward => hunks
+                    .map(|idx| (idx + count).min(diff.len() - 1)),
+                Direction::Backward => diff
                     .prev_hunk(cursor_line)
                     .map(|idx| idx.saturating_sub(count)),
             };
@@ -3062,7 +3062,7 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
             } else {
                 return range;
             };
-            let hunk = hunks.nth_hunk(hunk_idx);
+            let hunk = diff.nth_hunk(hunk_idx);
             let new_range = hunk_range(hunk, doc_text);
             if editor.mode == Mode::Select {
                 let head = if new_range.head < range.anchor {
@@ -4729,14 +4729,14 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
 
                 let textobject_change = |range: Range| -> Range {
                     let diff_handle = doc.diff_handle().unwrap();
-                    let hunks = diff_handle.hunks();
+                    let diff = diff_handle.load();
                     let line = range.cursor_line(text);
-                    let hunk_idx = if let Some(hunk_idx) = hunks.hunk_at(line as u32, false) {
+                    let hunk_idx = if let Some(hunk_idx) = diff.hunk_at(line as u32, false) {
                         hunk_idx
                     } else {
                         return range;
                     };
-                    let hunk = hunks.nth_hunk(hunk_idx).after;
+                    let hunk = diff.nth_hunk(hunk_idx).after;
 
                     let start = text.line_to_char(hunk.start as usize);
                     let end = text.line_to_char(hunk.end as usize);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1953,6 +1953,64 @@ fn run_shell_command(
     Ok(())
 }
 
+fn reset_diff_change(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+    ensure!(args.is_empty(), ":reset-diff-change takes no arguments");
+
+    let editor = &mut cx.editor;
+    let scrolloff = editor.config().scrolloff;
+
+    let (view, doc) = current!(editor);
+    // TODO refactor to use let..else once MSRV is raised to 1.65
+    let handle = match doc.diff_handle() {
+        Some(handle) => handle,
+        None => bail!("Diff is not available in the current buffer"),
+    };
+
+    let diff = handle.load();
+    let doc_text = doc.text().slice(..);
+    let line = doc.selection(view.id).primary().cursor_line(doc_text);
+
+    // TODO refactor to use let..else once MSRV is raised to 1.65
+    let hunk_idx = match diff.hunk_at(line as u32, true) {
+        Some(hunk_idx) => hunk_idx,
+        None => bail!("There is no change at the cursor"),
+    };
+    let hunk = diff.nth_hunk(hunk_idx);
+    let diff_base = diff.diff_base();
+    let before_start = diff_base.line_to_char(hunk.before.start as usize);
+    let before_end = diff_base.line_to_char(hunk.before.end as usize);
+    let text: Tendril = diff
+        .diff_base()
+        .slice(before_start..before_end)
+        .chunks()
+        .collect();
+    let anchor = doc_text.line_to_char(hunk.after.start as usize);
+    let transaction = Transaction::change(
+        doc.text(),
+        [(
+            anchor,
+            doc_text.line_to_char(hunk.after.end as usize),
+            (!text.is_empty()).then_some(text),
+        )]
+        .into_iter(),
+    );
+    drop(diff); // make borrow check happy
+    doc.apply(&transaction, view.id);
+    // select inserted text
+    let text_len = before_end - before_start;
+    doc.set_selection(view.id, Selection::single(anchor, anchor + text_len));
+    doc.append_changes_to_history(view);
+    view.ensure_cursor_in_view(doc, scrolloff);
+    Ok(())
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -2474,6 +2532,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             doc: "Run a shell command",
             fun: run_shell_command,
             completer: Some(completers::filename),
+        },
+       TypableCommand {
+            name: "reset-diff-change",
+            aliases: &["diffget", "diffg"],
+            doc: "Reset the diff change at the cursor position.",
+            fun: reset_diff_change,
+            completer: None,
         },
     ];
 

--- a/helix-vcs/src/diff/line_cache.rs
+++ b/helix-vcs/src/diff/line_cache.rs
@@ -43,6 +43,14 @@ impl InternedRopeLines {
         res
     }
 
+    pub fn doc(&self) -> Rope {
+        self.doc.clone()
+    }
+
+    pub fn diff_base(&self) -> Rope {
+        self.diff_base.clone()
+    }
+
     /// Updates the `diff_base` and optionally the document if `doc` is not None
     pub fn update_diff_base(&mut self, diff_base: Rope, doc: Option<Rope>) {
         self.interned.clear();

--- a/helix-vcs/src/diff/worker/test.rs
+++ b/helix-vcs/src/diff/worker/test.rs
@@ -12,12 +12,12 @@ impl DiffHandle {
         )
     }
     async fn into_diff(self, handle: JoinHandle<()>) -> Vec<Hunk> {
-        let hunks = self.hunks;
+        let diff = self.diff;
         // dropping the channel terminates the task
         drop(self.channel);
         handle.await.unwrap();
-        let hunks = hunks.lock();
-        Vec::clone(&*hunks)
+        let diff = diff.lock();
+        Vec::clone(&diff.hunks)
     }
 }
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -101,7 +101,7 @@ pub fn diff<'doc>(
     let deleted = theme.get("diff.minus");
     let modified = theme.get("diff.delta");
     if let Some(diff_handle) = doc.diff_handle() {
-        let hunks = diff_handle.hunks();
+        let hunks = diff_handle.load();
         let mut hunk_i = 0;
         let mut hunk = hunks.nth_hunk(hunk_i);
         Box::new(


### PR DESCRIPTION
Closes #4974

Adds the `:reset-diff-change` command  (aliases `:diffg` and `:diffget`) that resets a hunk back
to its original text. 

This change requires exposing the `diff_base` (the file that a diff was computed against). To accommodate that I slightly refactored the terminology the `DiffHandle` and renamed the `FileHunks` struct to `Diff` as it doesn't just contains hunks anymore.

