### PR TITLE
fleet-dark improvements

### DIFF
--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -66,8 +66,9 @@
 
 # ui specific
 "ui.background" = { bg = "Gray 10" } # .separator
-"ui.statusline" = { fg = "Gray 120", bg = "Gray 10" } # .inactive / .normal / .insert / .select
-# "ui.statusline.normal" = { fg = "Gray 120", bg = "darker"}
+"ui.statusline" = { fg = "Gray 120", bg = "Gray 20" } # .inactive / .normal / .insert / .select
+"ui.statusline.normal" = { fg = "Gray 120", bg = "Gray 20" }
+"ui.statusline.inactive" = { fg = "Gray 90"}
 "ui.statusline.insert" = { fg = "Gray 20", bg = "Blue 90" }
 "ui.statusline.select" = { fg = "Gray 20", bg = "Yellow 60" }
 
@@ -91,7 +92,7 @@
 "ui.text" = "Gray 120" # .focus / .info
 "ui.text.focus" = { fg = "White", bg = "Blue 40" }
 
-"ui.virtual" = "Gray 20" # .whitespace
+"ui.virtual" = "Gray 90" # .whitespace
 "ui.virtual.inlay-hint" = { fg = "Gray 70" }
 "ui.virtual.ruler" = { bg = "Gray 20" }
 


### PR DESCRIPTION
A few changes that does not comply with the original theme, but adjusts the theme to better fit the editor of choice.

* Statusline is now visible. This was an issue when using horizontal splits
* ui.virtual was adjusted to a much lighter color. This is an issue only because we are using the "reversed" modifier for the cursor, and thus this change is required to make the cursor visible again when moving through whitespace.  As a result, whitespace is now much more "in your face" when enabled. I consider this an okay price to pay. Feel free to disagree


![Screenshot 2023-03-20 at 10 01 25](https://user-images.githubusercontent.com/2630397/226292645-a13a4dbe-3c14-4bec-9c8e-ac3ab19e848f.png)
![Screenshot 2023-03-20 at 10 02 21](https://user-images.githubusercontent.com/2630397/226292858-db6534cc-6396-4dd5-8f17-d1a68d427dba.png)
