### PR TITLE
Auto indent on `insert_at_line_start`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -16,7 +16,9 @@ use helix_core::{
     history::UndoKind,
     increment, indent,
     indent::IndentStyle,
-    line_ending::{get_line_ending_of_str, line_end_char_index, str_is_line_ending},
+    line_ending::{
+        get_line_ending_of_str, line_end_char_index, str_is_line_ending,
+    },
     match_brackets,
     movement::{self, move_vertically_visual, Direction},
     object, pos_at_coords,
@@ -2756,9 +2758,66 @@ fn last_picker(cx: &mut Context) {
 }
 
 // I inserts at the first nonwhitespace character of each line with a selection
+// If the line is empty, automatically indent
 fn insert_at_line_start(cx: &mut Context) {
-    goto_first_nonwhitespace(cx);
     enter_insert_mode(cx);
+
+    let (view, doc) = current!(cx.editor);
+
+    let text = doc.text().slice(..);
+    let contents = doc.text();
+    let selection = doc.selection(view.id);
+
+    let language_config = doc.language_config();
+    let syntax = doc.syntax();
+    let tab_width = doc.tab_width();
+
+    let mut ranges = SmallVec::with_capacity(selection.len());
+    let mut offs = 0;
+
+    let mut transaction = Transaction::change_by_selection(contents, selection, |range| {
+        let cursor_line = range.cursor_line(text);
+        let cursor_line_start = text.line_to_char(cursor_line);
+
+        if line_end_char_index(&text, cursor_line) == cursor_line_start {
+            // line is empty => auto indent
+            let line_end_index = cursor_line_start;
+
+            let indent = indent::indent_for_newline(
+                language_config,
+                syntax,
+                &doc.indent_style,
+                tab_width,
+                text,
+                cursor_line,
+                line_end_index,
+                cursor_line,
+            );
+
+            // calculate new selection ranges
+            let pos = offs + cursor_line_start;
+            let indent_width = indent.chars().count();
+            ranges.push(Range::point(pos + indent_width));
+            offs += indent_width;
+
+            (line_end_index, line_end_index, Some(indent.into()))
+        } else {
+            // move cursor to the first non-whitespace character of the current line
+            let mut pos = cursor_line_start + offs;
+            let range = find_first_non_whitespace_char(text.line(cursor_line))
+                .map(|ws_offset| {
+                    pos += ws_offset;
+                    range.put_cursor(text, pos, cx.editor.mode == Mode::Select)
+                })
+                .unwrap_or(*range);
+            ranges.push(range);
+
+            (cursor_line_start, cursor_line_start, None)
+        }
+    });
+
+    transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
+    doc.apply(&transaction, view.id);
 }
 
 // A inserts at the end of each line with a selection

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -426,3 +426,56 @@ async fn test_delete_char_forward() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_insert_with_indent() -> anyhow::Result<()> {
+    const INPUT: &str = "\
+#[f|]#n foo() {
+    if let Some(_) = None {
+
+    }
+\x20
+}
+
+fn bar() {
+
+}";
+
+    // insert_at_line_start
+    test((
+        INPUT,
+        ":lang rust<ret>%<A-s>I",
+        "\
+#[f|]#n foo() {
+    #(i|)#f let Some(_) = None {
+        #(\n|)#\
+\x20   #(}|)#
+#(\x20|)#
+#(}|)#
+#(\n|)#\
+#(f|)#n bar() {
+    #(\n|)#\
+#(}|)#",
+    ))
+    .await?;
+
+    // insert_at_line_end
+    test((
+        INPUT,
+        ":lang rust<ret>%<A-s>A",
+        "\
+fn foo() {#[\n|]#\
+\x20   if let Some(_) = None {#(\n|)#\
+\x20       #(\n|)#\
+\x20   }#(\n|)#\
+\x20#(\n|)#\
+}#(\n|)#\
+#(\n|)#\
+fn bar() {#(\n|)#\
+\x20   #(\n|)#\
+}#(|)#",
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
First attempt at #4859. This makes `I` and `A` automatically indent, but **only** if the line is empty. Otherwise it behaves exactly as before. I thought about also handling indentation when the line only contains white space, but I left this out for now. Either way, this is a breaking change.

I roughly followed the implementation of `open_above`/`open_below`. Though, I'm not sure if the implementation is very good, all the text editing functions in the code base are new to me.

Here's the result of `insert_at_line_start` / `I` with this change (the only difference is on the empty line):

| before | master | this PR |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3957610/216818723-ad0aaaaa-2e30-4e54-9175-3696f2d9c996.png) | ![image](https://user-images.githubusercontent.com/3957610/216831840-375f8f7d-1950-4690-9fae-8418a5d20283.png) | ![image](https://user-images.githubusercontent.com/3957610/216818729-336b309b-3bab-42c5-8712-f200786dcbbe.png) |

I tried to handle all edge cases (i.e. cursor is at document start/end, multiple selections) and so far it seems to work. ~~I also plan to make `insert_at_line_end` behave similarly~~.

Edit: `insert_at_line_end` now works the same.

closes #4859