### PR TITLE
Feat: LSP Type Hints

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -118,9 +118,11 @@ The following statusline elements can be configured:
 | `enable`              | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.| `true` |
 | `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
+| `display-inlay-hints` | Display inlay hints[^2]                                     | `true`  |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
+[^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix
 
 ### `[editor.cursor-shape]` Section
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -118,11 +118,12 @@ The following statusline elements can be configured:
 | `enable`              | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.| `true` |
 | `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
-| `display-inlay-hints` | Display inlay hints[^2]                                     | `true`  |
+| `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
-[^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix
+[^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix.
+      Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances, please report any bugs you see so we can fix them!
 
 ### `[editor.cursor-shape]` Section
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -296,7 +296,6 @@ These scopes are used for theming the editor interface:
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
 | `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |
-| `ui.virtual.inlay-hint.padding`   | Style for inlay hint padding (helps not confusing it with regular whitespaces)                 |
 | `ui.virtual.inlay-hint.parameter` | Style for inlay hints of kind `parameter` (LSPs are not required to set a kind)                |
 | `ui.virtual.inlay-hint.type`      | Style for inlay hints of kind `type` (LSPs are not required to set a kind)                     |
 | `ui.virtual.wrap`                 | Soft-wrap indicator (see the [`editor.soft-wrap` config][editor-section])                      |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -261,58 +261,61 @@ These scopes are used for theming the editor interface:
       - `hover` - for hover popup UI
 
 
