### PR TITLE
use max_line_width + 1 during softwrap to account for newline char

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1212,11 +1212,11 @@ impl Document {
             .language_config()
             .and_then(|config| config.max_line_length)
         {
-            // we increase max_line_len by 1 because softwrap considers the newline characterr
-            // as part of the line length while the "typical" expectiation is that this is not the case
-            // In particular other commands like :reflow do not count the line terminator
-            // this is technically inconsistent for the last  line as that line never has a line terminator
-            // but having the last visual line exceed the width by 1 seems like a rare edgecase
+            // We increase max_line_len by 1 because softwrap considers the newline character
+            // as part of the line length while the "typical" expectation is that this is not the case.
+            // In particular other commands like :reflow do not count the line terminator.
+            // This is technically inconsistent for the last line as that line never has a line terminator
+            // but having the last visual line exceed the width by 1 seems like a rare edge case.
             viewport_width = viewport_width.min(max_line_len as u16 + 1)
         }
         let config = self.config.load();

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1212,7 +1212,12 @@ impl Document {
             .language_config()
             .and_then(|config| config.max_line_length)
         {
-            viewport_width = viewport_width.min(max_line_len as u16)
+            // we increase max_line_len by 1 because softwrap considers the newline characterr
+            // as part of the line length while the "typical" expectiation is that this is not the case
+            // In particular other commands like :reflow do not count the line terminator
+            // this is technically inconsistent for the last  line as that line never has a line terminator
+            // but having the last visual line exceed the width by 1 seems like a rare edgecase
+            viewport_width = viewport_width.min(max_line_len as u16 + 1)
         }
         let config = self.config.load();
         let soft_wrap = &config.soft_wrap;


### PR DESCRIPTION
Closes #5810

Helix soft wrap implementation always wraps lines so that the newline
character doesn't get cut off, so the line wraps one chars earlier than
in other editors. This is necessary, because newline chars are always
selectable in helix and must never be hidden.

However, That means that `max_line_width` currently wraps one char
earlier than expected. The typical definition of line width does not
include the newline character and other helix commands like `:reflow`
also don't count the newline character here.

This commit makes soft wrap use `max_line_width + 1` instead of
`max_line_width` to correct the impedance mismatch.
