### PR TITLE
Show diagnostic codes for LSP diagnostics

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,7 @@ use helix_view::{
 };
 use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc};
 
-use tui::buffer::Buffer as Surface;
+use tui::{buffer::Buffer as Surface, text::Span};
 
 use super::statusline;
 use super::{document::LineDecoration, lsp::SignatureHelp};
@@ -690,8 +690,8 @@ impl EditorView {
                 NumberOrString::String(s) => format!("({s})"),
             });
             if let Some(code) = code {
-                let text = Text::styled(code, style);
-                lines.extend(text.lines);
+                let span = Span::styled(code, style);
+                lines.push(span.into());
             }
         }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 use helix_core::{
+    diagnostic::NumberOrString,
     graphemes::{
         ensure_grapheme_boundary_next_byte, next_grapheme_boundary, prev_grapheme_boundary,
     },
@@ -684,6 +685,14 @@ impl EditorView {
                 });
             let text = Text::styled(&diagnostic.message, style);
             lines.extend(text.lines);
+            let code = diagnostic.code.as_ref().map(|x| match x {
+                NumberOrString::Number(n) => format!("({n})"),
+                NumberOrString::String(s) => format!("({s})"),
+            });
+            if let Some(code) = code {
+                let text = Text::styled(code, style);
+                lines.extend(text.lines);
+            }
         }
 
         let paragraph = Paragraph::new(lines)


### PR DESCRIPTION
Similar to #6095

**Problem** currently during diagnostic rendering only the description is shown but the code is also useful when one wants to ignore that error report.

**After this pr** errors will be rendered as follows.
![image](https://user-images.githubusercontent.com/6558089/226376130-da84b80a-1d3e-4171-9e52-8abb8cfc821e.png)

Now you know what code to use to ignore the error
![image](https://user-images.githubusercontent.com/6558089/226378153-10236d78-63bd-460a-a6f6-a830903949f0.png)
