### PR TITLE
Ignore invalid file URIs from LSP

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -703,7 +703,13 @@ impl Application {
                         }
                     }
                     Notification::PublishDiagnostics(mut params) => {
-                        let path = params.uri.to_file_path().unwrap();
+                        let path = match params.uri.to_file_path() {
+                            Ok(path) => path,
+                            Err(_) => {
+                                log::error!("Unsupported file URI: {}", params.uri);
+                                return;
+                            }
+                        };
                         let doc = self.editor.document_by_path_mut(&path);
 
                         if let Some(doc) = doc {


### PR DESCRIPTION
This PR changes a call to `unwrap()` to `match`. Currently the editor crashes when the LSP publishes diagnostics with an unsupported URI. With this PR it simply ignores them.

Submitting this patch because the [Cairo language server](https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-language-server) crashes Helix when it sends a file URI like `vfs://xxxxxx` where `vfs` refers to the internal in-memory file system of the Cairo language server.

I'm not sure if this is considered a bug of the Cairo lang server as I don't know for sure if schemes other than `file` is allowed. But in any case I think we shouldn't panic here.