### PR TITLE
Fix python constant identifier highlight

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -94,7 +94,7 @@
 ; Variables
 
 ((identifier) @constant
- (#match? @constant "^[A-Z_]{2,}$"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))


### PR DESCRIPTION
- Fix: python query highlight now support single-character and alphanumeric constant identifier. 

Merging this PR would close #6730 issue.