### PR TITLE
flip symbol range in LSP goto commands

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -205,7 +205,9 @@ fn jump_to_location(
             log::warn!("lsp position out of bounds - {:?}", location.range);
             return;
         };
-    doc.set_selection(view.id, Selection::single(new_range.anchor, new_range.head));
+    // we flip the range so that the cursor sits on the start of the symbol
+    // (for example start of the function).
+    doc.set_selection(view.id, Selection::single(new_range.head, new_range.anchor));
     align_view(doc, view, Align::Center);
 }
 


### PR DESCRIPTION
In #5986 the various LSP based goto commands were changed to select the entire symbol range instead of just placing the cursor at the symbol start to bring them in line with other pickers like diagnostics/symbol picker. However, in the symbol picker and the diagnostic picker the range sent by the LSP is flipped, so the cursor is placed at the start of the range (the start of the function instead of the end for example). This is very useful when jumping to the definition of large symbols like modules/classes or function.

This PR adjusts the LSP goto commands to match the other LSP pickers in this regard. This behavior is closer to the old behaviour (which paced the cursor at the start of the symbol too but just didn't add the remaining selection) and I therefore added it to the bugfix release sice this feels like a (very minor) usability regression to me.
