### PR TITLE
dracula theme: style inlay hints as comments

### DIFF
--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -45,6 +45,9 @@
 "ui.virtual.whitespace" = { fg = "subtle" }
 "ui.virtual.wrap" = { fg = "subtle" }
 "ui.virtual.ruler" = { bg = "background_dark"}
+"ui.virtual.inlay-hint" = { fg = "comment" }
+"ui.virtual.inlay-hint.parameter" = { fg = "comment", modifiers = ["italic"] }
+"ui.virtual.inlay-hint.type" = { fg = "comment", modifiers = ["italic"] }
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }


### PR DESCRIPTION
This styles all inlay hints in the same color as comments. Additionally, types and parameters will be italic.

<img width="850" alt="Bildschirm­foto 2023-03-31 um 21 48 30" src="https://user-images.githubusercontent.com/7622248/229216988-61982d06-3a48-419e-9535-30fbf0a42e21.png">

I haven't yet found any colors I really like for styling types and parameters differently, though I'm open to suggestions. 

For reference, this is what it looks like using the same colors as ordinary types and parameters, respectively, but with an additional dim modifier:
<img width="847" alt="Bildschirm­foto 2023-03-31 um 21 47 29" src="https://user-images.githubusercontent.com/7622248/229217264-e2091c35-7cff-4c43-964f-312777313e8f.png">
