### PR TITLE
Add inlay hints styling to darcula theme

### DIFF
--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -23,7 +23,7 @@
 "ui.virtual.ruler" = { bg = "grey02" }
 "ui.virtual.indent-guide" = "grey02"
 "ui.virtual.whitespace" = "grey03"
-"ui.virtual.inlay-hint" = {fg = "grey03", modifiers = ["italic"] }
+"ui.virtual.inlay-hint" = { fg = "grey03", modifiers = ["italic"] }
 "ui.bufferline" = { fg = "grey04", bg = "grey00" }
 "ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
 

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -23,6 +23,7 @@
 "ui.virtual.ruler" = { bg = "grey02" }
 "ui.virtual.indent-guide" = "grey02"
 "ui.virtual.whitespace" = "grey03"
+"ui.virtual.inlay-hint" = {fg = "grey03", modifiers = ["italic"] }
 "ui.bufferline" = { fg = "grey04", bg = "grey00" }
 "ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
 


### PR DESCRIPTION
Currently affects `darcula` and `darcula-solid` themes.

![image](https://user-images.githubusercontent.com/24444379/231599387-4cf69cd3-1c17-43fb-a59c-1016deb67ac0.png)
![image](https://user-images.githubusercontent.com/24444379/231600443-7393d7cc-06bc-440c-9365-c31077aded5a.png)

