### PR TITLE
feat: Update `tree-sitter-sql` and migrate `highlights.scm` to match grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1434,7 +1434,7 @@ injection-regex = "sql"
 
 [[grammar]]
 name = "sql"
-source = { git = "https://github.com/DerekStride/tree-sitter-sql", rev = "4fe05b2d81565ddb689d2f415e07afdacc515c52" }
+source = { git = "https://github.com/DerekStride/tree-sitter-sql", rev = "286e10c5bc5d1703ee8f9afb351165a9a6182be1" }
 
 [[language]]
 name = "gdscript"

--- a/runtime/queries/sql/highlights.scm
+++ b/runtime/queries/sql/highlights.scm
@@ -5,13 +5,16 @@
 (keyword_gin) @function.builtin
 (keyword_brin) @function.builtin
 
-(invocation
-  name: (identifier) @function.builtin
-  parameter: [(field)]? @variable.other.member)
+(cast
+  name: (identifier) @function.builtin)
   
 (count
-  name: (identifier) @function.builtin
-  parameter: [(field)]? @variable.other.member)
+  name: (identifier) @function.builtin)
+
+(keyword_group_concat) @function.builtin  
+
+(invocation
+  name: (identifier) @function.builtin)
   
 (table_reference
   name: (identifier) @namespace)
@@ -25,7 +28,6 @@
 (field
   table_alias: (identifier) @variable.parameter
   name: (identifier) @variable.other.member)
-
 
 (comment) @comment
 
@@ -100,12 +102,16 @@
   (keyword_as)
   (keyword_distinct)
   (keyword_constraint)
+  ; (keyword_cast)
   ; (keyword_count)
+  ; (keyword_group_concat)
+  (keyword_separator)
   (keyword_max)
   (keyword_min)
   (keyword_avg)
   (keyword_end)
   (keyword_force)
+  (keyword_ignore)
   (keyword_using)
   (keyword_use)
   (keyword_index)
@@ -115,8 +121,6 @@
   (keyword_auto_increment)
   (keyword_default)
   (keyword_cascade)
-  (keyword_between)
-  (keyword_window)
   (keyword_with)
   (keyword_no)
   (keyword_data)
@@ -127,6 +131,7 @@
   (keyword_owner)
   (keyword_temp)
   (keyword_temporary)
+  (keyword_unlogged)
   (keyword_union)
   (keyword_all)
   (keyword_except)
@@ -136,8 +141,35 @@
   (keyword_commit)
   (keyword_rollback)
   (keyword_transaction)
-  (keyword_group_concat)
-  (keyword_separator)
+  (keyword_over)
+  (keyword_nulls)
+  (keyword_first)
+  (keyword_last)
+  (keyword_window)
+  (keyword_range)
+  (keyword_rows)
+  (keyword_groups)
+  (keyword_between)
+  (keyword_unbounded)
+  (keyword_preceding)
+  (keyword_following)
+  (keyword_exclude)
+  (keyword_current)
+  (keyword_row)
+  (keyword_ties)
+  (keyword_others)
+  (keyword_only)
+  (keyword_unique)
+  (keyword_concurrently)
+  ; (keyword_btree)
+  ; (keyword_hash)
+  ; (keyword_gist)
+  ; (keyword_spgist)
+  ; (keyword_gin)
+  ; (keyword_brin)
+  (keyword_like)
+  (keyword_similar)
+  (keyword_preserve)
 ] @keyword
 
 [
@@ -157,6 +189,7 @@
 
 [
   (keyword_boolean)
+
   (keyword_smallserial)
   (keyword_serial)
   (keyword_bigserial)
@@ -193,4 +226,15 @@
   (keyword_geography)
   (keyword_box2d)
   (keyword_box3d)
+
+  (char)
+  (varchar)
+  (numeric)
+
+  (keyword_oid)
+  (keyword_name)
+  (keyword_regclass)
+  (keyword_regnamespace)
+  (keyword_regproc)
+  (keyword_regtype)
 ] @type.builtin

--- a/runtime/queries/sql/highlights.scm
+++ b/runtime/queries/sql/highlights.scm
@@ -1,7 +1,6 @@
-(keyword_gist) @function.builtin
-(keyword_btree) @function.builtin
 (keyword_btree) @function.builtin
 (keyword_hash) @function.builtin
+(keyword_gist) @function.builtin
 (keyword_spgist) @function.builtin
 (keyword_gin) @function.builtin
 (keyword_brin) @function.builtin

--- a/runtime/queries/sql/highlights.scm
+++ b/runtime/queries/sql/highlights.scm
@@ -4,7 +4,6 @@
 (keyword_spgist) @function.builtin
 (keyword_gin) @function.builtin
 (keyword_brin) @function.builtin
-(keyword_float) @function.builtin
 
 (invocation
   name: (identifier) @function.builtin
@@ -169,6 +168,7 @@
   (numeric)
   (keyword_real)
   (double)
+  (float)
 
   (keyword_money)
 


### PR DESCRIPTION
# Upstream changes

Diff: https://github.com/DerekStride/tree-sitter-sql/compare/4fe05b2d81565ddb689d2f415e07afdacc515c52...286e10c5bc5d1703ee8f9afb351165a9a6182be1

- [Default values in Column Definitions](https://github.com/DerekStride/tree-sitter-sql/commit/e2f0f3f74dbc4c2f77a8a85bd8e5599fa248a7ec)
- [Detect empty comments](https://github.com/DerekStride/tree-sitter-sql/commit/bca2ad23df7a662e9050474e0170cc13c000f7ec)
- [Allow for nested joins](https://github.com/DerekStride/tree-sitter-sql/commit/bb58ae16e62e8ad252a4359d54191257892f0acc)
- [Parse more functionality of the `CREATE TABLE` statement](https://github.com/DerekStride/tree-sitter-sql/commit/286e10c5bc5d1703ee8f9afb351165a9a6182be1)

# PR changes

- Update to current `tree-sitter-sql` `main` `HEAD`.
- Migrate grammar to match https://github.com/DerekStride/tree-sitter-sql/blob/286e10c5bc5d1703ee8f9afb351165a9a6182be1/grammar.js
  - Add keywords which were newly added in upstream diff
  - Add new `CAST()` builtin fn
  - Query `GROUP_CONCAT()` properly
  - Remove unnecessary explicit `parameter` query in `count` and `invocation`
  - Sort builtin fns alphabetically
  - Sort keywords like in source grammar, for easier future comparison and updates
  - Add lots of previously missing keywords (which had been added to upstream grammar already before the current upstream diff)
  - Some whitespace changes to match upstream grammar
