### PR TITLE
feat: lint for `ui.virtual` and catch present and future virtual based features

### DIFF
--- a/xtask/src/themelint.rs
+++ b/xtask/src/themelint.rs
@@ -36,15 +36,14 @@ fn get_rules() -> Vec<Require> {
         Require::Difference("ui.statusline.normal", "ui.statusline.select"),
         // Check for editor.cursorline
         Require::Existence(Rule::has_bg("ui.cursorline.primary")),
+        // Check for general ui.virtual (such as inlay-hint)
+        Require::Existence(Rule::has_fg("ui.virtual")),
         // Check for editor.whitespace
         Require::Existence(Rule::has_fg("ui.virtual.whitespace")),
         // Check fir rulers
         Require::Existence(Rule::has_either("ui.virtual.indent-guide")),
         // Check for editor.rulers
         Require::Existence(Rule::has_either("ui.virtual.ruler")),
-        // Check for editor.lsp.display-inlay-hints
-        Require::Existence(Rule::has_either("ui.virtual.inlay-hint.parameter")),
-        Require::Existence(Rule::has_either("ui.virtual.inlay-hint.type")),
         // Check for menus and prompts
         Require::Existence(Rule::has_both("ui.menu")),
         Require::Existence(Rule::has_both("ui.help")),

--- a/xtask/src/themelint.rs
+++ b/xtask/src/themelint.rs
@@ -42,6 +42,9 @@ fn get_rules() -> Vec<Require> {
         Require::Existence(Rule::has_either("ui.virtual.indent-guide")),
         // Check for editor.rulers
         Require::Existence(Rule::has_either("ui.virtual.ruler")),
+        // Check for editor.lsp.display-inlay-hints
+        Require::Existence(Rule::has_either("ui.virtual.inlay-hint.parameter")),
+        Require::Existence(Rule::has_either("ui.virtual.inlay-hint.type")),
         // Check for menus and prompts
         Require::Existence(Rule::has_both("ui.menu")),
         Require::Existence(Rule::has_both("ui.help")),


### PR DESCRIPTION
Since #5934 closed #2070 I think the linter should check for these.

Maybe it's about time that we run the linter against PRs with changes to `/runtime/themes`?

EDIT: this now lints for `ui.virtual` as a catch all for present and future virtual text.