### PR TITLE
Fix new clippy lints

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -68,7 +68,7 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
     let mut min_next_line = 0;
     for selection in selection {
         let (start, end) = selection.line_range(text);
-        let start = start.max(min_next_line).min(text.len_lines());
+        let start = start.clamp(min_next_line, text.len_lines());
         let end = (end + 1).min(text.len_lines());
 
         lines.extend(start..end);

--- a/helix-core/src/increment/integer.rs
+++ b/helix-core/src/increment/integer.rs
@@ -69,8 +69,8 @@ pub fn increment(selected_text: &str, amount: i64) -> Option<String> {
                 let (lower_count, upper_count): (usize, usize) =
                     number.chars().fold((0, 0), |(lower, upper), c| {
                         (
-                            lower + c.is_ascii_lowercase().then(|| 1).unwrap_or(0),
-                            upper + c.is_ascii_uppercase().then(|| 1).unwrap_or(0),
+                            lower + c.is_ascii_lowercase() as usize,
+                            upper + c.is_ascii_uppercase() as usize,
                         )
                     });
                 if upper_count > lower_count {

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -604,7 +604,7 @@ pub fn treesitter_indent_for_pos(
                 &mut cursor,
                 text,
                 query_range,
-                new_line.then(|| (line, byte_pos)),
+                new_line.then_some((line, byte_pos)),
             );
             ts_parser.cursors.push(cursor);
             (query_result, deepest_preceding)
@@ -624,7 +624,7 @@ pub fn treesitter_indent_for_pos(
             tab_width,
         );
     }
-    let mut first_in_line = get_first_in_line(node, new_line.then(|| byte_pos));
+    let mut first_in_line = get_first_in_line(node, new_line.then_some(byte_pos));
 
     let mut result = Indentation::default();
     // We always keep track of all the indent changes on one line, in order to only indent once

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -427,7 +427,7 @@ impl TextObjectQuery {
                 let nodes: Vec<_> = mat
                     .captures
                     .iter()
-                    .filter_map(|cap| (cap.index == capture_idx).then(|| cap.node))
+                    .filter_map(|cap| (cap.index == capture_idx).then_some(cap.node))
                     .collect();
 
                 if nodes.len() > 1 {

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -628,7 +628,7 @@ impl Client {
         Some(self.notify::<lsp::notification::DidSaveTextDocument>(
             lsp::DidSaveTextDocumentParams {
                 text_document,
-                text: include_text.then(|| text.into()),
+                text: include_text.then_some(text.into()),
             },
         ))
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -959,9 +959,11 @@ fn goto_window(cx: &mut Context, align: Align) {
         Align::Bottom => {
             view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff + count)
         }
-    }
-    .max(view.offset.vertical_offset + scrolloff)
-    .min(view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff));
+    };
+    let visual_line = visual_line.clamp(
+        view.offset.vertical_offset + scrolloff,
+        view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff),
+    );
 
     let pos = view
         .pos_at_visual_coords(doc, visual_line as u16, 0, false)

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -42,7 +42,7 @@ fn filter_picker_entry(entry: &DirEntry, root: &Path, dedup_symlinks: bool) -> b
             .path()
             .canonicalize()
             .ok()
-            .map_or(false, |path| !path.starts_with(&root));
+            .map_or(false, |path| !path.starts_with(root));
     }
 
     true

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -402,7 +402,7 @@ impl<'a> TextRenderer<'a> {
         is_in_indent_area: &mut bool,
         position: Position,
     ) {
-        let cut_off_start = self.col_offset.saturating_sub(position.col as usize);
+        let cut_off_start = self.col_offset.saturating_sub(position.col);
         let is_whitespace = grapheme.is_whitespace();
 
         // TODO is it correct to apply the whitspace style to all unicode white spaces?
@@ -413,7 +413,7 @@ impl<'a> TextRenderer<'a> {
         let width = grapheme.width();
         let grapheme = match grapheme {
             Grapheme::Tab { width } => {
-                let grapheme_tab_width = char_to_byte_idx(&self.tab, width as usize);
+                let grapheme_tab_width = char_to_byte_idx(&self.tab, width);
                 &self.tab[..grapheme_tab_width]
             }
             // TODO special rendering for other whitespaces?
@@ -423,8 +423,8 @@ impl<'a> TextRenderer<'a> {
             Grapheme::Newline => &self.newline,
         };
 
-        let in_bounds = self.col_offset <= (position.col as usize)
-            && (position.col as usize) < self.viewport.width as usize + self.col_offset;
+        let in_bounds = self.col_offset <= position.col
+            && position.col < self.viewport.width as usize + self.col_offset;
 
         if in_bounds {
             self.surface.set_string(
@@ -433,10 +433,10 @@ impl<'a> TextRenderer<'a> {
                 grapheme,
                 style,
             );
-        } else if cut_off_start != 0 && cut_off_start < width as usize {
+        } else if cut_off_start != 0 && cut_off_start < width {
             // partially on screen
             let rect = Rect::new(
-                self.viewport.x as u16,
+                self.viewport.x,
                 self.viewport.y + position.row as u16,
                 (width - cut_off_start) as u16,
                 1,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -206,7 +206,7 @@ impl EditorView {
             highlights,
             theme,
             &mut line_decorations,
-            &mut *translated_positions,
+            &mut translated_positions,
         );
         Self::render_rulers(editor, doc, view, inner, surface, theme);
 
@@ -723,12 +723,7 @@ impl EditorView {
         let viewport = view.area;
 
         let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
-            let area = Rect::new(
-                viewport.x,
-                viewport.y + pos.visual_line as u16,
-                viewport.width,
-                1,
-            );
+            let area = Rect::new(viewport.x, viewport.y + pos.visual_line, viewport.width, 1);
             if primary_line == pos.doc_line {
                 renderer.surface.set_style(area, primary_style);
             } else if secondary_lines.binary_search(&pos.doc_line).is_ok() {

--- a/helix-term/src/ui/fuzzy_match.rs
+++ b/helix-term/src/ui/fuzzy_match.rs
@@ -25,7 +25,7 @@ impl QueryAtom {
             _ => QueryAtomKind::Fuzzy,
         };
 
-        if atom.starts_with(&['^', '\'']) {
+        if atom.starts_with(['^', '\'']) {
             atom.remove(0);
         }
 

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -89,7 +89,7 @@ fn directory() {
     std::fs::create_dir(&dir).expect("");
     let file = dir.join("file.txt");
     let contents = b"foo".as_slice();
-    File::create(&file).unwrap().write_all(contents).unwrap();
+    File::create(file).unwrap().write_all(contents).unwrap();
 
     create_commit(temp_git.path(), true);
 

--- a/helix-view/src/base64.rs
+++ b/helix-view/src/base64.rs
@@ -36,7 +36,7 @@ const LOW_SIX_BITS: u32 = 0x3F;
 pub fn encode(input: &[u8]) -> String {
     let rem = input.len() % 3;
     let complete_chunks = input.len() / 3;
-    let remainder_chunk = if rem == 0 { 0 } else { 1 };
+    let remainder_chunk = usize::from(rem != 0);
     let encoded_size = (complete_chunks + remainder_chunk) * 4;
 
     let mut output = vec![0; encoded_size];

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -258,7 +258,7 @@ pub mod provider {
                 .args(args)
                 .output()
                 .ok()
-                .and_then(|out| out.status.success().then(|| ())) // TODO: use then_some when stabilized
+                .and_then(|out| out.status.success().then_some(()))
                 .is_some()
         }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1096,7 +1096,7 @@ impl Document {
     /// Language server if it has been initialized.
     pub fn language_server(&self) -> Option<&helix_lsp::Client> {
         let server = self.language_server.as_deref()?;
-        server.is_initialized().then(|| server)
+        server.is_initialized().then_some(server)
     }
 
     pub fn diff_handle(&self) -> Option<&DiffHandle> {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -7,9 +7,8 @@ use crate::{
 };
 
 fn count_digits(n: usize) -> usize {
-    // NOTE: if int_log gets standardized in stdlib, can use checked_log10
-    // (https://github.com/rust-lang/rust/issues/70887#issue)
-    std::iter::successors(Some(n), |&n| (n >= 10).then(|| n / 10)).count()
+    // TODO: use checked_log10 when MSRV reaches 1.67
+    std::iter::successors(Some(n), |&n| (n >= 10).then_some(n / 10)).count()
 }
 
 pub type GutterFn<'doc> = Box<dyn FnMut(usize, bool, bool, &mut String) -> Option<Style> + 'doc>;
@@ -199,8 +198,7 @@ pub fn line_numbers<'doc>(
                     write!(out, "{:>1$}", " ", width).unwrap();
                 }
 
-                // TODO: Use then_some when MSRV reaches 1.62
-                first_visual_line.then(|| style)
+                first_visual_line.then_some(style)
             }
         },
     )

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -380,7 +380,7 @@ impl std::str::FromStr for KeyEvent {
                 let function: String = function.chars().skip(1).collect();
                 let function = str::parse::<u8>(&function)?;
                 (function > 0 && function < 13)
-                    .then(|| KeyCode::F(function))
+                    .then_some(KeyCode::F(function))
                     .ok_or_else(|| anyhow!("Invalid function key '{}'", function))?
             }
             invalid => return Err(anyhow!("Invalid key code '{}'", invalid)),

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -243,7 +243,7 @@ impl View {
                 true
             }
             Some((visual_pos, _)) if visual_pos.row >= vertical_viewport_end - scrolloff => {
-                if CENTERING && visual_pos.row >= vertical_viewport_end as usize {
+                if CENTERING && visual_pos.row >= vertical_viewport_end {
                     // cursor out of view
                     return None;
                 }

--- a/xtask/src/themelint.rs
+++ b/xtask/src/themelint.rs
@@ -156,7 +156,7 @@ pub fn lint(file: String) -> Result<(), DynError> {
         return Ok(());
     }
     let path = path::themes().join(file.clone() + ".toml");
-    let theme = std::fs::read_to_string(&path).unwrap();
+    let theme = std::fs::read_to_string(path).unwrap();
     let theme: Theme = toml::from_str(&theme).expect("Failed to parse theme");
 
     let mut messages: Vec<String> = vec![];


### PR DESCRIPTION
With the MSRV raised to 1.63 we can now resolve all clippy lints that showup with 1.67. These new lints are actually improving the code (instead of just being false positives/pedantic like some other lints) so it seemed worth it to include the fixes. Particularly in #5420 I missed alot of unnecesary `usize` casts (so `usize` -> `usize`), because I changed types of some variables while working on that.