### PR TITLE
Tabulate buffer picker contents

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2425,20 +2425,15 @@ fn buffer_picker(cx: &mut Context) {
                 None => SCRATCH_BUFFER_NAME,
             };
 
-            let mut flags = Vec::new();
+            let mut flags = String::new();
             if self.is_modified {
-                flags.push("+");
+                flags.push('+');
             }
             if self.is_current {
-                flags.push("*");
+                flags.push('*');
             }
 
-            let flag = if flags.is_empty() {
-                "".into()
-            } else {
-                format!(" ({})", flags.join(""))
-            };
-            format!("{} {}{}", self.id, path, flag).into()
+            Row::new([self.id.to_string(), flags, path.to_string()])
         }
     }
 


### PR DESCRIPTION
Arranges the document id, file flags (is-modified, is-current) and file path in a table leveraging https://github.com/helix-editor/helix/pull/3053.

| Before | After |
| --- | --- |
| ![before][1] | ![after][2] |

[1]: https://user-images.githubusercontent.com/23398472/216238043-ac5fa30d-7865-4127-9d7b-96a56d01c294.png
[2]: https://user-images.githubusercontent.com/23398472/216238080-f4a824e3-9964-4bec-b385-a2357ee23777.png
