### PR TITLE
Update gruvbox color themes to support inlay hint

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -60,6 +60,7 @@
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.inlay-hint" = { fg = "gray1" }
 
 "diagnostic.warning" = { underline = { color = "orange1", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }

--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -66,6 +66,7 @@
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.inlay-hint" = { fg = "gray1" }
 
 "markup.heading" = "aqua1"
 "markup.bold" = { modifiers = ["bold"] }

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -61,6 +61,7 @@
 "ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.inlay-hint" = { fg = "gray1" }
 
 "diagnostic.warning" = { underline = { color = "orange1", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }


### PR DESCRIPTION
The gruvbox themes (`gruvbox`, `gruvbox dark hard` and `guvbox light`) don't provide a colour for the new virtual inlay hints. Looking at the original repo, and other derivatives, there doesn't appear to be a clear definition of what inlay hints should be. Although most sources indicate that it can be the same as the color for comments.

Considering that, this commit sets the new field on each of the three themes to be `gray1`, same as commented text.

`gruvbox` old:
<img width="800" alt="Screenshot 2023-03-12 at 20 42 54" src="https://user-images.githubusercontent.com/8218521/224573163-925226ac-081f-4765-a5b1-2fd980edfe10.png">

`gruvbox` new:
<img width="800" alt="Screenshot 2023-03-12 at 20 41 19" src="https://user-images.githubusercontent.com/8218521/224573233-fbd4658f-1311-4887-be03-1131b9fc6883.png">

`gruvbox dark hard` old:
<img width="800" alt="Screenshot 2023-03-12 at 20 42 59" src="https://user-images.githubusercontent.com/8218521/224573248-97fe93a7-d1bf-4c66-bea4-7e9d5d91565b.png">

`gruvbox dark hard` new:
<img width="800" alt="Screenshot 2023-03-12 at 20 41 47" src="https://user-images.githubusercontent.com/8218521/224573257-92423bd6-dda8-4793-a296-6d450812cc73.png">

`guvbox light` old:
<img width="800" alt="Screenshot 2023-03-12 at 20 43 07" src="https://user-images.githubusercontent.com/8218521/224573264-ae9913bc-9e8e-4726-9a60-36e639e585f8.png">

`guvbox light` new:
<img width="800" alt="Screenshot 2023-03-12 at 20 41 54" src="https://user-images.githubusercontent.com/8218521/224573266-bd3df3b1-b669-4418-ad17-9eaa4743f8b9.png">