### PR TITLE
ignore case while filtering completions

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -79,7 +79,7 @@ impl<T: Item> Menu<T> {
         Self {
             options,
             editor_data,
-            matcher: Box::default(),
+            matcher: Box::new(Matcher::default().ignore_case()),
             matches,
             cursor: None,
             widths: Vec::new(),


### PR DESCRIPTION
Fixes #2017

This PR changes the fuzzy matching in the completion menu to be always case insensitive.
We never really documented that it used smart casing and I don't think that is actually desirable here.
A common use-case for competitions is mistyping/misremembering an identifier and using autocomplete to fixup that problem. For that use-case case sensitive matching is actually detrimental. Other editors like nvim/vscode/intellij also seem to always use case insensitive auto completions.

Note that the original reproduction case from #2017 already seems to work:
![case_insensitive](https://user-images.githubusercontent.com/61850714/219198616-ff99ebad-d982-46fc-ab56-bc621413fde0.png)

However after this fix the following also works which doesn't work on master (see screenshot)

![case_sensitive_comp](https://user-images.githubusercontent.com/61850714/219198641-69149680-d3ed-4a21-9434-407905152f85.png)

Note that we rank completions by their fuzzy matching score which gives a penalty for case mismatch in case ignore case is enabled soo if both `Foo` and `FOO` exist both would show up but `Foo` would be ranked first.