### PR TITLE
Replace 'Visual' (mode) with 'Select' in tutor

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -994,7 +994,7 @@ lines.
 
  * Type * to set the search register to the primary selection.
 
- * Type n / N in Visual mode to add selections on each search
+ * Type n / N in Select mode to add selections on each search
    match.
 
  * Press Ctrl-s to save position to the jumplist.


### PR DESCRIPTION
Hello! I noticed the tutor has a single reference to Visual mode in what I understand is Select mode. I imagine it can be easy for people coming from vim to mix the naming up, so I think it will be helpful to be consistent in the tutor.

Thanks!