### PR TITLE
Expand selection to whole word when pressing `*`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1906,18 +1906,37 @@ fn extend_search_prev(cx: &mut Context) {
 }
 
 fn search_selection(cx: &mut Context) {
+    let count = cx.count();
     let (view, doc) = current!(cx.editor);
     let contents = doc.text().slice(..);
 
-    let regex = doc
-        .selection(view.id)
-        .iter()
-        .map(|selection| regex::escape(&selection.fragment(contents)))
-        .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join("|");
+    let regex; // The fragment to set in the search register
 
+    // Checks whether there is only one selection with a width of 1
+    let selections = doc.selection(view.id);
+    let primary = selections.primary();
+    if selections.len() == 1 && primary.len() == 1 {
+        let text = doc.text();
+        let text_slice = text.slice(..);
+        // In this case select the WORD under the cursor
+        let current_word = textobject::textobject_word(
+            text_slice,
+            primary,
+            textobject::TextObject::Inside,
+            count,
+            false,
+        );
+        let text_to_search = current_word.fragment(text_slice).to_string();
+        regex = regex::escape(&text_to_search);
+    } else {
+        regex = selections
+            .iter()
+            .map(|selection| regex::escape(&selection.fragment(contents)))
+            .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join("|");
+    }
     let msg = format!("register '{}' set to '{}'", '/', &regex);
     cx.editor.registers.push('/', regex);
     cx.editor.set_status(msg);


### PR DESCRIPTION
Refs #6045 

This is an attempt at adding the functionality discussed in [this issue](#6045) (and earlier on matrix).

I'm open to suggestions, I've barely learned Rust, and it was a long time ago and seldom used it, so i'm very... rusty.

Please let me know if this is useful, relevant, and how it could be improved!