### PR TITLE
tui: Handle keyboard enhancement check failure

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -78,21 +78,20 @@ where
     }
 
     #[inline]
-    fn supports_keyboard_enhancement_protocol(&self) -> io::Result<bool> {
-        self.supports_keyboard_enhancement_protocol
-            .get_or_try_init(|| {
+    fn supports_keyboard_enhancement_protocol(&self) -> bool {
+        *self.supports_keyboard_enhancement_protocol
+            .get_or_init(|| {
                 use std::time::Instant;
 
                 let now = Instant::now();
-                let support = terminal::supports_keyboard_enhancement();
+                let supported = matches!(terminal::supports_keyboard_enhancement(), Ok(true));
                 log::debug!(
                     "The keyboard enhancement protocol is {}supported in this terminal (checked in {:?})",
-                    if matches!(support, Ok(true)) { "" } else { "not " },
+                    if supported { "" } else { "not " },
                     Instant::now().duration_since(now)
                 );
-                support
+                supported
             })
-            .copied()
     }
 }
 
@@ -125,7 +124,7 @@ where
         if config.enable_mouse_capture {
             execute!(self.buffer, EnableMouseCapture)?;
         }
-        if self.supports_keyboard_enhancement_protocol()? {
+        if self.supports_keyboard_enhancement_protocol() {
             execute!(
                 self.buffer,
                 PushKeyboardEnhancementFlags(
@@ -143,7 +142,7 @@ where
         if config.enable_mouse_capture {
             execute!(self.buffer, DisableMouseCapture)?;
         }
-        if self.supports_keyboard_enhancement_protocol()? {
+        if self.supports_keyboard_enhancement_protocol() {
             execute!(self.buffer, PopKeyboardEnhancementFlags)?;
         }
         execute!(


### PR DESCRIPTION
If the terminal doesn't send the primary device attributes response to the query, the `terminal::supports_keyboard_enhancement` function from crossterm may timeout and return an Err.

We should interpret this error to mean that the terminal doesn't support the keyboard enhancement protocol rather than an error in claiming the terminal.

This was a bug introduced in the refactor in #6194