### PR TITLE
:log-open opens the current log file as specified by --log

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -11,6 +11,8 @@ static RUNTIME_DIRS: once_cell::sync::Lazy<Vec<PathBuf>> =
 
 static CONFIG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
 
+static LOG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
+
 pub fn initialize_config_file(specified_file: Option<PathBuf>) {
     let config_file = specified_file.unwrap_or_else(|| {
         let config_dir = config_dir();
@@ -24,6 +26,16 @@ pub fn initialize_config_file(specified_file: Option<PathBuf>) {
 
     // We should only initialize this value once.
     CONFIG_FILE.set(config_file).ok();
+}
+
+pub fn initialize_log_file(specified_file: Option<PathBuf>) {
+    let log_file = specified_file.unwrap_or_else(|| {
+        let cache_dir = cache_dir();
+        cache_dir.join("helix.log")
+    });
+
+    // We should only intialize this value once.
+    LOG_FILE.set(log_file).ok();
 }
 
 /// A list of runtime directories from highest to lowest priority

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -28,14 +28,9 @@ pub fn initialize_config_file(specified_file: Option<PathBuf>) {
     CONFIG_FILE.set(config_file).ok();
 }
 
-pub fn initialize_log_file(specified_file: Option<PathBuf>) {
-    let log_file = specified_file.unwrap_or_else(|| {
-        let cache_dir = cache_dir();
-        cache_dir.join("helix.log")
-    });
-
+pub fn initialize_log_file(specified_file: PathBuf) {
     // We should only intialize this value once.
-    LOG_FILE.set(log_file).ok();
+    LOG_FILE.set(specified_file).ok();
 }
 
 /// A list of runtime directories from highest to lowest priority

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -149,7 +149,10 @@ pub fn lang_config_file() -> PathBuf {
 }
 
 pub fn log_file() -> PathBuf {
-    cache_dir().join("helix.log")
+    LOG_FILE
+        .get()
+        .map(|path| path.to_path_buf())
+        .unwrap_or_else(|| cache_dir.join("helix.log"))
 }
 
 /// Merge two TOML documents, merging values from `right` onto `left`

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -152,7 +152,7 @@ pub fn log_file() -> PathBuf {
     LOG_FILE
         .get()
         .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| cache_dir.join("helix.log"))
+        .unwrap_or_else(|| cache_dir().join("helix.log"))
 }
 
 /// Merge two TOML documents, merging values from `right` onto `left`

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -117,6 +117,7 @@ FLAGS:
     }
 
     let logpath = args.log_file.as_ref().cloned().unwrap_or(logpath);
+    helix_loader::initialize_log_file(logpath.clone());
     setup_logging(logpath, args.verbosity).context("failed to initialize logging")?;
 
     let config_dir = helix_loader::config_dir();


### PR DESCRIPTION
MR should fix the issue mentioned in https://github.com/helix-editor/helix/issues/6469.

I used a similar implementation to `CONFIG_FILE`. Tests should still be added but I'll ensure people agree on the implementation first.

Fixes #6469