### PR TITLE
Fix `shrink_selection` with multiple cursors.

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -615,11 +615,6 @@ impl Selection {
 
     // returns true if self ⊇ other
     pub fn contains(&self, other: &Selection) -> bool {
-        // can't contain other if it is larger
-        if other.len() > self.len() {
-            return false;
-        }
-
         let (mut iter_self, mut iter_other) = (self.iter(), other.iter());
         let (mut ele_self, mut ele_other) = (iter_self.next(), iter_other.next());
 
@@ -635,7 +630,20 @@ impl Selection {
                     };
                 }
                 (None, Some(_)) => {
-                    // exhausted `self`, we can't match the reminder of `other`
+                    // Other might still contain all of its ranges in a single range of self,
+                    let mut still_subset: bool;
+                    for self_range in self {
+                        still_subset = true;
+                        for other_range in other {
+                            if !self_range.contains_range(other_range) {
+                                still_subset = false;
+                                break;
+                            }
+                        }
+                        if still_subset {
+                            return true;
+                        }
+                    }
                     return false;
                 }
                 (_, None) => {
@@ -1230,5 +1238,8 @@ mod test {
             vec!((3, 4), (7, 9))
         ));
         assert!(!contains(vec!((1, 1), (5, 6)), vec!((1, 6))));
+
+        // multiple ranges of other are all contained in one range of self,
+        assert!(contains(vec!((7, 13)), vec!((7, 9), (11, 12))));
     }
 }

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -630,20 +630,7 @@ impl Selection {
                     };
                 }
                 (None, Some(_)) => {
-                    // Other might still contain all of its ranges in a single range of self,
-                    let mut still_subset: bool;
-                    for self_range in self {
-                        still_subset = true;
-                        for other_range in other {
-                            if !self_range.contains_range(other_range) {
-                                still_subset = false;
-                                break;
-                            }
-                        }
-                        if still_subset {
-                            return true;
-                        }
-                    }
+                    // exhausted `self`, we can't match the reminder of `other`
                     return false;
                 }
                 (_, None) => {
@@ -1239,7 +1226,10 @@ mod test {
         ));
         assert!(!contains(vec!((1, 1), (5, 6)), vec!((1, 6))));
 
-        // multiple ranges of other are all contained in one range of self,
-        assert!(contains(vec!((7, 13)), vec!((7, 9), (11, 12))));
+        // multiple ranges of other are all contained in some ranges of self,
+        assert!(contains(
+            vec!((1, 4), (7, 10)),
+            vec!((1, 2), (3, 4), (7, 9))
+        ));
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4327,7 +4327,6 @@ fn shrink_selection(cx: &mut Context) {
         // try to restore previous selection
         if let Some(prev_selection) = view.object_selections.pop() {
             if current_selection.contains(&prev_selection) {
-                // allow shrinking the selection only if current selection contains the previous object selection
                 doc.set_selection(view.id, prev_selection);
                 return;
             } else {


### PR DESCRIPTION
Fixes #6092 

Caused by some incorrect assumptions that missed an edge case in the `Selection.contains()` calculation. Tests were added accordingly.

[![asciicast](https://asciinema.org/a/NINyXHNywRUe6ULYZo4nGQjCi.svg)](https://asciinema.org/a/NINyXHNywRUe6ULYZo4nGQjCi?t=23)