### PR TITLE
Extend keybindings for picker vertical movements

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -650,10 +650,10 @@ impl<T: Item + 'static> Component for Picker<T> {
         cx.editor.reset_idle_timer();
 
         match key_event {
-            shift!(Tab) | key!(Up) | ctrl!('p') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') | ctrl!('k') => {
                 self.move_by(1, Direction::Backward);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') => {
+            key!(Tab) | key!(Down) | ctrl!('n') | ctrl!('j') => {
                 self.move_by(1, Direction::Forward);
             }
             key!(PageDown) | ctrl!('d') => {


### PR DESCRIPTION
Extend vertical movements in the picker to 'ctrl+j' and 'ctrl+k'

This is mostly to be aligned to the keybindings of  other widespread tools such as `fzf`, `zellij`, `gitui`, ...