### PR TITLE
Highlight sqlx's `query_scalar{,_unchecked}` macros as SQL

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -41,7 +41,7 @@
 (macro_invocation
   macro: (scoped_identifier
     path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query_as (#match? @_query "^query_as(_unchecked)?$"))
+    name: (identifier) @_query_as (#match? @_query_as "^query_as(_unchecked)?$"))
   (token_tree
     ; Only the second argument is SQL
     .

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -52,6 +52,18 @@
   )
   (#set! injection.language "sql"))
 
+; Highlight SQL in `sqlx::query_scalar!()`
+(macro_invocation
+  macro: (scoped_identifier
+    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
+    name: (identifier) @_query (#eq? @_query "query_scalar"))
+  (token_tree
+    ; Only the first argument is SQL
+    .
+    [(string_literal) (raw_string_literal)] @injection.content
+  )
+  (#set! injection.language "sql"))
+
 ; Highlight SQL in `sqlx::query_unchecked!()`
 (macro_invocation
   macro: (scoped_identifier
@@ -75,6 +87,18 @@
     ; Allow anything as the first argument in case the user has lower case type
     ; names for some reason
     (_)
+    [(string_literal) (raw_string_literal)] @injection.content
+  )
+  (#set! injection.language "sql"))
+
+; Highlight SQL in `sqlx::query_scalar_unchecked!()`
+(macro_invocation
+  macro: (scoped_identifier
+    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
+    name: (identifier) @_query (#eq? @_query "query_scalar_unchecked"))
+  (token_tree
+    ; Only the first argument is SQL
+    .
     [(string_literal) (raw_string_literal)] @injection.content
   )
   (#set! injection.language "sql"))

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -25,11 +25,11 @@
   arguments: (arguments (raw_string_literal) @injection.content)
   (#set! injection.language "regex"))
 
-; Highlight SQL in `sqlx::query!()`
+; Highlight SQL in `sqlx::query!()`, `sqlx::query_scalar!()`, and `sqlx::query_scalar_unchecked!()`
 (macro_invocation
   macro: (scoped_identifier
     path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query (#eq? @_query "query"))
+    name: (identifier) @_query (#match? @_query "^query(_scalar|_scalar_unchecked)?$"))
   (token_tree
     ; Only the first argument is SQL
     .
@@ -37,68 +37,17 @@
   )
   (#set! injection.language "sql"))
 
-; Highlight SQL in `sqlx::query_as!()`
+; Highlight SQL in `sqlx::query_as!()` and `sqlx::query_as_unchecked!()`
 (macro_invocation
   macro: (scoped_identifier
     path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query_as (#eq? @_query_as "query_as"))
+    name: (identifier) @_query_as (#match? @_query "^query_as(_unchecked)?$"))
   (token_tree
     ; Only the second argument is SQL
     .
     ; Allow anything as the first argument in case the user has lower case type
     ; names for some reason
     (_)
-    [(string_literal) (raw_string_literal)] @injection.content
-  )
-  (#set! injection.language "sql"))
-
-; Highlight SQL in `sqlx::query_scalar!()`
-(macro_invocation
-  macro: (scoped_identifier
-    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query (#eq? @_query "query_scalar"))
-  (token_tree
-    ; Only the first argument is SQL
-    .
-    [(string_literal) (raw_string_literal)] @injection.content
-  )
-  (#set! injection.language "sql"))
-
-; Highlight SQL in `sqlx::query_unchecked!()`
-(macro_invocation
-  macro: (scoped_identifier
-    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query_as (#eq? @_query_as "query_unchecked"))
-  (token_tree
-    ; Only the first argument is SQL
-    .
-    [(string_literal) (raw_string_literal)] @injection.content
-  )
-  (#set! injection.language "sql"))
-
-; Highlight SQL in `sqlx::query_as_unchecked!()`
-(macro_invocation
-  macro: (scoped_identifier
-    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query_as (#eq? @_query_as "query_as_unchecked"))
-  (token_tree
-    ; Only the second argument is SQL
-    .
-    ; Allow anything as the first argument in case the user has lower case type
-    ; names for some reason
-    (_)
-    [(string_literal) (raw_string_literal)] @injection.content
-  )
-  (#set! injection.language "sql"))
-
-; Highlight SQL in `sqlx::query_scalar_unchecked!()`
-(macro_invocation
-  macro: (scoped_identifier
-    path: (identifier) @_sqlx (#eq? @_sqlx "sqlx")
-    name: (identifier) @_query (#eq? @_query "query_scalar_unchecked"))
-  (token_tree
-    ; Only the first argument is SQL
-    .
     [(string_literal) (raw_string_literal)] @injection.content
   )
   (#set! injection.language "sql"))


### PR DESCRIPTION
I noticed these two were missing, so I figured we should add them for completeness.