### PR TITLE
Fix go locals query for var_spec identifiers

### DIFF
--- a/runtime/queries/go/locals.scm
+++ b/runtime/queries/go/locals.scm
@@ -12,7 +12,7 @@
           (identifier) @local.definition))
 
 (var_spec
-  name: (identifier) @local.definition)
+  (identifier) @local.definition)
 
 (for_statement
  (range_clause


### PR DESCRIPTION
This pull request makes a tiny fix to the `var_spec` locals query for Go. The existing query makes use of the "name" field, but when there are multiple variables in the same declaration, only the first gets captured. It's fine for us to not specify the field, because if a type or a value is provided, any identifier nodes within them either have a different name such as type_identifier, or they're nested within a further sub-expression. Below are some screenshots showing the change, and the edge cases that I considered, which seem to be handled correctly with the updated query:

- before (`b` is not recognized as a local):
  ![2023-04-15T00:56:57,614124292-04:00](https://user-images.githubusercontent.com/36740602/232184079-8312db2b-c1f9-44d1-aae5-303461f11a35.png)
- after (`b` is recognized as a local):
  ![2023-04-15T00:57:08,485659065-04:00](https://user-images.githubusercontent.com/36740602/232184099-8ce34a74-7b83-4476-a4e6-5ff52d2c240e.png)
- after, with a type identifier (`c` is not recognized as local):
  ![2023-04-15T00:57:19,085946770-04:00](https://user-images.githubusercontent.com/36740602/232184118-4fd0410d-d24d-4e90-8e9f-71d90e60a261.png)
- after, with assigned value identifiers (`c` is not recognized as local):
  ![2023-04-15T00:57:34,326121245-04:00](https://user-images.githubusercontent.com/36740602/232184157-06a53432-4d41-481c-8ac8-1c30d6a5ade3.png)