### PR TITLE
Improved file reload error message

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -776,7 +776,7 @@ impl Document {
         let path = self
             .path()
             .filter(|path| path.exists())
-            .ok_or_else(|| anyhow!("can't find file to reload from"))?
+            .ok_or_else(|| anyhow!("can't find file to reload from {:?}", self.display_name()))?
             .to_owned();
 
         let mut file = std::fs::File::open(&path)?;


### PR DESCRIPTION
Improvements on `helix-view/document.rs` reload function to show file paths on error based on the idea of #6222.
Currently this only shows one of the possible missing files due to how errors are handles with `anyhow`.
I would like to add a multi line output with all of the missing file paths but i'm not sure in how it could be done, if someone has an idea i would really appreciate it.