### PR TITLE
correctly handle completion rerequest

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -33,7 +33,7 @@ use helix_core::{
 use helix_view::{
     clipboard::ClipboardType,
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
-    editor::{Action, Motion},
+    editor::{Action, CompleteAction, Motion},
     info::Info,
     input::KeyEvent,
     keyboard::KeyCode,
@@ -4213,7 +4213,12 @@ pub fn completion(cx: &mut Context) {
     iter.reverse();
     let offset = iter.take_while(|ch| chars::char_is_word(*ch)).count();
     let start_offset = cursor.saturating_sub(offset);
-    let savepoint = doc.savepoint(view);
+    let savepoint = if let Some(CompleteAction::Selected { savepoint }) = &cx.editor.last_completion
+    {
+        savepoint.clone()
+    } else {
+        doc.savepoint(view)
+    };
 
     let trigger_doc = doc.id();
     let trigger_view = view.id;

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -226,14 +226,14 @@ impl Completion {
             match event {
                 PromptEvent::Abort => {}
                 PromptEvent::Update => {
-                    // Update creates "ghost" transactiosn which are not send to the
-                    // lsp server to avoid messing up rerequesting completions. Once a
-                    // completion has been selected (with) tab it's always accepted whenever anything
+                    // Update creates "ghost" transactions which are not sent to the
+                    // lsp server to avoid messing up re-requesting completions. Once a
+                    // completion has been selected (with tab, c-n or c-p) it's always accepted whenever anything
                     // is typed. The only way to avoid that is to explicitly abort the completion
-                    // with esc/c-c. This will remove the "ghost" transaction.
+                    // with c-c. This will remove the "ghost" transaction.
                     //
-                    // The ghost transaction is modeled with a transaction that is not send to the LS.
-                    // (apply_temporary) and a savepoint. It's extremly important this savepoint is restored
+                    // The ghost transaction is modeled with a transaction that is not sent to the LS.
+                    // (apply_temporary) and a savepoint. It's extremely important this savepoint is restored
                     // (also without sending the transaction to the LS) *before any further transaction is applied*.
                     // Otherwise incremental sync breaks (since the state of the LS doesn't match the state the transaction
                     // is applied to).
@@ -293,7 +293,7 @@ impl Completion {
                         changes: completion_changes(&transaction, trigger_offset),
                     });
 
-                    // TOOD: add additional _edits to completion_changes?
+                    // TODO: add additional _edits to completion_changes?
                     if let Some(additional_edits) = item.item.additional_text_edits {
                         if !additional_edits.is_empty() {
                             let transaction = util::generate_transaction_from_edits(

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -253,6 +253,17 @@ impl Completion {
                     // always present here
                     let item = item.unwrap();
 
+                    // apply additional edits, mostly used to auto import unqualified types
+                    let resolved_item = if item
+                        .additional_text_edits
+                        .as_ref()
+                        .map(|edits| !edits.is_empty())
+                        .unwrap_or(false)
+                    {
+                        None
+                    } else {
+                        Self::resolve_completion_item(doc, item.clone())
+                    };
 
                     // if more text was entered, remove it
                     doc.restore(view, &savepoint, true);
@@ -272,17 +283,6 @@ impl Completion {
                         changes: completion_changes(&transaction, trigger_offset),
                     });
 
-                    // apply additional edits, mostly used to auto import unqualified types
-                    let resolved_item = if item
-                        .additional_text_edits
-                        .as_ref()
-                        .map(|edits| !edits.is_empty())
-                        .unwrap_or(false)
-                    {
-                        None
-                    } else {
-                        Self::resolve_completion_item(doc, item.clone())
-                    };
                     if let Some(additional_edits) = resolved_item
                         .as_ref()
                         .and_then(|item| item.additional_text_edits.as_ref())

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1078,7 +1078,7 @@ impl Document {
         self.apply_inner(transaction, view_id, true)
     }
 
-    /// Apply a [`Transaction`] to the [`Document`] to change its text.
+    /// Apply a [`Transaction`] to the [`Document`] to change its text
     /// without notifying the language servers. This is useful for temporary transactions
     /// that must not influence the server.
     pub fn apply_temporary(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -915,7 +915,12 @@ impl Document {
     }
 
     /// Apply a [`Transaction`] to the [`Document`] to change its text.
-    fn apply_impl(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
+    fn apply_impl(
+        &mut self,
+        transaction: &Transaction,
+        view_id: ViewId,
+        emit_lsp_notification: bool,
+    ) -> bool {
         use helix_core::Assoc;
 
         let old_doc = self.text().clone();
@@ -1011,25 +1016,31 @@ impl Document {
                 apply_inlay_hint_changes(padding_after_inlay_hints);
             }
 
-            // emit lsp notification
-            if let Some(language_server) = self.language_server() {
-                let notify = language_server.text_document_did_change(
-                    self.versioned_identifier(),
-                    &old_doc,
-                    self.text(),
-                    changes,
-                );
+            if emit_lsp_notification {
+                // emit lsp notification
+                if let Some(language_server) = self.language_server() {
+                    let notify = language_server.text_document_did_change(
+                        self.versioned_identifier(),
+                        &old_doc,
+                        self.text(),
+                        changes,
+                    );
 
-                if let Some(notify) = notify {
-                    tokio::spawn(notify);
+                    if let Some(notify) = notify {
+                        tokio::spawn(notify);
+                    }
                 }
             }
         }
         success
     }
 
-    /// Apply a [`Transaction`] to the [`Document`] to change its text.
-    pub fn apply(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
+    fn apply_inner(
+        &mut self,
+        transaction: &Transaction,
+        view_id: ViewId,
+        emit_lsp_notification: bool,
+    ) -> bool {
         // store the state just before any changes are made. This allows us to undo to the
         // state just before a transaction was applied.
         if self.changes.is_empty() && !transaction.changes().is_empty() {
@@ -1039,7 +1050,7 @@ impl Document {
             });
         }
 
-        let success = self.apply_impl(transaction, view_id);
+        let success = self.apply_impl(transaction, view_id, emit_lsp_notification);
 
         if !transaction.changes().is_empty() {
             // Compose this transaction with the previous one
@@ -1049,12 +1060,23 @@ impl Document {
         }
         success
     }
+    /// Apply a [`Transaction`] to the [`Document`] to change its text.
+    pub fn apply(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
+        self.apply_inner(transaction, view_id, true)
+    }
+
+    /// Apply a [`Transaction`] to the [`Document`] to change its text.
+    /// without notifying the language servers. This is useful for temporary transactions
+    /// that must not influence the server.
+    pub fn apply_temporary(&mut self, transaction: &Transaction, view_id: ViewId) -> bool {
+        self.apply_inner(transaction, view_id, false)
+    }
 
     fn undo_redo_impl(&mut self, view: &mut View, undo: bool) -> bool {
         let mut history = self.history.take();
         let txn = if undo { history.undo() } else { history.redo() };
         let success = if let Some(txn) = txn {
-            self.apply_impl(txn, view.id)
+            self.apply_impl(txn, view.id, true)
         } else {
             false
         };
@@ -1094,7 +1116,7 @@ impl Document {
         savepoint
     }
 
-    pub fn restore(&mut self, view: &mut View, savepoint: &SavePoint) {
+    pub fn restore(&mut self, view: &mut View, savepoint: &SavePoint, emit_lsp_notification: bool) {
         assert_eq!(
             savepoint.view, view.id,
             "Savepoint must not be used with a different view!"
@@ -1109,7 +1131,7 @@ impl Document {
 
         let savepoint_ref = self.savepoints.remove(savepoint_idx);
         let mut revert = savepoint.revert.lock();
-        self.apply(&revert, view.id);
+        self.apply_inner(&revert, view.id, emit_lsp_notification);
         *revert = Transaction::new(self.text()).with_selection(self.selection(view.id).clone());
         self.savepoints.push(savepoint_ref)
     }
@@ -1122,7 +1144,7 @@ impl Document {
         };
         let mut success = false;
         for txn in txns {
-            if self.apply_impl(&txn, view.id) {
+            if self.apply_impl(&txn, view.id, true) {
                 success = true;
             }
         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -113,6 +113,19 @@ pub struct SavePoint {
     /// The view this savepoint is associated with
     pub view: ViewId,
     revert: Mutex<Transaction>,
+    pub text: Rope,
+}
+
+impl SavePoint {
+    pub fn cursor(&self) -> usize {
+        // we always create transactions with selections
+        self.revert
+            .lock()
+            .selection()
+            .unwrap()
+            .primary()
+            .cursor(self.text.slice(..))
+    }
 }
 
 pub struct Document {
@@ -1111,6 +1124,7 @@ impl Document {
         let savepoint = Arc::new(SavePoint {
             view: view.id,
             revert: Mutex::new(revert),
+            text: self.text.clone(),
         });
         self.savepoints.push(Arc::downgrade(&savepoint));
         savepoint

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -905,7 +905,7 @@ pub enum CompleteAction {
         trigger_offset: usize,
         changes: Vec<Change>,
     },
-    /// A savepoint of the currently active completion. The completion
+    /// A savepoint of the currently selected completion. The savepoint
     /// MUST be restored before sending any event to the LSP
     Selected { savepoint: Arc<SavePoint> },
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,7 +1,7 @@
 use crate::{
     align_view,
     clipboard::{get_clipboard_provider, ClipboardProvider},
-    document::{DocumentSavedEventFuture, DocumentSavedEventResult, Mode},
+    document::{DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint},
     graphics::{CursorKind, Rect},
     info::Info,
     input::KeyEvent,
@@ -900,9 +900,14 @@ enum ThemeAction {
 }
 
 #[derive(Debug, Clone)]
-pub struct CompleteAction {
-    pub trigger_offset: usize,
-    pub changes: Vec<Change>,
+pub enum CompleteAction {
+    Applied {
+        trigger_offset: usize,
+        changes: Vec<Change>,
+    },
+    /// A savepoint of the currently active completion. The completion
+    /// MUST be restored before sending any event to the LSP
+    Selected { savepoint: Arc<SavePoint> },
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Alternative to #6511
Closes #6259
Closes #6261
Fixes a similar bug with the typescript LSP reported on matrix where imports would be duplicated. 

This PR resolved the same issue as #6511 but keeps the current behavior of previewing the current completion. This is achieved by generating "ghost" transactions. Ghost transactions are normal transactions that are never sent to the LS.

Maintaining such transactions is tricky/dangerous because we always need to undo them (with the undo transaction also not sent to the LS) before we apply any other transaction to the document. Otherwise, we would send invalid changes to LS with incremental sync and therefore break the server (until `:lsp-restart`).

To that end I used the more generic savepoints introduced in #6173. The completion menu now saves a second savepoint before a completion option is first selected with tab/s-tab. The completion preview (so what you see when hitting tab but before pressing `<ret>`) is now such a ghost transaction. To ensure these transactions are always removed there have been some behavioral changes:

* both c-c and esc now reset the document to the savepoint created before previewing a transaction (or do nothing otherwise)
* As soon as a completion is selected with "tab" (previewed) it becomes "active" as soon as any key not captured by the completion menu is pressed the completion is fully applied (same as pressing enter) automatically. So there are no "half applied" completions anymore

This behavior matches Kakoune (which also automatically applies the transaction when hitting enter as discovered by @the-mikedavis). 

This approach is safe regarding the hazards mentioned above because as soon as a ghost transaction is applied it will always be realized when pressing any key (that isn't consumed by the completion menu). The only remaining hazard are "async" edits (or savepoints like completions request) that are created without an explicit key press. These might pickup the ghost document state. I think there aren't really any of those (besides completions themselves where I habe taken great care to cover all edge-cases) because any async transaction would require a savepoint (otherwise the transaction would refer to a potentially outdated document state) and the only use of savepoint is completions/completion replay (which always require a keypress). If we ever want to add other async transaction we might think about generalizing the system a bit but that will require some more complex design. For now I simply expanded the existing `Editor::last_complete` field to cover the usecase here.


The type script import problem was actually a special case of the more general problem fixed by this PR. It was caused by resolving completions *after they were already applied*. The general problem was the same (we send didChange and then rerequested a completion) but fixing it furthermore required moving the request in a3a4645. It seems other clients are running into this issue too (for example nvim) so getting this right is difficult but vscode seems to handle this correctly (also using some ghost text it seems). See https://github.com/typescript-language-server/typescript-language-server/issues/699 (the examples there also cause bugs on master but work with this PR or #6511).

#6261 was caused by us resolving a completion multiple times. The LSP standard doesn't explicitly state it but the intention seems to be that completion items are only resolved once (since resolving is intended to delay expensive calculations). Helix now separately tracks whether a completion item has been resolved and therefore mirrors vscode in that regard. I think that this was really always the intention of the helix code (continuously querying the server is quite inefficient) and the check we did just wasn't quite correct