### PR TITLE
queries/php: add missing keywords `unset` and `clone`

### DIFF
--- a/runtime/queries/php/highlights.scm
+++ b/runtime/queries/php/highlights.scm
@@ -164,6 +164,8 @@
   "private" 
   "protected" 
   "public" 
+  "clone"
+  "unset"
 ] @keyword
 
 [


### PR DESCRIPTION
this pr is just simple fix for missing keywords in php queries