### PR TITLE
Adjust everforest to resemble original more closely

### DIFF
--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -1,81 +1,93 @@
-# Everforest (Dark Hard)
-# Author: CptPotato
+# Everforest (Dark Medium)
+# Authors: CptPotato, basbebe
 
 # Original Author:
 # URL: https://github.com/sainnhe/everforest
-# Filename: autoload/everforest.vim
+# Filename: colors/everforest.vim
 # Author: sainnhe
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"type" = "yellow"
-"constant" = "purple"
+"type" = { fg = "yellow", modifiers = ["italic"] }
+"constant" = "fg"
+"constant.builtin" = { fg = "purple", modifiers = ["italic"] }
+"constant.builtin.boolean" = "purple"
 "constant.numeric" = "purple"
-"constant.character.escape" = "orange"
-"string" = "green"
-"string.regexp" = "blue"
-"comment" = "grey0"
+"constant.character.escape" = "green"
+"string" = "aqua"
+"string.regexp" = "green"
+"string.special" = "yellow"
+"comment" = { fg = "grey1", modifiers = ["italic"] }
 "variable" = "fg"
-"variable.builtin" = "blue"
+"variable.builtin" = { fg = "purple", modifiers = ["italic"] }
 "variable.parameter" = "fg"
-"variable.other.member" = "fg"
-"label" = "aqua"
+"variable.other.member" = "blue"
+"label" = "orange"
 "punctuation" = "grey2"
-"punctuation.delimiter" = "grey2"
+"punctuation.delimiter" = "grey1"
 "punctuation.bracket" = "fg"
+"punctuation.special" = "blue"
 "keyword" = "red"
-"keyword.directive" = "aqua"
+"keyword.operator" = "orange"
+"keyword.directive" = "purple"
+"keyword.storage" = "orange"
 "operator" = "orange"
 "function" = "green"
-"function.builtin" = "blue"
-"function.macro" = "aqua"
-"tag" = "yellow"
-"namespace" = "aqua"
-"attribute" = "aqua"
-"constructor" = "yellow"
-"module" = "blue"
-"special" = "orange"
+"function.macro" = "green"
+"tag" = "orange"
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+"attribute" = { fg = "purple", modifiers = ["italic"] }
+"constructor" = "green"
+"module" = "yellow"
+"special" = "blue"
 
-"markup.heading.marker" = "grey2"
+"markup.heading.marker" = "grey1"
 "markup.heading.1" = { fg = "red", modifiers = ["bold"] }
 "markup.heading.2" = { fg = "orange", modifiers = ["bold"] }
 "markup.heading.3" = { fg = "yellow", modifiers = ["bold"] }
 "markup.heading.4" = { fg = "green", modifiers = ["bold"] }
 "markup.heading.5" = { fg = "blue", modifiers = ["bold"] }
-"markup.heading.6" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "purple", modifiers = ["bold"] }
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "blue", underline = { style = "line" } }
+"markup.link.label" = "orange"
 "markup.link.text" = "purple"
-"markup.quote" = "grey2"
-"markup.raw" = "green"
+"markup.quote" = "grey1"
+"markup.raw.inline" = "green"
+"markup.raw.block" = "aqua"
 
 "diff.plus" = "green"
-"diff.delta" = "orange"
+"diff.delta" = "blue"
 "diff.minus" = "red"
 
 "ui.background" = { bg = "bg0" }
-"ui.background.separator" = "grey0"
-"ui.cursor" = { fg = "bg0", bg = "fg" }
-"ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
+"ui.background.separator" = "bg_visual"
+"ui.cursor" = { fg = "bg1", bg = "grey2" }
 "ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
+"ui.cursor.primary" = { fg = "bg0", bg = "fg" }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg2" }
 "ui.selection" = { bg = "bg3" }
 "ui.linenr" = "grey0"
