### PR TITLE
fleet_dark: theme inlay hints

### DIFF
--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -92,6 +92,7 @@
 "ui.text.focus" = { fg = "White", bg = "Blue 40" }
 
 "ui.virtual" = "Gray 80" # .whitespace
+"ui.virtual.inlay-hint" = "Purple 20"
 # "ui.virtual.ruler" = { bg = "darker"}
 
 "hint" = "Gray 80"


### PR DESCRIPTION
<img width="1552" alt="Screenshot 2023-03-10 at 11 52 01 PM" src="https://user-images.githubusercontent.com/67773714/224465675-801d8c41-fde3-465e-88d5-5dc17a6425bb.png">

Diverges from Fleet, as far as I know they don't have inlay hints.