### PR TITLE
theme(onedark): Add ui.highlight scope

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -59,9 +59,11 @@
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.match" = { fg = "blue", modifiers = ["underlined"]}
 
-"ui.selection" = { bg = "light-gray" }
+"ui.selection" = { bg = "faint-gray" }
 "ui.selection.primary" = { bg = "gray" }
 "ui.cursorline.primary" = { bg = "light-black" }
+
+"ui.highlight" = { bg = "gray" }
 
 "ui.linenr" = { fg = "linenr" }
 "ui.linenr.selected" = { fg = "white" }


### PR DESCRIPTION
ui.highlight is used in hightlighting lines in the picker preview. Also change the grey shade of the secondary selections to not obstruct comment text (earlier the bg of secondary selections and fg of comments were the same).

Fixes #5750.