### PR TITLE
Add Podfile and *.podspec to the file types for ruby

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -519,7 +519,7 @@ source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder", "jb"]
+file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder", "jb", "Podfile", "podspec"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
These file types are used with [CocoaPods](https://cocoapods.org) – a dependency manager for Swift and Objective-C Cocoa projects. They should be recognized as ruby files. 

Here is the page from their wiki: https://github.com/CocoaPods/CocoaPods/wiki/Make-your-text-editor-recognize-the-CocoaPods-files