### PR TITLE
Update inlay-hint color for mellow & rasmus themes

### DIFF
--- a/runtime/themes/mellow.toml
+++ b/runtime/themes/mellow.toml
@@ -80,6 +80,7 @@
 
 "ui.virtual" = { fg = "gray02" }
 "ui.virtual.indent-guide" = { fg = "gray02" }
+"ui.virtual.inlay-hint" = { fg = "gray04" }
 
 "ui.selection" = { bg = "gray03" }
 "ui.selection.primary" = { bg = "gray03" }

--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -85,6 +85,7 @@
 
 "ui.virtual" = { fg = "gray03" }
 "ui.virtual.indent-guide" = { fg = "gray04" }
+"ui.virtual.inlay-hint" = { fg = "gray05" }
 
 "ui.selection" = { bg = "gray03" }
 "ui.selection.primary" = { bg = "gray03" }


### PR DESCRIPTION
Changes:

- Update/Add inlay-hint color for `mellow` theme.
- Update/Add inlay-hint color for `rasmus` theme.