### PR TITLE
Allow overriding config and cache dir by env var

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -130,7 +130,7 @@ pub fn config_dir() -> PathBuf {
 }
 
 /// Determines the path to the configuration directory
-/// if the env var `HELIX_CONFIG_DIR` is set, that will override it
+/// if the env var `HELIX_CACHE_DIR` is set, that will override it
 /// if the dest of either the path or the env var is a symlink
 /// it will attempt to follow it (though not recursively).
 pub fn cache_dir() -> PathBuf {


### PR DESCRIPTION
Howdy folks. I wanted to add the ability to have my helix config behind a symlink for myself, then I saw the TODOs and figured I might as well kill two birds with one stone. 

I would have added tests, but `helix-loader` doesn't seem to have any and I wasn't quite sure how to hook it into the current framework. It's a very small change so I think it's okay, but if anyone would like to see them added and is willing to help me for a few minutes I'm happy to add them. 

If there's any additional requirements I wasn't aware of, please let me know. 

cheers :wave: 