### PR TITLE
Pin tree-sitter at git master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,8 +2154,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4423c784fe11398ca91e505cdc71356b07b1a924fc8735cfab5333afe3e18bc"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14#c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ inherits = "test"
 package.helix-core.opt-level = 2
 package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
+
+[patch.crates-io]
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }


### PR DESCRIPTION
Tree-sitter has some unreleased improvements that can speed up small queries and prevent hangs due to error recovery in some parsers. This change pins tree-sitter to the latest master.

Neovim also pins tree-sitter to a commit on master.

(Distributions could decide to ignore this patch if they don't allow git revisions - there are no changes in the Helix codebase that require the new changes to tree-sitter.)

Fixes https://github.com/helix-editor/helix/issues/4862
See https://github.com/tree-sitter/tree-sitter/pull/2085