### PR TITLE
Fix utf8 length handling for shellwords

### DIFF
--- a/helix-core/src/shellwords.rs
+++ b/helix-core/src/shellwords.rs
@@ -129,8 +129,9 @@ impl<'a> From<&'a str> for Shellwords<'a> {
                 DquoteEscaped => Dquoted,
             };
 
-            if i >= input.len() - 1 && end == 0 {
-                end = i + 1;
+            let c_len = c.len_utf8();
+            if i == input.len() - c_len && end == 0 {
+                end = i + c_len;
             }
 
             if end > 0 {
@@ -332,5 +333,18 @@ mod test {
     fn test_parts() {
         assert_eq!(Shellwords::from(":o a").parts(), &[":o", "a"]);
         assert_eq!(Shellwords::from(":o a\\ ").parts(), &[":o", "a\\"]);
+    }
+
+    #[test]
+    fn test_multibyte_at_end() {
+        assert_eq!(Shellwords::from("𒀀").parts(), &["𒀀"]);
+        assert_eq!(
+            Shellwords::from(":sh echo 𒀀").parts(),
+            &[":sh", "echo", "𒀀"]
+        );
+        assert_eq!(
+            Shellwords::from(":sh echo 𒀀 hello world𒀀").parts(),
+            &[":sh", "echo", "𒀀", "hello", "world𒀀"]
+        );
     }
 }


### PR DESCRIPTION
If the last argument to shellwords ends in a multibyte utf8 character the entire argument will be dropped.
e.g. `:sh echo test1 test2𒀀` will only output `test1`