### PR TITLE
Fix aarch64 macos release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,12 @@ jobs:
           target: x86_64-pc-windows-msvc
           cross: false
         # 23.03: build issues
-        # - build: aarch64-macos
-        #   os: macos-latest
-        #   rust: stable
-        #   target: aarch64-apple-darwin
-        #   cross: false
-        #   skip_tests: true  # x86_64 host can't run aarch64 code
+        - build: aarch64-macos
+          os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
+          cross: false
+          skip_tests: true  # x86_64 host can't run aarch64 code
         # - build: x86_64-win-gnu
         #   os: windows-2019
         #   rust: stable-x86_64-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
                   exe=".exe"
               fi
               pkgname=helix-$GITHUB_REF_NAME-$platform
-              mkdir $pkgname
+              mkdir -p $pkgname
               cp $source/LICENSE $source/README.md $pkgname
               mkdir $pkgname/contrib
               cp -r $source/contrib/completion $pkgname/contrib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,12 @@ jobs:
           mkdir -p runtime/grammars/sources
           tar xJf grammars/grammars.tar.xz -C runtime/grammars/sources
 
+      # The rust-toolchain action ignores rust-toolchain.toml files.
+      # Removing this before building with cargo ensures that the rust-toolchain
+      # is considered the same between installation and usage.
+      - name: Remove the rust-toolchain.toml file
+        run: rm rust-toolchain.toml
+
       - name: Install ${{ matrix.rust }} toolchain
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Fixes #6495

See the dry-run https://github.com/helix-editor/helix/actions/runs/4576449372

This could be solved instead by using `rustup target add ${{ matrix.target }}` but that would be papering over the problem: we do install stable-aarch64-apple-darwin but that's for the wrong Rust version. `cargo` looks to use 1.65 because of the `rust-toolchain.toml` file but `dtolnay/rust-toolchain` installs it for stable which is 1.68.2 currently.