### PR TITLE
(Updated) Apply motion API refinements

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1239,12 +1239,7 @@ fn extend_next_long_word_end(cx: &mut Context) {
     extend_word_impl(cx, movement::move_next_long_word_end)
 }
 
-enum SearchDirection {
-    Next,
-    Prev,
-}
-
-fn find_char(cx: &mut Context, search_direction: SearchDirection, inclusive: bool, extend: bool) {
+fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, extend: bool) {
     // TODO: count is reset to 1 before next key so we move it into the closure here.
     // Would be nice to carry over.
     let count = cx.count();
@@ -1277,11 +1272,11 @@ fn find_char(cx: &mut Context, search_direction: SearchDirection, inclusive: boo
             _ => return,
         };
         let motion = move |editor: &mut Editor| {
-            match search_direction {
-                SearchDirection::Next => {
+            match direction {
+                Direction::Forward => {
                     find_char_impl(editor, &find_next_char_impl, inclusive, extend, ch, count)
                 }
-                SearchDirection::Prev => {
+                Direction::Backward => {
                     find_char_impl(editor, &find_prev_char_impl, inclusive, extend, ch, count)
                 }
             };
@@ -1366,35 +1361,35 @@ fn find_prev_char_impl(
 }
 
 fn find_till_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Next, false, false);
+    find_char(cx, Direction::Forward, false, false);
 }
 
 fn find_next_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Next, true, false)
+    find_char(cx, Direction::Forward, true, false)
 }
 
 fn extend_till_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Next, false, true)
+    find_char(cx, Direction::Forward, false, true)
 }
 
 fn extend_next_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Next, true, true)
+    find_char(cx, Direction::Forward, true, true)
 }
 
 fn till_prev_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Prev, false, false)
+    find_char(cx, Direction::Backward, false, false)
 }
 
 fn find_prev_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Prev, true, false)
+    find_char(cx, Direction::Backward, true, false)
 }
 
 fn extend_till_prev_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Prev, false, true)
+    find_char(cx, Direction::Backward, false, true)
 }
 
 fn extend_prev_char(cx: &mut Context) {
-    find_char(cx, SearchDirection::Prev, true, true)
+    find_char(cx, Direction::Backward, true, true)
 }
 
 fn repeat_last_motion(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1239,7 +1239,7 @@ fn extend_next_long_word_end(cx: &mut Context) {
     extend_word_impl(cx, movement::move_next_long_word_end)
 }
 
-fn will_find_char<F>(cx: &mut Context, search_fn: F, inclusive: bool, extend: bool)
+fn find_char<F>(cx: &mut Context, search_fn: F, inclusive: bool, extend: bool)
 where
     F: Fn(RopeSlice, char, usize, usize, bool) -> Option<usize> + 'static,
 {
@@ -1358,35 +1358,35 @@ fn find_prev_char_impl(
 }
 
 fn find_till_char(cx: &mut Context) {
-    will_find_char(cx, find_next_char_impl, false, false)
+    find_char(cx, find_next_char_impl, false, false)
 }
 
 fn find_next_char(cx: &mut Context) {
-    will_find_char(cx, find_next_char_impl, true, false)
+    find_char(cx, find_next_char_impl, true, false)
 }
 
 fn extend_till_char(cx: &mut Context) {
-    will_find_char(cx, find_next_char_impl, false, true)
+    find_char(cx, find_next_char_impl, false, true)
 }
 
 fn extend_next_char(cx: &mut Context) {
-    will_find_char(cx, find_next_char_impl, true, true)
+    find_char(cx, find_next_char_impl, true, true)
 }
 
 fn till_prev_char(cx: &mut Context) {
-    will_find_char(cx, find_prev_char_impl, false, false)
+    find_char(cx, find_prev_char_impl, false, false)
 }
 
 fn find_prev_char(cx: &mut Context) {
-    will_find_char(cx, find_prev_char_impl, true, false)
+    find_char(cx, find_prev_char_impl, true, false)
 }
 
 fn extend_till_prev_char(cx: &mut Context) {
-    will_find_char(cx, find_prev_char_impl, false, true)
+    find_char(cx, find_prev_char_impl, false, true)
 }
 
 fn extend_prev_char(cx: &mut Context) {
-    will_find_char(cx, find_prev_char_impl, true, true)
+    find_char(cx, find_prev_char_impl, true, true)
 }
 
 fn repeat_last_motion(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1099,8 +1099,7 @@ where
             .transform(|range| move_fn(text, range, count, behavior));
         doc.set_selection(view.id, selection);
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion)
 }
 
 fn goto_prev_paragraph(cx: &mut Context) {
@@ -1276,6 +1275,7 @@ where
             _ => return,
         };
 
+        // NOTE: not using _apply_motion as the repitition isn't identical
         find_char_impl(cx.editor, &search_fn, inclusive, extend, ch, count);
         cx.editor.last_motion = Some(Motion(Box::new(move |editor: &mut Editor| {
             find_char_impl(editor, &search_fn, inclusive, extend, ch, 1);
@@ -3248,8 +3248,7 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
 
         doc.set_selection(view.id, selection)
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion);
 }
 
 /// Returns the [Range] for a [Hunk] in the given text.
@@ -4584,8 +4583,7 @@ fn expand_selection(cx: &mut Context) {
             }
         }
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion);
 }
 
 fn shrink_selection(cx: &mut Context) {
@@ -4609,8 +4607,7 @@ fn shrink_selection(cx: &mut Context) {
             doc.set_selection(view.id, selection);
         }
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion);
 }
 
 fn select_sibling_impl<F>(cx: &mut Context, sibling_fn: &'static F)
@@ -4628,8 +4625,7 @@ where
             doc.set_selection(view.id, selection);
         }
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion);
 }
 
 fn select_next_sibling(cx: &mut Context) {
@@ -4912,8 +4908,7 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
             editor.set_status("Syntax-tree is not available in current buffer");
         }
     };
