### PR TITLE
feat: add pem language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -93,6 +93,7 @@
 | openscad | ✓ |  |  | `openscad-lsp` |
 | org | ✓ |  |  |  |
 | pascal | ✓ | ✓ |  | `pasls` |
+| pem | ✓ |  |  |  |
 | perl | ✓ | ✓ | ✓ |  |
 | php | ✓ | ✓ | ✓ | `intelephense` |
 | ponylang | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2134,3 +2134,15 @@ grammar = "xml"
 '"' = '"'
 "'" = "'"
 "<" = ">"
+
+[[language]]
+name = "pem"
+scope = "source.pem"
+file-types = ["pem", "cert", "crt"]
+injection-regex = "pem"
+roots = []
+grammar = "pem"
+
+[[grammar]]
+name = "pem"
+source = { git = "https://github.com/mtoohey31/tree-sitter-pem", rev = "be67a4330a1aa507c7297bc322204f936ec1132c" }

--- a/runtime/queries/pem/highlights.scm
+++ b/runtime/queries/pem/highlights.scm
@@ -1,0 +1,7 @@
+(label) @constant
+
+(preeb) @keyword
+(posteb) @keyword
+
+(base64pad) @string.special.symbol
+(laxbase64text) @string


### PR DESCRIPTION
This merge request adds support for PEM files. I'm not sure whether this sort of less commonly editied filetype is something we'd like to support out of the box, but I've been working with PEM files pretty frequently recently, so I figured I'd suggest adding support. Here's a screenshot with the nord theme:

![helix-pem](https://user-images.githubusercontent.com/36740602/216509734-9d6c06ed-175a-4a41-9080-c924d6674316.png)