### PR TITLE
Fix completion race conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
+ "parking_lot",
  "serde",
  "serde_json",
  "slotmap",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5,6 +5,7 @@ pub(crate) mod typed;
 pub use dap::*;
 use helix_vcs::Hunk;
 pub use lsp::*;
+use tokio::sync::oneshot;
 use tui::widgets::Row;
 pub use typed::*;
 
@@ -4166,6 +4167,24 @@ pub fn completion(cx: &mut Context) {
         None => return,
     };
 
+    // setup a chanel that allows the request to be canceled
+    let (tx, rx) = oneshot::channel();
+    // set completion_request so that this request can be canceled
+    // by setting completion_request, the old channel stored there is dropped
+    // and the associated request is automatically dropped
+    cx.editor.completion_request_handle = Some(tx);
+    let future = async move {
+        tokio::select! {
+            biased;
+            _ = rx => {
+                Ok(serde_json::Value::Null)
+            }
+            res = future => {
+                res
+            }
+        }
+    };
+
     let trigger_offset = cursor;
 
     // TODO: trigger_offset should be the cursor offset but we also need a starting offset from where we want to apply
@@ -4178,11 +4197,19 @@ pub fn completion(cx: &mut Context) {
     let start_offset = cursor.saturating_sub(offset);
     let savepoint = doc.savepoint(view);
 
+    let trigger_doc = doc.id();
+    let trigger_view = view.id;
+
     cx.callback(
         future,
         move |editor, compositor, response: Option<lsp::CompletionResponse>| {
-            if editor.mode != Mode::Insert {
-                // we're not in insert mode anymore
+            let (view, doc) = current_ref!(editor);
+            // check if the completion request is stale.
+            //
+            // Completions are completed asynchrounsly and therefore the user could
+            //switch document/view or leave insert mode. In all of thoise cases the
+            // completion should be discarded
+            if editor.mode != Mode::Insert || view.id != trigger_view || doc.id() != trigger_doc {
                 return;
             }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4176,7 +4176,7 @@ pub fn completion(cx: &mut Context) {
     iter.reverse();
     let offset = iter.take_while(|ch| chars::char_is_word(*ch)).count();
     let start_offset = cursor.saturating_sub(offset);
-    doc.savepoint();
+    doc.savepoint(&view);
 
     cx.callback(
         future,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4176,7 +4176,7 @@ pub fn completion(cx: &mut Context) {
     iter.reverse();
     let offset = iter.take_while(|ch| chars::char_is_word(*ch)).count();
     let start_offset = cursor.saturating_sub(offset);
-    doc.savepoint(&view);
+    let savepoint = doc.savepoint(view);
 
     cx.callback(
         future,
@@ -4204,6 +4204,7 @@ pub fn completion(cx: &mut Context) {
             let ui = compositor.find::<ui::EditorView>().unwrap();
             ui.set_completion(
                 editor,
+                savepoint,
                 items,
                 offset_encoding,
                 start_offset,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4176,6 +4176,7 @@ pub fn completion(cx: &mut Context) {
     iter.reverse();
     let offset = iter.take_while(|ch| chars::char_is_word(*ch)).count();
     let start_offset = cursor.saturating_sub(offset);
+    doc.savepoint();
 
     cx.callback(
         future,

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -193,7 +193,7 @@ impl Completion {
                     );
 
                     // initialize a savepoint
-                    doc.savepoint();
+                    doc.savepoint(&view);
                     doc.apply(&transaction, view.id);
 
                     editor.last_completion = Some(CompleteAction {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -820,6 +820,7 @@ impl EditorView {
                 (Mode::Insert, Mode::Normal) => {
                     // if exiting insert mode, remove completion
                     self.completion = None;
+                    cxt.editor.completion_request_handle = None;
 
                     // TODO: Use an on_mode_change hook to remove signature help
                     cxt.jobs.callback(async {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -914,8 +914,8 @@ impl EditorView {
                                 doc.apply(&tx, view.id);
                             }
                             InsertEvent::TriggerCompletion => {
-                                let (_, doc) = current!(cxt.editor);
-                                doc.savepoint();
+                                let (view, doc) = current!(cxt.editor);
+                                doc.savepoint(view);
                             }
                         }
                     }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -957,9 +957,6 @@ impl EditorView {
             return;
         }
 
-        // Immediately initialize a savepoint
-        doc_mut!(editor).savepoint();
-
         editor.last_completion = None;
         self.last_insert.1.push(InsertEvent::TriggerCompletion);
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -940,17 +940,25 @@ impl EditorView {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn set_completion(
         &mut self,
         editor: &mut Editor,
+        savepoint: Arc<SavePoint>,
         items: Vec<helix_lsp::lsp::CompletionItem>,
         offset_encoding: helix_lsp::OffsetEncoding,
         start_offset: usize,
         trigger_offset: usize,
         size: Rect,
     ) {
-        let mut completion =
-            Completion::new(editor, items, offset_encoding, start_offset, trigger_offset);
+        let mut completion = Completion::new(
+            editor,
+            savepoint,
+            items,
+            offset_encoding,
+            start_offset,
+            trigger_offset,
+        );
 
         if completion.is_empty() {
             // skip if we got no completion results
@@ -969,8 +977,6 @@ impl EditorView {
         self.completion = None;
 
         // Clear any savepoints
-        let doc = doc_mut!(editor);
-        doc.savepoint = None;
         editor.clear_idle_timer(); // don't retrigger
     }
 

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -43,6 +43,7 @@ toml = "0.7"
 log = "~0.4"
 
 which = "4.4"
+parking_lot = "0.12.1"
 
 
 [target.'cfg(windows)'.dependencies]

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -941,7 +941,8 @@ impl Document {
     }
 
     pub fn savepoint(&mut self) {
-        self.savepoint = Some(Transaction::new(self.text()));
+        self.savepoint =
+            Some(Transaction::new(self.text()).with_selection(self.selection(view.id).clone()));
     }
 
     pub fn restore(&mut self, view: &mut View) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -31,7 +31,7 @@ use std::{
 use tokio::{
     sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-        Notify, RwLock,
+        oneshot, Notify, RwLock,
     },
     time::{sleep, Duration, Instant, Sleep},
 };
@@ -881,6 +881,14 @@ pub struct Editor {
     /// avoid calculating the cursor position multiple
     /// times during rendering and should not be set by other functions.
     pub cursor_cache: Cell<Option<Option<Position>>>,
+    /// When a new completion request is sent to the server old
+    /// unifinished request must be dropped. Each completion
+    /// request is associated with a channel that cancels
+    /// when the channel is dropped. That channel is stored
+    /// here. When a new completion request is sent this
+    /// field is set and any old requests are automatically
+    /// canceled as a result
+    pub completion_request_handle: Option<oneshot::Sender<()>>,
 }
 
 pub type RedrawHandle = (Arc<Notify>, Arc<RwLock<()>>);
@@ -979,6 +987,7 @@ impl Editor {
             redraw_handle: Default::default(),
             needs_redraw: false,
             cursor_cache: Cell::new(None),
+            completion_request_handle: None,
         }
     }
 


### PR DESCRIPTION
Supercedes #1819

This PR resolves multiple problems with the completions.
The root cause of all of these issues were shortcomings in the way savepoints are handled.
Savepoints are set when a completion is triggered so that the changes sent by the server
can be applied correctly (refer to the same document).

The exact explanation is a bit tricky. I will provide an overview here but looking at the commits individually also helps. Every commit has a separate explanation/justification and usually just contains a couple of LOC of changes and therefore makes the explanation more digestible.

# Overview
 
The savepoint is currently created when the completion request **response was received**. However, a (spec compliant) language server computes the completion response for the document state when it **receives the completion request**. That means that any changes between sending the completion requests to the server and receiving a response can cause all kinds of issues. For example if completion is requested at `foo::` and you keep typing `ba` before the response arrives and then select the `bar` completion the result is `foo::babar` instead of `foo::bar`.

The savepoint was moved to the completion request in 5545aad. However, this actually introduces new issues as there is only a single savepoint tracked on the document at a given time. The completion popup restores the savepoint whenever a new completion option is selected. However, if a new completion request is created while the completion popup is open (idle timeout) and a completion is selected before a response is received, then the completion popup would restore the wrong savepoint (as the savepoint was overwritten during the request). To alleviate that problem the savepoint mechanism was changed in 7e42f25 so that we can track an arbitrary number of (reference counted) snapshots on the document.

I noticed that multiple completion requests could be active at the same time (either because of low idle timeout values or because the user manually invoked `<C-x>`). Because LSP servers can arbitrarily reorder non-dependent requests (and it's random which response helix processes first if both finish at the same time) these completions are essentially racing. This is not as much of an issue anymore with the previous fixes, but it can cause an outdated completion request to replace the current completion request (which is not good). It can also cause some flickering. Most importantly it makes the association of savepoints to the completion popup essentially non-deterministic and therefore impossible to repeat correctly (see below). Therefore, I introduced a mechanism to automatically discard any running completion requests when a new one is created in 0a22fd2. Completion requests are also discarded if view/document changes.

Repeating completions also operated under the assumption that completion trigger creates savepoints. As this is not the case anymore I had to add an `InsertEvent` for requesting completions. When this event is replayed a new savepoint is created and saved. When the `TriggerCompletion` event is replayed the savepoint from the last request is set as activated (simply moved to a different variable). From that point forward any `CompletionAction` events will use that savepoint. For this to work it's critical that the `TriggerCompletion` event always belongs to the last completion request (otherwise the wrong savepoint is used). That is ensured by dropping stale completion requests (explained in the previous paragraph).


Another small fix included here: Savepoints now also store the selection. This is important since we apply multicursor completions relative to the selections. Usually this wasn't necessary because cursors tend to map back to the same position. However, this isn't always the case and can cause weird behavior in edgecase. In particular with snippet support (#5864) some completion snippets can cause more complex changes/arbitrary selection changes, and it's important that the selection is fully reset.
