### PR TITLE
Theme: Papercolor: Add ui.highlight

### DIFF
--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -7,6 +7,7 @@
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
 "ui.selection" = {bg="selection_background", fg="selection_foreground"}
 "ui.cursorline" = {bg="cursorline_background"}
+"ui.highlight" = {bg="cursorline_background"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -6,6 +6,7 @@
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
 "ui.selection" = {bg="selection_background", fg="selection_foreground"}
+"ui.highlight" = {bg="cursorline_background"}
 "ui.cursorline" = {bg="cursorline_background"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}


### PR DESCRIPTION
Using the picker with syntax highlighting the
fallback `ui.selection` makes a lot of text,
especially for the light variant, hard to read.

Instead, use a lighter background for highlights
