### PR TITLE
adds a written command to clear the jumplist.

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1636,6 +1636,16 @@ pub(super) fn goto_line_number(
     Ok(())
 }
 
+pub (super) fn clear_jump_list(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    let (view, doc) = current!(cx.editor);
+    view.jumps.clear();
+    Ok(())
+}
+
 // Fetch the current value of a config option and output as status.
 fn get_option(
     cx: &mut compositor::Context,
@@ -2529,6 +2539,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             aliases: &["g"],
             doc: "Goto line number.",
             fun: goto_line_number,
+            completer: None,
+        },
+        TypableCommand {
+            name: "clear-jumplist",
+            aliases: &["cjl"],
+            doc: "Clears the jumplist",
+            fun: clear_jump_list,
             completer: None,
         },
         TypableCommand {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -33,6 +33,10 @@ impl JumpList {
         Self { jumps, current: 0 }
     }
 
+    pub fn clear(&mut self) {
+        self.jumps = VecDeque::with_capacity(JUMP_LIST_CAPACITY);
+    }
+
     pub fn push(&mut self, jump: Jump) {
         self.jumps.truncate(self.current);
         // don't push duplicates


### PR DESCRIPTION
Fixes #4757. Adds the typed command `:clear-jumplist` to completely clear the jumplist.