### PR TITLE
Show code point in statusline

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -108,6 +108,7 @@ The following statusline elements can be configured:
 | `primary-selection-length` | The number of characters currently in primary selection |
 | `position` | The cursor position |
 | `position-percentage` | The cursor position as a percentage of the total number of lines |
+| `code-point` | The code point under the cursor |
 | `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |
 | `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -489,6 +489,9 @@ pub enum StatusLineElement {
     /// The total line numbers of the current file
     TotalLineNumbers,
 
+    /// The code point under the cursor
+    CodePoint,
+
     /// A single space
     Spacer,
 }


### PR DESCRIPTION
This PR adds an option to show the code point under the cursor in the statusline. The code point is formatted using "U+" notation.
![Screenshot_20230207_002602](https://user-images.githubusercontent.com/44508205/217112642-581fe7b4-25a4-40eb-a35b-c459b7011138.png)