-"ui.linenr.selected" = "fg"
+"ui.linenr.selected" = "grey2"
 "ui.statusline" = { fg = "grey2", bg = "bg3" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
-"ui.statusline.normal" = { fg = "bg0", bg = "grey2", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "bg0", bg = "yellow", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
+"ui.statusline.insert" = { fg = "bg0", bg = "statusline2", modifiers = [
+  "bold",
+] }
 "ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
-"ui.bufferline" = { fg = "grey0", bg = "bg1" }
-"ui.bufferline.active" = { fg = "fg", bg = "bg3", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "grey2", bg = "bg3" }
+"ui.bufferline.active" = { fg = "bg0", bg = "statusline1", modifiers = ["bold"] }
 "ui.popup" = { fg = "grey2", bg = "bg2" }
-"ui.window" = { fg = "grey0", bg = "bg0" }
+"ui.window" = { fg = "bg4", bg = "bg_dim" }
 "ui.help" = { fg = "fg", bg = "bg2" }
 "ui.text" = "fg"
 "ui.text.focus" = "fg"
@@ -85,30 +97,30 @@
 "ui.virtual.indent-guide" = { fg = "bg4" }
 "ui.virtual.ruler" = { bg = "bg3" }
 
-"hint" = "blue"
-"info" = "aqua"
+"hint" = "green"
+"info" = "blue"
 "warning" = "yellow"
 "error" = "red"
 
-"diagnostic.hint" = { underline = { color = "blue", style = "curl" } }
-"diagnostic.info" = { underline = { color = "aqua", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
-
 [palette]
 
-bg0 = "#2b3339"
-bg1 = "#323c41"
-bg2 = "#3a454a"
-bg3 = "#445055"
-bg4 = "#4c555b"
-bg5 = "#53605c"
-bg_visual = "#503946"
-bg_red = "#4e3e43"
-bg_green = "#404d44"
-bg_blue = "#394f5a"
-bg_yellow = "#4a4940"
+bg_dim = "#232a2e"
+bg0 = "#2d353b"
+bg1 = "#343f44"
+bg2 = "#3d484d"
+bg3 = "#475258"
+bg4 = "#4f585e"
+bg5 = "#56635f"
+bg_visual = "#543a48"
+bg_red = "#514045"
+bg_green = "#425047"
+bg_blue = "#3a515d"
+bg_yellow = "#4d4c43"
 
 fg = "#d3c6aa"
 red = "#e67e80"
@@ -118,6 +130,7 @@ green = "#a7c080"
 aqua = "#83c092"
 blue = "#7fbbb3"
 purple = "#d699b6"
+
 grey0 = "#7a8478"
 grey1 = "#859289"
 grey2 = "#9da9a0"

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -8,7 +8,7 @@
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"type" = { fg = "yellow", modifiers = ["italic"] }
+"type" = "yellow"
 "constant" = "fg"
 "constant.builtin" = { fg = "purple", modifiers = ["italic"] }
 "constant.builtin.boolean" = "purple"
@@ -30,7 +30,7 @@
 "keyword" = "red"
 "keyword.operator" = "orange"
 "keyword.directive" = "purple"
-"keyword.storage" = "orange"
+"keyword.storage" = "red"
 "operator" = "orange"
 "function" = "green"
 "function.macro" = "green"
@@ -85,7 +85,9 @@
 ] }
 "ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
 "ui.bufferline" = { fg = "grey2", bg = "bg3" }
-"ui.bufferline.active" = { fg = "bg0", bg = "statusline1", modifiers = ["bold"] }
+"ui.bufferline.active" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
 "ui.popup" = { fg = "grey2", bg = "bg2" }
 "ui.window" = { fg = "bg4", bg = "bg_dim" }
 "ui.help" = { fg = "fg", bg = "bg2" }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -95,9 +95,11 @@
 "ui.text.focus" = "fg"
 "ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
+"ui.virtual.ruler" = { bg = "bg3" }
 "ui.virtual.whitespace" = { fg = "bg4" }
 "ui.virtual.indent-guide" = { fg = "bg4" }
-"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.inlay-hint" = { fg = "grey0" }
+"ui.virtual.wrap" = { fg = "grey0" }
 
 "hint" = "green"
 "info" = "blue"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -1,81 +1,95 @@
-# Everforest (Dark Hard)
-# Author: CptPotato
+# Everforest (Light Medium)
+# Authors: CptPotato, WindSoilder, basbebe
 
 # Original Author:
 # URL: https://github.com/sainnhe/everforest
-# Filename: autoload/everforest.vim
+# Filename: colors/everforest.vim
 # Author: sainnhe
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"type" = "yellow"
-"constant" = "purple"
+"type" = { fg = "yellow", modifiers = ["italic"] }
+"constant" = "fg"
+"constant.builtin" = { fg = "purple", modifiers = ["italic"] }
+"constant.builtin.boolean" = "purple"
 "constant.numeric" = "purple"
-"constant.character.escape" = "orange"
-"string" = "green"
-"string.regexp" = "blue"
-"comment" = "grey0"
+"constant.character.escape" = "green"
+"string" = "aqua"
+"string.regexp" = "green"
+"string.special" = "yellow"
+"comment" = { fg = "grey1", modifiers = ["italic"] }
 "variable" = "fg"
-"variable.builtin" = "blue"
+"variable.builtin" = { fg = "purple", modifiers = ["italic"] }
 "variable.parameter" = "fg"
-"variable.other.member" = "fg"
-"label" = "aqua"
+"variable.other.member" = "blue"
+"label" = "orange"
 "punctuation" = "grey2"
-"punctuation.delimiter" = "grey2"
+"punctuation.delimiter" = "grey1"
 "punctuation.bracket" = "fg"
+"punctuation.special" = "blue"
 "keyword" = "red"
-"keyword.directive" = "aqua"
+"keyword.operator" = "orange"
+"keyword.directive" = "purple"
+"keyword.storage" = "orange"
 "operator" = "orange"
 "function" = "green"
-"function.builtin" = "blue"
-"function.macro" = "aqua"
-"tag" = "yellow"
-"namespace" = "aqua"
-"attribute" = "aqua"
-"constructor" = "yellow"
-"module" = "blue"
-"special" = "orange"
+"function.macro" = "green"
+"tag" = "orange"
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+"attribute" = { fg = "purple", modifiers = ["italic"] }
+"constructor" = "green"
+"module" = "yellow"
+"special" = "blue"
 
-"markup.heading.marker" = "grey2"
+"markup.heading.marker" = "grey1"
 "markup.heading.1" = { fg = "red", modifiers = ["bold"] }
 "markup.heading.2" = { fg = "orange", modifiers = ["bold"] }
 "markup.heading.3" = { fg = "yellow", modifiers = ["bold"] }
 "markup.heading.4" = { fg = "green", modifiers = ["bold"] }
 "markup.heading.5" = { fg = "blue", modifiers = ["bold"] }
-"markup.heading.6" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "purple", modifiers = ["bold"] }
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "blue", underline = { style = "line" } }
+"markup.link.label" = "orange"
 "markup.link.text" = "purple"
