### PR TITLE
Switch default comment to #

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -60,7 +60,7 @@ fn find_line_comment(
 pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&str>) -> Transaction {
     let text = doc.slice(..);
 
-    let token = token.unwrap_or("//");
+    let token = token.unwrap_or("#");
     let comment = Tendril::from(format!("{} ", token));
 
     let mut lines: Vec<usize> = Vec::with_capacity(selection.len());
@@ -116,7 +116,7 @@ mod test {
         transaction.apply(&mut doc);
         selection = selection.map(transaction.changes());
 
-        assert_eq!(doc, "  // 1\n\n  // 2\n  // 3");
+        assert_eq!(doc, "  # 1\n\n  # 2\n  # 3");
 
         // uncomment
         let transaction = toggle_line_comments(&doc, &selection, None);
@@ -126,7 +126,7 @@ mod test {
         assert!(selection.len() == 1); // to ignore the selection unused warning
 
         // 0 margin comments
-        doc = Rope::from("  //1\n\n  //2\n  //3");
+        doc = Rope::from("  #1\n\n  #2\n  #3");
         // reset the selection.
         selection = Selection::single(0, doc.len_chars() - 1);
 
@@ -137,7 +137,7 @@ mod test {
         assert!(selection.len() == 1); // to ignore the selection unused warning
 
         // 0 margin comments, with no space
-        doc = Rope::from("//");
+        doc = Rope::from("#");
         // reset the selection.
         selection = Selection::single(0, doc.len_chars() - 1);
 


### PR DESCRIPTION
Having # as comment is far more common in non-support files like random configuration files as compared to //, so it will be using the correct comment at a higher chance.