### PR TITLE
fix position translation at EOF with softwrap

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -207,16 +207,19 @@ pub fn render_text<'t>(
             it
         } else {
             let mut last_pos = formatter.visual_pos();
-            last_pos.col -= 1;
-            // check if any positions translated on the fly (like cursor) are at the EOF
-            translate_positions(
-                char_pos + 1,
-                first_visible_char_idx,
-                translated_positions,
-                text_fmt,
-                renderer,
-                last_pos,
-            );
+            if last_pos.row >= row_off {
+                last_pos.col -= 1;
+                last_pos.row -= row_off;
+                // check if any positions translated on the fly (like cursor) are at the EOF
+                translate_positions(
+                    char_pos + 1,
+                    first_visible_char_idx,
+                    translated_positions,
+                    text_fmt,
+                    renderer,
+                    last_pos,
+                );
+            }
             break;
         };
 


### PR DESCRIPTION
Fixes #5782

The new rendering code added in #5420 performs char_idx -> visual_pos translations on the fly for performance reasons. This code needs a special case for the EOF character as that character is not a real char_idx in the text (it's rendered as virtual text but virtual text normally doesn't have a separate char_idx). When softwrap is enabled the view may be offset multiple visual lines from the start of the line. That means that any position needs to have a vertical offset applied (`pos.row -= row_offset`). This is always done for all graphemes that get actually rendered but because the EOF position takes a specical branch (only used for position translation) it needs to be done there too (which was missed so far).