### PR TITLE
Recognize .C and .H file types as cpp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -190,7 +190,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-c", rev = "7175a6dd
 name = "cpp"
 scope = "source.cpp"
 injection-regex = "cpp"
-file-types = ["cc", "hh", "c++", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino"]
+file-types = ["cc", "hh", "c++", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino", "C", "H"]
 roots = []
 comment-token = "//"
 language-server = { command = "clangd" }


### PR DESCRIPTION
.C, and .H and two more valid cpp source and header types. Note the capitalization, as opposed two .c, and .h for c files.
I also found a source that mentions the extensions multiple different compilers support https://stackoverflow.com/a/3223792