### PR TITLE
Change Odin grammar to `ap29600/tree-sitter-odin`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -98,7 +98,7 @@
 | nu | ✓ |  |  |  |
 | ocaml | ✓ |  | ✓ | `ocamllsp` |
 | ocaml-interface | ✓ |  |  | `ocamllsp` |
-| odin | ✓ |  |  | `ols` |
+| odin | ✓ |  | ✓ | `ols` |
 | opencl | ✓ | ✓ | ✓ | `clangd` |
 | openscad | ✓ |  |  | `openscad-lsp` |
 | org | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1674,7 +1674,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "odin"
-source = { git = "https://github.com/MineBill/tree-sitter-odin", rev = "da885f4a387f169b9b69fe0968259ee257a8f69a" }
+source = { git = "https://github.com/ap29600/tree-sitter-odin", rev = "62ffeb15eca4b8981115a1d7df499bcfa3887d43" }
 
 [[language]]
 name = "meson"

--- a/languages.toml
+++ b/languages.toml
@@ -1674,7 +1674,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "odin"
-source = { git = "https://github.com/ap29600/tree-sitter-odin", rev = "62ffeb15eca4b8981115a1d7df499bcfa3887d43" }
+source = { git = "https://github.com/ap29600/tree-sitter-odin", rev = "b219207e49ffca2952529d33e94ed63b1b75c4f1" }
 
 [[language]]
 name = "meson"

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -1,8 +1,8 @@
 (keyword) @keyword
 (operator) @operator
 
-(int_literal)   @constant.numeric
-(float_literal) @constant.numeric
+(int_literal)   @constant.numeric.integer
+(float_literal) @constant.numeric.float
 (rune_literal)  @string.character
 (bool_literal) @constant.builtin.boolean
 (nil) @constant.builtin

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -3,7 +3,7 @@
 
 (int_literal)   @constant.numeric.integer
 (float_literal) @constant.numeric.float
-(rune_literal)  @string.character
+(rune_literal)  @constant.character
 (bool_literal) @constant.builtin.boolean
 (nil) @constant.builtin
 

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -1,141 +1,29 @@
-; Function calls
+(keyword) @keyword
+(operator) @operator
 
-(call_expression
-  function: (identifier) @function)
+(int_literal)   @number
+(float_literal) @number
+(rune_literal)  @number
+(bool_literal) @boolean
+(nil) @constant.builtin
 
-(call_expression
-  function: (selector_expression
-    field: (field_identifier) @function))
+
+(ERROR) @error
+
+(type_identifier)    @type
+(package_identifier) @namespace
+(label_identifier)   @label
+
+(interpreted_string_literal) @string
+(raw_string_literal) @string
+(escape_sequence) @string.escape
+
+(comment) @comment
+(const_identifier) @constant
 
 
-; ; Function definitions
+(compiler_directive) @attribute
+(calling_convention) @attribute
 
-(function_declaration
-  name: (identifier) @function)
-
-(proc_group
-  (identifier) @function)
-
-; ; Identifiers
-
-(type_identifier) @type
-(field_identifier) @variable.other.member
 (identifier) @variable
-
-(const_declaration
-  (identifier) @constant)
-(const_declaration_with_type
-  (identifier) @constant)
-
-"any" @type
-
-(directive_identifier) @constant
-
-; ; Operators
-
-[
-  "?"
-  "-"
-  "-="
-  ":="
-  "!"
-  "!="
-  "*"
-  "*"
-  "*="
-  "/"
-  "/="
-  "&"
-  "&&"
-  "&="
-  "%"
-  "%="
-  "^"
-  "+"
-  "+="
-  "<-"
-  "<"
-  "<<"
-  "<<="
-  "<="
-  "="
-  "=="
-  ">"
-  ">="
-  ">>"
-  ">>="
-  "|"
-  "|="
-  "||"
-  "~"
-  ".."
-  "..<"
-  "..="
-  "::"
-] @operator
-
-; ; Keywords
-
-[
-  ; "asm"
-  "auto_cast"
-  ; "bit_set"
-  "cast"
-  ; "context"
-  ; "or_else"
-  ; "or_return"
-  "in"
-  ; "not_in"
-  "distinct"
-  "foreign"
-  "transmute"
-  ; "typeid"
-
-  "break"
-  "case"
-  "continue"
-  "defer"
-  "else"
-  "using"
-  "when"
-  "where"
-  "fallthrough"
-  "for"
-  "proc"
-  "if"
-  "import"
-  "map"
-  "package"
-  "return"
-  "struct"
-  "union"
-  "enum"
-  "switch"
-  "dynamic"
-] @keyword
-
-; ; Literals
-
-[
-  (interpreted_string_literal)
-  (raw_string_literal)
-  (rune_literal)
-] @string
-
-(escape_sequence) @constant.character.escape
-
-(int_literal) @constant.numeric.integer
-(float_literal) @constant.numeric.float
-(imaginary_literal) @constant.numeric
-
-[
-  (true)
-  (false)
-] @constant.builtin.boolean
-
-[
-  (nil)
-  (undefined)
-] @constant.builtin
-
-(comment) @comment.line
+(pragma_identifier) @attribute

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -1,14 +1,14 @@
 (keyword) @keyword
 (operator) @operator
 
-(int_literal)   @number
-(float_literal) @number
-(rune_literal)  @number
-(bool_literal) @boolean
+(int_literal)   @constant.numeric
+(float_literal) @constant.numeric
+(rune_literal)  @string.character
+(bool_literal) @constant.builtin.boolean
 (nil) @constant.builtin
 
 
-(ERROR) @error
+(ERROR) @special
 
 (type_identifier)    @type
 (package_identifier) @namespace
@@ -16,14 +16,14 @@
 
 (interpreted_string_literal) @string
 (raw_string_literal) @string
-(escape_sequence) @string.escape
+(escape_sequence) @constant.character.escape
 
 (comment) @comment
 (const_identifier) @constant
 
 
-(compiler_directive) @attribute
-(calling_convention) @attribute
+(compiler_directive) @keyword.directive
+(calling_convention) @string.special.symbol
 
 (identifier) @variable
-(pragma_identifier) @attribute
+(pragma_identifier) @keyword.directive

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -7,9 +7,6 @@
 (bool_literal) @constant.builtin.boolean
 (nil) @constant.builtin
 
-
-(ERROR) @special
-
 (type_identifier)    @type
 (package_identifier) @namespace
 (label_identifier)   @label

--- a/runtime/queries/odin/indents.scm
+++ b/runtime/queries/odin/indents.scm
@@ -1,0 +1,16 @@
+[
+ (foreign_block)
+ (block)
+ (compound_literal)
+ (proc_call)
+ (assignment_statement)
+ (const_declaration)
+ (var_declaration)
+ (switch_statement)
+] @indent
+
+[
+ ")"
+ "}"
+] @indent_end @branch
+

--- a/runtime/queries/odin/indents.scm
+++ b/runtime/queries/odin/indents.scm
@@ -12,5 +12,5 @@
 [
  ")"
  "}"
-] @indent_end @branch
+] @outdent
 


### PR DESCRIPTION
The previously adopted grammar, `MineBill/tree-sitter-odin`, is unmaintained and mentions my repository as an alternative source.