### PR TITLE
[WIP] Add option documentation to :set-option, :get-option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1092,7 @@ dependencies = [
  "quickcheck",
  "regex",
  "ropey",
+ "schemars",
  "serde",
  "serde_json",
  "slotmap",
@@ -1181,6 +1188,7 @@ dependencies = [
  "log",
  "once_cell",
  "pulldown-cmark",
+ "schemars",
  "serde",
  "serde_json",
  "signal-hook",
@@ -1244,6 +1252,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
+ "schemars",
  "serde",
  "serde_json",
  "slotmap",
@@ -1762,6 +1771,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1820,17 @@ name = "serde_derive"
 version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2469,5 +2513,7 @@ dependencies = [
  "helix-loader",
  "helix-term",
  "helix-view",
+ "schemars",
+ "serde_json",
  "toml",
 ]

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -46,6 +46,7 @@ chrono = { version = "0.4", default-features = false, features = ["alloc", "std"
 
 etcetera = "0.4"
 textwrap = "0.16.0"
+schemars = { version = "0.8.12", features = ["derive_json_schema"] }
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 use once_cell::sync::{Lazy, OnceCell};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use helix_loader::grammar::{get_language, load_runtime_file};
@@ -286,7 +287,7 @@ pub struct IndentationConfiguration {
 }
 
 /// Configuration for auto pairs
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields, untagged)]
 pub enum AutoPairConfig {
     /// Enables or disables auto pairing. False means disabled. True means to use the default pairs.
@@ -547,7 +548,7 @@ impl LanguageConfiguration {
             .ok()
     }
 }
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SoftWrap {
     /// Soft wrap lines that exceed viewport width. Default to off

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -65,6 +65,7 @@ serde = { version = "1.0", features = ["derive"] }
 # ripgrep for global search
 grep-regex = "0.1.11"
 grep-searcher = "0.1.11"
+schemars = { version = "0.8.12", features = ["derive_json_schema"] }
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1,5 +1,6 @@
 pub(crate) mod dap;
 pub(crate) mod lsp;
+pub(crate) mod runtime_options;
 pub(crate) mod typed;
 
 pub use dap::*;

--- a/helix-term/src/commands/runtime_options.rs
+++ b/helix-term/src/commands/runtime_options.rs
@@ -1,0 +1,419 @@
+use std::collections::HashMap;
+
+use schemars::schema_for;
+use serde;
+
+#[derive(Debug)]
+pub struct Options {
+    options: HashMap<String, Option>,
+}
+
+#[derive(Debug)]
+pub struct Documentation {
+    pub default: std::option::Option<String>,
+    pub description: std::option::Option<String>,
+}
+
+#[derive(Debug)]
+struct Option {
+    documentation: Documentation,
+    validation: std::option::Option<Validation>,
+}
+
+#[derive(Debug)]
+struct Validation {
+    kind: std::option::Option<OptionKind>,
+    one_of: std::option::Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+enum OptionKind {
+    Boolean,
+    Numeric,
+}
+
+#[derive(Default)]
+struct OptionBuilder {
+    default: std::option::Option<String>,
+    description: std::option::Option<String>,
+    validation: std::option::Option<Validation>,
+}
+
+impl Option {
+    fn builder() -> OptionBuilder {
+        OptionBuilder::default()
+    }
+}
+
+impl OptionBuilder {
+    fn with_description<T>(mut self, description: T) -> Self
+    where
+        T: Into<std::option::Option<String>>,
+    {
+        self.description = description.into();
+        self
+    }
+
+    fn with_default<T>(mut self, default: T) -> Self
+    where
+        T: Into<std::option::Option<String>>,
+    {
+        self.default = default.into();
+        self
+    }
+
+    fn must_be_boolean(mut self) -> Self {
+        // TODO: Now that we derive this, this is probably overkill.
+        self.validation = Some(Validation {
+            kind: Some(OptionKind::Boolean),
+            one_of: None,
+        });
+        self
+    }
+
+    fn must_be_numeric(mut self) -> Self {
+        self.validation = Some(Validation {
+            kind: Some(OptionKind::Numeric),
+            one_of: None,
+        });
+        self
+    }
+
+    fn must_be_one_of(mut self, values: Vec<String>) -> Self {
+        self.validation = Some(Validation {
+            kind: None,
+            one_of: Some(values),
+        });
+        self
+    }
+
+    fn build(self) -> Option {
+        Option {
+            documentation: Documentation {
+                description: self.description,
+                default: self.default,
+            },
+            validation: self.validation,
+        }
+    }
+}
+
+// `from_config` translates the embedded JSON Schema into a minimal representation
+// of the configuration options available to be set at runtime.
+pub fn from_config() -> anyhow::Result<Options> {
+    use schemars::schema::*;
+
+    let mut options = HashMap::new();
+    let root_schema: RootSchema = schema_for!(helix_view::editor::Config);
+
+    fn bool_to_option(metadata: Metadata) -> Option {
+        Option::builder()
+            .with_default(metadata.default.unwrap().as_bool().map(|b| b.to_string()))
+            .with_description(metadata.description)
+            .must_be_boolean()
+            .build()
+    }
+
+    fn number_to_option(metadata: Metadata) -> Option {
+        Option::builder()
+            .with_default(metadata.default.unwrap().as_u64().map(|n| n.to_string()))
+            .with_description(metadata.description)
+            .must_be_numeric()
+            .build()
+    }
+
+    fn enum_to_option(schemas: &Vec<Schema>, metadata: Metadata) -> Option {
+        Option::builder()
+            .with_default(
+                metadata
+                    .default
+                    // We add _or_default() here because enums with manual Default implementations
+                    // are not picked up by JsonSchema derive. Example: CursorKind.
+                    .unwrap_or_default()
+                    .as_str()
+                    .map(|s| s.to_owned()),
+            )
+            .with_description(metadata.description)
+            .must_be_one_of(
+                schemas
+                    .iter()
+                    .map(|s| s.clone().into_object())
+                    .flat_map(|s| s.enum_values.unwrap_or_default())
+                    .map(|v| v.as_str().unwrap().to_owned())
+                    .collect(),
+            )
+            .build()
+    }
+
+    // For options where we don't have runtime validation on :set-option, still extract
+    // the default and doc comment for use in the editor and during documentation generation.
+    fn no_validation_option(metadata: Metadata) -> Option {
+        Option::builder()
+            // REVIEW: This formats the default as JSON. This is probably correct or close most of the time.
+            .with_default(metadata.default.map(|v| v.to_string()))
+            .with_description(metadata.description)
+            .build()
+    }
+
+    fn qualify_prefix(prefix: &Vec<String>, node: String) -> String {
+        let mut prefix = prefix.clone();
+        prefix.push(node);
+        prefix.join(".")
+    }
+
+    fn traverse_schema(
+        prefix: Vec<String>,
+        root_schema: &RootSchema,
+        mut schema: SchemaObject,
+        options: &mut HashMap<String, Option>,
+    ) {
+        use schemars::schema::SingleOrVec::{Single, Vec};
+
+        for (key, value) in &schema.object().properties {
+            let qualified_option_name = qualify_prefix(&prefix, key.to_owned());
+            log::debug!("inspecting schema for {}", qualified_option_name);
+
+            match value {
+                Schema::Object(object) => {
+                    let mut object = object.clone();
+                    let metadata = object.clone().metadata().clone();
+
+                    match &object.instance_type {
+                        Some(Single(t)) if **t == InstanceType::Boolean => {
+                            options.insert(qualified_option_name, bool_to_option(metadata));
+                        }
+
+                        Some(Single(t)) if **t == InstanceType::Integer => {
+                            options.insert(qualified_option_name, number_to_option(metadata));
+                        }
+
+                        Some(Single(t)) if **t == InstanceType::Array => {
+                            options.insert(qualified_option_name, no_validation_option(metadata));
+                        }
+
+                        Some(Single(s)) if **s == InstanceType::String => {
+                            // TODO: We could adapt the string validation from JsonSchema for min/max
+                            //       length and patterns. For `char` types it correctly sets length 1,
+                            //       for example.
+                            options.insert(qualified_option_name, no_validation_option(metadata));
+                        }
+
+                        // TODO: Other optional types could be supported.
+                        Some(Vec(v)) if **v == vec![InstanceType::Integer, InstanceType::Null] => {
+                            // TODO: This isn't quite right as "null" is currently accepted.
+                            options.insert(qualified_option_name, number_to_option(metadata));
+                        }
+
+                        // This is what happens when another enum or struct is referenced.
+                        None if object.subschemas.is_some() => {
+                            // If we have an allOf schema, we might be an enum.
+                            if let Some(schemas) = &object.subschemas().all_of {
+                                let reference =
+                                    schemas.first().map(|s| s.clone().into_object().reference);
+
+                                if let Some(Some(reference_id)) = reference {
+                                    let reference_id = reference_id.split("/").last().unwrap();
+
+                                    let mut definition = root_schema
+                                        .definitions
+                                        .get(reference_id)
+                                        .unwrap()
+                                        .clone()
+                                        .into_object();
+
+                                    // If the definition has a subschema oneOf, it's likely an enum.
+                                    if let Some(schemas) = &definition.subschemas().one_of {
+                                        options.insert(
+                                            key.to_owned(),
+                                            enum_to_option(schemas, metadata),
+                                        );
+                                    } else if definition.object.is_some() {
+                                        let mut prefix = prefix.clone();
+                                        prefix.push(key.to_owned());
+
+                                        log::debug!("recursing: {:?}", prefix);
+
+                                        // If the definition has object validations, it's a sub-structure we
+                                        // should recurse into.
+                                        traverse_schema(prefix, &root_schema, definition, options);
+                                    } else {
+                                        log::debug!(
+                                            "unhandled referenced subschema: {}:\n{:#?}",
+                                            qualified_option_name,
+                                            definition.subschemas()
+                                        );
+                                    }
+                                } else {
+                                    log::debug!(
+                                        "invalid reference_id for {}: {:?}",
+                                        qualified_option_name,
+                                        reference
+                                    );
+                                }
+                            } else {
+                                log::debug!(
+                                    "unhandled subschema type: {}:\n{:#?}",
+                                    qualified_option_name,
+                                    object.subschemas()
+                                );
+                            }
+                        }
+                        _ => {
+                            log::debug!("option cannot be parsed: {}", qualified_option_name);
+                            log::debug!("\n{:#?}", object);
+                        }
+                    }
+                }
+                _ => {
+                    log::debug!(
+                        "option did not have Object schema: {}",
+                        qualified_option_name
+                    );
+                    log::debug!("\n{:#?}", value);
+                }
+            }
+        }
+    }
+
+    traverse_schema(
+        vec![],
+        &root_schema,
+        root_schema.schema.clone(),
+        &mut options,
+    );
+
+    // log::debug!("options: {:?}", options);
+
+    Ok(Options { options })
+}
+
+impl Options {
+    pub fn get_help(&self, name: &str) -> std::option::Option<&Documentation> {
+        self.options.get(name).map(|o| &o.documentation)
+    }
+
+    pub fn validate(&self, name: &str, value: &str) -> anyhow::Result<()> {
+        match self.options.get(name).map(|o| &o.validation) {
+            Some(Some(validation)) => validation.validate(value),
+
+            // If we don't have any knowledge of this option, assume it validates. If it's truly invalid,
+            // it will fail to apply to the actual config objects.
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Validation {
+    fn validate(&self, value: &str) -> anyhow::Result<()> {
+        log::debug!("validate: {:?}", self);
+        match self.kind {
+            Some(OptionKind::Numeric) => {
+                if !value.parse::<usize>().is_ok() {
+                    anyhow::bail!("value must be numeric");
+                }
+            }
+            Some(OptionKind::Boolean) => {
+                if !value.parse::<bool>().is_ok() {
+                    anyhow::bail!("value must be one of: true, false");
+                }
+            }
+            None => (),
+        }
+
+        if let Some(one_of) = &self.one_of {
+            if !one_of.iter().any(|v| v == value) {
+                anyhow::bail!("value must be one of: {}", one_of.join(", "));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn test_actual_from_config() {
+    from_config().expect("loads ok");
+}
+
+// #[test]
+// fn test_get_help() {
+//     let options = from_str(
+//         r#"
+//             [my-option]
+//             description = "my excellent option"
+//             default = "`true`"
+
+//             ["nested.my-option"]
+//             description = "into the depths"
+//             default = "`false`"
+//         "#,
+//     )
+//     .expect("should parse");
+
+//     assert_eq!(Some("my excellent option"), options.get_help("my-option"));
+//     assert_eq!(
+//         Some("into the depths"),
+//         options.get_help("nested.my-option")
+//     );
+//     assert_eq!(None, options.get_help("not.a-command"));
+// }
+
+// #[test]
+// fn test_validations() {
+//     let options = from_str(
+//         r#"
+//             [boolean-only]
+//             description = "should be a boolean"
+//             default = "`true`"
+//             validation = { kind = "boolean" }
+
+//             [numeric-only]
+//             description = "should be a number"
+//             default = "`4`"
+//             validation = { kind = "numeric" }
+
+//             [one-of-a-set]
+//             description = "favorite color"
+//             default = "`red`"
+//             validation = { one-of = ["red", "blue", "green"] }
+//         "#,
+//     )
+//     .expect("should parse");
+
+//     #[rustfmt::skip]
+//     let ok_examples = [
+//         ("boolean-only", "true"),
+//         ("boolean-only", "false"),
+
+//         ("numeric-only", "0"),
+//         ("numeric-only", "12319872372"),
+
+//         ("one-of-a-set", "red"),
+//         ("one-of-a-set", "blue"),
+//         ("one-of-a-set", "green"),
+//     ];
+
+//     #[rustfmt::skip]
+//     let fail_examples = [
+//         ("boolean-only", "purple", "value must be one of: true, false"),
+
+//         ("numeric-only", "-1000", "value must be numeric"),
+//         ("numeric-only", "purple", "value must be numeric"),
+
+//         ("one-of-a-set", "purple", "value must be one of: red, blue, green"),
+//     ];
+
+//     for (name, value) in ok_examples {
+//         options
+//             .validate(name, value)
+//             .map_err(|_| format!("{} should allow value {}", name, value))
+//             .unwrap()
+//     }
+
+//     for (name, value, err_msg) in fail_examples {
+//         match options.validate(name, value) {
+//             Ok(_) => assert!(false, "{} should be invalid for {}", value, name),
+//             Err(e) => assert_eq!(err_msg, e.to_string()),
+//         }
+//     }
+// }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -44,6 +44,7 @@ log = "~0.4"
 
 which = "4.4"
 parking_lot = "0.12.1"
+schemars = { version = "0.8.12", features = ["derive_json_schema"] }
 
 
 [target.'cfg(windows)'.dependencies]

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -1,11 +1,12 @@
 use bitflags::bitflags;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{max, min},
     str::FromStr,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// UNSTABLE
 pub enum CursorKind {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,5 @@ helix-core = { version = "0.6", path = "../helix-core" }
 helix-view = { version = "0.6", path = "../helix-view" }
 helix-loader = { version = "0.6", path = "../helix-loader" }
 toml = "0.7"
+schemars = { version = "0.8.12", features = ["derive_json_schema"] }
+serde_json = "1.0.93"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,19 @@ pub mod tasks {
     use crate::themelint::{lint, lint_all};
     use crate::DynError;
 
+    use schemars::schema_for;
+
+    pub fn dump_config_schema() -> Result<(), DynError> {
+        let schema = schema_for!(helix_view::editor::Config);
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&schema).expect("valid schema to be generated")
+        );
+
+        Ok(())
+    }
+
     pub fn docgen() -> Result<(), DynError> {
         write(TYPABLE_COMMANDS_MD_OUTPUT, &typable_commands()?);
         write(LANG_SUPPORT_MD_OUTPUT, &lang_features()?);
@@ -54,6 +67,7 @@ fn main() -> Result<(), DynError> {
             "docgen" => tasks::docgen()?,
             "themelint" => tasks::themelint(env::args().nth(2))?,
             "query-check" => tasks::querycheck()?,
+            "dump-config-schema" => tasks::dump_config_schema()?,
             invalid => return Err(format!("Invalid task name: {}", invalid).into()),
         },
     };


### PR DESCRIPTION
~Closes #5938.~ Oops, I mean closes #5939.

Looking for some early feedback on approach here. The idea is that we move the options from `configuration.md` into a structured format that can be used both by docgen and the help built into the editor.

When combined with #5966 (which suppresses autocomplete for the second argument) this is the user experience:

[![asciicast](https://asciinema.org/a/jUqX3taJbjl0YP7nZN9SpCk38.svg)](https://asciinema.org/a/jUqX3taJbjl0YP7nZN9SpCk38)

If this general direction gets a few :+1:, I would do the following before merge:
- [ ] Finish importing all the options.
- [ ] Update `configuration.md` to be some sort of template that can pull sections of options from `runtime_options::Options` and build the tables dynamically.

Some open questions I have:
* The current approach is hacked in for a subset of specific commands. More generally, we want the ability to defer documentation optionally to a TypedCommand, perhaps by adding a `doc_fn: Option<Fn...>` to TypedCommand?
* Should the option-specific documentation be in _addition_ to the command documentation, perhaps separate by a `===` line, instead of replacing it?
* My `Lazy<Result<...>>` for the reference to `runtime_options::Options` is defensive against the runtime directory not having `help/options.toml`. Is this a good approach? Alternatives?
  * One option would just be baking the options into a const static instead of using toml. Thoughts?

Potential future roadmap:
* Auto-completers with more context that would allow us to auto-complete one-of validations in the editor (bufferline is a prime example).
* Color or popups when the pending value is not correct.
* More specific validators: numeric ranges, regular expressions, filesystem paths?