### PR TITLE
Prevent whitespace from rendering inside inlay hints

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -413,15 +413,15 @@ impl<'a> TextRenderer<'a> {
         let width = grapheme.width();
         let space = if is_virtual { " " } else { &self.space };
         let nbsp = if is_virtual { " " } else { &self.nbsp };
+        let tab = if is_virtual {
+            &self.virtual_tab
+        } else {
+            &self.tab
+        };
         let grapheme = match grapheme {
             Grapheme::Tab { width } => {
-                if !is_virtual {
-                    let grapheme_tab_width = char_to_byte_idx(&self.tab, width);
-                    &self.tab[..grapheme_tab_width]
-                } else {
-                    let grapheme_tab_width = char_to_byte_idx(&self.virtual_tab, width);
-                    &self.virtual_tab[..grapheme_tab_width]
-                }
+                let grapheme_tab_width = char_to_byte_idx(&tab, width);
+                &tab[..grapheme_tab_width]
             }
             // TODO special rendering for other whitespaces?
             Grapheme::Other { ref g } if g == " " => space,

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -287,9 +287,11 @@ pub fn render_text<'t>(
             style_span.0
         };
 
+        let virt = grapheme.is_virtual().clone();
         renderer.draw_grapheme(
             grapheme.grapheme,
             grapheme_style,
+            virt,
             &mut last_line_indent_level,
             &mut is_in_indent_area,
             pos,
@@ -392,6 +394,7 @@ impl<'a> TextRenderer<'a> {
         &mut self,
         grapheme: Grapheme,
         mut style: Style,
+        is_virtual: bool,
         last_indent_level: &mut usize,
         is_in_indent_area: &mut bool,
         position: Position,
@@ -405,14 +408,16 @@ impl<'a> TextRenderer<'a> {
         }
 
         let width = grapheme.width();
+        let space = if is_virtual { " " } else { &self.space };
+        let nbsp = if is_virtual { " " } else { &self.nbsp };
         let grapheme = match grapheme {
             Grapheme::Tab { width } => {
                 let grapheme_tab_width = char_to_byte_idx(&self.tab, width);
                 &self.tab[..grapheme_tab_width]
             }
             // TODO special rendering for other whitespaces?
-            Grapheme::Other { ref g } if g == " " => &self.space,
-            Grapheme::Other { ref g } if g == "\u{00A0}" => &self.nbsp,
+            Grapheme::Other { ref g } if g == " " => space,
+            Grapheme::Other { ref g } if g == "\u{00A0}" => nbsp,
             Grapheme::Other { ref g } => g,
             Grapheme::Newline => &self.newline,
         };

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -420,7 +420,7 @@ impl<'a> TextRenderer<'a> {
         };
         let grapheme = match grapheme {
             Grapheme::Tab { width } => {
-                let grapheme_tab_width = char_to_byte_idx(&tab, width);
+                let grapheme_tab_width = char_to_byte_idx(tab, width);
                 &tab[..grapheme_tab_width]
             }
             // TODO special rendering for other whitespaces?


### PR DESCRIPTION
Addresses most of #6297. 

Would like some advice on what should be done about tab rendering. Is it even needed to be addressed because I don't think the inlay hints would draw a tab?