### PR TITLE
ensure :toggle soft-wrap.enable works by default

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -749,7 +749,10 @@ impl Default for Config {
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
-            soft_wrap: SoftWrap::default(),
+            soft_wrap: SoftWrap {
+                enable: Some(false),
+                ..SoftWrap::default()
+            },
             text_width: 80,
             completion_replace: false,
             workspace_lsp_roots: Vec::new(),


### PR DESCRIPTION
Fixes #6605

As described in https://github.com/helix-editor/helix/pull/6656#issuecomment-1500887367 the correct fix here was simply to default to `Some(false)` for the global config (instead of `None` which lead to the same behaviour but caused issues with `:toggle`) while continuing to default to `None` for the language config so that the fallback keeps working correctly.
