### PR TITLE
feat(ui): deprecated completions

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -318,6 +318,10 @@ impl Client {
                                 ],
                             }),
                             insert_replace_support: Some(true),
+                            deprecated_support: Some(true),
+                            tag_support: Some(lsp::TagSupport {
+                                value_set: vec![lsp::CompletionItemTag::DEPRECATED],
+                            }),
                             ..Default::default()
                         }),
                         completion_item_kind: Some(lsp::CompletionItemKindCapability {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,6 +1,10 @@
 use crate::compositor::{Component, Context, Event, EventResult};
-use helix_view::{editor::CompleteAction, ViewId};
-use tui::buffer::Buffer as Surface;
+use helix_view::{
+    editor::CompleteAction,
+    theme::{Modifier, Style},
+    ViewId,
+};
+use tui::{buffer::Buffer as Surface, text::Span};
 
 use std::borrow::Cow;
 
@@ -33,8 +37,20 @@ impl menu::Item for CompletionItem {
     }
 
     fn format(&self, _data: &Self::Data) -> menu::Row {
+        let deprecated = if let Some(tags) = &self.tags {
+            tags.contains(&lsp::CompletionItemTag::DEPRECATED)
+        } else {
+            self.deprecated.unwrap_or_default()
+        };
         menu::Row::new(vec![
-            menu::Cell::from(self.label.as_str()),
+            menu::Cell::from(Span::styled(
+                self.label.as_str(),
+                if deprecated {
+                    Style::default().add_modifier(Modifier::CROSSED_OUT)
+                } else {
+                    Style::default()
+                },
+            )),
             menu::Cell::from(match self.kind {
                 Some(lsp::CompletionItemKind::TEXT) => "text",
                 Some(lsp::CompletionItemKind::METHOD) => "method",

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -37,11 +37,10 @@ impl menu::Item for CompletionItem {
     }
 
     fn format(&self, _data: &Self::Data) -> menu::Row {
-        let deprecated = if let Some(tags) = &self.tags {
-            tags.contains(&lsp::CompletionItemTag::DEPRECATED)
-        } else {
-            self.deprecated.unwrap_or_default()
-        };
+        let deprecated = self.deprecated.unwrap_or_default()
+            || self.tags.as_ref().map_or(false, |tags| {
+                tags.contains(&lsp::CompletionItemTag::DEPRECATED)
+            });
         menu::Row::new(vec![
             menu::Cell::from(Span::styled(
                 self.label.as_str(),


### PR DESCRIPTION
Mark deprecated completions using strike-through (CROSSED_OUT modifier). The deprection information is taken either from the `deprecated` field of the completion item or from the completion tags.

The `deprecated` field seems to be the older way of passing the deprecated information and it was already marked as deprecated for `Symbol`. In `CompletionItem` the `deprecated` field is still valid but it seems that the LSP is moving in the general direction of using tags for this kind of information and as such relying on tags as well seems reasonable and future-proof.

![Screenshot 2023-02-12 at 00 24 37](https://user-images.githubusercontent.com/15747583/218285729-1318b6dc-066f-4a0d-b105-302be708186e.png)
