### PR TITLE
Semantic tokens highlighting

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -50,6 +50,7 @@
 | `:lsp-workspace-command` | Open workspace command picker |
 | `:lsp-restart` | Restarts the Language Server that is in use by the current doc |
 | `:tree-sitter-scopes` | Display tree sitter scopes, primarily for theming and development. |
+| `:semantic-tokens` | Display the semantic tokens, primarily for theming and development. |
 | `:debug-start`, `:dbg` | Start a debug session from a given template with given parameters. |
 | `:debug-remote`, `:dbg-tcp` | Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters. |
 | `:debug-eval` | Evaluate expression in current debug context. |

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -26,6 +26,9 @@ use crate::{
     },
 };
 
+mod semantic_tokens;
+pub use semantic_tokens::*;
+
 use std::{
     borrow::Cow, cmp::Ordering, collections::BTreeMap, fmt::Write, path::PathBuf, sync::Arc,
 };

--- a/helix-term/src/commands/lsp/semantic_tokens.rs
+++ b/helix-term/src/commands/lsp/semantic_tokens.rs
@@ -1,0 +1,194 @@
+//! Semantic tokens computations for documents.
+//!
+//! The tokens are then used in highlighting.
+use std::future::Future;
+use std::sync::Arc;
+
+use helix_lsp::lsp;
+use helix_view::document::DocumentSemanticTokens;
+use helix_view::editor::Editor;
+use helix_view::{Document, View};
+
+pub fn compute_semantic_tokens_for_all_views(editor: &mut Editor, jobs: &mut crate::job::Jobs) {
+    if !editor.config().lsp.enable_semantic_tokens_highlighting {
+        return;
+    }
+
+    for (view, _) in editor.tree.views() {
+        let doc = match editor.documents.get(&view.doc) {
+            Some(doc) => doc,
+            None => continue,
+        };
+        if let Some(callback) = compute_semantic_tokens_for_view(view, doc) {
+            jobs.callback(callback);
+        }
+    }
+}
+
+pub(crate) fn compute_semantic_tokens_for_view(
+    view: &View,
+    doc: &Document,
+) -> Option<std::pin::Pin<Box<impl Future<Output = Result<crate::job::Callback, anyhow::Error>>>>> {
+    let language_server = doc.language_server()?;
+    let capabilities = language_server.capabilities();
+
+    let view_id = view.id;
+    let doc_id = view.doc;
+
+    let lsp_support_ranges = match capabilities.semantic_tokens_provider.as_ref()? {
+        lsp::SemanticTokensServerCapabilities::SemanticTokensOptions(opt) => opt.range?,
+        lsp::SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(opt) => {
+            opt.semantic_tokens_options.range?
+        }
+    };
+
+    if !lsp_support_ranges {
+        return None;
+    }
+
+    let doc_text = doc.text();
+    let len_lines = doc_text.len_lines();
+
+    // Compute ~3 times the current view height of semantic tokens, that way some scrolling
+    // will not show half the view with thel and half without while still being faster
+    // than computing all the hints for the full file (which could be dozens of time
+    // longer than the view is).
+    let view_height = view.inner_height();
+    let first_visible_line = doc_text.char_to_line(view.offset.anchor);
+    let first_line = first_visible_line.saturating_sub(view_height);
+    let last_line = first_visible_line
+        .saturating_add(view_height.saturating_mul(2))
+        .min(len_lines);
+
+    if !doc.semantic_tokens_outdated
+        && doc.semantic_tokens(view_id).map_or(false, |dst| {
+            dst.first_line == first_line && dst.last_line == last_line
+        })
+    {
+        return None;
+    }
+
+    let doc_slice = doc_text.slice(..);
+    let first_char_in_range = doc_slice.line_to_char(first_line);
+    let last_char_in_range = doc_slice.line_to_char(last_line);
+
+    let range = helix_lsp::util::range_to_lsp_range(
+        doc_text,
+        helix_core::Range::new(first_char_in_range, last_char_in_range),
+        language_server.offset_encoding(),
+    );
+
+    let future = language_server.text_document_semantic_tokens(doc.identifier(), range, None)?;
+
+    let callback = super::super::make_job_callback(
+        future,
+        move |editor, _compositor, response: Option<lsp::SemanticTokensRangeResult>| {
+            // The config was modified or the window was closed while the request was in flight
+            if !editor.config().lsp.enable_semantic_tokens_highlighting
+                || editor.tree.try_get(view_id).is_none()
+            {
+                return;
+            }
+
+            // Add annotations to relevant document, not the current one (it may have changed in between)
+            let doc = match editor.documents.get_mut(&doc_id) {
+                Some(doc) => doc,
+                None => return,
+            };
+
+            let mut dst = DocumentSemanticTokens {
+                first_line,
+                last_line,
+                tokens: Vec::new(),
+            };
+
+            // Immutable borrow of doc inside, conflicts with the `set_semantic_tokens` at the end
+            {
+                let (ls, data) = match (doc.language_server(), response) {
+                    (
+                        Some(ls),
+                        Some(
+                            lsp::SemanticTokensRangeResult::Tokens(lsp::SemanticTokens {
+                                data,
+                                ..
+                            })
+                            | lsp::SemanticTokensRangeResult::Partial(
+                                lsp::SemanticTokensPartialResult { data },
+                            ),
+                        ),
+                    ) if !data.is_empty() => (ls, data),
+                    _ => {
+                        doc.set_semantic_tokens(
+                            view_id,
+                            DocumentSemanticTokens {
+                                first_line,
+                                last_line,
+                                tokens: Vec::new(),
+                            },
+                        );
+                        doc.semantic_tokens_outdated = false;
+                        return;
+                    }
+                };
+
+                let offset_encoding = ls.offset_encoding();
+                let types_legend = ls.types_legend();
+                let modifiers_legend = ls.modifiers_legend();
+
+                let doc_text = doc.text();
+
+                let mut line = 0_u32;
+                let mut character = 0;
+
+                for token in data {
+                    line = line.saturating_add(token.delta_line);
+                    character = if token.delta_line > 0 {
+                        token.delta_start
+                    } else {
+                        character.saturating_add(token.delta_start)
+                    };
+
+                    let start = lsp::Position { line, character };
+                    let end = lsp::Position {
+                        line,
+                        character: character.saturating_add(token.length),
+                    };
+
+                    let range = match helix_lsp::util::lsp_range_to_range(
+                        doc_text,
+                        lsp::Range { start, end },
+                        offset_encoding,
+                    ) {
+                        Some(r) => r,
+                        None => continue,
+                    };
+
+                    let token_type = match types_legend.get(token.token_type as usize) {
+                        Some(ty) => Arc::clone(ty),
+                        None => continue,
+                    };
+
+                    let mut tokens_for_range =
+                        Vec::with_capacity(token.token_modifiers_bitset.count_ones() as usize + 1);
+                    tokens_for_range.push(token_type);
+
+                    for i in 0..u32::BITS {
+                        let mask = 1 << i;
+
+                        if token.token_modifiers_bitset & mask != 0 {
+                            if let Some(mo) = modifiers_legend.get(i as usize) {
+                                tokens_for_range.push(Arc::clone(mo));
+                            }
+                        }
+                    }
+
+                    dst.tokens.push((range, tokens_for_range));
+                }
+            }
+
+            doc.set_semantic_tokens(view_id, dst);
+        },
+    );
+
+    Some(callback)
+}

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1387,6 +1387,66 @@ fn tree_sitter_scopes(
     Ok(())
 }
 
