### PR TITLE
robustly handle invalid LSP ranges

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -129,7 +129,11 @@ pub mod util {
     ) -> Option<usize> {
         let pos_line = pos.line as usize;
         if pos_line > doc.len_lines() - 1 {
-            return None;
+            // If it extends past the end, truncate it to the end. This is because the
+            // way the LSP describes the range including the last newline is by
+            // specifying a line number after what we would call the last line.
+            log::warn!("LSP position {pos:?} out of range assuming EOF");
+            return Some(doc.len_chars());
         }
 
         // We need to be careful here to fully comply ith the LSP spec.
@@ -239,9 +243,20 @@ pub mod util {
 
     pub fn lsp_range_to_range(
         doc: &Rope,
-        range: lsp::Range,
+        mut range: lsp::Range,
         offset_encoding: OffsetEncoding,
     ) -> Option<Range> {
+        // This is sort of an edgecase. It's not clear from the spec how to deal with
+        // ranges where end < start. They don't make much sense but vscode simply caps start to end
+        // and because it's not specified quite a few LS rely on this as a result (for example the TS server)
+        if range.start > range.end {
+            log::error!(
+                "Invalid LSP range start {:?} > end {:?}, using an empty range at the end instead",
+                range.start,
+                range.end
+            );
+            range.start = range.end;
+        }
         let start = lsp_pos_to_pos(doc, range.start, offset_encoding)?;
         let end = lsp_pos_to_pos(doc, range.end, offset_encoding)?;
 
@@ -947,16 +962,16 @@ mod tests {
 
         test_case!("", (0, 0) => Some(0));
         test_case!("", (0, 1) => Some(0));
-        test_case!("", (1, 0) => None);
+        test_case!("", (1, 0) => Some(0));
         test_case!("\n\n", (0, 0) => Some(0));
         test_case!("\n\n", (1, 0) => Some(1));
         test_case!("\n\n", (1, 1) => Some(1));
         test_case!("\n\n", (2, 0) => Some(2));
-        test_case!("\n\n", (3, 0) => None);
+        test_case!("\n\n", (3, 0) => Some(2));
         test_case!("test\n\n\n\ncase", (4, 3) => Some(11));
         test_case!("test\n\n\n\ncase", (4, 4) => Some(12));
         test_case!("test\n\n\n\ncase", (4, 5) => Some(12));
-        test_case!("", (u32::MAX, u32::MAX) => None);
+        test_case!("", (u32::MAX, u32::MAX) => Some(0));
     }
 
     #[test]

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -141,16 +141,12 @@ impl Completion {
                         }
                     };
 
-                    let start_offset =
-                        match util::lsp_pos_to_pos(doc.text(), edit.range.start, offset_encoding) {
-                            Some(start) => start as i128 - primary_cursor as i128,
-                            None => return Transaction::new(doc.text()),
-                        };
-                    let end_offset =
-                        match util::lsp_pos_to_pos(doc.text(), edit.range.end, offset_encoding) {
-                            Some(end) => end as i128 - primary_cursor as i128,
-                            None => return Transaction::new(doc.text()),
-                        };
+                    let Some(range) = util::lsp_range_to_range(doc.text(), edit.range, offset_encoding) else{
+                        return Transaction::new(doc.text());
+                    };
+
+                    let start_offset = range.anchor as i128 - primary_cursor as i128;
+                    let end_offset = range.head as i128 - primary_cursor as i128;
 
                     (Some((start_offset, end_offset)), edit.new_text)
                 } else {


### PR DESCRIPTION
Fix crashes with the TS language server reported on matrix

The Problem is that the way helix deals with invalid LSP ranges is different from other editors right now. Helix currently panics if the start of a LSP range is after the end of the range. The standard doesn't actually state that this is forbidden. VSCode simply sets `start=end` in that case and there seem to be a few servers relying on this sadly. I matched that behavior but logged an error to make sure this is not missed when tracking down issues. Alternatively we could discard such ranges. We definitely shouldn't panic tough.

Similarly, we now allow ranges with line numbers past the end (simply treated as EOF). VSCode behaves the same and so does neovim. I copied their comment here:

> If it extends past the end, truncate it to the end. This is because the
> way the LSP describes the range including the last newline is by
> specifying a line number after what we would call the last line.
