### PR TITLE
Add undercurl config option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -53,6 +53,7 @@ signal to the Helix process on Unix operating systems, such as by using the comm
 | `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
 | `auto-info` | Whether to display info boxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
+| `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -137,7 +137,7 @@ impl Application {
         let syn_loader = std::sync::Arc::new(syntax::Loader::new(syn_loader_conf));
 
         #[cfg(not(feature = "integration"))]
-        let backend = CrosstermBackend::new(stdout());
+        let backend = CrosstermBackend::new(stdout(), &config.editor);
 
         #[cfg(feature = "integration")]
         let backend = TestBackend::new(120, 150);

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -14,7 +14,10 @@ use crossterm::{
     terminal::{self, Clear, ClearType},
     Command,
 };
-use helix_view::graphics::{Color, CursorKind, Modifier, Rect, UnderlineStyle};
+use helix_view::{
+    editor::Config as EditorConfig,
+    graphics::{Color, CursorKind, Modifier, Rect, UnderlineStyle},
+};
 use once_cell::sync::OnceCell;
 use std::{
     fmt,
@@ -39,14 +42,15 @@ impl Capabilities {
     /// Detect capabilities from the terminfo database located based
     /// on the $TERM environment variable. If detection fails, returns
     /// a default value where no capability is supported.
-    pub fn from_env_or_default() -> Self {
+    pub fn from_env_or_default(config: &EditorConfig) -> Self {
         match termini::TermInfo::from_env() {
             Err(_) => Capabilities::default(),
             Ok(t) => Capabilities {
                 // Smulx, VTE: https://unix.stackexchange.com/a/696253/246284
                 // Su (used by kitty): https://sw.kovidgoyal.net/kitty/underlines
                 // WezTerm supports underlines but a lot of distros don't properly install it's terminfo
-                has_extended_underlines: t.extended_cap("Smulx").is_some()
+                has_extended_underlines: config.undercurl
+                    || t.extended_cap("Smulx").is_some()
                     || t.extended_cap("Su").is_some()
                     || vte_version() >= Some(5102)
                     || matches!(term_program().as_deref(), Some("WezTerm")),
@@ -65,10 +69,10 @@ impl<W> CrosstermBackend<W>
 where
     W: Write,
 {
-    pub fn new(buffer: W) -> CrosstermBackend<W> {
+    pub fn new(buffer: W, config: &EditorConfig) -> CrosstermBackend<W> {
         CrosstermBackend {
             buffer,
-            capabilities: Capabilities::from_env_or_default(),
+            capabilities: Capabilities::from_env_or_default(config),
             supports_keyboard_enhancement_protocol: OnceCell::new(),
         }
     }

--- a/helix-tui/src/lib.rs
+++ b/helix-tui/src/lib.rs
@@ -25,10 +25,12 @@
 //! use std::io;
 //! use helix_tui::Terminal;
 //! use helix_tui::backend::CrosstermBackend;
+//! use helix_view::editor::Config;
 //!
 //! fn main() -> Result<(), io::Error> {
 //!     let stdout = io::stdout();
-//!     let backend = CrosstermBackend::new(stdout);
+//!     let config = Config::default();
+//!     let backend = CrosstermBackend::new(stdout, &config);
 //!     let mut terminal = Terminal::new(backend)?;
 //!     Ok(())
 //! }
@@ -56,11 +58,13 @@
 //! use helix_tui::backend::CrosstermBackend;
 //! use helix_tui::widgets::{Widget, Block, Borders};
 //! use helix_tui::layout::{Layout, Constraint, Direction};
+//! use helix_view::editor::Config;
 //!
 //! fn main() -> Result<(), io::Error> {
 //!     terminal::enable_raw_mode().unwrap();
 //!     let stdout = io::stdout();
-//!     let backend = CrosstermBackend::new(stdout);
+//!     let config = Config::default();
+//!     let backend = CrosstermBackend::new(stdout, &config);
 //!     let mut terminal = Terminal::new(backend)?;
 //!     // terminal.draw(|f| {
 //!     //     let size = f.size();
@@ -86,11 +90,13 @@
 //! use helix_tui::backend::CrosstermBackend;
 //! use helix_tui::widgets::{Widget, Block, Borders};
 //! use helix_tui::layout::{Layout, Constraint, Direction};
+//! use helix_view::editor::Config;
 //!
 //! fn main() -> Result<(), io::Error> {
 //!     terminal::enable_raw_mode().unwrap();
 //!     let stdout = io::stdout();
-//!     let backend = CrosstermBackend::new(stdout);
+//!     let config = Config::default();
+//!     let backend = CrosstermBackend::new(stdout, &config);
 //!     let mut terminal = Terminal::new(backend)?;
 //!     // terminal.draw(|f| {
 //!     //     let chunks = Layout::default()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -263,6 +263,8 @@ pub struct Config {
     pub cursor_shape: CursorShapeConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
+    /// Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative. Defaults to `false`.
+    pub undercurl: bool,
     /// Search configuration.
     #[serde(default)]
     pub search: SearchConfig,
@@ -731,6 +733,7 @@ impl Default for Config {
             statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),
             true_color: false,
+            undercurl: false,
             search: SearchConfig::default(),
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),


### PR DESCRIPTION
Fixes  #6196. If set to 'true' this option will force terminal undercurl support.

I don't have ArchLinux so tested this by setting `undercurl = true` in my config file and running a version of helix where `has_extended_underlines` was only set by the config option.

I didn't find any related integration tests that could help me in writing one for this. If needed (and someone can point me in the right direction) I may be able to add that as well.