### PR TITLE
feat(theme): Update pop-dark for color-modes

### DIFF
--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -29,9 +29,9 @@ error = { fg = 'brownD', bg = 'redE', modifiers = ['bold'] }
 'ui.linenr.selected' = { fg = 'orangeH' }
 'ui.cursorline' = { bg = 'brownH' }
 'ui.statusline.inactive' = { fg = 'greyT', bg = 'brownN' }
-'ui.statusline.normal' = { fg = 'greyT', bg = 'brownN' }
-'ui.statusline.select' = { fg = 'blueD', bg = 'brownN' }
-'ui.statusline.insert' = { fg = 'orangeD', bg = 'brownN' }
+'ui.statusline.normal' = { fg = 'greyT', bg = 'brownD' }
+'ui.statusline.select' = { fg = 'blueD', bg = 'brownD' }
+'ui.statusline.insert' = { fg = 'orangeN', bg = 'brownD' }
 'ui.help' = { fg = 'greyT', bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -29,9 +29,9 @@ error = { fg = 'brownD', bg = 'redE', modifiers = ['bold'] }
 'ui.linenr.selected' = { fg = 'orangeH' }
 'ui.cursorline' = { bg = 'brownH' }
 'ui.statusline.inactive' = { fg = 'greyT', bg = 'brownN' }
-'ui.statusline.normal' = { fg = 'greyT', bg = 'brownD' }
-'ui.statusline.select' = { fg = 'blueD', bg = 'brownD' }
-'ui.statusline.insert' = { fg = 'orangeN', bg = 'brownD' }
+'ui.statusline.normal' = { fg = 'greyT', bg = 'brownD', modifiers = ['bold'] }
+'ui.statusline.select' = { bg = 'blueL', fg = 'brownD', modifiers = ['bold'] }
+'ui.statusline.insert' = { bg = 'orangeL', fg = 'brownD', modifiers = ['bold'] }
 'ui.help' = { fg = 'greyT', bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -28,8 +28,10 @@ error = { fg = 'brownD', bg = 'redE', modifiers = ['bold'] }
 'ui.linenr' = { bg = 'brownU', fg = 'greyL' }
 'ui.linenr.selected' = { fg = 'orangeH' }
 'ui.cursorline' = { bg = 'brownH' }
-'ui.statusline' = { fg = 'greyT', bg = 'brownD' }
 'ui.statusline.inactive' = { fg = 'greyT', bg = 'brownN' }
+'ui.statusline.normal' = { fg = 'greyT', bg = 'brownN' }
+'ui.statusline.select' = { fg = 'blueD', bg = 'brownN' }
+'ui.statusline.insert' = { fg = 'orangeD', bg = 'brownN' }
 'ui.help' = { fg = 'greyT', bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }


### PR DESCRIPTION
After reading today through the updated docs i found and ran the `cargo xtask themelint`...
This fixes the issues around `ui.statusline.<MODE>`.
by adding the three missing keys for the `color-modes`-option.