### PR TITLE
enable rendering in integration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 xtask = "run --package xtask --"
-integration-test = "test --features integration --workspace --test integration"
+integration-test = "test --features integration --profile integration --workspace --test integration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,9 @@ lto = "fat"
 codegen-units = 1
 # strip = "debuginfo" # TODO: or strip = true
 opt-level = 3
+
+[profile.integration]
+inherits = "test"
+package.helix-core.opt-level = 2
+package.helix-tui.opt-level = 2
+package.helix-term.opt-level = 2

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -277,10 +277,6 @@ impl Application {
         Ok(app)
     }
 
-    #[cfg(feature = "integration")]
-    async fn render(&mut self) {}
-
-    #[cfg(not(feature = "integration"))]
     async fn render(&mut self) {
         let mut cx = crate::compositor::Context {
             editor: &mut self.editor,

--- a/helix-term/tests/test/write.rs
+++ b/helix-term/tests/test/write.rs
@@ -70,7 +70,7 @@ async fn test_write_quit() -> anyhow::Result<()> {
 async fn test_write_concurrent() -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
     let mut command = String::new();
-    const RANGE: RangeInclusive<i32> = 1..=5000;
+    const RANGE: RangeInclusive<i32> = 1..=1000;
     let mut app = helpers::AppBuilder::new()
         .with_file(file.path(), None)
         .build()?;


### PR DESCRIPTION
This will allow testing more of the code base, as well as enable UI- specific testing.

Debug mode builds are prohibitively slow for the tests, mostly because of the concurrency write tests. So there is now a profile for integration tests that sets the optimization level to 2 for a few helix crates, and lowers the number of rounds of concurrent writes to 1000.