### PR TITLE
Update tree-sitter-git-commit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1194,7 +1194,7 @@ text-width = 72
 
 [[grammar]]
 name = "git-commit"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "7421fd81840950c0ff4191733cee3b6ac06cb295" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "bd0ca5a6065f2cada3ac6a82a66db3ceff55fa6b" }
 
 [[language]]
 name = "diff"


### PR DESCRIPTION
The last update introduced a bug with comments where a comment would be recognized as a message if there were multiple newlines between the last message or subject and the comment, causing a noticeable change in highlighting. This change fixes that behavior.