### PR TITLE
Add C-j and C-k key bindings to Picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -618,10 +618,10 @@ impl<T: Item + 'static> Component for Picker<T> {
         cx.editor.reset_idle_timer();
 
         match key_event {
-            shift!(Tab) | key!(Up) | ctrl!('p') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') | ctrl!('k') => {
                 self.move_by(1, Direction::Backward);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') => {
+            key!(Tab) | key!(Down) | ctrl!('n') | ctrl!('j') => {
                 self.move_by(1, Direction::Forward);
             }
             key!(PageDown) | ctrl!('d') => {


### PR DESCRIPTION
Adds C-j and C-k bindings to the Picker components in order to align with the menu (e.g. auto completion) bindings that also let you navigate with those keys.