### PR TITLE
book: fix code highlighting in light theme

### DIFF
--- a/book/theme/css/variables.css
+++ b/book/theme/css/variables.css
@@ -131,7 +131,7 @@
 
     --links: #20609f;
 
-    --inline-code-color: #301900;
+    --inline-code-color: #a39e9b;
 
     --theme-popup-bg: #fafafa;
     --theme-popup-border: #cccccc;


### PR DESCRIPTION
ref. #3914

Inline code is not readable in nested lists and in table headers.

![image](https://user-images.githubusercontent.com/255417/222670560-f3055c01-a219-4c7d-937e-e69bd7cb9beb.png)

The offending CSS rule is [this one](https://github.com/helix-editor/helix/blob/ddc5bf4e606230dd8bc20c59b1cc114e93bbf1c0/book/theme/css/chrome.css#L199-L202):
```css
:not(pre):not(a):not(td):not(p) > .hljs {
    color: var(--inline-code-color);
    overflow-x: initial;
}
```

`--inline-code-color` is too dark and blends with the background. This variable was changed in https://github.com/helix-editor/helix/commit/4260b31ec059ffa2207f8f2541af1c3996b00cf9. The CSS rule was extended with `:not(td):not(p)` to fix blending in `p` and `td`.

But now inline code occurs in `li` and `th` also. It is possible to extend the with `:not(th):not(li)` but this will affect other color themes and potentially will make them less colorful. E.g. in `aui` orange here becomes grey:
![image](https://user-images.githubusercontent.com/255417/222678060-458eb7c2-7313-4c1c-96bb-506fa4a49baf.png)

Seems that the easiest solution that fixes readability of the light theme and does not affect other themes is to revert `--inline-code-color` to its original value.
