### PR TITLE
Display the most recent addition in register info

### DIFF
--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -74,7 +74,7 @@ impl Info {
             .map(|(ch, reg)| {
                 let content = reg
                     .read()
-                    .get(0)
+                    .last()
                     .and_then(|s| s.lines().next())
                     .unwrap_or_default();
                 (ch.to_string(), content)


### PR DESCRIPTION
Fixes #6314 

Search register stores every search in a vec, to be able to search for previous terms later.
This changes the infobox to show the latest addition to a register instead of the first.