### PR TITLE
ayu_evolve theme: remove variable.other.member

### DIFF
--- a/runtime/themes/ayu_evolve.toml
+++ b/runtime/themes/ayu_evolve.toml
@@ -3,7 +3,6 @@ inherits = 'ayu_dark'
 "keyword.control" = "orange"
 "keyword.storage" = "yellow"
 "keyword.storage.modifier" = "magenta"
-"variable.other.member" = "gray"
 "variable" = "light_gray"
 "constructor" = "magenta"
 "type.builtin" = { fg = "blue", modifiers = ["italic"] }


### PR DESCRIPTION
Reasoning explained in commit. The fault is mine from #5638 .