### PR TITLE
Add initial Smithy support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -123,6 +123,7 @@
 | scheme | ✓ |  |  |  |
 | scss | ✓ |  |  | `vscode-css-language-server` |
 | slint | ✓ |  | ✓ | `slint-lsp` |
+| smithy | ✓ |  |  | `cs` |
 | sml | ✓ |  |  |  |
 | solidity | ✓ |  |  | `solc` |
 | sql | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2352,7 +2352,7 @@ roots = ["smithy-build.json"]
 auto-format = false
 comment-token = "//"
 indent = { tab-width = 4, unit = "  "  }
-language-server = { command = "cs", args = ["launch", "com.disneystreaming.smithy:smithy-language-server:0.0.21", "--", "0"] }
+language-server = { command = "cs", args = ["launch", "com.disneystreaming.smithy:smithy-language-server:latest.release", "--", "0"] }
 
 [[grammar]]
 name = "smithy"

--- a/languages.toml
+++ b/languages.toml
@@ -2347,11 +2347,9 @@ name = "smithy"
 scope = "source.smithy"
 injection-regex = "smithy"
 file-types = ["smithy"]
-shebangs = []
 roots = ["smithy-build.json"]
-auto-format = false
 comment-token = "//"
-indent = { tab-width = 4, unit = "  "  }
+indent = { tab-width = 4, unit = "    " }
 language-server = { command = "cs", args = ["launch", "com.disneystreaming.smithy:smithy-language-server:latest.release", "--", "0"] }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -2341,3 +2341,19 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "capnp"
 source = { git = "https://github.com/amaanq/tree-sitter-capnp", rev = "fc6e2addf103861b9b3dffb82c543eb6b71061aa" }
+
+[[language]]
+name = "smithy"
+scope = "source.smithy"
+injection-regex = "smithy"
+file-types = ["smithy"]
+shebangs = []
+roots = ["smithy-build.json"]
+auto-format = false
+comment-token = "//"
+indent = { tab-width = 4, unit = "  "  }
+language-server = { command = "cs", args = ["launch", "com.disneystreaming.smithy:smithy-language-server:0.0.21", "--", "0"] }
+
+[[grammar]]
+name = "smithy"
+source = { git = "https://github.com/indoorvivants/tree-sitter-smithy", rev = "cf8c7eb9faf7c7049839585eac19c94af231e6a0" }

--- a/runtime/queries/smithy/highlights.scm
+++ b/runtime/queries/smithy/highlights.scm
@@ -1,6 +1,6 @@
 ; Queries are taken from: https://github.com/indoorvivants/tree-sitter-smithy/blob/main/queries/highlights.scm
 ; Preproc
-(control_key) @preproc
+(control_key) @keyword.directive
 
 ; Namespace
 (namespace) @namespace
@@ -21,13 +21,13 @@
 ] @type.builtin
 
 ; Fields (Members)
-; (field) @field
+; (field) @variable.other.member
 