+fn semantic_tokens(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    if !cx.editor.config().lsp.enable_semantic_tokens_highlighting {
+        cx.editor
+            .set_error("Semantic tokens are disabled in the configuration");
+        return Ok(());
+    }
+
+    let (view, doc) = current!(cx.editor);
+
+    let tokens = match doc.semantic_tokens(view.id) {
+        Some(dst) => &dst.tokens,
+        None => {
+            cx.editor
+                .set_status("No semantic tokens for this view or document");
+            return Ok(());
+        }
+    };
+
+    let text = doc.text().slice(..);
+    let pos = doc.selection(view.id).primary().cursor(text);
+
+    let tokens = tokens
+        .iter()
+        .filter_map(|(r, s)| (r.anchor <= pos && r.head > pos).then_some(s))
+        .collect::<Vec<_>>();
+
+    let contents = if tokens.is_empty() {
+        cx.editor
+            .set_status("No semantic tokens for element under cursor");
+        return Ok(());
+    } else if tokens.len() == 1 {
+        format!("```json\n{:?}\n```", tokens[0])
+    } else {
+        format!("```json\n{:?}\n```", tokens)
+    };
+
+    let callback = async move {
+        let call: job::Callback = Callback::EditorCompositor(Box::new(
+            move |editor: &mut Editor, compositor: &mut Compositor| {
+                let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
+                let popup = Popup::new("hover", contents).auto_close(true);
+                compositor.replace_or_push("hover", popup);
+            },
+        ));
+        Ok(call)
+    };
+
+    cx.jobs.callback(callback);
+
+    Ok(())
+}
+
 fn vsplit(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -2355,7 +2415,14 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             doc: "Display tree sitter scopes, primarily for theming and development.",
             fun: tree_sitter_scopes,
             completer: None,
-       },
+        },
+        TypableCommand {
+            name: "semantic-tokens",
+            aliases: &[],
+            doc: "Display the semantic tokens, primarily for theming and development.",
+            fun: semantic_tokens,
+            completer: None,
+        },
         TypableCommand {
             name: "debug-start",
             aliases: &["dbg"],

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -377,6 +377,8 @@ pub struct LspConfig {
     pub auto_signature_help: bool,
     /// Display docs under signature help popup
     pub display_signature_help_docs: bool,
+    /// Enable semantic tokens highlighting
+    pub enable_semantic_tokens_highlighting: bool,
 }
 
 impl Default for LspConfig {
@@ -386,6 +388,7 @@ impl Default for LspConfig {
             display_messages: false,
             auto_signature_help: true,
             display_signature_help_docs: true,
+            enable_semantic_tokens_highlighting: false,
         }
     }
 }