-| Key                         | Notes                                                                                          |
-| ---                         | ---                                                                                            |
-| `ui.background`             |                                                                                                |
-| `ui.background.separator`   | Picker separator below input line                                                              |
-| `ui.cursor`                 |                                                                                                |
-| `ui.cursor.normal`          |                                                                                                |
-| `ui.cursor.insert`          |                                                                                                |
-| `ui.cursor.select`          |                                                                                                |
-| `ui.cursor.match`           | Matching bracket etc.                                                                          |
-| `ui.cursor.primary`         | Cursor with primary selection                                                                  |
-| `ui.cursor.primary.normal`  |                                                                                                |
-| `ui.cursor.primary.insert`  |                                                                                                |
-| `ui.cursor.primary.select`  |                                                                                                |
-| `ui.gutter`                 | Gutter                                                                                         |
-| `ui.gutter.selected`        | Gutter for the line the cursor is on                                                           |
-| `ui.linenr`                 | Line numbers                                                                                   |
-| `ui.linenr.selected`        | Line number for the line the cursor is on                                                      |
-| `ui.statusline`             | Statusline                                                                                     |
-| `ui.statusline.inactive`    | Statusline (unfocused document)                                                                |
-| `ui.statusline.normal`      | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.insert`      | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.select`      | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
-| `ui.statusline.separator`   | Separator character in statusline                                                              |
-| `ui.popup`                  | Documentation popups (e.g. Space + k)                                                          |
-| `ui.popup.info`             | Prompt for multiple key options                                                                |
-| `ui.window`                 | Borderlines separating splits                                                                  |
-| `ui.help`                   | Description box for commands                                                                   |
-| `ui.text`                   | Command prompts, popup text, etc.                                                              |
-| `ui.text.focus`             |                                                                                                |
-| `ui.text.inactive`          | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
-| `ui.text.info`              | The key: command text in `ui.popup.info` boxes                                                 |
-| `ui.virtual.ruler`          | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
-| `ui.virtual.whitespace`     | Visible whitespace characters                                                                  |
-| `ui.virtual.indent-guide`   | Vertical indent width guides                                                                   |
-| `ui.virtual.wrap`           | Soft-wrap indicator (see the [`editor.soft-wrap` config][editor-section])                      |
-| `ui.menu`                   | Code and command completion menus                                                              |
-| `ui.menu.selected`          | Selected autocomplete item                                                                     |
-| `ui.menu.scroll`            | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |
-| `ui.selection`              | For selections in the editing area                                                             |
-| `ui.selection.primary`      |                                                                                                |
-| `ui.cursorline.primary`     | The line of the primary cursor ([if cursorline is enabled][editor-section])                    |
-| `ui.cursorline.secondary`   | The lines of any other cursors ([if cursorline is enabled][editor-section])                    |
-| `ui.cursorcolumn.primary`   | The column of the primary cursor ([if cursorcolumn is enabled][editor-section])                |
-| `ui.cursorcolumn.secondary` | The columns of any other cursors ([if cursorcolumn is enabled][editor-section])                |
-| `warning`                   | Diagnostics warning (gutter)                                                                   |
-| `error`                     | Diagnostics error (gutter)                                                                     |
-| `info`                      | Diagnostics info (gutter)                                                                      |
-| `hint`                      | Diagnostics hint (gutter)                                                                      |
-| `diagnostic`                | Diagnostics fallback style (editing area)                                                      |
-| `diagnostic.hint`           | Diagnostics hint (editing area)                                                                |
-| `diagnostic.info`           | Diagnostics info (editing area)                                                                |
-| `diagnostic.warning`        | Diagnostics warning (editing area)                                                             |
-| `diagnostic.error`          | Diagnostics error (editing area)                                                               |
+| Key                               | Notes                                                                                          |
+| ---                               | ---                                                                                            |
+| `ui.background`                   |                                                                                                |
+| `ui.background.separator`         | Picker separator below input line                                                              |
+| `ui.cursor`                       |                                                                                                |
+| `ui.cursor.normal`                |                                                                                                |
+| `ui.cursor.insert`                |                                                                                                |
+| `ui.cursor.select`                |                                                                                                |
+| `ui.cursor.match`                 | Matching bracket etc.                                                                          |
+| `ui.cursor.primary`               | Cursor with primary selection                                                                  |
+| `ui.cursor.primary.normal`        |                                                                                                |
+| `ui.cursor.primary.insert`        |                                                                                                |
+| `ui.cursor.primary.select`        |                                                                                                |
+| `ui.gutter`                       | Gutter                                                                                         |
+| `ui.gutter.selected`              | Gutter for the line the cursor is on                                                           |
+| `ui.linenr`                       | Line numbers                                                                                   |
+| `ui.linenr.selected`              | Line number for the line the cursor is on                                                      |
+| `ui.statusline`                   | Statusline                                                                                     |
+| `ui.statusline.inactive`          | Statusline (unfocused document)                                                                |
+| `ui.statusline.normal`            | Statusline mode during normal mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.insert`            | Statusline mode during insert mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.select`            | Statusline mode during select mode ([only if `editor.color-modes` is enabled][editor-section]) |
+| `ui.statusline.separator`         | Separator character in statusline                                                              |
+| `ui.popup`                        | Documentation popups (e.g. Space + k)                                                          |
+| `ui.popup.info`                   | Prompt for multiple key options                                                                |
+| `ui.window`                       | Borderlines separating splits                                                                  |
+| `ui.help`                         | Description box for commands                                                                   |
+| `ui.text`                         | Command prompts, popup text, etc.                                                              |
+| `ui.text.focus`                   |                                                                                                |
+| `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
+| `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
+| `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
+| `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
+| `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
+| `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |
+| `ui.virtual.inlay-hint.parameter` | Style for inlay hints of kind `parameter` (LSPs are not required to set a kind)                |
+| `ui.virtual.inlay-hint.type`      | Style for inlay hints of kind `type` (LSPs are not required to set a kind)                     |
+| `ui.virtual.wrap`                 | Soft-wrap indicator (see the [`editor.soft-wrap` config][editor-section])                      |
+| `ui.menu`                         | Code and command completion menus                                                              |
+| `ui.menu.selected`                | Selected autocomplete item                                                                     |
+| `ui.menu.scroll`                  | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |
+| `ui.selection`                    | For selections in the editing area                                                             |
+| `ui.selection.primary`            |                                                                                                |
+| `ui.cursorline.primary`           | The line of the primary cursor ([if cursorline is enabled][editor-section])                    |
+| `ui.cursorline.secondary`         | The lines of any other cursors ([if cursorline is enabled][editor-section])                    |
+| `ui.cursorcolumn.primary`         | The column of the primary cursor ([if cursorcolumn is enabled][editor-section])                |
+| `ui.cursorcolumn.secondary`       | The columns of any other cursors ([if cursorcolumn is enabled][editor-section])                |
+| `warning`                         | Diagnostics warning (gutter)                                                                   |
+| `error`                           | Diagnostics error (gutter)                                                                     |
+| `info`                            | Diagnostics info (gutter)                                                                      |
+| `hint`                            | Diagnostics hint (gutter)                                                                      |
+| `diagnostic`                      | Diagnostics fallback style (editing area)                                                      |
+| `diagnostic.hint`                 | Diagnostics hint (editing area)                                                                |
+| `diagnostic.info`                 | Diagnostics info (editing area)                                                                |
+| `diagnostic.warning`              | Diagnostics warning (editing area)                                                             |
+| `diagnostic.error`                | Diagnostics error (editing area)                                                               |
 
 [editor-section]: ./configuration.md#editor-section

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -296,6 +296,7 @@ These scopes are used for theming the editor interface:
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
 | `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |
+| `ui.virtual.inlay-hint.padding`   | Style for inlay hint padding (helps not confusing it with regular whitespaces)                 |
 | `ui.virtual.inlay-hint.parameter` | Style for inlay hints of kind `parameter` (LSPs are not required to set a kind)                |
 | `ui.virtual.inlay-hint.type`      | Style for inlay hints of kind `type` (LSPs are not required to set a kind)                     |
 | `ui.virtual.wrap`                 | Soft-wrap indicator (see the [`editor.soft-wrap` config][editor-section])                      |

--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -35,7 +35,7 @@ pub enum DiagnosticTag {
     Deprecated,
 }
 
-/// Corresponds to [`lsp_types::Diagnostic`](https://docs.rs/lsp-types/0.91.0/lsp_types/struct.Diagnostic.html)
+/// Corresponds to [`lsp_types::Diagnostic`](https://docs.rs/lsp-types/0.94.0/lsp_types/struct.Diagnostic.html)
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
     pub range: Range,

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -119,16 +119,7 @@ fn overlay() {
             "foobar",
             0,
             false,
-            &[
-                Overlay {
-                    char_idx: 0,
-                    grapheme: "X".into(),
-                },
-                Overlay {
-                    char_idx: 2,
-                    grapheme: "\t".into(),
-                },
-            ]
+            &[Overlay::new(0, "X"), Overlay::new(2, "\t")],
         ),
         "Xo  bar "
     );
@@ -138,18 +129,9 @@ fn overlay() {
             0,
             true,
             &[
-                Overlay {
-                    char_idx: 2,
-                    grapheme: "\t".into(),
-                },
-                Overlay {
-                    char_idx: 5,
-                    grapheme: "\t".into(),
-                },
-                Overlay {
-                    char_idx: 16,
-                    grapheme: "X".into(),
-                },
+                Overlay::new(2, "\t"),
+                Overlay::new(5, "\t"),
+                Overlay::new(16, "X"),
             ]
         ),
         "fo   f  o foo \n.foo Xoo foo foo \n.foo foo foo  "
@@ -170,24 +152,14 @@ fn annotate_text(text: &str, softwrap: bool, annotations: &[InlineAnnotation]) -
 #[test]
 fn annotation() {
     assert_eq!(
-        annotate_text(
-            "bar",
-            false,
-            &[InlineAnnotation {
-                char_idx: 0,
-                text: "foo".into(),
-            }]
-        ),
+        annotate_text("bar", false, &[InlineAnnotation::new(0, "foo")]),
         "foobar "
     );
     assert_eq!(
         annotate_text(
             &"foo ".repeat(10),
             true,
-            &[InlineAnnotation {
-                char_idx: 0,
-                text: "foo ".into(),
-            }]
+            &[InlineAnnotation::new(0, "foo ")]
         ),
         "foo foo foo foo \n.foo foo foo foo \n.foo foo foo  "
     );
@@ -199,20 +171,8 @@ fn annotation_and_overlay() {
             "bbar".into(),
             &TextFormat::new_test(false),
             TextAnnotations::default()
-                .add_inline_annotations(
-                    Rc::new([InlineAnnotation {
-                        char_idx: 0,
-                        text: "fooo".into(),
-                    }]),
-                    None
-                )
-                .add_overlay(
-                    Rc::new([Overlay {
-                        char_idx: 0,
-                        grapheme: "\t".into(),
-                    }]),
-                    None
-                ),
+                .add_inline_annotations(Rc::new([InlineAnnotation::new(0, "fooo")]), None)
+                .add_overlay(Rc::new([Overlay::new(0, "\t")]), None),
             0,
         )
         .0

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -15,6 +15,15 @@ pub struct InlineAnnotation {
     pub char_idx: usize,
 }
 
+impl InlineAnnotation {
+    pub fn new(char_idx: usize, text: impl Into<Tendril>) -> Self {
+        Self {
+            char_idx,
+            text: text.into(),
+        }
+    }
+}
+
 /// Represents a **single Grapheme** that is part of the document
 /// that start at `char_idx` that will be replaced with
 /// a different `grapheme`.
@@ -33,22 +42,13 @@ pub struct InlineAnnotation {
 /// use helix_core::text_annotations::Overlay;
 ///
 /// // replaces a
-/// Overlay {
-///   char_idx: 0,
-///   grapheme: "X".into(),
-/// };
+/// Overlay::new(0, "X");
 ///
 /// // replaces X͎̊͢͜͝͡
-/// Overlay{
-///   char_idx: 1,
-///   grapheme: "\t".into(),
-/// };
+/// Overlay::new(1, "\t");
 ///
 /// // replaces b
-/// Overlay{
-///   char_idx: 6,
-///   grapheme: "X̢̢̟͖̲͌̋̇͑͝".into(),
-/// };
+/// Overlay::new(6, "X̢̢̟͖̲͌̋̇͑͝");
 /// ```
 ///
 /// The following examples are invalid uses