-(key_identifier) @field
+(key_identifier) @variable.other.member
 (shape_member
-  (field) @field)
-(operation_field) @field
-(operation_error_field) @field
+  (field) @variable.other.member)
+(operation_field) @variable.other.member
+(operation_error_field) @variable.other.member
 
 ; Constants
 (enum_member
@@ -42,7 +42,7 @@
 (mixins
   (shape_id) @attribute)
 (trait_statement
-  (shape_id (#set! "priority" 105)) @attribute)
+  (shape_id @attribute)
 
 ; Operators
 [
@@ -68,13 +68,13 @@
 
 ; Literals
 (string) @string
-(escape_sequence) @string.escape
+(escape_sequence) @constant.character.escape
 
 (number) @number
 
 (float) @float
 
-(boolean) @boolean
+(boolean) @constant.builtin.boolean
 
 (null) @constant.builtin
 
@@ -99,4 +99,4 @@
 [
   (comment)
   (documentation_comment)
-] @comment @spell
+] @comment

--- a/runtime/queries/smithy/highlights.scm
+++ b/runtime/queries/smithy/highlights.scm
@@ -8,7 +8,7 @@
 ; Includes
 [
   "use"
-] @include
+] @keyword.control.import
 
 ; Builtins
 (primitive) @type.builtin

--- a/runtime/queries/smithy/highlights.scm
+++ b/runtime/queries/smithy/highlights.scm
@@ -31,7 +31,7 @@
 
 ; Constants
 (enum_member
-  (enum_field) @constant)
+  (enum_field) @type.enum)
 
 ; Types
 (identifier) @type
@@ -42,7 +42,7 @@
 (mixins
   (shape_id) @attribute)
 (trait_statement
-  (shape_id @attribute)
+  (shape_id @attribute))
 
 ; Operators
 [
@@ -70,9 +70,9 @@
 (string) @string
 (escape_sequence) @constant.character.escape
 
-(number) @number
+(number) @constant.numeric
 
-(float) @float
+(float) @constant.numeric.float
 
 (boolean) @constant.builtin.boolean
 

--- a/runtime/queries/smithy/highlights.scm
+++ b/runtime/queries/smithy/highlights.scm
@@ -1,0 +1,102 @@
+; Queries are taken from: https://github.com/indoorvivants/tree-sitter-smithy/blob/main/queries/highlights.scm
+; Preproc
+(control_key) @preproc
+
+; Namespace
+(namespace) @namespace
+
+; Includes
+[
+  "use"
+] @include
+
+; Builtins
+(primitive) @type.builtin
+[
+  "enum"
+  "intEnum"
+  "list"
+  "map"
+  "set"
+] @type.builtin
+
+; Fields (Members)
+; (field) @field
+
+(key_identifier) @field
+(shape_member
+  (field) @field)
+(operation_field) @field
+(operation_error_field) @field
+
+; Constants
+(enum_member
+  (enum_field) @constant)
+
+; Types
+(identifier) @type
+(structure_resource
+  (shape_id) @type)
+
+; Attributes
+(mixins
+  (shape_id) @attribute)
+(trait_statement
+  (shape_id (#set! "priority" 105)) @attribute)
+
+; Operators
+[
+  "@"
+  "-"
+  "="
+  ":="
+] @operator
+
+; Keywords
+[
+  "namespace"
+  "service"
+  "structure"
+  "operation"
+  "union"
+  "resource"
+  "metadata"
+  "apply"
+  "for"
+  "with"
+] @keyword
+
+; Literals
+(string) @string
+(escape_sequence) @string.escape
+
+(number) @number
+
+(float) @float
+
+(boolean) @boolean
+
+(null) @constant.builtin
+
+; Misc
+[
+  "$"
+  "#"
+] @punctuation.special
+
+["{" "}"] @punctuation.bracket
+
+["(" ")"] @punctuation.bracket
+
+["[" "]"] @punctuation.bracket
+
+[
+  ":"
+  "."
+] @punctuation.delimiter
+
+; Comments
+[
+  (comment)
+  (documentation_comment)
+] @comment @spell

--- a/runtime/queries/smithy/highlights.scm
+++ b/runtime/queries/smithy/highlights.scm
@@ -42,7 +42,7 @@
 (mixins
   (shape_id) @attribute)
 (trait_statement
-  (shape_id @attribute))
+  (shape_id) @attribute)
 
 ; Operators
 [

--- a/runtime/queries/smithy/injections.scm
+++ b/runtime/queries/smithy/injections.scm
@@ -1,3 +1,0 @@
-(block parameter: (expr) @injection.language
-  (contents) @injection.content
-  (#set! injection.include-children))

--- a/runtime/queries/smithy/injections.scm
+++ b/runtime/queries/smithy/injections.scm
@@ -1,0 +1,3 @@
+(block parameter: (expr) @injection.language
+  (contents) @injection.content
+  (#set! injection.include-children))


### PR DESCRIPTION
Adds syntax highlighting support for https://smithy.io/2.0/index.html a meta-modeling language to describe APIs.

LSP: https://github.com/disneystreaming/smithy-language-server
Treesitter grammar: https://github.com/indoorvivants/tree-sitter-smithy