@@ -1146,6 +1149,13 @@ impl Editor {
 
     fn _refresh(&mut self) {
         let config = self.config();
+
+        if !config.lsp.enable_semantic_tokens_highlighting {
+            for doc in self.documents_mut() {
+                doc.reset_all_semantic_tokens();
+            }
+        }
+
         for (view, _) in self.tree.views_mut() {
             let doc = doc_mut!(self, &view.doc);
             view.sync_changes(doc);


### PR DESCRIPTION
This PR introduces Semantic Highlighting capabilities to Helix.

## Unresolved question

In this first version, all semantic highlighting is done via a dumb list like this:

![Output of `:semantic-token` command in Helix with this PR](https://user-images.githubusercontent.com/7951708/221375203-edd5717c-68c8-4d9f-8854-e7483ce2dfa2.png)

But VsCode does it like this (https://rust-analyzer.github.io/manual.html#semantic-style-customizations):

```jsonc
{
  "editor.semanticTokenColorCustomizations": {
    "rules": {
      "*.mutable": {
        "fontStyle": "underline", // underline is the default
      },
    }
  },
}
```

I much prefer VsCode's version since it allows applying modifiers only to certain elements, like `variable.mutable`,
without too much repetions.

In a first version I could simply concatenate everything under `semantic.<type>.<mod1>.<mod2>...` so that people can
at least narrow it like in VsCode (though it will need dozens of similar lines).

Do we want the "glob-like" patterns in this PR or in a follow-up ?