### PR TITLE
Add .arb as a supported extension with json highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -160,7 +160,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 scope = "source.json"
 injection-regex = "json"
-file-types = ["json", "jsonc"]
+file-types = ["json", "jsonc", "arb"]
 roots = []
 language-server = { command = "vscode-json-language-server", args = ["--stdio"] }
 auto-format = true


### PR DESCRIPTION
ARB is a file format which is very commonly used in flutter development: https://localizely.com/flutter-arb/