### PR TITLE
Fix crash when deleting with multiple cursors

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -67,4 +67,4 @@ pub use syntax::Syntax;
 pub use diagnostic::Diagnostic;
 
 pub use line_ending::{LineEnding, DEFAULT_LINE_ENDING};
-pub use transaction::{Assoc, Change, ChangeSet, Operation, Transaction};
+pub use transaction::{Assoc, Change, ChangeSet, Deletion, Operation, Transaction};

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 
 /// (from, to, replacement)
 pub type Change = (usize, usize, Option<Tendril>);
+pub type Deletion = (usize, usize);
 
 // TODO: pub(crate)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -534,6 +535,41 @@ impl Transaction {
         Self::from(changeset)
     }
 
+    /// Generate a transaction from a set of potentially overlapping deletions
+    /// by merging overlapping deletions together.
+    pub fn delete<I>(doc: &Rope, deletions: I) -> Self
+    where
+        I: Iterator<Item = Deletion>,
+    {
+        let len = doc.len_chars();
+
+        let (lower, upper) = deletions.size_hint();
+        let size = upper.unwrap_or(lower);
+        let mut changeset = ChangeSet::with_capacity(2 * size + 1); // rough estimate
+
+        let mut last = 0;
+        for (mut from, to) in deletions {
+            if last > to {
+                continue;
+            }
+            if last > from {
+                from = last
+            }
+            debug_assert!(
+                from <= to,
+                "Edit end must end before it starts (should {from} <= {to})"
+            );
+            // Retain from last "to" to current "from"
+            changeset.retain(from - last);
+            changeset.delete(to - from);
+            last = to;
+        }
+
+        changeset.retain(len - last);
+
+        Self::from(changeset)
+    }
+
     /// Generate a transaction with a change per selection range.
     pub fn change_by_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
     where
@@ -578,6 +614,16 @@ impl Transaction {
             transaction,
             Selection::new(ranges, new_primary_idx.unwrap_or(0)),
         )
+    }
+
+    /// Generate a transaction with a deletion per selection range.
+    /// Compared to using `change_by_selection` directly these ranges may overlap.
+    /// In that case they are merged
+    pub fn delete_by_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
+    where
+        F: FnMut(&Range) -> Deletion,
+    {
+        Self::delete(doc, selection.iter().map(f))
     }
 
     /// Insert text at each selection head.

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -570,6 +570,11 @@ impl Transaction {
         Self::from(changeset)
     }
 
