### PR TITLE
Add option to return to normal mode on left click

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -39,6 +39,7 @@ signal to the Helix process on Unix operating systems, such as by using the comm
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
 | `middle-click-paste` | Middle click paste support | `true` |
+| `normal-mode-on-click` | Left click changes to normal mode | `false` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step | `3` |
 | `shell` | Shell to use when running external commands | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `absolute` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1074,6 +1074,10 @@ impl EditorView {
                     editor.focus(view_id);
                     editor.ensure_cursor_in_view(view_id);
 
+                    if config.normal_mode_on_click {
+                        editor.enter_normal_mode();
+                    }
+
                     return EventResult::Consumed(None);
                 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -281,6 +281,8 @@ pub struct Config {
     /// Whether to color modes with different colors. Defaults to `false`.
     pub color_modes: bool,
     pub soft_wrap: SoftWrap,
+    /// Whether to return to normal mode on left click. Defaults to `false`.
+    pub normal_mode_on_click: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -746,6 +748,7 @@ impl Default for Config {
             soft_wrap: SoftWrap::default(),
             text_width: 80,
             completion_replace: false,
+            normal_mode_on_click: false,
         }
     }
 }


### PR DESCRIPTION
Perhaps this is just a "me" problem, but I seem to find myself often forgetting to exit insert mode when clicking to a different area of code whilst editing and then being annoyed when the motions I type are inserted into the file. The behaviour I find that I want is to return to normal mode when clicking away. This pull request is my naive attempt at implementing this.

Please let me know if I am overlooking some mouse mode use-cases that this might break.