### PR TITLE
build(nix): update flake to use flake-parts and nci flake-parts module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677294491,
-        "narHash": "sha256-p09IOJqhUOM6egRJe4Ou1EXdTs/I9Pmm8e7pMYDlIWM=",
+        "lastModified": 1677297103,
+        "narHash": "sha256-ArlJIbp9NGV9yvhZdV0SOUFfRlI/kHeKoCk30NbSiLc=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "a525ed36c440854f296cd958f4ebf574f0ebe22c",
+        "rev": "a79272a2cb0942392bb3a5bf9a3ec6bc568795b2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "devshell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1667210711,
-        "narHash": "sha256-IoErjXZAkzYWHEpQqwu/DeRNJGFdR7X2OGbkhMqMrpw=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "96a9dd12b8a447840cc246e17a47b81a4268bba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "dream2nix": {
       "inputs": {
         "alejandra": [
@@ -42,10 +26,12 @@
         ],
         "crane": "crane",
         "devshell": [
-          "nci",
-          "devshell"
+          "nci"
         ],
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "nci",
+          "parts"
+        ],
         "flake-utils-pre-commit": [
           "nci"
         ],
@@ -70,37 +56,22 @@
         ],
         "pre-commit-hooks": [
           "nci"
+        ],
+        "pruned-racket-catalog": [
+          "nci"
         ]
       },
       "locked": {
-        "lastModified": 1671323629,
-        "narHash": "sha256-9KHTPjIDjfnzZ4NjpE3gGIVHVHopy6weRDYO/7Y3hF8=",
+        "lastModified": 1677289985,
+        "narHash": "sha256-lUp06cTTlWubeBGMZqPl9jODM99LpWMcwxRiscFAUJg=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "2d7d68505c8619410df2c6b6463985f97cbcba6e",
+        "rev": "28b973a8d4c30cc1cbb3377ea2023a76bc3fb889",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "dream2nix",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1668450977,
-        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -119,23 +90,40 @@
         "type": "github"
       }
     },
