### PR TITLE
Change smithy language server to the one from AWS

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2364,7 +2364,7 @@ file-types = ["smithy"]
 roots = ["smithy-build.json"]
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
-language-server = { command = "cs", args = ["launch", "com.disneystreaming.smithy:smithy-language-server:latest.release", "--", "0"] }
+language-server = { command = "cs", args = ["launch", "--contrib", "smithy-language-server", "--", "0"] }
 
 [[grammar]]
 name = "smithy"


### PR DESCRIPTION
Changes the current smithy language server to use the one from: https://github.com/awslabs/smithy-language-server
I've used both just fine(AWS one with VSCode and Disneys with helix) but I believe the AWS one is a bit nicer for general usage.

I'll update the wiki LS install instructions if this PR gets approved.