### PR TITLE
book: changed displayed key binding for diagnostics picker

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -277,8 +277,8 @@ This layer is a kludge of mappings, mostly pickers.
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
 | `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                            |
 | `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`                  |
-| `d`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                       |
-| `D`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`             |
+| `g`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                       |
+| `G`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`             |
 | `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                            |
 | `a`     | Apply code action (**LSP**)                                             | `code_action`                              |
 | `h`     | Select symbol references (**LSP**)                                      | `select_references_to_symbol_under_cursor` |


### PR DESCRIPTION
Currently the displayed key binding for diagnostics picker is 'd' and 'D', the right one should be 'g' and 'G'