+    "mk-naked-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676572903,
+        "narHash": "sha256-oQoDHHUTxNVSURfkFcYLuAK+btjs30T4rbEUtCUyKy8=",
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "rev": "aeca9f8aa592f5e8f71f407d081cb26fd30c5a57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
     "nci": {
       "inputs": {
-        "devshell": "devshell",
         "dream2nix": "dream2nix",
+        "mk-naked-shell": "mk-naked-shell",
         "nixpkgs": [
           "nixpkgs"
         ],
+        "parts": "parts",
         "rust-overlay": [
           "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1671430291,
-        "narHash": "sha256-UIc7H8F3N8rK72J/Vj5YJdV72tvDvYjH+UPsOFvlcsE=",
+        "lastModified": 1677294491,
+        "narHash": "sha256-p09IOJqhUOM6egRJe4Ou1EXdTs/I9Pmm8e7pMYDlIWM=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "b1b0d38b8c3b0d0e6a38638d5bbe10b0bc67522c",
+        "rev": "a525ed36c440854f296cd958f4ebf574f0ebe22c",
         "type": "github"
       },
       "original": {
@@ -146,11 +134,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
+        "lastModified": 1677063315,
+        "narHash": "sha256-qiB4ajTeAOVnVSAwCNEEkoybrAlA+cpeiBxLobHndE8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
+        "rev": "988cc958c57ce4350ec248d2d53087777f9e1949",
         "type": "github"
       },
       "original": {
@@ -163,11 +151,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1675183161,
+        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
         "type": "github"
       },
       "original": {
@@ -178,10 +166,50 @@
         "type": "github"
       }
     },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nci",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675933616,
+        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1675933616,
+        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nci": "nci",
         "nixpkgs": "nixpkgs",
+        "parts": "parts_2",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -193,11 +221,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671416426,
-        "narHash": "sha256-kpSH1Jrxfk2qd0pRPJn1eQdIOseGv5JuE+YaOrqU9s4=",
+        "lastModified": 1677292251,
+        "narHash": "sha256-D+6q5Z2MQn3UFJtqsM5/AvVHi3NXKZTIMZt1JGq/spA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fbaaff24f375ac25ec64268b0a0d63f91e474b7d",
+        "rev": "34cdbf6ad480ce13a6a526f57d8b9e609f3d65dc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -120,9 +120,11 @@
           else pkgs.clangStdenv;
         rustFlagsEnv =
           if stdenv.isLinux
-          then "$RUSTFLAGS\" -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment\""
+          then ''$RUSTFLAGS -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment''
           else "$RUSTFLAGS";
       in {
+        # by default NCI adds rust-analyzer component, but helix toolchain doesn't have rust-analyzer
+        nci.toolchains.shell.components = ["rust-src" "rustfmt" "clippy"];
         nci.projects."helix-project".relPath = "";
         nci.crates."helix-term" = {
           overrides = {

--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.rust-overlay.follows = "rust-overlay";
     };
+    parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    nci,
-    ...
-  }: let
-    lib = nixpkgs.lib;
-    ncl = nci.lib.nci-lib;
+  outputs = inp: let
     mkRootPath = rel:
       builtins.path {
         path = "${toString ./.}/${rel}";
@@ -32,6 +26,12 @@
         ".envrc"
         ".ignore"
         ".github"
+        ".gitignore"
+        "logo.svg"
+        "logo_dark.svg"
+        "logo_light.svg"
+        "rust-toolchain.toml"
+        "rustfmt.toml"
         "runtime"
         "screenshot.png"
         "book"
@@ -46,6 +46,7 @@
         "flake.lock"
       ];
       ignorePaths = path: type: let
+        inherit (inp.nixpkgs) lib;
         # split the nix store path into its components
         components = lib.splitString "/" path;
         # drop off the `/nix/hash-source` section from the path
@@ -61,122 +62,104 @@
         # filter out unnecessary paths
         filter = ignorePaths;
       };
-    outputs = nci.lib.makeOutputs {
-      root = ./.;
-      config = common: {
-        outputs = {
-          # rename helix-term to helix since it's our main package
-          rename = {"helix-term" = "helix";};
-          # Set default app to hx (binary is from helix-term release build)
-          # Set default package to helix-term release build
-          defaults = {
-            app = "hx";
-            package = "helix";
-          };
-        };
-        cCompiler.package = with common.pkgs;
-          if stdenv.isLinux
-          then gcc
-          else clang;
-        shell = {
-          packages = with common.pkgs;
-            [lld_13 cargo-flamegraph rust-analyzer]
-            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
-            ++ (lib.optional stdenv.isLinux lldb)
-            ++ (lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation);
-          env = [
-            {
-              name = "HELIX_RUNTIME";
-              eval = "$PWD/runtime";
-            }
-            {
-              name = "RUST_BACKTRACE";
-              value = "1";
-            }
-            {
-              name = "RUSTFLAGS";
-              eval =
-                if common.pkgs.stdenv.isLinux
-                then "$RUSTFLAGS\" -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment\""
-                else "$RUSTFLAGS";
-            }
-          ];
-        };
-      };
-      pkgConfig = common: {
-        helix-term = let
-          # Wrap helix with runtime
-          wrapper = _: old: let
-            inherit (common) pkgs;
-            makeOverridableHelix = old: config: let
-              grammars = pkgs.callPackage ./grammars.nix config;
-              runtimeDir = pkgs.runCommand "helix-runtime" {} ''
-                mkdir -p $out
-                ln -s ${mkRootPath "runtime"}/* $out
-                rm -r $out/grammars
-                ln -s ${grammars} $out/grammars
-              '';
-              helix-wrapped =
-                common.internal.pkgsSet.utils.wrapDerivation old
-                {
-                  nativeBuildInputs = [pkgs.makeWrapper];
-                  makeWrapperArgs = config.makeWrapperArgs or [];
-                }
-                ''
-                  rm -rf $out/bin
-                  mkdir -p $out/bin
-                  ln -sf ${old}/bin/* $out/bin/
-                  wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
-                '';
-            in
-              helix-wrapped
-              // {
-                override = makeOverridableHelix old;
-                passthru = helix-wrapped.passthru // {wrapper = wrapper {};};
-              };
-          in
-            makeOverridableHelix old {};
-        in {
-          inherit wrapper;
-          overrides.fix-build.overrideAttrs = prev: {
-            src = filteredSource;
-
-            # disable fetching and building of tree-sitter grammars in the helix-term build.rs
-            HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-
-            buildInputs = ncl.addBuildInputs prev [common.config.cCompiler.package.cc.lib];
-
-            # link languages and theme toml files since helix-term expects them (for tests)
-            preConfigure = ''
-              ${prev.preConfigure or ""}
-              ${
-                lib.concatMapStringsSep
-                "\n"
-                (path: "ln -sf ${mkRootPath path} ..")
-                ["languages.toml" "theme.toml" "base16_theme.toml"]
-              }
-            '';
-            checkPhase = ":";
-
-            meta.mainProgram = "hx";
-          };
-        };
-      };
-    };
   in
-    outputs
-    // {
-      packages =
-        lib.mapAttrs
-        (
-          system: packages:
-            packages
-            // {
-              helix-unwrapped = packages.helix.passthru.unwrapped;
-              helix-unwrapped-dev = packages.helix-dev.passthru.unwrapped;
+    inp.parts.lib.mkFlake {inputs = inp;} {
+      imports = [inp.nci.flakeModule];
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "i686-linux"
+      ];
+      perSystem = {
+        config,
+        pkgs,
+        lib,
+        ...
+      }: let
+        makeOverridableHelix = old: config: let
+          grammars = pkgs.callPackage ./grammars.nix config;
+          runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+            mkdir -p $out
+            ln -s ${mkRootPath "runtime"}/* $out
+            rm -r $out/grammars
+            ln -s ${grammars} $out/grammars
+          '';
+          helix-wrapped =
+            pkgs.runCommand
+            old.name
+            {
+              inherit (old) pname version;
+              meta = old.meta or {};
+              passthru =
+                (old.passthru or {})
+                // {
+                  unwrapped = old;
+                };
+              nativeBuildInputs = [pkgs.makeWrapper];
+              makeWrapperArgs = config.makeWrapperArgs or [];
             }
-        )
-        outputs.packages;
+            ''
+              cp -rs --no-preserve=mode,ownership ${old} $out
+              wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
+            '';
+        in
+          helix-wrapped
+          // {
+            override = makeOverridableHelix old;
+            passthru =
+              helix-wrapped.passthru
+              // {
+                wrapper = old: makeOverridableHelix old config;
+              };
+          };
+        stdenv =
+          if pkgs.stdenv.isLinux
+          then pkgs.stdenv
+          else pkgs.clangStdenv;
+        rustFlagsEnv =
+          if stdenv.isLinux
+          then "$RUSTFLAGS\" -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment\""
+          else "$RUSTFLAGS";
+      in {
+        nci.projects."helix-project".relPath = "";
+        nci.crates."helix-term" = {
+          overrides = {
+            add-meta.override = _: {meta.mainProgram = "hx";};
+            add-inputs.overrideAttrs = prev: {
+              buildInputs = (prev.buildInputs or []) ++ [stdenv.cc.cc.lib];
+            };
+            disable-grammar-builds = {
+              # disable fetching and building of tree-sitter grammars in the helix-term build.rs
+              HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+            };
+            disable-tests = {checkPhase = ":";};
+            set-stdenv.override = _: {inherit stdenv;};
+            set-filtered-src.override = _: {src = filteredSource;};
+          };
+        };
+
+        packages.helix-unwrapped = config.nci.outputs."helix-term".packages.release;
+        packages.helix-unwrapped-dev = config.nci.outputs."helix-term".packages.dev;
+        packages.helix = makeOverridableHelix config.packages.helix-unwrapped {};
+        packages.helix-dev = makeOverridableHelix config.packages.helix-unwrapped-dev {};
+        packages.default = config.packages.helix;
+
+        devShells.default = config.nci.outputs."helix-project".devShell.overrideAttrs (old: {
+          nativeBuildInputs =
+            (old.nativeBuildInputs or [])
+            ++ (with pkgs; [lld_13 cargo-flamegraph rust-analyzer])
+            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) pkgs.cargo-tarpaulin)
+            ++ (lib.optional stdenv.isLinux pkgs.lldb)
+            ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreFoundation);
+          shellHook = ''
+            export HELIX_RUNTIME="$PWD/runtime"
+            export RUST_BACKTRACE="1"
+            export RUSTFLAGS="${rustFlagsEnv}"
+          '';
+        });
+      };
     };
 
   nixConfig = {

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -12,10 +12,6 @@ include = ["src/**/*", "README.md"]
 default-run = "hx"
 rust-version = "1.57"
 
-[package.metadata.nix]
-build = true
-app = true
-
 [features]
 default = ["git"]
 unicode-lines = ["helix-core/unicode-lines"]


### PR DESCRIPTION
Rewrites most of the flake so that it uses `flake-parts` and the new NCI. Should be a lot more cleaner now