### PR TITLE
make :toggle-option print the new value

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1784,7 +1784,8 @@ fn toggle_option(
         .config_events
         .0
         .send(ConfigEvent::Update(config))?;
-    cx.editor.set_status(format!("{} = {}", key, new_value));
+    cx.editor
+        .set_status(format!("Option `{}` is now set to `{}`", key, new_value));
     Ok(())
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1770,12 +1770,12 @@ fn toggle_option(
     let pointer = format!("/{}", key.replace('.', "/"));
     let value = config.pointer_mut(&pointer).ok_or_else(key_error)?;
 
-    if let Value::Bool(b) = *value {
-        *value = Value::Bool(!b);
-    } else {
+    let Value::Bool(old_value) = *value else {
         anyhow::bail!("Key `{}` is not toggle-able", key)
-    }
+    };
 
+    let new_value = !old_value;
+    *value = Value::Bool(new_value);
     // This unwrap should never fail because we only replace one boolean value
     // with another, maintaining a valid json config
     let config = serde_json::from_value(config).unwrap();
@@ -1784,6 +1784,7 @@ fn toggle_option(
         .config_events
         .0
         .send(ConfigEvent::Update(config))?;
+    cx.editor.set_status(format!("{} = {}", key, new_value));
     Ok(())
 }
 


### PR DESCRIPTION
I think some kind of feedback is useful for this command. I chose to set the status line with format `key = new_value`. For example, `:toggle lsp.enable` will set the status line to `lsp.enable = false` or `lsp.enable = true` after successfully applying updated config to the editor.