### PR TITLE
adjust inlay hints, color modes and virtual for fleet dark

### DIFF
--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -67,9 +67,9 @@
 # ui specific
 "ui.background" = { bg = "Gray 10" } # .separator
 "ui.statusline" = { fg = "Gray 120", bg = "Gray 10" } # .inactive / .normal / .insert / .select
-# "ui.statusline.normal" = { fg = "lightest", bg = "darker"}
-# "ui.statusline.insert" = { fg = "lightest", bg = "blue_accent" }
-# "ui.statusline.select" = { fg = "lightest", bg = "orange_accent" }
+# "ui.statusline.normal" = { fg = "Gray 120", bg = "darker"}
+"ui.statusline.insert" = { fg = "Gray 20", bg = "Blue 90" }
+"ui.statusline.select" = { fg = "Gray 20", bg = "Yellow 60" }
 
 "ui.cursor" = { modifiers = ["reversed"] } # .insert / .select / .match / .primary
 "ui.cursor.match" = { bg = "Blue 30" } # .insert / .select / .match / .primary
@@ -92,7 +92,7 @@
 "ui.text.focus" = { fg = "White", bg = "Blue 40" }
 
 "ui.virtual" = "Gray 80" # .whitespace
-"ui.virtual.inlay-hint" = "Purple 20"
+"ui.virtual.inlay-hint" = { fg = "Gray 70" }
 # "ui.virtual.ruler" = { bg = "darker"}
 
 "hint" = "Gray 80"

--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -91,9 +91,9 @@
 "ui.text" = "Gray 120" # .focus / .info
 "ui.text.focus" = { fg = "White", bg = "Blue 40" }
 
-"ui.virtual" = "Gray 80" # .whitespace
+"ui.virtual" = "Gray 20" # .whitespace
 "ui.virtual.inlay-hint" = { fg = "Gray 70" }
-# "ui.virtual.ruler" = { bg = "darker"}
+"ui.virtual.ruler" = { bg = "Gray 20" }
 
 "hint" = "Gray 80"
 "info" = "#A366C4"


### PR DESCRIPTION
As Fleet does not have these, this is an interpretation and adaptation for helix.

* Adjust inlay hints to make them blend more into the background and not stand out as much.
* Bring back color modes
* EDIT: Adjusted virtual + ruler while I was at it

No errors from themelint

<img width="1624" alt="Screenshot 2023-03-15 at 13 07 27" src="https://user-images.githubusercontent.com/2630397/225304504-d7009035-17d9-4091-a66b-78db5a97a71f.png">
