### PR TITLE
Update ayu theme for inlay-hint

### DIFF
--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -47,6 +47,7 @@
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
 "ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.inlay-hint" = { fg = "#e6b450", bg = "#302a20" }  # original bg #e6b45033
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -47,6 +47,7 @@
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
 "ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.inlay-hint" = { fg = "#f4a028", bg = "#fcf2e3" }  # bg original #ffaa3333
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -47,6 +47,7 @@
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
 "ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.inlay-hint" = { fg = "#ffcc66", bg = "#47433d" }  # original bg #ffcc6633
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }
 "ui.selection" = { bg = "dark_gray" }


### PR DESCRIPTION
Based on vscode ayu badge.

Looks like no palette colors fit so I just put in the original color codes.

ayu_light

![Screenshot_20230316_091557](https://user-images.githubusercontent.com/4687791/225484549-d498751c-3393-4e2a-a7ec-0c78cb8d7c5c.png)

ayu_dark

![Screenshot_20230316_091612](https://user-images.githubusercontent.com/4687791/225484578-d0670068-24ca-49b7-a87b-677db336335c.png)

ayu_mirage

![Screenshot_20230316_091623](https://user-images.githubusercontent.com/4687791/225484601-cfac5b53-b230-424c-8a78-42e6d04b879a.png)

vscode ayu_light

![Screenshot_20230316_091836](https://user-images.githubusercontent.com/4687791/225484882-595c9fc4-7c09-4776-b489-7a1540ddfa04.png)

cc @enkodr 