### PR TITLE
60 fps progress spinner

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -500,6 +500,16 @@ impl Application {
         }
     }
 
+    pub async fn handle_frame_tick(&mut self) {
+        let editor_view = self
+            .compositor
+            .find::<ui::EditorView>()
+            .expect("expected at least one EditorView");
+        if editor_view.spinners_mut().spinning() {
+            self.render().await;
+        }
+    }
+
     pub fn handle_document_write(&mut self, doc_save_event: DocumentSavedEventResult) {
         let doc_save_event = match doc_save_event {
             Ok(event) => event,
@@ -599,6 +609,9 @@ impl Application {
                 {
                     return true;
                 }
+            }
+            EditorEvent::TickFrame => {
+                self.handle_frame_tick().await;
             }
         }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -872,7 +872,7 @@ impl Application {
                                 } else {
                                     self.lsp_progress.end_progress(server_id, &token);
                                     if !self.lsp_progress.is_progressing(server_id) {
-                                        editor_view.spinners_mut().get_or_create(server_id).stop();
+                                        editor_view.spinners_mut().stop(server_id);
                                     }
                                     self.editor.clear_status();
 
@@ -915,7 +915,7 @@ impl Application {
                         if let lsp::WorkDoneProgress::End(_) = work {
                             self.lsp_progress.end_progress(server_id, &token);
                             if !self.lsp_progress.is_progressing(server_id) {
-                                editor_view.spinners_mut().get_or_create(server_id).stop();
+                                editor_view.spinners_mut().stop(server_id);
                             }
                         } else {
                             self.lsp_progress.update(server_id, token, work);
@@ -991,10 +991,7 @@ impl Application {
                             .compositor
                             .find::<ui::EditorView>()
                             .expect("expected at least one EditorView");
-                        let spinner = editor_view.spinners_mut().get_or_create(server_id);
-                        if spinner.is_stopped() {
-                            spinner.start();
-                        }
+                        editor_view.spinners_mut().start(server_id);
 
                         Ok(serde_json::Value::Null)
                     }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -24,7 +24,7 @@ pub use menu::Menu;
 pub use picker::{DynamicPicker, FileLocation, FilePicker, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
-pub use spinner::{ProgressSpinners, Spinner};
+pub use spinner::ProgressSpinners;
 pub use text::Text;
 
 use helix_core::regex::Regex;

--- a/helix-term/src/ui/spinner.rs
+++ b/helix-term/src/ui/spinner.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 const FRAMES: &[&str] = &["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"];
-const INTERVAL: u128 = 80;
+// Using multiples of 2 allow compiling down to simpler instructions
+const INTERVAL: u128 = 128;
 
 #[derive(Default, Debug)]
 pub struct ProgressSpinners {

--- a/helix-term/src/ui/spinner.rs
+++ b/helix-term/src/ui/spinner.rs
@@ -19,6 +19,10 @@ impl ProgressSpinners {
         self.inner.remove(&id);
     }
 
+    pub fn spinning(&self) -> bool {
+        !self.inner.is_empty()
+    }
+
     pub fn frame(&self, id: usize) -> Option<&str> {
         let start = self.inner.get(&id)?;
         let idx =

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -206,12 +206,7 @@ where
         context
             .doc
             .language_server()
-            .and_then(|srv| {
-                context
-                    .spinners
-                    .get(srv.id())
-                    .and_then(|spinner| spinner.frame())
-            })
+            .and_then(|srv| context.spinners.frame(srv.id()))
             // Even if there's no spinner; reserve its space to avoid elements frequently shifting.
             .unwrap_or(" ")
             .to_string(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1593,16 +1593,16 @@ impl Editor {
                 }
 
                 _ = self.redraw_handle.0.notified() => {
-                    if  !self.needs_redraw{
+                    if !self.needs_redraw {
                         self.needs_redraw = true;
                         let timeout = Instant::now() + Duration::from_millis(96);
-                        if timeout < self.idle_timer.deadline(){
+                        if timeout < self.idle_timer.deadline() {
                             self.idle_timer.as_mut().reset(timeout)
                         }
                     }
                 }
 
-                _ = &mut self.idle_timer  => {
+                _ = &mut self.idle_timer => {
                     return EditorEvent::IdleTimer
                 }
             }


### PR DESCRIPTION
Previous spinner kinda look a bit weird given that it needs to wait for progress to spin, makes the editor feels laggy.

[![asciicast](https://asciinema.org/a/EKxA31vqAGWls2fZMXoS3km0Z.svg)](https://asciinema.org/a/EKxA31vqAGWls2fZMXoS3km0Z)

Now it spins at 60 fps which makes the editor look fast.

[![asciicast](https://asciinema.org/a/K64QU9629b8b56EZpcRRcvFNp.svg)](https://asciinema.org/a/K64QU9629b8b56EZpcRRcvFNp)

Not sure if there is a better way to do the interval timer at commit fb572fb5f604023a8f2e19b2909761ff32a197ec, not sure if there are any performance issues either.

The pause at the end to remove the progress message looks weird due to the idle timeout, I was thinking to remove it, but then I figure out if the last message is an error, user should see it, but so far I only see rust-analyzer outputting completed message, so not removing it as I am not sure.