### PR TITLE
dark_plus: theme inlay-hint

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -89,6 +89,7 @@
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
 "ui.virtual.indent-guide" = { fg = "dark_gray4" }
+"ui.virtual.inlay-hint" = { fg = "white", bg = "#444444" }
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }


### PR DESCRIPTION
Taken from the official theme:
```json
"editorInlayHint.background": "#4d4d4dcc",
"editorInlayHint.foreground": "#ffffff",
"editorInlayHint.parameterBackground": "#4d4d4dcc",
"editorInlayHint.parameterForeground": "#ffffff",
"editorInlayHint.typeBackground": "#4d4d4dcc",
"editorInlayHint.typeForeground": "#ffffff",
```