### PR TITLE
global indentation configuration

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -146,7 +146,7 @@ pub struct LanguageConfiguration {
     )]
     pub language_servers: Vec<LanguageServerFeatures>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub indent: Option<IndentationConfiguration>,
+    pub indent: Option<LanguageIndentationConfiguration>,
 
     #[serde(skip)]
     pub(crate) indent_query: OnceCell<Option<Query>>,
@@ -537,12 +537,20 @@ pub struct DebuggerQuirks {
     pub absolute_paths: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IndentationConfiguration {
     #[serde(deserialize_with = "deserialize_tab_width")]
     pub tab_width: usize,
     pub unit: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LanguageIndentationConfiguration {
+    #[serde(flatten)]
+    pub indent: IndentationConfiguration,
+    #[serde(default)]
+    pub required: bool,
 }
 
 /// How the indentation for a newly inserted line should be determined.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -643,7 +643,7 @@ use helix_lsp::{lsp, Client, LanguageServerId, LanguageServerName};
 use url::Url;
 
 impl Document {
-    pub fn from(
+    fn from0(
         text: Rope,
         encoding_with_bom_info: Option<(&'static Encoding, bool)>,
         config: Arc<dyn DynAccess<Config>>,
@@ -653,7 +653,7 @@ impl Document {
         let changes = ChangeSet::new(text.slice(..));
         let old_state = None;
 
-        let mut doc = Self {
+        Self {
             id: DocumentId::default(),
             path: None,
             encoding,
@@ -684,7 +684,15 @@ impl Document {
             focused_at: std::time::Instant::now(),
             readonly: false,
             jump_labels: HashMap::new(),
-        };
+        }
+    }
+
+    pub fn from(
+        text: Rope,
+        encoding_with_bom_info: Option<(&'static Encoding, bool)>,
+        config: Arc<dyn DynAccess<Config>>,
+    ) -> Self {
+        let mut doc = Self::from0(text, encoding_with_bom_info, config);
         doc.detect_indent_and_line_ending();
         doc
     }
@@ -722,7 +730,7 @@ impl Document {
             (Rope::from(line_ending.as_str()), encoding, false)
         };
 
-        let mut doc = Self::from(rope, Some((encoding, has_bom)), config);
+        let mut doc = Self::from0(rope, Some((encoding, has_bom)), config);
 
         // set the path and try detecting the language
         doc.set_path(Some(path));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -316,8 +316,7 @@ pub struct Config {
     pub rulers: Vec<u16>,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub indent: Option<IndentationConfiguration>,
+    pub indent: IndentationConfiguration,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
     /// Vertical indent width guides.
@@ -966,7 +965,7 @@ impl Default for Config {
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
-            indent: None,
+            indent: IndentationConfiguration::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -42,7 +42,7 @@ use anyhow::{anyhow, bail, Error};
 pub use helix_core::diagnostic::Severity;
 use helix_core::{
     auto_pairs::AutoPairs,
-    syntax::{self, AutoPairConfig, IndentationHeuristic, LanguageServerFeature, SoftWrap},
+    syntax::{self, AutoPairConfig, IndentationConfiguration, IndentationHeuristic, LanguageServerFeature, SoftWrap},
     Change, LineEnding, Position, Range, Selection, Uri, NATIVE_LINE_ENDING,
 };
 use helix_dap as dap;
@@ -316,6 +316,8 @@ pub struct Config {
     pub rulers: Vec<u16>,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent: Option<IndentationConfiguration>,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
     /// Vertical indent width guides.
@@ -964,6 +966,7 @@ impl Default for Config {
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
+            indent: None,
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,

--- a/languages.toml
+++ b/languages.toml
@@ -1440,7 +1440,7 @@ file-types = [{ glob = "Makefile" }, { glob = "makefile" }, "make", "mk", "mak",
 shebangs = ["make", "gmake"]
 injection-regex = "(make|makefile|Makefile|mk)"
 comment-token = "#"
-indent = { tab-width = 4, unit = "\t" }
+indent = { tab-width = 4, unit = "\t", required = true }
 
 [[grammar]]
 name = "make"

--- a/languages.toml
+++ b/languages.toml
@@ -3069,7 +3069,7 @@ file-types = ["nim", "nims", "nimble"]
 shebangs = []
 comment-token = "#"
 block-comment-tokens = { start = "#[", end = "]#" }
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 2, unit = "  ", required = true }
 language-servers = [ "nimlangserver" ]
 
 [language.auto-pairs]

--- a/languages.toml
+++ b/languages.toml
@@ -863,7 +863,7 @@ roots = ["pyproject.toml", "setup.py", "poetry.lock", "pyrightconfig.json"]
 comment-token = "#"
 language-servers = ["ruff", "jedi", "pylsp"]
 # TODO: pyls needs utf-8 offsets
-indent = { tab-width = 4, unit = "    " }
+indent = { tab-width = 4, unit = "    ", required = true }
 
 [[grammar]]
 name = "python"
@@ -1308,7 +1308,7 @@ name = "yaml"
 scope = "source.yaml"
 file-types = ["yml", "yaml"]
 comment-token = "#"
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 2, unit = "  ", required = true }
 language-servers = [ "yaml-language-server", "ansible-language-server" ]
 injection-regex = "yml|yaml"
 


### PR DESCRIPTION
Indentation can be configured globally as shown below.
```toml
[editor.indent]
tab-width = 4
unit = "t"
```
These settings are used when a buffer is loaded and an indentation style is not detected and override language-specific defaults. However, they can be overridden per language in `languages.toml` by setting `indent.required = true`.
```toml
[[language]]
name = "yaml"
indent = {tab-width = 2, unit = "  ", required = true}
```

Setting `indent.required = false` for a language in the user's `language.toml` requires setting `indent.{tab-width,unit}` too but I think that this is out of the scope of this patch given that the same happens when setting `indent.tab-width` or `indent.unit` only.
These changes should resolve #3159.