### PR TITLE
Add entering normal mode as autosave trigger

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -23,7 +23,7 @@ use helix_core::{
 };
 use helix_view::{
     document::{Mode, SavePoint, SCRATCH_BUFFER_NAME},
-    editor::{CompleteAction, CursorShapeConfig},
+    editor::{CompleteAction, CursorShapeConfig, AutoSaveTrigger},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
@@ -1346,7 +1346,7 @@ impl Component for EditorView {
             Event::IdleTimeout => self.handle_idle_timeout(&mut cx),
             Event::FocusGained => EventResult::Ignored(None),
             Event::FocusLost => {
-                if context.editor.config().auto_save {
+                if context.editor.config().auto_save.contains(&AutoSaveTrigger::Unfocused) {
                     if let Err(e) = commands::typed::write_all_impl(context, false, false) {
                         context.editor.set_error(format!("{}", e));
                     }


### PR DESCRIPTION
For me, autosave is an essential feature. But the 'unfocus' trigger doesn't work, since autosave also triggrers reformatting (which I think is useful), but causes a massive loss of context when triggered on unfocus. (I'd switch workspaces to copy some code and bam! autoformat moved my cursor around when I look back...)

However, when exiting edit mode, it's quite natural, as I've finished doing my edit, I actually want the formatter to clean it up. It is also a rather logical time to autosave, since I've just made an edit.

### TODOs
- [ ] Documentation: Wasn't there a command to generate the book documentations?
- [ ] Don't break compatibility: https://github.com/helix-editor/helix/pull/3178#discussion_r998702595 (how do I do that?(
- [ ] Update modification indicator in statusline after autosave.

### See also:
- Discussion: #3451 
- Conflicts with #5303 (Rebasing is easy, just inform me whether this or the other PR should be the lower commit)