### PR TITLE
theme/catppuccin: add ui.virtual.inlay-hint

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -89,6 +89,7 @@
 "ui.virtual" = "overlay0"
 "ui.virtual.ruler" = { bg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
+"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
 
 "ui.selection" = { bg = "surface1" }
 


### PR DESCRIPTION
this pr adds theme inlay hints for catppuccin

how it looks: 

![Screenshot from 2023-03-11 11-16-55](https://user-images.githubusercontent.com/116971836/224476386-7cc397ca-754a-4ebd-9e39-0d97454df84e.png)

![Screenshot from 2023-03-11 11-17-12](https://user-images.githubusercontent.com/116971836/224476359-0d384e77-cf99-4b20-9ba2-23c3e291327a.png)

![Screenshot from 2023-03-11 11-17-05](https://user-images.githubusercontent.com/116971836/224476398-b3372a33-fead-41e8-b3a0-61d088eeb5b0.png)

![Screenshot from 2023-03-11 11-17-02](https://user-images.githubusercontent.com/116971836/224476404-795d4259-f38b-4bcf-85de-0c0f1df13829.png)


