### PR TITLE
Update tree-sitter-git-commit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1194,7 +1194,7 @@ text-width = 72
 
 [[grammar]]
 name = "git-commit"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "bd0ca5a6065f2cada3ac6a82a66db3ceff55fa6b" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "db88cffa3952dd2328b741af5d0fc69bdb76704f" }
 
 [[language]]
 name = "diff"

--- a/runtime/queries/git-commit/highlights.scm
+++ b/runtime/queries/git-commit/highlights.scm
@@ -10,5 +10,9 @@
 (change kind: "modified" @diff.delta)
 (change kind: "renamed" @diff.delta.moved)
 
-[":" "->" (scissors)] @punctuation.delimiter
+(trailer
+  key: (trailer_key) @variable.other.member
+  value: (trailer_value) @string)
+
+[":" "=" "->" (scissors)] @punctuation.delimiter
 (comment) @comment


### PR DESCRIPTION
Trailers are now supported, for example 'Co-authored-by' or 'Signed-off-by'. Commits are also now recognized in message bodies.

![git-commit](https://user-images.githubusercontent.com/21230295/230921598-c757f9dd-8a85-4a0e-835d-ba535c2a5bce.png)
