### PR TITLE
Allow LSP server to be stopped

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -427,6 +427,19 @@ impl Registry {
         }
     }
 
+    pub fn stop(
+        &mut self,
+        language_config: &LanguageConfiguration,
+    ) {
+        let scope = language_config.scope.clone();
+
+        if let Some((_, client)) = self.inner.remove(&scope) {
+            tokio::spawn(async move {
+                let _ = client.force_shutdown().await;    
+            });
+        }
+    }
+
     pub fn get(
         &mut self,
         language_config: &LanguageConfiguration,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2544,16 +2544,13 @@ fn jumplist_picker(cx: &mut Context) {
         }
     };
 
+    let view = cx.editor.tree.get(cx.editor.tree.focus);
+    let jumps: Vec<_> = view.jumps.iter()
+        .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
+        .collect();
+    
     let picker = FilePicker::new(
-        cx.editor
-            .tree
-            .views()
-            .flat_map(|(view, _)| {
-                view.jumps
-                    .iter()
-                    .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
-            })
-            .collect(),
+        jumps,
         (),
         |cx, meta, action| {
             cx.editor.switch(meta.id, action);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1225,6 +1225,24 @@ fn lsp_restart(
     Ok(())
 }
 
+fn lsp_stop(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let (_view, doc) = current!(cx.editor);
+    let config = doc
+        .language_config()
+        .context("LSP not defined for the current document")?;
+
+    cx.editor.language_servers.stop(config);
+    Ok(())
+}
+
 fn tree_sitter_scopes(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -2164,6 +2182,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &[],
             doc: "Restarts the Language Server that is in use by the current doc",
             fun: lsp_restart,
+            completer: None,
+        },
+        TypableCommand {
+            name: "lsp-stop",
+            aliases: &[],
+            doc: "Stops the Language Server that is in use by the current doc",
+            fun: lsp_stop,
             completer: None,
         },
         TypableCommand {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -75,7 +75,7 @@ impl JumpList {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Jump> {
-        self.jumps.iter()
+        self.jumps.iter().rev()
     }
 
     /// Applies a [`Transaction`] of changes to the jumplist.


### PR DESCRIPTION
Sometimes you don't require the lsp to run, especially if you want to quickly have a look at a file part of a large project.

This PR allows to stop lsp when required via `:lsp-stop` command.

If required, lsp can be restarted via `lst-restart`.

Without having separate commands I was also thinking about having subcommands part a generic `:lsp` command.
That is, remove `lsp-restart`, `:lsp-stop` in favour of a more generic and extensible `lsp`.

The usage would be `:lsp start`, `:lsp stop`, `:lsp restart`.  (restart and start may be probably merged in a single start command)

