### PR TITLE
DAP: Add request ID to request timeout message

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -254,7 +254,7 @@ impl Client {
             // TODO: specifiable timeout, delay other calls until initialize success
             timeout(Duration::from_secs(20), callback_rx.recv())
                 .await
-                .map_err(|_| Error::Timeout)? // return Timeout
+                .map_err(|_| Error::Timeout(id))? // return Timeout
                 .ok_or(Error::StreamClosed)?
                 .map(|response| response.body.unwrap_or_default())
             // TODO: check response.success

--- a/helix-dap/src/lib.rs
+++ b/helix-dap/src/lib.rs
@@ -14,8 +14,8 @@ pub enum Error {
     Parse(#[from] serde_json::Error),
     #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),
-    #[error("request timed out")]
-    Timeout,
+    #[error("request {0} timed out")]
+    Timeout(u64),
     #[error("server closed the stream")]
     StreamClosed,
     #[error(transparent)]


### PR DESCRIPTION
This improves error logging for dap requests - without the ID it's hard to
know which request is the one that timed out, just like [6010](https://github.com/helix-editor/helix/pull/6010).