+    pub fn insert_at_eof(mut self, text: Tendril) -> Transaction {
+        self.changes.insert(text);
+        self
+    }
+
     /// Generate a transaction with a change per selection range.
     pub fn change_by_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
     where

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -788,42 +788,50 @@ fn extend_to_line_start(cx: &mut Context) {
 }
 
 fn kill_to_line_start(cx: &mut Context) {
-    delete_by_selection_insert_mode(cx, move |text, range| {
-        let line = range.cursor_line(text);
-        let first_char = text.line_to_char(line);
-        let anchor = range.cursor(text);
-        let head = if anchor == first_char && line != 0 {
-            // select until previous line
-            line_end_char_index(&text, line - 1)
-        } else if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
-            if first_char + pos < anchor {
-                // select until first non-blank in line if cursor is after it
-                first_char + pos
+    delete_by_selection_insert_mode(
+        cx,
+        move |text, range| {
+            let line = range.cursor_line(text);
+            let first_char = text.line_to_char(line);
+            let anchor = range.cursor(text);
+            let head = if anchor == first_char && line != 0 {
+                // select until previous line
+                line_end_char_index(&text, line - 1)
+            } else if let Some(pos) = find_first_non_whitespace_char(text.line(line)) {
+                if first_char + pos < anchor {
+                    // select until first non-blank in line if cursor is after it
+                    first_char + pos
+                } else {
+                    // select until start of line
+                    first_char
+                }
             } else {
                 // select until start of line
                 first_char
-            }
-        } else {
-            // select until start of line
-            first_char
-        };
-        (head, anchor)
-    });
+            };
+            (head, anchor)
+        },
+        Direction::Backward,
+    );
 }
 
 fn kill_to_line_end(cx: &mut Context) {
-    delete_by_selection_insert_mode(cx, |text, range| {
-        let line = range.cursor_line(text);
-        let line_end_pos = line_end_char_index(&text, line);
-        let pos = range.cursor(text);
+    delete_by_selection_insert_mode(
+        cx,
+        |text, range| {
+            let line = range.cursor_line(text);
+            let line_end_pos = line_end_char_index(&text, line);
+            let pos = range.cursor(text);
 
-        // if the cursor is on the newline char delete that
-        if pos == line_end_pos {
-            (pos, text.line_to_char(line + 1))
-        } else {
-            (pos, line_end_pos)
-        }
-    });
+            // if the cursor is on the newline char delete that
+            if pos == line_end_pos {
+                (pos, text.line_to_char(line + 1))
+            } else {
+                (pos, line_end_pos)
+            }
+        },
+        Direction::Forward,
+    );
 }
 
 fn goto_first_nonwhitespace(cx: &mut Context) {
@@ -2315,13 +2323,44 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
 fn delete_by_selection_insert_mode(
     cx: &mut Context,
     mut f: impl FnMut(RopeSlice, &Range) -> Deletion,
+    direction: Direction,
 ) {
     let (view, doc) = current!(cx.editor);
     let text = doc.text().slice(..);
-    let transaction =
+    let mut selection = SmallVec::new();
+    let mut insert_newline = false;
+    let text_len = text.len_chars();
+    let mut transaction =
         Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
-            f(text, range)
+            let (start, end) = f(text, range);
+            if direction == Direction::Forward {
+                let mut range = *range;
+                if range.head > range.anchor {
+                    insert_newline |= end == text_len;
+                    // move the cursor to the right so that the selection
+                    // doesn't shrink when deleting forward (so the text appears to
+                    // move to  left)
+                    // += 1 is enough here as the range is normalized to grapheme boundaries
+                    // later anyway
+                    range.head += 1;
+                }
+                selection.push(range);
+            }
+            (start, end)
         });
+
+    // in case we delete the last character and the cursor would be moved to the EOF char
+    // insert a newline, just like when entering append mode
+    if insert_newline {
+        transaction = transaction.insert_at_eof(doc.line_ending.as_str().into());
+    }
+
+    if direction == Direction::Forward {
+        doc.set_selection(
+            view.id,
+            Selection::new(selection, doc.selection(view.id).primary_index()),
+        );
+    }
     doc.apply(&transaction, view.id);
     lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
 }
@@ -3483,28 +3522,40 @@ pub mod insert {
 
     pub fn delete_char_forward(cx: &mut Context) {
         let count = cx.count();
-        delete_by_selection_insert_mode(cx, |text, range| {
-            let pos = range.cursor(text);
-            (pos, graphemes::nth_next_grapheme_boundary(text, pos, count))
-        })
+        delete_by_selection_insert_mode(
+            cx,
+            |text, range| {
+                let pos = range.cursor(text);
+                (pos, graphemes::nth_next_grapheme_boundary(text, pos, count))
+            },
+            Direction::Forward,
+        )
     }
 
     pub fn delete_word_backward(cx: &mut Context) {
         let count = cx.count();
-        delete_by_selection_insert_mode(cx, |text, range| {
-            let anchor = movement::move_prev_word_start(text, *range, count).from();
-            let next = Range::new(anchor, range.cursor(text));
-            let range = exclude_cursor(text, next, *range);
-            (range.from(), range.to())
-        });
+        delete_by_selection_insert_mode(
+            cx,
+            |text, range| {
+                let anchor = movement::move_prev_word_start(text, *range, count).from();
+                let next = Range::new(anchor, range.cursor(text));
+                let range = exclude_cursor(text, next, *range);
+                (range.from(), range.to())
+            },
+            Direction::Backward,
+        );
     }
 
     pub fn delete_word_forward(cx: &mut Context) {
         let count = cx.count();
-        delete_by_selection_insert_mode(cx, |text, range| {
-            let head = movement::move_next_word_end(text, *range, count).to();
-            (range.cursor(text), head)
-        });
+        delete_by_selection_insert_mode(
+            cx,
+            |text, range| {
+                let head = movement::move_next_word_end(text, *range, count).to();
+                (range.cursor(text), head)
+            },
+            Direction::Forward,
+        );
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2308,9 +2308,8 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
     };
 
     // then delete
-    let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
-        (range.from(), range.to(), None)
-    });
+    let transaction =
+        Transaction::delete_by_selection(doc.text(), selection, |range| (range.from(), range.to()));
     doc.apply(&transaction, view.id);
 
     match op {
@@ -2326,9 +2325,8 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
 
 #[inline]
 fn delete_selection_insert_mode(doc: &mut Document, view: &mut View, selection: &Selection) {
-    let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
-        (range.from(), range.to(), None)
-    });
+    let transaction =
+        Transaction::delete_by_selection(doc.text(), selection, |range| (range.from(), range.to()));
     doc.apply(&transaction, view.id);
 }
 