-"markup.quote" = "grey2"
-"markup.raw" = "green"
+"markup.quote" = "grey1"
+"markup.raw.inline" = "green"
+"markup.raw.block" = "aqua"
 
 "diff.plus" = "green"
-"diff.delta" = "orange"
+"diff.delta" = "blue"
 "diff.minus" = "red"
 
 "ui.background" = { bg = "bg0" }
-"ui.background.separator" = "grey0"
-"ui.cursor" = { fg = "bg0", bg = "fg" }
-"ui.cursor.match" = { fg = "orange", bg = "bg_yellow" }
+"ui.background.separator" = "bg_visual"
+"ui.cursor" = { fg = "bg1", bg = "grey2" }
 "ui.cursor.insert" = { fg = "bg0", bg = "grey1" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.match" = { bg = "bg4", modifiers = ["bold"] }
+"ui.cursor.primary" = { fg = "bg0", bg = "fg" }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg2" }
 "ui.selection" = { bg = "bg3" }
 "ui.linenr" = "grey0"
-"ui.linenr.selected" = "fg"
+"ui.linenr.selected" = "grey2"
 "ui.statusline" = { fg = "grey2", bg = "bg3" }
 "ui.statusline.inactive" = { fg = "grey0", bg = "bg1" }
-"ui.statusline.normal" = { fg = "bg0", bg = "grey2", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "bg0", bg = "yellow", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
+"ui.statusline.insert" = { fg = "bg0", bg = "statusline2", modifiers = [
+  "bold",
+] }
 "ui.statusline.select" = { fg = "bg0", bg = "blue", modifiers = ["bold"] }
-"ui.bufferline" = { fg = "grey0", bg = "bg1" }
-"ui.bufferline.active" = { fg = "fg", bg = "bg3", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "grey2", bg = "bg3" }
+"ui.bufferline.active" = { fg = "bg0", bg = "statusline1", modifiers = [
+  "bold",
+] }
 "ui.popup" = { fg = "grey2", bg = "bg2" }
-"ui.window" = { fg = "grey0", bg = "bg0" }
+"ui.window" = { fg = "bg4", bg = "bg_dim" }
 "ui.help" = { fg = "fg", bg = "bg2" }
 "ui.text" = "fg"
 "ui.text.focus" = "fg"
@@ -85,38 +99,43 @@
 "ui.virtual.indent-guide" = { fg = "bg4" }
 "ui.virtual.ruler" = { bg = "bg3" }
 
-"hint" = "blue"
-"info" = "aqua"
+"hint" = "green"
+"info" = "blue"
 "warning" = "yellow"
 "error" = "red"
 
-"diagnostic.hint" = { underline = { color = "blue", style = "curl" } }
-"diagnostic.info" = { underline = { color = "aqua", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
 [palette]
 
-bg0 = "#fff9e8"
-bg1 = "#f7f4e0"
-bg2 = "#f0eed9"
-bg3 = "#e9e8d2"
-bg4 = "#e1ddcb"
-bg5 = "#bec5b2"
-bg_visual = "#edf0cd"
-bg_red = "#fce5dc"
-bg_green = "#f1f3d4"
-bg_blue = "#eaf2eb"
-bg_yellow = "#fbefd0"
+bg_dim = "#efebd4"
+bg0 = "#fdf6e3"
+bg1 = "#f4f0d9"
+bg2 = "#efebd4"
+bg3 = "#e6e2cc"
+bg4 = "#e0dcc7"
+bg5 = "#bdc3af"
+bg_red = "#fbe3da"
+bg_visual = "#eaedc8"
+bg_yellow = "#faedcd"
+bg_green = "#f0f1d2"
+bg_blue = "#e9f0e9"
 
 fg = "#5c6a72"
 red = "#f85552"
 orange = "#f57d26"
 yellow = "#dfa000"
 green = "#8da101"
-aqua = "#35a77c"
 blue = "#3a94c5"
+aqua = "#35a77c"
 purple = "#df69ba"
+
 grey0 = "#a6b0a0"
 grey1 = "#939f91"
 grey2 = "#829181"
+statusline1 = "#93b259"
+statusline2 = "#708089"
+statusline3 = "#e66868"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -8,7 +8,7 @@
 # Email: sainnhe@gmail.com
 # License: MIT License
 
-"type" = { fg = "yellow", modifiers = ["italic"] }
+"type" = "yellow"
 "constant" = "fg"
 "constant.builtin" = { fg = "purple", modifiers = ["italic"] }
 "constant.builtin.boolean" = "purple"
@@ -30,7 +30,7 @@
 "keyword" = "red"
 "keyword.operator" = "orange"
 "keyword.directive" = "purple"
-"keyword.storage" = "orange"
+"keyword.storage" = "red"
 "operator" = "orange"
 "function" = "green"
 "function.macro" = "green"

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -95,9 +95,11 @@
 "ui.text.focus" = "fg"
 "ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
+"ui.virtual.ruler" = { bg = "bg3" }
 "ui.virtual.whitespace" = { fg = "bg4" }
 "ui.virtual.indent-guide" = { fg = "bg4" }
-"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.inlay-hint" = { fg = "grey0" }
+"ui.virtual.wrap" = { fg = "grey0" }
 
 "hint" = "green"
 "info" = "blue"


### PR DESCRIPTION
Adjust palettes and assignments:

- Color palettes of upstream everforest where tweaked since creation of this port:
  - https://github.com/sainnhe/everforest/pull/108
  - https://github.com/sainnhe/everforest/pull/109

- Move the helix everforest theme closer to the documented
 upstream vim theme