### PR TITLE
Fix ayu theme markup unreadable bg

### DIFF
--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -22,6 +22,9 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.raw.block" = "orange"
 "markup.link.url" = "blue"
 "markup.link.text" = "yellow"

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -22,7 +22,7 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
-"markup.raw.block" = { bg = "gray", fg = "orange" }
+"markup.raw.block" = "orange"
 "markup.link.url" = "blue"
 "markup.link.text" = "yellow"
 "markup.link.label" = "green"

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -22,7 +22,7 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
-"markup.raw.block" = { bg = "gray", fg = "orange" }
+"markup.raw.block" = "orange"
 "markup.link.url" = "blue"
 "markup.link.text" = "yellow"
 "markup.link.label" = "green"

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -22,8 +22,11 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.raw.block" = "orange"
-"markup.link.url" = "blue"
+"markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "yellow"
 "markup.link.label" = "green"
 "markup.quote" = "yellow"

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -22,6 +22,9 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
+"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.italic" = { fg = "orange", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.raw.block" = "orange"
 "markup.link.url" = "blue"
 "markup.link.text" = "yellow"

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -22,7 +22,7 @@
 "namespace" = "blue"
 "markup.heading" = "orange"
 "markup.list" = "yellow"
-"markup.raw.block" = { bg = "gray", fg = "orange" }
+"markup.raw.block" = "orange"
 "markup.link.url" = "blue"
 "markup.link.text" = "yellow"
 "markup.link.label" = "green"


### PR DESCRIPTION
Before

![Screenshot_20230401_233707](https://user-images.githubusercontent.com/4687791/229299152-51500b87-e237-4e79-aa50-508a258fc61d.png)

After

![Screenshot_20230401_233841](https://user-images.githubusercontent.com/4687791/229299238-a501223a-5930-4db9-a529-17c028466d91.png)

cc @enkodr 