### PR TITLE
Dim pane divider color in base16_transparent theme

### DIFF
--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -9,7 +9,7 @@
 "ui.linenr" = { fg = "light-gray" }
 "ui.linenr.selected" = { fg = "white",  modifiers = ["bold"] }
 "ui.popup" = { fg = "white" }
-"ui.window" = { fg = "white" }
+"ui.window" = { fg = "gray" }
 "ui.selection" = { bg = "gray" }
 "comment" = "light-gray"
 "ui.statusline" = { fg = "white" }


### PR DESCRIPTION
# Update divider color in `base16_transparent` theme

> Proposed change to [update panes separator color](https://github.com/helix-editor/helix/blob/23ed8c12f17c28ee888b5560d0ab2a9f9cd74dc9/runtime/themes/base16_transparent.toml#L12) in order to increse the focus on the actual code

current:
```toml
ui.window = { fg = "white" }
```
<img width="716" alt="proposed_terminal" src="https://user-images.githubusercontent.com/2312755/229287410-7b11823e-1e56-427a-bed0-94a841a75c65.png">

<img width="851" alt="current" src="https://user-images.githubusercontent.com/2312755/229287415-5521c888-bf9a-4eb3-bcd0-9428ee75fc04.png">

proposed: 
```toml
ui.window = { fg = "gray" }
```

<img width="716" alt="current_terminal" src="https://user-images.githubusercontent.com/2312755/229287411-81ff2d3e-6687-4787-a2f0-5c4712c918e4.png">
<img width="851" alt="proposed" src="https://user-images.githubusercontent.com/2312755/229287413-35bc97eb-4b06-4be1-9760-4061bc49c2de.png">

