### PR TITLE
feat: add nasm language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -85,6 +85,7 @@
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |
 | msbuild | ✓ |  | ✓ |  |
+| nasm | ✓ | ✓ |  |  |
 | nickel | ✓ |  | ✓ | `nls` |
 | nix | ✓ |  |  | `nil` |
 | nu | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2204,3 +2204,16 @@ comment-token = "#"
 [[grammar]]
 name = "po"
 source = { git = "https://github.com/erasin/tree-sitter-po", rev = "417cee9abb2053ed26b19e7de972398f2da9b29e" }
+
+[[language]]
+name = "nasm"
+scope = "source.nasm"
+file-types = ["asm", "s", "S", "nasm"]
+injection-regex = "n?asm"
+roots = []
+comment-token = ";"
+indent = { tab-width = 8, unit = "        " }
+
+[[grammar]]
+name = "nasm"
+source = { git = "https://github.com/naclsn/tree-sitter-nasm", rev = "a0db15db6fcfb1bf2cc8702500e55e558825c48b" }

--- a/runtime/queries/nasm/highlights.scm
+++ b/runtime/queries/nasm/highlights.scm
@@ -1,0 +1,130 @@
+(comment) @comment
+(ERROR) @error
+
+(label) @label
+
+[
+  (preproc_expression)
+  (line_here_token)
+  (section_here_token)
+] @variable.builtin
+(preproc_expression
+  "]" @variable.builtin)
+(preproc_expression
+  "}" @variable.builtin)
+
+(unary_expression
+  operator: _ @operator.unary)
+(binary_expression
+  operator: _ @operator.binary)
+(conditional_expression
+  "?" @operator
+  ":" @operator)
+
+[
+  ":"
+  ","
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(instruction_prefix) @keyword
+(actual_instruction
+  instruction: (word) @function)
+
+(call_syntax_expression
+  base: (word) @function)
+
+(size_hint) @type
+(struc_declaration
+  name: (word) @type)
+(struc_instance
+  name: (word) @type)
+
+(effective_address
+ hint: _ @type)
+(effective_address
+ segment: _ @constant.builtin)
+
+(register) @constant.builtin
+
+(number_literal) @number.integer
+(string_literal) @string
+(float_literal) @number.float
+(packed_bcd_literal) @number.integer
+
+((word) @constant
+  (#match? @constant "^[A-Z_][?A-Z_0-9]+$"))
+((word) @constant.builtin
+  (#match? @constant.builtin "^__\\?[A-Z_a-z0-9]+\\?__$"))
+(word) @variable
+
+(preproc_arg) @keyword
+
+[
+  (preproc_def)
+  (preproc_function_def)
+  (preproc_undef)
+  (preproc_alias)
+  (preproc_multiline_macro)
+  (preproc_multiline_unmacro)
+  (preproc_if)
+  (preproc_rotate)
+  (preproc_rep_loop)
+  (preproc_include)
+  (preproc_pathsearch)
+  (preproc_depend)
+  (preproc_use)
+  (preproc_push)
+  (preproc_pop)
+  (preproc_repl)
+  (preproc_arg)
+  (preproc_stacksize)
+  (preproc_local)
+  (preproc_reporting)
+  (preproc_pragma)
+  (preproc_line)
+  (preproc_clear)
+] @keyword
+[
+  (pseudo_instruction_dx)
+  (pseudo_instruction_resx)
+  (pseudo_instruction_incbin_command)
+  (pseudo_instruction_equ_command)
+  (pseudo_instruction_times_prefix)
+  (pseudo_instruction_alignx_macro)
+] @keyword
+[
+  (assembl_directive_target)
+  (assembl_directive_defaults)
+  (assembl_directive_sections)
+  (assembl_directive_absolute)
+  (assembl_directive_symbols)
+  (assembl_directive_common)
+  (assembl_directive_symbolfixes)
+  (assembl_directive_cpu)
+  (assembl_directive_floathandling)
+  (assembl_directive_org)
+  (assembl_directive_sectalign)
+
+  (assembl_directive_primitive_target)
+  (assembl_directive_primitive_defaults)
+  (assembl_directive_primitive_sections)
+  (assembl_directive_primitive_absolute)
+  (assembl_directive_primitive_symbols)
+  (assembl_directive_primitive_common)
+  (assembl_directive_primitive_symbolfixes)
+  (assembl_directive_primitive_cpu)
+  (assembl_directive_primitive_floathandling)
+  (assembl_directive_primitive_org)
+  (assembl_directive_primitive_sectalign)
+  (assembl_directive_primitive_warning)
+  (assembl_directive_primitive_map)
+] @keyword

--- a/runtime/queries/nasm/highlights.scm
+++ b/runtime/queries/nasm/highlights.scm
@@ -13,9 +13,9 @@
   "}" @variable.builtin)
 
 (unary_expression
-  operator: _ @operator.unary)
+  operator: _ @operator)
 (binary_expression
-  operator: _ @operator.binary)
+  operator: _ @operator)
 (conditional_expression
   "?" @operator
   ":" @operator)
@@ -54,10 +54,10 @@
 
 (register) @constant.builtin
 
-(number_literal) @number.integer
+(number_literal) @constant.numeric.integer
 (string_literal) @string
-(float_literal) @number.float
-(packed_bcd_literal) @number.integer
+(float_literal) @constant.numeric.float
+(packed_bcd_literal) @constant.numeric.integer
 
 ((word) @constant
   (#match? @constant "^[A-Z_][?A-Z_0-9]+$"))

--- a/runtime/queries/nasm/highlights.scm
+++ b/runtime/queries/nasm/highlights.scm
@@ -1,5 +1,4 @@
 (comment) @comment
-(ERROR) @error
 
 (label) @label
 

--- a/runtime/queries/nasm/highlights.scm
+++ b/runtime/queries/nasm/highlights.scm
@@ -2,15 +2,12 @@
 
 (label) @label
 
+(preproc_expression) @keyword.directive
+
 [
-  (preproc_expression)
   (line_here_token)
   (section_here_token)
 ] @variable.builtin
-(preproc_expression
-  "]" @variable.builtin)
-(preproc_expression
-  "}" @variable.builtin)
 
 (unary_expression
   operator: _ @operator)
@@ -65,7 +62,7 @@
   (#match? @constant.builtin "^__\\?[A-Z_a-z0-9]+\\?__$"))
 (word) @variable
 
-(preproc_arg) @keyword
+(preproc_arg) @keyword.directive
 
 [
   (preproc_def)
@@ -91,7 +88,7 @@
   (preproc_pragma)
   (preproc_line)
   (preproc_clear)
-] @keyword
+] @keyword.directive
 [
   (pseudo_instruction_dx)
   (pseudo_instruction_resx)
@@ -99,7 +96,7 @@
   (pseudo_instruction_equ_command)
   (pseudo_instruction_times_prefix)
   (pseudo_instruction_alignx_macro)
-] @keyword
+] @function.special
 [
   (assembl_directive_target)
   (assembl_directive_defaults)

--- a/runtime/queries/nasm/injections.scm
+++ b/runtime/queries/nasm/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/nasm/textobjects.scm
+++ b/runtime/queries/nasm/textobjects.scm
@@ -1,0 +1,15 @@
+(preproc_multiline_macro
+  body: (body) @function.inside) @function.around
+(struc_declaration
+  body: (struc_declaration_body) @class.inside) @class.around
+(struc_instance
+  body: (struc_instance_body) @class.inside) @class.around
+
+(preproc_function_def_parameters
+  (word) @parameter.inside)
+(call_syntax_arguments
+  (_) @parameter.inside)
+(operand) @parameter.inside
+
+(comment) @comment.inside
+(comment)+ @comment.around


### PR DESCRIPTION
This pull request adds nasm assembly as a language.

Closes #3329.

Under the issue mentioned above, there is a discussion about how to support various assembly flavours. I think the best approach is to add flavour-specific language definitions with the appropriate grammars, then users can override the `file-types` values as desired in their local `languages.toml` files so that the `.asm` extension (or whichever extension they're using) is recognized as the flavour that they're working with. Since nasm will be the only flavour supported so far after the changes in this merge request, I've included the `.asm` extension under nasm's `file-types` so that there is at least _some_ syntax highlighting out of the box, even though it might not be for the right flavour. If there's a different approach that might work better though, just let me know and I can rework things.

Also, CC @naclsn (the original author of the grammar and queries). I hope you don't mind me including your work here; I've copied the queries pretty much verbatim, only I've removed some todo-related comments that probably don't belong in the version inside this repository, and I've uncommented the `(ERROR) @error` highlight.

Edit: oh, and here's a screenshot:

![helix-nasm-nord](https://user-images.githubusercontent.com/36740602/220210811-52d43d04-fa12-4a74-8115-8122e0f9c7e6.png)