### PR TITLE
Add ability to disable typed command completion.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -57,6 +57,7 @@ on unix operating systems.
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file. | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `command-completion` | Whether to show completion for typed (`:`) commands. Can be `always`, `never` or `arguments` (only show contextual completion for arguments passed to commands). | `always` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2546,6 +2546,7 @@ pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableComma
 
 #[allow(clippy::unnecessary_unwrap)]
 pub(super) fn command_mode(cx: &mut Context) {
+    use helix_view::editor::CommandCompletion;
     use shellwords::Shellwords;
 
     let mut prompt = Prompt::new(
@@ -2559,6 +2560,10 @@ pub(super) fn command_mode(cx: &mut Context) {
             let words = shellwords.words();
 
             if words.is_empty() || (words.len() == 1 && !shellwords.ends_with_whitespace()) {
+                if editor.config().command_completion != CommandCompletion::Always {
+                    return Vec::new();
+                }
+
                 // If the command has not been finished yet, complete commands.
                 let mut matches: Vec<_> = typed::TYPABLE_COMMAND_LIST
                     .iter()
@@ -2575,6 +2580,10 @@ pub(super) fn command_mode(cx: &mut Context) {
                     .map(|(name, _)| (0.., name.into()))
                     .collect()
             } else {
+                if editor.config().command_completion == CommandCompletion::Never {
+                    return Vec::new();
+                }
+
                 // Otherwise, use the command's completer and the last shellword
                 // as completion input.
                 let (part, part_len) = if words.len() == 1 || shellwords.ends_with_whitespace() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -274,6 +274,7 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     pub soft_wrap: SoftWrap,
+    pub command_completion: CommandCompletion,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -573,6 +574,23 @@ impl Default for BufferLine {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CommandCompletion {
+    /// Do not display any completion when typing commands
+    Never,
+    /// Display completion immediately when typing commands, including the command itself
+    Always,
+    /// Only display completion for arguments to commands
+    Arguments,
+}
+
+impl Default for CommandCompletion {
+    fn default() -> Self {
+        CommandCompletion::Always
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LineNumber {
@@ -772,6 +790,7 @@ impl Default for Config {
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
             soft_wrap: SoftWrap::default(),
+            command_completion: CommandCompletion::default(),
         }
     }
 }


### PR DESCRIPTION
This is a naive implementation of #5354.

Notes:
* Because of how completion functions work, this both _hides_ the pop-up that completes the command names and arguments _and_ prevents tab completion from working.
* The contextual popups when you match a command are still shown.

It might be that what we really want is a configuration option either for all completors or for this completor specifically that suppresses the popup _until_ <kbd>tab</kbd> is pressed, but still completes the commands in the background. When I ran this with `never` I, personally, found not having tab completion a big setback. That said, it's an option for a reason and some users are clearly interested in it (I've seen people ask on Matrix and Reddit as well).