### PR TITLE
Update tree-sitter-git-rebase

### DIFF
--- a/runtime/queries/git-rebase/highlights.scm
+++ b/runtime/queries/git-rebase/highlights.scm
@@ -1,11 +1,36 @@
-(operation operator: ["p" "pick" "r" "reword" "e" "edit" "s" "squash" "m" "merge" "d" "drop" "b" "break" "x" "exec"] @keyword)
-(operation operator: ["l" "label" "t" "reset"] @function)
-(operation operator: ["f" "fixup"] @function.special)
+; a rough translation:
+; * constant.builtin - git hash
+; * constant - a git label
+; * keyword - command that acts on commits commits
+; * function - command that acts only on labels
+; * comment - discarded commentary on a command, has no effect on the rebase
+; * string - text used in the rebase operation
+; * operator - a 'switch' (used in fixup and merge), either -c or -C at time of writing
+
+(((command) @keyword
+  (label) @constant.builtin
+  (message)? @comment)
+ (#match? @keyword "^(p|pick|r|reword|e|edit|s|squash|d|drop)$"))
+
+(((command) @function
+  (label) @constant
+  (message)? @comment)
+ (#match? @function "^(l|label|t|reset)$"))
+
+((command) @keyword
+ (#match? @keyword "^(x|exec|b|break)$"))
+
+(((command) @attribute
+  (label) @constant.builtin
+  (message)? @comment)
+ (#match? @attribute "^(f|fixup)$"))
+
+(((command) @keyword
+  (label) @constant.builtin
+  (label) @constant
+  (message) @string)
+ (#match? @keyword "^(m|merge)$"))
 
 (option) @operator
-(label) @string.special.symbol
-(commit) @constant
-"#" @punctuation.delimiter
-(comment) @comment
 
-(ERROR) @error
+(comment) @comment

--- a/runtime/queries/git-rebase/highlights.scm
+++ b/runtime/queries/git-rebase/highlights.scm
@@ -15,7 +15,7 @@
 (((command) @function
   (label) @constant
   (message)? @comment)
- (#match? @function "^(l|label|t|reset)$"))
+ (#match? @function "^(l|label|t|reset|u|update-ref)$"))
 
 ((command) @keyword
  (#match? @keyword "^(x|exec|b|break)$"))

--- a/runtime/queries/git-rebase/injections.scm
+++ b/runtime/queries/git-rebase/injections.scm
@@ -1,4 +1,5 @@
-((operation
-   operator: ["x" "exec"]
-   (command) @injection.content)
- (#set! injection.language "bash"))
+(((command) @attribute
+  (message)? @injection.content)
+ (#match? @attribute "^(x|exec)$")
+ (#set! injection.language "bash")
+)


### PR DESCRIPTION
Update the `tree-sitter-git-rebase` grammar to incorporate the recent rewrite of the grammar, as well as the update-refs command. I basically just copied over the new example queries, and then added `u` and `update-ref`.

Depends on https://github.com/the-mikedavis/tree-sitter-git-rebase/pull/2 - after that is merged, I will update the `languages.toml`.

Screenshot of the result:

![image](https://user-images.githubusercontent.com/846275/219710187-d2d86226-449e-4ee1-99bf-a65083afe21d.png)