### PR TITLE
Fix diagnostic underline colors in catppuccin themes

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -103,10 +103,10 @@
 "ui.menu" = { fg = "overlay2", bg = "surface0" }
 "ui.menu.selected" = { fg = "text", bg = "surface1", modifiers = ["bold"] }
 
-"diagnostic.error".underline = { color = "red", style = "curl" }
-"diagnostic.warning".underline = { color = "yellow", style = "curl" }
-"diagnostic.info".underline = { color = "sky", style = "curl" }
-"diagnostic.hint".underline = { color = "teal", style = "curl" }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "sky", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
 
 error = "red"
 warning = "yellow"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -103,10 +103,10 @@
 "ui.menu" = { fg = "overlay2", bg = "surface0" }
 "ui.menu.selected" = { fg = "text", bg = "surface1", modifiers = ["bold"] }
 
-"diagnostic.error" = { fg = "red", underline = { color = "red", style = "curl" } }
-"diagnostic.warning" = { fg = "yellow", underline = { color = "yellow", style = "curl" } }
-"diagnostic.info" = { fg = "sky", underline = { color = "sky", style = "curl" } }
-"diagnostic.hint" = { fg = "teal", underline = { color = "teal", style = "curl" } }
+"diagnostic.error".underline = { color = "red", style = "curl" }
+"diagnostic.warning".underline = { color = "yellow", style = "curl" }
+"diagnostic.info".underline = { color = "sky", style = "curl" }
+"diagnostic.hint".underline = { color = "teal", style = "curl" }
 
 error = "red"
 warning = "yellow"


### PR DESCRIPTION
The current behavior sets the foreground color, and this is very difficult to read. Instead, only the underline itself should be a different color.