### PR TITLE
Add basic support for F# syntax highlighting.

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -38,6 +38,7 @@
 | esdl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
 | fortran | ✓ |  | ✓ | `fortls` |
+| fsharp | ✓ |  |  |  |
 | gdscript | ✓ | ✓ | ✓ |  |
 | git-attributes | ✓ |  |  |  |
 | git-commit | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2167,3 +2167,16 @@ comment-token = "#"
 [[grammar]]
 name = "hosts"
 source = { git = "https://github.com/ath3/tree-sitter-hosts", rev = "301b9379ce7dfc8bdbe2c2699a6887dcb73953f9" }
+
+[[language]]
+name = "fsharp"
+scope = "source.fsharp"
+injection-regex = "^fsharp$"
+file-types = ["fs"]
+roots = []
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "fsharp"
+source = { git = "https://github.com/Nsidorenco/tree-sitter-fsharp", rev = "700c8371016ec9dc68ac31c67328ef5c8b216cf5" }

--- a/runtime/queries/fsharp/highlights.scm
+++ b/runtime/queries/fsharp/highlights.scm
@@ -1,0 +1,33 @@
+"module" @keyword.other
+
+[
+  "let"
+  "rec"
+  "if"
+  "else"
+  "match"
+  "with"
+] @keyword.control
+
+[
+  "="
+] @keyword.type
+
+[
+  "static"
+  "member"
+] @keyword.other
+
+(identifier) @type
+
+[
+  (type_definition)
+  (union_type_defn)
+  (match_expression)
+  (function_or_value_defn)
+  (function_declaration_left)
+  (value_declaration_left)
+] @keyword.type
+
+(application_expression) @keyword.other
+


### PR DESCRIPTION
This integrates the [Nsidorenco's TS grammar](https://github.com/Nsidorenco/tree-sitter-fsharp) and provides some basic mapping of elements to syntax highlighting groups.

Some notes:
* A lot of the code I looked at had some errors parsing where I'd use `:tree-sitter-scopes` and see `["ERROR", "ERROR", "l"]` in place of useful scope mappings. As a result some files I looked at were partially highlighted. I suspect these are bugs in the TS grammar that will be ironed out over time, but didn't know enough to be sure. (Screenshot below).
* I'm a _super_ novice at F#, having written only a basic CLI program, so I'm sure these mappings could be improved. I offer this PR in a "something is better than nothing" state.

Fixes #4943.

![image](https://user-images.githubusercontent.com/662824/219051769-2f53bba6-eca3-4447-9eca-25bff1e31b3e.png)
