### PR TITLE
Document `ui.highlight` theme key

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -306,6 +306,7 @@ These scopes are used for theming the editor interface:
 | `ui.menu.scroll`                  | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |
 | `ui.selection`                    | For selections in the editing area                                                             |
 | `ui.selection.primary`            |                                                                                                |
+| `ui.highlight`                    | Highlighted lines in the picker preview                                                        |
 | `ui.cursorline.primary`           | The line of the primary cursor ([if cursorline is enabled][editor-section])                    |
 | `ui.cursorline.secondary`         | The lines of any other cursors ([if cursorline is enabled][editor-section])                    |
 | `ui.cursorcolumn.primary`         | The column of the primary cursor ([if cursorcolumn is enabled][editor-section])                |


### PR DESCRIPTION
This scope was added via https://github.com/helix-editor/helix/commit/bf5b9a9f354135933d7970863cf81e5a36585d03, but it was never documented.