### PR TITLE
Add xib and storyboard file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2068,7 +2068,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml", "mobileconfig", "plist"]
+file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
*.xib and *.storyboard files are just xml files used for UI development on Apple platforms.

About [xib](http://www.monobjc.net/xib-file-format.html) and [storyboard](https://chris-mash.medium.com/the-anatomy-of-an-ios-storyboard-d473a4076b25).