### PR TITLE
Implement LSP window/showDocument request

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -409,6 +409,7 @@ impl Client {
                 }),
                 window: Some(lsp::WindowClientCapabilities {
                     work_done_progress: Some(true),
+                    show_document: Some(lsp::ShowDocumentClientCapabilities { support: true }),
                     ..Default::default()
                 }),
                 general: Some(lsp::GeneralClientCapabilities {

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -527,6 +527,7 @@ pub enum MethodCall {
     WorkspaceFolders,
     WorkspaceConfiguration(lsp::ConfigurationParams),
     RegisterCapability(lsp::RegistrationParams),
+    ShowDocument(lsp::ShowDocumentParams),
 }
 
 impl MethodCall {
@@ -549,6 +550,10 @@ impl MethodCall {
             lsp::request::RegisterCapability::METHOD => {
                 let params: lsp::RegistrationParams = params.parse()?;
                 Self::RegisterCapability(params)
+            }
+            lsp::request::ShowDocument::METHOD => {
+                let params: lsp::ShowDocumentParams = params.parse()?;
+                Self::ShowDocument(params)
             }
             _ => {
                 return Err(Error::Unhandled);


### PR DESCRIPTION
Implements the LSP request for [`window/showDocument`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument).

This does not yet implement requests with the `external` parameter set to `true`, but it would probably best to do this in the same PR (as LSP servers would probably assume that to work). I believe there is no similar functionality in helix yet, and I wanted to check if my suggested approach would be welcome.

I suggest adding a `External` variant to the `Action` enum which is passed to `Editor::open`. The actual implementation could either be done using the [`open` crate](https://docs.rs/open/latest/open/) or by reimplementing the functionality of this crate.