### PR TITLE
ferra: fix ruler overriding foreground style

### DIFF
--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -52,7 +52,7 @@
 "ui.selection.primary" = { bg = "ferra_night", fg = "ferra_umber" }
 "ui.virtual" = { fg = "ferra_bark" }
 "ui.virtual.whitespace" = { fg = "ferra_bark" }
-"ui.virtual.ruler" = { fg = "ferra_night", bg = "ferra_ash" }
+"ui.virtual.ruler" = { bg = "ferra_ash" }
 "ui.virtual.indent-guide" = { fg = "ferra_ash" }
 "ui.virtual.inlay-hint" = { fg = "ferra_bark" }
 


### PR DESCRIPTION
Ferra's current ruler styling overrides the foreground style, which is an odd look only for characters in the ruler column. This commit removes the foreground styling for the ruler rule. This is more in line with what other themes do for the ruler.