### PR TITLE
Add support for Robot Framework files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -116,6 +116,7 @@
 | rego | ✓ |  |  | `regols` |
 | rescript | ✓ | ✓ |  | `rescript-language-server` |
 | rmarkdown | ✓ |  | ✓ | `R` |
+| robot | ✓ |  |  | `robotframework_ls` |
 | ron | ✓ |  | ✓ |  |
 | rst | ✓ |  |  |  |
 | ruby | ✓ | ✓ | ✓ | `solargraph` |

--- a/languages.toml
+++ b/languages.toml
@@ -1438,6 +1438,20 @@ indent = { tab-width = 4, unit = "    " }
 grammar = "rust"
 
 [[language]]
+name = "robot"
+scope = "source.robot"
+injection-regex = "robot"
+file-types = ["robot", "resource"]
+comment-token = "#"
+roots = []
+indent = { tab-width = 4, unit = " " }
+language-server = { command = "robotframework_ls" }
+
+[[grammar]]
+name = "robot"
+source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "f1142bfaa6acfce95e25d2c6d18d218f4f533927" }
+
+[[language]]
 name = "r"
 scope = "source.r"
 injection-regex = "(r|R)"

--- a/runtime/queries/robot/highlights.scm
+++ b/runtime/queries/robot/highlights.scm
@@ -1,0 +1,21 @@
+(comment) @comment
+(ellipses) @punctuation.delimiter
+
+(section_header) @keyword
+(extra_text) @comment
+
+(setting_statement) @keyword
+
+(variable_definition (variable_name) @variable)
+
+(keyword_definition (name) @function)
+(keyword_definition (body (keyword_setting) @keyword))
+
+(test_case_definition (name) @property)
+
+(keyword_invocation (keyword) @function)
+
+(argument (text_chunk) @string)
+(argument (scalar_variable) @string.special)
+(argument (list_variable) @string.special)
+(argument (dictionary_variable) @string.special)


### PR DESCRIPTION
Language server and tree-sitter support for Robot Framework files.

Highlight queries made by the author of the tree-sitter parser for Robot: https://github.com/robotframework/robotframework/issues/4495#issuecomment-1270691525 