### PR TITLE
LSP: Gracefully handle 'workspace/configuration' from a stopped server

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1033,8 +1033,7 @@ impl Application {
                                     None => self
                                         .editor
                                         .language_servers
-                                        .get_by_id(server_id)
-                                        .unwrap()
+                                        .get_by_id(server_id)?
                                         .config()?,
                                 };
                                 if let Some(section) = item.section.as_ref() {


### PR DESCRIPTION
Fixes #6687

Quick-fix is to propagate error replacing `.get_by_id(server_id).unwrap()` with `.get_by_id(server_id)?`. 

I've manually tested the fix. It works. Restarting LSP server after stopping it mid-flight works as expected.