### PR TITLE
Add blocking UI feedback to `goto_definition`, `goto_references`.

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,5 +1,5 @@
 use arc_swap::{access::Map, ArcSwap};
-use futures_util::Stream;
+use futures_util::{future::OptionFuture, Stream};
 use helix_core::{
     diagnostic::{DiagnosticTag, NumberOrString},
     path::get_relative_path,
@@ -11,7 +11,7 @@ use helix_view::{
     document::DocumentSavedEventResult,
     editor::{ConfigEvent, EditorEvent},
     graphics::Rect,
-    theme,
+    theme::{self, Modifier, Style},
     tree::Layout,
     Align, Editor,
 };
@@ -23,6 +23,7 @@ use crate::{
     commands::apply_workspace_edit,
     compositor::{Compositor, Event},
     config::Config,
+    ctrl,
     job::Jobs,
     keymap::Keymaps,
     ui::{self, overlay::overlayed},
@@ -284,6 +285,13 @@ impl Application {
         // reset cursor cache
         self.editor.cursor_cache.set(None);
 
+        if self.jobs.blocking_job.is_some() {
+            surface.set_style(
+                area.clip_bottom(1),
+                Style::default().add_modifier(Modifier::DIM),
+            );
+        }
+
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
         self.terminal.draw(pos, kind).unwrap();
     }
@@ -315,6 +323,13 @@ impl Application {
 
             tokio::select! {
                 biased;
+
+                Some(callback) = OptionFuture::from(self.jobs.blocking_job.as_mut()), if self.jobs.blocking_job.is_some() => {
+                    self.jobs.blocking_job = None;
+                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
+                    self.editor.clear_status();
+                    self.render().await;
+                }
 
                 Some(signal) = self.signals.next() => {
                     self.handle_signals(signal).await;
@@ -633,7 +648,22 @@ impl Application {
                 kind: crossterm::event::KeyEventKind::Release,
                 ..
             }) => false,
-            event => self.compositor.handle_event(&event.into(), &mut cx),
+
+            CrosstermEvent::Key(event)
+                if cx.jobs.blocking_job.is_some()
+                    && helix_view::input::KeyEvent::from(event) == ctrl!('c') =>
+            {
+                cx.jobs.blocking_job.as_ref().unwrap().cancel();
+                true
+            }
+
+            event => {
+                if cx.jobs.blocking_job.is_some() {
+                    false
+                } else {
+                    self.compositor.handle_event(&event.into(), &mut cx)
+                }
+            }
         };
 
         if should_redraw && !self.editor.should_close() {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -653,7 +653,9 @@ impl Application {
                 if cx.jobs.blocking_job.is_some()
                     && helix_view::input::KeyEvent::from(event) == ctrl!('c') =>
             {
-                cx.jobs.blocking_job.as_ref().unwrap().cancel();
+                cx.editor.clear_status();
+                cx.jobs.blocking_job = None;
+
                 true
             }
 
@@ -904,7 +906,9 @@ impl Application {
                                     if !self.lsp_progress.is_progressing(server_id) {
                                         editor_view.spinners_mut().get_or_create(server_id).stop();
                                     }
-                                    self.editor.clear_status();
+                                    if self.config.load().editor.lsp.display_messages {
+                                        self.editor.clear_status();
+                                    }
 
                                     // we want to render to clear any leftover spinners or messages
                                     return;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -51,7 +51,7 @@ use crate::{
     args,
     compositor::{self, Component, Compositor},
     filter_picker_entry,
-    job::Callback,
+    job::{BlockingJob, Callback, CancelSender},
     keymap::ReverseKeymap,
     ui::{
         self, editor::InsertEvent, overlay::overlayed, FilePicker, Picker, Popup, Prompt,
@@ -85,6 +85,7 @@ pub struct Context<'a> {
     pub editor: &'a mut Editor,
 
     pub callback: Option<crate::compositor::Callback>,
+    pub blocking_callback: Option<BlockingJob>,
     pub on_next_key_callback: Option<OnKeyCallback>,
     pub jobs: &'a mut Jobs,
 }
@@ -95,6 +96,15 @@ impl<'a> Context<'a> {
         self.callback = Some(Box::new(|compositor: &mut Compositor, _| {
             compositor.push(component)
         }));
+    }
+
+    pub fn push_layer_blocking(
+        &mut self,
+        layer: impl Future<Output = anyhow::Result<Box<dyn Component>>> + 'static,
+        cancel: CancelSender,
+        msg: &'static str,
+    ) {
+        self.blocking_callback = Some(BlockingJob::push_layer(layer, cancel, msg))
     }
 
     #[inline]
@@ -2647,6 +2657,7 @@ pub fn command_palette(cx: &mut Context) {
                     callback: None,
                     on_next_key_callback: None,
                     jobs: cx.jobs,
+                    blocking_callback: None,
                 };
                 let focus = view!(ctx.editor).id;
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1007,22 +1007,19 @@ pub fn goto_definition(cx: &mut Context) {
 
     let pos = doc.position(view.id, offset_encoding);
 
-    let future = match language_server.goto_definition(doc.identifier(), pos, None) {
-        Some(future) => future,
-        None => {
-            cx.editor
-                .set_error("Language server does not support goto-definition");
-            return;
-        }
-    };
-
-    cx.callback(
-        future,
-        move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
-            let items = to_locations(response);
-            goto_impl(editor, compositor, items, offset_encoding);
-        },
-    );
+    if let Some(future) = language_server.goto_definition(doc.identifier(), pos, None) {
+        cx.callback_blocking(
+            "goto_definition: Waiting on LSP...",
+            future,
+            move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
+                let items = to_locations(response);
+                goto_impl(editor, compositor, items, offset_encoding);
+            },
+        );
+    } else {
+        cx.editor
+            .set_error("Language server does not support goto-definition");
+    }
 }
 
 pub fn goto_type_definition(cx: &mut Context) {
@@ -1082,22 +1079,19 @@ pub fn goto_reference(cx: &mut Context) {
 
     let pos = doc.position(view.id, offset_encoding);
 
-    let future = match language_server.goto_reference(doc.identifier(), pos, None) {
-        Some(future) => future,
-        None => {
-            cx.editor
-                .set_error("Language server does not support goto-reference");
-            return;
-        }
-    };
-
-    cx.callback(
-        future,
-        move |editor, compositor, response: Option<Vec<lsp::Location>>| {
-            let items = response.unwrap_or_default();
-            goto_impl(editor, compositor, items, offset_encoding);
-        },
-    );
+    if let Some(future) = language_server.goto_reference(doc.identifier(), pos, None) {
+        cx.callback_blocking(
+            "goto_reference: Waiting on LSP...",
+            future,
+            move |editor, compositor, response: Option<Vec<lsp::Location>>| {
+                let items = response.unwrap_or_default();
+                goto_impl(editor, compositor, items, offset_encoding);
+            },
+        );
+    } else {
+        cx.editor
+            .set_error("Language server does not support goto-reference");
+    }
 }
 
 #[derive(PartialEq, Eq)]

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -1,6 +1,7 @@
 // Each component declares its own size constraints and gets fitted based on its parent.
 // Q: how does this work with popups?
 // cursive does compositor.screen_mut().add_layer_at(pos::absolute(x, y), <component>)
+use helix_core::diagnostic::Severity;
 use helix_core::Position;
 use helix_view::graphics::{CursorKind, Rect};
 
@@ -15,7 +16,7 @@ pub enum EventResult {
     Consumed(Option<Callback>),
 }
 
-use crate::job::Jobs;
+use crate::job::{BlockingJob, Jobs};
 use helix_view::Editor;
 
 pub use helix_view::input::Event;
@@ -27,6 +28,10 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    pub fn blocking_job(&mut self, blocking_callback: BlockingJob) {
+        self.editor.status_msg = Some((blocking_callback.msg.into(), Severity::Error));
+        self.jobs.blocking_job = Some(blocking_callback);
+    }
     /// Waits on all pending jobs, and then tries to flush all pending write
     /// operations for all documents.
     pub fn block_try_flush_writes(&mut self) -> anyhow::Result<()> {

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -31,7 +31,7 @@ pub fn cancelation() -> (CancelSender, CancelReciver) {
 #[derive(Debug)]
 pub struct CancelSender(watch::Sender<()>);
 
-/// A cancel flag that can be awaited in an async contex
+/// A cancel flag that can be awaited in an async context
 /// and cheaply checked with a non-blocking check for use in
 /// a synchronous call
 // using a watch intead of a Notify so we can implement is_cancelled
@@ -55,10 +55,8 @@ impl CancelReciver {
 /// * The user can cancel an unresponsive task with C-c
 pub struct BlockingJob {
     future: JobFuture,
-    // when blocking job is dropped all watchers are automatically notified
-    // so it looks like this is unused but it's use is infact in its Drop
-    // implementation. We could manuall call `self.cancel.send(())` but
-    // it's unnecessary as the `Drop` already handels that for us
+    // When a BlockingJob is dropped all watchers are notified by the Drop
+    // implementation of watch::channel.
     cancel: CancelSender,
     pub msg: &'static str,
 }


### PR DESCRIPTION
Based on some initial work by @pascalkuthe for general blocking UI components.

The main feature added here is user feedback for goto_definition and goto_references. Once initiated, they can be canceled with C-c if the user no longer wishes to wait.

I didn't want to create too much change in one PR, but if accepted this pattern should probably be applied to nearly all LSP commands and some DAP commands as well. I'd be happy to chase that down in a follow-up series of PRs.

Some thoughts on the implementation are below.

## Handling layered editor status.

The way editor status is implemented, it's easy to stomp on another async message. In fact, the handler for LSP incoming progress updates (see application.rs:909) previously cleared the status line regardless of whether the user had `lsp.display-status` enabled. This is likely just a simple bugfix (which enabled my added message not to be cleared prematurely), but it highlights the brittle nature of the current solution.

I'm wondering if longer term something like the LSP status struct that tracks all current background tasks should be leveled up to a general editor concept which can track multiple active activities and perhaps a priority rating of each, so that we can show the most urgent one (your currently requested action is blocked and waiting) vs. lower priority ones (other background LSP status update messages).

Because of all this, if you _do_ have `lsp.display-status` set, the LSP message I set gets trampled and you can just be left with a dim window for a bit while you wait (or cancel).

## Use of editor status vs. new layer.

I didn't pursue this option, but it occurred to me that since we're dimming and freezing the main UI until we can react to the user's request, we have a lot of real estate to play with. We could place a message here for example:

![image](https://user-images.githubusercontent.com/662824/227716926-a8d318e9-67bf-46e2-9e2c-de9bc95415db.png)

## Impact on LSP message handling.

One thing I don't understand well is how this impacts the LSP or the message handling. When the cancel message is sent, we de-allocate all the futures (I believe) waiting for the response. Any downside to that? Any LSP commands we should send to ignore the previous request?

