### PR TITLE
Improved yuck highlighting (and parser), and introduced a tag.builtin scope

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -215,6 +215,7 @@ We use a similar set of scopes as
   - `special` (preprocessor in C)
 
 - `tag` - Tags (e.g. `<body>` in HTML)
+  - `builtin`
 
 - `namespace`
 

--- a/languages.toml
+++ b/languages.toml
@@ -2206,7 +2206,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "yuck"
-source = { git = "https://github.com/Philipp-M/tree-sitter-yuck", rev = "9e97da5773f82123a8c8cccf8f7e795d140ed7d1" }
+source = { git = "https://github.com/Philipp-M/tree-sitter-yuck", rev = "e3d91a3c65decdea467adebe4127b8366fa47919" }
 
 [[language]]
 name = "prql"

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -43,7 +43,7 @@
 
 (number (integer)) @constant.numeric.integer
 
-(boolean) @boolean
+(boolean) @constant.builtin.boolean
 
 ; Strings
 

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -1,66 +1,107 @@
+; Errors
+
 (ERROR) @error
 
-(line_comment) @comment
+; Comments
 
-; keywords and symbols
+(comment) @comment
 
-(keyword) @keyword
-(symbol) @tag
+; Operators
 
-; literals
-
-(bool_literal) @constant.builtin.boolean
-(num_literal) @constant.numeric
-
-; strings
-(string_interpolation
-  (string_interpolation_start) @punctuation.special
-  (string_interpolation_end) @punctuation.special)
-
-(escape_sequence) @constant.character.escape
-
-(string
-  [
-    (unescaped_single_quote_string_fragment)
-    (unescaped_double_quote_string_fragment)
-    (unescaped_backtick_string_fragment)
-    "\""
-    "'"
-    "`"
-  ]) @string
-
-; operators and general punctuation
-
-(unary_expression
-  operator: _ @operator)
-
-(binary_expression
-  operator: _ @operator)
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "||"
+  "&&"
+  "=="
+  "!="
+  "=~"
+  ">"
+  "<"
+  ">="
+  "<="
+  "!"
+  "?."
+  "?:"
+] @operator
 
 (ternary_expression
-  operator: _ @operator)
+  ["?" ":"] @operator)
 
-[
-  ":"
-  "."
-  ","
-] @punctuation.delimiter
+; Punctuation
 
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
-[
-  ":"
-  "."
-  ","
-] @punctuation.delimiter
+[ ":" "." "," ] @punctuation.delimiter
 
-; Rest (general identifiers that are not yet catched)
+[ "{" "}" "[" "]" "(" ")" ] @punctuation.bracket
 
-(index) @variable
+; Literals
+
+(number (float)) @constant.numeric.float
+
+(number (integer)) @constant.numeric.integer
+
+(boolean) @boolean
+
+; Strings
+
+(escape_sequence) @string.escape
+
+(string_interpolation
+  "${" @punctuation.special
+  "}" @punctuation.special)
+
+[ (string_fragment) "\"" "'" "`" ] @string
+
+; Attributes & Fields
+
+(keyword) @attribute
+
+; Functions
+
+(function_call
+  name: (ident) @function.call)
+
+; Variables
+
 (ident) @variable
+
+(array
+  (symbol) @variable)
+
+; Builtin widgets
+
+(list .
+  ((symbol) @tag.builtin
+    (#match? @tag.builtin "^(box|button|calendar|centerbox|checkbox|circular-progress|color-button|color-chooser|combo-box-text|eventbox|expander|graph|image|input|label|literal|overlay|progress|revealer|scale|scroll|transform)$")))
+
+; Keywords
+
+; I think there's a bug in tree-sitter the anchor doesn't seem to be working, see
+; https://github.com/tree-sitter/tree-sitter/pull/2107
+(list .
+  ((symbol) @keyword
+    (#match? @keyword "^(defwindow|defwidget|defvar|defpoll|deflisten|geometry|children|struts)$")))
+
+(list .
+  ((symbol) @keyword.control.import
+    (#eq? @keyword.control.import "include")))
+
+; Loop
+
+(loop_widget . "for" @keyword.control.repeat . (symbol) @variable . "in" @keyword.operator . (symbol) @variable)
+
+(loop_widget . "for" @keyword.control.repeat . (symbol) @variable . "in" @keyword.operator)
+
+; Tags
+
+; TODO apply to every symbol in list? I think it should probably only be applied to the first child of the list
+(list
+  (symbol) @tag)
+
+; Other stuff that has not been catched by the previous queries yet
+
+(ident) @variable
+(index) @variable

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -62,7 +62,7 @@
 ; Functions
 
 (function_call
-  name: (ident) @function.call)
+  name: (ident) @function)
 
 ; Variables
 

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -47,7 +47,7 @@
 
 ; Strings
 
-(escape_sequence) @string.escape
+(escape_sequence) @constant.character.escape
 
 (string_interpolation
   "${" @punctuation.special

--- a/runtime/queries/yuck/injections.scm
+++ b/runtime/queries/yuck/injections.scm
@@ -1,2 +1,2 @@
-((line_comment) @injection.content
+((comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
This PR improves the tree-sitter-yuck parser and highlighting queries:
![ewwyucktshighlighting-next](https://user-images.githubusercontent.com/9267430/224202952-e940b076-0762-4cc2-a94c-8244398ba250.png)

It also introduces a new `tag.builtin` scope, as I think this is a relatively uncontroversial addition.