### PR TITLE
fix: Handle signals before crossterm events

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -345,11 +345,11 @@ impl Application {
             tokio::select! {
                 biased;
 
-                Some(event) = input_stream.next() => {
-                    self.handle_terminal_events(event).await;
-                }
                 Some(signal) = self.signals.next() => {
                     self.handle_signals(signal).await;
+                }
+                Some(event) = input_stream.next() => {
+                    self.handle_terminal_events(event).await;
                 }
                 Some(callback) = self.jobs.futures.next() => {
                     self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);


### PR DESCRIPTION
Since https://github.com/helix-editor/helix/commit/79bf5e3094e16a34637703b14c7bf090d2dcf155 `C-z` and `fg` has taken 2 seconds for me. This small change fixes that.