### PR TITLE
docs: describe tab-width and unit subkeys

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -56,7 +56,7 @@ These configuration keys are available:
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
 | `comment-token`       | The token to use as a comment-token                           |
-| `indent`              | The indent to use. Has sub keys `tab-width` and `unit`        |
+| `indent`              | The indent to use. Has sub keys `unit` (the text inserted into the document when indenting; usually set to N spaces or `"\t"` for tabs) and `tab-width` (the number of spaces rendered for a tab) |
 | `language-server`     | The Language Server to run. See the Language Server configuration section below. |
 | `config`              | Language Server configuration                                 |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |


### PR DESCRIPTION
This is a slight addition that explains what the `tab-width` and `unit` subkeys refer to in `languages.toml`. You can figure this out by reading the default configuration, but I thought it would be useful to make it more explicit.

I didn't see any commit style guidelines; let me know if anything needs to be changed.