### PR TITLE
Support bindings with the Super (Meta/Cmd/Win) modifier

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -50,8 +50,22 @@ t = ":run-shell-command cargo test"
 
 ## Special keys and modifiers
 
-Ctrl, Shift and Alt modifiers are encoded respectively with the prefixes
-`C-`, `S-` and `A-`. Special keys are encoded as follows:
+Ctrl, Shift and Alt modifiers are encoded respectively with the prefixes `C-`, `S-` and `A-`.
+
+The [Super key](https://en.wikipedia.org/wiki/Super_key_(keyboard_button)) - the Windows/Linux
+key or the Command key on Mac keyboards - is also supported when using a terminal emulator that
+supports the [enhanced keyboard protocol](https://github.com/helix-editor/helix/wiki/Terminal-Support#enhanced-keyboard-protocol).
+The super key is encoded with prefixes `Meta-`, `Cmd-` or `Win-`. These are all synonyms for the
+super modifier - binding a key with a `Win-` modifier will mean it can be used with the
+Windows/Linux key or the Command key.
+
+```toml
+[keys.normal]
+C-s = ":write" # Ctrl and 's' to write
+Cmd-s = ":write" # Cmd or Win or Meta and 's' to write
+```
+
+Special keys are encoded as follows:
 
 | Key name     | Representation |
 | ---          | ---            |

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -162,7 +162,12 @@ pub(crate) mod keys {
 impl fmt::Display for KeyEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "{}{}{}",
+            "{}{}{}{}",
+            if self.modifiers.contains(KeyModifiers::SUPER) {
+                "Meta-"
+            } else {
+                ""
+            },
             if self.modifiers.contains(KeyModifiers::SHIFT) {
                 "S-"
             } else {
@@ -312,6 +317,10 @@ impl UnicodeWidthStr for KeyEvent {
         if self.modifiers.contains(KeyModifiers::CONTROL) {
             width += 2;
         }
+        if self.modifiers.contains(KeyModifiers::SUPER) {
+            // "-Meta"
+            width += 5;
+        }
         width
     }
 
@@ -396,6 +405,7 @@ impl std::str::FromStr for KeyEvent {
                 "S" => KeyModifiers::SHIFT,
                 "A" => KeyModifiers::ALT,
                 "C" => KeyModifiers::CONTROL,
+                "Meta" | "Cmd" | "Win" => KeyModifiers::SUPER,
                 _ => return Err(anyhow!("Invalid key modifier '{}-'", token)),
             };
 
@@ -707,6 +717,28 @@ mod test {
             KeyEvent {
                 code: KeyCode::Char('W'),
                 modifiers: KeyModifiers::NONE
+            }
+        );
+
+        assert_eq!(
+            str::parse::<KeyEvent>("Meta-c").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::SUPER
+            }
+        );
+        assert_eq!(
+            str::parse::<KeyEvent>("Win-s").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('s'),
+                modifiers: KeyModifiers::SUPER
+            }
+        );
+        assert_eq!(
+            str::parse::<KeyEvent>("Cmd-d").unwrap(),
+            KeyEvent {
+                code: KeyCode::Char('d'),
+                modifiers: KeyModifiers::SUPER
             }
         );
     }

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -7,6 +7,7 @@ bitflags! {
         const SHIFT = 0b0000_0001;
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
+        const SUPER = 0b0000_1000;
         const NONE = 0b0000_0000;
     }
 }
@@ -26,6 +27,9 @@ impl From<KeyModifiers> for crossterm::event::KeyModifiers {
         }
         if key_modifiers.contains(KeyModifiers::ALT) {
             result.insert(CKeyModifiers::ALT);
+        }
+        if key_modifiers.contains(KeyModifiers::SUPER) {
+            result.insert(CKeyModifiers::SUPER);
         }
 
         result
@@ -47,6 +51,9 @@ impl From<crossterm::event::KeyModifiers> for KeyModifiers {
         }
         if val.contains(CKeyModifiers::ALT) {
             result.insert(KeyModifiers::ALT);
+        }
+        if val.contains(CKeyModifiers::SUPER) {
+            result.insert(KeyModifiers::SUPER);
         }
 
         result


### PR DESCRIPTION
Terminals which support the enhanced keyboard protocol send events for keys pressed with the Super modifier (Windows/Linux key or the Command key). We can support keybindings with the Super modifier in Helix with a few small changes: mapping the event from crossterm and parsing/representing the modifier in the KeyEvent string representation.

The binding can be done with `Meta-`, `Win-` or `Cmd-` prefixes - these are all synonymous. For example `keys.normal.Cmd-s = ":write"`.

Closes https://github.com/helix-editor/helix/issues/2913
Closes https://github.com/helix-editor/helix/issues/6582