### PR TITLE
Add `.env.dist` to `source.env` language scope

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2007,7 +2007,7 @@ source = { git = "https://github.com/hh9527/tree-sitter-wit", rev = "c917790ab9a
 [[language]]
 name = "env"
 scope = "source.env"
-file-types = [".env", ".env.local", ".env.development", ".env.production", ".envrc"]
+file-types = [".env", ".env.local", ".env.development", ".env.production", ".env.dist", ".envrc"]
 injection-regex = "env"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
`.env.dist` files are distributed `.env` files without secrets /  `.env`-templates.

These are not currently highlighted by Helix.

This PR adds them to the `source.env` scope, alongside other common `.env.*`.