### PR TITLE
Add comment-token to the hosts language definition

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2162,6 +2162,7 @@ name = "hosts"
 scope = "source.hosts"
 file-types = ["hosts"]
 roots = []
+comment-token = "#"
 
 [[grammar]]
 name = "hosts"


### PR DESCRIPTION
`hosts` file uses `#` character as a comment token.

[hosts(5)](https://www.man7.org/linux/man-pages/man5/hosts.5.html)