### PR TITLE
Only apply completions on confirmation

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -220,8 +220,6 @@ impl Completion {
                 }
                 PromptEvent::Update => {}
                 PromptEvent::Validate => {
-                    // if more text was entered, remove it
-                    doc.restore(view, &savepoint);
                     // always present here
                     let item = item.unwrap();
 
@@ -235,13 +233,6 @@ impl Completion {
                         replace_mode,
                     );
 
-                    doc.apply(&transaction, view.id);
-
-                    editor.last_completion = Some(CompleteAction {
-                        trigger_offset,
-                        changes: completion_changes(&transaction, trigger_offset),
-                    });
-
                     // apply additional edits, mostly used to auto import unqualified types
                     let resolved_item = if item
                         .additional_text_edits
@@ -254,6 +245,14 @@ impl Completion {
                         Self::resolve_completion_item(doc, item.clone())
                     };
 
+                    // if more text was entered, remove it
+                    doc.restore(view, &savepoint);
+                    doc.apply(&transaction, view.id);
+
+                    editor.last_completion = Some(CompleteAction {
+                        trigger_offset,
+                        changes: completion_changes(&transaction, trigger_offset),
+                    });
                     if let Some(additional_edits) = resolved_item
                         .as_ref()
                         .and_then(|item| item.additional_text_edits.as_ref())

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -213,36 +213,15 @@ impl Completion {
 
             let (view, doc) = current!(editor);
 
-            // if more text was entered, remove it
-            doc.restore(view, &savepoint);
-
             match event {
                 PromptEvent::Abort => {
+                    doc.restore(view, &savepoint);
                     editor.last_completion = None;
                 }
-                PromptEvent::Update => {
-                    // always present here
-                    let item = item.unwrap();
-
-                    let transaction = item_to_transaction(
-                        doc,
-                        view.id,
-                        item,
-                        offset_encoding,
-                        trigger_offset,
-                        true,
-                        replace_mode,
-                    );
-
-                    // initialize a savepoint
-                    doc.apply(&transaction, view.id);
-
-                    editor.last_completion = Some(CompleteAction {
-                        trigger_offset,
-                        changes: completion_changes(&transaction, trigger_offset),
-                    });
-                }
+                PromptEvent::Update => {}
                 PromptEvent::Validate => {
+                    // if more text was entered, remove it
+                    doc.restore(view, &savepoint);
                     // always present here
                     let item = item.unwrap();
 


### PR DESCRIPTION
Closes #6259
Closes #6261 (and a similar bug with the typesecript LSP reported on matrix)

Helix currently immediately "partly" (without additional edits) applies completion items when they are selected. This fundamentally breaks assumptions from the LSP protocol. LSP protocol relies on rerequsting completions dynamically. We already do this on idle timeout, but our support is subpar right now (we ignore `incomplete` completion responses) so rerequsting completions will become even more critical.

However, by immediately applying the completions we easily break rerequests for snippets. Snippets move the cursor (inside the applies completion) and usually are more complex syntactic items that completely discard any existing filters. 

I checked out other editors and all IDEs I tested (VSCode, Clion/Intellij, Sublime) only apply completions once explicitly selected. To make the experience smoother (and inline with other IDEs) I changed the completion menu to always automatically select the first completion option. This means you can keep typing until the desired completion is on top and the just hit `<ret>` once to confirm. 

This change also makes the completion menu work better as a sort of inline picker. The text you type is used as a fuzzy match query. You can scroll without messing up this query and confirm your pick by hitting enter.
