### PR TITLE
added ctrl+j readline-style alias for Enter key

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -408,7 +408,7 @@ Keys to use within picker. Remapping currently not supported.
 | `PageDown`, `Ctrl-d`         | Page down         |
 | `Home`                       | Go to first entry |
 | `End`                        | Go to last entry  |
-| `Enter`                      | Open selected     |
+| `Enter`, `Ctrl-j`            | Open selected     |
 | `Ctrl-s`                     | Open horizontally |
 | `Ctrl-v`                     | Open vertically   |
 | `Ctrl-t`                     | Toggle preview    |
@@ -439,4 +439,4 @@ Keys to use within prompt, Remapping currently not supported.
 | `Ctrl-r`                                    | Insert the content of the register selected by following input char     |
 | `Tab`                                       | Select next completion item                                             |
 | `BackTab`                                   | Select previous completion item                                         |
-| `Enter`                                     | Open selected                                                           |
+| `Enter`, `Ctrl-j`                           | Open selected                                                           |

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -263,7 +263,7 @@ impl<T: Item + 'static> Component for Menu<T> {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if let Some(selection) = self.selection() {
                     (self.callback_fn)(cx.editor, Some(selection), MenuEvent::Validate);
                     return EventResult::Consumed(close_fn);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -672,7 +672,7 @@ impl<T: Item + 'static> Component for Picker<T> {
                     (self.callback_fn)(cx, option, Action::Load);
                 }
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if let Some(option) = self.selection() {
                     (self.callback_fn)(cx, option, Action::Replace);
                 }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -539,7 +539,7 @@ impl Component for Prompt {
                     (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if self.selection.is_some() && self.line.ends_with(std::path::MAIN_SEPARATOR) {
                     self.recalculate_completion(cx.editor);
                 } else {


### PR DESCRIPTION
Hi, added ctrl+j to menu, picker and prompt to be more in-line with the other readline-style keybinds (ctrl+p, ctrl+n, ctrl+h etc.)