### PR TITLE
Do not add intermediate lines to jumplist with :<linenum> command.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2715,10 +2715,15 @@ fn push_jump(view: &mut View, doc: &Document) {
 }
 
 fn goto_line(cx: &mut Context) {
-    goto_line_impl(cx.editor, cx.count)
+    if cx.count.is_some() {
+        goto_line_without_jumplist(cx.editor, cx.count);
+
+        let (view, doc) = current!(cx.editor);
+        push_jump(view, doc);
+    }
 }
 
-fn goto_line_impl(editor: &mut Editor, count: Option<NonZeroUsize>) {
+fn goto_line_without_jumplist(editor: &mut Editor, count: Option<NonZeroUsize>) {
     if let Some(count) = count {
         let (view, doc) = current!(editor);
         let text = doc.text().slice(..);
@@ -2735,7 +2740,6 @@ fn goto_line_impl(editor: &mut Editor, count: Option<NonZeroUsize>) {
             .clone()
             .transform(|range| range.put_cursor(text, pos, editor.mode == Mode::Select));
 
-        push_jump(view, doc);
         doc.set_selection(view.id, selection);
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4313,18 +4313,15 @@ fn jump_forward(cx: &mut Context) {
 }
 
 fn jump_backward(cx: &mut Context) {
-    jump_backward_impl(cx.editor, cx.count());
-}
-
-fn jump_backward_impl(editor: &mut Editor, count: usize) {
-    let config = editor.config();
-    let (view, doc) = current!(editor);
+    let count = cx.count();
+    let config = cx.editor.config();
+    let (view, doc) = current!(cx.editor);
     let doc_id = doc.id();
 
     if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
         view.doc = *id;
         let selection = selection.clone();
-        let (view, doc) = current!(editor); // refetch doc
+        let (view, doc) = current!(cx.editor); // refetch doc
 
         if doc.id() != doc_id {
             view.add_to_history(doc_id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2716,10 +2716,10 @@ fn push_jump(view: &mut View, doc: &Document) {
 
 fn goto_line(cx: &mut Context) {
     if cx.count.is_some() {
-        goto_line_without_jumplist(cx.editor, cx.count);
-
         let (view, doc) = current!(cx.editor);
         push_jump(view, doc);
+
+        goto_line_without_jumplist(cx.editor, cx.count);
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4313,15 +4313,18 @@ fn jump_forward(cx: &mut Context) {
 }
 
 fn jump_backward(cx: &mut Context) {
-    let count = cx.count();
-    let config = cx.editor.config();
-    let (view, doc) = current!(cx.editor);
+    jump_backward_impl(cx.editor, cx.count());
+}
+
+fn jump_backward_impl(editor: &mut Editor, count: usize) {
+    let config = editor.config();
+    let (view, doc) = current!(editor);
     let doc_id = doc.id();
 
     if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
         view.doc = *id;
         let selection = selection.clone();
-        let (view, doc) = current!(cx.editor); // refetch doc
+        let (view, doc) = current!(editor); // refetch doc
 
         if doc.id() != doc_id {
             view.add_to_history(doc_id);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1412,15 +1412,9 @@ fn tutor(
 
 fn undo_goto_line_number_preview(cx: &mut compositor::Context) {
     if cx.editor.goto_line_number_preview {
-        log::info!("undoing goto_line_number preview, jumping backwards");
-        // if let Some(line_number) = cx.editor.last_line_number {
-        // goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line_number));
-
         // Remove the jump we added during the preview session.
         jump_backward_impl(cx.editor, 1);
 
-        // let (view, doc) = current!(cx.editor);
-        // view.ensure_cursor_in_view(doc, line_number);
         cx.editor.goto_line_number_preview = false;
     }
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1445,15 +1445,20 @@ pub(super) fn goto_line_number(
                 }
                 return Ok(());
             }
-            let (view, doc) = current!(cx.editor);
-            let text = doc.text().slice(..);
-            let line = doc.selection(view.id).primary().cursor_line(text);
-            cx.editor.last_line_number.get_or_insert(line + 1);
 
-            let line = args[0].parse::<usize>()?;
-            goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line));
+            cx.editor.last_line_number.get_or_insert_with(|| {
+                let (view, doc) = current!(cx.editor);
+
+                let text = doc.text().slice(..);
+                let line = doc.selection(view.id).primary().cursor_line(text);
+
+                line + 1
+            });
+
             let (view, doc) = current!(cx.editor);
+            let line = args[0].parse::<usize>()?;
             view.ensure_cursor_in_view(doc, line);
+            goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line));
         }
     }
     Ok(())

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1410,53 +1410,60 @@ fn tutor(
     Ok(())
 }
 
+fn undo_goto_line_number_preview(cx: &mut compositor::Context) {
+    if cx.editor.goto_line_number_preview {
+        log::info!("undoing goto_line_number preview, jumping backwards");
+        // if let Some(line_number) = cx.editor.last_line_number {
+        // goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line_number));
+
+        // Remove the jump we added during the preview session.
+        jump_backward_impl(cx.editor, 1);
+
+        // let (view, doc) = current!(cx.editor);
+        // view.ensure_cursor_in_view(doc, line_number);
+        cx.editor.goto_line_number_preview = false;
+    }
+}
+
+fn start_goto_line_number_preview(cx: &mut compositor::Context) {
+    if !cx.editor.goto_line_number_preview {
+        let (view, doc) = current!(cx.editor);
+
+        // Allow the user to jump back to the previous location before invoking
+        // `goto_line_number`.
+        push_jump(view, doc);
+
+        cx.editor.goto_line_number_preview = true;
+    }
+}
+
 pub(super) fn goto_line_number(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     match event {
-        PromptEvent::Abort => {
-            if let Some(line_number) = cx.editor.last_line_number {
-                goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line_number));
-                let (view, doc) = current!(cx.editor);
-                view.ensure_cursor_in_view(doc, line_number);
-                cx.editor.last_line_number = None;
-            }
-            return Ok(());
-        }
+        PromptEvent::Abort => undo_goto_line_number_preview(cx),
+
         PromptEvent::Validate => {
             ensure!(!args.is_empty(), "Line number required");
-
-            let (view, doc) = current!(cx.editor);
-            push_jump(view, doc);
-
-            cx.editor.last_line_number = None;
+            cx.editor.goto_line_number_preview = false;
         }
+
         PromptEvent::Update => {
+            // When a user hits backspace and there are no numbers left,
+            // we can bring them back to their original selection(s).
             if args.is_empty() {
-                if let Some(line_number) = cx.editor.last_line_number {
-                    // When a user hits backspace and there are no numbers left,
-                    // we can bring them back to their original line
-                    goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line_number));
-                    let (view, doc) = current!(cx.editor);
-                    view.ensure_cursor_in_view(doc, line_number);
-                    cx.editor.last_line_number = None;
-                }
+                undo_goto_line_number_preview(cx);
                 return Ok(());
             }
+            if !cx.editor.goto_line_number_preview {
+                start_goto_line_number_preview(cx);
+            }
 
-            cx.editor.last_line_number.get_or_insert_with(|| {
-                let (view, doc) = current!(cx.editor);
-
-                let text = doc.text().slice(..);
-                let line = doc.selection(view.id).primary().cursor_line(text);
-
-                line + 1
-            });
+            let line = args[0].parse::<usize>()?;
 
             let (view, doc) = current!(cx.editor);
-            let line = args[0].parse::<usize>()?;
             view.ensure_cursor_in_view(doc, line);
             goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line));
         }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1415,7 +1415,7 @@ fn abort_goto_line_number_preview(cx: &mut compositor::Context) {
         let scrolloff = cx.editor.config().scrolloff;
 
         let (view, doc) = current!(cx.editor);
-        doc.set_selection(view.id, last_selection.clone());
+        doc.set_selection(view.id, last_selection);
         view.ensure_cursor_in_view(doc, scrolloff);
     }
 }
@@ -1454,10 +1454,14 @@ pub(super) fn goto_line_number(
             // is moved to the appropriate location.
             update_goto_line_number_preview(cx, args)?;
 
-            if let Some(last_selection) = cx.editor.last_selection.take() {
-                let (view, doc) = current!(cx.editor);
-                view.jumps.push((doc.id(), last_selection.clone()));
-            }
+            let last_selection = cx
+                .editor
+                .last_selection
+                .take()
+                .expect("update_goto_line_number_preview should always set last_selection");
+
+            let (view, doc) = current!(cx.editor);
+            view.jumps.push((doc.id(), last_selection));
         }
 
         // When a user hits backspace and there are no numbers left,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1411,12 +1411,12 @@ fn tutor(
 }
 
 fn abort_goto_line_number_preview(cx: &mut compositor::Context) {
-    if let Some(last_selection) = &cx.editor.last_selection {
+    if let Some(last_selection) = cx.editor.last_selection.take() {
         let scrolloff = cx.editor.config().scrolloff;
+
         let (view, doc) = current!(cx.editor);
         doc.set_selection(view.id, last_selection.clone());
         view.ensure_cursor_in_view(doc, scrolloff);
-        cx.editor.last_selection = None;
     }
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1412,9 +1412,15 @@ fn tutor(
 
 fn undo_goto_line_number_preview(cx: &mut compositor::Context) {
     if cx.editor.goto_line_number_preview {
+        log::info!("undoing goto_line_number preview, jumping backwards");
+        // if let Some(line_number) = cx.editor.last_line_number {
+        // goto_line_without_jumplist(cx.editor, NonZeroUsize::new(line_number));
+
         // Remove the jump we added during the preview session.
         jump_backward_impl(cx.editor, 1);
 
+        // let (view, doc) = current!(cx.editor);
+        // view.ensure_cursor_in_view(doc, line_number);
         cx.editor.goto_line_number_preview = false;
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -793,10 +793,7 @@ pub struct Editor {
     /// The currently applied editor theme. While previewing a theme, the previewed theme
     /// is set here.
     pub theme: Theme,
-
-    // Are we currently previewing a goto_line_number typed command (`:goto <linenum>`, `:<linenum>`)?
-    pub goto_line_number_preview: bool,
-
+    pub last_line_number: Option<usize>,
     pub status_msg: Option<(Cow<'static, str>, Severity)>,
     pub autoinfo: Option<Info>,
 
@@ -899,7 +896,7 @@ impl Editor {
             syn_loader,
             theme_loader,
             last_theme: None,
-            goto_line_number_preview: false,
+            last_line_number: None,
             registers: Registers::default(),
             clipboard_provider: get_clipboard_provider(),
             status_msg: None,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -38,12 +38,12 @@ use anyhow::{anyhow, bail, Error};
 
 pub use helix_core::diagnostic::Severity;
 pub use helix_core::register::Registers;
-use helix_core::Position;
 use helix_core::{
     auto_pairs::AutoPairs,
     syntax::{self, AutoPairConfig},
     Change,
 };
+use helix_core::{Position, Selection};
 use helix_dap as dap;
 use helix_lsp::lsp;
 
@@ -793,7 +793,12 @@ pub struct Editor {
     /// The currently applied editor theme. While previewing a theme, the previewed theme
     /// is set here.
     pub theme: Theme,
-    pub last_line_number: Option<usize>,
+
+    /// The primary Selection prior to starting a goto_line_number preview. This is
+    /// restored when the preview is aborted, or added to the jumplist when it is
+    /// confirmed.
+    pub last_selection: Option<Selection>,
+
     pub status_msg: Option<(Cow<'static, str>, Severity)>,
     pub autoinfo: Option<Info>,
 
@@ -896,7 +901,7 @@ impl Editor {
             syn_loader,
             theme_loader,
             last_theme: None,
-            last_line_number: None,
+            last_selection: None,
             registers: Registers::default(),
             clipboard_provider: get_clipboard_provider(),
             status_msg: None,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -793,7 +793,10 @@ pub struct Editor {
     /// The currently applied editor theme. While previewing a theme, the previewed theme
     /// is set here.
     pub theme: Theme,
-    pub last_line_number: Option<usize>,
+
+    // Are we currently previewing a goto_line_number typed command (`:goto <linenum>`, `:<linenum>`)?
+    pub goto_line_number_preview: bool,
+
     pub status_msg: Option<(Cow<'static, str>, Severity)>,
     pub autoinfo: Option<Info>,
 
@@ -896,7 +899,7 @@ impl Editor {
             syn_loader,
             theme_loader,
             last_theme: None,
-            last_line_number: None,
+            goto_line_number_preview: false,
             registers: Registers::default(),
             clipboard_provider: get_clipboard_provider(),
             status_msg: None,

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -21,21 +21,18 @@ type Jump = (DocumentId, Selection);
 #[derive(Debug, Clone)]
 pub struct JumpList {
     jumps: VecDeque<Jump>,
-    current_idx: usize,
+    current: usize,
 }
 
 impl JumpList {
     pub fn new(initial: Jump) -> Self {
         let mut jumps = VecDeque::with_capacity(JUMP_LIST_CAPACITY);
         jumps.push_back(initial);
-        Self {
-            jumps,
-            current_idx: 0,
-        }
+        Self { jumps, current: 0 }
     }
 
     pub fn push(&mut self, jump: Jump) {
-        self.jumps.truncate(self.current_idx + 1);
+        self.jumps.truncate(self.current);
         // don't push duplicates
         if self.jumps.back() != Some(&jump) {
             // If the jumplist is full, drop the oldest item.
@@ -44,14 +41,14 @@ impl JumpList {
             }
 
             self.jumps.push_back(jump);
-            self.current_idx = self.jumps.len() - 1;
+            self.current = self.jumps.len();
         }
     }
 
     pub fn forward(&mut self, count: usize) -> Option<&Jump> {
-        if self.current_idx + count < self.jumps.len() {
-            self.current_idx += count;
-            self.jumps.get(self.current_idx)
+        if self.current + count < self.jumps.len() {
+            self.current += count;
+            self.jumps.get(self.current)
         } else {
             None
         }
@@ -59,13 +56,13 @@ impl JumpList {
 
     // Taking view and doc to prevent unnecessary cloning when jump is not required.
     pub fn backward(&mut self, view_id: ViewId, doc: &mut Document, count: usize) -> Option<&Jump> {
-        if let Some(current) = self.current_idx.checked_sub(count) {
-            if self.current_idx == self.jumps.len() {
+        if let Some(current) = self.current.checked_sub(count) {
+            if self.current == self.jumps.len() {
                 let jump = (doc.id(), doc.selection(view_id).clone());
                 self.push(jump);
             }
-            self.current_idx = current;
-            self.jumps.get(self.current_idx)
+            self.current = current;
+            self.jumps.get(self.current)
         } else {
             None
         }


### PR DESCRIPTION
Based on [this discussion](https://github.com/helix-editor/helix/discussions/5741). (@the-mikedavis)

This patch:
* Only appends to the jumplist when the `:<linenum>` invocation is accepted with <kbd>Enter</kbd> (`PromptEvent::Validate`).
* Fixes what appears to be a bug in the jumplist behavior where the `current` pointer points past the end of the list when it's appended to, resulting in a "dead" invocation of `C-o`. This caused issues with the previous implementation especially, as it would append to the list _twice_ implicitly during validate (since the movement logic previous lived outside the handler for the `PromptEvent::Update` event.
