### PR TITLE
always build grammars with c++14 and c11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "log",
  "once_cell",
  "serde",
+ "tempfile",
  "threadpool",
  "toml",
  "tree-sitter",

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4"
 # cloning/compiling tree-sitter grammars
 cc = { version = "1" }
 threadpool = { version = "1.0" }
+tempfile = "3.5.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.7"


### PR DESCRIPTION
Closes #6788

Usually, modern compilers always default to c++ 14 or c++17 anyway. Clang defaults to c++14 and gcc to c++17. MSVC++ even dropped support for older standards in msvc17 (and defaults to c++14) However, it seems that apple-clang sometimes (but not always) defaults to c++98. By explicitly setting the argument we can work around such cases.

This also ensures more consistent builds across various systems (that may default to newer c++ standards in the future) and provides more easily understood error messages on ancient systems that don't support c++14 yet.
