### PR TITLE
feat(debug): highlight current line

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -276,8 +276,11 @@ These scopes are used for theming the editor interface:
 | `ui.cursor.primary.normal`        |                                                                                                |
 | `ui.cursor.primary.insert`        |                                                                                                |
 | `ui.cursor.primary.select`        |                                                                                                |
+| `ui.debug.breakpoint`             | Breakpoint indicator, found in the gutter                                                      |
+| `ui.debug.active`                 | Indicator for the line at which debugging execution is paused at, found in the gutter          |
 | `ui.gutter`                       | Gutter                                                                                         |
 | `ui.gutter.selected`              | Gutter for the line the cursor is on                                                           |
+| `ui.highlight.frameline`          | Line at which debugging execution is paused at                                                 |
 | `ui.linenr`                       | Line numbers                                                                                   |
 | `ui.linenr.selected`              | Line number for the line the cursor is on                                                      |
 | `ui.statusline`                   | Statusline                                                                                     |

--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -512,4 +512,10 @@ impl Client {
 
         self.call::<requests::SetExceptionBreakpoints>(args)
     }
+
+    pub fn current_stack_frame(&self) -> Option<&StackFrame> {
+        self.stack_frames
+            .get(&self.thread_id?)?
+            .get(self.active_frame?)
+    }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -10,6 +10,7 @@ use crate::{
     view::ViewPosition,
     Align, Document, DocumentId, View, ViewId,
 };
+use dap::StackFrame;
 use helix_vcs::DiffProviderRegistry;
 
 use futures_util::stream::select_all::SelectAll;
@@ -1656,6 +1657,12 @@ impl Editor {
             doc.set_selection(view.id, selection);
             doc.restore_cursor = false;
         }
+    }
+
+    pub fn current_stack_frame(&self) -> Option<&StackFrame> {
+        self.debugger
+            .as_ref()
+            .and_then(|debugger| debugger.current_stack_frame())
     }
 }
 

--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -12,6 +12,8 @@
 "ui.virtual.ruler" = { bg = "acme_bar_bg" }
 "ui.cursor.match" = {bg="acme_bar_bg"}
 "ui.cursor" = {bg="cursor", fg="white"}
+"ui.debug" = {fg="orange"}
+"ui.highlight.frameline" = {bg="#da8581"}
 "string" = "red"
 "comment" = "green"
 "ui.help" = {fg="black", bg="acme_bg"}

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -26,6 +26,8 @@
 "ui.cursor.primary" = { fg = "my_white", modifiers = ["reversed"] }
 "ui.cursorline.primary" = { bg = "my_black" }
 "ui.cursorline.secondary" = { bg = "my_black" }
+"ui.highlight.frameline" = { bg = "#8b6904" }
+"ui.debug" = { fg = "my_yellow1", bg = "my_gray0" }
 "ui.text" = "my_white"
 "operator" = "my_white"
 "ui.text.focus" = "my_white"

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -61,6 +61,8 @@
 "diagnostic.error"= { underline = { color = "red", style="curl"} }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
+"ui.debug" = { fg = "orange", bg = "background" }
+"ui.highlight.frameline" = { bg = "#0067a3" }
 
 "special" = "orange"
 

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -61,6 +61,8 @@
 "diagnostic.error"= { underline = { color = "red", style = "curl" } }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
+"ui.debug" = { fg = "orange", bg = "background" }
+"ui.highlight.frameline" = { bg = "#cfe0f2" }
 
 "special" = "orange"
 

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -61,6 +61,8 @@
 "diagnostic.error"= { underline = { color = "red", style = "curl" } }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
+"ui.debug" = { fg = "orange", bg = "background" }
+"ui.highlight.frameline" = { bg = "#0067a3" }
 
 "special" = "orange"
 

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -25,6 +25,8 @@
 "ui.cursor.primary" = { fg = "background", bg = "cyan", modifiers = ["dim"] }
 "ui.cursorline.primary" = { bg = "background_dark" }
 "ui.help" = { fg = "foreground", bg = "background_dark" }
+"ui.debug" = { fg = "red" }
+"ui.highlight.frameline" = { fg = "black", bg = "red" }
 "ui.linenr" = { fg = "comment" }
 "ui.linenr.selected" = { fg = "foreground" }
 "ui.menu" = { fg = "foreground", bg = "background_dark" }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -25,6 +25,8 @@
 "ui.cursor.match" = { fg = "green", modifiers = ["underlined"] }
 "ui.cursor.primary" = { fg = "background", bg = "cyan", modifiers = ["dim"] }
 "ui.help" = { fg = "foreground", bg = "background_dark" }
+"ui.debug" = { fg = "red" }
+"ui.highlight.frameline" = { fg = "black", bg = "red" }
 "ui.linenr" = { fg = "comment" }
 "ui.linenr.selected" = { fg = "foreground" }
 "ui.menu" = { fg = "foreground", bg = "background_dark" }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -64,6 +64,7 @@
 "ui.cursorline.primary" = { bg = "light-black" }
 
 "ui.highlight" = { bg = "gray" }
+"ui.highlight.frameline" = { bg = "#97202a" }
 
 "ui.linenr" = { fg = "linenr" }
 "ui.linenr.selected" = { fg = "white" }
@@ -83,6 +84,8 @@
 "ui.menu" = { fg = "white", bg = "gray" }
 "ui.menu.selected" = { fg = "black", bg = "blue" }
 "ui.menu.scroll" = { fg = "white", bg = "light-gray" }
+
+"ui.debug" = { fg = "red" }
 
 [palette]
 

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -78,6 +78,8 @@
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 
 "ui.help" = { fg = "white", bg = "gray" }
+"ui.debug" = { fg = "red" }
+"ui.highlight.frameline" = { bg = "#97202a" }
 "ui.popup" = { bg = "gray" }
 "ui.window" = { fg = "gray" }
 "ui.menu" = { fg = "white", bg = "gray" }

--- a/theme.toml
+++ b/theme.toml
@@ -69,7 +69,9 @@ label = "honey"
 "ui.cursor" = { modifiers = ["reversed"] }
 "ui.cursorline.primary" = { bg = "bossanova" }
 "ui.highlight" = { bg = "bossanova" }
-
+"ui.highlight.frameline" = { bg = "#634450" }
+"ui.debug" = { fg = "#634450" }
+"ui.debug.breakpoint" = { fg = "apricot" }
 "ui.menu" = { fg = "lavender", bg = "revolver" }
 "ui.menu.selected" = { fg = "revolver", bg = "white" }
 "ui.menu.scroll" = { fg = "lavender", bg = "comet" }


### PR DESCRIPTION
Add new theme highlight keys, for setting the colour of the breakpoint
character and the current line at which execution has been paused at.
The two new keys are `ui.highlight.frameline` and `ui.debug.breakpoint`.
Highlight according to those keys, both the line at which debugging
is paused at and the breakpoint indicator.

Add an indicator for the current line at which execution is paused
at, themed by the `ui.debug.active` theme scope. Update various themes
to showcase how the new functionality works.

Better icons are dependent on #2869, and as such will be handled in the
future, once it lands.

Closes: #5952
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>