### PR TITLE
Ignore key-release keyboard events

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -638,6 +638,11 @@ impl Application {
                 self.compositor
                     .handle_event(&Event::Resize(width, height), &mut cx)
             }
+            // Ignore keyboard release events.
+            CrosstermEvent::Key(crossterm::event::KeyEvent {
+                kind: crossterm::event::KeyEventKind::Release,
+                ..
+            }) => false,
             event => self.compositor.handle_event(&event.into(), &mut cx),
         };
 


### PR DESCRIPTION
Since crossterm 0.26.x, we receive press/release keyboard events on Windows always. We can ignore the release events though to emulate the behavior of keyboard input on Windows on crossterm 0.25.x.

Fixes #6133