### PR TITLE
Refactor picker/menu logic into an options manager which can be fed with multiple different item sources (async, sync, refetch)

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum OffsetEncoding {
     /// UTF-8 code units aka bytes
     Utf8,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -348,11 +348,11 @@ impl Application {
                     self.handle_signals(signal).await;
                 }
                 Some(callback) = self.jobs.futures.next() => {
-                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
+                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, &self.jobs, callback);
                     self.render().await;
                 }
                 Some(callback) = self.jobs.wait_futures.next() => {
-                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
+                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, &self.jobs, callback);
                     self.render().await;
                 }
                 event = self.editor.wait_event() => {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1289,7 +1289,8 @@ fn lsp_workspace_command(
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
                 move |_editor: &mut Editor, compositor: &mut Compositor| {
-                    let picker = ui::Picker::new(commands, (), |cx, command, _action| {
+                    let option_manager = OptionsManager::create_from_items(commands, ());
+                    let picker = ui::Picker::new(option_manager, |cx, command, _action| {
                         execute_lsp_command(cx.editor, command.clone());
                     });
                     compositor.push(Box::new(overlayed(picker)))

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -32,8 +32,8 @@ use std::{num::NonZeroUsize, path::PathBuf, rc::Rc};
 
 use tui::buffer::Buffer as Surface;
 
-use super::statusline;
 use super::{document::LineDecoration, lsp::SignatureHelp};
+use super::{menu::OptionsManager, statusline, CompletionItem};
 
 pub struct EditorView {
     pub keymaps: Keymaps,
@@ -943,14 +943,12 @@ impl EditorView {
     pub fn set_completion(
         &mut self,
         editor: &mut Editor,
-        items: Vec<helix_lsp::lsp::CompletionItem>,
-        offset_encoding: helix_lsp::OffsetEncoding,
+        option_manager: OptionsManager<CompletionItem>,
         start_offset: usize,
         trigger_offset: usize,
         size: Rect,
     ) {
-        let mut completion =
-            Completion::new(editor, items, offset_encoding, start_offset, trigger_offset);
+        let mut completion = Completion::new(editor, option_manager, start_offset, trigger_offset);
 
         if completion.is_empty() {
             // skip if we got no completion results

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,22 +1,34 @@
-use std::{borrow::Cow, path::PathBuf};
+use std::{
+    borrow::Cow,
+    cmp::{self, Ordering},
+    mem::swap,
+    path::PathBuf,
+    sync::Arc,
+};
 
 use crate::{
     compositor::{Callback, Component, Compositor, Context, Event, EventResult},
-    ctrl, key, shift,
+    ctrl, job, key, shift,
+};
+use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, StreamExt};
+
+use helix_core::movement::Direction;
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    Notify,
 };
 use tui::{buffer::Buffer as Surface, widgets::Table};
 
 pub use tui::widgets::{Cell, Row};
 
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
-use fuzzy_matcher::FuzzyMatcher;
 
 use helix_view::{graphics::Rect, Editor};
 use tui::layout::Constraint;
 
-pub trait Item {
+pub trait Item: Send + 'static {
     /// Additional editor state that is used for label calculation.
-    type Data;
+    type Data: Send;
 
     fn format(&self, data: &Self::Data) -> Row;
 
@@ -45,16 +57,637 @@ impl Item for PathBuf {
 
 pub type MenuCallback<T> = Box<dyn Fn(&mut Editor, Option<&T>, MenuEvent)>;
 
-pub struct Menu<T: Item> {
-    options: Vec<T>,
-    editor_data: T::Data,
+type AsyncData<T> = BoxFuture<'static, anyhow::Result<Vec<T>>>;
+type AsyncRefetchWithQuery<T> = Box<dyn Fn(&str, &mut Editor) -> AsyncData<T> + Send>;
 
-    cursor: Option<usize>,
+pub enum ItemSource<T: Item> {
+    AsyncData(Option<AsyncData<T>>, <T as Item>::Data),
+    // TODO maybe "generalize" this by using conditional functions
+    // uses the current pattern/query to refetch new data
+    AsyncRefetchOnIdleTimeoutWithPattern(AsyncRefetchWithQuery<T>, <T as Item>::Data),
+    Data(Vec<T>, <T as Item>::Data),
+}
 
+impl<T: Item> ItemSource<T> {
+    pub fn editor_data(&self) -> &<T as Item>::Data {
+        match self {
+            ItemSource::Data(_, editor_data) => editor_data,
+            ItemSource::AsyncData(_, editor_data) => editor_data,
+            ItemSource::AsyncRefetchOnIdleTimeoutWithPattern(_, editor_data) => editor_data,
+        }
+    }
+    pub fn from_async_data(
+        future: BoxFuture<'static, anyhow::Result<Vec<T>>>,
+        editor_data: <T as Item>::Data,
+    ) -> Self {
+        Self::AsyncData(Some(future), editor_data)
+    }
+
+    pub fn from_data(data: Vec<T>, editor_data: <T as Item>::Data) -> Self {
+        Self::Data(data, editor_data)
+    }
+
+    pub fn from_async_refetch_on_idle_timeout_with_pattern(
+        fetch: AsyncRefetchWithQuery<T>,
+        editor_data: <T as Item>::Data,
+    ) -> Self {
+        Self::AsyncRefetchOnIdleTimeoutWithPattern(fetch, editor_data)
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+struct Match {
+    option_index: usize,
+    score: i64,
+    option_source: usize,
+    len: usize,
+}
+
+impl Match {
+    fn key(&self) -> impl Ord {
+        (
+            cmp::Reverse(self.score),
+            self.len,
+            self.option_source,
+            self.option_index,
+        )
+    }
+}
+
+enum ItemSourceMessage<T> {
+    Items {
+        item_source_idx: usize,
+        items: anyhow::Result<Vec<T>>,
+    },
+    NoFurtherItems,
+}
+
+impl PartialOrd for Match {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Match {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key().cmp(&other.key())
+    }
+}
+
+pub struct OptionsManager<T: Item> {
+    options: Vec<Vec<T>>,
+    options_receiver: UnboundedReceiver<ItemSourceMessage<T>>,
+    options_sender: UnboundedSender<ItemSourceMessage<T>>,
+    matches: Vec<Match>,
     matcher: Box<Matcher>,
-    /// (index, score)
-    matches: Vec<(usize, i64)>,
+    cursor: Option<usize>,
+    item_sources: Vec<ItemSource<T>>,
+    previous_pattern: (String, FuzzyQuery),
+    last_pattern_on_idle_timeout: String,
+    cursor_always_selects: bool,
+    awaiting_async_options: bool,
+    has_refetch_item_sources: bool,
+}
 
+// TODO Could be extended to a general error handling callback (e.g. errors while fetching)
+pub type NoItemsAvailableCallback = Box<dyn FnOnce(&mut Editor) + Send + 'static>;
+
+impl<T: Item> OptionsManager<T> {
+    pub fn create_from_items(items: Vec<T>, editor_data: <T as Item>::Data) -> Self {
+        let item_source = ItemSource::Data(vec![], editor_data);
+        Self::create_with_item_sources(vec![item_source], [(0, items)], false)
+    }
+
+    fn create_with_item_sources<I>(
+        item_sources: Vec<ItemSource<T>>,
+        items: I,
+        has_refetch_item_sources: bool,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (usize, Vec<T>)>,
+    {
+        // vec![vec![]; item_sources.len()] requires T: Clone
+        let options = (0..item_sources.len()).map(|_| vec![]).collect();
+
+        let (options_sender, options_receiver) = unbounded_channel();
+        let mut options_manager = Self {
+            item_sources,
+            matches: vec![],
+            matcher: Box::new(Matcher::default().ignore_case()),
+            cursor: None,
+            options,
+            options_receiver,
+            options_sender,
+            previous_pattern: (String::new(), FuzzyQuery::default()),
+            last_pattern_on_idle_timeout: String::new(),
+            cursor_always_selects: false,
+            awaiting_async_options: false,
+            has_refetch_item_sources,
+        };
+        for (item_source_idx, items) in items {
+            options_manager.options[item_source_idx] = items;
+        }
+        options_manager.force_score();
+        options_manager
+    }
+
+    fn create_options_manager_async<C>(
+        mut requests: FuturesUnordered<
+            impl Future<Output = (usize, anyhow::Result<Vec<T>>)> + Send + 'static,
+        >,
+        item_sources: Vec<ItemSource<T>>,
+        has_refetch_item_sources: bool,
+        create_options_container: C,
+        no_items_available: Option<NoItemsAvailableCallback>,
+    ) -> BoxFuture<'static, anyhow::Result<job::Callback>>
+    where
+        C: FnOnce(&mut Editor, &mut Compositor, OptionsManager<T>) + Send + 'static,
+    {
+        async move {
+            let request = requests.next().await;
+            let call =
+                job::Callback::EditorCompositorJobs(Box::new(move |editor, compositor, jobs| {
+                    let (item_source_idx, items) = match request {
+                        Some(r) => r,
+                        None => {
+                            return if let Some(no_items_available) = no_items_available {
+                                no_items_available(editor)
+                            }
+                        }
+                    };
+                    let items = items.unwrap_or_default(); // TODO show error somewhere instead of swalloing it here?
+                    if items.is_empty() {
+                        // items are empty, try the next item source
+                        jobs.callback(Self::create_options_manager_async(
+                            requests,
+                            item_sources,
+                            has_refetch_item_sources,
+                            create_options_container,
+                            no_items_available,
+                        ));
+                    } else {
+                        let mut option_manager = Self::create_with_item_sources(
+                            item_sources,
+                            [(item_source_idx, items)],
+                            has_refetch_item_sources,
+                        );
+                        let options_sender = option_manager.options_sender.clone();
+                        if !requests.is_empty() {
+                            option_manager.awaiting_async_options = true;
+                            jobs.spawn(Self::extend_options_manager_async(
+                                requests,
+                                options_sender,
+                                editor.redraw_handle.0.clone(),
+                            ));
+                        }
+                        // callback that adds ui like menu with the options_manager as argument
+                        create_options_container(editor, compositor, option_manager);
+                    }
+                }));
+            Ok(call)
+        }
+        .boxed()
+    }
+
+    fn extend_options_manager_async(
+        mut requests: FuturesUnordered<
+            impl Future<Output = (usize, anyhow::Result<Vec<T>>)> + Send + 'static,
+        >,
+        options_sender: UnboundedSender<ItemSourceMessage<T>>,
+        redraw_notify: Arc<Notify>,
+    ) -> BoxFuture<'static, anyhow::Result<()>> {
+        async move {
+            while let Some((item_source_idx, items)) = requests.next().await {
+                // ignore error, as it just indicates that the options manager is gone (i.e. closed), so just discard this future
+                if options_sender
+                    .send(ItemSourceMessage::Items {
+                        item_source_idx,
+                        items,
+                    })
+                    .is_err()
+                {
+                    return Ok(());
+                };
+                redraw_notify.notify_one();
+            }
+            let _ = options_sender.send(ItemSourceMessage::NoFurtherItems);
+            Ok(())
+        }
+        .boxed()
+    }
+
+    pub fn create_from_item_sources<F>(
+        mut item_sources: Vec<ItemSource<T>>,
+        editor: &mut Editor,
+        jobs: &job::Jobs,
+        create_options_container: F,
+        no_items_available: Option<NoItemsAvailableCallback>, // It's a dynamic dispatch to avoid explicit typing with 'None' for the callbacks
+    ) where
+        F: FnOnce(&mut Editor, &mut Compositor, OptionsManager<T>) + Send + 'static,
+    {
+        let async_requests: FuturesUnordered<_> = item_sources
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, item_source)| match item_source {
+                ItemSource::AsyncData(data, _) => data
+                    .take()
+                    .map(|data| async move { (idx, data.await) }.boxed()),
+                ItemSource::AsyncRefetchOnIdleTimeoutWithPattern(fetch, _) => {
+                    let future = fetch("", editor);
+                    Some(async move { (idx, future.await) }.boxed())
+                }
+                _ => None,
+            })
+            .collect();
+        let sync_items: Vec<_> = item_sources
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, item_source)| match item_source {
+                ItemSource::Data(data, _) if !data.is_empty() => {
+                    let mut new_data = vec![];
+                    swap(data, &mut new_data);
+                    Some((idx, new_data))
+                }
+                _ => None,
+            })
+            .collect();
+        let has_refetch_item_sources = item_sources.iter().any(|item_source| {
+            matches!(
+                item_source,
+                ItemSource::AsyncRefetchOnIdleTimeoutWithPattern(_, _)
+            )
+        });
+
+        // no items available
+        if async_requests.is_empty() && sync_items.is_empty() {
+            if let Some(no_items_available) = no_items_available {
+                no_items_available(editor);
+            }
+            return;
+        }
+
+        if !sync_items.is_empty() {
+            // TODO this could be done in sync, but it needs the compositor in scope
+            jobs.callback(async move {
+                Ok(job::Callback::EditorCompositorJobs(Box::new(
+                    move |editor, compositor, jobs| {
+                        let mut option_manager = Self::create_with_item_sources(
+                            item_sources,
+                            sync_items,
+                            has_refetch_item_sources,
+                        );
+                        let option_sender = option_manager.options_sender.clone();
+                        if !async_requests.is_empty() {
+                            option_manager.awaiting_async_options = true;
+                            jobs.spawn(Self::extend_options_manager_async(
+                                async_requests,
+                                option_sender,
+                                editor.redraw_handle.0.clone(),
+                            ))
+                        }
+                        create_options_container(editor, compositor, option_manager);
+                    },
+                )))
+            });
+        } else {
+            jobs.callback(Self::create_options_manager_async(
+                async_requests,
+                item_sources,
+                has_refetch_item_sources,
+                create_options_container,
+                no_items_available,
+            ));
+        }
+    }
+
+    pub fn refetch_on_idle_timeout(&mut self, editor: &mut Editor, jobs: &job::Jobs) -> bool {
+        if !self.has_refetch_item_sources
+            || (self.last_pattern_on_idle_timeout == self.previous_pattern.0.clone())
+        {
+            return false;
+        }
+
+        let requests: FuturesUnordered<_> = self
+            .item_sources
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item_source)| match item_source {
+                ItemSource::AsyncRefetchOnIdleTimeoutWithPattern(fetch, _) => {
+                    let future = fetch(&self.previous_pattern.0, editor);
+                    Some(async move { (idx, future.await) }.boxed())
+                }
+                _ => None,
+            })
+            .collect();
+
+        if !requests.is_empty() {
+            self.last_pattern_on_idle_timeout = self.previous_pattern.0.clone();
+            self.awaiting_async_options = true;
+            jobs.spawn(Self::extend_options_manager_async(
+                requests,
+                self.options_sender.clone(),
+                editor.redraw_handle.0.clone(),
+            ));
+            return true;
+        }
+        false
+    }
+
+    pub fn poll_for_new_options(&mut self) -> bool {
+        if !self.awaiting_async_options {
+            return false;
+        }
+        let mut new_options_added = false;
+        // TODO handle errors somehow?
+        while let Ok(message) = self.options_receiver.try_recv() {
+            match message {
+                ItemSourceMessage::Items {
+                    item_source_idx,
+                    items: Ok(items),
+                } => {
+                    if items.is_empty() && self.options[item_source_idx].is_empty() {
+                        continue;
+                    }
+                    new_options_added = true;
+                    // TODO this could be extended by getting the matched option and try to find it in the new options
+                    let cursor_on_old_option = matches!(self.cursor.and_then(|cursor| self.matches.get(cursor)),
+                                                        Some(Match { option_source, ..}) if *option_source == item_source_idx);
+                    if cursor_on_old_option {
+                        self.cursor = if self.cursor_always_selects {
+                            Some(0)
+                        } else {
+                            None
+                        };
+                    }
+                    self.options[item_source_idx] = items;
+                }
+                ItemSourceMessage::NoFurtherItems => self.awaiting_async_options = false,
+                _ => (), // TODO handle error somehow?
+            }
+        }
+        if new_options_added {
+            self.force_score();
+        }
+        new_options_added
+    }
+
+    pub fn options(&self) -> impl Iterator<Item = (&T, &T::Data)> {
+        self.options
+            .iter()
+            .enumerate()
+            .flat_map(move |(idx, options)| {
+                options
+                    .iter()
+                    .map(move |o| (o, self.item_sources[idx].editor_data()))
+            })
+    }
+
+    pub fn options_len(&self) -> usize {
+        self.options.iter().map(Vec::len).sum()
+    }
+
+    pub fn matches(&self) -> impl Iterator<Item = (&T, &T::Data)> {
+        self.matches.iter().map(
+            |Match {
+                 option_index,
+                 option_source,
+                 ..
+             }| {
+                (
+                    &self.options[*option_source][*option_index],
+                    self.item_sources[*option_source].editor_data(),
+                )
+            },
+        )
+    }
+
+    pub fn cursor(&self) -> Option<usize> {
+        self.cursor
+    }
+
+    // TODO should probably be an enum
+    pub fn set_cursor_selection_mode(&mut self, cursor_always_selects: bool) {
+        self.cursor_always_selects = cursor_always_selects;
+        if cursor_always_selects && self.cursor.is_none() && !self.matches.is_empty() {
+            self.cursor = Some(0);
+        }
+    }
+
+    // if pattern is None, use the previously used last pattern
+    pub fn score(&mut self, pattern: Option<&str>, reset_cursor: bool, force_recalculation: bool) {
+        if reset_cursor && self.cursor.is_some() {
+            self.cursor = if self.cursor_always_selects {
+                Some(0)
+            } else {
+                None
+            };
+        }
+
+        let pattern = match pattern {
+            Some(pattern) if pattern == self.previous_pattern.0 && !force_recalculation => return,
+            None if !force_recalculation => return,
+            None => &self.previous_pattern.0,
+            Some(pattern) => pattern,
+        };
+        let prev_selected_option = if !reset_cursor {
+            self.cursor.and_then(|c| {
+                self.matches.get(c).map(
+                    |Match {
+                         option_source,
+                         option_index,
+                         ..
+                     }| (*option_source, *option_index),
+                )
+            })
+        } else {
+            None
+        };
+
+        let (query, is_refined) = self
+            .previous_pattern
+            .1
+            .refine(pattern, &self.previous_pattern.0);
+
+        if pattern.is_empty() {
+            // Fast path for no pattern.
+            self.matches.clear();
+            self.matches
+                .extend(self.item_sources.iter().enumerate().flat_map(
+                    |(option_source, item_source)| {
+                        self.options[option_source].iter().enumerate().map(
+                            move |(option_index, option)| {
+                                let text = option.filter_text(item_source.editor_data());
+                                Match {
+                                    option_index,
+                                    option_source,
+                                    score: 0,
+                                    len: text.chars().count(),
+                                }
+                            },
+                        )
+                    },
+                ));
+        } else if is_refined && !force_recalculation {
+            // optimization: if the pattern is a more specific version of the previous one
+            // then we can score the filtered set.
+            self.matches.retain_mut(|omatch| {
+                let option = &self.options[omatch.option_source][omatch.option_index];
+                let text = option.sort_text(self.item_sources[omatch.option_source].editor_data());
+
+                match query.fuzzy_match(&text, &self.matcher) {
+                    Some(s) => {
+                        // Update the score
+                        omatch.score = s;
+                        true
+                    }
+                    None => false,
+                }
+            });
+
+            self.matches.sort();
+        } else {
+            self.matches.clear();
+            let matcher = &self.matcher;
+            let query = &query;
+            self.matches
+                .extend(self.item_sources.iter().enumerate().flat_map(
+                    |(option_source, item_source)| {
+                        self.options[option_source].iter().enumerate().filter_map(
+                            move |(option_index, option)| {
+                                let text = option.filter_text(item_source.editor_data());
+                                query.fuzzy_match(&text, matcher).map(|score| Match {
+                                    option_index,
+                                    option_source,
+                                    score,
+                                    len: text.chars().count(),
+                                })
+                            },
+                        )
+                    },
+                ));
+
+            self.matches.sort();
+        }
+
+        // reset cursor position or recover position based on previous matched option
+        if !reset_cursor {
+            self.cursor = self
+                .matches
+                .iter()
+                .enumerate()
+                .find_map(|(index, m)| {
+                    if Some((m.option_source, m.option_index)) == prev_selected_option {
+                        Some(index)
+                    } else {
+                        None
+                    }
+                })
+                .or(if self.cursor_always_selects {
+                    Some(0)
+                } else {
+                    None
+                });
+        };
+        if self.previous_pattern.0 != pattern {
+            self.previous_pattern.0 = pattern.to_owned();
+        }
+        self.previous_pattern.1 = query;
+    }
+
+    pub fn force_score(&mut self) {
+        self.score(None, false, true)
+    }
+
+    pub fn clear(&mut self) {
+        self.matches.clear();
+
+        // reset cursor position
+        self.cursor = None;
+    }
+
+    /// Move the cursor by a number of lines, either down (`Forward`) or up (`Backward`)
+    pub fn move_cursor_by(&mut self, amount: usize, direction: Direction) {
+        let len = self.matches.len();
+
+        if len == 0 {
+            // No results, can't move.
+            return;
+        }
+
+        if amount != 0 {
+            self.cursor = Some(match (direction, self.cursor) {
+                (Direction::Forward, Some(cursor)) => cursor.saturating_add(amount) % len,
+                (Direction::Backward, Some(cursor)) => {
+                    cursor.saturating_add(len).saturating_sub(amount) % len
+                }
+                (Direction::Forward, None) => amount - 1,
+                (Direction::Backward, None) => len.saturating_sub(amount),
+            });
+        }
+    }
+
+    /// Move the cursor to the first entry
+    pub fn to_start(&mut self) {
+        self.cursor = Some(0);
+    }
+
+    /// Move the cursor to the last entry
+    pub fn to_end(&mut self) {
+        self.cursor = Some(self.matches.len().saturating_sub(1));
+    }
+
+    pub fn selection(&self) -> Option<&T> {
+        self.cursor.and_then(|cursor| {
+            self.matches.get(cursor).map(
+                |Match {
+                     option_index,
+                     option_source,
+                     ..
+                 }| &self.options[*option_source][*option_index],
+            )
+        })
+    }
+
+    pub fn selection_mut(&mut self) -> Option<&mut T> {
+        self.cursor.and_then(|cursor| {
+            self.matches.get(cursor).map(
+                |Match {
+                     option_index,
+                     option_source,
+                     ..
+                 }| &mut self.options[*option_source][*option_index],
+            )
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.matches.is_empty()
+    }
+
+    pub fn matches_len(&self) -> usize {
+        self.matches.len()
+    }
+
+    pub fn matcher(&self) -> &Matcher {
+        &self.matcher
+    }
+}
+
+impl<T: Item + PartialEq> OptionsManager<T> {
+    fn replace_option(&mut self, old_option: T, new_option: T) {
+        for options in &mut self.options {
+            for option in options {
+                if old_option == *option {
+                    *option = new_option;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+pub struct Menu<T: Item> {
+    options_manager: OptionsManager<T>,
     widths: Vec<Constraint>,
 
     callback_fn: MenuCallback<T>,
@@ -65,23 +698,17 @@ pub struct Menu<T: Item> {
     recalculate: bool,
 }
 
+use super::{fuzzy_match::FuzzyQuery, PromptEvent as MenuEvent};
+
 impl<T: Item> Menu<T> {
     const LEFT_PADDING: usize = 1;
 
-    // TODO: it's like a slimmed down picker, share code? (picker = menu + prompt with different
-    // rendering)
     pub fn new(
-        options: Vec<T>,
-        editor_data: <T as Item>::Data,
+        options_manager: OptionsManager<T>,
         callback_fn: impl Fn(&mut Editor, Option<&T>, MenuEvent) + 'static,
     ) -> Self {
-        let matches = (0..options.len()).map(|i| (i, 0)).collect();
         Self {
-            options,
-            editor_data,
-            matcher: Box::new(Matcher::default().ignore_case()),
-            matches,
-            cursor: None,
+            options_manager,
             widths: Vec::new(),
             callback_fn: Box::new(callback_fn),
             scroll: 0,
@@ -92,74 +719,53 @@ impl<T: Item> Menu<T> {
     }
 
     pub fn score(&mut self, pattern: &str) {
-        // reuse the matches allocation
-        self.matches.clear();
-        self.matches.extend(
-            self.options
-                .iter()
-                .enumerate()
-                .filter_map(|(index, option)| {
-                    let text = option.filter_text(&self.editor_data);
-                    // TODO: using fuzzy_indices could give us the char idx for match highlighting
-                    self.matcher
-                        .fuzzy_match(&text, pattern)
-                        .map(|score| (index, score))
-                }),
-        );
-        // Order of equal elements needs to be preserved as LSP preselected items come in order of high to low priority
-        self.matches.sort_by_key(|(_, score)| -score);
-
-        // reset cursor position
-        self.cursor = None;
+        // TODO reset cursor?
+        self.options_manager.score(Some(pattern), false, false);
         self.scroll = 0;
         self.recalculate = true;
     }
 
     pub fn clear(&mut self) {
-        self.matches.clear();
-
-        // reset cursor position
-        self.cursor = None;
+        self.options_manager.clear();
         self.scroll = 0;
     }
 
     pub fn move_up(&mut self) {
-        let len = self.matches.len();
-        let max_index = len.saturating_sub(1);
-        let pos = self.cursor.map_or(max_index, |i| (i + max_index) % len) % len;
-        self.cursor = Some(pos);
+        self.options_manager.move_cursor_by(1, Direction::Backward);
         self.adjust_scroll();
     }
 
     pub fn move_down(&mut self) {
-        let len = self.matches.len();
-        let pos = self.cursor.map_or(0, |i| i + 1) % len;
-        self.cursor = Some(pos);
+        self.options_manager.move_cursor_by(1, Direction::Forward);
         self.adjust_scroll();
     }
 
     fn recalculate_size(&mut self, viewport: (u16, u16)) {
         let n = self
-            .options
-            .first()
-            .map(|option| option.format(&self.editor_data).cells.len())
+            .options_manager
+            .options()
+            .next()
+            .map(|(option, editor_data)| option.format(editor_data).cells.len())
             .unwrap_or_default();
-        let max_lens = self.options.iter().fold(vec![0; n], |mut acc, option| {
-            let row = option.format(&self.editor_data);
-            // maintain max for each column
-            for (acc, cell) in acc.iter_mut().zip(row.cells.iter()) {
-                let width = cell.content.width();
-                if width > *acc {
-                    *acc = width;
-                }
-            }
+        let max_lens =
+            self.options_manager
+                .options()
+                .fold(vec![0; n], |mut acc, (option, editor_data)| {
+                    let row = option.format(editor_data);
+                    // maintain max for each column
+                    for (acc, cell) in acc.iter_mut().zip(row.cells.iter()) {
+                        let width = cell.content.width();
+                        if width > *acc {
+                            *acc = width;
+                        }
+                    }
 
-            acc
-        });
+                    acc
+                });
 
-        let height = self.matches.len().min(10).min(viewport.1 as usize);
+        let height = self.len().min(10).min(viewport.1 as usize);
         // do all the matches fit on a single screen?
-        let fits = self.matches.len() <= height;
+        let fits = self.len() <= height;
 
         let mut len = max_lens.iter().sum::<usize>() + n;
 
@@ -184,7 +790,7 @@ impl<T: Item> Menu<T> {
 
     fn adjust_scroll(&mut self) {
         let win_height = self.size.1 as usize;
-        if let Some(cursor) = self.cursor {
+        if let Some(cursor) = self.options_manager.cursor() {
             let mut scroll = self.scroll;
             if cursor > (win_height + scroll).saturating_sub(1) {
                 // scroll down
@@ -198,47 +804,31 @@ impl<T: Item> Menu<T> {
     }
 
     pub fn selection(&self) -> Option<&T> {
-        self.cursor.and_then(|cursor| {
-            self.matches
-                .get(cursor)
-                .map(|(index, _score)| &self.options[*index])
-        })
+        self.options_manager.selection()
     }
 
     pub fn selection_mut(&mut self) -> Option<&mut T> {
-        self.cursor.and_then(|cursor| {
-            self.matches
-                .get(cursor)
-                .map(|(index, _score)| &mut self.options[*index])
-        })
+        self.options_manager.selection_mut()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.matches.is_empty()
+        self.options_manager.is_empty()
     }
 
     pub fn len(&self) -> usize {
-        self.matches.len()
+        self.options_manager.matches_len()
     }
 }
 
-impl<T: Item + PartialEq> Menu<T> {
-    pub fn replace_option(&mut self, old_option: T, new_option: T) {
-        for option in &mut self.options {
-            if old_option == *option {
-                *option = new_option;
-                break;
-            }
-        }
-    }
-}
-
-use super::PromptEvent as MenuEvent;
-
-impl<T: Item + 'static> Component for Menu<T> {
+impl<T: Item> Component for Menu<T> {
     fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
         let event = match event {
             Event::Key(event) => *event,
+            Event::IdleTimeout => {
+                self.options_manager
+                    .refetch_on_idle_timeout(cx.editor, cx.jobs);
+                return EventResult::Consumed(None);
+            }
             _ => return EventResult::Ignored(None),
         };
 
@@ -295,6 +885,7 @@ impl<T: Item + 'static> Component for Menu<T> {
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
+        self.recalculate |= self.options_manager.poll_for_new_options();
         if viewport != self.viewport || self.recalculate {
             self.recalculate_size(viewport);
         }
@@ -303,6 +894,7 @@ impl<T: Item + 'static> Component for Menu<T> {
     }
 
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        self.options_manager.poll_for_new_options();
         let theme = &cx.editor.theme;
         let style = theme
             .try_get("ui.menu")
@@ -312,14 +904,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let scroll = self.scroll;
 
-        let options: Vec<_> = self
-            .matches
-            .iter()
-            .map(|(index, _score)| {
-                // (index, self.options.get(*index).unwrap()) // get_unchecked
-                &self.options[*index] // get_unchecked
-            })
-            .collect();
+        let options: Vec<_> = self.options_manager.matches().collect();
 
         let len = options.len();
 
@@ -331,7 +916,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let rows = options
             .iter()
-            .map(|option| option.format(&self.editor_data));
+            .map(|(option, editor_data)| option.format(editor_data));
         let table = Table::new(rows)
             .style(style)
             .highlight_style(selected)
@@ -345,11 +930,11 @@ impl<T: Item + 'static> Component for Menu<T> {
             surface,
             &mut TableState {
                 offset: scroll,
-                selected: self.cursor,
+                selected: self.options_manager.cursor(),
             },
         );
 
-        if let Some(cursor) = self.cursor {
+        if let Some(cursor) = self.options_manager.cursor() {
             let offset_from_top = cursor - scroll;
             let left = &mut surface[(area.left(), area.y + offset_from_top as u16)];
             left.set_style(selected);
@@ -383,5 +968,11 @@ impl<T: Item + 'static> Component for Menu<T> {
                 }
             }
         }
+    }
+}
+
+impl<T: Item + PartialEq> Menu<T> {
+    pub fn replace_option(&mut self, old_option: T, new_option: T) {
+        self.options_manager.replace_option(old_option, new_option);
     }
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -17,11 +17,12 @@ mod text;
 use crate::compositor::{Component, Compositor};
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
-pub use completion::Completion;
+use crate::ui::menu::OptionsManager;
+pub use completion::{Completion, CompletionItem};
 pub use editor::EditorView;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{DynamicPicker, FileLocation, FilePicker, Picker};
+pub use picker::{FileLocation, FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
@@ -217,9 +218,9 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
+    let option_manager = OptionsManager::create_from_items(files, root);
     FilePicker::new(
-        files,
-        root,
+        option_manager,
         move |cx, path: &PathBuf, action| {
             if let Err(e) = cx.editor.open(path, action) {
                 let err = if let Some(err) = e.source() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -709,7 +709,7 @@ pub struct WhitespaceCharacters {
 impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
-            space: '·',    // U+00B7
+            space: '·',   // U+00B7
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE


### PR DESCRIPTION
This PR unifies the functionality of the `Picker` and the `Menu` in the struct `OptionsManager` (i.e. matching/filtering, sorting, cursor management etc.), and extends the logic of `score` by being able to retain the cursor position (which is useful, if new entries are added async).

The main reason for this PR though is to have multiple option `ItemSource`s, which can be async and which may be refetched (see #5055) to provide the options for the `OptionsManager`. It currently allows 3 different input sources: synchronous data, asynchronous data, and asynchronous functions which provide the data, which are reexecuted after an `IdleTimeout` occured (similar as #5055).
This PR is or will be a requirement for #2507 (currently provided by #3082), which I will rebase onto this PR soon.

Noticeable effects right now:

* The `Menu` now has the more sophisticated logic of the picker (mostly better caching while changing the query)
* The `Menu` currently *doesn't* reset the cursor position, if `score()` is called (effectively different pattern query), I'm not sure  if we should keep this behavior, I guess it needs some testing and feedback. I have kept the original behavior of the Picker (everytime `score()` changes it resets the cursor)

This PR is an alternative to #3082, which I wasn't completely happy with (adding options async was/is kind of a hack to keep it simple) thus this PR will supersede it. It was originally motivated by #5055 and how to integrate that logic into #2507 (which is not done yet). The PR unfortunately grew a little bit more than I've anticipated, but in general I think it's the cleaner and more future proof way to be able to have async item sources, which may change the options overtime.
For example the same logic of #5055 could be simply implemented for the completion menu with different multiple completion sources, whether it makes sense or not (though also one of the motivations of this PR to have this possibility).
This should also cleanup and greatly (hopefully) simplify #2507.

## Technical Overview

To make reviewing easier (I hope) I provide a technical summary of this PR:

* `OptionsManager` contains all logic that is necessary to manage options (d'oh), that means:
    * Filtering/matching of options with `score()` which takes a few more parameters now:
        * *Optional* pattern to be able to recalculate the score without providing a pattern (necessary for async addition of the options)
        * Boolean flag to retain the cursor, since it will likely be annoying, if an item source takes so long that the user is already selecting options of a different item source and it gets resetted because score has to be called again for matches that respect the new option source).
        * force_recalculation, kind of an optimization, if nothing external has changed (except new async options) 
    * The `OptionsManager` is fed by `ItemSource`s
        * Fetching of items from the item source is started by the creation of the `OptionsManager` (`create_from_item_sources`), and as soon one item source provides some items a construction callback is executed (see below) 
        * Async fetching is done by looping over `FuturesUnordered` async requests and adding the options via an `mpsc`, I wanted to avoid any `Mutex` or something alike to keep the rest of the logic as is (and likely to be more performant as well). Thus instead the editor `redraw_handle` is notified when new options are available and in the render functions new options are polled (via `poll_for_new_options`). Although not optimal, it was IMHO the best tradeoff (I tried different solutions, and came to that conclusion).
        * Options are stored with an additional index to the item source to be able to easily change the options on the fly, it provides some iterator wrapper functions to access the options/matches outside as usual.
    * When using the `OptionManager` with async sources, I have decided (to mostly mirror current logic) to use a "constructor callback" in the `create_from_item_sources` for creating e.g. the actual `Menu` or `Picker` when at least one item is available (this callback is only then executed), otherwise an optional other callback can show e.g. editor status messages, when there was no item source provided any data.
    * The `(File-)Picker` and `Menu` now takes the `OptionsManager` instead of the items or editor data (this is now provided in the `ItemSource`)
    * For sync data it's also possible to directly create the `OptionsManager` without a callback using `create_from_items` but only with this function.
* I've imported the `CompletionItem` from #2507 to provide additional information where the item came from (which language server id and offset encoding) when multiple language servers are used as Item source, it's currently an enum to avoid unnecessary refactoring if other completion sources are added (such as #2608 or #1015), though it's not really relevant for this PR currently (as the doc has just one language server anyway), but I think it may be easier to review it here separated from #2507 and it's also the (only) dependency of #2507 for #2608 
* The `DynamicPicker` is removed as this behavior can now be modeled with a `ItemSource::AsyncRefetchOnIdleTimeoutWithPattern` which is done for the `workspace_symbol_picker`