### PR TITLE
LSP: Separate diagnostic picker message and code

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -32,8 +32,7 @@ use crate::{
 };
 
 use std::{
-    borrow::Cow, cmp::Ordering, collections::BTreeMap, fmt::Write, future::Future, path::PathBuf,
-    sync::Arc,
+    cmp::Ordering, collections::BTreeMap, fmt::Write, future::Future, path::PathBuf, sync::Arc,
 };
 
 /// Gets the language server that is attached to a document, and
@@ -138,15 +137,11 @@ impl ui::menu::Item for PickerDiagnostic {
         // remove background as it is distracting in the picker list
         style.bg = None;
 
-        let code: Cow<'_, str> = self
-            .diag
-            .code
-            .as_ref()
-            .map(|c| match c {
-                NumberOrString::Number(n) => n.to_string().into(),
-                NumberOrString::String(s) => s.as_str().into(),
-            })
-            .unwrap_or_default();
+        let code = match self.diag.code.as_ref() {
+            Some(NumberOrString::Number(n)) => format!(" ({n})"),
+            Some(NumberOrString::String(s)) => format!(" ({s})"),
+            None => String::new(),
+        };
 
         let path = match format {
             DiagnosticsFormat::HideSourcePath => String::new(),


### PR DESCRIPTION
**Problem**
Currently in master lsp errors are reported as follows, as you can see the diagnostic message and code are attached to each other making it hard to read.
![grafik](https://user-images.githubusercontent.com/6558089/221137033-287ce6f2-c033-42ac-8e6f-079c10eac84a.png)

**This pr** solves that.
![grafik](https://user-images.githubusercontent.com/6558089/221136964-d3cb7733-a28b-4a32-a496-6808accb6186.png)
