### PR TITLE
Switch statusline & prompt

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -224,10 +224,7 @@ impl EditorView {
 
         Self::render_diagnostics(doc, view, inner, surface, theme);
 
-        let statusline_area = view
-            .area
-            .clip_top(view.area.height.saturating_sub(1))
-            .clip_bottom(1); // -1 from bottom to remove commandline
+        let statusline_area = view.area.clip_top(view.area.height);
 
         let mut context =
             statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
@@ -1388,7 +1385,7 @@ impl Component for EditorView {
 
             surface.set_string(
                 area.x,
-                area.y + area.height.saturating_sub(1),
+                area.y + area.height.saturating_sub(2),
                 status_msg,
                 style,
             );

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -372,7 +372,7 @@ impl Prompt {
 
         let completion_area = Rect::new(
             area.x,
-            (area.height - height).saturating_sub(1),
+            (area.height - height).saturating_sub(2),
             area.width,
             height,
         );
@@ -447,7 +447,7 @@ impl Prompt {
             text.render(inner, surface, cx);
         }
 
-        let line = area.height - 1;
+        let line = area.height - 2;
         // render buffer text
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
@@ -639,7 +639,7 @@ impl Component for Prompt {
     }
 
     fn cursor(&self, area: Rect, _editor: &Editor) -> (Option<Position>, CursorKind) {
-        let line = area.height as usize - 1;
+        let line = area.height as usize - 2;
         (
             Some(Position::new(
                 area.y as usize + line,


### PR DESCRIPTION
#5758 

This switches the position of the statusline with the position of the prompt to improve readability of the statusline while the prompt is opened.

TODO:
- [ ] split not rendering correctly