### PR TITLE
Add support for formatting GDScript with GDFormat

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1545,6 +1545,7 @@ file-types = ["gd"]
 shebangs = []
 roots = ["project.godot"]
 auto-format = true
+formatter = { command = "gdformat", args = ["-"] }
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
 


### PR DESCRIPTION
Without this change, GDScript code doesn't get formatted.

You can install GDFormat like this:
```
# On Windows
pip install gdtoolkit

# On MacOS and Linux
pip3 install gdtoolkit
```