### PR TITLE
Change misleading message

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5035,7 +5035,7 @@ async fn shell_impl_async(
             log::error!("Shell error: {}", err);
             bail!("Shell error: {}", err);
         }
-        bail!("Shell command failed");
+        bail!("[Process exited 1]");
     } else if !output.stderr.is_empty() {
         log::debug!(
             "Command printed to stderr: {}",


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/5716

Simple text change copied from nvim so running commands like `explorer` which opens up file explorer on Windows doesn't explicitly say failed when it actually works.

New:

![image](https://user-images.githubusercontent.com/19632758/217677826-65e23955-6b7d-4036-aec5-299756e290cb.png)