### PR TITLE
match against unix file path [windows] (#5414)

### DIFF
--- a/helix-term/src/ui/fuzzy_match.rs
+++ b/helix-term/src/ui/fuzzy_match.rs
@@ -42,13 +42,21 @@ impl QueryAtom {
             }
         }
 
+        atom = atom.replace('\\', "");
+
+        if std::env::consts::OS == "windows" {
+            atom = atom.replace('/', "\\");
+        }
+
+        // not ideal but fuzzy_matches only knows ascii uppercase so more consistent
+        // to behave the same
+        let ignore_case =
+            kind != QueryAtomKind::Fuzzy && atom.chars().all(|c| c.is_ascii_lowercase());
+
         Some(QueryAtom {
             kind,
-            atom: atom.replace('\\', ""),
-            // not ideal but fuzzy_matches only knows ascii uppercase so more consistent
-            // to behave the same
-            ignore_case: kind != QueryAtomKind::Fuzzy
-                && atom.chars().all(|c| c.is_ascii_lowercase()),
+            atom,
+            ignore_case,
             inverse,
         })
     }


### PR DESCRIPTION
This commit introduces a change to the Atom, whereby '/' are replace with '\\' on Windows. This allows the user to type in unix style paths and have it successfully match against Windows file paths.

Fixes #5414

https://user-images.githubusercontent.com/6916093/229416948-6b33b395-5e76-475c-9692-a38a22973e25.mp4

