### PR TITLE
update bass grammar and queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -3,7 +3,7 @@
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ |  | ✓ | `bash-language-server` |
-| bass | ✓ |  |  | `bass` |
+| bass | ✓ |  | ✓ | `bass` |
 | beancount | ✓ |  |  |  |
 | bibtex | ✓ |  |  | `texlab` |
 | bicep | ✓ |  |  | `bicep-langserver` |

--- a/languages.toml
+++ b/languages.toml
@@ -2000,7 +2000,7 @@ language-server = { command = "bass", args = ["--lsp"] }
 
 [[grammar]]
 name = "bass"
-source = { git = "https://github.com/vito/tree-sitter-bass", rev = "501133e260d768ed4e1fd7374912ed5c86d6fd90" }
+source = { git = "https://github.com/vito/tree-sitter-bass", rev = "8799f28aa873c14ae133fe2e9240a0d4e78e9502" }
 
 [[language]]
 name = "wat"

--- a/runtime/queries/bass/folds.scm
+++ b/runtime/queries/bass/folds.scm
@@ -1,0 +1,5 @@
+[
+  (list)
+  (scope)
+  (cons)
+] @fold

--- a/runtime/queries/bass/highlights.scm
+++ b/runtime/queries/bass/highlights.scm
@@ -1,75 +1,58 @@
-; GENERATED VIA https://github.com/vito/tree-sitter-bass
+;; Includes
 
