### PR TITLE
Inline Diagnostics

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -16,6 +16,7 @@
   - [`[editor.gutters.spacer]` Section](#editorguttersspacer-section)
 - [`[editor.soft-wrap]` Section](#editorsoft-wrap-section)
 - [`[editor.smart-tab]` Section](#editorsmart-tab-section)
+- [`[editor.inline-diagnostics]` Section](#editorinline-diagnostics-section)
 
 ### `[editor]` Section
 
@@ -50,6 +51,7 @@
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |
 | `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`
 | `jump-label-alphabet` | The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. | `"abcdefghijklmnopqrstuvwxyz"`
+| `end-of-line-diagnostics` | Minimum severity of diagnostics to render at the end of the line. Set to `disable` to disable entirely. Refer to the setting about `inline-diagnostics` for more details | "disable"
 
 ### `[editor.statusline]` Section
 
@@ -392,4 +394,42 @@ S-tab = "move_parent_node_start"
 [keys.select]
 tab = "extend_parent_node_end"
 S-tab = "extend_parent_node_start"
+```
+
+### `[editor.inline-diagnostics]` Section
+
+Options for rendering diagnostics inside the text like shown below
+
+```
+fn main() {
+  let foo = bar;
+            └─ no such value in this scope
+}
+````
+
+| Key        | Description | Default |
+|------------|-------------|---------|
+| `cursor-line` | The minimum severity that a diagnostic must have to be shown inline on the line that contains the primary cursor. Set to `disable` to not show any diagnostics inline. This option does not have any effect when in insert-mode and will only take effect 350ms after moving the cursor to a different line. | `"disable"` |
+| `other-lines` | The minimum severity that a diagnostic must have to be shown inline on a line that does not contain the cursor-line. Set to `disable` to not show any diagnostics inline. | `"disable"` |
+| `prefix-len` | How many horizontal bars `─` are rendered before the diagnostic text.  | `1` |
+| `max-wrap` | Equivalent of the `editor.soft-wrap.max-wrap` option for diagnostics.  | `20` |
+| `max-diagnostics` | Maximum number of diagnostics to render inline for a given line  | `10` |
+
+The (first) diagnostic with the highest severity that is not shown inline is rendered at the end of the line (as long as its severity is higher than the `end-of-line-diagnostics` config option):
+
+```
+fn main() {
+  let baz = 1;
+  let foo = bar; a local variable with a similar name exists: baz
+            └─ no such value in this scope
+}
+```
+
+
+The new diagnostic rendering is not yet enabled by default. As soon as end of line or inline diagnostics are enabled the old diagnostics rendering is automatically disabled. The recommended default setting are:
+
+```
+end-of-line-diagnostics = "hint"
+[editor.inline-diagnostics]
+cursor-line = "warning" # show warnings and errors on the cursorline inline
 ```

--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -4,7 +4,8 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Describes the severity level of a [`Diagnostic`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     Hint,
     Info,
@@ -23,6 +24,12 @@ impl Default for Severity {
 pub struct Range {
     pub start: usize,
     pub end: usize,
+}
+
+impl Range {
+    pub fn contains(self, pos: usize) -> bool {
+        (self.start..self.end).contains(&pos)
+    }
 }
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
@@ -69,5 +76,12 @@ slotmap::new_key_type! {
 impl fmt::Display for LanguageServerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+impl Diagnostic {
+    #[inline]
+    pub fn severity(&self) -> Severity {
+        self.severity.unwrap_or(Severity::Warning)
     }
 }

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -182,7 +182,7 @@ pub struct DocumentFormatter<'t> {
     line_pos: usize,
     exhausted: bool,
 
-    inline_anntoation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
+    inline_annotation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
 
     // softwrap specific
     /// The indentation of the current line
@@ -227,7 +227,7 @@ impl<'t> DocumentFormatter<'t> {
             word_buf: Vec::with_capacity(64),
             word_i: 0,
             line_pos: block_line_idx,
-            inline_anntoation_graphemes: None,
+            inline_annotation_graphemes: None,
         }
     }
 
@@ -237,7 +237,7 @@ impl<'t> DocumentFormatter<'t> {
     ) -> Option<(&'t str, Option<Highlight>)> {
         loop {
             if let Some(&mut (ref mut annotation, highlight)) =
-                self.inline_anntoation_graphemes.as_mut()
+                self.inline_annotation_graphemes.as_mut()
             {
                 if let Some(grapheme) = annotation.next() {
                     return Some((grapheme, highlight));
@@ -247,7 +247,7 @@ impl<'t> DocumentFormatter<'t> {
             if let Some((annotation, highlight)) =
                 self.annotations.next_inline_annotation_at(char_pos)
             {
-                self.inline_anntoation_graphemes = Some((
+                self.inline_annotation_graphemes = Some((
                     UnicodeSegmentation::graphemes(&*annotation.text, true),
                     highlight,
                 ))

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -23,18 +23,18 @@ impl<'t> DocumentFormatter<'t> {
         let viewport_width = self.text_fmt.viewport_width;
         let mut line = 0;
 
-        for (grapheme, pos) in self {
-            if pos.row != line {
+        for grapheme in self {
+            if grapheme.visual_pos.row != line {
                 line += 1;
-                assert_eq!(pos.row, line);
-                write!(res, "\n{}", ".".repeat(pos.col)).unwrap();
+                assert_eq!(grapheme.visual_pos.row, line);
+                write!(res, "\n{}", ".".repeat(grapheme.visual_pos.col)).unwrap();
                 assert!(
-                    pos.col <= viewport_width as usize,
+                    grapheme.visual_pos.col <= viewport_width as usize,
                     "softwrapped failed {}<={viewport_width}",
-                    pos.col
+                    grapheme.visual_pos.col
                 );
             }
-            write!(res, "{}", grapheme.grapheme).unwrap();
+            write!(res, "{}", grapheme.raw).unwrap();
         }
 
         res
@@ -48,7 +48,6 @@ fn softwrap_text(text: &str) -> String {
         &TextAnnotations::default(),
         0,
     )
-    .0
     .collect_to_str()
 }
 
@@ -106,7 +105,6 @@ fn overlay_text(text: &str, char_pos: usize, softwrap: bool, overlays: &[Overlay
         TextAnnotations::default().add_overlay(overlays, None),
         char_pos,
     )
-    .0
     .collect_to_str()
 }
 
@@ -143,7 +141,6 @@ fn annotate_text(text: &str, softwrap: bool, annotations: &[InlineAnnotation]) -
         TextAnnotations::default().add_inline_annotations(annotations, None),
         0,
     )
-    .0
     .collect_to_str()
 }
 
@@ -182,7 +179,6 @@ fn annotation_and_overlay() {
                 .add_overlay(overlay.as_slice(), None),
             0,
         )
-        .0
         .collect_to_str(),
         "fooo  bar "
     );

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -28,6 +28,11 @@ pub enum Grapheme<'a> {
 }
 
 impl<'a> Grapheme<'a> {
+    pub fn new_decoration(g: &'static str) -> Grapheme<'a> {
+        assert_ne!(g, "\t");
+        Grapheme::new(g.into(), 0, 0)
+    }
+
     pub fn new(g: GraphemeStr<'a>, visual_x: usize, tab_width: u16) -> Grapheme<'a> {
         match g {
             g if g == "\t" => Grapheme::Tab {

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -53,8 +53,8 @@ pub use {regex, tree_sitter};
 
 pub use graphemes::RopeGraphemes;
 pub use position::{
-    char_idx_at_visual_offset, coords_at_pos, pos_at_coords, visual_offset_from_anchor,
-    visual_offset_from_block, Position, VisualOffsetError,
+    char_idx_at_visual_offset, coords_at_pos, pos_at_coords, softwrapped_dimensions,
+    visual_offset_from_anchor, visual_offset_from_block, Position, VisualOffsetError,
 };
 #[allow(deprecated)]
 pub use position::{pos_at_visual_coords, visual_coords_at_pos};

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -79,19 +79,19 @@ pub fn move_vertically_visual(
         Direction::Backward => -(count as isize),
     };
 
-    // TODO how to handle inline annotations that span an entire visual line (very unlikely).
-
     // Compute visual offset relative to block start to avoid trasversing the block twice
     row_off += visual_pos.row as isize;
-    let new_pos = char_idx_at_visual_offset(
+    let (mut new_pos, virtual_rows) = char_idx_at_visual_offset(
         slice,
         block_off,
         row_off,
         new_col as usize,
         text_fmt,
         annotations,
-    )
-    .0;
+    );
+    if dir == Direction::Forward {
+        new_pos += (virtual_rows != 0) as usize;
+    }
 
     // Special-case to avoid moving to the end of the last non-empty line.
     if behaviour == Movement::Extend && slice.line(slice.char_to_line(new_pos)).len_chars() == 0 {

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -171,6 +171,17 @@ pub fn visual_offset_from_block(
     (last_pos, block_start)
 }
 
+/// Returns the height of the given text when softwrapping
+pub fn softwrapped_dimensions(text: RopeSlice, text_fmt: &TextFormat) -> (usize, u16) {
+    let last_pos =
+        visual_offset_from_block(text, 0, usize::MAX, text_fmt, &TextAnnotations::default()).0;
+    if last_pos.row == 0 {
+        (1, last_pos.col as u16)
+    } else {
+        (last_pos.row + 1, text_fmt.viewport_width)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VisualOffsetError {
     PosBeforeAnchorRow,

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, cmp::Ordering};
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
 
 use crate::{
     chars::char_is_line_ending,
@@ -14,6 +18,38 @@ use crate::{
 pub struct Position {
     pub row: usize,
     pub col: usize,
+}
+
+impl AddAssign for Position {
+    fn add_assign(&mut self, rhs: Self) {
+        self.row += rhs.row;
+        self.col += rhs.col;
+    }
+}
+
+impl SubAssign for Position {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.row -= rhs.row;
+        self.col -= rhs.col;
+    }
+}
+
+impl Sub for Position {
+    type Output = Position;
+
+    fn sub(mut self, rhs: Self) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl Add for Position {
+    type Output = Position;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
 }
 
 impl Position {

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -334,7 +334,9 @@ impl<'a> TextAnnotations<'a> {
         layer: &'a [InlineAnnotation],
         highlight: Option<Highlight>,
     ) -> &mut Self {
-        self.inline_annotations.push((layer, highlight).into());
+        if !layer.is_empty() {
+            self.inline_annotations.push((layer, highlight).into());
+        }
         self
     }
 
@@ -349,7 +351,9 @@ impl<'a> TextAnnotations<'a> {
     /// If multiple layers contain overlay at the same position
     /// the overlay from the layer added last will be show.
     pub fn add_overlay(&mut self, layer: &'a [Overlay], highlight: Option<Highlight>) -> &mut Self {
-        self.overlays.push((layer, highlight).into());
+        if !layer.is_empty() {
+            self.overlays.push((layer, highlight).into());
+        }
         self
     }
 

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -1,8 +1,12 @@
 use std::cell::Cell;
+use std::cmp::Ordering;
+use std::fmt::Debug;
 use std::ops::Range;
+use std::ptr::NonNull;
 
+use crate::doc_formatter::FormattedGrapheme;
 use crate::syntax::Highlight;
-use crate::Tendril;
+use crate::{Position, Tendril};
 
 /// An inline annotation is continuous text shown
 /// on the screen before the grapheme that starts at
@@ -75,19 +79,98 @@ impl Overlay {
     }
 }
 
-/// Line annotations allow for virtual text between normal
-/// text lines. They cause `height` empty lines to be inserted
-/// below the document line that contains `anchor_char_idx`.
+/// Line annotations allow inserting virtual text lines between normal text
+/// lines.  These lines can be filled with text in the rendering code as their
+/// contents have no effect beyond visual appearance.
 ///
-/// These lines can be filled with text in the rendering code
-/// as their contents have no effect beyond visual appearance.
+/// The height of virtual text is usually not known ahead of time as virtual
+/// text often requires softwrapping. Furthermore the height of some virtual
+/// text like side-by-side diffs depends on the height of the text (again
+/// influenced by softwrap) and other virtual text. Therefore line annotations
+/// are computed on the fly instead of ahead of time like other annotations.
 ///
-/// To insert a line after a document line simply set
-/// `anchor_char_idx` to `doc.line_to_char(line_idx)`
-#[derive(Debug, Clone)]
-pub struct LineAnnotation {
-    pub anchor_char_idx: usize,
-    pub height: usize,
+/// The core of this trait `insert_virtual_lines` function. It is called at the
+/// end of every  visual line and allows the `LineAnnotation` to insert empty
+/// virtual lines. Apart from that the `LineAnnotation` trait has multiple
+/// methods that allow it to track anchors in the document.
+///
+/// When a new traversal of a document starts `reset_pos` is called. Afterwards
+/// the other functions are called with indices that are larger then the
+/// one passed to `reset_pos`. This allows performing a binary search (use
+/// `partition_point`) in `reset_pos` once and then to only look at the next
+/// anchor during each method call.
+///
+/// The `reset_pos`, `skip_conceal` and `process_anchor` functions all return a
+/// `char_idx` anchor. This anchor is stored when transversing the document and
+/// when the grapheme at the anchor is traversed the `process_anchor` function
+/// is called.
+///
+/// # Note
+///
+/// All functions only receive immutable references to `self`.
+/// `LineAnnotation`s that want to store an internal position or
+/// state of some kind should use `Cell`. Using interior mutability for
+/// caches is preferable as otherwise a lot of lifetimes become invariant
+/// which complicates APIs a lot.
+pub trait LineAnnotation {
+    /// Resets the internal position to `char_idx`. This function is called
+    /// when a new traversal of a document starts.
+    ///
+    /// All `char_idx` passed to `insert_virtual_lines` are strictly monotonically increasing
+    /// with the first `char_idx` greater or equal to the `char_idx`
+    /// passed to this function.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn reset_pos(&mut self, _char_idx: usize) -> usize {
+        usize::MAX
+    }
+
+    /// Called when a text is concealed that contains an anchor registered by this `LineAnnotation`.
+    /// In this case the line decorations  **must** ensure that virtual text anchored within that
+    /// char range is skipped.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// **after the end of conceal_end_char_idx**
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn skip_concealed_anchors(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.reset_pos(conceal_end_char_idx)
+    }
+
+    /// Process an anchor (horizontal position is provided) and returns the next anchor.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn process_anchor(&mut self, _grapheme: &FormattedGrapheme) -> usize {
+        usize::MAX
+    }
+
+    /// This function is called at the end of a visual line to insert virtual text
+    ///
+    /// # Returns
+    ///
+    /// The number of additional virtual lines to reserve
+    ///
+    /// # Note
+    ///
+    /// The `line_end_visual_pos` parameter indicates the visual vertical distance
+    /// from the start of block where the traversal starts.  This includes the offset
+    /// from other `LineAnnotations`. This allows inline annotations to consider
+    /// the height of the text and "align" two different documents (like for side
+    /// by side diffs).  These annotations that want to "align" two documents should
+    /// therefore be added last so that other virtual text is also considered while aligning
+    fn insert_virtual_lines(
+        &mut self,
+        line_end_char_idx: usize,
+        line_end_visual_pos: Position,
+        doc_line: usize,
+    ) -> Position;
 }
 
 #[derive(Debug)]
@@ -143,13 +226,68 @@ fn reset_pos<A, M>(layers: &[Layer<A, M>], pos: usize, get_pos: impl Fn(&A) -> u
     }
 }
 
+/// Safety: We store LineAnnotation in a NonNull pointer. This is necessary to work
+/// around an unfortunate inconsistency in rusts variance system that unnnecesarily
+/// makes the lifetime invariant if implemented with safe code. This makes the
+/// DocFormatter API very cumbersome/basically impossible to work with.
+///
+/// Normally object types `dyn Foo + 'a` are covariant so if we used `Box<dyn LineAnnotation + 'a>` below
+/// everything would be alright. However we want to use `Cell<Box<dyn LineAnnotation + 'a>>`
+/// to be able to call the mutable function on `LineAnnotation`. The problem is that
+/// some types like `Cell` make all their arguments invariant. This is important for soundness
+/// normally for the same reasons that `&'a mut T` is invariant over `T`
+/// (see <https://doc.rust-lang.org/nomicon/subtyping.html>). However for `&'a mut` (`dyn Foo + 'b`)
+/// there is a specical rule in the language to make `'b` covariant (otherwise trait objects would be
+/// super annoying to use). See  <https://users.rust-lang.org/t/solved-variance-of-dyn-trait-a> for
+/// why this is sound. Sadly that rule doesn't apply to `Cell<Box<(dyn Foo + 'a)>`
+/// (or other invariant types like `UnsafeCell` or `*mut (dyn Foo + 'a)`).
+///
+/// We sidestep the problem by using `NonNull` which is covariant. In the
+/// special case of trait objects this is sound (easily checked by adding a
+/// `PhantomData<&'a mut Foo + 'a)>` field). We don't need an explicit `Cell`
+/// type here because we never hand out any refereces to the trait objects. That
+/// means any reference to the pointer can create a valid multable reference
+/// that is covariant over `'a` (or in other words it's a raw pointer, as long as
+/// we don't hand out references we are free to do whatever we want).
+struct RawBox<T: ?Sized>(NonNull<T>);
+
+impl<T: ?Sized> RawBox<T> {
+    /// Safety: Only a single mutable reference
+    /// created by this function may exist at a given time.
+    #[allow(clippy::mut_from_ref)]
+    unsafe fn get(&self) -> &mut T {
+        &mut *self.0.as_ptr()
+    }
+}
+impl<T: ?Sized> From<Box<T>> for RawBox<T> {
+    fn from(box_: Box<T>) -> Self {
+        // obviously safe because Box::into_raw never returns null
+        unsafe { Self(NonNull::new_unchecked(Box::into_raw(box_))) }
+    }
+}
+
+impl<T: ?Sized> Drop for RawBox<T> {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.0.as_ptr())) }
+    }
+}
+
 /// Annotations that change that is displayed when the document is render.
 /// Also commonly called virtual text.
-#[derive(Default, Debug, Clone)]
+#[derive(Default)]
 pub struct TextAnnotations<'a> {
     inline_annotations: Vec<Layer<'a, InlineAnnotation, Option<Highlight>>>,
     overlays: Vec<Layer<'a, Overlay, Option<Highlight>>>,
-    line_annotations: Vec<Layer<'a, LineAnnotation, ()>>,
+    line_annotations: Vec<(Cell<usize>, RawBox<dyn LineAnnotation + 'a>)>,
+}
+
+impl Debug for TextAnnotations<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextAnnotations")
+            .field("inline_annotations", &self.inline_annotations)
+            .field("overlays", &self.overlays)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> TextAnnotations<'a> {
@@ -157,9 +295,9 @@ impl<'a> TextAnnotations<'a> {
     pub fn reset_pos(&self, char_idx: usize) {
         reset_pos(&self.inline_annotations, char_idx, |annot| annot.char_idx);
         reset_pos(&self.overlays, char_idx, |annot| annot.char_idx);
-        reset_pos(&self.line_annotations, char_idx, |annot| {
-            annot.anchor_char_idx
-        });
+        for (next_anchor, layer) in &self.line_annotations {
+            next_anchor.set(unsafe { layer.get().reset_pos(char_idx) });
+        }
     }
 
     pub fn collect_overlay_highlights(
@@ -219,8 +357,9 @@ impl<'a> TextAnnotations<'a> {
     ///
     /// The line annotations **must be sorted** by their `char_idx`.
     /// Multiple line annotations with the same `char_idx` **are not allowed**.
-    pub fn add_line_annotation(&mut self, layer: &'a [LineAnnotation]) -> &mut Self {
-        self.line_annotations.push((layer, ()).into());
+    pub fn add_line_annotation(&mut self, layer: Box<dyn LineAnnotation + 'a>) -> &mut Self {
+        self.line_annotations
+            .push((Cell::new(usize::MAX), layer.into()));
         self
     }
 
@@ -250,21 +389,35 @@ impl<'a> TextAnnotations<'a> {
         overlay
     }
 
-    pub(crate) fn annotation_lines_at(&self, char_idx: usize) -> usize {
-        self.line_annotations
-            .iter()
-            .map(|layer| {
-                let mut lines = 0;
-                while let Some(annot) = layer.annotations.get(layer.current_index.get()) {
-                    if annot.anchor_char_idx == char_idx {
-                        layer.current_index.set(layer.current_index.get() + 1);
-                        lines += annot.height
-                    } else {
-                        break;
+    pub(crate) fn process_virtual_text_anchors(&self, grapheme: &FormattedGrapheme) {
+        for (next_anchor, layer) in &self.line_annotations {
+            loop {
+                match next_anchor.get().cmp(&grapheme.char_idx) {
+                    Ordering::Less => next_anchor
+                        .set(unsafe { layer.get().skip_concealed_anchors(grapheme.char_idx) }),
+                    Ordering::Equal => {
+                        next_anchor.set(unsafe { layer.get().process_anchor(grapheme) })
                     }
-                }
-                lines
-            })
-            .sum()
+                    Ordering::Greater => break,
+                };
+            }
+        }
+    }
+
+    pub(crate) fn virtual_lines_at(
+        &self,
+        char_idx: usize,
+        line_end_visual_pos: Position,
+        doc_line: usize,
+    ) -> usize {
+        let mut virt_off = Position::new(0, 0);
+        for (_, layer) in &self.line_annotations {
+            virt_off += unsafe {
+                layer
+                    .get()
+                    .insert_virtual_lines(char_idx, line_end_visual_pos + virt_off, doc_line)
+            };
+        }
+        virt_off.row
     }
 }

--- a/helix-event/src/debounce.rs
+++ b/helix-event/src/debounce.rs
@@ -28,7 +28,10 @@ pub trait AsyncHook: Sync + Send + 'static + Sized {
         // so it should only be reached in case of total CPU overload.
         // However, a bounded channel is much more efficient so it's nice to use here
         let (tx, rx) = mpsc::channel(128);
-        tokio::spawn(run(self, rx));
+        // only spawn worker if we are inside runtime to avoid having to spawn a runtime for unrelated unit tests
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(run(self, rx));
+        }
         tx
     }
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -290,7 +290,7 @@ impl Application {
         self.compositor.render(area, surface, &mut cx);
         let (pos, kind) = self.compositor.cursor(area, &self.editor);
         // reset cursor cache
-        self.editor.cursor_cache.set(None);
+        self.editor.cursor_cache.reset();
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
         self.terminal.draw(pos, kind).unwrap();

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -11,6 +11,7 @@ use helix_view::{
     align_view,
     document::{DocumentOpenError, DocumentSavedEventResult},
     editor::{ConfigEvent, EditorEvent},
+    events::DiagnosticsDidChange,
     graphics::Rect,
     theme,
     tree::Layout,
@@ -834,6 +835,12 @@ impl Application {
                                 &unchanged_diag_sources,
                                 Some(server_id),
                             );
+
+                            let doc = doc.id();
+                            helix_event::dispatch(DiagnosticsDidChange {
+                                editor: &mut self.editor,
+                                doc,
+                            });
                         }
                     }
                     Notification::ShowMessage(params) => {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -771,7 +771,7 @@ impl Application {
                                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
                                         params
                                             .diagnostics
-                                            .sort_unstable_by_key(|d| (d.severity, d.range.start));
+                                            .sort_by_key(|d| (d.severity, d.range.start));
                                     }
                                     for source in &lang_conf.persistent_diagnostic_sources {
                                         let new_diagnostics = params
@@ -812,9 +812,8 @@ impl Application {
 
                         // Sort diagnostics first by severity and then by line numbers.
                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
-                        diagnostics.sort_unstable_by_key(|(d, server_id)| {
-                            (d.severity, d.range.start, *server_id)
-                        });
+                        diagnostics
+                            .sort_by_key(|(d, server_id)| (d.severity, d.range.start, *server_id));
 
                         if let Some(doc) = doc {
                             let diagnostic_of_language_server_and_not_in_unchanged_sources =

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3550,6 +3550,8 @@ fn goto_first_diag(cx: &mut Context) {
         None => return,
     };
     doc.set_selection(view.id, selection);
+    view.diagnostics_handler
+        .immediately_show_diagnostic(doc, view.id);
 }
 
 fn goto_last_diag(cx: &mut Context) {
@@ -3559,6 +3561,8 @@ fn goto_last_diag(cx: &mut Context) {
         None => return,
     };
     doc.set_selection(view.id, selection);
+    view.diagnostics_handler
+        .immediately_show_diagnostic(doc, view.id);
 }
 
 fn goto_next_diag(cx: &mut Context) {
@@ -3581,6 +3585,8 @@ fn goto_next_diag(cx: &mut Context) {
             None => return,
         };
         doc.set_selection(view.id, selection);
+        view.diagnostics_handler
+            .immediately_show_diagnostic(doc, view.id);
     };
 
     cx.editor.apply_motion(motion);
@@ -3609,6 +3615,8 @@ fn goto_prev_diag(cx: &mut Context) {
             None => return,
         };
         doc.set_selection(view.id, selection);
+        view.diagnostics_handler
+            .immediately_show_diagnostic(doc, view.id);
     };
     cx.editor.apply_motion(motion)
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1711,6 +1711,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
                 &mut annotations,
             )
         });
+        drop(annotations);
         doc.set_selection(view.id, selection);
         return;
     }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -271,7 +271,10 @@ fn diag_picker(
             let Some(path) = uri.as_path() else {
                 return;
             };
-            jump_to_position(cx.editor, path, diag.range, *offset_encoding, action)
+            jump_to_position(cx.editor, path, diag.range, *offset_encoding, action);
+            let (view, doc) = current!(cx.editor);
+            view.diagnostics_handler
+                .immediately_show_diagnostic(doc, view.id);
         },
     )
     .with_preview(move |_editor, PickerDiagnostic { uri, diag, .. }| {

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -1,6 +1,6 @@
 use helix_event::{events, register_event};
 use helix_view::document::Mode;
-use helix_view::events::{DocumentDidChange, SelectionDidChange};
+use helix_view::events::{DiagnosticsDidChange, DocumentDidChange, SelectionDidChange};
 
 use crate::commands;
 use crate::keymap::MappableCommand;
@@ -17,4 +17,5 @@ pub fn register() {
     register_event::<PostCommand>();
     register_event::<DocumentDidChange>();
     register_event::<SelectionDidChange>();
+    register_event::<DiagnosticsDidChange>();
 }

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -14,6 +14,7 @@ pub use helix_view::handlers::Handlers;
 
 mod auto_save;
 pub mod completion;
+mod diagnostics;
 mod signature_help;
 
 pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
@@ -32,5 +33,6 @@ pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
     completion::register_hooks(&handlers);
     signature_help::register_hooks(&handlers);
     auto_save::register_hooks(&handlers);
+    diagnostics::register_hooks(&handlers);
     handlers
 }

--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -1,0 +1,24 @@
+use helix_event::{register_hook, send_blocking};
+use helix_view::document::Mode;
+use helix_view::events::DiagnosticsDidChange;
+use helix_view::handlers::diagnostics::DiagnosticEvent;
+use helix_view::handlers::Handlers;
+
+use crate::events::OnModeSwitch;
+
+pub(super) fn register_hooks(_handlers: &Handlers) {
+    register_hook!(move |event: &mut DiagnosticsDidChange<'_>| {
+        if event.editor.mode != Mode::Insert {
+            for (view, _) in event.editor.tree.views_mut() {
+                send_blocking(&view.diagnostics_handler.events, DiagnosticEvent::Refresh)
+            }
+        }
+        Ok(())
+    });
+    register_hook!(move |event: &mut OnModeSwitch<'_, '_>| {
+        for (view, _) in event.cx.editor.tree.views_mut() {
+            view.diagnostics_handler.active = event.new_mode != Mode::Insert;
+        }
+        Ok(())
+    });
+}

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -448,14 +448,12 @@ impl Component for Completion {
         // ---
         // option.documentation
 
-        let (view, doc) = current!(cx.editor);
-        let language = doc.language_name().unwrap_or("");
-        let text = doc.text().slice(..);
-        let cursor_pos = doc.selection(view.id).primary().cursor(text);
-        let coords = view
-            .screen_coords_at_pos(doc, text, cursor_pos)
-            .expect("cursor must be in view");
+        let Some(coords) = cx.editor.cursor().0 else {
+            return;
+        };
         let cursor_pos = coords.row as u16;
+        let doc = doc!(cx.editor);
+        let language = doc.language_name().unwrap_or("");
 
         let markdowned = |lang: &str, detail: Option<&str>, doc: Option<&str>| {
             let md = match (detail, doc) {

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -68,10 +68,7 @@ impl<H: Iterator<Item = HighlightEvent>> Iterator for StyleIter<'_, H> {
                 HighlightEvent::HighlightEnd => {
                     self.active_highlights.pop();
                 }
-                HighlightEvent::Source { start, mut end } => {
-                    if start == end {
-                        continue;
-                    }
+                HighlightEvent::Source { mut end, .. } => {
                     let style = self
                         .active_highlights
                         .iter()
@@ -300,12 +297,12 @@ pub fn render_text<'t>(
         }
 
         // acquire the correct grapheme style
-        if char_pos >= syntax_style_span.1 {
+        while char_pos >= syntax_style_span.1 {
             syntax_style_span = syntax_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
-        if char_pos >= overlay_style_span.1 {
+        while char_pos >= overlay_style_span.1 {
             overlay_style_span = overlay_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -186,11 +186,18 @@ impl EditorView {
                 primary_cursor,
             });
         }
+        let width = view.inner_width(doc);
+        let config = doc.config.load();
+        let enable_cursor_line = view
+            .diagnostics_handler
+            .show_cursorline_diagnostics(doc, view.id);
+        let inline_diagnostic_config = config.inline_diagnostics.prepare(width, enable_cursor_line);
         decorations.add_decoration(InlineDiagnostics::new(
             doc,
             theme,
             primary_cursor,
-            config.lsp.inline_diagnostics.clone(),
+            inline_diagnostic_config,
+            config.end_of_line_diagnostics,
         ));
         render_document(
             surface,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -22,6 +22,7 @@ use helix_core::{
     visual_offset_from_block, Change, Position, Range, Selection, Transaction,
 };
 use helix_view::{
+    annotations::diagnostics::DiagnosticFilter,
     document::{Mode, SavePoint, SCRATCH_BUFFER_NAME},
     editor::{CompleteAction, CursorShapeConfig},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
@@ -185,6 +186,12 @@ impl EditorView {
                 primary_cursor,
             });
         }
+        decorations.add_decoration(InlineDiagnostics::new(
+            doc,
+            theme,
+            primary_cursor,
+            config.lsp.inline_diagnostics.clone(),
+        ));
         render_document(
             surface,
             inner,
@@ -210,7 +217,11 @@ impl EditorView {
             }
         }
 
-        Self::render_diagnostics(doc, view, inner, surface, theme);
+        if config.inline_diagnostics.disabled()
+            && config.end_of_line_diagnostics == DiagnosticFilter::Disable
+        {
+            Self::render_diagnostics(doc, view, inner, surface, theme);
+        }
 
         let statusline_area = view
             .area

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -12,6 +12,7 @@ mod prompt;
 mod spinner;
 mod statusline;
 mod text;
+mod text_decorations;
 
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -7,8 +7,9 @@ use crate::{
     ctrl, key, shift,
     ui::{
         self,
-        document::{render_document, LineDecoration, LinePos, TextRenderer},
+        document::{render_document, LinePos, TextRenderer},
         picker::query::PickerQuery,
+        text_decorations::DecorationManager,
         EditorView,
     },
 };
@@ -895,7 +896,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 }
                 overlay_highlights = Box::new(helix_core::syntax::merge(overlay_highlights, spans));
             }
-            let mut decorations: Vec<Box<dyn LineDecoration>> = Vec::new();
+            let mut decorations = DecorationManager::default();
 
             if let Some((start, end)) = range {
                 let style = cx
@@ -907,14 +908,14 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                     if (start..=end).contains(&pos.doc_line) {
                         let area = Rect::new(
                             renderer.viewport.x,
-                            renderer.viewport.y + pos.visual_line,
+                            pos.visual_line,
                             renderer.viewport.width,
                             1,
                         );
-                        renderer.surface.set_style(area, style)
+                        renderer.set_style(area, style)
                     }
                 };
-                decorations.push(Box::new(draw_highlight))
+                decorations.add_decoration(draw_highlight);
             }
 
             render_document(
@@ -927,8 +928,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 syntax_highlights,
                 overlay_highlights,
                 &cx.editor.theme,
-                &mut decorations,
-                &mut [],
+                decorations,
             );
         }
     }

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -1,0 +1,175 @@
+use std::cmp::Ordering;
+
+use helix_core::doc_formatter::FormattedGrapheme;
+use helix_core::Position;
+use helix_view::editor::CursorCache;
+
+use crate::ui::document::{LinePos, TextRenderer};
+
+pub use diagnostics::InlineDiagnostics;
+
+mod diagnostics;
+
+/// Decorations are the primary mechanism for extending the text rendering.
+///
+/// Any on-screen element which is anchored to the rendered text in some form
+/// should be implemented using this trait. Translating char positions to
+/// on-screen positions can be expensive and should not be done manually in the
+/// ui loop. Instead such translations are automatically performed on the fly
+/// while the text is being rendered. The results are provided to this trait by
+/// the rendering infrastructure.
+///
+/// To reserve space for virtual text lines (which is then filled by this trait) emit appropriate
+/// [`LineAnnotation`](helix_core::text_annotations::LineAnnotation)s in [`helix_view::View::text_annotations`]
+pub trait Decoration {
+    /// Called **before** a **visual** line is rendered. A visual line does not
+    /// necessarily correspond to a single line in a document as soft wrapping can
+    /// spread a single document line across multiple visual lines.
+    ///
+    /// This function is called before text is rendered as any decorations should
+    /// never overlap the document text. That means that setting the forground color
+    /// here is (essentially) useless as the text color is overwritten by the
+    /// rendered text. This _of course_ doesn't apply when rendering inside virtual lines
+    /// below the line reserved by `LineAnnotation`s as no text will be rendered here.
+    fn decorate_line(&mut self, _renderer: &mut TextRenderer, _pos: LinePos) {}
+
+    /// Called **after** a **visual** line is rendered. A visual line does not
+    /// necessarily correspond to a single line in a document as soft wrapping can
+    /// spread a single document line across multiple visual lines.
+    ///
+    /// This function is called after text is rendered so that decorations can collect
+    /// horizontal positions on the line (see [`Decoration::decorate_grapheme`]) first and
+    /// use those positions` while rendering
+    /// virtual text.
+    /// That means that setting the forground color
+    /// here is (essentially) useless as the text color is overwritten by the
+    /// rendered text. This -ofcourse- doesn't apply when rendering inside virtual lines
+    /// below the line reserved by `LineAnnotation`s. e as no text will be rendered here.
+    /// **Note**: To avoid overlapping decorations in the virtual lines, each decoration
+    /// must return the number of virtual text lines it has taken up. Each `Decoration` recieves
+    /// an offset `virt_off` based on these return values where it can render virtual text:
+    ///
+    /// That means that a `render_line` implementation that returns `X` can render virtual text
+    /// in the following area:
+    /// ``` no-compile
+    /// let start = inner.y + pos.virtual_line + virt_off;
+    /// start .. start + X
+    /// ````
+    fn render_virt_lines(
+        &mut self,
+        _renderer: &mut TextRenderer,
+        _pos: LinePos,
+        _virt_off: Position,
+    ) -> Position {
+        Position::new(0, 0)
+    }
+
+    fn reset_pos(&mut self, _pos: usize) -> usize {
+        usize::MAX
+    }
+
+    fn skip_concealed_anchor(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.reset_pos(conceal_end_char_idx)
+    }
+
+    /// This function is called **before** the grapheme at `char_idx` is rendered.
+    ///
+    /// # Returns
+    ///
+    /// The char idx of the next grapheme that  this function should be called for
+    fn decorate_grapheme(
+        &mut self,
+        _renderer: &mut TextRenderer,
+        _grapheme: &FormattedGrapheme,
+    ) -> usize {
+        usize::MAX
+    }
+}
+
+impl<F: FnMut(&mut TextRenderer, LinePos)> Decoration for F {
+    fn decorate_line(&mut self, renderer: &mut TextRenderer, pos: LinePos) {
+        self(renderer, pos);
+    }
+}
+
+#[derive(Default)]
+pub struct DecorationManager<'a> {
+    decorations: Vec<(Box<dyn Decoration + 'a>, usize)>,
+}
+
+impl<'a> DecorationManager<'a> {
+    pub fn add_decoration(&mut self, decoration: impl Decoration + 'a) {
+        self.decorations.push((Box::new(decoration), 0));
+    }
+
+    pub fn prepare_for_rendering(&mut self, first_visible_char: usize) {
+        for (decoration, next_position) in &mut self.decorations {
+            *next_position = decoration.reset_pos(first_visible_char)
+        }
+    }
+
+    pub fn decorate_grapheme(&mut self, renderer: &mut TextRenderer, grapheme: &FormattedGrapheme) {
+        for (decoration, hook_char_idx) in &mut self.decorations {
+            loop {
+                match (*hook_char_idx).cmp(&grapheme.char_idx) {
+                    // this grapheme has been concealed or we are at the first grapheme
+                    Ordering::Less => {
+                        *hook_char_idx = decoration.skip_concealed_anchor(grapheme.char_idx)
+                    }
+                    Ordering::Equal => {
+                        *hook_char_idx = decoration.decorate_grapheme(renderer, grapheme)
+                    }
+                    Ordering::Greater => break,
+                }
+            }
+        }
+    }
+
+    pub fn decorate_line(&mut self, renderer: &mut TextRenderer, pos: LinePos) {
+        for (decoration, _) in &mut self.decorations {
+            decoration.decorate_line(renderer, pos);
+        }
+    }
+
+    pub fn render_virtual_lines(
+        &mut self,
+        renderer: &mut TextRenderer,
+        pos: LinePos,
+        line_width: usize,
+    ) {
+        let mut virt_off = Position::new(1, line_width); // start at 1 so the line is never overwritten
+        for (decoration, _) in &mut self.decorations {
+            virt_off += decoration.render_virt_lines(renderer, pos, virt_off);
+        }
+    }
+}
+
+/// Cursor rendering is done externally so all the cursor decoration
+/// does is save the position of primary cursor
+pub struct Cursor<'a> {
+    pub cache: &'a CursorCache,
+    pub primary_cursor: usize,
+}
+impl Decoration for Cursor<'_> {
+    fn reset_pos(&mut self, pos: usize) -> usize {
+        if pos <= self.primary_cursor {
+            self.primary_cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn decorate_grapheme(
+        &mut self,
+        renderer: &mut TextRenderer,
+        grapheme: &FormattedGrapheme,
+    ) -> usize {
+        if renderer.column_in_bounds(grapheme.visual_pos.col)
+            && renderer.offset.row < grapheme.visual_pos.row
+        {
+            let position = grapheme.visual_pos - renderer.offset;
+            self.cache.set(Some(position));
+        }
+        usize::MAX
+    }
+}

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -1,0 +1,305 @@
+use std::cmp::Ordering;
+
+use helix_core::diagnostic::Severity;
+use helix_core::doc_formatter::{DocumentFormatter, FormattedGrapheme};
+use helix_core::graphemes::Grapheme;
+use helix_core::text_annotations::TextAnnotations;
+use helix_core::{Diagnostic, Position};
+use helix_view::annotations::diagnostics::{
+    DiagnosticFilter, InlineDiagnosticAccumulator, InlineDiagnosticsConfig,
+};
+
+use helix_view::theme::Style;
+use helix_view::{Document, Theme};
+
+use crate::ui::document::{LinePos, TextRenderer};
+use crate::ui::text_decorations::Decoration;
+
+#[derive(Debug)]
+struct Styles {
+    hint: Style,
+    info: Style,
+    warning: Style,
+    error: Style,
+}
+
+impl Styles {
+    fn new(theme: &Theme) -> Styles {
+        Styles {
+            hint: theme.get("hint"),
+            info: theme.get("info"),
+            warning: theme.get("warning"),
+            error: theme.get("error"),
+        }
+    }
+
+    fn severity_style(&self, severity: Severity) -> Style {
+        match severity {
+            Severity::Hint => self.hint,
+            Severity::Info => self.info,
+            Severity::Warning => self.warning,
+            Severity::Error => self.error,
+        }
+    }
+}
+
+pub struct InlineDiagnostics<'a> {
+    state: InlineDiagnosticAccumulator<'a>,
+    eol_diagnostics: DiagnosticFilter,
+    styles: Styles,
+}
+
+impl<'a> InlineDiagnostics<'a> {
+    pub fn new(
+        doc: &'a Document,
+        theme: &Theme,
+        cursor: usize,
+        config: InlineDiagnosticsConfig,
+        eol_diagnostics: DiagnosticFilter,
+    ) -> Self {
+        InlineDiagnostics {
+            state: InlineDiagnosticAccumulator::new(cursor, doc, config),
+            styles: Styles::new(theme),
+            eol_diagnostics,
+        }
+    }
+}
+
+const BL_CORNER: &str = "┘";
+const TR_CORNER: &str = "┌";
+const BR_CORNER: &str = "└";
+const STACK: &str = "├";
+const MULTI: &str = "┴";
+const HOR_BAR: &str = "─";
+const VER_BAR: &str = "│";
+
+struct Renderer<'a, 'b> {
+    renderer: &'a mut TextRenderer<'b>,
+    first_row: u16,
+    row: u16,
+    config: &'a InlineDiagnosticsConfig,
+    styles: &'a Styles,
+}
+
+impl Renderer<'_, '_> {
+    fn draw_decoration(&mut self, g: &'static str, severity: Severity, col: u16) {
+        self.draw_decoration_at(g, severity, col, self.row)
+    }
+
+    fn draw_decoration_at(&mut self, g: &'static str, severity: Severity, col: u16, row: u16) {
+        self.renderer.draw_decoration_grapheme(
+            Grapheme::new_decoration(g),
+            self.styles.severity_style(severity),
+            row,
+            col,
+        );
+    }
+
+    fn draw_eol_diagnostic(&mut self, diag: &Diagnostic, row: u16, col: usize) -> u16 {
+        let style = self.styles.severity_style(diag.severity());
+        let width = self.renderer.viewport.width;
+        if !self.renderer.column_in_bounds(col + 1) {
+            return 0;
+        }
+        let col = (col - self.renderer.offset.col) as u16;
+        let (new_col, _) = self.renderer.set_string_truncated(
+            self.renderer.viewport.x + col + 1,
+            row,
+            &diag.message,
+            width.saturating_sub(col + 1) as usize,
+            |_| style,
+            true,
+            false,
+        );
+        new_col - col
+    }
+
+    fn draw_diagnostic(&mut self, diag: &Diagnostic, col: u16, next_severity: Option<Severity>) {
+        let severity = diag.severity();
+        let (sym, sym_severity) = if let Some(next_severity) = next_severity {
+            (STACK, next_severity.max(severity))
+        } else {
+            (BR_CORNER, severity)
+        };
+        self.draw_decoration(sym, sym_severity, col);
+        for i in 0..self.config.prefix_len {
+            self.draw_decoration(HOR_BAR, severity, col + i + 1);
+        }
+
+        let text_col = col + self.config.prefix_len + 1;
+        let text_fmt = self.config.text_fmt(text_col, self.renderer.viewport.width);
+        let annotations = TextAnnotations::default();
+        let formatter = DocumentFormatter::new_at_prev_checkpoint(
+            diag.message.as_str().trim().into(),
+            &text_fmt,
+            &annotations,
+            0,
+        );
+        let mut last_row = 0;
+        let style = self.styles.severity_style(severity);
+        for grapheme in formatter {
+            last_row = grapheme.visual_pos.row;
+            self.renderer.draw_decoration_grapheme(
+                grapheme.raw,
+                style,
+                self.row + grapheme.visual_pos.row as u16,
+                text_col + grapheme.visual_pos.col as u16,
+            );
+        }
+        self.row += 1;
+        // height is last_row + 1 and extra_rows is height - 1
+        let extra_lines = last_row;
+        if let Some(next_severity) = next_severity {
+            for _ in 0..extra_lines {
+                self.draw_decoration(VER_BAR, next_severity, col);
+                self.row += 1;
+            }
+        } else {
+            self.row += extra_lines as u16;
+        }
+    }
+
+    fn draw_multi_diagnostics(&mut self, stack: &mut Vec<(&Diagnostic, u16)>) {
+        let Some(&(last_diag, last_anchor)) = stack.last() else {
+            return;
+        };
+        let start = self
+            .config
+            .max_diagnostic_start(self.renderer.viewport.width);
+
+        if last_anchor <= start {
+            return;
+        }
+        let mut severity = last_diag.severity();
+        let mut last_anchor = last_anchor;
+        self.draw_decoration(BL_CORNER, severity, last_anchor);
+        let mut stacked_diagnostics = 1;
+        for &(diag, anchor) in stack.iter().rev().skip(1) {
+            let sym = match anchor.cmp(&start) {
+                Ordering::Less => break,
+                Ordering::Equal => STACK,
+                Ordering::Greater => MULTI,
+            };
+            stacked_diagnostics += 1;
+            severity = severity.max(diag.severity());
+            let old_severity = severity;
+            if anchor == last_anchor && severity == old_severity {
+                continue;
+            }
+            for col in (anchor + 1)..last_anchor {
+                self.draw_decoration(HOR_BAR, old_severity, col)
+            }
+            self.draw_decoration(sym, severity, anchor);
+            last_anchor = anchor;
+        }
+
+        // if no diagnostic anchor was found exactly at the start of the
+        // diagnostic text  draw an upwards corner and ensure the last piece
+        // of the line is not missing
+        if last_anchor != start {
+            for col in (start + 1)..last_anchor {
+                self.draw_decoration(HOR_BAR, severity, col)
+            }
+            self.draw_decoration(TR_CORNER, severity, start)
+        }
+        self.row += 1;
+        let stacked_diagnostics = &stack[stack.len() - stacked_diagnostics..];
+
+        for (i, (diag, _)) in stacked_diagnostics.iter().rev().enumerate() {
+            let next_severity = stacked_diagnostics[..stacked_diagnostics.len() - i - 1]
+                .iter()
+                .map(|(diag, _)| diag.severity())
+                .max();
+            self.draw_diagnostic(diag, start, next_severity);
+        }
+
+        stack.truncate(stack.len() - stacked_diagnostics.len());
+    }
+
+    fn draw_diagnostics(&mut self, stack: &mut Vec<(&Diagnostic, u16)>) {
+        let mut stack = stack.drain(..).rev().peekable();
+        let mut last_anchor = self.renderer.viewport.width;
+        while let Some((diag, anchor)) = stack.next() {
+            if anchor != last_anchor {
+                for row in self.first_row..self.row {
+                    self.draw_decoration_at(VER_BAR, diag.severity(), anchor, row);
+                }
+            }
+            let next_severity = stack.peek().and_then(|&(diag, next_anchor)| {
+                (next_anchor == anchor).then_some(diag.severity())
+            });
+            self.draw_diagnostic(diag, anchor, next_severity);
+            last_anchor = anchor;
+        }
+    }
+}
+
+impl Decoration for InlineDiagnostics<'_> {
+    fn render_virt_lines(
+        &mut self,
+        renderer: &mut TextRenderer,
+        pos: LinePos,
+        virt_off: Position,
+    ) -> Position {
+        let mut col_off = 0;
+        let filter = self.state.filter();
+        let eol_diagnostic = match self.eol_diagnostics {
+            DiagnosticFilter::Enable(eol_filter) => {
+                let eol_diganogistcs = self
+                    .state
+                    .stack
+                    .iter()
+                    .filter(|(diag, _)| eol_filter <= diag.severity());
+                match filter {
+                    DiagnosticFilter::Enable(filter) => eol_diganogistcs
+                        .filter(|(diag, _)| filter > diag.severity())
+                        .max_by_key(|(diagnostic, _)| diagnostic.severity),
+                    DiagnosticFilter::Disable => {
+                        eol_diganogistcs.max_by_key(|(diagnostic, _)| diagnostic.severity)
+                    }
+                }
+            }
+            DiagnosticFilter::Disable => None,
+        };
+        if let Some((eol_diagnostic, _)) = eol_diagnostic {
+            let mut renderer = Renderer {
+                renderer,
+                first_row: pos.visual_line,
+                row: pos.visual_line,
+                config: &self.state.config,
+                styles: &self.styles,
+            };
+            col_off = renderer.draw_eol_diagnostic(eol_diagnostic, pos.visual_line, virt_off.col);
+        }
+
+        self.state.compute_line_diagnostics();
+        let mut renderer = Renderer {
+            renderer,
+            first_row: pos.visual_line + virt_off.row as u16,
+            row: pos.visual_line + virt_off.row as u16,
+            config: &self.state.config,
+            styles: &self.styles,
+        };
+        renderer.draw_multi_diagnostics(&mut self.state.stack);
+        renderer.draw_diagnostics(&mut self.state.stack);
+        let horizontal_off = renderer.row - renderer.first_row;
+        Position::new(horizontal_off as usize, col_off as usize)
+    }
+
+    fn reset_pos(&mut self, pos: usize) -> usize {
+        self.state.reset_pos(pos)
+    }
+
+    fn skip_concealed_anchor(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.state.skip_concealed(conceal_end_char_idx)
+    }
+
+    fn decorate_grapheme(
+        &mut self,
+        renderer: &mut TextRenderer,
+        grapheme: &FormattedGrapheme,
+    ) -> usize {
+        self.state
+            .proccess_anchor(grapheme, renderer.viewport.width, renderer.offset.col)
+    }
+}

--- a/helix-view/src/annotations.rs
+++ b/helix-view/src/annotations.rs
@@ -1,0 +1,1 @@
+pub mod diagnostics;

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -1,0 +1,309 @@
+use helix_core::diagnostic::Severity;
+use helix_core::doc_formatter::{FormattedGrapheme, TextFormat};
+use helix_core::text_annotations::LineAnnotation;
+use helix_core::{softwrapped_dimensions, Diagnostic, Position};
+use serde::{Deserialize, Serialize};
+
+use crate::Document;
+
+/// Describes the severity level of a [`Diagnostic`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub enum DiagnosticFilter {
+    Disable,
+    Enable(Severity),
+}
+
+impl<'de> Deserialize<'de> for DiagnosticFilter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match &*String::deserialize(deserializer)? {
+            "disable" => Ok(DiagnosticFilter::Disable),
+            "hint" => Ok(DiagnosticFilter::Enable(Severity::Hint)),
+            "info" => Ok(DiagnosticFilter::Enable(Severity::Info)),
+            "warning" => Ok(DiagnosticFilter::Enable(Severity::Warning)),
+            "error" => Ok(DiagnosticFilter::Enable(Severity::Error)),
+            variant => Err(serde::de::Error::unknown_variant(
+                variant,
+                &["disable", "hint", "info", "warning", "error"],
+            )),
+        }
+    }
+}
+
+impl Serialize for DiagnosticFilter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let filter = match self {
+            DiagnosticFilter::Disable => "disable",
+            DiagnosticFilter::Enable(Severity::Hint) => "hint",
+            DiagnosticFilter::Enable(Severity::Info) => "info",
+            DiagnosticFilter::Enable(Severity::Warning) => "warning",
+            DiagnosticFilter::Enable(Severity::Error) => "error",
+        };
+        filter.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct InlineDiagnosticsConfig {
+    pub cursor_line: DiagnosticFilter,
+    pub other_lines: DiagnosticFilter,
+    pub min_diagnostic_width: u16,
+    pub prefix_len: u16,
+    pub max_wrap: u16,
+    pub max_diagnostics: usize,
+}
+
+impl InlineDiagnosticsConfig {
+    // last column where to start diagnostics
+    // every diagnostics that start afterwards will be displayed with a "backwards
+    // line" to ensure they are still rendered with `min_diagnostic_widht`. If `width`
+    // it too small to display diagnostics with atleast `min_diagnostic_width` space
+    // (or inline diagnostics are displed) `None` is returned. In that case inline
+    // diagnostics should not be shown
+    pub fn enable(&self, width: u16) -> bool {
+        let disabled = matches!(
+            self,
+            Self {
+                cursor_line: DiagnosticFilter::Disable,
+                other_lines: DiagnosticFilter::Disable,
+                ..
+            }
+        );
+        !disabled && width >= self.min_diagnostic_width + self.prefix_len
+    }
+
+    pub fn max_diagnostic_start(&self, width: u16) -> u16 {
+        width - self.min_diagnostic_width - self.prefix_len
+    }
+
+    pub fn text_fmt(&self, anchor_col: u16, width: u16) -> TextFormat {
+        let width = if anchor_col > self.max_diagnostic_start(width) {
+            self.min_diagnostic_width
+        } else {
+            width - anchor_col - self.prefix_len
+        };
+
+        TextFormat {
+            soft_wrap: true,
+            tab_width: 4,
+            max_wrap: self.max_wrap.min(width / 4),
+            max_indent_retain: 0,
+            wrap_indicator: "".into(),
+            wrap_indicator_highlight: None,
+            viewport_width: width,
+            soft_wrap_at_text_width: true,
+        }
+    }
+}
+
+impl Default for InlineDiagnosticsConfig {
+    fn default() -> Self {
+        InlineDiagnosticsConfig {
+            cursor_line: DiagnosticFilter::Disable,
+            other_lines: DiagnosticFilter::Disable,
+            min_diagnostic_width: 40,
+            prefix_len: 1,
+            max_wrap: 20,
+            max_diagnostics: 10,
+        }
+    }
+}
+
+pub struct InlineDiagnosticAccumulator<'a> {
+    idx: usize,
+    doc: &'a Document,
+    pub stack: Vec<(&'a Diagnostic, u16)>,
+    pub config: InlineDiagnosticsConfig,
+    cursor: usize,
+    cursor_line: bool,
+}
+
+impl<'a> InlineDiagnosticAccumulator<'a> {
+    pub fn new(cursor: usize, doc: &'a Document, config: InlineDiagnosticsConfig) -> Self {
+        InlineDiagnosticAccumulator {
+            idx: 0,
+            doc,
+            stack: Vec::new(),
+            config,
+            cursor,
+            cursor_line: false,
+        }
+    }
+
+    pub fn reset_pos(&mut self, char_idx: usize) -> usize {
+        self.idx = 0;
+        self.clear();
+        self.skip_concealed(char_idx)
+    }
+
+    pub fn skip_concealed(&mut self, conceal_end_char_idx: usize) -> usize {
+        let diagnostics = &self.doc.diagnostics[self.idx..];
+        let idx = diagnostics.partition_point(|diag| diag.range.start < conceal_end_char_idx);
+        self.idx += idx;
+        self.next_anchor(conceal_end_char_idx)
+    }
+
+    pub fn next_anchor(&self, current_char_idx: usize) -> usize {
+        let next_diag_start = self
+            .doc
+            .diagnostics
+            .get(self.idx)
+            .map_or(usize::MAX, |diag| diag.range.start);
+        if (current_char_idx..next_diag_start).contains(&self.cursor) {
+            self.cursor
+        } else {
+            next_diag_start
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.cursor_line = false;
+        self.stack.clear();
+    }
+
+    fn process_anchor_impl(
+        &mut self,
+        grapheme: &FormattedGrapheme,
+        width: u16,
+        horizontal_off: usize,
+    ) -> bool {
+        // TODO: doing the cursor tracking here works well but is somewhat
+        // duplicate effort/tedious maybe centralize this somehwere?
+        // In the DocFormatter?
+        if grapheme.char_idx == self.cursor {
+            self.cursor_line = true;
+            if self
+                .doc
+                .diagnostics
+                .get(self.idx)
+                .map_or(true, |diag| diag.range.start != grapheme.char_idx)
+            {
+                return false;
+            }
+        }
+
+        let Some(anchor_col) = grapheme.visual_pos.col.checked_sub(horizontal_off) else {
+            return true;
+        };
+        if anchor_col >= width as usize {
+            return true;
+        }
+
+        for diag in &self.doc.diagnostics[self.idx..] {
+            if diag.range.start != grapheme.char_idx {
+                break;
+            }
+            self.stack.push((diag, anchor_col as u16));
+            self.idx += 1;
+        }
+        false
+    }
+
+    pub fn proccess_anchor(
+        &mut self,
+        grapheme: &FormattedGrapheme,
+        width: u16,
+        horizontal_off: usize,
+    ) -> usize {
+        if self.process_anchor_impl(grapheme, width, horizontal_off) {
+            self.idx += self.doc.diagnostics[self.idx..]
+                .iter()
+                .take_while(|diag| diag.range.start == grapheme.char_idx)
+                .count();
+        }
+        self.next_anchor(grapheme.char_idx + 1)
+    }
+
+    pub fn filter(&self) -> DiagnosticFilter {
+        if self.cursor_line {
+            self.config.cursor_line
+        } else {
+            self.config.other_lines
+        }
+    }
+
+    pub fn compute_line_diagnostics(&mut self) {
+        let filter = if self.cursor_line {
+            self.cursor_line = false;
+            self.config.cursor_line
+        } else {
+            self.config.other_lines
+        };
+        let DiagnosticFilter::Enable(filter) = filter else {
+            self.stack.clear();
+            return;
+        };
+        self.stack.retain(|(diag, _)| diag.severity() >= filter);
+        self.stack.truncate(self.config.max_diagnostics)
+    }
+
+    pub fn has_multi(&self, width: u16) -> bool {
+        self.stack.last().map_or(false, |&(_, anchor)| {
+            anchor > self.config.max_diagnostic_start(width)
+        })
+    }
+}
+
+pub(crate) struct InlineDiagnostics<'a> {
+    state: InlineDiagnosticAccumulator<'a>,
+    width: u16,
+    horizontal_off: usize,
+}
+
+impl<'a> InlineDiagnostics<'a> {
+    #[allow(clippy::new_ret_no_self)]
+    pub(crate) fn new(
+        doc: &'a Document,
+        cursor: usize,
+        width: u16,
+        horizontal_off: usize,
+        config: InlineDiagnosticsConfig,
+    ) -> Box<dyn LineAnnotation + 'a> {
+        Box::new(InlineDiagnostics {
+            state: InlineDiagnosticAccumulator::new(cursor, doc, config),
+            width,
+            horizontal_off,
+        })
+    }
+}
+
+impl LineAnnotation for InlineDiagnostics<'_> {
+    fn reset_pos(&mut self, char_idx: usize) -> usize {
+        self.state.reset_pos(char_idx)
+    }
+
+    fn skip_concealed_anchors(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.state.skip_concealed(conceal_end_char_idx)
+    }
+
+    fn process_anchor(&mut self, grapheme: &FormattedGrapheme) -> usize {
+        self.state
+            .proccess_anchor(grapheme, self.width, self.horizontal_off)
+    }
+
+    fn insert_virtual_lines(
+        &mut self,
+        _line_end_char_idx: usize,
+        _line_end_visual_pos: Position,
+        _doc_line: usize,
+    ) -> Position {
+        self.state.compute_line_diagnostics();
+        let multi = self.state.has_multi(self.width);
+        let diagostic_height: usize = self
+            .state
+            .stack
+            .drain(..)
+            .map(|(diag, anchor)| {
+                let text_fmt = self.state.config.text_fmt(anchor, self.width);
+                softwrapped_dimensions(diag.message.as_str().trim().into(), &text_fmt).0
+            })
+            .sum();
+        Position::new(multi as usize + diagostic_height, 0)
+    }
+}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -99,7 +99,6 @@ impl Serialize for Mode {
         serializer.collect_str(self)
     }
 }
-
 /// A snapshot of the text of a document that we want to write out to disk
 #[derive(Debug, Clone)]
 pub struct DocumentSavedEvent {
@@ -1321,7 +1320,7 @@ impl Document {
                 true
             });
 
-            self.diagnostics.sort_unstable_by_key(|diagnostic| {
+            self.diagnostics.sort_by_key(|diagnostic| {
                 (diagnostic.range, diagnostic.severity, diagnostic.provider)
             });
 
@@ -1911,9 +1910,8 @@ impl Document {
             });
         }
         self.diagnostics.extend(diagnostics);
-        self.diagnostics.sort_unstable_by_key(|diagnostic| {
-            (diagnostic.range, diagnostic.severity, diagnostic.provider)
-        });
+        self.diagnostics
+            .sort_by_key(|diagnostic| (diagnostic.range, diagnostic.severity, diagnostic.provider));
     }
 
     /// clears diagnostics for a given language server id if set, otherwise all diagnostics are cleared

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1953,7 +1953,7 @@ impl Document {
             .language_config()
             .and_then(|config| config.text_width)
             .unwrap_or(config.text_width);
-        let soft_wrap_at_text_width = self
+        let mut soft_wrap_at_text_width = self
             .language_config()
             .and_then(|config| {
                 config
@@ -1964,12 +1964,13 @@ impl Document {
             .or(config.soft_wrap.wrap_at_text_width)
             .unwrap_or(false);
         if soft_wrap_at_text_width {
-            // We increase max_line_len by 1 because softwrap considers the newline character
-            // as part of the line length while the "typical" expectation is that this is not the case.
-            // In particular other commands like :reflow do not count the line terminator.
-            // This is technically inconsistent for the last line as that line never has a line terminator
-            // but having the last visual line exceed the width by 1 seems like a rare edge case.
-            viewport_width = viewport_width.min(text_width as u16 + 1)
+            // if the viewport is smaller than the specified
+            // width then this setting has no effcet
+            if text_width >= viewport_width as usize {
+                soft_wrap_at_text_width = false;
+            } else {
+                viewport_width = text_width as u16;
+            }
         }
         let config = self.config.load();
         let editor_soft_wrap = &config.soft_wrap;
@@ -2006,6 +2007,7 @@ impl Document {
             wrap_indicator_highlight: theme
                 .and_then(|theme| theme.find_scope_index("ui.virtual.wrap"))
                 .map(Highlight),
+            soft_wrap_at_text_width,
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,5 +1,6 @@
 use crate::{
     align_view,
+    annotations::diagnostics::{DiagnosticFilter, InlineDiagnosticsConfig},
     document::{
         DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
     },
@@ -343,6 +344,9 @@ pub struct Config {
         deserialize_with = "deserialize_alphabet"
     )]
     pub jump_label_alphabet: Vec<char>,
+    /// Display diagnostic below the line they occur.
+    pub inline_diagnostics: InlineDiagnosticsConfig,
+    pub end_of_line_diagnostics: DiagnosticFilter,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -975,6 +979,8 @@ impl Default for Config {
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
+            inline_diagnostics: InlineDiagnosticsConfig::default(),
+            end_of_line_diagnostics: DiagnosticFilter::Disable,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1070,10 +1070,10 @@ pub struct Editor {
     /// This cache is only a performance optimization to
     /// avoid calculating the cursor position multiple
     /// times during rendering and should not be set by other functions.
-    pub cursor_cache: Cell<Option<Option<Position>>>,
     pub handlers: Handlers,
 
     pub mouse_down_range: Option<Range>,
+    pub cursor_cache: CursorCache,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1188,9 +1188,9 @@ impl Editor {
             exit_code: 0,
             config_events: unbounded_channel(),
             needs_redraw: false,
-            cursor_cache: Cell::new(None),
             handlers,
             mouse_down_range: None,
+            cursor_cache: CursorCache::default(),
         }
     }
 
@@ -1985,15 +1985,7 @@ impl Editor {
     pub fn cursor(&self) -> (Option<Position>, CursorKind) {
         let config = self.config();
         let (view, doc) = current_ref!(self);
-        let cursor = doc
-            .selection(view.id)
-            .primary()
-            .cursor(doc.text().slice(..));
-        let pos = self
-            .cursor_cache
-            .get()
-            .unwrap_or_else(|| view.screen_coords_at_pos(doc, doc.text().slice(..), cursor));
-        if let Some(mut pos) = pos {
+        if let Some(mut pos) = self.cursor_cache.get(view, doc) {
             let inner = view.inner_area(doc);
             pos.col += inner.x as usize;
             pos.row += inner.y as usize;
@@ -2186,5 +2178,30 @@ fn try_restore_indent(doc: &mut Document, view: &mut View) {
                 (line_start_pos, pos, None)
             });
         doc.apply(&transaction, view.id);
+    }
+}
+
+#[derive(Default)]
+pub struct CursorCache(Cell<Option<Option<Position>>>);
+
+impl CursorCache {
+    pub fn get(&self, view: &View, doc: &Document) -> Option<Position> {
+        if let Some(pos) = self.0.get() {
+            return pos;
+        }
+
+        let text = doc.text().slice(..);
+        let cursor = doc.selection(view.id).primary().cursor(text);
+        let res = view.screen_coords_at_pos(doc, text, cursor);
+        self.set(res);
+        res
+    }
+
+    pub fn set(&self, cursor_pos: Option<Position>) {
+        self.0.set(Some(cursor_pos))
+    }
+
+    pub fn reset(&self) {
+        self.0.set(None)
     }
 }

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -1,9 +1,10 @@
 use helix_core::Rope;
 use helix_event::events;
 
-use crate::{Document, ViewId};
+use crate::{Document, DocumentId, Editor, ViewId};
 
 events! {
     DocumentDidChange<'a> { doc: &'a mut Document, view: ViewId, old_text: &'a Rope  }
     SelectionDidChange<'a> { doc: &'a mut Document, view: ViewId }
+    DiagnosticsDidChange<'a> { editor: &'a mut Editor, doc: DocumentId }
 }

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -5,6 +5,7 @@ use crate::handlers::lsp::SignatureHelpInvoked;
 use crate::{DocumentId, Editor, ViewId};
 
 pub mod dap;
+pub mod diagnostics;
 pub mod lsp;
 
 #[derive(Debug)]

--- a/helix-view/src/handlers/diagnostics.rs
+++ b/helix-view/src/handlers/diagnostics.rs
@@ -1,0 +1,131 @@
+use std::cell::Cell;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Arc;
+use std::time::Duration;
+
+use helix_event::{request_redraw, send_blocking, AsyncHook};
+use tokio::sync::mpsc::Sender;
+use tokio::time::Instant;
+
+use crate::{Document, DocumentId, ViewId};
+
+#[derive(Debug)]
+pub enum DiagnosticEvent {
+    CursorLineChanged { generation: usize },
+    Refresh,
+}
+
+struct DiagnosticTimeout {
+    active_generation: Arc<AtomicUsize>,
+    generation: usize,
+}
+
+const TIMEOUT: Duration = Duration::from_millis(350);
+
+impl AsyncHook for DiagnosticTimeout {
+    type Event = DiagnosticEvent;
+
+    fn handle_event(
+        &mut self,
+        event: DiagnosticEvent,
+        timeout: Option<Instant>,
+    ) -> Option<Instant> {
+        match event {
+            DiagnosticEvent::CursorLineChanged { generation } => {
+                if generation > self.generation {
+                    self.generation = generation;
+                    Some(Instant::now() + TIMEOUT)
+                } else {
+                    timeout
+                }
+            }
+            DiagnosticEvent::Refresh if timeout.is_some() => Some(Instant::now() + TIMEOUT),
+            DiagnosticEvent::Refresh => None,
+        }
+    }
+
+    fn finish_debounce(&mut self) {
+        if self.active_generation.load(atomic::Ordering::Relaxed) < self.generation {
+            self.active_generation
+                .store(self.generation, atomic::Ordering::Relaxed);
+            request_redraw();
+        }
+    }
+}
+
+pub struct DiagnosticsHandler {
+    active_generation: Arc<AtomicUsize>,
+    generation: Cell<usize>,
+    last_doc: Cell<DocumentId>,
+    last_cursor_line: Cell<usize>,
+    pub active: bool,
+    pub events: Sender<DiagnosticEvent>,
+}
+
+// make sure we never share handlers across multiple views this is a stop
+// gap solution. We just shouldn't be cloneing a view to begin with (we do
+// for :hsplit/vsplit) and really this should not be view specific to begin with
+// but to fix that larger architecutre changes are needed
+impl Clone for DiagnosticsHandler {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl DiagnosticsHandler {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let active_generation = Arc::new(AtomicUsize::new(0));
+        let events = DiagnosticTimeout {
+            active_generation: active_generation.clone(),
+            generation: 0,
+        }
+        .spawn();
+        Self {
+            active_generation,
+            generation: Cell::new(0),
+            events,
+            last_doc: Cell::new(DocumentId(NonZeroUsize::new(usize::MAX).unwrap())),
+            last_cursor_line: Cell::new(usize::MAX),
+            active: true,
+        }
+    }
+}
+
+impl DiagnosticsHandler {
+    pub fn immediately_show_diagnostic(&self, doc: &Document, view: ViewId) {
+        self.last_doc.set(doc.id());
+        let cursor_line = doc
+            .selection(view)
+            .primary()
+            .cursor_line(doc.text().slice(..));
+        self.last_cursor_line.set(cursor_line);
+        self.active_generation
+            .store(self.generation.get(), atomic::Ordering::Relaxed);
+    }
+    pub fn show_cursorline_diagnostics(&self, doc: &Document, view: ViewId) -> bool {
+        if !self.active {
+            return false;
+        }
+        let cursor_line = doc
+            .selection(view)
+            .primary()
+            .cursor_line(doc.text().slice(..));
+        if self.last_cursor_line.get() == cursor_line && self.last_doc.get() == doc.id() {
+            let active_generation = self.active_generation.load(atomic::Ordering::Relaxed);
+            self.generation.get() == active_generation
+        } else {
+            self.last_doc.set(doc.id());
+            self.last_cursor_line.set(cursor_line);
+            self.generation.set(self.generation.get() + 1);
+            send_blocking(
+                &self.events,
+                DiagnosticEvent::CursorLineChanged {
+                    generation: self.generation.get(),
+                },
+            );
+            false
+        }
+    }
+}

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod macros;
 
+pub mod annotations;
 pub mod base64;
 pub mod clipboard;
 pub mod document;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -393,11 +393,6 @@ impl View {
         text: RopeSlice,
         pos: usize,
     ) -> Option<Position> {
-        if pos < self.offset.anchor {
-            // Line is not visible on screen
-            return None;
-        }
-
         let viewport = self.inner_area(doc);
         let text_fmt = doc.text_format(viewport.width, None);
         let annotations = self.text_annotations(doc, None);


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/3272
Closes #3078
closes https://github.com/helix-editor/helix/issues/1462
Closes https://github.com/helix-editor/helix/issues/1953
Supersedes #6059

This PR implements inline diagnostics just like #6059. However, it also contains a streamlined virtual text API and significantly improves on the implementation in #6059.

The various improvements and bugfixes made to the virtual text API are currently part of this PR until it's been tested more. I will spin those out into a separate PR later. These should address the various bugs and panics discovered by poeple in #6059. Only the last commit contains an implementation of inline diagnostics.

Due to the changes to the virtual text API I had to essentially rebuild #6059 as most changes in that PR became unnecessary by the improvements in the virtual text API.

I also rebuild the ASCII rendering to support soft wrapping. Diagnostics which exceed the width of the screen are now soft wrapped automatically. Additionally, there is a minimum width setting for diagnostics. Any diagnostics so far to the right that there is not this minimum width available are displayed using a backwards arching line. See screenshot below:

![image](https://user-images.githubusercontent.com/61850714/227398597-3201a925-7241-463f-b6ea-22851386eb9d.png)


Additionally, this PR implements a severity-based filter for diagnostics. This allows users to choose one of the following:
* a minimum severity for inline diagnostics: `"warning"`
* a list of severities to allow (useful if a certain LSP spams one particular severity). `["warning", "errror"]` Using an empty list disables inline diagnostics

The diagnostics to display can be separately configured for the line that currently contains the cursor. By disabling diagnostics for all other lines users can therefore only display diagnostics on the current line too. By default, only warnings/errors are displayed, on the cursor line all diagnostics are displayed. I am open to changing the default here, but this did feel quite nice to use in my testing.

Additionally, some details of the soft wrapping can be configured. 
Currently, a draft as this needs more documentation, a separate PR for most of the virtual text changes, and more testing. That said it should work quite well already, and I invite people to try this out.

