### PR TITLE
Add indents.scm for Julia

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -68,7 +68,7 @@
 | json | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
-| julia | ✓ |  |  | `julia` |
+| julia | ✓ |  | ✓ | `julia` |
 | kdl | ✓ |  |  |  |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
 | latex | ✓ | ✓ |  | `texlab` |

--- a/runtime/queries/julia/indents.scm
+++ b/runtime/queries/julia/indents.scm
@@ -1,0 +1,16 @@
+[
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+  (compound_expression)
+  (let_statement)
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (do_clause)
+  (parameter_list)
+] @indent
+
+[
+  "end"
+] @outdent


### PR DESCRIPTION
Automatic indentation for my favorite programming language, filling in one of the holes in the language support chart.