### PR TITLE
feat(languages): highlight .svg as xml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2068,7 +2068,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard"]
+file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
Add "svg" as a file type for xml.

Fixes: https://github.com/helix-editor/helix/issues/6337