@@ -57,21 +57,24 @@ pub struct InlineAnnotation {
 /// use helix_core::text_annotations::Overlay;
 ///
 /// // overlay is not aligned at grapheme boundary
-/// Overlay{
-///   char_idx: 3,
-///   grapheme: "x".into(),
-/// };
+/// Overlay::new(3, "x");
 ///
 /// // overlay contains multiple graphemes
-/// Overlay{
-///   char_idx: 0,
-///   grapheme: "xy".into(),
-/// };
+/// Overlay::new(0, "xy");
 /// ```
 #[derive(Debug, Clone)]
 pub struct Overlay {
     pub char_idx: usize,
     pub grapheme: Tendril,
+}
+
+impl Overlay {
+    pub fn new(char_idx: usize, grapheme: impl Into<Tendril>) -> Self {
+        Self {
+            char_idx,
+            grapheme: grapheme.into(),
+        }
+    }
 }
 
 /// Line annotations allow for virtual text between normal

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -733,6 +733,31 @@ impl Client {
         Some(self.call::<lsp::request::SignatureHelpRequest>(params))
     }
 
+    pub fn text_document_range_inlay_hints(
+        &self,
+        text_document: lsp::TextDocumentIdentifier,
+        range: lsp::Range,
+        work_done_token: Option<lsp::ProgressToken>,
+    ) -> Option<impl Future<Output = Result<Value>>> {
+        let capabilities = self.capabilities.get().unwrap();
+
+        match capabilities.inlay_hint_provider {
+            Some(
+                lsp::OneOf::Left(true)
+                | lsp::OneOf::Right(lsp::InlayHintServerCapabilities::Options(_)),
+            ) => (),
+            _ => return None,
+        }
+
+        let params = lsp::InlayHintParams {
+            text_document,
+            range,
+            work_done_progress_params: lsp::WorkDoneProgressParams { work_done_token },
+        };
+
+        Some(self.call::<lsp::request::InlayHintRequest>(params))
+    }
+
     pub fn text_document_hover(
         &self,
         text_document: lsp::TextDocumentIdentifier,

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -315,6 +315,9 @@ impl Client {
                     execute_command: Some(lsp::DynamicRegistrationClientCapabilities {
                         dynamic_registration: Some(false),
                     }),
+                    inlay_hint: Some(lsp::InlayHintWorkspaceClientCapabilities {
+                        refresh_support: Some(false),
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(lsp::TextDocumentClientCapabilities {
@@ -385,6 +388,10 @@ impl Client {
                     }),
                     publish_diagnostics: Some(lsp::PublishDiagnosticsClientCapabilities {
                         ..Default::default()
+                    }),
+                    inlay_hint: Some(lsp::InlayHintClientCapabilities {
+                        dynamic_registration: Some(false),
+                        resolve_support: None,
                     }),
                     ..Default::default()
                 }),

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -15,8 +15,13 @@ use tui::{
 
 use super::{align_view, push_jump, Align, Context, Editor, Open};
 
-use helix_core::{path, Selection};
-use helix_view::{document::Mode, editor::Action, theme::Style};
+use helix_core::{path, text_annotations::InlineAnnotation, Selection};
+use helix_view::{
+    document::{DocumentInlayHints, DocumentInlayHintsId, Mode},
+    editor::Action,
+    theme::Style,
+    Document, View,
+};
 
 use crate::{
     compositor::{self, Compositor},
@@ -27,7 +32,8 @@ use crate::{
 };
 
 use std::{
-    borrow::Cow, cmp::Ordering, collections::BTreeMap, fmt::Write, path::PathBuf, sync::Arc,
+    borrow::Cow, cmp::Ordering, collections::BTreeMap, fmt::Write, future::Future, path::PathBuf,
+    sync::Arc,
 };
 
 /// Gets the language server that is attached to a document, and
@@ -1390,4 +1396,171 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
             doc.set_selection(view.id, selection);
         },
     );
+}
+
+pub fn compute_inlay_hints_for_all_views(editor: &mut Editor, jobs: &mut crate::job::Jobs) {
+    if !editor.config().lsp.display_inlay_hints {
+        for doc in editor.documents.values_mut() {
+            doc.reset_all_inlay_hints();
+        }
+        return;
+    }
+
+    for (view, _) in editor.tree.views() {
+        let doc = match editor.documents.get_mut(&view.doc) {
+            Some(doc) => doc,
+            None => continue,
+        };
+        if let Some(callback) = compute_inlay_hints_for_view(view, doc) {
+            jobs.callback(callback);
+        }
+    }
+}
+
+fn compute_inlay_hints_for_view(
+    view: &View,
+    doc: &mut Document,
+) -> Option<std::pin::Pin<Box<impl Future<Output = Result<crate::job::Callback, anyhow::Error>>>>> {
+    let view_id = view.id;
+    let doc_id = view.doc;
+    let revision = doc.get_current_revision();
+
+    let language_server = doc.language_server()?;
+
+    let capabilities = language_server.capabilities();
+
+    let (future, new_doc_inlay_hints_id) = match capabilities.inlay_hint_provider {
+        Some(
+            lsp::OneOf::Left(true)
+            | lsp::OneOf::Right(lsp::InlayHintServerCapabilities::Options(_)),
+        ) => {
+            let doc_text = doc.text();
+            let len_lines = doc_text.len_lines();
+
+            // Compute ~3 times the current view height of inlay hints, that way some scrolling
+            // will not show half the view with hints and half without while still being faster
+            // than computing all the hints for the full file (which could be dozens of time
+            // longer than the view is).
+            let view_height = view.inner_height();
+            let first_visible_line = doc_text.char_to_line(view.offset.anchor);
+            let first_line = first_visible_line.saturating_sub(view_height);
+            let last_line = first_visible_line
+                .saturating_add(view_height.saturating_mul(2))
+                .min(len_lines);
+
+            let new_doc_inlay_hint_id = DocumentInlayHintsId {
+                revision,
+                first_line,
+                last_line,
+            };
+            // Don't recompute the annotations in case nothing has changed about the view
+            if doc
+                .get_inlay_hints(view_id)
+                .map_or(false, |dih| dih.id == new_doc_inlay_hint_id)
+            {
+                return None;
+            }
+
+            let doc_slice = doc_text.slice(..);
+            let first_char_in_range = doc_slice.line_to_char(first_line);
+            let last_char_in_range = doc_slice.line_to_char(last_line);
+
+            let range = helix_lsp::util::range_to_lsp_range(
+                doc_text,
+                helix_core::Range::new(first_char_in_range, last_char_in_range),
+                language_server.offset_encoding(),
+            );
+
+            (
+                language_server.text_document_range_inlay_hints(doc.identifier(), range, None),
+                new_doc_inlay_hint_id,
+            )
+        }
+        _ => return None,
+    };
+
+    let callback = super::make_job_callback(
+        future?,
+        move |editor, _compositor, response: Option<Vec<lsp::InlayHint>>| {
+            // The config was modified or the window was closed while the request was in flight
+            if !editor.config().lsp.display_inlay_hints || editor.tree.try_get(view_id).is_none() {
+                return;
+            }
+
+            // Add annotations to relevant document, not the current one (it may have changed in between)
+            let doc = match editor.documents.get_mut(&doc_id) {
+                Some(doc) => doc,
+                None => return,
+            };
+
+            let mut hints = match response {
+                Some(h) if !h.is_empty() => h,
+                _ => return,
+            };
+
+            let offset_encoding = match doc.language_server() {
+                Some(ls) => ls.offset_encoding(),
+                None => return,
+            };
+
+            // Most language servers will already send them sorted but ensure this is the case to
+            // avoid errors on our end.
+            hints.sort_unstable_by_key(|inlay_hint| inlay_hint.position);
+
+            let mut type_inlay_hints = Vec::new();
+            let mut parameter_inlay_hints = Vec::new();
+            let mut other_inlay_hints = Vec::new();
+
+            let doc_text = doc.text();
+
+            for hint in hints {
+                let char_idx =
+                    match helix_lsp::util::lsp_pos_to_pos(doc_text, hint.position, offset_encoding)
+                    {
+                        Some(pos) => pos,
+                        // Skip inlay hints that have no "real" position
+                        None => continue,
+                    };
+
+                let label = match hint.label {
+                    lsp::InlayHintLabel::String(s) => s,
+                    lsp::InlayHintLabel::LabelParts(parts) => parts
+                        .into_iter()
+                        .map(|p| p.value)
+                        .collect::<Vec<_>>()
+                        .join(""),
+                };
+
+                let inlay_hints_vec = match hint.kind {
+                    Some(lsp::InlayHintKind::TYPE) => &mut type_inlay_hints,
+                    Some(lsp::InlayHintKind::PARAMETER) => &mut parameter_inlay_hints,
+                    // We can't warn on unknown kind here since LSPs are free to set it or not, for
+                    // example Rust Analyzer does not: every kind will be `None`.
+                    _ => &mut other_inlay_hints,
+                };
+
+                if let Some(true) = hint.padding_left {
+                    inlay_hints_vec.push(InlineAnnotation::new(char_idx, " "));
+                }
+
+                inlay_hints_vec.push(InlineAnnotation::new(char_idx, label));
+
+                if let Some(true) = hint.padding_right {
+                    inlay_hints_vec.push(InlineAnnotation::new(char_idx, " "));
+                }
+            }
+
+            doc.set_inlay_hints(
+                view_id,
+                DocumentInlayHints {
+                    id: new_doc_inlay_hints_id,
+                    type_inlay_hints: type_inlay_hints.into(),
+                    parameter_inlay_hints: parameter_inlay_hints.into(),
+                    other_inlay_hints: other_inlay_hints.into(),
+                },
+            );
+        },
+    );
+
+    Some(callback)
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1504,9 +1504,11 @@ fn compute_inlay_hints_for_view(
             // avoid errors on our end.
             hints.sort_unstable_by_key(|inlay_hint| inlay_hint.position);
 
+            let mut padding_before_inlay_hints = Vec::new();
             let mut type_inlay_hints = Vec::new();
             let mut parameter_inlay_hints = Vec::new();
             let mut other_inlay_hints = Vec::new();
+            let mut padding_after_inlay_hints = Vec::new();
 
             let doc_text = doc.text();
 
@@ -1537,13 +1539,13 @@ fn compute_inlay_hints_for_view(
                 };
 
                 if let Some(true) = hint.padding_left {
-                    inlay_hints_vec.push(InlineAnnotation::new(char_idx, " "));
+                    padding_before_inlay_hints.push(InlineAnnotation::new(char_idx, " "));
                 }
 
                 inlay_hints_vec.push(InlineAnnotation::new(char_idx, label));
 
                 if let Some(true) = hint.padding_right {
-                    inlay_hints_vec.push(InlineAnnotation::new(char_idx, " "));
+                    padding_after_inlay_hints.push(InlineAnnotation::new(char_idx, " "));
                 }
             }
 
@@ -1554,6 +1556,8 @@ fn compute_inlay_hints_for_view(
                     type_inlay_hints: type_inlay_hints.into(),
                     parameter_inlay_hints: parameter_inlay_hints.into(),
                     other_inlay_hints: other_inlay_hints.into(),
+                    padding_before_inlay_hints: padding_before_inlay_hints.into(),
+                    padding_after_inlay_hints: padding_after_inlay_hints.into(),
                 },
             );
         },

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1400,9 +1400,6 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
 
 pub fn compute_inlay_hints_for_all_views(editor: &mut Editor, jobs: &mut crate::job::Jobs) {
     if !editor.config().lsp.display_inlay_hints {
-        for doc in editor.documents.values_mut() {
-            doc.reset_all_inlay_hints();
-        }
         return;
     }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1455,7 +1455,7 @@ fn compute_inlay_hints_for_view(
             };
             // Don't recompute the annotations in case nothing has changed about the view
             if doc
-                .get_inlay_hints(view_id)
+                .inlay_hints(view_id)
                 .map_or(false, |dih| dih.id == new_doc_inlay_hint_id)
             {
                 return None;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1002,6 +1002,10 @@ impl EditorView {
         event: &MouseEvent,
         cxt: &mut commands::Context,
     ) -> EventResult {
+        if event.kind != MouseEventKind::Moved {
+            cxt.editor.reset_idle_timer();
+        }
+
         let config = cxt.editor.config();
         let MouseEvent {
             kind,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -978,6 +978,8 @@ impl EditorView {
     }
 
     pub fn handle_idle_timeout(&mut self, cx: &mut commands::Context) -> EventResult {
+        commands::compute_inlay_hints_for_all_views(cx.editor, cx.jobs);
+
         if let Some(completion) = &mut self.completion {
             return if completion.ensure_item_resolved(cx) {
                 EventResult::Consumed(None)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -225,6 +225,9 @@ impl<T: Item> FilePicker<T> {
                 let loader = cx.editor.syn_loader.clone();
                 doc.detect_language(loader);
             }
+
+            // QUESTION: do we want to compute inlay hints in pickers too ? Probably not for now
+            // but it could be interesting in the future
         }
 
         EventResult::Consumed(None)
@@ -339,6 +342,7 @@ impl<T: Item + 'static> Component for FilePicker<T> {
                 inner,
                 doc,
                 offset,
+                // TODO: compute text annotations asynchronously here (like inlay hints)
                 &TextAnnotations::default(),
                 highlights,
                 &cx.editor.theme,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1392,6 +1392,8 @@ impl Document {
         }
     }
 
+    /// Get the text annotations that apply to the whole document, those that do not apply to any
+    /// specific view.
     pub fn text_annotations(&self, _theme: Option<&Theme>) -> TextAnnotations {
         TextAnnotations::default()
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1161,6 +1161,7 @@ impl Document {
         &self.selections[&view_id]
     }
 
+    #[inline]
     pub fn selections(&self) -> &HashMap<ViewId, Selection> {
         &self.selections
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -114,7 +114,7 @@ pub struct Document {
     /// Inlay hints annotations for the document, by view.
     ///
     /// To know if they're up-to-date, check the `id` field in `DocumentInlayHints`.
-    inlay_hints: HashMap<ViewId, DocumentInlayHints>,
+    pub(crate) inlay_hints: HashMap<ViewId, DocumentInlayHints>,
 
     path: Option<PathBuf>,
     encoding: &'static encoding::Encoding,
@@ -1392,42 +1392,8 @@ impl Document {
         }
     }
 
-    pub fn text_annotations(&self, view_id: ViewId, theme: Option<&Theme>) -> TextAnnotations {
-        let mut text_annotations = TextAnnotations::default();
-
-        let DocumentInlayHints {
-            id: _,
-            type_inlay_hints,
-            parameter_inlay_hints,
-            other_inlay_hints,
-        } = match self.inlay_hints.get(&view_id) {
-            Some(doc_inlay_hints) => doc_inlay_hints,
-            None => return text_annotations,
-        };
-
-        let type_style = theme
-            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.type"))
-            .map(Highlight);
-        let parameter_style = theme
-            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.parameter"))
-            .map(Highlight);
-        let other_style = theme
-            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint"))
-            .map(Highlight);
-
-        let mut add_annotations = |annotations: &Rc<[_]>, style| {
-            if !annotations.is_empty() {
-                text_annotations.add_inline_annotations(Rc::clone(annotations), style);
-            }
-        };
-
-        // Overlapping annotations are ignored apart from the first so the order here is not random:
-        // types -> parameters -> others should hopefully be the "correct" order for most use cases.
-        add_annotations(type_inlay_hints, type_style);
-        add_annotations(parameter_inlay_hints, parameter_style);
-        add_annotations(other_inlay_hints, other_style);
-
-        text_annotations
+    pub fn text_annotations(&self, _theme: Option<&Theme>) -> TextAnnotations {
+        TextAnnotations::default()
     }
 
     /// Set the inlay hints for this document and `view_id`.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1404,7 +1404,7 @@ impl Document {
     }
 
     /// Get the inlay hints for this document and `view_id`.
-    pub fn get_inlay_hints(&self, view_id: ViewId) -> Option<&DocumentInlayHints> {
+    pub fn inlay_hints(&self, view_id: ViewId) -> Option<&DocumentInlayHints> {
         self.inlay_hints.get(&view_id)
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1120,6 +1120,19 @@ impl Editor {
 
     fn _refresh(&mut self) {
         let config = self.config();
+
+        // Reset the inlay hints annotations *before* updating the views, that way we ensure they
+        // will disappear during the `.sync_change(doc)` call below.
+        //
+        // We can't simply check this config when rendering because inlay hints are only parts of
+        // the possible annotations, and others could still be active, so we need to selectively
+        // drop the inlay hints.
+        if !config.lsp.display_inlay_hints {
+            for doc in self.documents_mut() {
+                doc.reset_all_inlay_hints();
+            }
+        }
+
         for (view, _) in self.tree.views_mut() {
             let doc = doc_mut!(self, &view.doc);
             view.sync_changes(doc);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -342,6 +342,8 @@ pub struct LspConfig {
     pub auto_signature_help: bool,
     /// Display docs under signature help popup
     pub display_signature_help_docs: bool,
+    /// Display inlay hints
+    pub display_inlay_hints: bool,
 }
 
 impl Default for LspConfig {
@@ -351,6 +353,7 @@ impl Default for LspConfig {
             display_messages: false,
             auto_signature_help: true,
             display_signature_help_docs: true,
+            display_inlay_hints: false,
         }
     }
 }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -278,16 +278,15 @@ impl Tree {
         self.try_get(index).unwrap()
     }
 
-    /// Try to get reference to a [View] by index. Returns `None` if node content is not a [Content::View]
-    /// # Panics
+    /// Try to get reference to a [View] by index. Returns `None` if node content is not a [`Content::View`].
     ///
-    /// Panics if `index` is not in self.nodes. This can be checked with [Self::contains]
+    /// Does not panic if the view does not exists anymore.
     pub fn try_get(&self, index: ViewId) -> Option<&View> {
-        match &self.nodes[index] {
-            Node {
+        match self.nodes.get(index) {
+            Some(Node {
                 content: Content::View(view),
                 ..
-            } => Some(view),
+            }) => Some(view),
             _ => None,
         }
     }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -431,9 +431,6 @@ impl View {
         let other_style = theme
             .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint"))
             .map(Highlight);
-        let padding_style = theme
-            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.padding"))
-            .map(Highlight);
 
         let mut add_annotations = |annotations: &Rc<[_]>, style| {
             if !annotations.is_empty() {
@@ -444,11 +441,11 @@ impl View {
         // Overlapping annotations are ignored apart from the first so the order here is not random:
         // types -> parameters -> others should hopefully be the "correct" order for most use cases,
         // with the padding coming before and after as expected.
-        add_annotations(padding_before_inlay_hints, padding_style);
+        add_annotations(padding_before_inlay_hints, None);
         add_annotations(type_inlay_hints, type_style);
         add_annotations(parameter_inlay_hints, parameter_style);
         add_annotations(other_inlay_hints, other_style);
-        add_annotations(padding_after_inlay_hints, padding_style);
+        add_annotations(padding_after_inlay_hints, None);
 
         text_annotations
     }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -1,19 +1,21 @@
 use crate::{
     align_view,
+    document::DocumentInlayHints,
     editor::{GutterConfig, GutterType},
     graphics::Rect,
     Align, Document, DocumentId, Theme, ViewId,
 };
 
 use helix_core::{
-    char_idx_at_visual_offset, doc_formatter::TextFormat, text_annotations::TextAnnotations,
-    visual_offset_from_anchor, visual_offset_from_block, Position, RopeSlice, Selection,
-    Transaction,
+    char_idx_at_visual_offset, doc_formatter::TextFormat, syntax::Highlight,
+    text_annotations::TextAnnotations, visual_offset_from_anchor, visual_offset_from_block,
+    Position, RopeSlice, Selection, Transaction,
 };
 
 use std::{
     collections::{HashMap, VecDeque},
     fmt,
+    rc::Rc,
 };
 
 const JUMP_LIST_CAPACITY: usize = 30;
@@ -405,7 +407,42 @@ impl View {
     /// Get the text annotations to display in the current view for the given document and theme.
     pub fn text_annotations(&self, doc: &Document, theme: Option<&Theme>) -> TextAnnotations {
         // TODO custom annotations for custom views like side by side diffs
-        doc.text_annotations(self.id, theme)
+
+        let mut text_annotations = doc.text_annotations(theme);
+
+        let DocumentInlayHints {
+            id: _,
+            type_inlay_hints,
+            parameter_inlay_hints,
+            other_inlay_hints,
+        } = match doc.inlay_hints.get(&self.id) {
+            Some(doc_inlay_hints) => doc_inlay_hints,
+            None => return text_annotations,
+        };
+
+        let type_style = theme
+            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.type"))
+            .map(Highlight);
+        let parameter_style = theme
+            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.parameter"))
+            .map(Highlight);
+        let other_style = theme
+            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint"))
+            .map(Highlight);
+
+        let mut add_annotations = |annotations: &Rc<[_]>, style| {
+            if !annotations.is_empty() {
+                text_annotations.add_inline_annotations(Rc::clone(annotations), style);
+            }
+        };
+
+        // Overlapping annotations are ignored apart from the first so the order here is not random:
+        // types -> parameters -> others should hopefully be the "correct" order for most use cases.
+        add_annotations(type_inlay_hints, type_style);
+        add_annotations(parameter_inlay_hints, parameter_style);
+        add_annotations(other_inlay_hints, other_style);
+
+        text_annotations
     }
 
     pub fn text_pos_at_screen_coords(

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -402,9 +402,10 @@ impl View {
         Some(pos)
     }
 
+    /// Get the text annotations to display in the current view for the given document and theme.
     pub fn text_annotations(&self, doc: &Document, theme: Option<&Theme>) -> TextAnnotations {
         // TODO custom annotations for custom views like side by side diffs
-        doc.text_annotations(theme)
+        doc.text_annotations(self.id, theme)
     }
 
     pub fn text_pos_at_screen_coords(

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -415,6 +415,8 @@ impl View {
             type_inlay_hints,
             parameter_inlay_hints,
             other_inlay_hints,
+            padding_before_inlay_hints,
+            padding_after_inlay_hints,
         } = match doc.inlay_hints.get(&self.id) {
             Some(doc_inlay_hints) => doc_inlay_hints,
             None => return text_annotations,
@@ -429,6 +431,9 @@ impl View {
         let other_style = theme
             .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint"))
             .map(Highlight);
+        let padding_style = theme
+            .and_then(|t| t.find_scope_index("ui.virtual.inlay-hint.padding"))
+            .map(Highlight);
 
         let mut add_annotations = |annotations: &Rc<[_]>, style| {
             if !annotations.is_empty() {
@@ -437,10 +442,13 @@ impl View {
         };
 
         // Overlapping annotations are ignored apart from the first so the order here is not random:
-        // types -> parameters -> others should hopefully be the "correct" order for most use cases.
+        // types -> parameters -> others should hopefully be the "correct" order for most use cases,
+        // with the padding coming before and after as expected.
+        add_annotations(padding_before_inlay_hints, padding_style);
         add_annotations(type_inlay_hints, type_style);
         add_annotations(parameter_inlay_hints, parameter_style);
         add_annotations(other_inlay_hints, other_style);
+        add_annotations(padding_after_inlay_hints, padding_style);
 
         text_annotations
     }

--- a/languages.toml
+++ b/languages.toml
@@ -19,6 +19,14 @@ indent = { tab-width = 4, unit = "    " }
 '"' = '"'
 '`' = '`'
 
+[language.config]
+inlayHints.bindingModeHints.enable = false
+inlayHints.closingBraceHints.minLines = 10
+inlayHints.closureReturnTypeHints.enable = "with_block"
+inlayHints.discriminantHints.enable = "fieldless"
+inlayHints.lifetimeElisionHints.enable = "skip_trivial"
+inlayHints.typeHints.hideClosureInitialization = false
+
 [language.debugger]
 name = "lldb-vscode"
 transport = "stdio"
@@ -291,6 +299,14 @@ language-server = { command = "gopls" }
 # TODO: gopls needs utf-8 offsets?
 indent = { tab-width = 4, unit = "\t" }
 
+[language.config.hints]
+assignVariableTypes = true
+compositeLiteralFields = true
+constantValues = true
+functionTypeParameters = true
+parameterNames = true
+rangeVariableTypes = true
+
 [language.debugger]
 name = "go"
 transport = "tcp"
@@ -382,6 +398,18 @@ comment-token = "//"
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "javascript" }
 indent = { tab-width = 2, unit = "  " }
 
+[language.config]
+hostInfo = "helix"
+
+[language.config.javascript.inlayHints]
+includeInlayEnumMemberValueHints = true
+includeInlayFunctionLikeReturnTypeHints = true
+includeInlayFunctionParameterTypeHints = true
+includeInlayParameterNameHints = "all"
+includeInlayParameterNameHintsWhenArgumentMatchesName = true
+includeInlayPropertyDeclarationTypeHints = true
+includeInlayVariableTypeHints = true
+
 [language.debugger]
 name = "node-debug2"
 transport = "stdio"
@@ -409,6 +437,18 @@ language-server = { command = "typescript-language-server", args = ["--stdio"], 
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
+[language.config]
+hostInfo = "helix"
+
+[language.config.javascript.inlayHints]
+includeInlayEnumMemberValueHints = true
+includeInlayFunctionLikeReturnTypeHints = true
+includeInlayFunctionParameterTypeHints = true
+includeInlayParameterNameHints = "all"
+includeInlayParameterNameHintsWhenArgumentMatchesName = true
+includeInlayPropertyDeclarationTypeHints = true
+includeInlayVariableTypeHints = true
+
 [[language]]
 name = "typescript"
 scope = "source.ts"
@@ -419,6 +459,18 @@ roots = []
 # TODO: highlights-params
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "typescript"}
 indent = { tab-width = 2, unit = "  " }
+
+[language.config]
+hostInfo = "helix"
+
+[language.config.typescript.inlayHints]
+includeInlayEnumMemberValueHints = true
+includeInlayFunctionLikeReturnTypeHints = true
+includeInlayFunctionParameterTypeHints = true
+includeInlayParameterNameHints = "all"
+includeInlayParameterNameHintsWhenArgumentMatchesName = true
+includeInlayPropertyDeclarationTypeHints = true
+includeInlayVariableTypeHints = true
 
 [[grammar]]
 name = "typescript"
@@ -433,6 +485,18 @@ roots = []
 # TODO: highlights-params
 language-server = { command = "typescript-language-server", args = ["--stdio"], language-id = "typescriptreact" }
 indent = { tab-width = 2, unit = "  " }
+
+[language.config]
+hostInfo = "helix"
+
+[language.config.typescript.inlayHints]
+includeInlayEnumMemberValueHints = true
+includeInlayFunctionLikeReturnTypeHints = true
+includeInlayFunctionParameterTypeHints = true
+includeInlayParameterNameHints = "all"
+includeInlayParameterNameHintsWhenArgumentMatchesName = true
+includeInlayPropertyDeclarationTypeHints = true
+includeInlayVariableTypeHints = true
 
 [[grammar]]
 name = "tsx"
@@ -739,6 +803,14 @@ roots = [".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git"]
 comment-token = "--"
 indent = { tab-width = 2, unit = "  " }
 language-server = { command = "lua-language-server", args = [] }
+
+[language.config.Lua.hint]
+enable = true
+arrayIndex = "Enable"
+setType = true
+paramName = "All"
+paramType = true
+await = true
 
 [[grammar]]
 name = "lua"


### PR DESCRIPTION
Add support for LSP type hints (merged in version 3.17 of the spec, a few month old now).

For now, I only added it in the main editor views, pickers do not have type hints.
Even if we decide they need to, I would prefer doing it in another PR since this one is already big
enough as it is.

I'll join a screen in a comment below, and if people could try it out with their LSPs and configs, it
would be very useful, since I pretty much only use Rust-Analyzer so testing may be somewhat limited still.

Closes #2070

EDIT: [instructions to test](https://github.com/helix-editor/helix/pull/5934#issuecomment-1445040945)