### PR TITLE
Fix completion on paths containing spaces

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2764,13 +2764,10 @@ pub(super) fn command_mode(cx: &mut Context) {
             } else {
                 // Otherwise, use the command's completer and the last shellword
                 // as completion input.
-                let (part, part_len) = if words.len() == 1 || shellwords.ends_with_whitespace() {
+                let (word, word_len) = if words.len() == 1 || shellwords.ends_with_whitespace() {
                     (&Cow::Borrowed(""), 0)
                 } else {
-                    (
-                        words.last().unwrap(),
-                        shellwords.parts().last().unwrap().len(),
-                    )
+                    (words.last().unwrap(), words.last().unwrap().len())
                 };
 
                 let argument_number = argument_number_of(&shellwords);
@@ -2779,13 +2776,13 @@ pub(super) fn command_mode(cx: &mut Context) {
                     .get(&words[0] as &str)
                     .map(|tc| tc.completer_for_argument_number(argument_number))
                 {
-                    completer(editor, part)
+                    completer(editor, word)
                         .into_iter()
                         .map(|(range, file)| {
                             let file = shellwords::escape(file);
 
                             // offset ranges to input
-                            let offset = input.len() - part_len;
+                            let offset = input.len() - word_len;
                             let range = (range.start + offset)..;
                             (range, file)
                         })


### PR DESCRIPTION
It solves #5779

Before:
![render1681600147669](https://user-images.githubusercontent.com/44394533/232335422-b9d8b344-08eb-4092-b86f-4d1c920c5d6a.gif)

After:

![render1681600980390](https://user-images.githubusercontent.com/44394533/232335425-99c844df-e06d-4ea7-a50e-89571de9b4fa.gif)

P.S. I fixed this by getting word_len for a range replacement from the actual word being displayed (instead of initial representation of a path from autocomp), hope that was an initial idea here.