### PR TITLE
Add python interactive else dedent

### DIFF
--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -72,4 +72,6 @@
   "elif" @outdent)
 (else_clause
   "else" @outdent)
-
+(ERROR
+  (_) @outdent ":" . 
+  (#match? @outdent "^(else|elif)"))


### PR DESCRIPTION
Python else statements were not dedented automatically, so adding a pattern to capture this case,

Example code:
```python
def test():
    if True:
        print("Ok")
        else: # After pressing ":", the line will become
    else:
```