@@ -3415,10 +3413,10 @@ pub mod insert {
         let auto_pairs = doc.auto_pairs(cx.editor);
 
         let transaction =
-            Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
+            Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
                 let pos = range.cursor(text);
                 if pos == 0 {
-                    return (pos, pos, None);
+                    return (pos, pos);
                 }
                 let line_start_pos = text.line_to_char(range.cursor_line(text));
                 // consider to delete by indent level if all characters before `pos` are indent units.
@@ -3426,11 +3424,7 @@ pub mod insert {
                 if !fragment.is_empty() && fragment.chars().all(|ch| ch == ' ' || ch == '\t') {
                     if text.get_char(pos.saturating_sub(1)) == Some('\t') {
                         // fast path, delete one char
-                        (
-                            graphemes::nth_prev_grapheme_boundary(text, pos, 1),
-                            pos,
-                            None,
-                        )
+                        (graphemes::nth_prev_grapheme_boundary(text, pos, 1), pos)
                     } else {
                         let width: usize = fragment
                             .chars()
@@ -3457,7 +3451,7 @@ pub mod insert {
                                 _ => break,
                             }
                         }
-                        (start, pos, None) // delete!
+                        (start, pos) // delete!
                     }
                 } else {
                     match (
@@ -3475,17 +3469,12 @@ pub mod insert {
                             (
                                 graphemes::nth_prev_grapheme_boundary(text, pos, count),
                                 graphemes::nth_next_grapheme_boundary(text, pos, count),
-                                None,
                             )
                         }
                         _ =>
                         // delete 1 char
                         {
-                            (
-                                graphemes::nth_prev_grapheme_boundary(text, pos, count),
-                                pos,
-                                None,
-                            )
+                            (graphemes::nth_prev_grapheme_boundary(text, pos, count), pos)
                         }
                     }
                 }
@@ -3501,13 +3490,9 @@ pub mod insert {
         let (view, doc) = current!(cx.editor);
         let text = doc.text().slice(..);
         let transaction =
-            Transaction::change_by_selection(doc.text(), doc.selection(view.id), |range| {
+            Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
                 let pos = range.cursor(text);
-                (
-                    pos,
-                    graphemes::nth_next_grapheme_boundary(text, pos, count),
-                    None,
-                )
+                (pos, graphemes::nth_next_grapheme_boundary(text, pos, count))
             });
         doc.apply(&transaction, view.id);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -27,8 +27,8 @@ use helix_core::{
     textobject,
     tree_sitter::Node,
     unicode::width::UnicodeWidthChar,
-    visual_offset_from_block, LineEnding, Position, Range, Rope, RopeGraphemes, RopeSlice,
-    Selection, SmallVec, Tendril, Transaction,
+    visual_offset_from_block, Deletion, LineEnding, Position, Range, Rope, RopeGraphemes,
+    RopeSlice, Selection, SmallVec, Tendril, Transaction,
 };
 use helix_view::{
     clipboard::ClipboardType,
@@ -788,10 +788,7 @@ fn extend_to_line_start(cx: &mut Context) {
 }
 
 fn kill_to_line_start(cx: &mut Context) {
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
+    delete_by_selection_insert_mode(cx, move |text, range| {
         let line = range.cursor_line(text);
         let first_char = text.line_to_char(line);
         let anchor = range.cursor(text);
@@ -810,32 +807,23 @@ fn kill_to_line_start(cx: &mut Context) {
             // select until start of line
             first_char
         };
-        Range::new(head, anchor)
+        (head, anchor)
     });
-    delete_selection_insert_mode(doc, view, &selection);
-
-    lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
 }
 
 fn kill_to_line_end(cx: &mut Context) {
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
+    delete_by_selection_insert_mode(cx, |text, range| {
         let line = range.cursor_line(text);
         let line_end_pos = line_end_char_index(&text, line);
         let pos = range.cursor(text);
 
-        let mut new_range = range.put_cursor(text, line_end_pos, true);
-        // don't want to remove the line separator itself if the cursor doesn't reach the end of line.
-        if pos != line_end_pos {
-            new_range.head = line_end_pos;
+        // if the cursor is on the newline char delete that
+        if pos == line_end_pos {
+            (pos, text.line_to_char(line + 1))
+        } else {
+            (pos, line_end_pos)
         }
-        new_range
     });
-    delete_selection_insert_mode(doc, view, &selection);
-
-    lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
 }
 
 fn goto_first_nonwhitespace(cx: &mut Context) {
@@ -2324,10 +2312,18 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
 }
 
 #[inline]
-fn delete_selection_insert_mode(doc: &mut Document, view: &mut View, selection: &Selection) {
+fn delete_by_selection_insert_mode(
+    cx: &mut Context,
+    mut f: impl FnMut(RopeSlice, &Range) -> Deletion,
+) {
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
     let transaction =
-        Transaction::delete_by_selection(doc.text(), selection, |range| (range.from(), range.to()));
+        Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
+            f(text, range)
+        });
     doc.apply(&transaction, view.id);
+    lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
 }
 
 fn delete_selection(cx: &mut Context) {
@@ -3487,46 +3483,28 @@ pub mod insert {
 
     pub fn delete_char_forward(cx: &mut Context) {
         let count = cx.count();
-        let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-        let transaction =
-            Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
-                let pos = range.cursor(text);
-                (pos, graphemes::nth_next_grapheme_boundary(text, pos, count))
-            });
-        doc.apply(&transaction, view.id);
-
-        lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
+        delete_by_selection_insert_mode(cx, |text, range| {
+            let pos = range.cursor(text);
+            (pos, graphemes::nth_next_grapheme_boundary(text, pos, count))
+        })
     }
 
     pub fn delete_word_backward(cx: &mut Context) {
         let count = cx.count();
-        let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-
-        let selection = doc.selection(view.id).clone().transform(|range| {
-            let anchor = movement::move_prev_word_start(text, range, count).from();
+        delete_by_selection_insert_mode(cx, |text, range| {
+            let anchor = movement::move_prev_word_start(text, *range, count).from();
             let next = Range::new(anchor, range.cursor(text));
-            exclude_cursor(text, next, range)
+            let range = exclude_cursor(text, next, *range);
+            (range.from(), range.to())
         });
-        delete_selection_insert_mode(doc, view, &selection);
-
-        lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
     }
 
     pub fn delete_word_forward(cx: &mut Context) {
         let count = cx.count();
-        let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-
-        let selection = doc.selection(view.id).clone().transform(|range| {
-            let head = movement::move_next_word_end(text, range, count).to();
-            Range::new(range.cursor(text), head)
+        delete_by_selection_insert_mode(cx, |text, range| {
+            let head = movement::move_next_word_end(text, *range, count).to();
+            (range.cursor(text), head)
         });
-
-        delete_selection_insert_mode(doc, view, &selection);
-
-        lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);
     }
 }
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -12,15 +12,13 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
             #[lo|]#rem
             ipsum
             dolor
-            "})
-        .as_str(),
+            "}),
         "CC",
         platform_line(indoc! {"\
             #(lo|)#rem
             #(ip|)#sum
             #[do|]#lor
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -30,15 +28,13 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
             #[|lo]#rem
             ipsum
             dolor
-            "})
-        .as_str(),
+            "}),
         "CC",
         platform_line(indoc! {"\
             #(|lo)#rem
             #(|ip)#sum
             #[|do]#lor
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -47,14 +43,12 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
         platform_line(indoc! {"\
             test
             #[testitem|]#
-            "})
-        .as_str(),
+            "}),
         "<A-C>",
         platform_line(indoc! {"\
             test
             #[testitem|]#
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -63,14 +57,12 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
         platform_line(indoc! {"\
             test
             #[test|]#
-            "})
-        .as_str(),
+            "}),
         "<A-C>",
         platform_line(indoc! {"\
             #[test|]#
             #(test|)#
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -79,14 +71,12 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
         platform_line(indoc! {"\
             #[testitem|]#
             test
-            "})
-        .as_str(),
+            "}),
         "C",
         platform_line(indoc! {"\
             #[testitem|]#
             test
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -95,14 +85,12 @@ async fn test_selection_duplication() -> anyhow::Result<()> {
         platform_line(indoc! {"\
             #[test|]#
             test
-            "})
-        .as_str(),
+            "}),
         "C",
         platform_line(indoc! {"\
             #(test|)#
             #[test|]#
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
     Ok(())
@@ -174,15 +162,13 @@ async fn test_multi_selection_paste() -> anyhow::Result<()> {
             #[|lorem]#
             #(|ipsum)#
             #(|dolor)#
-            "})
-        .as_str(),
+            "}),
         "yp",
         platform_line(indoc! {"\
             lorem#[|lorem]#
             ipsum#(|ipsum)#
             dolor#(|dolor)#
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -197,8 +183,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             #[|lorem]#
             #(|ipsum)#
             #(|dolor)#
-            "})
-        .as_str(),
+            "}),
         "|echo foo<ret>",
         platform_line(indoc! {"\
             #[|foo\n]#
@@ -207,8 +192,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             
             #(|foo\n)#
             
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -218,8 +202,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             #[|lorem]#
             #(|ipsum)#
             #(|dolor)#
-            "})
-        .as_str(),
+            "}),
         "!echo foo<ret>",
         platform_line(indoc! {"\
             #[|foo\n]#
@@ -228,8 +211,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             ipsum
             #(|foo\n)#
             dolor
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -239,8 +221,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             #[|lorem]#
             #(|ipsum)#
             #(|dolor)#
-            "})
-        .as_str(),
+            "}),
         "<A-!>echo foo<ret>",
         platform_line(indoc! {"\
             lorem#[|foo\n]#
@@ -249,8 +230,7 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             
             dolor#(|foo\n)#
             
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -294,16 +274,14 @@ async fn test_extend_line() -> anyhow::Result<()> {
             ipsum
             dolor
             
-            "})
-        .as_str(),
+            "}),
         "x2x",
         platform_line(indoc! {"\
             #[lorem
             ipsum
             dolor\n|]#
             
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -313,15 +291,13 @@ async fn test_extend_line() -> anyhow::Result<()> {
             #[l|]#orem
             ipsum
             
-            "})
-        .as_str(),
+            "}),
         "2x",
         platform_line(indoc! {"\
             #[lorem
             ipsum\n|]#
             
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 
@@ -390,15 +366,15 @@ async fn test_character_info() -> anyhow::Result<()> {
 async fn test_delete_char_backward() -> anyhow::Result<()> {
     // don't panic when deleting overlapping ranges
     test((
-        platform_line("#(x|)# #[x|]#").as_str(),
+        platform_line("#(x|)# #[x|]#"),
         "c<space><backspace><esc>",
-        platform_line("#[\n|]#").as_str(),
+        platform_line("#[\n|]#"),
     ))
     .await?;
     test((
-        platform_line("#( |)##( |)#a#( |)#axx#[x|]#a").as_str(),
+        platform_line("#( |)##( |)#a#( |)#axx#[x|]#a"),
         "li<backspace><esc>",
-        platform_line("#(a|)##(|a)#xx#[|a]#").as_str(),
+        platform_line("#(a|)##(|a)#xx#[|a]#"),
     ))
     .await?;
 
@@ -409,9 +385,9 @@ async fn test_delete_char_backward() -> anyhow::Result<()> {
 async fn test_delete_word_backward() -> anyhow::Result<()> {
     // don't panic when deleting overlapping ranges
     test((
-        platform_line("fo#[o|]#ba#(r|)#").as_str(),
+        platform_line("fo#[o|]#ba#(r|)#"),
         "a<C-w><esc>",
-        platform_line("#[\n|]#").as_str(),
+        platform_line("#[\n|]#"),
     ))
     .await?;
     Ok(())
@@ -421,9 +397,9 @@ async fn test_delete_word_backward() -> anyhow::Result<()> {
 async fn test_delete_word_forward() -> anyhow::Result<()> {
     // don't panic when deleting overlapping ranges
     test((
-        platform_line("fo#[o|]#b#(|ar)#").as_str(),
+        platform_line("fo#[o|]#b#(|ar)#"),
         "i<A-d><esc>",
-        platform_line("fo#[\n|]#").as_str(),
+        platform_line("fo#[\n|]#"),
     ))
     .await?;
     Ok(())
@@ -437,16 +413,14 @@ async fn test_delete_char_forward() -> anyhow::Result<()> {
                 #(abc|)#ef
                 #(abc|)#f
                 #(abc|)#
-            "})
-        .as_str(),
+            "}),
         "a<del><esc>",
         platform_line(indoc! {"\
                 #[abc|]#ef
                 #(abc|)#f
                 #(abc|)#
                 #(abc|)#
-            "})
-        .as_str(),
+            "}),
     ))
     .await?;
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -429,3 +429,26 @@ async fn test_delete_word_forward() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_char_forward() -> anyhow::Result<()> {
+    test((
+        platform_line(indoc! {"\
+                #[abc|]#def
+                #(abc|)#ef
+                #(abc|)#f
+                #(abc|)#
+            "})
+        .as_str(),
+        "a<del><esc>",
+        platform_line(indoc! {"\
+                #[abc|]#ef
+                #(abc|)#f
+                #(abc|)#
+                #(abc|)#
+            "})
+        .as_str(),
+    ))
+    .await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -385,3 +385,47 @@ async fn test_character_info() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_char_backward() -> anyhow::Result<()> {
+    // don't panic when deleting overlapping ranges
+    test((
+        platform_line("#(x|)# #[x|]#").as_str(),
+        "c<space><backspace><esc>",
+        platform_line("#[\n|]#").as_str(),
+    ))
+    .await?;
+    test((
+        platform_line("#( |)##( |)#a#( |)#axx#[x|]#a").as_str(),
+        "li<backspace><esc>",
+        platform_line("#(a|)##(|a)#xx#[|a]#").as_str(),
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_word_backward() -> anyhow::Result<()> {
+    // don't panic when deleting overlapping ranges
+    test((
+        platform_line("fo#[o|]#ba#(r|)#").as_str(),
+        "a<C-w><esc>",
+        platform_line("#[\n|]#").as_str(),
+    ))
+    .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_word_forward() -> anyhow::Result<()> {
+    // don't panic when deleting overlapping ranges
+    test((
+        platform_line("fo#[o|]#b#(|ar)#").as_str(),
+        "i<A-d><esc>",
+        platform_line("fo#[\n|]#").as_str(),
+    ))
+    .await?;
+    Ok(())
+}
+


### PR DESCRIPTION
Fixes #6021
Fixes https://github.com/helix-editor/helix/issues/5272
Fixes https://github.com/helix-editor/helix/issues/6029

The `delete_char_backward` command delete indentation when at the start of the line. The problem is that this can cause multiple overlaing deletions with multiple cursors. For example in #6021 one of the cursors is after the 3. space and one after the 1. char. Because the indent unit is 4 spaces `delete_char_backward` deletes to the start of the line for both cursors. The generated transaction is therefore invalid which causes an integer underflow when the transaction is applied.

I fixed a similar crash in #5728. Mutlicursors potentially generating overlapping changes is a common pitfall and something we should be wary of. In that PR I simply discarded changes that overlapped a previous change. That seemed the right behaviour to me for the **replacements** created by completions. For **deletions** however we can simply merge the overlapping deletions together (otherwise the behaviour here would be incorrect). To that end I added a new `delete` and `delete_by_selection` function which does not accept a tendril for replacement and allows overlapping ranges.

In the process I noticed that the `delete_by_selection_insert_mode` function was implemented a bit weirdly:
* It requires a selection rather then a closure like `Transaction::change_by_selection` which requires cloneing the selection
* Calles generating transaction causes some weirdlooking code
* It doesn't automatically invoke `lsp::signature_help_impl(cx, SignatureHelpInvoked::Automatic);` eventough all callsites do (wihout doing that its barely wort moving the logic to a shared function)

Therefore I cleaned up that function a little in a second commit as I was touching that code anyways (and there were no open PRs that touch that code).
If we don't want these cosmetic changes I can easily drop that second commit.
