### PR TITLE
Update tree-sitter-git-commit, add comment textobject

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -41,7 +41,7 @@
 | fortran | ✓ |  | ✓ | `fortls` |
 | gdscript | ✓ | ✓ | ✓ |  |
 | git-attributes | ✓ |  |  |  |
-| git-commit | ✓ |  |  |  |
+| git-commit | ✓ | ✓ |  |  |
 | git-config | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1194,7 +1194,7 @@ text-width = 72
 
 [[grammar]]
 name = "git-commit"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "318dd72abfaa7b8044c1d1fbeabcd06deaaf038f" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "7421fd81840950c0ff4191733cee3b6ac06cb295" }
 
 [[language]]
 name = "diff"

--- a/runtime/queries/git-commit/textobjects.scm
+++ b/runtime/queries/git-commit/textobjects.scm
@@ -1,0 +1,2 @@
+(comment) @comment.inside
+(comment)+ @comment.around


### PR DESCRIPTION
The update includes a fix for comments in commit messages where there was no space separating the '#' and the comment text.

The comment textobject can be useful occasionally to jump to the summary part of the commit edit message.

See https://github.com/the-mikedavis/tree-sitter-git-commit/issues/7