### PR TITLE
Clarify `Context`

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -21,7 +21,7 @@ use tui::backend::Backend;
 use crate::{
     args::Args,
     commands::apply_workspace_edit,
-    compositor::{Compositor, Event},
+    compositor::{Compositor, Event, CompositorContext},
     config::Config,
     job::Jobs,
     keymap::Keymaps,
@@ -278,7 +278,7 @@ impl Application {
     }
 
     async fn render(&mut self) {
-        let mut cx = crate::compositor::CompositorContext {
+        let mut cx = CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,
@@ -495,7 +495,7 @@ impl Application {
     }
 
     pub async fn handle_idle_timeout(&mut self) {
-        let mut cx = crate::compositor::CompositorContext {
+        let mut cx = CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,
@@ -615,7 +615,7 @@ impl Application {
         &mut self,
         event: Result<CrosstermEvent, crossterm::ErrorKind>,
     ) {
-        let mut cx = crate::compositor::CompositorContext {
+        let mut cx = CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -278,7 +278,7 @@ impl Application {
     }
 
     async fn render(&mut self) {
-        let mut cx = crate::compositor::Context {
+        let mut cx = crate::compositor::CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,
@@ -495,7 +495,7 @@ impl Application {
     }
 
     pub async fn handle_idle_timeout(&mut self) {
-        let mut cx = crate::compositor::Context {
+        let mut cx = crate::compositor::CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,
@@ -615,7 +615,7 @@ impl Application {
         &mut self,
         event: Result<CrosstermEvent, crossterm::ErrorKind>,
     ) {
-        let mut cx = crate::compositor::Context {
+        let mut cx = crate::compositor::CompositorContext {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
             scroll: None,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -21,7 +21,7 @@ use tui::backend::Backend;
 use crate::{
     args::Args,
     commands::apply_workspace_edit,
-    compositor::{Compositor, Event, CompositorContext},
+    compositor::{Compositor, CompositorContext, Event},
     config::Config,
     job::Jobs,
     keymap::Keymaps,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -48,7 +48,7 @@ use movement::Movement;
 
 use crate::{
     args,
-    compositor::{self, Component, Compositor},
+    compositor::{self, Component, Compositor, CompositorContext},
     filter_picker_entry,
     job::Callback,
     keymap::ReverseKeymap,
@@ -172,7 +172,7 @@ impl MappableCommand {
             Self::Typable { name, args, doc: _ } => {
                 let args: Vec<Cow<str>> = args.iter().map(Cow::from).collect();
                 if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
-                    let mut cx = compositor::CompositorContext {
+                    let mut cx = CompositorContext {
                         editor: cx.editor,
                         jobs: cx.jobs,
                         scroll: None,
@@ -2609,7 +2609,7 @@ impl ui::menu::Item for MappableCommand {
 
 pub fn command_palette(cx: &mut CommandContext) {
     cx.callback = Some(Box::new(
-        move |compositor: &mut Compositor, cx: &mut compositor::CompositorContext| {
+        move |compositor: &mut Compositor, cx: &mut CompositorContext| {
             let keymap = compositor.find::<ui::EditorView>().unwrap().keymaps.map()
                 [&cx.editor.mode]
                 .reverse_map();
@@ -5052,7 +5052,7 @@ async fn shell_impl_async(
     Ok((tendril, output.status.success()))
 }
 
-fn shell(cx: &mut compositor::CompositorContext, cmd: &str, behavior: &ShellBehavior) {
+fn shell(cx: &mut CompositorContext, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
         ShellBehavior::Replace | ShellBehavior::Ignore => true,
         ShellBehavior::Insert | ShellBehavior::Append => false,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -172,7 +172,7 @@ impl MappableCommand {
             Self::Typable { name, args, doc: _ } => {
                 let args: Vec<Cow<str>> = args.iter().map(Cow::from).collect();
                 if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
-                    let mut cx = compositor::Context {
+                    let mut cx = compositor::CompositorContext {
                         editor: cx.editor,
                         jobs: cx.jobs,
                         scroll: None,
@@ -2609,7 +2609,7 @@ impl ui::menu::Item for MappableCommand {
 
 pub fn command_palette(cx: &mut Context) {
     cx.callback = Some(Box::new(
-        move |compositor: &mut Compositor, cx: &mut compositor::Context| {
+        move |compositor: &mut Compositor, cx: &mut compositor::CompositorContext| {
             let keymap = compositor.find::<ui::EditorView>().unwrap().keymaps.map()
                 [&cx.editor.mode]
                 .reverse_map();
@@ -5052,7 +5052,7 @@ async fn shell_impl_async(
     Ok((tendril, output.status.success()))
 }
 
-fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
+fn shell(cx: &mut compositor::CompositorContext, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
         ShellBehavior::Replace | ShellBehavior::Ignore => true,
         ShellBehavior::Insert | ShellBehavior::Append => false,

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -1,4 +1,4 @@
-use super::{Context, Editor};
+use super::{CommandContext, Editor};
 use crate::{
     compositor::{self, Compositor},
     job::{Callback, Jobs},
@@ -55,7 +55,7 @@ impl ui::menu::Item for Thread {
 }
 
 fn thread_picker(
-    cx: &mut Context,
+    cx: &mut CommandContext,
     callback_fn: impl Fn(&mut Editor, &dap::Thread) + Send + 'static,
 ) {
     let debugger = debugger!(cx.editor);
@@ -248,7 +248,7 @@ pub fn dap_start_impl(
     Ok(())
 }
 
-pub fn dap_launch(cx: &mut Context) {
+pub fn dap_launch(cx: &mut CommandContext) {
     if cx.editor.debugger.is_some() {
         cx.editor.set_error("Debugger is already running");
         return;
@@ -356,7 +356,7 @@ fn debug_parameter_prompt(
     )
 }
 
-pub fn dap_toggle_breakpoint(cx: &mut Context) {
+pub fn dap_toggle_breakpoint(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let path = match doc.path() {
         Some(path) => path.clone(),
@@ -371,7 +371,7 @@ pub fn dap_toggle_breakpoint(cx: &mut Context) {
     dap_toggle_breakpoint_impl(cx, path, line);
 }
 
-pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) {
+pub fn dap_toggle_breakpoint_impl(cx: &mut CommandContext, path: PathBuf, line: usize) {
     // TODO: need to map breakpoints over edits and update them?
     // we shouldn't really allow editing while debug is running though
 
@@ -397,7 +397,7 @@ pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) 
     }
 }
 
-pub fn dap_continue(cx: &mut Context) {
+pub fn dap_continue(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     if let Some(thread_id) = debugger.thread_id {
@@ -416,7 +416,7 @@ pub fn dap_continue(cx: &mut Context) {
     }
 }
 
-pub fn dap_pause(cx: &mut Context) {
+pub fn dap_pause(cx: &mut CommandContext) {
     thread_picker(cx, |editor, thread| {
         let debugger = debugger!(editor);
         let request = debugger.pause(thread.id);
@@ -427,7 +427,7 @@ pub fn dap_pause(cx: &mut Context) {
     })
 }
 
-pub fn dap_step_in(cx: &mut Context) {
+pub fn dap_step_in(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     if let Some(thread_id) = debugger.thread_id {
@@ -442,7 +442,7 @@ pub fn dap_step_in(cx: &mut Context) {
     }
 }
 
-pub fn dap_step_out(cx: &mut Context) {
+pub fn dap_step_out(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     if let Some(thread_id) = debugger.thread_id {
@@ -456,7 +456,7 @@ pub fn dap_step_out(cx: &mut Context) {
     }
 }
 
-pub fn dap_next(cx: &mut Context) {
+pub fn dap_next(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     if let Some(thread_id) = debugger.thread_id {
@@ -470,7 +470,7 @@ pub fn dap_next(cx: &mut Context) {
     }
 }
 
-pub fn dap_variables(cx: &mut Context) {
+pub fn dap_variables(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     if debugger.thread_id.is_none() {
@@ -536,7 +536,7 @@ pub fn dap_variables(cx: &mut Context) {
     cx.push_layer(Box::new(popup));
 }
 
-pub fn dap_terminate(cx: &mut Context) {
+pub fn dap_terminate(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     let request = debugger.disconnect();
@@ -546,7 +546,7 @@ pub fn dap_terminate(cx: &mut Context) {
     });
 }
 
-pub fn dap_enable_exceptions(cx: &mut Context) {
+pub fn dap_enable_exceptions(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     let filters = match &debugger.capabilities().exception_breakpoint_filters {
@@ -565,7 +565,7 @@ pub fn dap_enable_exceptions(cx: &mut Context) {
     )
 }
 
-pub fn dap_disable_exceptions(cx: &mut Context) {
+pub fn dap_disable_exceptions(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     let request = debugger.set_exception_breakpoints(Vec::new());
@@ -580,7 +580,7 @@ pub fn dap_disable_exceptions(cx: &mut Context) {
 }
 
 // TODO: both edit condition and edit log need to be stable: we might get new breakpoints from the debugger which can change offsets
-pub fn dap_edit_condition(cx: &mut Context) {
+pub fn dap_edit_condition(cx: &mut CommandContext) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
         let path = match doc!(cx.editor).path() {
             Some(path) => path.clone(),
@@ -622,7 +622,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
     }
 }
 
-pub fn dap_edit_log(cx: &mut Context) {
+pub fn dap_edit_log(cx: &mut CommandContext) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
         let path = match doc!(cx.editor).path() {
             Some(path) => path.clone(),
@@ -663,12 +663,12 @@ pub fn dap_edit_log(cx: &mut Context) {
     }
 }
 
-pub fn dap_switch_thread(cx: &mut Context) {
+pub fn dap_switch_thread(cx: &mut CommandContext) {
     thread_picker(cx, |editor, thread| {
         block_on(select_thread_id(editor, thread.id, true));
     })
 }
-pub fn dap_switch_stack_frame(cx: &mut Context) {
+pub fn dap_switch_stack_frame(cx: &mut CommandContext) {
     let debugger = debugger!(cx.editor);
 
     let thread_id = match debugger.thread_id {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -1,6 +1,6 @@
 use super::{CommandContext, Editor};
 use crate::{
-    compositor::{self, Compositor},
+    compositor::{Compositor, CompositorContext},
     job::{Callback, Jobs},
     ui::{self, overlay::overlayed, FilePicker, Picker, Popup, Prompt, PromptEvent, Text},
 };
@@ -130,7 +130,7 @@ fn dap_callback<T, F>(
 }
 
 pub fn dap_start_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     name: Option<&str>,
     socket: Option<std::net::SocketAddr>,
     params: Option<Vec<std::borrow::Cow<str>>>,

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -130,7 +130,7 @@ fn dap_callback<T, F>(
 }
 
 pub fn dap_start_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     name: Option<&str>,
     socket: Option<std::net::SocketAddr>,
     params: Option<Vec<std::borrow::Cow<str>>>,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -13,7 +13,7 @@ use tui::{
     widgets::Row,
 };
 
-use super::{align_view, push_jump, Align, Context, Editor, Open};
+use super::{align_view, push_jump, Align, CommandContext, Editor, Open};
 
 use helix_core::{path, Selection};
 use helix_view::{document::Mode, editor::Action, theme::Style};
@@ -262,7 +262,7 @@ enum DiagnosticsFormat {
 }
 
 fn diag_picker(
-    cx: &Context,
+    cx: &CommandContext,
     diagnostics: BTreeMap<lsp::Url, Vec<lsp::Diagnostic>>,
     current_path: Option<lsp::Url>,
     format: DiagnosticsFormat,
@@ -318,7 +318,7 @@ fn diag_picker(
     .truncate_start(false)
 }
 
-pub fn symbol_picker(cx: &mut Context) {
+pub fn symbol_picker(cx: &mut CommandContext) {
     fn nested_to_flat(
         list: &mut Vec<lsp::SymbolInformation>,
         file: &lsp::TextDocumentIdentifier,
@@ -377,7 +377,7 @@ pub fn symbol_picker(cx: &mut Context) {
     )
 }
 
-pub fn workspace_symbol_picker(cx: &mut Context) {
+pub fn workspace_symbol_picker(cx: &mut CommandContext) {
     let doc = doc!(cx.editor);
     let current_url = doc.url();
     let language_server = language_server!(cx.editor, doc);
@@ -435,7 +435,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     )
 }
 
-pub fn diagnostics_picker(cx: &mut Context) {
+pub fn diagnostics_picker(cx: &mut CommandContext) {
     let doc = doc!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     if let Some(current_url) = doc.url() {
@@ -457,7 +457,7 @@ pub fn diagnostics_picker(cx: &mut Context) {
     }
 }
 
-pub fn workspace_diagnostics_picker(cx: &mut Context) {
+pub fn workspace_diagnostics_picker(cx: &mut CommandContext) {
     let doc = doc!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let current_url = doc.url();
@@ -540,7 +540,7 @@ fn action_fixes_diagnostics(action: &CodeActionOrCommand) -> bool {
     )
 }
 
-pub fn code_action(cx: &mut Context) {
+pub fn code_action(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
 
     let language_server = language_server!(cx.editor, doc);
@@ -919,7 +919,7 @@ fn to_locations(definitions: Option<lsp::GotoDefinitionResponse>) -> Vec<lsp::Lo
     }
 }
 
-pub fn goto_declaration(cx: &mut Context) {
+pub fn goto_declaration(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -944,7 +944,7 @@ pub fn goto_declaration(cx: &mut Context) {
     );
 }
 
-pub fn goto_definition(cx: &mut Context) {
+pub fn goto_definition(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -969,7 +969,7 @@ pub fn goto_definition(cx: &mut Context) {
     );
 }
 
-pub fn goto_type_definition(cx: &mut Context) {
+pub fn goto_type_definition(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -994,7 +994,7 @@ pub fn goto_type_definition(cx: &mut Context) {
     );
 }
 
-pub fn goto_implementation(cx: &mut Context) {
+pub fn goto_implementation(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -1019,7 +1019,7 @@ pub fn goto_implementation(cx: &mut Context) {
     );
 }
 
-pub fn goto_reference(cx: &mut Context) {
+pub fn goto_reference(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -1050,11 +1050,11 @@ pub enum SignatureHelpInvoked {
     Automatic,
 }
 
-pub fn signature_help(cx: &mut Context) {
+pub fn signature_help(cx: &mut CommandContext) {
     signature_help_impl(cx, SignatureHelpInvoked::Manual)
 }
 
-pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
+pub fn signature_help_impl(cx: &mut CommandContext, invoked: SignatureHelpInvoked) {
     let (view, doc) = current!(cx.editor);
     let was_manually_invoked = invoked == SignatureHelpInvoked::Manual;
 
@@ -1174,7 +1174,7 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
     );
 }
 
-pub fn hover(cx: &mut Context) {
+pub fn hover(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();
@@ -1231,7 +1231,7 @@ pub fn hover(cx: &mut Context) {
     );
 }
 
-pub fn rename_symbol(cx: &mut Context) {
+pub fn rename_symbol(cx: &mut CommandContext) {
     let (view, doc) = current_ref!(cx.editor);
     let text = doc.text().slice(..);
     let primary_selection = doc.selection(view.id).primary();
@@ -1277,7 +1277,7 @@ pub fn rename_symbol(cx: &mut Context) {
     );
 }
 
-pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
+pub fn select_references_to_symbol_under_cursor(cx: &mut CommandContext) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
     let offset_encoding = language_server.offset_encoding();

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -19,7 +19,7 @@ use helix_core::{path, Selection};
 use helix_view::{document::Mode, editor::Action, theme::Style};
 
 use crate::{
-    compositor::{self, Compositor},
+    compositor::{Compositor, CompositorContext},
     ui::{
         self, lsp::SignatureHelp, overlay::overlayed, DynamicPicker, FileLocation, FilePicker,
         Popup, PromptEvent,
@@ -1249,7 +1249,7 @@ pub fn rename_symbol(cx: &mut CommandContext) {
         prefill,
         None,
         ui::completers::none,
-        move |cx: &mut compositor::CompositorContext, input: &str, event: PromptEvent| {
+        move |cx: &mut CompositorContext, input: &str, event: PromptEvent| {
             if event != PromptEvent::Validate {
                 return;
             }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1249,7 +1249,7 @@ pub fn rename_symbol(cx: &mut Context) {
         prefill,
         None,
         ui::completers::none,
-        move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
+        move |cx: &mut compositor::CompositorContext, input: &str, event: PromptEvent| {
             if event != PromptEvent::Validate {
                 return;
             }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -316,11 +316,7 @@ fn write_impl(
     Ok(())
 }
 
-fn write(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn write(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -507,11 +503,7 @@ fn earlier(
     Ok(())
 }
 
-fn later(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn later(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -730,11 +722,7 @@ fn force_quit_all(
     quit_all_impl(cx, true)
 }
 
-fn cquit(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn cquit(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -766,11 +754,7 @@ fn force_cquit(
     quit_all_impl(cx, true)
 }
 
-fn theme(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn theme(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     let true_color = cx.editor.config.load().true_color || crate::true_color();
     match event {
         PromptEvent::Abort => {
@@ -1232,11 +1216,7 @@ fn reload_all(
 }
 
 /// Update the [`Document`] if it has been modified.
-fn update(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn update(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1387,11 +1367,7 @@ fn tree_sitter_scopes(
     Ok(())
 }
 
-fn vsplit(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn vsplit(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1410,11 +1386,7 @@ fn vsplit(
     Ok(())
 }
 
-fn hsplit(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn hsplit(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1525,11 +1497,7 @@ fn debug_remote(
     dap_start_impl(cx, name.as_deref(), address, Some(args))
 }
 
-fn tutor(
-    cx: &mut CompositorContext,
-    _args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn tutor(cx: &mut CompositorContext, _args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1743,11 +1711,7 @@ fn sort_reverse(
     sort_impl(cx, args, true)
 }
 
-fn sort_impl(
-    cx: &mut CompositorContext,
-    _args: &[Cow<str>],
-    reverse: bool,
-) -> anyhow::Result<()> {
+fn sort_impl(cx: &mut CompositorContext, _args: &[Cow<str>], reverse: bool) -> anyhow::Result<()> {
     let scrolloff = cx.editor.config().scrolloff;
     let (view, doc) = current!(cx.editor);
     let text = doc.text().slice(..);
@@ -1779,11 +1743,7 @@ fn sort_impl(
     Ok(())
 }
 
-fn reflow(
-    cx: &mut CompositorContext,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn reflow(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2545,7 +2545,7 @@ pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableComma
     });
 
 #[allow(clippy::unnecessary_unwrap)]
-pub(super) fn command_mode(cx: &mut Context) {
+pub(super) fn command_mode(cx: &mut CommandContext) {
     use shellwords::Shellwords;
 
     let mut prompt = Prompt::new(

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -17,11 +17,11 @@ pub struct TypableCommand {
     pub aliases: &'static [&'static str],
     pub doc: &'static str,
     // params, flags, helper, completer
-    pub fun: fn(&mut compositor::CompositorContext, &[Cow<str>], PromptEvent) -> anyhow::Result<()>,
+    pub fun: fn(&mut CompositorContext, &[Cow<str>], PromptEvent) -> anyhow::Result<()>,
     pub completer: Option<Completer>,
 }
 
-fn quit(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn quit(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     log::debug!("quitting...");
 
     if event != PromptEvent::Validate {
@@ -42,7 +42,7 @@ fn quit(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: Prompt
 }
 
 fn force_quit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -58,7 +58,7 @@ fn force_quit(
     Ok(())
 }
 
-fn open(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn open(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -94,7 +94,7 @@ fn open(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: Prompt
 }
 
 fn buffer_close_by_ids_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     doc_ids: &[DocumentId],
     force: bool,
 ) -> anyhow::Result<()> {
@@ -166,7 +166,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<Docum
 }
 
 fn buffer_close(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -179,7 +179,7 @@ fn buffer_close(
 }
 
 fn force_buffer_close(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -201,7 +201,7 @@ fn buffer_gather_others_impl(editor: &mut Editor) -> Vec<DocumentId> {
 }
 
 fn buffer_close_others(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -214,7 +214,7 @@ fn buffer_close_others(
 }
 
 fn force_buffer_close_others(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -231,7 +231,7 @@ fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
 }
 
 fn buffer_close_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -244,7 +244,7 @@ fn buffer_close_all(
 }
 
 fn force_buffer_close_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -257,7 +257,7 @@ fn force_buffer_close_all(
 }
 
 fn buffer_next(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -270,7 +270,7 @@ fn buffer_next(
 }
 
 fn buffer_previous(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -283,7 +283,7 @@ fn buffer_previous(
 }
 
 fn write_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     path: Option<&Cow<str>>,
     force: bool,
 ) -> anyhow::Result<()> {
@@ -317,7 +317,7 @@ fn write_impl(
 }
 
 fn write(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -329,7 +329,7 @@ fn write(
 }
 
 fn force_write(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -341,7 +341,7 @@ fn force_write(
 }
 
 fn new_file(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -355,7 +355,7 @@ fn new_file(
 }
 
 fn format(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -372,7 +372,7 @@ fn format(
     Ok(())
 }
 fn set_indent_style(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -415,7 +415,7 @@ fn set_indent_style(
 
 /// Sets or reports the current document's line ending setting.
 fn set_line_ending(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -488,7 +488,7 @@ fn set_line_ending(
 }
 
 fn earlier(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -508,7 +508,7 @@ fn earlier(
 }
 
 fn later(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -527,7 +527,7 @@ fn later(
 }
 
 fn write_quit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -541,7 +541,7 @@ fn write_quit(
 }
 
 fn force_write_quit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -580,7 +580,7 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
 }
 
 pub fn write_all_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     force: bool,
     write_scratch: bool,
 ) -> anyhow::Result<()> {
@@ -656,7 +656,7 @@ pub fn write_all_impl(
 }
 
 fn write_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -668,7 +668,7 @@ fn write_all(
 }
 
 fn write_all_quit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -680,7 +680,7 @@ fn write_all_quit(
 }
 
 fn force_write_all_quit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -691,7 +691,7 @@ fn force_write_all_quit(
     quit_all_impl(cx, true)
 }
 
-fn quit_all_impl(cx: &mut compositor::CompositorContext, force: bool) -> anyhow::Result<()> {
+fn quit_all_impl(cx: &mut CompositorContext, force: bool) -> anyhow::Result<()> {
     cx.block_try_flush_writes()?;
     if !force {
         buffers_remaining_impl(cx.editor)?;
@@ -707,7 +707,7 @@ fn quit_all_impl(cx: &mut compositor::CompositorContext, force: bool) -> anyhow:
 }
 
 fn quit_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -719,7 +719,7 @@ fn quit_all(
 }
 
 fn force_quit_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -731,7 +731,7 @@ fn force_quit_all(
 }
 
 fn cquit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -749,7 +749,7 @@ fn cquit(
 }
 
 fn force_cquit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -767,7 +767,7 @@ fn force_cquit(
 }
 
 fn theme(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -812,7 +812,7 @@ fn theme(
 }
 
 fn yank_main_selection_to_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -824,7 +824,7 @@ fn yank_main_selection_to_clipboard(
 }
 
 fn yank_joined_to_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -839,7 +839,7 @@ fn yank_joined_to_clipboard(
 }
 
 fn yank_main_selection_to_primary_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -851,7 +851,7 @@ fn yank_main_selection_to_primary_clipboard(
 }
 
 fn yank_joined_to_primary_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -866,7 +866,7 @@ fn yank_joined_to_primary_clipboard(
 }
 
 fn paste_clipboard_after(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -878,7 +878,7 @@ fn paste_clipboard_after(
 }
 
 fn paste_clipboard_before(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -890,7 +890,7 @@ fn paste_clipboard_before(
 }
 
 fn paste_primary_clipboard_after(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -902,7 +902,7 @@ fn paste_primary_clipboard_after(
 }
 
 fn paste_primary_clipboard_before(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -914,7 +914,7 @@ fn paste_primary_clipboard_before(
 }
 
 fn replace_selections_with_clipboard_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     clipboard_type: ClipboardType,
 ) -> anyhow::Result<()> {
     let scrolloff = cx.editor.config().scrolloff;
@@ -937,7 +937,7 @@ fn replace_selections_with_clipboard_impl(
 }
 
 fn replace_selections_with_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -949,7 +949,7 @@ fn replace_selections_with_clipboard(
 }
 
 fn replace_selections_with_primary_clipboard(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -961,7 +961,7 @@ fn replace_selections_with_primary_clipboard(
 }
 
 fn show_clipboard_provider(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -975,7 +975,7 @@ fn show_clipboard_provider(
 }
 
 fn change_current_directory(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1003,7 +1003,7 @@ fn change_current_directory(
 }
 
 fn show_current_directory(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1019,7 +1019,7 @@ fn show_current_directory(
 
 /// Sets the [`Document`]'s encoding..
 fn set_encoding(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1039,7 +1039,7 @@ fn set_encoding(
 
 /// Shows info about the character under the primary cursor.
 fn get_character_info(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1164,7 +1164,7 @@ fn get_character_info(
 
 /// Reload the [`Document`] from its source file.
 fn reload(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1182,7 +1182,7 @@ fn reload(
 }
 
 fn reload_all(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1233,7 +1233,7 @@ fn reload_all(
 
 /// Update the [`Document`] if it has been modified.
 fn update(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1250,7 +1250,7 @@ fn update(
 }
 
 fn lsp_workspace_command(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1321,7 +1321,7 @@ fn lsp_workspace_command(
 }
 
 fn lsp_restart(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1355,7 +1355,7 @@ fn lsp_restart(
 }
 
 fn tree_sitter_scopes(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1388,7 +1388,7 @@ fn tree_sitter_scopes(
 }
 
 fn vsplit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1411,7 +1411,7 @@ fn vsplit(
 }
 
 fn hsplit(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1434,7 +1434,7 @@ fn hsplit(
 }
 
 fn vsplit_new(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1448,7 +1448,7 @@ fn vsplit_new(
 }
 
 fn hsplit_new(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1462,7 +1462,7 @@ fn hsplit_new(
 }
 
 fn debug_eval(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1488,7 +1488,7 @@ fn debug_eval(
 }
 
 fn debug_start(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1505,7 +1505,7 @@ fn debug_start(
 }
 
 fn debug_remote(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1526,7 +1526,7 @@ fn debug_remote(
 }
 
 fn tutor(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1542,7 +1542,7 @@ fn tutor(
 }
 
 pub(super) fn goto_line_number(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1587,7 +1587,7 @@ pub(super) fn goto_line_number(
 
 // Fetch the current value of a config option and output as status.
 fn get_option(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1613,7 +1613,7 @@ fn get_option(
 /// Change config at runtime. Access nested values by dot syntax, for
 /// example to disable smart case search, use `:set search.smart-case false`.
 fn set_option(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1652,7 +1652,7 @@ fn set_option(
 /// syntax, for example to toggle smart case search, use `:toggle search.smart-
 /// case`.
 fn toggle_option(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1690,7 +1690,7 @@ fn toggle_option(
 
 /// Change the language of the current buffer at runtime.
 fn language(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1723,7 +1723,7 @@ fn language(
     Ok(())
 }
 
-fn sort(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn sort(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1732,7 +1732,7 @@ fn sort(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: Prompt
 }
 
 fn sort_reverse(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1744,7 +1744,7 @@ fn sort_reverse(
 }
 
 fn sort_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     reverse: bool,
 ) -> anyhow::Result<()> {
@@ -1780,7 +1780,7 @@ fn sort_impl(
 }
 
 fn reflow(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1825,7 +1825,7 @@ fn reflow(
 }
 
 fn tree_sitter_subtree(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1868,7 +1868,7 @@ fn tree_sitter_subtree(
 }
 
 fn open_config(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1882,7 +1882,7 @@ fn open_config(
 }
 
 fn open_log(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1895,7 +1895,7 @@ fn open_log(
 }
 
 fn refresh_config(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1908,7 +1908,7 @@ fn refresh_config(
 }
 
 fn append_output(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1922,7 +1922,7 @@ fn append_output(
 }
 
 fn insert_output(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1936,19 +1936,19 @@ fn insert_output(
 }
 
 fn pipe_to(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
 
-fn pipe(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn pipe(cx: &mut CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Replace)
 }
 
 fn pipe_impl(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
     behavior: &ShellBehavior,
@@ -1963,7 +1963,7 @@ fn pipe_impl(
 }
 
 fn run_shell_command(
-    cx: &mut compositor::CompositorContext,
+    cx: &mut CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -2607,7 +2607,7 @@ pub(super) fn command_mode(cx: &mut CommandContext) {
                 }
             }
         }, // completion
-        move |cx: &mut compositor::CompositorContext, input: &str, event: PromptEvent| {
+        move |cx: &mut CompositorContext, input: &str, event: PromptEvent| {
             let parts = input.split_whitespace().collect::<Vec<&str>>();
             if parts.is_empty() {
                 return;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -17,11 +17,11 @@ pub struct TypableCommand {
     pub aliases: &'static [&'static str],
     pub doc: &'static str,
     // params, flags, helper, completer
-    pub fun: fn(&mut compositor::Context, &[Cow<str>], PromptEvent) -> anyhow::Result<()>,
+    pub fun: fn(&mut compositor::CompositorContext, &[Cow<str>], PromptEvent) -> anyhow::Result<()>,
     pub completer: Option<Completer>,
 }
 
-fn quit(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn quit(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     log::debug!("quitting...");
 
     if event != PromptEvent::Validate {
@@ -42,7 +42,7 @@ fn quit(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
 }
 
 fn force_quit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -58,7 +58,7 @@ fn force_quit(
     Ok(())
 }
 
-fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn open(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -94,7 +94,7 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
 }
 
 fn buffer_close_by_ids_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     doc_ids: &[DocumentId],
     force: bool,
 ) -> anyhow::Result<()> {
@@ -166,7 +166,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: &[Cow<str>]) -> Vec<Docum
 }
 
 fn buffer_close(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -179,7 +179,7 @@ fn buffer_close(
 }
 
 fn force_buffer_close(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -201,7 +201,7 @@ fn buffer_gather_others_impl(editor: &mut Editor) -> Vec<DocumentId> {
 }
 
 fn buffer_close_others(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -214,7 +214,7 @@ fn buffer_close_others(
 }
 
 fn force_buffer_close_others(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -231,7 +231,7 @@ fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
 }
 
 fn buffer_close_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -244,7 +244,7 @@ fn buffer_close_all(
 }
 
 fn force_buffer_close_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -257,7 +257,7 @@ fn force_buffer_close_all(
 }
 
 fn buffer_next(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -270,7 +270,7 @@ fn buffer_next(
 }
 
 fn buffer_previous(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -283,7 +283,7 @@ fn buffer_previous(
 }
 
 fn write_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     path: Option<&Cow<str>>,
     force: bool,
 ) -> anyhow::Result<()> {
@@ -317,7 +317,7 @@ fn write_impl(
 }
 
 fn write(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -329,7 +329,7 @@ fn write(
 }
 
 fn force_write(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -341,7 +341,7 @@ fn force_write(
 }
 
 fn new_file(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -355,7 +355,7 @@ fn new_file(
 }
 
 fn format(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -372,7 +372,7 @@ fn format(
     Ok(())
 }
 fn set_indent_style(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -415,7 +415,7 @@ fn set_indent_style(
 
 /// Sets or reports the current document's line ending setting.
 fn set_line_ending(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -488,7 +488,7 @@ fn set_line_ending(
 }
 
 fn earlier(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -508,7 +508,7 @@ fn earlier(
 }
 
 fn later(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -527,7 +527,7 @@ fn later(
 }
 
 fn write_quit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -541,7 +541,7 @@ fn write_quit(
 }
 
 fn force_write_quit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -580,7 +580,7 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
 }
 
 pub fn write_all_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     force: bool,
     write_scratch: bool,
 ) -> anyhow::Result<()> {
@@ -656,7 +656,7 @@ pub fn write_all_impl(
 }
 
 fn write_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -668,7 +668,7 @@ fn write_all(
 }
 
 fn write_all_quit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -680,7 +680,7 @@ fn write_all_quit(
 }
 
 fn force_write_all_quit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -691,7 +691,7 @@ fn force_write_all_quit(
     quit_all_impl(cx, true)
 }
 
-fn quit_all_impl(cx: &mut compositor::Context, force: bool) -> anyhow::Result<()> {
+fn quit_all_impl(cx: &mut compositor::CompositorContext, force: bool) -> anyhow::Result<()> {
     cx.block_try_flush_writes()?;
     if !force {
         buffers_remaining_impl(cx.editor)?;
@@ -707,7 +707,7 @@ fn quit_all_impl(cx: &mut compositor::Context, force: bool) -> anyhow::Result<()
 }
 
 fn quit_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -719,7 +719,7 @@ fn quit_all(
 }
 
 fn force_quit_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -731,7 +731,7 @@ fn force_quit_all(
 }
 
 fn cquit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -749,7 +749,7 @@ fn cquit(
 }
 
 fn force_cquit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -767,7 +767,7 @@ fn force_cquit(
 }
 
 fn theme(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -812,7 +812,7 @@ fn theme(
 }
 
 fn yank_main_selection_to_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -824,7 +824,7 @@ fn yank_main_selection_to_clipboard(
 }
 
 fn yank_joined_to_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -839,7 +839,7 @@ fn yank_joined_to_clipboard(
 }
 
 fn yank_main_selection_to_primary_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -851,7 +851,7 @@ fn yank_main_selection_to_primary_clipboard(
 }
 
 fn yank_joined_to_primary_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -866,7 +866,7 @@ fn yank_joined_to_primary_clipboard(
 }
 
 fn paste_clipboard_after(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -878,7 +878,7 @@ fn paste_clipboard_after(
 }
 
 fn paste_clipboard_before(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -890,7 +890,7 @@ fn paste_clipboard_before(
 }
 
 fn paste_primary_clipboard_after(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -902,7 +902,7 @@ fn paste_primary_clipboard_after(
 }
 
 fn paste_primary_clipboard_before(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -914,7 +914,7 @@ fn paste_primary_clipboard_before(
 }
 
 fn replace_selections_with_clipboard_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     clipboard_type: ClipboardType,
 ) -> anyhow::Result<()> {
     let scrolloff = cx.editor.config().scrolloff;
@@ -937,7 +937,7 @@ fn replace_selections_with_clipboard_impl(
 }
 
 fn replace_selections_with_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -949,7 +949,7 @@ fn replace_selections_with_clipboard(
 }
 
 fn replace_selections_with_primary_clipboard(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -961,7 +961,7 @@ fn replace_selections_with_primary_clipboard(
 }
 
 fn show_clipboard_provider(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -975,7 +975,7 @@ fn show_clipboard_provider(
 }
 
 fn change_current_directory(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1003,7 +1003,7 @@ fn change_current_directory(
 }
 
 fn show_current_directory(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1019,7 +1019,7 @@ fn show_current_directory(
 
 /// Sets the [`Document`]'s encoding..
 fn set_encoding(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1039,7 +1039,7 @@ fn set_encoding(
 
 /// Shows info about the character under the primary cursor.
 fn get_character_info(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1164,7 +1164,7 @@ fn get_character_info(
 
 /// Reload the [`Document`] from its source file.
 fn reload(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1182,7 +1182,7 @@ fn reload(
 }
 
 fn reload_all(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1233,7 +1233,7 @@ fn reload_all(
 
 /// Update the [`Document`] if it has been modified.
 fn update(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1250,7 +1250,7 @@ fn update(
 }
 
 fn lsp_workspace_command(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1321,7 +1321,7 @@ fn lsp_workspace_command(
 }
 
 fn lsp_restart(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1355,7 +1355,7 @@ fn lsp_restart(
 }
 
 fn tree_sitter_scopes(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1388,7 +1388,7 @@ fn tree_sitter_scopes(
 }
 
 fn vsplit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1411,7 +1411,7 @@ fn vsplit(
 }
 
 fn hsplit(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1434,7 +1434,7 @@ fn hsplit(
 }
 
 fn vsplit_new(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1448,7 +1448,7 @@ fn vsplit_new(
 }
 
 fn hsplit_new(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1462,7 +1462,7 @@ fn hsplit_new(
 }
 
 fn debug_eval(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1488,7 +1488,7 @@ fn debug_eval(
 }
 
 fn debug_start(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1505,7 +1505,7 @@ fn debug_start(
 }
 
 fn debug_remote(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1526,7 +1526,7 @@ fn debug_remote(
 }
 
 fn tutor(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1542,7 +1542,7 @@ fn tutor(
 }
 
 pub(super) fn goto_line_number(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1587,7 +1587,7 @@ pub(super) fn goto_line_number(
 
 // Fetch the current value of a config option and output as status.
 fn get_option(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1613,7 +1613,7 @@ fn get_option(
 /// Change config at runtime. Access nested values by dot syntax, for
 /// example to disable smart case search, use `:set search.smart-case false`.
 fn set_option(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1652,7 +1652,7 @@ fn set_option(
 /// syntax, for example to toggle smart case search, use `:toggle search.smart-
 /// case`.
 fn toggle_option(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1690,7 +1690,7 @@ fn toggle_option(
 
 /// Change the language of the current buffer at runtime.
 fn language(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1723,7 +1723,7 @@ fn language(
     Ok(())
 }
 
-fn sort(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn sort(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -1732,7 +1732,7 @@ fn sort(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
 }
 
 fn sort_reverse(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1744,7 +1744,7 @@ fn sort_reverse(
 }
 
 fn sort_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     reverse: bool,
 ) -> anyhow::Result<()> {
@@ -1780,7 +1780,7 @@ fn sort_impl(
 }
 
 fn reflow(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1825,7 +1825,7 @@ fn reflow(
 }
 
 fn tree_sitter_subtree(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1868,7 +1868,7 @@ fn tree_sitter_subtree(
 }
 
 fn open_config(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1882,7 +1882,7 @@ fn open_config(
 }
 
 fn open_log(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1895,7 +1895,7 @@ fn open_log(
 }
 
 fn refresh_config(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     _args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1908,7 +1908,7 @@ fn refresh_config(
 }
 
 fn append_output(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1922,7 +1922,7 @@ fn append_output(
 }
 
 fn insert_output(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -1936,19 +1936,19 @@ fn insert_output(
 }
 
 fn pipe_to(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
 
-fn pipe(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+fn pipe(cx: &mut compositor::CompositorContext, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Replace)
 }
 
 fn pipe_impl(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
     behavior: &ShellBehavior,
@@ -1963,7 +1963,7 @@ fn pipe_impl(
 }
 
 fn run_shell_command(
-    cx: &mut compositor::Context,
+    cx: &mut compositor::CompositorContext,
     args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
@@ -2607,7 +2607,7 @@ pub(super) fn command_mode(cx: &mut Context) {
                 }
             }
         }, // completion
-        move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
+        move |cx: &mut compositor::CompositorContext, input: &str, event: PromptEvent| {
             let parts = input.split_whitespace().collect::<Vec<&str>>();
             if parts.is_empty() {
                 return;

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,4 +1,4 @@
-use crate::compositor::{Component, CompositorContext, Event, EventResult};
+use crate::{compositor::{Component, CompositorContext, Event, EventResult}, commands::CommandContext};
 use helix_view::{
     editor::CompleteAction,
     theme::{Modifier, Style},
@@ -11,7 +11,6 @@ use std::borrow::Cow;
 use helix_core::{Change, Transaction};
 use helix_view::{graphics::Rect, Document, Editor};
 
-use crate::commands;
 use crate::ui::{menu, Markdown, Menu, Popup, PromptEvent};
 
 use helix_lsp::{lsp, util};
@@ -313,7 +312,7 @@ impl Completion {
         }
     }
 
-    pub fn update(&mut self, cx: &mut commands::CommandContext) {
+    pub fn update(&mut self, cx: &mut CommandContext) {
         self.recompute_filter(cx.editor)
     }
 
@@ -327,7 +326,7 @@ impl Completion {
 
     /// Asynchronously requests that the currently selection completion item is
     /// resolved through LSP `completionItem/resolve`.
-    pub fn ensure_item_resolved(&mut self, cx: &mut commands::CommandContext) -> bool {
+    pub fn ensure_item_resolved(&mut self, cx: &mut CommandContext) -> bool {
         // > If computing full completion items is expensive, servers can additionally provide a
         // > handler for the completion item resolve request. ...
         // > A typical use case is for example: the `textDocument/completion` request doesn't fill

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,4 +1,4 @@
-use crate::compositor::{Component, Context, Event, EventResult};
+use crate::compositor::{Component, CompositorContext, Event, EventResult};
 use helix_view::{
     editor::CompleteAction,
     theme::{Modifier, Style},
@@ -375,7 +375,7 @@ impl Completion {
 }
 
 impl Component for Completion {
-    fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
+    fn handle_event(&mut self, event: &Event, cx: &mut CompositorContext) -> EventResult {
         self.popup.handle_event(event, cx)
     }
 
@@ -383,7 +383,7 @@ impl Component for Completion {
         self.popup.required_size(viewport)
     }
 
-    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         self.popup.render(area, surface, cx);
 
         // if we have a selection, render a markdown popup on top/below with info

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -313,7 +313,7 @@ impl Completion {
         }
     }
 
-    pub fn update(&mut self, cx: &mut commands::Context) {
+    pub fn update(&mut self, cx: &mut commands::CommandContext) {
         self.recompute_filter(cx.editor)
     }
 
@@ -327,7 +327,7 @@ impl Completion {
 
     /// Asynchronously requests that the currently selection completion item is
     /// resolved through LSP `completionItem/resolve`.
-    pub fn ensure_item_resolved(&mut self, cx: &mut commands::Context) -> bool {
+    pub fn ensure_item_resolved(&mut self, cx: &mut commands::CommandContext) -> bool {
         // > If computing full completion items is expensive, servers can additionally provide a
         // > handler for the completion item resolve request. ...
         // > A typical use case is for example: the `textDocument/completion` request doesn't fill

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,4 +1,7 @@
-use crate::{compositor::{Component, CompositorContext, Event, EventResult}, commands::CommandContext};
+use crate::{
+    commands::CommandContext,
+    compositor::{Component, CompositorContext, Event, EventResult},
+};
 use helix_view::{
     editor::CompleteAction,
     theme::{Modifier, Style},

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::{self, OnKeyCallback, CommandContext},
+    commands::{self, CommandContext, OnKeyCallback},
     compositor::{Component, CompositorContext, Event, EventResult},
     job::{self, Callback},
     key,
@@ -997,11 +997,7 @@ impl EditorView {
 }
 
 impl EditorView {
-    fn handle_mouse_event(
-        &mut self,
-        event: &MouseEvent,
-        cxt: &mut CommandContext,
-    ) -> EventResult {
+    fn handle_mouse_event(&mut self, event: &MouseEvent, cxt: &mut CommandContext) -> EventResult {
         let config = cxt.editor.config();
         let MouseEvent {
             kind,
@@ -1182,11 +1178,7 @@ impl EditorView {
 }
 
 impl Component for EditorView {
-    fn handle_event(
-        &mut self,
-        event: &Event,
-        context: &mut CompositorContext,
-    ) -> EventResult {
+    fn handle_event(&mut self, event: &Event, context: &mut CompositorContext) -> EventResult {
         let mut cx = CommandContext {
             editor: context.editor,
             count: None,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::{self, OnKeyCallback},
+    commands::{self, OnKeyCallback, CommandContext},
     compositor::{Component, CompositorContext, Event, EventResult},
     job::{self, Callback},
     key,
@@ -794,7 +794,7 @@ impl EditorView {
     fn handle_keymap_event(
         &mut self,
         mode: Mode,
-        cxt: &mut commands::CommandContext,
+        cxt: &mut CommandContext,
         event: KeyEvent,
     ) -> Option<KeymapResult> {
         let mut last_mode = mode;
@@ -850,7 +850,7 @@ impl EditorView {
         None
     }
 
-    fn insert_mode(&mut self, cx: &mut commands::CommandContext, event: KeyEvent) {
+    fn insert_mode(&mut self, cx: &mut CommandContext, event: KeyEvent) {
         if let Some(keyresult) = self.handle_keymap_event(Mode::Insert, cx, event) {
             match keyresult {
                 KeymapResult::NotFound => {
@@ -877,7 +877,7 @@ impl EditorView {
         }
     }
 
-    fn command_mode(&mut self, mode: Mode, cxt: &mut commands::CommandContext, event: KeyEvent) {
+    fn command_mode(&mut self, mode: Mode, cxt: &mut CommandContext, event: KeyEvent) {
         match (event, cxt.editor.count) {
             // count handling
             (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _) => {
@@ -977,7 +977,7 @@ impl EditorView {
         editor.clear_idle_timer(); // don't retrigger
     }
 
-    pub fn handle_idle_timeout(&mut self, cx: &mut commands::CommandContext) -> EventResult {
+    pub fn handle_idle_timeout(&mut self, cx: &mut CommandContext) -> EventResult {
         if let Some(completion) = &mut self.completion {
             return if completion.ensure_item_resolved(cx) {
                 EventResult::Consumed(None)
@@ -1000,7 +1000,7 @@ impl EditorView {
     fn handle_mouse_event(
         &mut self,
         event: &MouseEvent,
-        cxt: &mut commands::CommandContext,
+        cxt: &mut CommandContext,
     ) -> EventResult {
         let config = cxt.editor.config();
         let MouseEvent {
@@ -1187,7 +1187,7 @@ impl Component for EditorView {
         event: &Event,
         context: &mut crate::compositor::CompositorContext,
     ) -> EventResult {
-        let mut cx = commands::CommandContext {
+        let mut cx = CommandContext {
             editor: context.editor,
             count: None,
             register: None,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,6 +1,6 @@
 use crate::{
     commands::{self, OnKeyCallback},
-    compositor::{Component, Context, Event, EventResult},
+    compositor::{Component, CompositorContext, Event, EventResult},
     job::{self, Callback},
     key,
     keymap::{KeymapResult, Keymaps},
@@ -1185,7 +1185,7 @@ impl Component for EditorView {
     fn handle_event(
         &mut self,
         event: &Event,
-        context: &mut crate::compositor::Context,
+        context: &mut crate::compositor::CompositorContext,
     ) -> EventResult {
         let mut cx = commands::Context {
             editor: context.editor,
@@ -1241,7 +1241,7 @@ impl Component for EditorView {
                             let mut consumed = false;
                             if let Some(completion) = &mut self.completion {
                                 // use a fake context here
-                                let mut cx = Context {
+                                let mut cx = CompositorContext {
                                     editor: cx.editor,
                                     jobs: cx.jobs,
                                     scroll: None,
@@ -1330,7 +1330,7 @@ impl Component for EditorView {
         }
     }
 
-    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         // clear with background color
         surface.set_style(area, cx.editor.theme.get("ui.background"));
         let config = cx.editor.config();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -794,7 +794,7 @@ impl EditorView {
     fn handle_keymap_event(
         &mut self,
         mode: Mode,
-        cxt: &mut commands::Context,
+        cxt: &mut commands::CommandContext,
         event: KeyEvent,
     ) -> Option<KeymapResult> {
         let mut last_mode = mode;
@@ -850,7 +850,7 @@ impl EditorView {
         None
     }
 
-    fn insert_mode(&mut self, cx: &mut commands::Context, event: KeyEvent) {
+    fn insert_mode(&mut self, cx: &mut commands::CommandContext, event: KeyEvent) {
         if let Some(keyresult) = self.handle_keymap_event(Mode::Insert, cx, event) {
             match keyresult {
                 KeymapResult::NotFound => {
@@ -877,7 +877,7 @@ impl EditorView {
         }
     }
 
-    fn command_mode(&mut self, mode: Mode, cxt: &mut commands::Context, event: KeyEvent) {
+    fn command_mode(&mut self, mode: Mode, cxt: &mut commands::CommandContext, event: KeyEvent) {
         match (event, cxt.editor.count) {
             // count handling
             (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _) => {
@@ -977,7 +977,7 @@ impl EditorView {
         editor.clear_idle_timer(); // don't retrigger
     }
 
-    pub fn handle_idle_timeout(&mut self, cx: &mut commands::Context) -> EventResult {
+    pub fn handle_idle_timeout(&mut self, cx: &mut commands::CommandContext) -> EventResult {
         if let Some(completion) = &mut self.completion {
             return if completion.ensure_item_resolved(cx) {
                 EventResult::Consumed(None)
@@ -1000,7 +1000,7 @@ impl EditorView {
     fn handle_mouse_event(
         &mut self,
         event: &MouseEvent,
-        cxt: &mut commands::Context,
+        cxt: &mut commands::CommandContext,
     ) -> EventResult {
         let config = cxt.editor.config();
         let MouseEvent {
@@ -1187,7 +1187,7 @@ impl Component for EditorView {
         event: &Event,
         context: &mut crate::compositor::CompositorContext,
     ) -> EventResult {
-        let mut cx = commands::Context {
+        let mut cx = commands::CommandContext {
             editor: context.editor,
             count: None,
             register: None,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1185,7 +1185,7 @@ impl Component for EditorView {
     fn handle_event(
         &mut self,
         event: &Event,
-        context: &mut crate::compositor::CompositorContext,
+        context: &mut CompositorContext,
     ) -> EventResult {
         let mut cx = CommandContext {
             editor: context.editor,

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -1,11 +1,11 @@
-use crate::compositor::{Component, Context};
+use crate::compositor::{Component, CompositorContext};
 use helix_view::graphics::{Margin, Rect};
 use helix_view::info::Info;
 use tui::buffer::Buffer as Surface;
 use tui::widgets::{Block, Borders, Paragraph, Widget};
 
 impl Component for Info {
-    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         let text_style = cx.editor.theme.get("ui.text.info");
         let popup_style = cx.editor.theme.get("ui.popup.info");
 

--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -5,7 +5,7 @@ use helix_view::graphics::{Margin, Rect, Style};
 use tui::buffer::Buffer;
 use tui::widgets::{BorderType, Paragraph, Widget, Wrap};
 
-use crate::compositor::{Component, Compositor, Context};
+use crate::compositor::{Component, Compositor, CompositorContext};
 
 use crate::ui::Markdown;
 
@@ -48,7 +48,7 @@ impl SignatureHelp {
 }
 
 impl Component for SignatureHelp {
-    fn render(&mut self, area: Rect, surface: &mut Buffer, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Buffer, cx: &mut CompositorContext) {
         let margin = Margin::horizontal(1);
 
         let active_param_span = self.active_param_range.map(|(start, end)| {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -1,4 +1,4 @@
-use crate::compositor::{Component, Context};
+use crate::compositor::{Component, CompositorContext};
 use tui::{
     buffer::Buffer as Surface,
     text::{Span, Spans, Text},
@@ -327,7 +327,7 @@ impl Markdown {
 }
 
 impl Component for Markdown {
-    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         use tui::widgets::{Paragraph, Widget, Wrap};
 
         let text = self.parse(Some(&cx.editor.theme));

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, path::PathBuf};
 
 use crate::{
-    compositor::{Callback, Component, Compositor, Context, Event, EventResult},
+    compositor::{Callback, Component, Compositor, CompositorContext, Event, EventResult},
     ctrl, key, shift,
 };
 use tui::{buffer::Buffer as Surface, widgets::Table};
@@ -236,7 +236,7 @@ impl<T: Item + PartialEq> Menu<T> {
 use super::PromptEvent as MenuEvent;
 
 impl<T: Item + 'static> Component for Menu<T> {
-    fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
+    fn handle_event(&mut self, event: &Event, cx: &mut CompositorContext) -> EventResult {
         let event = match event {
             Event::Key(event) => *event,
             _ => return EventResult::Ignored(None),
@@ -302,7 +302,7 @@ impl<T: Item + 'static> Component for Menu<T> {
         Some(self.size)
     }
 
-    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         let theme = &cx.editor.theme;
         let style = theme
             .try_get("ui.menu")

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -15,7 +15,7 @@ mod statusline;
 mod text;
 
 use crate::commands::CommandContext;
-use crate::compositor::{Component, Compositor};
+use crate::compositor::{Component, Compositor, CompositorContext};
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
 pub use completion::Completion;
@@ -39,7 +39,7 @@ pub fn prompt(
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
-    callback_fn: impl FnMut(&mut crate::compositor::CompositorContext, &str, PromptEvent) + 'static,
+    callback_fn: impl FnMut(&mut CompositorContext, &str, PromptEvent) + 'static,
 ) {
     let mut prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn);
     // Calculate the initial completion
@@ -53,7 +53,7 @@ pub fn prompt_with_input(
     input: String,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
-    callback_fn: impl FnMut(&mut crate::compositor::CompositorContext, &str, PromptEvent) + 'static,
+    callback_fn: impl FnMut(&mut CompositorContext, &str, PromptEvent) + 'static,
 ) {
     let prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn)
         .with_line(input, cx.editor);
@@ -77,7 +77,7 @@ pub fn regex_prompt(
         prompt,
         history_register,
         completion_fn,
-        move |cx: &mut crate::compositor::CompositorContext, input: &str, event: PromptEvent| {
+        move |cx: &mut CompositorContext, input: &str, event: PromptEvent| {
             match event {
                 PromptEvent::Abort => {
                     let (view, doc) = current!(cx.editor);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -34,7 +34,7 @@ use helix_view::Editor;
 use std::path::PathBuf;
 
 pub fn prompt(
-    cx: &mut crate::commands::Context,
+    cx: &mut crate::commands::CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
@@ -47,7 +47,7 @@ pub fn prompt(
 }
 
 pub fn prompt_with_input(
-    cx: &mut crate::commands::Context,
+    cx: &mut crate::commands::CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     input: String,
     history_register: Option<char>,
@@ -60,7 +60,7 @@ pub fn prompt_with_input(
 }
 
 pub fn regex_prompt(
-    cx: &mut crate::commands::Context,
+    cx: &mut crate::commands::CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -38,7 +38,7 @@ pub fn prompt(
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
-    callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
+    callback_fn: impl FnMut(&mut crate::compositor::CompositorContext, &str, PromptEvent) + 'static,
 ) {
     let mut prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn);
     // Calculate the initial completion
@@ -52,7 +52,7 @@ pub fn prompt_with_input(
     input: String,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
-    callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
+    callback_fn: impl FnMut(&mut crate::compositor::CompositorContext, &str, PromptEvent) + 'static,
 ) {
     let prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn)
         .with_line(input, cx.editor);
@@ -76,7 +76,7 @@ pub fn regex_prompt(
         prompt,
         history_register,
         completion_fn,
-        move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
+        move |cx: &mut crate::compositor::CompositorContext, input: &str, event: PromptEvent| {
             match event {
                 PromptEvent::Abort => {
                     let (view, doc) = current!(cx.editor);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -14,6 +14,7 @@ mod spinner;
 mod statusline;
 mod text;
 
+use crate::commands::CommandContext;
 use crate::compositor::{Component, Compositor};
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
@@ -34,7 +35,7 @@ use helix_view::Editor;
 use std::path::PathBuf;
 
 pub fn prompt(
-    cx: &mut crate::commands::CommandContext,
+    cx: &mut CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
@@ -47,7 +48,7 @@ pub fn prompt(
 }
 
 pub fn prompt_with_input(
-    cx: &mut crate::commands::CommandContext,
+    cx: &mut CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     input: String,
     history_register: Option<char>,
@@ -60,7 +61,7 @@ pub fn prompt_with_input(
 }
 
 pub fn regex_prompt(
-    cx: &mut crate::commands::CommandContext,
+    cx: &mut CommandContext,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -5,7 +5,7 @@ use helix_view::{
 };
 use tui::buffer::Buffer;
 
-use crate::compositor::{Component, Context, Event, EventResult};
+use crate::compositor::{Component, CompositorContext, Event, EventResult};
 
 /// Contains a component placed in the center of the parent component
 pub struct Overlay<T> {
@@ -43,7 +43,7 @@ fn clip_rect_relative(rect: Rect, percent_horizontal: u8, percent_vertical: u8) 
 }
 
 impl<T: Component + 'static> Component for Overlay<T> {
-    fn render(&mut self, area: Rect, frame: &mut Buffer, ctx: &mut Context) {
+    fn render(&mut self, area: Rect, frame: &mut Buffer, ctx: &mut CompositorContext) {
         let dimensions = (self.calc_child_size)(area);
         self.content.render(dimensions, frame, ctx)
     }
@@ -61,7 +61,7 @@ impl<T: Component + 'static> Component for Overlay<T> {
         Some((width, height))
     }
 
-    fn handle_event(&mut self, event: &Event, ctx: &mut Context) -> EventResult {
+    fn handle_event(&mut self, event: &Event, ctx: &mut CompositorContext) -> EventResult {
         self.content.handle_event(event, ctx)
     }
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -1,6 +1,6 @@
 use crate::{
     commands::Open,
-    compositor::{Callback, Component, Context, Event, EventResult},
+    compositor::{Callback, Component, CompositorContext, Event, EventResult},
     ctrl, key,
 };
 use tui::buffer::Buffer as Surface;
@@ -88,7 +88,7 @@ impl<T: Component> Popup<T> {
 
     /// Calculate the position where the popup should be rendered and return the coordinates of the
     /// top left corner.
-    pub fn get_rel_position(&mut self, viewport: Rect, cx: &Context) -> (u16, u16) {
+    pub fn get_rel_position(&mut self, viewport: Rect, cx: &CompositorContext) -> (u16, u16) {
         let position = self
             .position
             .get_or_insert_with(|| cx.editor.cursor().0.unwrap_or_default());
@@ -158,7 +158,7 @@ impl<T: Component> Popup<T> {
 }
 
 impl<T: Component> Component for Popup<T> {
-    fn handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
+    fn handle_event(&mut self, event: &Event, cx: &mut CompositorContext) -> EventResult {
         let key = match event {
             Event::Key(event) => *event,
             Event::Resize(_, _) => {
@@ -231,7 +231,7 @@ impl<T: Component> Component for Popup<T> {
         Some(self.size)
     }
 
-    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
+    fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut CompositorContext) {
         // trigger required_size so we recalculate if the child changed
         self.required_size((viewport.width, viewport.height));
 

--- a/helix-term/src/ui/text.rs
+++ b/helix-term/src/ui/text.rs
@@ -1,4 +1,4 @@
-use crate::compositor::{Component, Context};
+use crate::compositor::{Component, CompositorContext};
 use tui::buffer::Buffer as Surface;
 
 use helix_view::graphics::Rect;
@@ -30,7 +30,7 @@ impl From<tui::text::Text<'static>> for Text {
 }
 
 impl Component for Text {
-    fn render(&mut self, area: Rect, surface: &mut Surface, _cx: &mut Context) {
+    fn render(&mut self, area: Rect, surface: &mut Surface, _cx: &mut CompositorContext) {
         use tui::widgets::{Paragraph, Widget, Wrap};
 
         let par = Paragraph::new(self.contents.clone()).wrap(Wrap { trim: false });


### PR DESCRIPTION
#### Summary:  
`Context` -> `CompositorContext`
`Context` -> `CommandContext`


Driving me nuts when trying to understand code with `cx`/`ctx`/`cxt` when both commands::Context and compositor::Context are in scope.
