### PR TITLE
Unify usage of indent_style

### DIFF
--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -46,11 +46,13 @@ fn test_treesitter_indent(file_name: &str, lang_scope: &str) {
     for i in 0..doc.len_lines() {
         let line = text.line(i);
         if let Some(pos) = helix_core::find_first_non_whitespace_char(line) {
+            let tab_and_indent_width: usize = 4;
             let suggested_indent = treesitter_indent_for_pos(
                 indent_query,
                 &syntax,
-                &IndentStyle::Spaces(4),
-                4,
+                &IndentStyle::Spaces(tab_and_indent_width as u8),
+                tab_and_indent_width,
+                tab_and_indent_width,
                 text,
                 i,
                 text.line_to_char(i) + pos,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3365,8 +3365,8 @@ pub mod insert {
         let count = cx.count();
         let (view, doc) = current_ref!(cx.editor);
         let text = doc.text().slice(..);
-        let indent_unit = doc.indent_style.as_str();
-        let tab_size = doc.tab_width();
+        let tab_width = doc.tab_width();
+        let indent_width = doc.indent_width();
         let auto_pairs = doc.auto_pairs(cx.editor);
 
         let transaction =
@@ -3387,18 +3387,11 @@ pub mod insert {
                             None,
                         )
                     } else {
-                        let unit_len = indent_unit.chars().count();
-                        // NOTE: indent_unit always contains 'only spaces' or 'only tab' according to `IndentStyle` definition.
-                        let unit_size = if indent_unit.starts_with('\t') {
-                            tab_size * unit_len
-                        } else {
-                            unit_len
-                        };
                         let width: usize = fragment
                             .chars()
                             .map(|ch| {
                                 if ch == '\t' {
-                                    tab_size
+                                    tab_width
                                 } else {
                                     // it can be none if it still meet control characters other than '\t'
                                     // here just set the width to 1 (or some value better?).
@@ -3406,9 +3399,9 @@ pub mod insert {
                                 }
                             })
                             .sum();
-                        let mut drop = width % unit_size; // round down to nearest unit
+                        let mut drop = width % indent_width; // round down to nearest unit
                         if drop == 0 {
-                            drop = unit_size
+                            drop = indent_width
                         }; // if it's already at a unit, consume a whole unit
                         let mut chars = fragment.chars().rev();
                         let mut start = pos;
@@ -3950,7 +3943,7 @@ fn unindent(cx: &mut Context) {
     let lines = get_lines(doc, view.id);
     let mut changes = Vec::with_capacity(lines.len());
     let tab_width = doc.tab_width();
-    let indent_width = count * tab_width;
+    let indent_width = count * doc.indent_width();
 
     for line_idx in lines {
         let line = doc.text().line(line_idx);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1122,11 +1122,16 @@ impl Document {
         self.syntax.as_ref()
     }
 
-    /// Tab size in columns.
+    /// The width that the tab character is rendered at
     pub fn tab_width(&self) -> usize {
         self.language_config()
             .and_then(|config| config.indent.as_ref())
             .map_or(4, |config| config.tab_width) // fallback to 4 columns
+    }
+
+    // The width (in spaces) of a level of indentation.
+    pub fn indent_width(&self) -> usize {
+        self.indent_style.indent_width(self.tab_width())
     }
 
     pub fn changes(&self) -> &ChangeSet {


### PR DESCRIPTION
Previously, we used sometimes `doc.indent_style` and sometimes `doc.language_config.indent`. This caused some issues if they differ (e.g. if a non-default indent style is auto-detected in a document or manually set). For example, in a markdown file, setting `:indent-style 8` and then continuously pressing enter (starting on an indented line) increases the indent each time. This happens because the indent_style used to detect the indentation level of an existing line is different from the indent_style used to convert an indentation level to a string. The same issue occurs in any language without indent queries.
 
With these changes, `language_config.indent` is only used to initialize `doc.indent_style` and afterwards ignored. Resolves #2236 and #3406.