### PR TITLE
Add exit code to command failed msg

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5043,7 +5043,10 @@ async fn shell_impl_async(
             log::error!("Shell error: {}", err);
             bail!("Shell error: {}", err);
         }
-        bail!("Shell command failed");
+        match output.status.code() {
+            Some(exit_code) => bail!("Shell command failed: status {}", exit_code),
+            None => bail!("Shell command failed"),
+        }
     } else if !output.stderr.is_empty() {
         log::debug!(
             "Command printed to stderr: {}",


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/5716 (last pr here https://github.com/helix-editor/helix/pull/5885)

Added the actual exit code to the `Shell command failed` message to be less ambiguous. Main reason is because some commands still succeed with exit codes other than 0.

Thx @CptPotato for the explanation. 👍 