### PR TITLE
Add theme keys for (un)checked markup list items

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -228,6 +228,8 @@ We use a similar set of scopes as
   - `list`
     - `unnumbered`
     - `numbered`
+    - `checked`
+    - `unchecked`
   - `bold`
   - `italic`
   - `strikethrough`

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -39,6 +39,9 @@
   (list_marker_parenthesis)
 ] @markup.list.numbered
 
+(task_list_marker_checked) @markup.list.checked
+(task_list_marker_unchecked) @markup.list.unchecked
+
 (thematic_break) @punctuation.special
 
 [

--- a/runtime/themes/onelight.toml
+++ b/runtime/themes/onelight.toml
@@ -80,9 +80,11 @@
 "markup.list" = { fg = "light-blue" }
 "markup.list.unnumbered" = { fg = "light-blue" }
 "markup.list.numbered" = { fg = "light-blue" }
+"markup.list.checked" = { fg = "green" }
+"markup.list.unchecked" = { fg = "blue" }
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "purple", modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.strikethrough" = { fg = "red", modifiers = ["crossed_out"] }
 "markup.link" = { fg = "light-blue" }
 "markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "light-blue" }


### PR DESCRIPTION
- https://github.com/MDeiml/tree-sitter-markdown/blob/split_parser/tree-sitter-markdown/corpus/extension_task_list.txt

```markdown
- [x] foo
  - [ ] bar
  - [x] baz
- [ ] bim
```