### PR TITLE
Prevent completion menu after navigation in insert mode

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -881,6 +881,8 @@ pub struct Editor {
     pub next_document_id: DocumentId,
     pub documents: BTreeMap<DocumentId, Document>,
 
+    pub last_event_is_char: bool,
+
     // We Flatten<> to resolve the inner DocumentSavedEventFuture. For that we need a stream of streams, hence the Once<>.
     // https://stackoverflow.com/a/66875668
     pub saves: HashMap<DocumentId, UnboundedSender<Once<DocumentSavedEventFuture>>>,
@@ -1062,6 +1064,7 @@ impl Editor {
             needs_redraw: false,
             cursor_cache: Cell::new(None),
             completion_request_handle: None,
+            last_event_is_char: false,
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -881,6 +881,8 @@ pub struct Editor {
     pub next_document_id: DocumentId,
     pub documents: BTreeMap<DocumentId, Document>,
 
+    // To know if the user is currently inserting chars or moving in Insert Mode
+    // https://github.com/helix-editor/helix/pull/5803
     pub last_event_is_char: bool,
 
     // We Flatten<> to resolve the inner DocumentSavedEventFuture. For that we need a stream of streams, hence the Once<>.


### PR DESCRIPTION
This is a replacement for #4144 , after the comment from @the-mikedavis :

> It would be better to be able [...] to prevent the completion menu from opening at all after any navigation in insert mode

Related issues: #2027 #2581.

The auto-completion menu now pops if you are in insert mode AND you have inserted something, as soon as you move again or do a ^C, you need to insert something again. This behavior is similar to what other IDE do (like Android Studio)