### PR TITLE
tui: Allow toggling mouse capture at runtime

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -361,6 +361,9 @@ impl Application {
             ConfigEvent::Update(editor_config) => {
                 let mut app_config = (*self.config.load().clone()).clone();
                 app_config.editor = *editor_config;
+                if let Err(err) = self.terminal.reconfigure(app_config.editor.clone().into()) {
+                    self.editor.set_error(err.to_string());
+                };
                 self.config.store(Arc::new(app_config));
             }
         }
@@ -419,6 +422,8 @@ impl Application {
                 .map_err(|err| anyhow::anyhow!("Failed to load config: {}", err))?;
             self.refresh_language_config()?;
             self.refresh_theme(&default_config)?;
+            self.terminal
+                .reconfigure(default_config.editor.clone().into())?;
             // Store new config
             self.config.store(Arc::new(default_config));
             Ok(())

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -14,6 +14,7 @@ pub use self::test::TestBackend;
 
 pub trait Backend {
     fn claim(&mut self, config: Config) -> Result<(), io::Error>;
+    fn reconfigure(&mut self, config: Config) -> Result<(), io::Error>;
     fn restore(&mut self, config: Config) -> Result<(), io::Error>;
     fn force_restore() -> Result<(), io::Error>;
     fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -111,6 +111,10 @@ impl Backend for TestBackend {
         Ok(())
     }
 
+    fn reconfigure(&mut self, _config: Config) -> Result<(), io::Error> {
+        Ok(())
+    }
+
     fn restore(&mut self, _config: Config) -> Result<(), io::Error> {
         Ok(())
     }

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -116,6 +116,10 @@ where
         self.backend.claim(config)
     }
 
+    pub fn reconfigure(&mut self, config: Config) -> io::Result<()> {
+        self.backend.reconfigure(config)
+    }
+
     pub fn restore(&mut self, config: Config) -> io::Result<()> {
         self.backend.restore(config)
     }


### PR DESCRIPTION
This picks up changes to the `editor.mouse` option at runtime - either through `:set-option` or `:config-reload`. When the value changes, we tell the terminal to enable or disable mouse capture sequences.

Closes #6638
Closes #5648
Closes #5931