### PR TITLE
Ensure history is completed and cursor is in view after pasting

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3734,6 +3734,7 @@ fn paste_impl(
     }
 
     doc.apply(&transaction, view.id);
+    doc.append_changes_to_history(view);
 }
 
 pub(crate) fn paste_bracketed_value(cx: &mut Context, contents: String) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -913,6 +913,7 @@ fn replace_selections_with_clipboard_impl(
     cx: &mut compositor::Context,
     clipboard_type: ClipboardType,
 ) -> anyhow::Result<()> {
+    let scrolloff = cx.editor.config().scrolloff;
     let (view, doc) = current!(cx.editor);
 
     match cx.editor.clipboard_provider.get_contents(clipboard_type) {
@@ -924,6 +925,7 @@ fn replace_selections_with_clipboard_impl(
 
             doc.apply(&transaction, view.id);
             doc.append_changes_to_history(view);
+            view.ensure_cursor_in_view(doc, scrolloff);
             Ok(())
         }
         Err(e) => Err(e.context("Couldn't get system clipboard contents")),
@@ -1570,6 +1572,7 @@ fn sort_impl(
     _args: &[Cow<str>],
     reverse: bool,
 ) -> anyhow::Result<()> {
+    let scrolloff = cx.editor.config().scrolloff;
     let (view, doc) = current!(cx.editor);
     let text = doc.text().slice(..);
 
@@ -1595,6 +1598,7 @@ fn sort_impl(
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view);
+    view.ensure_cursor_in_view(doc, scrolloff);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #5733

This PR ensures that the cursor is in view and that any changes are appended to history when using typeable commands instead of keybindings. If changes are not saved to history crashes can occur later. For example the reproduction case for #5733 uses middle mouse to trigger the `:clipboard-paste-before` command which causes the undo command to produce a crash later. 

While looking into a fix, I noticed that `ensure_cursor_in_view` was also not being called. When the cursor is at the EOF (`vgegl`) of a large file and replaced with a very short string from the clipboard the view currently becomes empty (no visible text or line numbers). That second bug is fixed by adding the `ensure_cursor_in_view` call.
