### PR TITLE
minor: R lang config update --slave to --no-echo

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1446,7 +1446,7 @@ shebangs = ["r", "R"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
-language-server = { command = "R", args = ["--slave", "-e", "languageserver::run()"] }
+language-server = { command = "R", args = ["--no-echo", "-e", "languageserver::run()"] }
 
 [[grammar]]
 name = "r"


### PR DESCRIPTION
R `--slave` option was replaced by `--no-echo` in 2019; update `languages.toml` to reflect this change.