### PR TITLE
Remove text bg from monokai

### DIFF
--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -78,7 +78,7 @@
 "ui.statusline" = { fg = "active_text", bg = "#414339" }
 "ui.statusline.inactive" = { fg = "active_text", bg = "#75715e" }
 
-"ui.text" = { fg = "text", bg = "background" }
+"ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "active_text" }
 
 "warning" = { fg = "#cca700" }


### PR DESCRIPTION
Fixes #5961

I originally assumed that this was a regression introduced by #5420 (which it technically is). In that PR the picker highlight was changed to be rendered in the background (behin text) instead of in the forground. This was mostly an oversight, because rendering in the background is the default with the new line decoration API.

However upon investigating further I found this to be consistent with other similar highlights like:
* Buffer line
* Buffer column
* Current DAP frame

The only thing that is really rendered in the foreground is the selection (which uses the syntax highlighting API). All of this is for good reason because otherwise these overlays would hide the cursor/selection. Therefore I think its more consistent to keep the same behavior for the picker highlight too.

While the cursor is not a concern here I think it would be weird to handle the picker highlight differently than all these other highlights. In particular because the DAP frame uses the exact same highlight key (at-least right now) and was always rendered in the background even before #5420. I think that any foreground styling for text should only be handled by the syntax highlighting (and avoided if possible). Similarly any `bg` styling for text should be avoided. The cause of #5961 was that monokai definied a `bg` color for `ui.text` (identical to `ui.background`) which overwrote the background color from `ui.highlight`. This also causes similar issues with bufferline/column and the DAP frame. All this PR does is remove the `bg` color from `ui.text` in monokai.


I belive the long term solution for the problem is to:
* Clearly document that text highlights should only theme the `fg` color.
* Clearly document that anything that is rendered on top of text should only theme the `bg` color.
* Make the theme linter automatically detect these cases