### PR TITLE
Fix `file-picker.follow-symlinks` config option name in docs

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -161,7 +161,7 @@ All git related options are only enabled in a git repository.
 | Key | Description | Default |
 |--|--|---------|
 |`hidden` | Enables ignoring hidden files | true
-|`follow-links` | Follow symlinks instead of ignoring them | true
+|`follow-symlinks` | Follow symlinks instead of ignoring them | true
 |`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | true
 |`parents` | Enables reading ignore files from parent directories | true
 |`ignore` | Enables reading `.ignore` files | true


### PR DESCRIPTION
discovered this while using the current release, if it has changed in master reject this.