### PR TITLE
Colorize inlay hints in the boo_berry theme

### DIFF
--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -52,6 +52,7 @@
 "ui.virtual.whitespace" = { fg = "berry_desaturated" }
 "ui.virtual.ruler" = { bg = "berry_dim" }
 "ui.virtual.indent-guide" = { fg = "berry_fade" }
+"ui.virtual.inlay-hint" = { fg = "berry_desaturated" }
 
 "diff.plus" = { fg = "mint" }
 "diff.delta" = { fg = "gold" }


### PR DESCRIPTION
I set the color of inlay hint in the boo_berry theme which is my favorite pick when using helix.

Before:
![image](https://user-images.githubusercontent.com/6007810/230422920-4324866c-9842-4548-8547-8cc2fdfeab74.png)

After:
![image](https://user-images.githubusercontent.com/6007810/230422326-e4c51928-ebf9-44d7-a4d1-921b8850c5e3.png)

I chose the color that looks best to me, but if there's a more suitable color, please recommend it to me.