### PR TITLE
Fix minor oversights in positioning code

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -98,7 +98,7 @@ pub use {regex, tree_sitter};
 pub use graphemes::RopeGraphemes;
 pub use position::{
     char_idx_at_visual_offset, coords_at_pos, pos_at_coords, visual_offset_from_anchor,
-    visual_offset_from_block, Position,
+    visual_offset_from_block, Position, VisualOffsetError,
 };
 #[allow(deprecated)]
 pub use position::{pos_at_visual_coords, visual_coords_at_pos};

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -317,10 +317,11 @@ pub fn char_idx_at_visual_offset<'a>(
     text_fmt: &TextFormat,
     annotations: &TextAnnotations,
 ) -> (usize, usize) {
+    let mut pos = anchor;
     // convert row relative to visual line containing anchor to row relative to a block containing anchor (anchor may change)
     loop {
         let (visual_pos_in_block, block_char_offset) =
-            visual_offset_from_block(text, anchor, anchor, text_fmt, annotations);
+            visual_offset_from_block(text, anchor, pos, text_fmt, annotations);
         row_offset += visual_pos_in_block.row as isize;
         anchor = block_char_offset;
         if row_offset >= 0 {
@@ -332,10 +333,10 @@ pub fn char_idx_at_visual_offset<'a>(
             break;
         }
         // the row_offset is negative so we need to look at the previous block
-        // set the anchor to the last char before the current block
-        // this char index is also always a line earlier so increase the row_offset by 1
+        // set the anchor to the last char before the current block so that we can compute
+        // the distance of this block from the start of the previous block
+        pos = anchor;
         anchor -= 1;
-        row_offset += 1;
     }
 
     char_idx_at_visual_block_offset(

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::convert::identity;
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -113,9 +112,7 @@ impl<A, M> Layer<A, M> {
     pub fn reset_pos(&self, char_idx: usize, get_char_idx: impl Fn(&A) -> usize) {
         let new_index = self
             .annotations
-            .binary_search_by_key(&char_idx, get_char_idx)
-            .unwrap_or_else(identity);
-
+            .partition_point(|annot| get_char_idx(annot) < char_idx);
         self.current_index.set(new_index);
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1470,7 +1470,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
     let cursor = range.cursor(text);
     let height = view.inner_height();
 
-    let scrolloff = config.scrolloff.min(height / 2);
+    let scrolloff = config.scrolloff.min(height.saturating_sub(1) as usize / 2);
     let offset = match direction {
         Forward => offset as isize,
         Backward => -(offset as isize),
@@ -1510,7 +1510,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
             head = char_idx_at_visual_offset(
                 doc_text,
                 view.offset.anchor,
-                (view.offset.vertical_offset + height - scrolloff) as isize,
+                (view.offset.vertical_offset + height - scrolloff - 1) as isize,
                 0,
                 &text_fmt,
                 &annotations,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1489,18 +1489,19 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction) {
         &annotations,
     );
 
-    let head;
+    let mut head;
     match direction {
         Forward => {
-            head = char_idx_at_visual_offset(
+            let off;
+            (head, off) = char_idx_at_visual_offset(
                 doc_text,
                 view.offset.anchor,
                 (view.offset.vertical_offset + scrolloff) as isize,
                 0,
                 &text_fmt,
                 &annotations,
-            )
-            .0;
+            );
+            head += (off != 0) as usize;
             if head <= cursor {
                 return;
             }

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -175,7 +175,6 @@ pub fn render_text<'t>(
         text_annotations,
     );
     row_off += offset.vertical_offset;
-    assert_eq!(0, offset.vertical_offset);
 
     let (mut formatter, mut first_visible_char_idx) =
         DocumentFormatter::new_at_prev_checkpoint(text, text_fmt, text_annotations, offset.anchor);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1038,10 +1038,15 @@ impl EditorView {
             ..
         } = *event;
 
-        let pos_and_view = |editor: &Editor, row, column| {
+        let pos_and_view = |editor: &Editor, row, column, ignore_virtual_text| {
             editor.tree.views().find_map(|(view, _focus)| {
-                view.pos_at_screen_coords(&editor.documents[&view.doc], row, column, true)
-                    .map(|pos| (pos, view.id))
+                view.pos_at_screen_coords(
+                    &editor.documents[&view.doc],
+                    row,
+                    column,
+                    ignore_virtual_text,
+                )
+                .map(|pos| (pos, view.id))
             })
         };
 
@@ -1056,7 +1061,7 @@ impl EditorView {
             MouseEventKind::Down(MouseButton::Left) => {
                 let editor = &mut cxt.editor;
 
-                if let Some((pos, view_id)) = pos_and_view(editor, row, column) {
+                if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
                     let doc = doc_mut!(editor, &view!(editor, view_id).doc);
 
                     if modifiers == KeyModifiers::ALT {
@@ -1120,7 +1125,7 @@ impl EditorView {
                     _ => unreachable!(),
                 };
 
-                match pos_and_view(cxt.editor, row, column) {
+                match pos_and_view(cxt.editor, row, column, false) {
                     Some((_, view_id)) => cxt.editor.tree.focus = view_id,
                     None => return EventResult::Ignored(None),
                 }
@@ -1191,7 +1196,7 @@ impl EditorView {
                     return EventResult::Consumed(None);
                 }
 
-                if let Some((pos, view_id)) = pos_and_view(editor, row, column) {
+                if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
                     let doc = doc_mut!(editor, &view!(editor, view_id).doc);
                     doc.set_selection(view_id, Selection::point(pos));
                     cxt.editor.focus(view_id);


### PR DESCRIPTION
Extracted from #6417
Fixes #6397


This is a collection of bugfixes for oversights introduced in #5420 that I noticed while working on #6417. I backported these to a standalone PR, so they can merged independently of the larger changes in #6417. It's a bit of a kitchen sink PR in that these fixes are pretty independent of each other, but it didn't seem worth splitting each commit into seperate PR because they are mostly not large changes and didn't really contain any design decisions (just bugfixes) so it didn't seem like they would need separate discussion.

Each commit in this PR is a standalone bugfix mostly independent of the other fixes. As such I added a detailed description to each commit to describe what it's doing from a technical point of view. A short summery below

* ec37277, be49329 and b4988e0 fix some inconsistencies/bugs in the scrolling (see also #6397)
* e6b386f fixes position calculations for virtual text at the end of a line
* b4cb4dd fixes a bug where some virtual text might be "randomly" cut of at the start of the view
* cafdf92 fixes crashes/artifacts after edits before the view in the edge case where the cursor was also moved backwards
* 520c144 removes an asssert that makes no sense anymore and can cause for virtual text that takes multiple lines
