### PR TITLE
Add comment-end-token language config option

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -58,6 +58,7 @@ These configuration keys are available:
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
 | `comment-token`       | The token to use as a comment-token                           |
+| `comment-end-token`   | The token to use to end comments (in languages with no line comments) |
 | `indent`              | The indent to use. Has sub keys `unit` (the text inserted into the document when indenting; usually set to N spaces or `"\t"` for tabs) and `tab-width` (the number of spaces rendered for a tab) |
 | `language-server`     | The Language Server to run. See the Language Server configuration section below. |
 | `config`              | Language Server configuration                                 |

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -82,6 +82,7 @@ pub struct LanguageConfiguration {
     pub shebangs: Vec<String>, // interpreter(s) associated with language
     pub roots: Vec<String>,        // these indicate project roots <.git, Cargo.toml>
     pub comment_token: Option<String>,
+    pub comment_end_token: Option<String>,
     pub max_line_length: Option<usize>,
 
     #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4221,7 +4221,14 @@ fn toggle_comments(cx: &mut Context) {
         .language_config()
         .and_then(|lc| lc.comment_token.as_ref())
         .map(|tc| tc.as_ref());
-    let transaction = comment::toggle_line_comments(doc.text(), doc.selection(view.id), token);
+
+    let end_token = doc
+        .language_config()
+        .and_then(|lc| lc.comment_end_token.as_ref())
+        .map(|tc| tc.as_ref());
+
+    let transaction =
+        comment::toggle_line_comments(doc.text(), doc.selection(view.id), token, end_token);
 
     doc.apply(&transaction, view.id);
     exit_select_mode(cx);

--- a/languages.toml
+++ b/languages.toml
@@ -707,7 +707,8 @@ injection-regex = "ocaml"
 file-types = ["ml"]
 shebangs = []
 roots = []
-comment-token = "(**)"
+comment-token = "(*"
+comment-end-token = "*)"
 language-server = { command = "ocamllsp" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -721,7 +722,8 @@ scope = "source.ocaml.interface"
 file-types = ["mli"]
 shebangs = []
 roots = []
-comment-token = "(**)"
+comment-token = "(*"
+comment-end-token = "*)"
 language-server = { command = "ocamllsp" }
 indent = { tab-width = 2, unit = "  " }
 
@@ -1870,6 +1872,7 @@ scope = "source.sml"
 injection-regex = "sml"
 file-types = ["sml"]
 comment-token = "(*"
+comment-end-token = "*)"
 roots = []
 
 [[grammar]]


### PR DESCRIPTION
Some languages lack line comments and only have block comments, in which case an end of comment token is needed to comment single lines.