### PR TITLE
Improve markdown highlights and add latex injection

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1026,7 +1026,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "markdown"
-source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "a7de4be29783a6e25f3240c90afea52f2417faa3", subpath = "tree-sitter-markdown" }
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "7e7aa9a25ca9729db9fe22912f8f47bdb403a979", subpath = "tree-sitter-markdown" }
 
 [[language]]
 name = "markdown.inline"
@@ -1038,7 +1038,7 @@ grammar = "markdown_inline"
 
 [[grammar]]
 name = "markdown_inline"
-source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "a7de4be29783a6e25f3240c90afea52f2417faa3", subpath = "tree-sitter-markdown-inline" }
+source = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "7e7aa9a25ca9729db9fe22912f8f47bdb403a979", subpath = "tree-sitter-markdown-inline" }
 
 [[language]]
 name = "dart"

--- a/runtime/queries/markdown.inline/injections.scm
+++ b/runtime/queries/markdown.inline/injections.scm
@@ -1,2 +1,4 @@
 
 ((html_tag) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
+
+((latex_block) @injection.content (#set! injection.language "latex") (#set! injection.include-unnamed-children))

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -39,7 +39,7 @@
   (list_marker_parenthesis)
 ] @markup.list.numbered
 
-(thematic_break) @punctuation.delimiter
+(thematic_break) @punctuation.special
 
 [
   (block_continuation)
@@ -51,3 +51,9 @@
 ] @string.escape
 
 (block_quote) @markup.quote
+
+(pipe_table_row
+  "|" @punctuation.special)
+(pipe_table_header
+  "|" @punctuation.special)
+(pipe_table_delimiter_row) @punctuation.special


### PR DESCRIPTION
* Changes some nodes from `punctuation.delimiter` to `punctuation.special` which is more accurate in regards to highlighting.
* Updates markdown grammar to newest commit
* Adds language injection for newly added `latex_block` node