### PR TITLE
xml: highlight .xsd as XML files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2069,7 +2069,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg"]
+file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg", "xsd"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
xsd or "XML Schema Definition" files are in XML format and should therefore be highlighted as such