### PR TITLE
Allow truncation of table row text

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -347,6 +347,7 @@ impl<T: Item + 'static> Component for Menu<T> {
                 offset: scroll,
                 selected: self.cursor,
             },
+            false,
         );
 
         if let Some(cursor) = self.cursor {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -885,6 +885,7 @@ impl<T: Item + 'static> Component for Picker<T> {
                 offset: 0,
                 selected: Some(cursor),
             },
+            self.truncate_start,
         );
     }
 

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -434,6 +434,20 @@ impl Buffer {
     }
 
     pub fn set_spans_truncated(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {
+        // if the spans contains only 1 span and the
+        // content length of that span is 1, we can
+        // assume that we dont need to truncate the
+        // string.
+        if spans.0.len() == 1 {
+            match spans.0.first() {
+                Some(s) if s.content.len() == 1 => {
+                    return self.set_stringn(x, y, s.content.as_ref(), width as usize, s.style)
+                }
+                // if we pass the above checks, we continue as normal
+                _ => {}
+            }
+        }
+
         let mut remaining_width = width;
         let mut alt_x = x;
         let (text, styles) =

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -434,20 +434,6 @@ impl Buffer {
     }
 
     pub fn set_spans_truncated(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {
-        // if the spans contains only 1 span and the
-        // content length of that span is 1, we can
-        // assume that we dont need to truncate the
-        // string.
-        if spans.0.len() == 1 {
-            match spans.0.first() {
-                Some(s) if s.content.len() == 1 => {
-                    return self.set_stringn(x, y, s.content.as_ref(), width as usize, s.style)
-                }
-                // if we pass the above checks, we continue as normal
-                _ => {}
-            }
-        }
-
         let mut remaining_width = width;
         let mut alt_x = x;
         let (text, styles) =

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -434,28 +434,16 @@ impl Buffer {
     }
 
     pub fn set_spans_truncated(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {
-        let mut remaining_width = width;
-        let mut alt_x = x;
-        let (text, styles) =
-            spans
-                .0
-                .iter()
-                .fold((String::new(), vec![]), |(mut s, mut h), span| {
-                    s.push_str(span.content.as_ref());
-                    let mut styles = span
-                        .styled_graphemes(span.style)
-                        .map(|grapheme| grapheme.style)
-                        .collect();
-                    h.append(&mut styles);
+        let mut text = String::new();
+        let mut styles = vec![];
 
-                    let w = span.width() as u16;
-                    alt_x = alt_x + w;
-                    remaining_width = remaining_width.saturating_sub(w);
+        for span in &spans.0 {
+            text.push_str(span.content.as_ref());
+            span.styled_graphemes(span.style)
+                .for_each(|grapheme| styles.push(grapheme.style));
+        }
 
-                    (s, h)
-                });
-        self.set_string_truncated(x, y, &text, width.into(), |idx| styles[idx], true, true);
-        (x, y)
+        self.set_string_truncated(x, y, &text, width.into(), |idx| styles[idx], true, true)
     }
 
     pub fn set_spans(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -433,6 +433,31 @@ impl Buffer {
         (x_offset as u16, y)
     }
 
+    pub fn set_spans_truncated(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {
+        let mut remaining_width = width;
+        let mut alt_x = x;
+        let (text, styles) =
+            spans
+                .0
+                .iter()
+                .fold((String::new(), vec![]), |(mut s, mut h), span| {
+                    s.push_str(span.content.as_ref());
+                    let mut styles = span
+                        .styled_graphemes(span.style)
+                        .map(|grapheme| grapheme.style)
+                        .collect();
+                    h.append(&mut styles);
+
+                    let w = span.width() as u16;
+                    alt_x = alt_x + w;
+                    remaining_width = remaining_width.saturating_sub(w);
+
+                    (s, h)
+                });
+        self.set_string_truncated(x, y, &text, width.into(), |idx| styles[idx], true, true);
+        (x, y)
+    }
+
     pub fn set_spans(&mut self, x: u16, y: u16, spans: &Spans, width: u16) -> (u16, u16) {
         let mut remaining_width = width;
         let mut x = x;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -359,7 +359,7 @@ impl<'a> Table<'a> {
         area: Rect,
         buf: &mut Buffer,
         state: &mut TableState,
-        truncate_rows: bool,
+        truncate: bool,
     ) {
         if area.area() == 0 {
             return;
@@ -407,6 +407,7 @@ impl<'a> Table<'a> {
                         width: *width,
                         height: max_header_height,
                     },
+                    false,
                 );
                 col += *width + self.column_spacing;
             }
@@ -460,34 +461,24 @@ impl<'a> Table<'a> {
                     width: *width,
                     height: table_row.height,
                 };
-                if truncate_rows {
-                    render_cell_truncated(buf, cell, rect);
-                } else {
-                    render_cell(buf, cell, rect);
-                }
+                render_cell(buf, cell, rect, truncate);
                 col += *width + self.column_spacing;
             }
         }
     }
 }
 
-fn render_cell_truncated(buf: &mut Buffer, cell: &Cell, area: Rect) {
+fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect, truncate: bool) {
     buf.set_style(area, cell.style);
     for (i, spans) in cell.content.lines.iter().enumerate() {
         if i as u16 >= area.height {
             break;
         }
-        buf.set_spans_truncated(area.x, area.y + i as u16, spans, area.width);
-    }
-}
-
-fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect) {
-    buf.set_style(area, cell.style);
-    for (i, spans) in cell.content.lines.iter().enumerate() {
-        if i as u16 >= area.height {
-            break;
+        if cell.content.width() > 1 && truncate {
+            buf.set_spans_truncated(area.x, area.y + i as u16, spans, area.width);
+        } else {
+            buf.set_spans(area.x, area.y + i as u16, spans, area.width);
         }
-        buf.set_spans(area.x, area.y + i as u16, spans, area.width);
     }
 }
 

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -455,13 +455,17 @@ impl<'a> Table<'a> {
                 if is_selected {
                     buf.set_style(table_row_area, self.highlight_style);
                 }
-                let rect = Rect {
-                    x: col,
-                    y: row,
-                    width: *width,
-                    height: table_row.height,
-                };
-                render_cell(buf, cell, rect, truncate);
+                render_cell(
+                    buf,
+                    cell,
+                    Rect {
+                        x: col,
+                        y: row,
+                        width: *width,
+                        height: table_row.height,
+                    },
+                    truncate,
+                );
                 col += *width + self.column_spacing;
             }
         }


### PR DESCRIPTION
This fixes the regression mentioned in https://github.com/helix-editor/helix/issues/6346 where paths in the file picker were no longer being truncated.
We now allow all pickers who have `self.truncate_start` set to `true` to render truncated rows.

Not sure if I'm going about this the right way, any feedback is appreciated :)