### PR TITLE
LSP: No-op client/registerCapability requests

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -530,6 +530,7 @@ pub enum MethodCall {
     ApplyWorkspaceEdit(lsp::ApplyWorkspaceEditParams),
     WorkspaceFolders,
     WorkspaceConfiguration(lsp::ConfigurationParams),
+    RegisterCapability(lsp::RegistrationParams),
 }
 
 impl MethodCall {
@@ -548,6 +549,10 @@ impl MethodCall {
             lsp::request::WorkspaceConfiguration::METHOD => {
                 let params: lsp::ConfigurationParams = params.parse()?;
                 Self::WorkspaceConfiguration(params)
+            }
+            lsp::request::RegisterCapability::METHOD => {
+                let params: lsp::RegistrationParams = params.parse()?;
+                Self::RegisterCapability(params)
             }
             _ => {
                 return Err(Error::Unhandled);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1014,6 +1014,17 @@ impl Application {
                             .collect();
                         Ok(json!(result))
                     }
+                    Ok(MethodCall::RegisterCapability(_params)) => {
+                        log::warn!("Ignoring a client/registerCapability request because dynamic capability registration is not enabled. Please report this upstream to the language server");
+                        // Language Servers based on the `vscode-languageserver-node` library often send
+                        // client/registerCapability even though we do not enable dynamic registration
+                        // for any capabilities. We should send a MethodNotFound JSONRPC error in this
+                        // case but that rejects the registration promise in the server which causes an
+                        // exit. So we work around this by ignoring the request and sending back an OK
+                        // response.
+
+                        Ok(serde_json::Value::Null)
+                    }
                 };
 
                 let language_server = match self.editor.language_servers.get_by_id(server_id) {


### PR DESCRIPTION
Some language servers send this request even though we don't enable dynamic capability registration. In some language servers that use the vscode-languageserver-node dependency, replying with an error can cause the server to exit because an un-caught rejected promise is fatal.

Replying with a JSONRPC error that the method is not handled is the correct thing to do but given that it causes some language servers in the wild to exit and that ignoring it doesn't cause any harm, we can workaround the exits by just sending an OK and doing nothing. This is similar to a workaround done by neovim.

Recent examples: #6230, #6243