### PR TITLE
Fix 'attempt to divide by zero' panic

### DIFF
--- a/helix-term/src/ui/text.rs
+++ b/helix-term/src/ui/text.rs
@@ -58,7 +58,7 @@ pub fn required_size(text: &tui::text::Text, max_text_width: u16) -> (u16, u16) 
         let content_width = content.width() as u16;
         if content_width > max_text_width {
             text_width = max_text_width;
-            height += content_width / max_text_width;
+            height += content_width.checked_div(max_text_width).unwrap_or(0);
         } else if content_width > text_width {
             text_width = content_width;
         }


### PR DESCRIPTION
Helix crashed when I cut the window too much.
```
thread 'main' panicked at 'attempt to divide by zero', helix-term/src/ui/text.rs:61:23
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:64:14
   2: core::panicking::panic
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:111:5
   3: helix_term::ui::text::required_size
   4: <helix_term::ui::markdown::Markdown as helix_term::compositor::Component>::required_size
   5: <helix_term::ui::popup::Popup<T> as helix_term::compositor::Component>::required_size
   6: <helix_term::ui::popup::Popup<T> as helix_term::compositor::Component>::render
   7: helix_term::application::Application::render::{{closure}}
   8: helix_term::application::Application::run::{{closure}}
   9: tokio::runtime::park::CachedParkThread::block_on
  10: tokio::runtime::runtime::Runtime::block_on
  11: hx::main
```