### PR TITLE
CI: Update cachix/install-nix-action to v20

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install nix
-      uses: cachix/install-nix-action@v19
+      uses: cachix/install-nix-action@v20
 
     - name: Authenticate with Cachix
       uses: cachix/cachix-action@v12


### PR DESCRIPTION
This fixes an issue with installing Nix 1.14 which causes the cachix/cachix-action in the next step to fail.

See https://github.com/cachix/install-nix-action/issues/161