### PR TITLE
Update gleam grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1425,7 +1425,7 @@ language-server = { command = "gleam", args = ["lsp"] }
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "d6cbdf3477fcdb0b4d811518a356f9b5cd1795ed" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "ae79782c00656945db69641378e688cdb78d52c1" }
 
 [[language]]
 name = "ron"

--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -77,6 +77,7 @@
   "if"
   "import"
   "let"
+  "panic"
   "todo"
   "try"
   "type"


### PR DESCRIPTION
Adds support for the new `let assert ...` as only `assert ...` has been deprecated in gleam.