### PR TITLE
tree-sitter(haskell): use quasiquoters as an injection point

### DIFF
--- a/runtime/queries/haskell/injections.scm
+++ b/runtime/queries/haskell/injections.scm
@@ -1,2 +1,6 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+(quasiquote
+ (quoter) @injection.language
+ (quasiquote_body) @injection.content)


### PR DESCRIPTION
Similar to tagged templates in JS, quasiquoters allow to embed external languages in haskell, so it makes sense to treat them as an injection point.

I have been using it locally for a few weeks now.