### PR TITLE
Recognize .cts and .mts file type as TypeScript

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -453,7 +453,7 @@ includeInlayVariableTypeHints = true
 name = "typescript"
 scope = "source.ts"
 injection-regex = "(ts|typescript)"
-file-types = ["ts"]
+file-types = ["ts", "mts", "cts"]
 shebangs = []
 roots = []
 # TODO: highlights-params


### PR DESCRIPTION
TypeScript can use three type of file extensions:
  - .ts  for regular TypeScript
  - .cts for CommonJS modules
  - .mts for ES modules

Official documentation on supported file extensions:
https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions
