### PR TITLE
tui: Only query keyboard enhancement support once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "crossterm",
  "helix-core",
  "helix-view",
+ "once_cell",
  "serde",
  "termini",
  "unicode-segmentation",

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -112,12 +112,10 @@ fn restore_term() -> Result<(), Error> {
     let mut stdout = stdout();
     // reset cursor shape
     write!(stdout, "\x1B[0 q")?;
-    if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
-        execute!(stdout, PopKeyboardEnhancementFlags)?;
-    }
     // Ignore errors on disabling, this might trigger on windows if we call
     // disable without calling enable previously
     let _ = execute!(stdout, DisableMouseCapture);
+    let _ = execute!(stdout, PopKeyboardEnhancementFlags);
     execute!(
         stdout,
         DisableBracketedPaste,
@@ -1071,7 +1069,10 @@ impl Application {
         if self.config.load().editor.mouse {
             execute!(stdout, EnableMouseCapture)?;
         }
-        if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
+        if matches!(
+            self.terminal.supports_keyboard_enhancement_protocol(),
+            Ok(true)
+        ) {
             log::debug!("The enhanced keyboard protocol is supported on this terminal");
             execute!(
                 stdout,

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -22,5 +22,6 @@ unicode-segmentation = "1.10"
 crossterm = { version = "0.26", optional = true }
 termini = "0.1"
 serde = { version = "1", "optional" = true, features = ["derive"]}
+once_cell = "1.17"
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -10,6 +10,7 @@ use crossterm::{
     Command,
 };
 use helix_view::graphics::{Color, CursorKind, Modifier, Rect, UnderlineStyle};
+use once_cell::sync::OnceCell;
 use std::{
     fmt,
     io::{self, Write},
@@ -52,6 +53,7 @@ impl Capabilities {
 pub struct CrosstermBackend<W: Write> {
     buffer: W,
     capabilities: Capabilities,
+    supports_keyboard_enhancement_protocol: OnceCell<bool>,
 }
 
 impl<W> CrosstermBackend<W>
@@ -62,6 +64,7 @@ where
         CrosstermBackend {
             buffer,
             capabilities: Capabilities::from_env_or_default(),
+            supports_keyboard_enhancement_protocol: OnceCell::new(),
         }
     }
 }
@@ -186,6 +189,12 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.buffer.flush()
+    }
+
+    fn supports_keyboard_enhancement_protocol(&self) -> Result<bool, io::Error> {
+        self.supports_keyboard_enhancement_protocol
+            .get_or_try_init(terminal::supports_keyboard_enhancement)
+            .copied()
     }
 }
 

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -23,4 +23,5 @@ pub trait Backend {
     fn clear(&mut self) -> Result<(), io::Error>;
     fn size(&self) -> Result<Rect, io::Error>;
     fn flush(&mut self) -> Result<(), io::Error>;
+    fn supports_keyboard_enhancement_protocol(&self) -> Result<bool, io::Error>;
 }

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -147,4 +147,8 @@ impl Backend for TestBackend {
     fn flush(&mut self) -> Result<(), io::Error> {
         Ok(())
     }
+
+    fn supports_keyboard_enhancement_protocol(&self) -> Result<bool, io::Error> {
+        Ok(false)
+    }
 }

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -222,4 +222,10 @@ where
     pub fn size(&self) -> io::Result<Rect> {
         self.backend.size()
     }
+
+    /// Checks whether the host terminal emulator supports the keyboard
+    /// enhancement protocol for disambiguating keycodes.
+    pub fn supports_keyboard_enhancement_protocol(&self) -> io::Result<bool> {
+        self.backend.supports_keyboard_enhancement_protocol()
+    }
 }


### PR DESCRIPTION
We query the host terminal emulator to check whether it supports the keyboard enhancement protocol after entering raw mode on startup. We only need to check this value once though, so we can store the result in a OnceCell to prevent repeated queries. The query for keyboard enhancement support times out and fails when suspending (C-z) and resuming (`fg`) which can cause delays and leaves sequences in the terminal after Helix suspends or exits. Caching in the OnceCell prevents this behavior.

Fixes #6149