### PR TITLE
log failures in the git integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
 name = "helix-vcs"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "arc-swap",
  "gix",
  "helix-core",

--- a/helix-vcs/Cargo.toml
+++ b/helix-vcs/Cargo.toml
@@ -19,6 +19,7 @@ arc-swap = { version = "1.6.0" }
 
 gix = { version = "0.41.0", default-features = false , optional = true }
 imara-diff = "0.1.5"
+anyhow = "1"
 
 log = "0.4"
 

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -54,7 +54,7 @@ fn missing_file() {
     let file = temp_git.path().join("file.txt");
     File::create(&file).unwrap().write_all(b"foo").unwrap();
 
-    assert_eq!(Git.get_diff_base(&file), None);
+    assert!(Git.get_diff_base(&file).is_err());
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn unmodified_file() {
     let contents = b"foo".as_slice();
     File::create(&file).unwrap().write_all(contents).unwrap();
     create_commit(temp_git.path(), true);
-    assert_eq!(Git.get_diff_base(&file), Some(Vec::from(contents)));
+    assert_eq!(Git.get_diff_base(&file).unwrap(), Vec::from(contents));
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn modified_file() {
     create_commit(temp_git.path(), true);
     File::create(&file).unwrap().write_all(b"bar").unwrap();
 
-    assert_eq!(Git.get_diff_base(&file), Some(Vec::from(contents)));
+    assert_eq!(Git.get_diff_base(&file).unwrap(), Vec::from(contents));
 }
 
 /// Test that `get_file_head` does not return content for a directory.
@@ -95,7 +95,7 @@ fn directory() {
 
     std::fs::remove_dir_all(&dir).unwrap();
     File::create(&dir).unwrap().write_all(b"bar").unwrap();
-    assert_eq!(Git.get_diff_base(&dir), None);
+    assert!(Git.get_diff_base(&dir).is_err());
 }
 
 /// Test that `get_file_head` does not return content for a symlink.
@@ -116,6 +116,6 @@ fn symlink() {
     symlink("file.txt", &file_link).unwrap();
 
     create_commit(temp_git.path(), true);
-    assert_eq!(Git.get_diff_base(&file_link), None);
-    assert_eq!(Git.get_diff_base(&file), Some(Vec::from(contents)));
+    assert!(Git.get_diff_base(&file_link).is_err());
+    assert_eq!(Git.get_diff_base(&file).unwrap(), Vec::from(contents));
 }

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, Result};
 use arc_swap::ArcSwap;
 use std::{path::Path, sync::Arc};
 
@@ -18,19 +19,19 @@ pub trait DiffProvider {
     /// if this provider is used.
     /// The data is returned as raw byte without any decoding or encoding performed
     /// to ensure all file encodings are handled correctly.
-    fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>>;
-    fn get_current_head_name(&self, file: &Path) -> Option<Arc<ArcSwap<Box<str>>>>;
+    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>>;
+    fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>>;
 }
 
 #[doc(hidden)]
 pub struct Dummy;
 impl DiffProvider for Dummy {
-    fn get_diff_base(&self, _file: &Path) -> Option<Vec<u8>> {
-        None
+    fn get_diff_base(&self, _file: &Path) -> Result<Vec<u8>> {
+        bail!("helix was compiled without git support")
     }
 
-    fn get_current_head_name(&self, _file: &Path) -> Option<Arc<ArcSwap<Box<str>>>> {
-        None
+    fn get_current_head_name(&self, _file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+        bail!("helix was compiled without git support")
     }
 }
 
@@ -42,13 +43,27 @@ impl DiffProviderRegistry {
     pub fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>> {
         self.providers
             .iter()
-            .find_map(|provider| provider.get_diff_base(file))
+            .find_map(|provider| match provider.get_diff_base(file) {
+                Ok(res) => Some(res),
+                Err(err) => {
+                    log::error!("{err:#?}");
+                    log::error!("failed to open diff base for {}", file.display());
+                    None
+                }
+            })
     }
 
     pub fn get_current_head_name(&self, file: &Path) -> Option<Arc<ArcSwap<Box<str>>>> {
         self.providers
             .iter()
-            .find_map(|provider| provider.get_current_head_name(file))
+            .find_map(|provider| match provider.get_current_head_name(file) {
+                Ok(res) => Some(res),
+                Err(err) => {
+                    log::error!("{err:#?}");
+                    log::error!("failed to obtain current head name for {}", file.display());
+                    None
+                }
+            })
     }
 }
 


### PR DESCRIPTION
Issues with the diff gutter like #6358 are pretty hard to debug right now because there is essentially no logging of failures in the git integration (they all get turned into options). This PR makes the functions of the `DiffProvider` trait return a Result and log any failures.