### PR TITLE
Add support for the uxntal language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -134,6 +134,7 @@
 | twig | ✓ |  |  |  |
 | typescript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | ungrammar | ✓ |  |  |  |
+| uxntal | ✓ |  |  |  |
 | v | ✓ |  |  | `v` |
 | vala | ✓ |  |  | `vala-language-server` |
 | verilog | ✓ | ✓ |  | `svlangserver` |

--- a/languages.toml
+++ b/languages.toml
@@ -2167,3 +2167,16 @@ comment-token = "#"
 [[grammar]]
 name = "hosts"
 source = { git = "https://github.com/ath3/tree-sitter-hosts", rev = "301b9379ce7dfc8bdbe2c2699a6887dcb73953f9" }
+
+[[language]]
+name = "uxntal"
+scope = "source.tal"
+injection-regex = "tal"
+file-types = ["tal"]
+roots = []
+auto-format = false
+comment-token = "("
+
+[[grammar]]
+name = "uxntal"
+source = { git = "https://github.com/Jummit/tree-sitter-uxntal", rev = "9297e95ef74380b0ad84c4fd98f91e9f6e4319e6" }

--- a/runtime/queries/uxntal/highlights.scm
+++ b/runtime/queries/uxntal/highlights.scm
@@ -1,0 +1,15 @@
+; highlights.scm
+
+(identifier) @keyword
+(number) @constant.numeric
+(comment) @comment
+(raw_character) @constant.character
+(literal_hex) @constant.numeric.integer
+(macro_definition) @function
+(label_definition) @label
+(sub_label_definition) @label
+(relative_pad) @constant
+(label) @label
+(sub_label) @label
+(ERROR) @error
+["[" "]" "{" "}"] @punctuation.bracket


### PR DESCRIPTION
About [uxntnal](https://wiki.xxiivv.com/site/uxntal.html).

I'm also the author of the tree-sitter grammar, and it's not fully complete. I still think this is better than no syntax highlighting though.

![screenshot](https://user-images.githubusercontent.com/28286961/219882439-c3679bdd-ff53-403c-8cf7-6ac3d8e05e93.png)
