### PR TITLE
Add test-running capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "helix-dap",
  "helix-loader",
  "helix-lsp",
+ "helix-test",
  "helix-tui",
  "helix-vcs",
  "helix-view",
@@ -1228,6 +1229,14 @@ dependencies = [
  "tokio-stream",
  "toml",
  "which",
+]
+
+[[package]]
+name = "helix-test"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "helix-core",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -31,6 +31,7 @@ helix-core = { version = "0.6", path = "../helix-core" }
 helix-view = { version = "0.6", path = "../helix-view" }
 helix-lsp = { version = "0.6", path = "../helix-lsp" }
 helix-dap = { version = "0.6", path = "../helix-dap" }
+helix-test = { version = "0.6", path = "../helix-test" }
 helix-vcs = { version = "0.6", path = "../helix-vcs" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
 

--- a/helix-term/src/executor.rs
+++ b/helix-term/src/executor.rs
@@ -1,0 +1,82 @@
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::process::Command;
+
+pub trait Executor {
+    fn execute(&self, command: Command) -> anyhow::Result<()>;
+}
+
+pub struct Direct;
+
+impl Executor for Direct {
+    fn execute(&self, mut command: Command) -> anyhow::Result<()> {
+        let output = command.output()?;
+        let output_text = std::str::from_utf8(&output.stdout)?;
+        println!("{}", output_text);
+        Ok(())
+    }
+}
+
+pub struct Tmux {
+    pane: String,
+}
+
+impl Tmux {
+    pub fn new() -> Self {
+        Tmux{
+            pane: String::from("!"), // last pane
+        }
+    }
+}
+
+impl Executor for Tmux {
+    fn execute(&self, command: Command) -> anyhow::Result<()> {
+        // Need to make this smarter
+        let mut command_vec = vec![command.get_program()];
+        for arg in command.get_args() {
+            command_vec.push(arg);
+        }
+        //command_vec.extend(command.get_args().collect());
+        let command_to_send = command_vec.join(OsStr::new(" "));
+        let command_to_send = shellify(command.get_current_dir(), &command_to_send);
+
+        std::process::Command::new("tmux")
+            .args([OsStr::new("send-keys"), OsStr::new("-t"), OsStr::new(&self.pane), &command_to_send, OsStr::new("Enter")])
+            .spawn()?
+            .wait()?;
+
+        Ok(())
+    }
+}
+
+pub fn get() -> Box<dyn Executor> {
+    if let Ok(_) = std::env::var("TMUX") {
+        Box::new(Tmux::new())
+    } else {
+        Box::new(Direct{})
+    }
+}
+
+fn shellify(dir: Option<&Path>, cmd: &OsStr) -> OsString {
+    if let Ok(shell) = std::env::var("SHELL") {
+        match shell.as_str() {
+            "/bin/sh" | "/bin/bash" | "/bin/zsh" => {
+                let mut result = OsString::from("clear; ");
+                match dir {
+                    Some(dir) => {
+                        // ???: Better way to format an OsString?
+                        result.push("(cd ");
+                        result.push(dir.as_os_str());
+                        result.push(" && ");
+                        result.push(cmd);
+                        result.push(")");
+                    },
+                    None => result.push(cmd),
+                }
+                return result;
+            },
+            _ => (),
+        }
+    }
+    OsString::from(cmd)
+}

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -272,6 +272,9 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "k" => hover,
             "r" => rename_symbol,
             "h" => select_references_to_symbol_under_cursor,
+            "t" => { "Test"
+                "b" => test_buffer,
+            },
             "?" => command_palette,
         },
         "z" => { "View"

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -6,6 +6,7 @@ pub mod args;
 pub mod commands;
 pub mod compositor;
 pub mod config;
+pub mod executor;
 pub mod health;
 pub mod job;
 pub mod keymap;

--- a/helix-test/Cargo.toml
+++ b/helix-test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "helix-test"
+version = "0.6.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-test/src/lib.rs
+++ b/helix-test/src/lib.rs
@@ -1,0 +1,58 @@
+use anyhow::anyhow;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn run(path: PathBuf) -> anyhow::Result<Command> {
+    let mut runner = None;
+    let mut dir = path.clone();
+
+    while runner.is_none() {
+        if !dir.pop() {
+            return Err(anyhow!("No viable test runner found"));
+        }
+        runner = get_runner(dir.as_path());
+    }
+
+    let command = runner.unwrap().get_command(path.as_path());
+    Ok(command)
+}
+
+/// This method attempts to get a test runner for the current directory. It will usually use
+/// file-based cues, such as the existence of Cargo.toml, to determine what test runner is
+/// appropriate for the context.
+fn get_runner(dir: &Path) -> Option<Box<dyn Runner>> {
+    if let Some(cargo) = Cargo::detect(dir) {
+        Some(Box::new(cargo))
+    } else {
+        None
+    }
+}
+
+pub trait Runner {
+    fn get_command(&self, path: &Path) -> Command;
+}
+
+struct Cargo {
+    dir: PathBuf,
+}
+
+impl Cargo {
+    fn detect(dir: &Path) -> Option<Cargo> {
+        if dir.join("Cargo.toml").exists() {
+            Some(Cargo{
+                dir: dir.to_path_buf(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Runner for Cargo {
+    fn get_command(&self, path: &Path) -> Command {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("test").arg(&path.strip_prefix(&self.dir).unwrap_or(path).as_os_str());
+        cmd.current_dir(&self.dir);
+        cmd
+    }
+}


### PR DESCRIPTION
This PR is an initial proof-of-concept for adding test-running support to Helix, and is heavily inspired by [vim-test](https://github.com/vim-test/vim-test). To execute a test, open its file, and then execute `<Space> t b`. (Currently, only Cargo-based tests are supported)

Running tests from Helix requires two things:

1. The ability to execute arbitrary commands.
2. Logic to determine the correct command to run for a given file.

### Executing Arbitrary Commands

To execute arbitrary commands, a new module has been added for defining command executors. Because Helix does not (yet) have an [integrated terminal](https://github.com/helix-editor/helix/pull/4649), there are two executors defined: `Tmux`, which integrates with tmux to execute test commands in another pane, and `Direct`, which executes the test command as a background process and prints the results.

Additional executors can easily be added for different multiplexers. This is equivalent to what `vim-test` calls [strategies](https://github.com/vim-test/vim-test#strategies). The `Tmux` executor implemented here is similar to the [vimux](https://github.com/preservim/vimux) strategy.

### Determining Test Commands

A new `helix-test` project has been added to hold the logic for determining what command to run. The relevant function will walk up the file tree, attempting to match against all known test runners, and returning the first one that matches. For example, as soon as `Cargo.toml` is seen, the `Cargo` test runner is returned. This test runner will then be asked to build the test command for the relevant file.

`vim-test` supports quite a few executors, all of which are good candidates for porting over to Helix as well.

### Next Steps

I'm open to feedback on both the feature as a concept, and its specific implementation here.

One option as well would be to hold off until Helix's plugin system has stabilized, and then implement this as a plugin, but given Helix's large amount of core functionality, I think this would not be out-of-place living within Helix itself.