### PR TITLE
Added yuck language support (for eww)

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -147,4 +147,5 @@
 | xit | ✓ |  |  |  |
 | xml | ✓ |  | ✓ |  |
 | yaml | ✓ |  | ✓ | `yaml-language-server` |
+| yuck | ✓ |  |  |  |
 | zig | ✓ | ✓ | ✓ | `zls` |

--- a/languages.toml
+++ b/languages.toml
@@ -2180,3 +2180,16 @@ comment-token = "("
 [[grammar]]
 name = "uxntal"
 source = { git = "https://github.com/Jummit/tree-sitter-uxntal", rev = "9297e95ef74380b0ad84c4fd98f91e9f6e4319e6" }
+
+[[language]]
+name = "yuck"
+scope = "source.yuck"
+injection-regex = "yuck"
+file-types = ["yuck"]
+roots = []
+comment-token = ";"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "yuck"
+source = { git = "https://github.com/Philipp-M/tree-sitter-yuck", rev = "9e97da5773f82123a8c8cccf8f7e795d140ed7d1" }

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -15,7 +15,7 @@
 ; strings
 (string_interpolation
   (string_interpolation_start) @punctuation.special
-  (string_interpolation_end) @punctuation.special) @embedded
+  (string_interpolation_end) @punctuation.special)
 
 (escape_sequence) @constant.character.escape
 

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -1,0 +1,66 @@
+(ERROR) @error
+
+(line_comment) @comment
+
+; keywords and symbols
+
+(keyword) @keyword
+(symbol) @tag
+
+; literals
+
+(bool_literal) @constant.builtin.boolean
+(num_literal) @constant.numeric
+
+; strings
+(string_interpolation
+  (string_interpolation_start) @punctuation.special
+  (string_interpolation_end) @punctuation.special) @embedded
+
+(escape_sequence) @constant.character.escape
+
+(string
+  [
+    (unescaped_single_quote_string_fragment)
+    (unescaped_double_quote_string_fragment)
+    (unescaped_backtick_string_fragment)
+    "\""
+    "'"
+    "`"
+  ]) @string
+
+; operators and general punctuation
+
+(unary_expression
+  operator: _ @operator)
+
+(binary_expression
+  operator: _ @operator)
+
+(ternary_expression
+  operator: _ @operator)
+
+[
+  ":"
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+[
+  ":"
+  "."
+  ","
+] @punctuation.delimiter
+
+; Rest (general identifiers that are not yet catched)
+
+(index) @variable
+(ident) @variable

--- a/runtime/queries/yuck/injections.scm
+++ b/runtime/queries/yuck/injections.scm
@@ -1,0 +1,2 @@
+((line_comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
Adds syntax highlighting support for yuck (DSL for eww). The parser should be complete now and closely follows the original lalrpop parser in eww.

![ewwyucktshighlighting](https://user-images.githubusercontent.com/9267430/220141521-042039a8-e7e8-4386-ad70-75f4033f1b85.png)
