### PR TITLE
FIX: LSP snippet placeholder

### DIFF
--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -314,7 +314,7 @@ mod parser {
                 "${",
                 digit(),
                 ":",
-                one_or_more(choice!(anything(), text)),
+                zero_or_more(choice!(anything(), text)),
                 "}"
             ),
             |seq| SnippetElement::Placeholder {


### PR DESCRIPTION
```
  placeholder ::= '${' int ':' any '}'
```

Resolve the case where any is null.

Resolve #6288