### PR TITLE
Adds support for right-hand gutters and Scrollbar gutter item

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -34,7 +34,7 @@
 | `cursorline` | Highlight all lines with a cursor | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `true` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
+| `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer` and `scrollbar`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `gutters` | Gutters to display on the right-hand side of the window. Configuration is identical to the `gutters` key above, but specified gutters will be rendered right-to-left. | `[]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -35,6 +35,7 @@
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `true` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
+| `gutters` | Gutters to display on the right-hand side of the window. Configuration is identical to the `gutters` key above, but specified gutters will be rendered right-to-left. | `[]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -16,6 +16,7 @@
   - [`[editor.gutters.diagnostics]` Section](#editorguttersdiagnostics-section)
   - [`[editor.gutters.diff]` Section](#editorguttersdiff-section)
   - [`[editor.gutters.spacer]` Section](#editorguttersspacer-section)
+- [`[editor.gutters-right]` Section](#editorgutters-right-section)
 - [`[editor.soft-wrap]` Section](#editorsoft-wrap-section)
 - [`[editor.smart-tab]` Section](#editorsmart-tab-section)
 - [`[editor.inline-diagnostics]` Section](#editorinline-diagnostics-section)

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -35,7 +35,7 @@
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `true` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer` and `scrollbar`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
-| `gutters` | Gutters to display on the right-hand side of the window. Configuration is identical to the `gutters` key above, but specified gutters will be rendered right-to-left. | `[]` |
+| `gutters-right` | Gutters to display on the right-hand side of the window. Configuration is identical to the `gutters` key above, but specified gutters will be rendered right-to-left. | `[]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
@@ -380,6 +380,19 @@ Other diff providers will eventually be supported by a future plugin system.
 There are currently no options for this section.
 
 #### `[editor.gutters.spacer]` Section
+
+Currently unused
+
+#### `[editor.gutters.scrollbar]` Section
+
+### `[editor.gutters-right]` Section
+
+Configuration options are identical to `[editor.gutters]` Section.
+
+```toml
+[editor]
+gutters-right = ["scrollbar"]
+```
 
 Currently unused
 

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -247,6 +247,14 @@ pub fn render_text(
         last_line_end = grapheme.visual_pos.col + grapheme_width;
     }
 
+    let remaining_viewport_lines =
+        last_line_pos.visual_line..renderer.viewport.height.saturating_sub(1);
+    for _ in remaining_viewport_lines {
+        last_line_pos.doc_line += 1;
+        last_line_pos.visual_line += 1;
+        decorations.decorate_line(renderer, last_line_pos);
+    }
+
     renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
     decorations.render_virtual_lines(renderer, last_line_pos, last_line_end)
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -163,7 +163,7 @@ impl EditorView {
             }
         }
 
-        let gutter_overflow = view.gutter_offset(doc) == 0;
+        let gutter_overflow = view.gutter_offset(doc) + view.gutter_offset_right(doc) == 0;
         if !gutter_overflow {
             Self::render_gutters(
                 editor,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -710,6 +710,8 @@ pub enum GutterType {
     Spacer,
     /// Highlight local changes
     Diff,
+    /// Show scrollbar
+    Scrollbar,
 }
 
 impl std::str::FromStr for GutterType {
@@ -721,8 +723,9 @@ impl std::str::FromStr for GutterType {
             "spacer" => Ok(Self::Spacer),
             "line-numbers" => Ok(Self::LineNumbers),
             "diff" => Ok(Self::Diff),
+            "scrollbar" => Ok(Self::Scrollbar),
             _ => anyhow::bail!(
-                "Gutter type can only be `diagnostics`, `spacer`, `line-numbers` or `diff`."
+                "Gutter type can only be `diagnostics`, `spacer`, `line-numbers`, `diff`, or `scrollbar`."
             ),
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -263,6 +263,8 @@ pub struct Config {
     pub cursorcolumn: bool,
     #[serde(deserialize_with = "deserialize_gutter_seq_or_struct")]
     pub gutters: GutterConfig,
+    #[serde(deserialize_with = "deserialize_gutter_seq_or_struct")]
+    pub gutters_right: GutterConfig,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
     /// Automatic insertion of pairs to parentheses, brackets,
@@ -969,6 +971,7 @@ impl Default for Config {
             cursorline: false,
             cursorcolumn: false,
             gutters: GutterConfig::default(),
+            gutters_right: GutterConfig::from(Vec::new()),
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
@@ -1679,7 +1682,13 @@ impl Editor {
                     .try_get(self.tree.focus)
                     .filter(|v| id == v.doc) // Different Document
                     .cloned()
-                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
+                    .unwrap_or_else(|| {
+                        View::new(
+                            id,
+                            self.config().gutters.clone(),
+                            self.config().gutters_right.clone(),
+                        )
+                    });
                 let view_id = self.tree.split(
                     view,
                     match action {
@@ -1863,7 +1872,11 @@ impl Editor {
                 .map(|(&doc_id, _)| doc_id)
                 .next()
                 .unwrap_or_else(|| self.new_document(Document::default(self.config.clone())));
-            let view = View::new(doc_id, self.config().gutters.clone());
+            let view = View::new(
+                doc_id,
+                self.config().gutters.clone(),
+                self.config().gutters_right.clone(),
+            );
             let view_id = self.tree.insert(view);
             let doc = doc_mut!(self, &doc_id);
             doc.ensure_view_init(view_id);

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -338,7 +338,11 @@ mod tests {
 
     #[test]
     fn test_default_gutter_widths() {
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -363,7 +367,11 @@ mod tests {
             ..Default::default()
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(
+            DocumentId::default(),
+            gutters,
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -381,7 +389,11 @@ mod tests {
             line_numbers: GutterLineNumbersConfig { min_width: 10 },
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(
+            DocumentId::default(),
+            gutters,
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -403,7 +415,11 @@ mod tests {
             line_numbers: GutterLineNumbersConfig { min_width: 1 },
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(
+            DocumentId::default(),
+            gutters,
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("a\nb");

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -207,7 +207,9 @@ pub fn line_numbers<'doc>(
 
     Box::new(
         move |line: usize, selected: bool, first_visual_line: bool, out: &mut String| {
-            if line == last_line_in_view && !draw_last {
+            if line > last_line_in_view {
+                None
+            } else if line == last_line_in_view && !draw_last {
                 write!(out, "{:>1$}", '~', width).unwrap();
                 Some(linenr)
             } else {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -736,22 +736,38 @@ mod test {
             width: 180,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
 
         // Tree in test
@@ -792,28 +808,44 @@ mod test {
         });
 
         let doc_l0 = DocumentId::default();
-        let mut view = View::new(doc_l0, GutterConfig::default());
+        let mut view = View::new(
+            doc_l0,
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
 
         let doc_r0 = DocumentId::default();
-        let view = View::new(doc_r0, GutterConfig::default());
+        let view = View::new(
+            doc_r0,
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
 
         let doc_l1 = DocumentId::default();
-        let view = View::new(doc_l1, GutterConfig::default());
+        let view = View::new(
+            doc_l1,
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
 
         let doc_l2 = DocumentId::default();
-        let view = View::new(doc_l2, GutterConfig::default());
+        let view = View::new(
+            doc_l2,
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;
 
@@ -908,19 +940,35 @@ mod test {
             width: tree_area_width,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Horizontal);
 
         tree.remove(tree.focus);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         tree.split(view, Layout::Vertical);
 
         // Make sure that we only have one level in the tree.
@@ -946,12 +994,20 @@ mod test {
             width: tree_area_width,
             height: tree_area_height,
         });
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(
+            DocumentId::default(),
+            GutterConfig::default(),
+            GutterConfig::from(Vec::new()),
+        );
         view.area = Rect::new(0, 0, tree_area_width, tree_area_height);
         tree.insert(view);
 
         for _ in 0..9 {
-            let view = View::new(DocumentId::default(), GutterConfig::default());
+            let view = View::new(
+                DocumentId::default(),
+                GutterConfig::default(),
+                GutterConfig::from(Vec::new()),
+            );
             tree.split(view, Layout::Vertical);
         }
 


### PR DESCRIPTION
Relates to https://github.com/helix-editor/helix/issues/2210

First time contributor, so please let me know if I'm missing anything!

## Overview
- Adds support for gutter items rendered on the right-hand side of the view
- Adds support for a new "scrollbar" gutter item
  - Note: this item is not added to the default configuration for the left- or right-hand gutter

## Architectural Changes
- A `gutters-right` configuration option is exposed as a sibling to the existing `gutters` option
- `View` now accepts an additional `gutters_right` parameter as a `GutterConfig` object
- Gutter item functions are now called for each visible line in the view, rather than stopping at the last line of document contents
  - See `last_line` initialization within `render_gutter_item` for more context
- A `Scrollbar` variant was added to the `GutterType` enum

## Design feedback needed
This `gutters` vs. `gutters-right` implementation seemed like the easiest approach (and was also passive to the existing config file setup), but I quite like how the `editor.statusline` configuration is subdivided into `left`, `center`, and `right` partitions.

- [ ] Should we wrap gutter configuration into similar `left` and `right` partitions?