### PR TITLE
Fix scrolloff at view bottom

### DIFF
--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -242,7 +242,7 @@ impl View {
                 at_top = true;
                 true
             }
-            Some((visual_pos, _)) if visual_pos.row >= vertical_viewport_end - scrolloff => {
+            Some((visual_pos, _)) if visual_pos.row + scrolloff + 1 >= vertical_viewport_end => {
                 if CENTERING && visual_pos.row >= vertical_viewport_end {
                     // cursor out of view
                     return None;
@@ -257,7 +257,7 @@ impl View {
             let v_off = if at_top {
                 scrolloff as isize
             } else {
-                viewport.height as isize - scrolloff as isize
+                viewport.height as isize - scrolloff as isize - 1
             };
             (offset.anchor, offset.vertical_offset) =
                 char_idx_at_visual_offset(doc_text, cursor, -v_off, 0, &text_fmt, &annotations);


### PR DESCRIPTION
Fixes #6141

Fixes a regression introduced in #5420 where a scrolloff of `x - 1` was used instead of `x` at the bottom of the screen (but not at the top). This was especially problematic if the scrolloff was set to `0` in that case the scrolloff behaved as tough set to `-1` and the cursor disappeared from the view if scrolled to the bottom (see #6141).
