### PR TITLE
use editor.shell for formatter

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -447,8 +447,11 @@ impl Document {
         {
             use std::process::Stdio;
             let text = self.text().clone();
-            let mut process = tokio::process::Command::new(&formatter.command);
+            let shell = &self.config.load().shell;
+            let mut process = tokio::process::Command::new(&shell[0]);
             process
+                .args(&shell[1..])
+                .arg(&formatter.command)
                 .args(&formatter.args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
# Objective

- Resolves #5538

## Solution

- Copied the way that the shell is used in `helix_term::commands::shell_impl_async`: https://github.com/helix-editor/helix/blob/b2e83f81e10089a0e81ce33c4beb51aefc29a62e/helix-term/src/commands.rs#L4996-L5001

---

## Changelog

now passes external formatters to `editor.shell`