### PR TITLE
Update Nix and Erlang highlights

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1317,6 +1317,7 @@ scope = "source.erlang"
 injection-regex = "erl(ang)?"
 file-types = ["erl", "hrl", "app", "rebar.config", "rebar.lock"]
 roots = ["rebar.config"]
+shebangs = ["escript"]
 comment-token = "%%"
 indent = { tab-width = 4, unit = "    " }
 language-server = { command = "erlang_ls" }

--- a/languages.toml
+++ b/languages.toml
@@ -591,7 +591,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nix"
-source = { git = "https://github.com/cstrahan/tree-sitter-nix", rev = "6b71a810c0acd49b980c50fc79092561f7cee307" }
+source = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "6b71a810c0acd49b980c50fc79092561f7cee307" }
 
 [[language]]
 name = "ruby"

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -65,6 +65,16 @@
 (function_capture module: (atom) @namespace)
 (function_capture function: (atom) @function)
 
+; Macros
+(macro
+  "?"+ @constant
+  name: (_) @constant
+  !arguments)
+
+(macro
+  "?"+ @keyword.directive
+  name: (_) @keyword.directive)
+
 ; Ignored variables
 ((variable) @comment.discard
  (#match? @comment.discard "^_"))
@@ -124,16 +134,6 @@
 (binary_operator operator: _ @operator)
 (unary_operator operator: _ @operator)
 ["/" ":" "->"] @operator
-
-; Macros
-(macro
-  "?"+ @constant
-  name: (_) @constant
-  !arguments)
-
-(macro
-  "?"+ @keyword.directive
-  name: (_) @keyword.directive)
 
 ; Comments
 (tripledot) @comment.discard

--- a/runtime/queries/nix/highlights.scm
+++ b/runtime/queries/nix/highlights.scm
@@ -95,6 +95,8 @@
   "."
   ","
   "="
+  ":"
+  (ellipses)
 ] @punctuation.delimiter
 
 [


### PR DESCRIPTION
**Nix**:

* Switch nix grammar repository location to the new repo. The author has transferred the repository to `nix-community`: https://github.com/nix-community/tree-sitter-nix
* Capture `:` and `...` as `punctuation.delimiter`.

**Erlang**:

* Macros that start with underscore were incorrectly marked as `comment.unused` rather than `keyword.directive` due to an ordering issue of those two patterns.
* Recognize escripts as Erlang by the shebang.