### PR TITLE
Rename the json server executable

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -154,7 +154,7 @@ scope = "source.json"
 injection-regex = "json"
 file-types = ["json", "jsonc"]
 roots = []
-language-server = { command = "vscode-json-language-server", args = ["--stdio"] }
+language-server = { command = "vscode-json-languageserver", args = ["--stdio"] }
 auto-format = true
 config = { "provideFormatter" = true }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Installing the language server from NPM has the name set to `vscode-json-languageserver`

Currently, it needs to be edited manually in `languages.toml` file for it to be recognised.