### PR TITLE
Initial support for history search in command-line mode

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1148,4 +1148,8 @@ impl Application {
 
         errs
     }
+
+    pub fn get_compositor_layers(&self) -> &Vec<Box<dyn crate::compositor::Component>> {
+        &self.compositor.layers
+    }
 }

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -75,7 +75,7 @@ pub trait Component: Any + AnyComponent {
 }
 
 pub struct Compositor {
-    layers: Vec<Box<dyn Component>>,
+    pub(crate) layers: Vec<Box<dyn Component>>,
     area: Rect,
 
     pub(crate) last_picker: Option<Box<dyn Component>>,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -9,7 +9,7 @@ pub mod menu;
 pub mod overlay;
 mod picker;
 pub mod popup;
-mod prompt;
+pub mod prompt;
 mod spinner;
 mod statusline;
 mod text;

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -28,6 +28,7 @@ pub struct Prompt {
     selection: Option<usize>,
     history_register: Option<char>,
     history_pos: Option<usize>,
+    history_search: Option<String>,
     completion_fn: CompletionFn,
     callback_fn: CallbackFn,
     pub doc_fn: DocFn,
@@ -79,6 +80,7 @@ impl Prompt {
             selection: None,
             history_register,
             history_pos: None,
+            history_search: None,
             completion_fn: Box::new(completion_fn),
             callback_fn: Box::new(callback_fn),
             doc_fn: Box::new(|_| None),
@@ -302,17 +304,123 @@ impl Prompt {
             _ => return,
         };
 
+        let len = values.len();
+        let end = len.saturating_sub(1);
+
+        let (line, index) = match direction {
+            CompletionDirection::Forward => {
+                if self.history_pos.is_none() {
+                    return;
+                }
+
+                let index = self.history_pos.map_or(0, |i| i + 1);
+
+                if index > end {
+                    ("".to_string(), end)
+                } else {
+                    (values[index].to_string(), index)
+                }
+            }
+            CompletionDirection::Backward => {
+                let index = self.history_pos.unwrap_or(len).saturating_sub(1);
+
+                (values[index].to_string(), index)
+            }
+        };
+
+        self.line = line;
+        self.history_pos = Some(index);
+
+        self.move_end();
+        (self.callback_fn)(cx, &self.line, PromptEvent::Update);
+        self.recalculate_completion(cx.editor);
+    }
+
+    pub fn search_history(
+        &mut self,
+        cx: &mut Context,
+        register: char,
+        direction: CompletionDirection,
+    ) {
+        (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
+        let values = match cx.editor.registers.read(register) {
+            Some(values) if !values.is_empty() => values,
+            _ => return,
+        };
+
         let end = values.len().saturating_sub(1);
 
-        let index = match direction {
-            CompletionDirection::Forward => self.history_pos.map_or(0, |i| i + 1),
-            CompletionDirection::Backward => {
-                self.history_pos.unwrap_or(values.len()).saturating_sub(1)
-            }
-        }
-        .min(end);
+        let (before_cursor, _) = self.line.split_at(self.cursor);
+        let is_search = if self.history_pos.is_some() {
+            self.history_search.is_some()
+        } else {
+            !before_cursor.is_empty()
+        };
 
-        self.line = values[index].clone();
+        // Save initial search input
+        if is_search && self.history_search.is_none() {
+            self.history_search = Some(before_cursor.to_string());
+        }
+
+        let search_term = before_cursor.to_string();
+        let history_search = self.history_search.as_ref().unwrap_or(&search_term);
+
+        let (line, index) = match direction {
+            CompletionDirection::Forward => {
+                if self.history_pos.is_none() {
+                    return;
+                }
+
+                let mut index = self.history_pos.map_or(0, |i| i + 1);
+
+                let search_match = values
+                    .iter()
+                    .enumerate()
+                    .skip(index)
+                    .find(|(_, item)| item.starts_with(history_search))
+                    .map(|(i, _)| i);
+
+                if let Some(search_match) = search_match {
+                    index = search_match;
+                }
+
+                // Go back to initial state
+                if index > end || (is_search && search_match.is_none()) {
+                    let line = if is_search {
+                        history_search.to_string()
+                    } else {
+                        "".to_string()
+                    };
+
+                    self.history_search = None;
+
+                    (line, end)
+                } else {
+                    (values[index].to_string(), index)
+                }
+            }
+            CompletionDirection::Backward => {
+                let mut index = if is_search {
+                    self.history_pos.unwrap_or(values.len())
+                } else {
+                    self.history_pos
+                        .map_or(values.len(), |i| i.saturating_sub(1))
+                };
+
+                index = values
+                    .iter()
+                    .enumerate()
+                    .take(index)
+                    .rev()
+                    .find(|(_, item)| item.starts_with(history_search))
+                    .map(|(i, _)| i)
+                    .unwrap_or(index);
+
+                (values[index].to_string(), index)
+            }
+        };
+
+        self.line = line;
 
         self.history_pos = Some(index);
 
@@ -571,14 +679,24 @@ impl Component for Prompt {
                     return close_fn;
                 }
             }
-            ctrl!('p') | key!(Up) => {
+            ctrl!('p') => {
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Backward);
                 }
             }
-            ctrl!('n') | key!(Down) => {
+            ctrl!('n') => {
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Forward);
+                }
+            }
+            key!(Up) => {
+                if let Some(register) = self.history_register {
+                    self.search_history(cx, register, CompletionDirection::Backward);
+                }
+            }
+            key!(Down) => {
+                if let Some(register) = self.history_register {
+                    self.search_history(cx, register, CompletionDirection::Forward);
                 }
             }
             key!(Tab) => {

--- a/helix-term/tests/test/prompt.rs
+++ b/helix-term/tests/test/prompt.rs
@@ -1,16 +1,323 @@
+use helix_term::application::Application;
+use helix_term::ui::prompt::Prompt;
+
 use super::*;
 
+fn get_prompt(app: &Application) -> &Prompt {
+    let type_name = std::any::type_name::<Prompt>();
+
+    app.get_compositor_layers()
+        .iter()
+        .find(|component| component.type_name() == type_name)
+        .and_then(|component| component.as_any().downcast_ref::<Prompt>())
+        .expect("expected prompt component")
+}
+
 #[tokio::test(flavor = "multi_thread")]
-async fn test_history_completion() -> anyhow::Result<()> {
+async fn history_completion() -> anyhow::Result<()> {
     test_key_sequence(
         &mut AppBuilder::new().build()?,
         Some(":asdf<ret>:theme d<C-n><tab>"),
         Some(&|app| {
             assert!(!app.editor.is_err());
+
+            // Before this PR:
+            // assert_eq!("asdf", get_prompt(app).line());
+
+            assert_eq!("theme darcula", get_prompt(app).line());
         }),
         false,
     )
-    .await?;
+    .await
+}
 
-    Ok(())
+#[tokio::test(flavor = "multi_thread")]
+async fn history_control_previous() -> anyhow::Result<()> {
+    test_key_sequences(
+        &mut AppBuilder::new().build()?,
+        vec![
+            (
+                Some(":1<ret>:2<ret>:3<ret>:"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] (no input)");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-p>"),
+                Some(&|app| {
+                    assert_eq!("1", get_prompt(app).line(), "[1,2,3] ^^^");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn history_control_next() -> anyhow::Result<()> {
+    test_key_sequences(
+        &mut AppBuilder::new().build()?,
+        vec![
+            (
+                Some(":1<ret>:2<ret>:3<ret>:<C-n>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] v (no-op)");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-n>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] ^v (reset)");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-n>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^^v");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-p><C-n>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^^v");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-p><C-p><C-n>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^^^v (one extra ^)");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-p><C-n><C-n>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^^^vv");
+                }),
+            ),
+            (
+                Some("<esc>:<C-p><C-p><C-p><C-n><C-n><C-n>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] ^^^vvv (reset)");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn history_arrow_up() -> anyhow::Result<()> {
+    test_key_sequences(
+        &mut AppBuilder::new().build()?,
+        vec![
+            (
+                Some(":1<ret>:2<ret>:3<ret>:"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] (no input)");
+                }),
+            ),
+            (
+                Some("<esc>:<up>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><up>"),
+                Some(&|app| {
+                    assert_eq!("1", get_prompt(app).line(), "[1,2,3] ^^^");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn history_arrow_down() -> anyhow::Result<()> {
+    test_key_sequences(
+        &mut AppBuilder::new().build()?,
+        vec![
+            (
+                Some(":1<ret>:2<ret>:3<ret>:<down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] v (no-op)");
+                }),
+            ),
+            (
+                Some("<esc>:<up><down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[1,2,3] ^v (reset)");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><down>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^^v");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><up><down>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^^v");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><up><up><down>"),
+                Some(&|app| {
+                    assert_eq!("2", get_prompt(app).line(), "[1,2,3] ^^^^v (one extra ^)");
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><up><down><down>"),
+                Some(&|app| {
+                    assert_eq!("3", get_prompt(app).line(), "[1,2,3] ^^^vv");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn history_partial_search() -> anyhow::Result<()> {
+    test_key_sequences(
+        &mut AppBuilder::new().build()?,
+        vec![
+            (
+                Some(":10<ret>:20<ret>:100<ret>:200<ret>:1"),
+                Some(&|app| {
+                    assert_eq!("1", get_prompt(app).line(), "[10,20,100,200] (no search)");
+                }),
+            ),
+            (
+                Some("<esc>:1<up>"),
+                Some(&|app| {
+                    assert_eq!("100", get_prompt(app).line(), "[10,20,100,200] ^");
+                }),
+            ),
+            (
+                Some("<esc>:1<up><up>"),
+                Some(&|app| {
+                    assert_eq!("10", get_prompt(app).line(), "[10,20,100,200] ^^");
+                }),
+            ),
+            (
+                Some("<esc>:1<up><up><up>"),
+                Some(&|app| {
+                    assert_eq!(
+                        "10",
+                        get_prompt(app).line(),
+                        "[10,20,100,200] ^^^ (one extra ^)"
+                    );
+                }),
+            ),
+            (
+                Some("<esc>:1<up><up><up><down>"),
+                Some(&|app| {
+                    assert_eq!("100", get_prompt(app).line(), "[10,20,100,200] ^^^v");
+                }),
+            ),
+            (
+                Some("<esc>:1<up><up><up><down><down>"),
+                Some(&|app| {
+                    assert_eq!(
+                        "1",
+                        get_prompt(app).line(),
+                        "[10,20,100,200] ^^^vv (back to search term)"
+                    );
+                }),
+            ),
+            (
+                Some("<esc>:1<up><up><up><down><down><down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line(), "[10,20,100,200] ^^^vvv (reset)");
+                }),
+            ),
+            (
+                Some("<esc>:aaa1<ret>:bbb1<ret>:aaa2<ret>:bbb2<ret>:a"),
+                Some(&|app| {
+                    assert_eq!("a", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up>"),
+                Some(&|app| {
+                    assert_eq!("aaa2", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up>"),
+                Some(&|app| {
+                    assert_eq!("aaa1", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up>"),
+                Some(&|app| {
+                    assert_eq!("aaa1", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up><up>"),
+                Some(&|app| {
+                    assert_eq!("aaa1", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up><up><down>"),
+                Some(&|app| {
+                    assert_eq!("aaa2", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up><up><down><down>"),
+                Some(&|app| {
+                    assert_eq!("a", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up><up><down><down><down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:a<up><up><up><up><down><down><down><down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line());
+                }),
+            ),
+            (
+                Some("<esc>:<up><up><up><up><down><down><down><down>"),
+                Some(&|app| {
+                    assert_eq!("", get_prompt(app).line());
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
 }

--- a/helix-term/tests/test/prompt.rs
+++ b/helix-term/tests/test/prompt.rs
@@ -256,66 +256,6 @@ async fn history_partial_search() -> anyhow::Result<()> {
                     assert_eq!("", get_prompt(app).line(), "[10,20,100,200] ^^^vvv (reset)");
                 }),
             ),
-            (
-                Some("<esc>:aaa1<ret>:bbb1<ret>:aaa2<ret>:bbb2<ret>:a"),
-                Some(&|app| {
-                    assert_eq!("a", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up>"),
-                Some(&|app| {
-                    assert_eq!("aaa2", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up>"),
-                Some(&|app| {
-                    assert_eq!("aaa1", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up>"),
-                Some(&|app| {
-                    assert_eq!("aaa1", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up><up>"),
-                Some(&|app| {
-                    assert_eq!("aaa1", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up><up><down>"),
-                Some(&|app| {
-                    assert_eq!("aaa2", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up><up><down><down>"),
-                Some(&|app| {
-                    assert_eq!("a", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up><up><down><down><down>"),
-                Some(&|app| {
-                    assert_eq!("", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:a<up><up><up><up><down><down><down><down>"),
-                Some(&|app| {
-                    assert_eq!("", get_prompt(app).line());
-                }),
-            ),
-            (
-                Some("<esc>:<up><up><up><up><down><down><down><down>"),
-                Some(&|app| {
-                    assert_eq!("", get_prompt(app).line());
-                }),
-            ),
         ],
         false,
     )


### PR DESCRIPTION
This is an attempt to implement "partial history search" allowing `:a<Up>` to show the previous entry starting with "a".

Added search for `<Up>`/`<Down>` and `<C-p>`/`<C-n>` and changed their behavior, even with no search term:
- `:<Up><Down>` now goes back to the initial empty state
- and prevent `<C-n>` or `<Up>` from cycling back the first history entry.

The prompt value at the end of the existing `history_completion` test was "asdf" before but now `<tab>` seems to have an effect, I am guessing this test should only verify the absence of errors?

Maybe this could apply to "/" and "?" as well.
