### PR TITLE
theme: update adwaita-dark for bufferline

### DIFF
--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -99,6 +99,9 @@
 "diagnostic.error" = { fg = "red_4", modifiers = ["underlined"] }
 "diagnostic.warning" = { fg = "yellow_2", modifiers = ["underlined"] }
 
+"ui.bufferline" = { fg = "dark_2", bg = "libadwaita_dark" }
+"ui.bufferline.active" = { fg = "light_4", bg = "libadwaita_dark_alt" }
+
 [palette]
 blue_1 = "#99C1F1"
 blue_2 = "#62A0EA"


### PR DESCRIPTION
The adwaita-dark theme has no distinction between active and inactive buffers on a bufferline. Add contrast to clarify differences.

### before:

![20230317-20_39_23](https://user-images.githubusercontent.com/24674436/225894666-bc49f97d-eb03-44a7-8c78-15e76f6f18d3.png)

### after:

![20230317-20_37_42](https://user-images.githubusercontent.com/24674436/225894716-1561ab56-21c8-4db8-8d71-a9bd46915556.png)
