### PR TITLE
add goto next/prev error (bound to ]e/[e)

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -104,6 +104,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "[" => { "Left bracket"
             "d" => goto_prev_diag,
             "D" => goto_first_diag,
+            "e" => goto_prev_error,
             "g" => goto_prev_change,
             "G" => goto_first_change,
             "f" => goto_prev_function,
@@ -117,6 +118,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "]" => { "Right bracket"
             "d" => goto_next_diag,
             "D" => goto_last_diag,
+            "e" => goto_next_error,
             "g" => goto_next_change,
             "G" => goto_last_change,
             "f" => goto_next_function,


### PR DESCRIPTION
some of my projects have a warnings from very verbose linters, this helps navigate the files when fixes errors.