-;;; comments
+((symbol) @keyword.control.import
+  (#match? @keyword.control.import "^(use|import|load)$"))
 
-(comment) @comment.line
+;; Keywords
 
-;;; punctuation
+((symbol) @keyword
+  (#match? @keyword "^(do|doc)$"))
 
-["(" ")" "[" "]" "{" "}"] @punctuation.bracket
-
-;;; constants
-
-[(ignore) (null)] @constant.builtin
-
-(bool) @constant.builtin.boolean
-
-(int) @constant.numeric.integer
-
-;;; strings
-
-;; string literals
-
-(string) @string
-(string (string_escape) @constant.character.escape)
-
-;; keywords (symbol literals)
+; Keywords construct a symbol
 
 (keyword) @string.special.symbol
 
-;; paths
+;; Operators
 
-(dot) @string.special.path
-(dotdot) @string.special.path
-(command) @string.special.path
-(subpath (symbol) @string.special.path)
+; TODO: classify
+((symbol) @operator (#match? @operator "^(&|\\*|\\+|-|<|<=|=|>|>=)$"))
 
-; slashes in a path denote a combiner call
-(subpath (slash) @function)
+;; Defining
 
+((list
+  . (symbol) @label
+  . (symbol) @function
+  (symbol)? @parameter)
+  (#match? @label "^(def|defop|defn)$"))
 
+((cons
+  . (symbol) @label
+  . (symbol) @function
+  (symbol)? @parameter)
+  (#match? @label "^(def|defop|defn)$"))
 
-;;; specific highlighting for builtins & special forms
+((symbol) @label
+  (#match? @label "^(def|defop|defn)$"))
 
-;; symbol classification based highlighting
+;; Builtins
 
-(list . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
-(cons . (symbol) @keyword.control.conditional (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
+((symbol) @function.builtin
+  (#match? @function.builtin "^(dump|mkfs|json|log|error|now|cons|wrap|unwrap|eval|make-scope|bind|meta|with-meta|null\\?|ignore\\?|boolean\\?|number\\?|string\\?|symbol\\?|scope\\?|sink\\?|source\\?|list\\?|pair\\?|applicative\\?|operative\\?|combiner\\?|path\\?|empty\\?|thunk\\?|\\+|\\*|quot|-|max|min|=|>|>=|<|<=|list->source|across|emit|next|reduce-kv|assoc|symbol->string|string->symbol|str|substring|trim|scope->list|string->fs-path|string->cmd-path|string->dir|subpath|path-name|path-stem|with-image|with-dir|with-args|with-cmd|with-stdin|with-env|with-insecure|with-label|with-port|with-tls|with-mount|thunk-cmd|thunk-args|resolve|start|addr|wait|read|cache-dir|binds\\?|recall-memo|store-memo|mask|list|list\\*|first|rest|length|second|third|map|map-pairs|foldr|foldl|concat|append|filter|conj|list->scope|merge|apply|id|always|vals|keys|memo|succeeds\\?|run|last|take|collect|take-all|insecure!|from|cd|wrap-cmd|mkfile|path-base|not)$"))
 
-(list . (symbol) @keyword.control.repeat (#match? @keyword.control.repeat "^(each)$"))
-(cons . (symbol) @keyword.control.repeat (#match? @keyword.control.repeat "^(each)$"))
+((symbol) @function.macro
+  (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|assert|for|\\$|linux)$"))
 
-(list . (symbol) @label (#match? @label "^(def|defop|defn)$"))
-(cons . (symbol) @label (#match? @label "^(def|defop|defn)$"))
+;; Conditionals
 
-(list . (symbol) @function.builtin (#match? @function.builtin "^(dump|mkfs|json|log|error|now|cons|wrap|unwrap|eval|make-scope|bind|meta|with-meta|null\\?|ignore\\?|boolean\\?|number\\?|string\\?|symbol\\?|scope\\?|sink\\?|source\\?|list\\?|pair\\?|applicative\\?|operative\\?|combiner\\?|path\\?|empty\\?|thunk\\?|\\+|\\*|quot|-|max|min|=|>|>=|<|<=|list->source|across|emit|next|reduce-kv|assoc|symbol->string|string->symbol|str|substring|trim|scope->list|string->fs-path|string->cmd-path|string->dir|subpath|path-name|path-stem|with-image|with-dir|with-args|with-cmd|with-stdin|with-env|with-insecure|with-label|with-port|with-tls|with-mount|thunk-cmd|thunk-args|resolve|start|addr|wait|read|cache-dir|binds\\?|recall-memo|store-memo|mask|list|list\\*|first|rest|length|second|third|map|map-pairs|foldr|foldl|append|filter|conj|list->scope|merge|apply|id|always|vals|keys|memo|succeeds\\?|run|last|take|take-all|insecure!|from|cd|wrap-cmd|mkfile|path-base|not)$"))
-(cons . (symbol) @function.builtin (#match? @function.builtin "^(dump|mkfs|json|log|error|now|cons|wrap|unwrap|eval|make-scope|bind|meta|with-meta|null\\?|ignore\\?|boolean\\?|number\\?|string\\?|symbol\\?|scope\\?|sink\\?|source\\?|list\\?|pair\\?|applicative\\?|operative\\?|combiner\\?|path\\?|empty\\?|thunk\\?|\\+|\\*|quot|-|max|min|=|>|>=|<|<=|list->source|across|emit|next|reduce-kv|assoc|symbol->string|string->symbol|str|substring|trim|scope->list|string->fs-path|string->cmd-path|string->dir|subpath|path-name|path-stem|with-image|with-dir|with-args|with-cmd|with-stdin|with-env|with-insecure|with-label|with-port|with-tls|with-mount|thunk-cmd|thunk-args|resolve|start|addr|wait|read|cache-dir|binds\\?|recall-memo|store-memo|mask|list|list\\*|first|rest|length|second|third|map|map-pairs|foldr|foldl|append|filter|conj|list->scope|merge|apply|id|always|vals|keys|memo|succeeds\\?|run|last|take|take-all|insecure!|from|cd|wrap-cmd|mkfile|path-base|not)$"))
+((symbol) @keyword.control.conditional
+  (#match? @keyword.control.conditional "^(if|case|cond|when)$"))
 
-(list . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
-(cons . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
+;; Repeats
 
-(list . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
-(cons . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
+((symbol) @keyword.control.repeat
+  (#match? @keyword.control.repeat "^(each)$"))
 
-(list . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))
-(cons . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))
-
-
-;; special cases
-
-; [a & b] highlights & as operator rather than a regular symbol
-(list (symbol) @operator (#match? @operator "&"))
-(cons (symbol) @operator (#match? @operator "&"))
+;; Special forms
 
 ; (-> x y z) highlights first x as var, y z as function
 (list
@@ -89,13 +72,60 @@
   (_)
   (symbol) @function)
 
-;;; generic highlighting for all forms
+;; Functions
 
-; first symbol in a list form is a combiner call
-(list . (symbol) @function)
+(list
+  . (symbol) @function)
 
-; highlight symbols as vars only when they're clearly vars
+;; Variables
+
+(list (symbol) @variable)
+
 (cons (symbol) @variable)
+
 (scope (symbol) @variable)
-(path form: (symbol) @variable)
-(symbind form: (symbol) @variable)
+
+(symbind (symbol) @variable)
+
+;; Namespaces
+
+(symbind
+  (symbol) @namespace
+  . (keyword))
+
+;; Punctuation
+
+[ "(" ")" ] @punctuation.bracket
+
+[ "{" "}" ] @punctuation.bracket
+
+[ "[" "]" ] @punctuation.bracket
+
+((symbol) @punctuation.delimiter
+  (#eq? @punctuation.delimiter "->"))
+
+;; Literals
+
+(string) @string
+
+(escape_sequence) @constant.character.escape
+
+(path) @string.special.path
+(command) @string.special.path
+
+(number) @constant.numeric.integer
+
+(boolean) @constant.builtin.boolean
+
+[
+  (ignore)
+  (null)
+] @constant.builtin
+
+[
+  "^"
+] @character.special
+
+;; Comments
+
+(comment) @comment.line @spell

--- a/runtime/queries/bass/indents.scm
+++ b/runtime/queries/bass/indents.scm
@@ -1,0 +1,22 @@
+[
+  (list)
+  (scope)
+  (cons)
+] @indent
+
+[
+  ")"
+  "}"
+  "]"
+] @indent_end
+
+[ "(" ")" ] @branch
+
+[ "{" "}" ] @branch
+
+[ "[" "]" ] @branch
+
+[
+  (ERROR)
+  (comment)
+] @auto

--- a/runtime/queries/bass/injections.scm
+++ b/runtime/queries/bass/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/runtime/queries/bass/locals.scm
+++ b/runtime/queries/bass/locals.scm
@@ -1,0 +1,18 @@
+; Scopes
+
+[
+  (list)
+  (scope)
+] @scope
+
+; References
+
+(symbol) @reference
+
+; Definitions
+
+((list
+  . (symbol) @_fnkw
+  . (symbol) @definition.function
+  (symbol)? @definition.parameter)
+  (#match? @_fnkw "^(def|defop|defn)$"))


### PR DESCRIPTION
Hiya, this is a follow-up to #3771 that bumps to the latest grammar (now rewritten by @amaanq :pray:), updates the highlight rules, and adds a few more queries:

* `folds.scm`
* `indents.scm`
* `injections.scm`
* `locals.scm`

Tested locally on my machine and all seems well.