### PR TITLE
LSP workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "helix-parsec",
  "log",
  "lsp-types",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror",

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -30,6 +30,9 @@ You can use a custom configuration file by specifying it with the `-c` or
 Additionally, you can reload the configuration file by sending the USR1
 signal to the Helix process on Unix operating systems, such as by using the command `pkill -USR1 hx`.
 
+Finally, you can have a `config.toml` local to a project by putting it under a `.helix` directory in your repository.
+Its settings will be merged with the configuration directory `config.toml` and the built-in configuration.
+
 ## Editor
 
 ### `[editor]` Section
@@ -58,6 +61,7 @@ signal to the Helix process on Unix operating systems, such as by using the comm
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap_at_text_width` is set | `80` |
+| `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 
 ### `[editor.statusline]` Section
 

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -70,6 +70,7 @@
 | `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
+| `:config-open-workspace` | Open the workspace config.toml file. |
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output before each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -64,6 +64,7 @@ These configuration keys are available:
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap_at_text_width` is set, defaults to `editor.text-width`   |
+| `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. | `` |
 
 ### File-type detection and the `file-types` key
 

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -64,7 +64,7 @@ These configuration keys are available:
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap_at_text_width` is set, defaults to `editor.text-width`   |
-| `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. | `` |
+| `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. |
 
 ### File-type detection and the `file-types` key
 

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -36,53 +36,10 @@ pub mod unicode {
     pub use unicode_width as width;
 }
 
+pub use helix_loader::find_workspace;
+
 pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
     line.chars().position(|ch| !ch.is_whitespace())
-}
-
-/// Find project root.
-///
-/// Order of detection:
-/// * Top-most folder containing a root marker in current git repository
-/// * Git repository root if no marker detected
-/// * Top-most folder containing a root marker if not git repository detected
-/// * Current working directory as fallback
-pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::PathBuf {
-    let current_dir = std::env::current_dir().expect("unable to determine current directory");
-
-    let root = match root {
-        Some(root) => {
-            let root = std::path::Path::new(root);
-            if root.is_absolute() {
-                root.to_path_buf()
-            } else {
-                current_dir.join(root)
-            }
-        }
-        None => current_dir.clone(),
-    };
-
-    let mut top_marker = None;
-    for ancestor in root.ancestors() {
-        if root_markers
-            .iter()
-            .any(|marker| ancestor.join(marker).exists())
-        {
-            top_marker = Some(ancestor);
-        }
-
-        if ancestor.join(".git").exists() {
-            // Top marker is repo root if not root marker was detected yet
-            if top_marker.is_none() {
-                top_marker = Some(ancestor);
-            }
-            // Don't go higher than repo if we're in one
-            break;
-        }
-    }
-
-    // Return the found top marker or the current_dir as fallback
-    top_marker.map_or(current_dir, |a| a.to_path_buf())
 }
 
 pub use ropey::{self, str_utils, Rope, RopeBuilder, RopeSlice};

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -20,7 +20,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     mem::{replace, transmute},
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
 };
