### PR TITLE
Add elm treesitter textobjects

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -30,7 +30,7 @@
 | eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |
 | elixir | ✓ | ✓ | ✓ | `elixir-ls` |
-| elm | ✓ |  |  | `elm-language-server` |
+| elm | ✓ | ✓ |  | `elm-language-server` |
 | elvish | ✓ |  |  | `elvish` |
 | env | ✓ |  |  |  |
 | erb | ✓ |  |  |  |

--- a/runtime/queries/elm/textobjects.scm
+++ b/runtime/queries/elm/textobjects.scm
@@ -1,0 +1,63 @@
+(line_comment) @comment.inside
+(line_comment)+ @comment.around
+(block_comment) @comment.inside
+(block_comment)+ @comment.around
+
+((type_annotation)?
+  (value_declaration
+    (function_declaration_left (lower_case_identifier))
+    (eq)
+    (_) @function.inside
+  )
+) @function.around
+
+(parenthesized_expr
+  (anonymous_function_expr
+    (
+      (arrow)
+      (_) @function.inside
+    )
+  )
+) @function.around
+
+(value_declaration
+  (function_declaration_left
+    (lower_pattern
+      (lower_case_identifier) @parameter.inside @parameter.around
+    )
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (pattern) @parameter.inside @parameter.around
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (tuple_pattern
+      (pattern) @parameter.inside
+    ) @parameter.around
+  )
+)
+
+(value_declaration
+  (function_declaration_left
+    (record_pattern
+      (lower_pattern
+        (lower_case_identifier) @parameter.inside
+      )
+    ) @parameter.around
+  )
+)
+
+(parenthesized_expr
+  (anonymous_function_expr
+    (
+      (backslash)
+      (pattern) @parameter.inside
+      (arrow)
+    )
+  )
+)


### PR DESCRIPTION
Fixes #6083 

This is a first (naive) attempt at adding treesitter text objects for the elm language.

To test this out, copy the [textobjects.scm](runtime/queries/elm/textobjects.scm) file to your runtime folder in `runtime/queries/elm` and restart helix.

To find where your runtime folder is, use `hx --health | grep runtime`.

It should now allow you to select
- the code of function with `mif`
- the function itself with its optional type annotation with `maf`
- a function parameter with `mia` or `mac`
- a line of block comment with `mic` or `mac`

And you can navigate with the same text objects, so
- previous or next function with `[f` or `]f`
- previous or next parameter with `[a` or `]a`
- previous or next comment with `[c` or `]c`