### PR TITLE
Render tab with indent-guides

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -338,16 +338,9 @@ impl<'a> TextRenderer<'a> {
 
         let tab_width = doc.tab_width();
         let tab = if ws_render.tab() == WhitespaceRenderValue::All {
-            if editor_config.indent_guides.render {
-                std::iter::once(ws_chars.tabpad)
-                    .chain(std::iter::once(ws_chars.tab))
-                    .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 2))
-                    .collect()
-            } else {
-                std::iter::once(ws_chars.tab)
-                    .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
-                    .collect()
-            }
+            std::iter::once(ws_chars.tab)
+                .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
+                .collect()
         } else {
             " ".repeat(tab_width)
         };
@@ -484,6 +477,19 @@ impl<'a> TextRenderer<'a> {
                 as u16;
             let y = self.viewport.y + row;
             debug_assert!(self.surface.in_bounds(x, y));
+            // move tab index +1
+            if self.surface.get(x + 1, y).is_some() {
+                let str_replace = self.surface.get(x, y).unwrap();
+                let tab_idx = char_to_byte_idx(&self.tab, 1);
+                if Some(str_replace.symbol.as_str()) == self.tab.get(..tab_idx) {
+                    self.surface.set_string(
+                        x + 1,
+                        y,
+                        str_replace.symbol.clone(),
+                        str_replace.style(),
+                    );
+                }
+            }
             self.surface
                 .set_string(x, y, &self.indent_guide_char, self.indent_guide_style);
         }

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -338,9 +338,16 @@ impl<'a> TextRenderer<'a> {
 
         let tab_width = doc.tab_width();
         let tab = if ws_render.tab() == WhitespaceRenderValue::All {
-            std::iter::once(ws_chars.tab)
-                .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
-                .collect()
+            if editor_config.indent_guides.render {
+                std::iter::once(ws_chars.tabpad)
+                    .chain(std::iter::once(ws_chars.tab))
+                    .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 2))
+                    .collect()
+            } else {
+                std::iter::once(ws_chars.tab)
+                    .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
+                    .collect()
+            }
         } else {
             " ".repeat(tab_width)
         };

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1304,6 +1304,7 @@ impl Document {
         self.language_config()
             .and_then(|config| config.indent.as_ref())
             .map_or(4, |config| config.tab_width) // fallback to 4 columns
+            .clamp(2, 32)
     }
 
     // The width (in spaces) of a level of indentation.


### PR DESCRIPTION
- fix #6051
- fix when set `tab-width=0` ,will get panic `thread 'main' panicked at 'attempt to calculate the remainder with a divisor of zero', helix-core/src/graphemes.rs:20:26`

set indent guides render false

![3](https://user-images.githubusercontent.com/716514/228726208-25659dd0-7bcc-47f9-9250-e29c23f469c3.png)



before:
![1](https://user-images.githubusercontent.com/716514/228726505-07954e5e-9fd6-44d0-9b8b-4a29a10e7750.png)



after:
![2](https://user-images.githubusercontent.com/716514/228725296-768227c3-2c97-4825-bb3d-a9ffb7dde1b9.png)



> this has set `tabpad = "·"`