@@ -127,6 +127,10 @@ pub struct LanguageConfiguration {
     pub auto_pairs: Option<AutoPairs>,
 
     pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+
+    /// Hardcoded LSP root directories relative to the workspace root, like `examples` or `tools/fuzz`.
+    /// Falling back to the current working directory if none are configured.
+    pub workspace_lsp_roots: Option<Vec<PathBuf>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -9,35 +9,38 @@ pub fn default_lang_config() -> toml::Value {
 
 /// User configured languages.toml file, merged with the default config.
 pub fn user_lang_config() -> Result<toml::Value, toml::de::Error> {
-    let config = [crate::config_dir(), crate::find_workspace().join(".helix")]
-        .into_iter()
-        .map(|path| path.join("languages.toml"))
-        .filter_map(|file| {
-            std::fs::read_to_string(file)
-                .map(|config| toml::from_str(&config))
-                .ok()
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .fold(default_lang_config(), |a, b| {
-            // combines for example
-            // b:
-            //   [[language]]
-            //   name = "toml"
-            //   language-server = { command = "taplo", args = ["lsp", "stdio"] }
-            //
-            // a:
-            //   [[language]]
-            //   language-server = { command = "/usr/bin/taplo" }
-            //
-            // into:
-            //   [[language]]
-            //   name = "toml"
-            //   language-server = { command = "/usr/bin/taplo" }
-            //
-            // thus it overrides the third depth-level of b with values of a if they exist, but otherwise merges their values
-            crate::merge_toml_values(a, b, 3)
-        });
+    let config = [
+        crate::config_dir(),
+        crate::find_workspace().0.join(".helix"),
+    ]
+    .into_iter()
+    .map(|path| path.join("languages.toml"))
+    .filter_map(|file| {
+        std::fs::read_to_string(file)
+            .map(|config| toml::from_str(&config))
+            .ok()
+    })
+    .collect::<Result<Vec<_>, _>>()?
+    .into_iter()
+    .fold(default_lang_config(), |a, b| {
+        // combines for example
+        // b:
+        //   [[language]]
+        //   name = "toml"
+        //   language-server = { command = "taplo", args = ["lsp", "stdio"] }
+        //
+        // a:
+        //   [[language]]
+        //   language-server = { command = "/usr/bin/taplo" }
+        //
+        // into:
+        //   [[language]]
+        //   name = "toml"
+        //   language-server = { command = "/usr/bin/taplo" }
+        //
+        // thus it overrides the third depth-level of b with values of a if they exist, but otherwise merges their values
+        crate::merge_toml_values(a, b, 3)
+    });
 
     Ok(config)
 }

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -129,7 +129,7 @@ pub fn config_file() -> PathBuf {
 }
 
 pub fn workspace_config_file() -> PathBuf {
-    find_workspace().join(".helix").join("config.toml")
+    find_workspace().0.join(".helix").join("config.toml")
 }
 
 pub fn lang_config_file() -> PathBuf {
@@ -283,14 +283,19 @@ mod merge_toml_tests {
 }
 
 /// Finds the current workspace folder.
-/// Used as a ceiling dir for root resolve, for the filepicker and other related
-pub fn find_workspace() -> PathBuf {
+/// Used as a ceiling dir for LSP root resolution, the filepicker and potentially as a future filewatching root
+///
+/// This function starts searching the FS upward from the CWD
+/// and returns the first directory that contains either `.git` or `.helix`.
+/// If no workspace was found returns (CWD, true).
+/// Otherwise (workspace, false) is returned
+pub fn find_workspace() -> (PathBuf, bool) {
     let current_dir = std::env::current_dir().expect("unable to determine current directory");
     for ancestor in current_dir.ancestors() {
         if ancestor.join(".git").exists() || ancestor.join(".helix").exists() {
-            return ancestor.to_owned();
+            return (ancestor.to_owned(), false);
         }
     }
 
-    current_dir
+    (current_dir, true)
 }

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -42,7 +42,7 @@ fn prioritize_runtime_dirs() -> Vec<PathBuf> {
     let mut rt_dirs = Vec::new();
     if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
         // this is the directory of the crate being run by cargo, we need the workspace path so we take the parent
-        let path = std::path::PathBuf::from(dir).parent().unwrap().join(RT_DIR);
+        let path = PathBuf::from(dir).parent().unwrap().join(RT_DIR);
         log::debug!("runtime dir: {}", path.to_string_lossy());
         rt_dirs.push(path);
     }
@@ -113,15 +113,6 @@ pub fn config_dir() -> PathBuf {
     path
 }
 
-pub fn local_config_dirs() -> Vec<PathBuf> {
-    let directories = find_local_config_dirs()
-        .into_iter()
-        .map(|path| path.join(".helix"))
-        .collect();
-    log::debug!("Located configuration folders: {:?}", directories);
-    directories
-}
-
 pub fn cache_dir() -> PathBuf {
     // TODO: allow env var override
     let strategy = choose_base_strategy().expect("Unable to find the config directory!");
@@ -137,28 +128,16 @@ pub fn config_file() -> PathBuf {
         .unwrap_or_else(|| config_dir().join("config.toml"))
 }
 
+pub fn workspace_config_file() -> PathBuf {
+    find_workspace().join(".helix").join("config.toml")
+}
+
 pub fn lang_config_file() -> PathBuf {
     config_dir().join("languages.toml")
 }
 
 pub fn log_file() -> PathBuf {
     cache_dir().join("helix.log")
-}
-
-pub fn find_local_config_dirs() -> Vec<PathBuf> {
-    let current_dir = std::env::current_dir().expect("unable to determine current directory");
-    let mut directories = Vec::new();
-
-    for ancestor in current_dir.ancestors() {
-        if ancestor.join(".git").exists() {
-            directories.push(ancestor.to_path_buf());
-            // Don't go higher than repo if we're in one
-            break;
-        } else if ancestor.join(".helix").is_dir() {
-            directories.push(ancestor.to_path_buf());
-        }
-    }
-    directories
 }
 
 /// Merge two TOML documents, merging values from `right` onto `left`
@@ -301,4 +280,17 @@ mod merge_toml_tests {
             &vec![Value::String("lsp".into())]
         )
     }
+}
+
+/// Finds the current workspace folder.
+/// Used as a ceiling dir for root resolve, for the filepicker and other related
+pub fn find_workspace() -> PathBuf {
+    let current_dir = std::env::current_dir().expect("unable to determine current directory");
+    for ancestor in current_dir.ancestors() {
+        if ancestor.join(".git").exists() || ancestor.join(".helix").exists() {
+            return ancestor.to_owned();
+        }
+    }
+
+    current_dir
 }

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -27,3 +27,4 @@ thiserror = "1.0"
 tokio = { version = "1.26", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "sync"] }
 tokio-stream = "0.1.12"
 which = "4.4"
+parking_lot = "0.12.1"

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1,13 +1,17 @@
 use crate::{
-    find_root, jsonrpc,
+    find_lsp_workspace, jsonrpc,
     transport::{Payload, Transport},
     Call, Error, OffsetEncoding, Result,
 };
 
-use helix_core::{ChangeSet, Rope};
+use helix_core::{find_workspace, ChangeSet, Rope};
 use helix_loader::{self, VERSION_AND_GIT_HASH};
-use lsp::PositionEncodingKind;
+use lsp::{
+    notification::DidChangeWorkspaceFolders, DidChangeWorkspaceFoldersParams, OneOf,
+    PositionEncodingKind, WorkspaceFolder, WorkspaceFoldersChangeEvent,
+};
 use lsp_types as lsp;
+use parking_lot::Mutex;
 use serde::Deserialize;
 use serde_json::Value;
 use std::future::Future;
@@ -26,6 +30,17 @@ use tokio::{
     },
 };
 
+fn workspace_for_uri(uri: lsp::Url) -> WorkspaceFolder {
+    lsp::WorkspaceFolder {
+        name: uri
+            .path_segments()
+            .and_then(|segments| segments.last())
+            .map(|basename| basename.to_string())
+            .unwrap_or_default(),
+        uri,
+    }
+}
+
 #[derive(Debug)]
 pub struct Client {
     id: usize,
@@ -36,11 +51,120 @@ pub struct Client {
     config: Option<Value>,
     root_path: std::path::PathBuf,
     root_uri: Option<lsp::Url>,
-    workspace_folders: Vec<lsp::WorkspaceFolder>,
+    workspace_folders: Mutex<Vec<lsp::WorkspaceFolder>>,
+    initalize_notify: Arc<Notify>,
+    /// workspace folders added while the server is still initalizing
     req_timeout: u64,
 }
 
 impl Client {
+    pub fn try_add_doc(
+        self: &Arc<Self>,
+        root_markers: &[String],
+        manual_roots: &[PathBuf],
+        doc_path: Option<&std::path::PathBuf>,
+        may_support_workspace: bool,
+    ) -> bool {
+        let (workspace, workspace_is_cwd) = find_workspace();
+        let root = find_lsp_workspace(
+            doc_path
+                .and_then(|x| x.parent().and_then(|x| x.to_str()))
+                .unwrap_or("."),
+            root_markers,
+            manual_roots,
+            &workspace,
+            workspace_is_cwd,
+        );
+        let root_uri = root
+            .as_ref()
+            .and_then(|root| lsp::Url::from_file_path(root).ok());
+
+        if self.root_path == root.unwrap_or(workspace)
+            || root_uri.as_ref().map_or(false, |root_uri| {
+                self.workspace_folders
+                    .lock()
+                    .iter()
+                    .any(|workspace| &workspace.uri == root_uri)
+            })
+        {
+            // workspace URI is already registered so we can use this client
+            return true;
+        }
+
+        // this server definitly doesn't support multiple workspace, no need to check capabilities
+        if !may_support_workspace {
+            return false;
+        }
+
+        let Some(capabilities) = self.capabilities.get() else {
+            let client = Arc::clone(self);
+            // initalization hasn't finished yet, deal with this new root later
+            // TODO: In the edgecase that a **new root** is added
+            // for an LSP that **doesn't support workspace_folders** before initaliation is finished
+            // the new roots are ignored.
+            // That particular edgecase would require retroactively spawning new LSP
+            // clients and therefore also require us to retroactively update the corresponding
+            // documents LSP client handle. It's doable but a pretty weird edgecase so let's
+            // wait and see if anyone ever runs into it.
+            tokio::spawn(async move {
+                client.initalize_notify.notified().await;
+                if let Some(workspace_folders_caps) = client
+                    .capabilities()
+                    .workspace
+                    .as_ref()
+                    .and_then(|cap| cap.workspace_folders.as_ref())
+                    .filter(|cap| cap.supported.unwrap_or(false))
+                {
+                    client.add_workspace_folder(
+                        root_uri,
+                        &workspace_folders_caps.change_notifications,
+                    );
+                }
+            });
+            return true;
+        };
+
+        if let Some(workspace_folders_caps) = capabilities
+            .workspace
+            .as_ref()
+            .and_then(|cap| cap.workspace_folders.as_ref())
+            .filter(|cap| cap.supported.unwrap_or(false))
+        {
+            self.add_workspace_folder(root_uri, &workspace_folders_caps.change_notifications);
+            true
+        } else {
+            // the server doesn't support multi workspaces, we need a new client
+            false
+        }
+    }
+
+    fn add_workspace_folder(
+        &self,
+        root_uri: Option<lsp::Url>,
+        change_notifications: &Option<OneOf<bool, String>>,
+    ) {
+        // root_uri is None just means that there isn't really any LSP workspace
+        // associated with this file. For servers that support multiple workspaces
+        // there is just one server so we can always just use that shared instance.
+        // No need to add a new workspace root here as there is no logical root for this file
+        // let the server deal with this
+        let Some(root_uri) = root_uri else {
+            return;
+        };
+
+        // server supports workspace folders, let's add the new root to the list
+        self.workspace_folders
+            .lock()
+            .push(workspace_for_uri(root_uri.clone()));
+        if &Some(OneOf::Left(false)) == change_notifications {
+            // server specifically opted out of DidWorkspaceChange notifications
+            // let's assume the server will request the workspace folders itself
+            // and that we can therefore reuse the client (but are done now)
+            return;
+        }
+        tokio::spawn(self.did_change_workspace(vec![workspace_for_uri(root_uri)], Vec::new()));
+    }
+
     #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
     pub fn start(
@@ -76,30 +200,25 @@ impl Client {
 
         let (server_rx, server_tx, initialize_notify) =
             Transport::start(reader, writer, stderr, id);
-
-        let root_path = find_root(
+        let (workspace, workspace_is_cwd) = find_workspace();
+        let root = find_lsp_workspace(
             doc_path
                 .and_then(|x| x.parent().and_then(|x| x.to_str()))
                 .unwrap_or("."),
             root_markers,
             manual_roots,
+            &workspace,
+            workspace_is_cwd,
         );
 
-        let root_uri = lsp::Url::from_file_path(root_path.clone()).ok();
+        // `root_uri` and `workspace_folder` can be empty in case there is no workspace
+        // `root_url` can not, use `workspace` as a fallback
+        let root_path = root.clone().unwrap_or_else(|| workspace.clone());
+        let root_uri = root.and_then(|root| lsp::Url::from_file_path(root).ok());
 
-        // TODO: support multiple workspace folders
         let workspace_folders = root_uri
             .clone()
-            .map(|root| {
-                vec![lsp::WorkspaceFolder {
-                    name: root
-                        .path_segments()
-                        .and_then(|segments| segments.last())
-                        .map(|basename| basename.to_string())
-                        .unwrap_or_default(),
-                    uri: root,
-                }]
-            })
+            .map(|root| vec![workspace_for_uri(root)])
             .unwrap_or_default();
 
         let client = Self {
@@ -110,10 +229,10 @@ impl Client {
             capabilities: OnceCell::new(),
             config,
             req_timeout,
-
             root_path,
             root_uri,
-            workspace_folders,
+            workspace_folders: Mutex::new(workspace_folders),
+            initalize_notify: initialize_notify.clone(),
         };
 
         Ok((client, server_rx, initialize_notify))
@@ -169,8 +288,10 @@ impl Client {
         self.config.as_ref()
     }
 
-    pub fn workspace_folders(&self) -> &[lsp::WorkspaceFolder] {
-        &self.workspace_folders
+    pub async fn workspace_folders(
+        &self,
+    ) -> parking_lot::MutexGuard<'_, Vec<lsp::WorkspaceFolder>> {
+        self.workspace_folders.lock()
     }
 
     /// Execute a RPC request on the language server.
@@ -298,7 +419,7 @@ impl Client {
         #[allow(deprecated)]
         let params = lsp::InitializeParams {
             process_id: Some(std::process::id()),
-            workspace_folders: Some(self.workspace_folders.clone()),
+            workspace_folders: Some(self.workspace_folders.lock().clone()),
             // root_path is obsolete, but some clients like pyright still use it so we specify both.
             // clients will prefer _uri if possible
             root_path: self.root_path.to_str().map(|path| path.to_owned()),
@@ -467,6 +588,16 @@ impl Client {
         self.notify::<lsp::notification::DidChangeConfiguration>(
             lsp::DidChangeConfigurationParams { settings },
         )
+    }
+
+    pub fn did_change_workspace(
+        &self,
+        added: Vec<WorkspaceFolder>,
+        removed: Vec<WorkspaceFolder>,
+    ) -> impl Future<Output = Result<()>> {
+        self.notify::<DidChangeWorkspaceFolders>(DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent { added, removed },
+        })
     }
 
     // -------------------------------------------------------------------------------------------

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1018,7 +1018,7 @@ impl Application {
                         let language_server =
                             self.editor.language_servers.get_by_id(server_id).unwrap();
 
-                        Ok(json!(language_server.workspace_folders()))
+                        Ok(json!(&*language_server.workspace_folders().await))
                     }
                     Ok(MethodCall::WorkspaceConfiguration(params)) => {
                         let result: Vec<_> = params

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -12,7 +12,7 @@ pub use typed::*;
 use helix_core::{
     char_idx_at_visual_offset, comment,
     doc_formatter::TextFormat,
-    encoding, find_first_non_whitespace_char, find_root, graphemes,
+    encoding, find_first_non_whitespace_char, find_workspace, graphemes,
     history::UndoKind,
     increment, indent,
     indent::IndentStyle,
@@ -2418,9 +2418,7 @@ fn append_mode(cx: &mut Context) {
 }
 
 fn file_picker(cx: &mut Context) {
-    // We don't specify language markers, root will be the root of the current
-    // git repo or the current dir if we're not in a repo
-    let root = find_root(None, &[]);
+    let root = find_workspace();
     let picker = ui::file_picker(root, &cx.editor.config());
     cx.push_layer(Box::new(overlayed(picker)));
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2418,7 +2418,7 @@ fn append_mode(cx: &mut Context) {
 }
 
 fn file_picker(cx: &mut Context) {
-    let root = find_workspace();
+    let root = find_workspace().0;
     let picker = ui::file_picker(root, &cx.editor.config());
     cx.push_layer(Box::new(overlayed(picker)));
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1371,13 +1371,16 @@ fn lsp_restart(
         return Ok(());
     }
 
+    let editor_config = cx.editor.config.load();
     let (_view, doc) = current!(cx.editor);
     let config = doc
         .language_config()
         .context("LSP not defined for the current document")?;
 
     let scope = config.scope.clone();
-    cx.editor.language_servers.restart(config, doc.path())?;
+    cx.editor
+        .language_servers
+        .restart(config, doc.path(), &editor_config.workspace_lsp_roots)?;
 
     // This collect is needed because refresh_language_server would need to re-borrow editor.
     let document_ids_to_refresh: Vec<DocumentId> = cx
@@ -1967,6 +1970,20 @@ fn open_config(
 
     cx.editor
         .open(&helix_loader::config_file(), Action::Replace)?;
+    Ok(())
+}
+
+fn open_workspace_config(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .open(&helix_loader::workspace_config_file(), Action::Replace)?;
     Ok(())
 }
 
@@ -2644,6 +2661,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Open the user config.toml file.",
             fun: open_config,
+            signature: CommandSignature::none(),
+        },
+        TypableCommand {
+            name: "config-open-workspace",
+            aliases: &[],
+            doc: "Open the workspace config.toml file.",
+            fun: open_workspace_config,
             signature: CommandSignature::none(),
         },
         TypableCommand {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,27 +1,34 @@
-use crate::keymap::{default::default, merge_keys, Keymap};
+use crate::keymap;
+use crate::keymap::{merge_keys, Keymap};
+use helix_loader::merge_toml_values;
 use helix_view::document::Mode;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::fs;
 use std::io::Error as IOError;
-use std::path::PathBuf;
 use toml::de::Error as TomlError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Config {
+    pub theme: Option<String>,
+    pub keys: HashMap<Mode, Keymap>,
+    pub editor: helix_view::editor::Config,
+}
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Config {
+pub struct ConfigRaw {
     pub theme: Option<String>,
-    #[serde(default = "default")]
-    pub keys: HashMap<Mode, Keymap>,
-    #[serde(default)]
-    pub editor: helix_view::editor::Config,
+    pub keys: Option<HashMap<Mode, Keymap>>,
+    pub editor: Option<toml::Value>,
 }
 
 impl Default for Config {
     fn default() -> Config {
         Config {
             theme: None,
-            keys: default(),
+            keys: keymap::default(),
             editor: helix_view::editor::Config::default(),
         }
     }
@@ -31,6 +38,12 @@ impl Default for Config {
 pub enum ConfigLoadError {
     BadConfig(TomlError),
     Error(IOError),
+}
+
+impl Default for ConfigLoadError {
+    fn default() -> Self {
+        ConfigLoadError::Error(IOError::new(std::io::ErrorKind::NotFound, "place holder"))
+    }
 }
 
 impl Display for ConfigLoadError {
@@ -43,23 +56,84 @@ impl Display for ConfigLoadError {
 }
 
 impl Config {
-    pub fn load(config_path: PathBuf) -> Result<Config, ConfigLoadError> {
-        match std::fs::read_to_string(config_path) {
-            Ok(config) => toml::from_str(&config)
-                .map(merge_keys)
-                .map_err(ConfigLoadError::BadConfig),
-            Err(err) => Err(ConfigLoadError::Error(err)),
-        }
+    pub fn load(
+        global: Result<String, ConfigLoadError>,
+        local: Result<String, ConfigLoadError>,
+    ) -> Result<Config, ConfigLoadError> {
+        let global_config: Result<ConfigRaw, ConfigLoadError> =
+            global.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
+        let local_config: Result<ConfigRaw, ConfigLoadError> =
+            local.and_then(|file| toml::from_str(&file).map_err(ConfigLoadError::BadConfig));
+        let res = match (global_config, local_config) {
+            (Ok(global), Ok(local)) => {
+                let mut keys = keymap::default();
+                if let Some(global_keys) = global.keys {
+                    merge_keys(&mut keys, global_keys)
+                }
+                if let Some(local_keys) = local.keys {
+                    merge_keys(&mut keys, local_keys)
+                }
+
+                let editor = match (global.editor, local.editor) {
+                    (None, None) => helix_view::editor::Config::default(),
+                    (None, Some(val)) | (Some(val), None) => {
+                        val.try_into().map_err(ConfigLoadError::BadConfig)?
+                    }
+                    (Some(global), Some(local)) => merge_toml_values(global, local, 3)
+                        .try_into()
+                        .map_err(ConfigLoadError::BadConfig)?,
+                };
+
+                Config {
+                    theme: local.theme.or(global.theme),
+                    keys,
+                    editor,
+                }
+            }
+            // if any configs are invalid return that first
+            (_, Err(ConfigLoadError::BadConfig(err)))
+            | (Err(ConfigLoadError::BadConfig(err)), _) => {
+                return Err(ConfigLoadError::BadConfig(err))
+            }
+            (Ok(config), Err(_)) | (Err(_), Ok(config)) => {
+                let mut keys = keymap::default();
+                if let Some(keymap) = config.keys {
+                    merge_keys(&mut keys, keymap);
+                }
+                Config {
+                    theme: config.theme,
+                    keys,
+                    editor: config.editor.map_or_else(
+                        || Ok(helix_view::editor::Config::default()),
+                        |val| val.try_into().map_err(ConfigLoadError::BadConfig),
+                    )?,
+                }
+            }
+            // these are just two io errors return the one for the global config
+            (Err(err), Err(_)) => return Err(err),
+        };
+
+        Ok(res)
     }
 
     pub fn load_default() -> Result<Config, ConfigLoadError> {
-        Config::load(helix_loader::config_file())
+        let global_config =
+            fs::read_to_string(helix_loader::config_file()).map_err(ConfigLoadError::Error);
+        let local_config = fs::read_to_string(helix_loader::workspace_config_file())
+            .map_err(ConfigLoadError::Error);
+        Config::load(global_config, local_config)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    impl Config {
+        fn load_test(config: &str) -> Config {
+            Config::load(Ok(config.to_owned()), Err(ConfigLoadError::default())).unwrap()
+        }
+    }
 
     #[test]
     fn parsing_keymaps_config_file() {
@@ -77,18 +151,24 @@ mod tests {
             A-F12 = "move_next_word_end"
         "#;
 
+        let mut keys = keymap::default();
+        merge_keys(
+            &mut keys,
+            hashmap! {
+                Mode::Insert => Keymap::new(keymap!({ "Insert mode"
+                    "y" => move_line_down,
+                    "S-C-a" => delete_selection,
+                })),
+                Mode::Normal => Keymap::new(keymap!({ "Normal mode"
+                    "A-F12" => move_next_word_end,
+                })),
+            },
+        );
+
         assert_eq!(
-            toml::from_str::<Config>(sample_keymaps).unwrap(),
+            Config::load_test(sample_keymaps),
             Config {
-                keys: hashmap! {
-                    Mode::Insert => Keymap::new(keymap!({ "Insert mode"
-                        "y" => move_line_down,
-                        "S-C-a" => delete_selection,
-                    })),
-                    Mode::Normal => Keymap::new(keymap!({ "Normal mode"
-                        "A-F12" => move_next_word_end,
-                    })),
-                },
+                keys,
                 ..Default::default()
             }
         );
@@ -97,11 +177,11 @@ mod tests {
     #[test]
     fn keys_resolve_to_correct_defaults() {
         // From serde default
-        let default_keys = toml::from_str::<Config>("").unwrap().keys;
-        assert_eq!(default_keys, default());
+        let default_keys = Config::load_test("").keys;
+        assert_eq!(default_keys, keymap::default());
 
         // From the Default trait
         let default_keys = Config::default().keys;
-        assert_eq!(default_keys, default());
+        assert_eq!(default_keys, keymap::default());
     }
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -3,7 +3,7 @@ use crossterm::event::EventStream;
 use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
-use helix_term::config::Config;
+use helix_term::config::{Config, ConfigLoadError};
 use std::path::PathBuf;
 
 fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
@@ -126,18 +126,19 @@ FLAGS:
 
     helix_loader::initialize_config_file(args.config_file.clone());
 
-    let config = match std::fs::read_to_string(helix_loader::config_file()) {
-        Ok(config) => toml::from_str(&config)
-            .map(helix_term::keymap::merge_keys)
-            .unwrap_or_else(|err| {
-                eprintln!("Bad config: {}", err);
-                eprintln!("Press <ENTER> to continue with default config");
-                use std::io::Read;
-                let _ = std::io::stdin().read(&mut []);
-                Config::default()
-            }),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Config::default(),
-        Err(err) => return Err(Error::new(err)),
+    let config = match Config::load_default() {
+        Ok(config) => config,
+        Err(ConfigLoadError::Error(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            Config::default()
+        }
+        Err(ConfigLoadError::Error(err)) => return Err(Error::new(err)),
+        Err(ConfigLoadError::BadConfig(err)) => {
+            eprintln!("Bad config: {}", err);
+            eprintln!("Press <ENTER> to continue with default config");
+            use std::io::Read;
+            let _ = std::io::stdin().read(&mut []);
+            Config::default()
+        }
     };
 
     let syn_loader_conf = helix_core::config::user_syntax_loader().unwrap_or_else(|err| {

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::File,
     io::{Read, Write},
+    mem::replace,
     path::PathBuf,
     time::Duration,
 };
@@ -222,10 +223,11 @@ pub fn temp_file_with_contents<S: AsRef<str>>(
 
 /// Generates a config with defaults more suitable for integration tests
 pub fn test_config() -> Config {
-    merge_keys(Config {
+    Config {
         editor: test_editor_config(),
+        keys: helix_term::keymap::default(),
         ..Default::default()
-    })
+    }
 }
 
 pub fn test_editor_config() -> helix_view::editor::Config {
@@ -300,8 +302,10 @@ impl AppBuilder {
 
     // Remove this attribute once `with_config` is used in a test:
     #[allow(dead_code)]
-    pub fn with_config(mut self, config: Config) -> Self {
-        self.config = helix_term::keymap::merge_keys(config);
+    pub fn with_config(mut self, mut config: Config) -> Self {
+        let keys = replace(&mut config.keys, helix_term::keymap::default());
+        merge_keys(&mut config.keys, keys);
+        self.config = config;
         self
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -281,6 +281,8 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     pub soft_wrap: SoftWrap,
+    /// Workspace specific lsp ceiling dirs
+    pub workspace_lsp_roots: Vec<PathBuf>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -751,6 +753,7 @@ impl Default for Config {
             soft_wrap: SoftWrap::default(),
             text_width: 80,
             completion_replace: false,
+            workspace_lsp_roots: Vec::new(),
         }
     }
 }
@@ -1091,15 +1094,14 @@ impl Editor {
         }
 
         // if doc doesn't have a URL it's a scratch buffer, ignore it
-        let (lang, path) = {
-            let doc = self.document(doc_id)?;
-            (doc.language.clone(), doc.path().cloned())
-        };
+        let doc = self.document(doc_id)?;
+        let (lang, path) = (doc.language.clone(), doc.path().cloned());
+        let root_dirs = &doc.config.load().workspace_lsp_roots;
 
         // try to find a language server based on the language name
         let language_server = lang.as_ref().and_then(|language| {
             self.language_servers
-                .get(language, path.as_ref())
+                .get(language, path.as_ref(), root_dirs)
                 .map_err(|e| {
                     log::error!(
                         "Failed to initialize the LSP for `{}` {{ {} }}",


### PR DESCRIPTION
Supersedes #4439 and (mostly) #3207
Fixes: #3993
Fixes: #4436
fixes #5852
Closes #5919

The aim of this PR is primarily to address the problem from #4439 as described in https://github.com/helix-editor/helix/pull/4439#issuecomment-1345568363. As the solution described there uses a workspace config I ended up implementing support for that as well. The syntax I proposed in https://github.com/helix-editor/helix/pull/4439#issuecomment-1345568363 didn't quite work out as adding a new top-level header (that can be accessed in `helix-view`) like `[workspace]` would have required more changes that didn't seem worth the effort here. Furthermore, the language specialization I proposed in my comment is incompatible with the toml standard (sadly). I ended up with the following solution:

To force LSP to stop searching for roots in the `fuzz` folder you can
add the following `.helix/config.toml` file:
``` toml
[editor]
workspace-lsp-roots = ["fuzz"]
```

To only apply this setting only to `rust` (but not other languages where this might cause problems) you can add the following `.helix/languages.toml` file instead:

``` toml
[[language]]
name = "rust"
workspace-lsp-roots = ["fuzz"]
```

To handle local config I originally wanted to pull in #3207, but when I started reviewing the changes there I quickly found many things that required changes so that I decided to reimplement the functionality here instead. Compared to #3207 this PR does not implement the security setting for workspace config. It's disabled by default anyway so that feature can be added as a separate followup PR (or #3207 could be rebased on this)

Furthermore, this PR correctly handles:
* Respect local config during `:config-reload` and `:set` (would require larger refactor with #3207)
* Full keymap merging of arbitrary nested keybindings (just like merging with the default keymap works on master)
* Unify config loading in `helix-term/src/main.rs` and during config-reload/set

Finally, this PR contains on breaking change: How `.helix` is treated. Currently, we simply merge all `.helix/langauges.toml` from the CWD to the workspace root. This PR changes the workspace lookup so `.helix` acts just like `.git`. It's not intended for marking LSP roots (that's what `workspace-roots` is for) but rather for cases where:
* You are working without `git`
* Monorepos where you want to really only work on part of the repo as a workspace (I am talking HUGE monorepos like the windows monorepo) for all operations (including the file picker)

As the workspace root search always stops at the first `.helix` directory, there is only a single `.helix/config.toml` and `.helix/languages.toml`, so the merging behavior is removed (breaking change I was talking about). In addition to the use-cases listed above this also ensure that it's always clear what the `workspace-roots` setting is referring to: A path relative to the parent of `.helix`. When multiple configs are merged it can be quite confusing what these directories refer to otherwise. Finally, this behavior is also more inline with other editors (like `.vscode` for VSCode).


