### PR TITLE
feature: add a `toggle-option` command

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2438,7 +2438,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &["toggle"],
             doc: "Toggle a boolean config option at runtime.\nFor example to toggle smart case search, use `:toggle search.smart-case`.",
             fun: toggle_option,
-            completer: Some(completers::setting),
+            completer: Some(completers::boolean_setting),
         },
         TypableCommand {
             name: "get-option",


### PR DESCRIPTION
This commands allows to toggle boolean options, with a dedicated completer that only suggests boolean options
It does not support other enumerated types.

> :toggle softwrap.enable

Alternative options:

> :set !softwrap.enable # ok as well (as long as options cannot start with a !), consistent with vim, i think
> :set softwrap.enable ! # possibly ambiguous