### PR TITLE
Fix crash in goto_window_center at EOF

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -960,10 +960,9 @@ fn goto_window(cx: &mut Context, align: Align) {
             view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff + count)
         }
     };
-    let visual_line = visual_line.clamp(
-        view.offset.vertical_offset + scrolloff,
-        view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff),
-    );
+    let visual_line = visual_line
+        .max(view.offset.vertical_offset + scrolloff)
+        .min(view.offset.vertical_offset + last_visual_line.saturating_sub(scrolloff));
 
     let pos = view
         .pos_at_visual_coords(doc, visual_line as u16, 0, false)


### PR DESCRIPTION
Fixes #5965

Reverts a small change from #5892 that caused crashes at the EOF.
`std::cmp::clamp` crashes when `max < min` which was the case at the EOF.
By using `max(..).min(..)` directly we ensure that the `min` always takes predence and avoid the crash.

In the other place where `min/max`  was replaced with `clamp` in #5892 it is impossible for `max < min` to occur
and therefore didn't need to be reverted.