### PR TITLE
indent snippets to line indent instead of completion start

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -345,6 +345,7 @@ pub mod util {
         line_ending: &str,
         include_placeholder: bool,
         tab_width: usize,
+        indent_width: usize,
     ) -> Transaction {
         let text = doc.slice(..);
 
@@ -374,19 +375,14 @@ pub mod util {
                 let mapped_replacement_end = (replacement_end as i128 + off) as usize;
 
                 let line_idx = mapped_doc.char_to_line(mapped_replacement_start);
-                let pos_on_line = mapped_replacement_start - mapped_doc.line_to_char(line_idx);
-
-                // we only care about the actual offset here (not virtual text/softwrap)
-                // so it's ok to use the deprecated function here
-                #[allow(deprecated)]
-                let width = helix_core::visual_coords_at_pos(
+                let indent_level = helix_core::indent::indent_level_for_line(
                     mapped_doc.line(line_idx),
-                    pos_on_line,
                     tab_width,
-                )
-                .col;
+                    indent_width,
+                ) * indent_width;
+
                 let newline_with_offset = format!(
-                    "{line_ending}{blank:width$}",
+                    "{line_ending}{blank:indent_level$}",
                     line_ending = line_ending,
                     blank = ""
                 );

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -182,6 +182,7 @@ impl Completion {
                             doc.line_ending.as_str(),
                             include_placeholder,
                             doc.tab_width(),
+                            doc.indent_width(),
                         ),
                         Err(err) => {
                             log::error!(


### PR DESCRIPTION
Fixes #6255

The way multi-line snippet indentation was implemented in #5864 was incorrect. Lines inserted in snippets were indented to align with the start of the snippet. However, snippets are supposed to be indented to match the indentation level of the line they are on, see vscode: https://github.com/microsoft/vscode/blob/1d0175478873e6ad29033d84925ce5d936032b3c/src/vs/editor/contrib/snippet/browser/snippetSession.ts#L404

This makes a lot more sense as this basically just ensures that snippet newlines are identical to hitting tab manually. Note that I opted not to run indentation queries here. The LS should be aware of any language specific indentation needs and wouldn't expect the client to do this for him (the standard also specifies that snippets should be adjusted to the indentation of the **insert line**)