### PR TITLE
Exiting during LSP initialization fixed

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -407,6 +407,19 @@ impl Client {
 
     /// Forcefully shuts down the language server ignoring any errors.
     pub async fn force_shutdown(&self) -> Result<()> {
+        if !self.is_initialized() {
+            return match self.exit().await {
+                Err(e) => {
+                    log::warn!(
+                        "language server failed to exit during initialization - {}",
+                        e
+                    );
+                    return Err(e);
+                }
+                _ => Ok(()),
+            };
+        }
+
         if let Err(e) = self.shutdown().await {
             log::warn!("language server failed to terminate gracefully - {}", e);
         }


### PR DESCRIPTION
Quick fix for issue #5732, by sending exit notification to language servers that are not yet initialized.