### PR TITLE
Show current language when no argument is provided

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -59,7 +59,7 @@
 | `:hsplit-new`, `:hnew` | Open a scratch buffer in a horizontal split. |
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Goto line number. |
-| `:set-language`, `:lang` | Set the language of current buffer. |
+| `:set-language`, `:lang` | Set the language of current buffer (show current language if no value specified). |
 | `:set-option`, `:set` | Set a config option at runtime.<br>For example to disable smart case search, use `:set search.smart-case false`. |
 | `:get-option`, `:get` | Get the current value of a config option. |
 | `:sort` | Sort ranges in selection. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -6,6 +6,7 @@ use crate::job::Job;
 use super::*;
 
 use helix_core::encoding;
+use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::editor::{Action, CloseError, ConfigEvent};
 use ui::completers::{self, Completer};
 
@@ -1656,13 +1657,20 @@ fn language(
         return Ok(());
     }
 
+    if args.is_empty() {
+        let doc = doc!(cx.editor);
+        let language = &doc.language_name().unwrap_or(DEFAULT_LANGUAGE_NAME);
+        cx.editor.set_status(language.to_string());
+        return Ok(());
+    }
+
     if args.len() != 1 {
         anyhow::bail!("Bad arguments. Usage: `:set-language language`");
     }
 
     let doc = doc_mut!(cx.editor);
 
-    if args[0] == "text" {
+    if args[0] == DEFAULT_LANGUAGE_NAME {
         doc.set_language(None, None)
     } else {
         doc.set_language_by_language_id(&args[0], cx.editor.syn_loader.clone())?;
@@ -2373,7 +2381,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "set-language",
             aliases: &["lang"],
-            doc: "Set the language of current buffer.",
+            doc: "Set the language of current buffer (show current language if no value specified).",
             fun: language,
             completer: Some(completers::language),
         },

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,5 +1,6 @@
 use helix_core::{coords_at_pos, encoding, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
+use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::Rect,
@@ -402,7 +403,7 @@ fn render_file_type<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    let file_type = context.doc.language_name().unwrap_or("text");
+    let file_type = context.doc.language_name().unwrap_or(DEFAULT_LANGUAGE_NAME);
 
     write(context, format!(" {} ", file_type), None);
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -39,6 +39,8 @@ const BUF_SIZE: usize = 8192;
 
 const DEFAULT_INDENT: IndentStyle = IndentStyle::Tabs;
 
+pub const DEFAULT_LANGUAGE_NAME: &str = "text";
+
 pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
The command `:set-language` and `:lang` now behaves like `:theme`, as mentioned [here](https://github.com/helix-editor/helix/discussions/5847#discussioncomment-4883555).

- Should the default value "text" be used, like in the statusline, maybe define a constant?
- I expected `:language` to work, is there any reason against adding it as an alias?