-    motion(cx.editor);
-    cx.editor.last_motion = Some(Motion(Box::new(motion)));
+    _apply_motion(cx, motion);
 }
 
 fn goto_next_function(cx: &mut Context) {
@@ -4962,6 +4957,12 @@ fn select_textobject_around(cx: &mut Context) {
 
 fn select_textobject_inner(cx: &mut Context) {
     select_textobject(cx, textobject::TextObject::Inside);
+}
+
+//TODO: move
+fn _apply_motion<F: Fn(&mut Editor) + 'static>(cx: &mut Context, motion: F) {
+    motion(cx.editor);
+    cx.editor.last_motion = Some(Motion(Box::new(motion)));
 }
 
 fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
@@ -5034,8 +5035,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 });
                 doc.set_selection(view.id, selection);
             };
-            textobject(cx.editor);
-            cx.editor.last_motion = Some(Motion(Box::new(textobject)));
+            _apply_motion(cx, textobject);
         }
     });
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -896,8 +896,7 @@ pub struct Editor {
     pub auto_pairs: Option<AutoPairs>,
 
     pub idle_timer: Pin<Box<Sleep>>,
-    #[allow(clippy::complexity)]
-    last_motion: Option<Arc<dyn Fn(&mut Editor)>>,
+    last_motion: LastMotion,
     pub last_completion: Option<CompleteAction>,
 
     pub exit_code: i32,
@@ -930,6 +929,8 @@ pub struct Editor {
     /// canceled as a result
     pub completion_request_handle: Option<oneshot::Sender<()>>,
 }
+
+pub type LastMotion = Option<Arc<dyn Fn(&mut Editor)>>;
 
 pub type RedrawHandle = (Arc<Notify>, Arc<RwLock<()>>);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -897,7 +897,7 @@ pub struct Editor {
 
     pub idle_timer: Pin<Box<Sleep>>,
     #[allow(clippy::complexity)]
-    last_motion: Option<Arc<Box<dyn Fn(&mut Editor)>>>,
+    last_motion: Option<Arc<dyn Fn(&mut Editor)>>,
     pub last_completion: Option<CompleteAction>,
 
     pub exit_code: i32,
@@ -1039,7 +1039,7 @@ impl Editor {
 
     pub fn apply_motion<F: Fn(&mut Self) + 'static>(&mut self, motion: F) {
         motion(self);
-        self.last_motion = Some(Arc::new(Box::new(motion)));
+        self.last_motion = Some(Arc::new(motion));
     }
 
     pub fn repeat_last_motion(&mut self, count: usize) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1044,11 +1044,11 @@ impl Editor {
     }
 
     pub fn repeat_last_motion(&mut self, count: usize) {
-        if let Some(motion) = &self.last_motion {
-            let motion = motion.clone();
+        if let Some(motion) = self.last_motion.take() {
             for _ in 0..count {
                 motion(self);
             }
+            self.last_motion = Some(motion);
         }
     }
     /// Current editing mode for the [`Editor`].

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -896,7 +896,7 @@ pub struct Editor {
     pub auto_pairs: Option<AutoPairs>,
 
     pub idle_timer: Pin<Box<Sleep>>,
-    last_motion: LastMotion,
+    last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
 
     pub exit_code: i32,
@@ -930,7 +930,7 @@ pub struct Editor {
     pub completion_request_handle: Option<oneshot::Sender<()>>,
 }
 
-pub type LastMotion = Option<Arc<dyn Fn(&mut Editor)>>;
+pub type Motion = Arc<dyn Fn(&mut Editor)>;
 
 pub type RedrawHandle = (Arc<Notify>, Arc<RwLock<()>>);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -930,7 +930,7 @@ pub struct Editor {
     pub completion_request_handle: Option<oneshot::Sender<()>>,
 }
 
-pub type Motion = Arc<dyn Fn(&mut Editor)>;
+pub type Motion = Box<dyn Fn(&mut Editor)>;
 
 pub type RedrawHandle = (Arc<Notify>, Arc<RwLock<()>>);
 
@@ -1040,7 +1040,7 @@ impl Editor {
 
     pub fn apply_motion<F: Fn(&mut Self) + 'static>(&mut self, motion: F) {
         motion(self);
-        self.last_motion = Some(Arc::new(motion));
+        self.last_motion = Some(Box::new(motion));
     }
 
     pub fn repeat_last_motion(&mut self, count: usize) {


### PR DESCRIPTION
Same as #6061 but without relying on #6056 as per the discussion we had there.

## Summary:

`last_motion` is now a private field and can only be set by calling `editor.apply_motion()`. Thus removing the need (and possibility of forgetting) to write the following every time a motion is to be applied and saved:

```
motion(editor); 
editor.last_motion = motion
```

Now it's just: `editor.apply_motion(motion)`

New behavior that fell out from this is that repetitions of t,T,f,F motions are stored with the context of extension/move and count. (Not defaulting to extend by 1 count). So 3f -> repeat_last_motion becomes 3f and not 1f. I'm not sure the old behavior was intentional, as I saw no discussion of it when introduced in #891.

## Conflicts

Of all the open PRs that are currently mergeable with master, and pass all CI checks; only #2869 conflicts with this one. There it is simply an import statement in command.rs that needs to be changed.

```
 5 ▍<<<<<<< HEAD
 4  │   editor::Action,
 3 ▍=======
 2 ▍│   editor::{Action, Motion} 
 1 ▍│   icons::Icons,
43 ▍>>>>>>> TEMP_2869
```


