### PR TITLE
Move terminal claim/restore to helix-tui, cache keyboard enhancement support query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "helix-core",
  "helix-view",
  "log",
+ "once_cell",
  "serde",
  "termini",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "crossterm",
  "helix-core",
  "helix-view",
+ "log",
  "serde",
  "termini",
  "unicode-segmentation",

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -30,22 +30,14 @@ use crate::{
 
 use log::{debug, error, warn};
 use std::{
-    io::{stdin, stdout, Write},
+    io::{stdin, stdout},
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, Error};
 
-use crossterm::{
-    event::{
-        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
-        EnableFocusChange, EnableMouseCapture, Event as CrosstermEvent, KeyboardEnhancementFlags,
-        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
-    },
-    execute, terminal,
-    tty::IsTty,
-};
+use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
 #[cfg(not(windows))]
 use {
     signal_hook::{consts::signal, low_level},
@@ -63,10 +55,12 @@ use tui::backend::CrosstermBackend;
 use tui::backend::TestBackend;
 
 #[cfg(not(feature = "integration"))]
-type Terminal = tui::terminal::Terminal<CrosstermBackend<std::io::Stdout>>;
+type TerminalBackend = CrosstermBackend<std::io::Stdout>;
 
 #[cfg(feature = "integration")]
-type Terminal = tui::terminal::Terminal<TestBackend>;
+type TerminalBackend = TestBackend;
+
+type Terminal = tui::terminal::Terminal<TerminalBackend>;
 
 pub struct Application {
     compositor: Compositor,
@@ -106,26 +100,6 @@ fn setup_integration_logging() {
         .level(level)
         .chain(std::io::stdout())
         .apply();
-}
-
-fn restore_term() -> Result<(), Error> {
-    let mut stdout = stdout();
-    // reset cursor shape
-    write!(stdout, "\x1B[0 q")?;
-    if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
-        execute!(stdout, PopKeyboardEnhancementFlags)?;
-    }
-    // Ignore errors on disabling, this might trigger on windows if we call
-    // disable without calling enable previously
-    let _ = execute!(stdout, DisableMouseCapture);
-    execute!(
-        stdout,
-        DisableBracketedPaste,
-        DisableFocusChange,
-        terminal::LeaveAlternateScreen
-    )?;
-    terminal::disable_raw_mode()?;
-    Ok(())
 }
 
 impl Application {
@@ -472,13 +446,7 @@ impl Application {
     pub async fn handle_signals(&mut self, signal: i32) {
         match signal {
             signal::SIGTSTP => {
-                // restore cursor
-                use helix_view::graphics::CursorKind;
-                self.terminal
-                    .backend_mut()
-                    .show_cursor(CursorKind::Block)
-                    .ok();
-                restore_term().unwrap();
+                self.restore_term().unwrap();
                 low_level::emulate_default_handler(signal::SIGTSTP).unwrap();
             }
             signal::SIGCONT => {
@@ -1054,37 +1022,19 @@ impl Application {
         }
     }
 
-    async fn claim_term(&mut self) -> Result<(), Error> {
-        use helix_view::graphics::CursorKind;
-        terminal::enable_raw_mode()?;
-        if self.terminal.cursor_kind() == CursorKind::Hidden {
-            self.terminal.backend_mut().hide_cursor().ok();
-        }
-        let mut stdout = stdout();
-        execute!(
-            stdout,
-            terminal::EnterAlternateScreen,
-            EnableBracketedPaste,
-            EnableFocusChange
-        )?;
-        execute!(stdout, terminal::Clear(terminal::ClearType::All))?;
-        if self.config.load().editor.mouse {
-            execute!(stdout, EnableMouseCapture)?;
-        }
-        if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
-            log::debug!("The enhanced keyboard protocol is supported on this terminal");
-            execute!(
-                stdout,
-                PushKeyboardEnhancementFlags(
-                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-                )
-            )?;
-        } else {
-            log::debug!("The enhanced keyboard protocol is not supported on this terminal");
-        }
+    async fn claim_term(&mut self) -> std::io::Result<()> {
+        let terminal_config = self.config.load().editor.clone().into();
+        self.terminal.claim(terminal_config)
+    }
 
-        Ok(())
+    fn restore_term(&mut self) -> std::io::Result<()> {
+        let terminal_config = self.config.load().editor.clone().into();
+        use helix_view::graphics::CursorKind;
+        self.terminal
+            .backend_mut()
+            .show_cursor(CursorKind::Block)
+            .ok();
+        self.terminal.restore(terminal_config)
     }
 
     pub async fn run<S>(&mut self, input_stream: &mut S) -> Result<i32, Error>
@@ -1099,7 +1049,7 @@ impl Application {
             // We can't handle errors properly inside this closure.  And it's
             // probably not a good idea to `unwrap()` inside a panic handler.
             // So we just ignore the `Result`.
-            let _ = restore_term();
+            let _ = TerminalBackend::force_restore();
             hook(info);
         }));
 
@@ -1107,13 +1057,7 @@ impl Application {
 
         let close_errs = self.close().await;
 
-        // restore cursor
-        use helix_view::graphics::CursorKind;
-        self.terminal
-            .backend_mut()
-            .show_cursor(CursorKind::Block)
-            .ok();
-        restore_term()?;
+        self.restore_term()?;
 
         for err in close_errs {
             self.editor.exit_code = 1;

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -22,6 +22,7 @@ unicode-segmentation = "1.10"
 crossterm = { version = "0.26", optional = true }
 termini = "0.1"
 serde = { version = "1", "optional" = true, features = ["derive"]}
+once_cell = "1.17"
 log = "~0.4"
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -22,5 +22,6 @@ unicode-segmentation = "1.10"
 crossterm = { version = "0.26", optional = true }
 termini = "0.1"
 serde = { version = "1", "optional" = true, features = ["derive"]}
+log = "~0.4"
 helix-view = { version = "0.6", path = "../helix-view", features = ["term"] }
 helix-core = { version = "0.6", path = "../helix-core" }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -1,6 +1,11 @@
-use crate::{backend::Backend, buffer::Cell};
+use crate::{backend::Backend, buffer::Cell, terminal::Config};
 use crossterm::{
     cursor::{Hide, MoveTo, SetCursorStyle, Show},
+    event::{
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute, queue,
     style::{
         Attribute as CAttribute, Color as CColor, Print, SetAttribute, SetBackgroundColor,
@@ -83,6 +88,69 @@ impl<W> Backend for CrosstermBackend<W>
 where
     W: Write,
 {
+    fn claim(&mut self, config: Config) -> io::Result<()> {
+        terminal::enable_raw_mode()?;
+        execute!(
+            self.buffer,
+            terminal::EnterAlternateScreen,
+            EnableBracketedPaste,
+            EnableFocusChange
+        )?;
+        execute!(self.buffer, terminal::Clear(terminal::ClearType::All))?;
+        if config.enable_mouse_capture {
+            execute!(self.buffer, EnableMouseCapture)?;
+        }
+        if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
+            log::debug!("The enhanced keyboard protocol is supported on this terminal");
+            execute!(
+                self.buffer,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+                )
+            )?;
+        } else {
+            log::debug!("The enhanced keyboard protocol is not supported on this terminal");
+        }
+        Ok(())
+    }
+
+    fn restore(&mut self, config: Config) -> io::Result<()> {
+        // reset cursor shape
+        write!(self.buffer, "\x1B[0 q")?;
+        if config.enable_mouse_capture {
+            execute!(self.buffer, DisableMouseCapture)?;
+        }
+        if matches!(terminal::supports_keyboard_enhancement(), Ok(true)) {
+            execute!(self.buffer, PopKeyboardEnhancementFlags)?;
+        }
+        execute!(
+            self.buffer,
+            DisableBracketedPaste,
+            DisableFocusChange,
+            terminal::LeaveAlternateScreen
+        )?;
+        terminal::disable_raw_mode()
+    }
+
+    fn force_restore() -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        // reset cursor shape
+        write!(stdout, "\x1B[0 q")?;
+        // Ignore errors on disabling, this might trigger on windows if we call
+        // disable without calling enable previously
+        let _ = execute!(stdout, DisableMouseCapture);
+        let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+        execute!(
+            stdout,
+            DisableBracketedPaste,
+            DisableFocusChange,
+            terminal::LeaveAlternateScreen
+        )?;
+        terminal::disable_raw_mode()
+    }
+
     fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::buffer::Cell;
+use crate::{buffer::Cell, terminal::Config};
 
 use helix_view::graphics::{CursorKind, Rect};
 
@@ -13,6 +13,9 @@ mod test;
 pub use self::test::TestBackend;
 
 pub trait Backend {
+    fn claim(&mut self, config: Config) -> Result<(), io::Error>;
+    fn restore(&mut self, config: Config) -> Result<(), io::Error>;
+    fn force_restore() -> Result<(), io::Error>;
     fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>;

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -1,6 +1,7 @@
 use crate::{
     backend::Backend,
     buffer::{Buffer, Cell},
+    terminal::Config,
 };
 use helix_core::unicode::width::UnicodeWidthStr;
 use helix_view::graphics::{CursorKind, Rect};
@@ -106,6 +107,18 @@ impl TestBackend {
 }
 
 impl Backend for TestBackend {
+    fn claim(&mut self, _config: Config) -> Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn restore(&mut self, _config: Config) -> Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn force_restore() -> Result<(), io::Error> {
+        Ok(())
+    }
+
     fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -1,4 +1,5 @@
 use crate::{backend::Backend, buffer::Buffer};
+use helix_view::editor::Config as EditorConfig;
 use helix_view::graphics::{CursorKind, Rect};
 use std::io;
 
@@ -14,6 +15,19 @@ enum ResizeBehavior {
 pub struct Viewport {
     area: Rect,
     resize_behavior: ResizeBehavior,
+}
+
+#[derive(Debug)]
+pub struct Config {
+    pub enable_mouse_capture: bool,
+}
+
+impl From<EditorConfig> for Config {
+    fn from(config: EditorConfig) -> Self {
+        Self {
+            enable_mouse_capture: config.mouse,
+        }
+    }
 }
 
 impl Viewport {
@@ -96,6 +110,14 @@ where
             cursor_kind: CursorKind::Block,
             viewport: options.viewport,
         })
+    }
+
+    pub fn claim(&mut self, config: Config) -> io::Result<()> {
+        self.backend.claim(config)
+    }
+
+    pub fn restore(&mut self, config: Config) -> io::Result<()> {
+        self.backend.restore(config)
     }
 
     // /// Get a Frame object which provides a consistent view into the terminal state for rendering.


### PR DESCRIPTION
This is #6160 but in a way that is more extendable in the long-term. This will make it easier to add checks for other host terminal information like initial cursor shape, title line, whether the terminal supports synchronized output, etc. without adding a whole bunch of fields to Application or functions to the Terminal trait.

The first commit in this change moves `Application::claim_term` and `application::restore_term` to `helix-tui` into the crossterm backend. I believe this is the more proper place for this code and it makes the second change much easier: we cache whether the terminal supports the enhanced keyboard protocol, resolving #6149 (though it would stil be nice to improve this upstream).