### PR TITLE
Add injection for Markdown strings in Julia

### DIFF
--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -26,3 +26,9 @@
     prefix: (identifier) @function.macro) @injection.content
   (#eq? @function.macro "re")
   (#set! injection.language "regex"))
+
+(
+  (prefixed_string_literal
+    prefix: (identifier) @function.macro) @injection.content
+  (#eq? @function.macro "md")
+  (#set! injection.language "markdown"))


### PR DESCRIPTION
Julia has support for Markdown strings, denoted by `md"foo"`.  This PR adds an injection for highlighting these as Markdown.