### PR TITLE
Fix the infinite loop when copying the cursor to the top of the file

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1617,6 +1617,10 @@ fn copy_selection_on_line(cx: &mut Context, direction: Direction) {
                 sels += 1;
             }
 
+            if anchor_row == 0 && head_row == 0 {
+                break;
+            }
+
             i += 1;
         }
     }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -132,6 +132,70 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
         .as_str(),
     ))
     .await?;
+
+    // Copy the selection to previous line, skipping the first line in the file
+    test((
+        platform_line(indoc! {"\
+            test
+            #[testitem|]#
+            "})
+        .as_str(),
+        "<A-C>",
+        platform_line(indoc! {"\
+            test
+            #[testitem|]#
+            "})
+        .as_str(),
+    ))
+    .await?;
+
+    // Copy the selection to previous line, including the first line in the file
+    test((
+        platform_line(indoc! {"\
+            test
+            #[test|]#
+            "})
+        .as_str(),
+        "<A-C>",
+        platform_line(indoc! {"\
+            #[test|]#
+            #(test|)#
+            "})
+        .as_str(),
+    ))
+    .await?;
+
+    // Copy the selection to next line, skipping the last line in the file
+    test((
+        platform_line(indoc! {"\
+            #[testitem|]#
+            test
+            "})
+        .as_str(),
+        "C",
+        platform_line(indoc! {"\
+            #[testitem|]#
+            test
+            "})
+        .as_str(),
+    ))
+    .await?;
+
+    // Copy the selection to next line, including the last line in the file
+    test((
+        platform_line(indoc! {"\
+            #[test|]#
+            test
+            "})
+        .as_str(),
+        "C",
+        platform_line(indoc! {"\
+            #(test|)#
+            #[test|]#
+            "})
+        .as_str(),
+    ))
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
Example:
```
test
testitem
```

Select line 2 with x, then type Alt-C; Helix will go into an infinite loop. The saturating_sub keeps the head_row and anchor_row pinned at 0, and a selection is never made since the first line is too short.