### PR TITLE
Robust snippet parsing

### DIFF
--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -388,6 +388,12 @@ mod parser {
                 default: None,
                 regex: None,
             }),
+            // ${var}
+            map(seq!("${", var(), "}",), |values| SnippetElement::Variable {
+                name: values.1,
+                default: None,
+                regex: None,
+            }),
             // ${var:default}
             map(
                 seq!(

--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -311,9 +311,9 @@ mod parser {
             seq!(
                 "/",
                 // TODO parse as ECMAScript and convert to rust regex
-                non_empty(text(&['/'], &['/'])),
+                text(&['/'], &['/']),
                 "/",
-                one_or_more(choice!(
+                zero_or_more(choice!(
                     format(),
                     // text doesn't parse $, if format fails we just accept the $ as text
                     map("$", |_| FormatItem::Text("$".into())),

--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -196,23 +196,23 @@ mod parser {
 
     fn var<'a>() -> impl Parser<'a, Output = &'a str> {
         // var = [_a-zA-Z][_a-zA-Z0-9]*
-        move |input: &'a str| match input
-            .char_indices()
-            .take_while(|(p, c)| {
-                *c == '_'
-                    || if *p == 0 {
-                        c.is_ascii_alphabetic()
-                    } else {
-                        c.is_ascii_alphanumeric()
-                    }
-            })
-            .last()
-        {
-            Some((index, c)) if index >= 1 => {
-                let index = index + c.len_utf8();
-                Ok((&input[index..], &input[0..index]))
-            }
-            _ => Err(input),
+        move |input: &'a str| {
+            input
+                .char_indices()
+                .take_while(|(p, c)| {
+                    *c == '_'
+                        || if *p == 0 {
+                            c.is_ascii_alphabetic()
+                        } else {
+                            c.is_ascii_alphanumeric()
+                        }
+                })
+                .last()
+                .map(|(index, c)| {
+                    let index = index + c.len_utf8();
+                    (&input[index..], &input[0..index])
+                })
+                .ok_or(input)
         }
     }
 


### PR DESCRIPTION
Closes #6347

Fixes a bunch of small bugs in the snippet parsing, mostly relating to escape sequences. The LSP standard is incomplete, ambigous/missleading and sometimes even downright wrong so I just used the vscode implementation as a reference. I have started porting a bunch of tests over from there to be sure we are doing the right thing now. However due to the sheer number of tests I stopped with that at some point to preserver my sanity.

The large number of inserted lines are just tests, the code changes itself are pretty minor.