### PR TITLE
Add `Containerfile` file-type for dockerfile language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1072,8 +1072,8 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "f6bb
 name = "dockerfile"
 scope = "source.dockerfile"
 injection-regex = "docker|dockerfile"
-roots = ["Dockerfile"]
-file-types = ["Dockerfile", "dockerfile"]
+roots = ["Dockerfile", "Containerfile"]
+file-types = ["Dockerfile", "dockerfile", "Containerfile"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "docker-langserver", args = ["--stdio"] }

--- a/languages.toml
+++ b/languages.toml
@@ -1073,7 +1073,7 @@ name = "dockerfile"
 scope = "source.dockerfile"
 injection-regex = "docker|dockerfile"
 roots = ["Dockerfile", "Containerfile"]
-file-types = ["Dockerfile", "dockerfile", "Containerfile"]
+file-types = ["Dockerfile", "dockerfile", "Containerfile", "containerfile"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "docker-langserver", args = ["--stdio"] }


### PR DESCRIPTION
The `Containerfile` is a vendor independent name for the `Dockerfile` when using things like `podman`. It has the same syntax and therefore it is possible to extend the `file-types`.
But I am not sure whether it would be better to define a different language with the same parameters. It would better show being vendor independent but also a bit more bloat.
Further I am not sure why there is a lowercase `dockerfile` in the `file-types` and if it is also needed for the `Containerfile`.