### PR TITLE
Fix highlighting in picker with multiple columns

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -812,7 +812,10 @@ impl<T: Item + 'static> Component for Picker<T> {
                 for cell in row.cells.iter_mut() {
                     let spans = match cell.content.lines.get(0) {
                         Some(s) => s,
-                        None => continue,
+                        None => {
+                            cell_start_byte_offset += TEMP_CELL_SEP.len();
+                            continue;
+                        }
                     };
 
                     let mut cell_len = 0;

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -453,10 +453,12 @@ impl<'a> From<&Text<'a>> for String {
         let mut output = String::with_capacity(size);
 
         for spans in &text.lines {
+            if !output.is_empty() {
+                output.push('\n');
+            }
             for span in &spans.0 {
                 output.push_str(&span.content);
             }
-            output.push('\n');
         }
         output
     }


### PR DESCRIPTION
Fixes #6254

This could be probably done in a less hacky way, but I didn't want to overcomplicate things.