### PR TITLE
Add inlay-hint style for solarized themes.

### DIFF
--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -41,6 +41,7 @@
 "ui.background" = { bg = "base03" }
 
 "ui.virtual.whitespace" = { fg = "base01" }
+"ui.virtual.inlay-hint" = { fg = "base01", modifiers = ["italic"] }
 
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -42,6 +42,7 @@
 "ui.background" = { bg = "base03" }
 
 "ui.virtual.whitespace" = { fg = "base01" }
+"ui.virtual.inlay-hint" = { fg = "base01", modifiers = ["italic"] }
 
 # 行号栏
 # line number column


### PR DESCRIPTION
This uses the same color as comments, which is a light gray in both dark and light.
I think it also looks nice with italics, to visually distinguish it from "real" gray text like comments.
Without this, virtual hints were defaulting to the same white color used for identifiers, which looked confusing.
![1678922019](https://user-images.githubusercontent.com/2496231/225464504-16e8db41-c771-44c5-9c74-dfe38c1e76ef.png)
