### PR TITLE
flake: pass helix' wrapper through

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
         };
       };
       pkgConfig = common: {
-        helix-term = {
+        helix-term = let
           # Wrap helix with runtime
           wrapper = _: old: let
             inherit (common) pkgs;
@@ -130,9 +130,14 @@
                 '';
             in
               helix-wrapped
-              // {override = makeOverridableHelix old;};
+              // {
+                override = makeOverridableHelix old;
+                passthru = helix-wrapped.passthru // {wrapper = wrapper {};};
+              };
           in
             makeOverridableHelix old {};
+        in {
+          inherit wrapper;
           overrides.fix-build.overrideAttrs = prev: {
             src = filteredSource;
 


### PR DESCRIPTION
This allows easily (re)making helix (wrapped) from an overriden helix-unwrapped derivation, e.g. if one wanted to patch helix from nix:

```nix
helix.passthru.wrapper (helix-unwrapped.overrideAttrs (old: {
  patches = old.patches ++ [ ./cargo-tree-sitter.patch ];
}))
```

I needed this to patch helix from my own nixos configuration flake after hitting #4862.