### PR TITLE
Added `ferra` theme

### DIFF
--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -1,3 +1,5 @@
+# Author : Casper Rogild Storm <casper@asynkron.xyz>
+
 "comment" = { fg = "ferra_bark", modifiers = ["italic"] }
 "constant" = { fg = "ferra_sage" }
 "function" = { fg = "ferra_coral" }

--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -1,0 +1,80 @@
+"comment" = { fg = "ferra_bark", modifiers = ["italic"] }
+"constant" = { fg = "ferra_sage" }
+"function" = { fg = "ferra_coral" }
+"function.macro" = { fg = "ferra_mist" }
+"keyword" = { fg = "ferra_mist" }
+"operator" = { fg = "ferra_mist" }
+"punctuation" = { fg = "ferra_blush" }
+"string" = { fg = "ferra_sage" }
+"type" = { fg = "ferra_rose" }
+"variable" = { fg = "ferra_blush" }
+"variable.builtin" = { fg = "ferra_rose" }
+"tag" = { fg = "ferra_sage" }
+"label" = { fg = "ferra_sage" }
+"attribute" = { fg = "ferra_blush" }
+"namespace" = { fg = "ferra_blush" }
+"module" = { fg = "ferra_blush" }
+
+"markup.heading" = { fg = "ferra_sage", modifiers = ["bold"] }
+"markup.heading.marker" = { fg = "ferra_bark" }
+"markup.list" = { fg = "ferra_mist" }
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "ferra_rose", modifiers = ["underlined"] }
+"markup.link.text" = { fg = "ferra_rose" }
+"markup.quote" = { fg = "ferra_bark" }
+"markup.raw" = { fg = "ferra_coral" }
+
+"ui.background" = { bg = "ferra_night" }
+"ui.cursor" = { fg = "ferra_night", bg = "ferra_blush" }
+"ui.cursor.match" = { fg = "ferra_night", bg = "ferra_bark" }
+"ui.cursor.select" = { fg = "ferra_night", bg = "ferra_rose" }
+"ui.cursor.insert" = { fg = "ferra_night", bg = "ferra_coral" }
+"ui.linenr" = { fg = "ferra_bark" }
+"ui.linenr.selected" = { fg = "ferra_blush" }
+"ui.cursorline" = { fg = "ferra_blush", bg = "ferra_ash" }
+"ui.statusline" = { fg = "ferra_blush", bg = "ferra_ash" }
+"ui.statusline.inactive" = { fg = "ferra_bark", bg = "ferra_ash" }
+"ui.statusline.normal" = { fg = "ferra_ash", bg = "ferra_blush" }
+"ui.statusline.insert" = { fg = "ferra_ash", bg = "ferra_coral" }
+"ui.statusline.select" = { fg = "ferra_ash", bg = "ferra_rose" }
+"ui.popup" = { fg = "ferra_blush", bg = "ferra_ash" }
+"ui.window" = { fg = "ferra_bark", bg = "ferra_night" }
+"ui.help" = { fg = "ferra_blush", bg = "ferra_ash" }
+"ui.text" = { fg = "ferra_blush" }
+"ui.text.focus" = { fg = "ferra_coral" }
+"ui.menu" = { fg = "ferra_blush", bg = "ferra_ash" }
+"ui.menu.selected" = { fg = "ferra_coral", bg = "ferra_ash" }
+"ui.selection" = { bg = "ferra_umber" }
+"ui.virtual.whitespace" = { fg = "ferra_bark" }
+"ui.virtual.ruler" = { bg = "ferra_ash" }
+"ui.virtual.indent-guide" = { fg = "ferra_ash" }
+"ui.virtual.inlay-hint" = { fg = "ferra_bark"}
+
+"diff.plus" = { fg = "ferra_sage" }
+"diff.delta" = { fg = "ferra_blush" }
+"diff.minus" = { fg = "ferra_ember" }
+
+"error" = { fg = "ferra_ember" }
+"warning" = { fg = "ferra_honey" }
+"info" = { fg = "ferra_blush" }
+"hint" = { fg = "ferra_blush" }
+
+"diagnostic.warning" = { underline = { color = "ferra_honey", style = "curl" } }
+"diagnostic.error" = { underline = { color = "ferra_ember", style = "curl" } }
+"diagnostic.info" = { underline = { color = "ferra_blush", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "ferra_blush", style = "curl" } }
+
+[palette]
+ferra_night = "#2b292d"
+ferra_ash = "#383539"
+ferra_umber = "#4d424b"
+ferra_bark = "#6F5D63"
+ferra_mist = "#D1D1E0"
+ferra_sage = "#B1B695"
+ferra_blush = "#fecdb2"
+ferra_coral = "#ffa07a"
+ferra_rose = "#F6B6C9"
+ferra_ember = "#e06b75"
+ferra_honey = "#F5D76E"

--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -48,11 +48,13 @@
 "ui.text.focus" = { fg = "ferra_coral" }
 "ui.menu" = { fg = "ferra_blush", bg = "ferra_ash" }
 "ui.menu.selected" = { fg = "ferra_coral", bg = "ferra_ash" }
-"ui.selection" = { bg = "ferra_umber" }
+"ui.selection" = { bg = "ferra_umber", fg = "ferra_night" }
+"ui.selection.primary" = { bg = "ferra_night", fg = "ferra_umber" }
+"ui.virtual" = { fg = "ferra_bark" }
 "ui.virtual.whitespace" = { fg = "ferra_bark" }
-"ui.virtual.ruler" = { bg = "ferra_ash" }
+"ui.virtual.ruler" = { fg = "ferra_night", bg = "ferra_ash" }
 "ui.virtual.indent-guide" = { fg = "ferra_ash" }
-"ui.virtual.inlay-hint" = { fg = "ferra_bark"}
+"ui.virtual.inlay-hint" = { fg = "ferra_bark" }
 
 "diff.plus" = { fg = "ferra_sage" }
 "diff.delta" = { fg = "ferra_blush" }


### PR DESCRIPTION
This PR adds my theme `ferra`. It's a original theme I created a few years ago. A small description for the theme:

> Ferra is a visually appealing theme that is inspired by the vibrant colors of [Kanagawa](https://github.com/rebelot/kanagawa.nvim) and the warm tones of [Gruvbox](https://github.com/morhetz/gruvbox). This theme features a rich palette of earthy browns and greens, accented by subtle pops of blush, coral, and rose. The result is a harmonious blend of colors that is both inviting and easy on the eyes.

Running `cargo xtask themelint ferra` shows no current linting errors:

```sh
➜  helix git:(theme/ferra) ✗ cargo xtask themelint ferra
   Finished dev [unoptimized + debuginfo] target(s) in 0.13s
   Running `target/debug/xtask themelint ferra`
```

Let me know what you think, and let me know if you find any errors with it which I might have missed while porting it. I have mostly tested this with Rust.

![image](https://user-images.githubusercontent.com/2248455/230317439-d719fa51-8513-4576-ac5a-9af1b549fc05.png)



