### PR TITLE
xml: add mobileconfig & plist file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1967,7 +1967,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml"]
+file-types = ["xml", "mobileconfig", "plist"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
I have to often deal with these files, so I'm adding them here.
- `.mobileconfig` files are configuration profiles for Apple devices.
- `.plist` is just another format created by Apple, although `.plist` files can also have binary data instead of XML.