### PR TITLE
produce error when grammar build fails

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::time::SystemTime;
@@ -179,10 +179,10 @@ pub fn build_grammars(target: Option<String>) -> Result<()> {
 
     if !errors.is_empty() {
         let len = errors.len();
-        println!("{} grammars failed to build", len);
         for (i, error) in errors.into_iter().enumerate() {
-            println!("\tFailure {}/{}: {}", i, len, error);
+            println!("Failure {}/{}: {}", i, len, error);
         }
+        bail!("{} grammars failed to build", len);
     }
 
     Ok(())

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -98,15 +98,12 @@ pub fn fetch_grammars() -> Result<()> {
     let mut git_up_to_date = 0;
     let mut non_git = Vec::new();
 
-    for res in results {
+    for (grammar_id, res) in results {
         match res {
             Ok(FetchStatus::GitUpToDate) => git_up_to_date += 1,
-            Ok(FetchStatus::GitUpdated {
-                grammar_id,
-                revision,
-            }) => git_updated.push((grammar_id, revision)),
-            Ok(FetchStatus::NonGit { grammar_id }) => non_git.push(grammar_id),
-            Err(e) => errors.push(e),
+            Ok(FetchStatus::GitUpdated { revision }) => git_updated.push((grammar_id, revision)),
+            Ok(FetchStatus::NonGit) => non_git.push(grammar_id),
+            Err(e) => errors.push((grammar_id, e)),
         }
     }
 
@@ -138,10 +135,10 @@ pub fn fetch_grammars() -> Result<()> {
 
     if !errors.is_empty() {
         let len = errors.len();
-        println!("{} grammars failed to fetch", len);
-        for (i, error) in errors.into_iter().enumerate() {
-            println!("\tFailure {}/{}: {}", i + 1, len, error);
+        for (i, (grammar, error)) in errors.into_iter().enumerate() {
+            println!("Failure {}/{len}: {grammar} {error}", i + 1);
         }
+        bail!("{len} grammars failed to fetch");
     }
 
     Ok(())
@@ -158,11 +155,11 @@ pub fn build_grammars(target: Option<String>) -> Result<()> {
     let mut already_built = 0;
     let mut built = Vec::new();
 
-    for res in results {
+    for (grammar_id, res) in results {
         match res {
             Ok(BuildStatus::AlreadyBuilt) => already_built += 1,
-            Ok(BuildStatus::Built { grammar_id }) => built.push(grammar_id),
-            Err(e) => errors.push(e),
+            Ok(BuildStatus::Built) => built.push(grammar_id),
+            Err(e) => errors.push((grammar_id, e)),
         }
     }
 
@@ -179,10 +176,10 @@ pub fn build_grammars(target: Option<String>) -> Result<()> {
 
     if !errors.is_empty() {
         let len = errors.len();
-        for (i, error) in errors.into_iter().enumerate() {
-            println!("Failure {}/{}: {}", i, len, error);
+        for (i, (grammar_id, error)) in errors.into_iter().enumerate() {
+            println!("Failure {}/{len}: {grammar_id} {error}", i + 1);
         }
-        bail!("{} grammars failed to build", len);
+        bail!("{len} grammars failed to build");
     }
 
     Ok(())
@@ -214,7 +211,7 @@ fn get_grammar_configs() -> Result<Vec<GrammarConfiguration>> {
     Ok(grammars)
 }
 
-fn run_parallel<F, Res>(grammars: Vec<GrammarConfiguration>, job: F) -> Vec<Result<Res>>
+fn run_parallel<F, Res>(grammars: Vec<GrammarConfiguration>, job: F) -> Vec<(String, Result<Res>)>
 where
     F: Fn(GrammarConfiguration) -> Result<Res> + Send + 'static + Clone,
     Res: Send + 'static,
@@ -229,7 +226,7 @@ where
         pool.execute(move || {
             // Ignore any SendErrors, if any job in another thread has encountered an
             // error the Receiver will be closed causing this send to fail.
-            let _ = tx.send(job(grammar));
+            let _ = tx.send((grammar.grammar_id.clone(), job(grammar)));
         });
     }
 
@@ -240,13 +237,8 @@ where
 
 enum FetchStatus {
     GitUpToDate,
-    GitUpdated {
-        grammar_id: String,
-        revision: String,
-    },
-    NonGit {
-        grammar_id: String,
-    },
+    GitUpdated { revision: String },
+    NonGit,
 }
 
 fn fetch_grammar(grammar: GrammarConfiguration) -> Result<FetchStatus> {
@@ -287,17 +279,12 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<FetchStatus> {
             )?;
             git(&grammar_dir, ["checkout", &revision])?;
 
-            Ok(FetchStatus::GitUpdated {
-                grammar_id: grammar.grammar_id,
-                revision,
-            })
+            Ok(FetchStatus::GitUpdated { revision })
         } else {
             Ok(FetchStatus::GitUpToDate)
         }
     } else {
-        Ok(FetchStatus::NonGit {
-            grammar_id: grammar.grammar_id,
-        })
+        Ok(FetchStatus::NonGit)
     }
 }
 
@@ -347,7 +334,7 @@ where
 
 enum BuildStatus {
     AlreadyBuilt,
-    Built { grammar_id: String },
+    Built,
 }
 
 fn build_grammar(grammar: GrammarConfiguration, target: Option<&str>) -> Result<BuildStatus> {
@@ -533,9 +520,7 @@ fn build_tree_sitter_library(
         ));
     }
 
-    Ok(BuildStatus::Built {
-        grammar_id: grammar.grammar_id,
-    })
+    Ok(BuildStatus::Built)
 }
 
 fn needs_recompile(


### PR DESCRIPTION
Fixes the issue described in https://github.com/helix-editor/helix/pull/6792#issuecomment-1512058559.

Currently, grammar builds fail without actually aborting the build (even tough that seems to be the intention since we explicitly call `except`) because we only print to stdout when the build fails but don't actually return an error. This makes diagnosing and fixing build failures harder. This PR fixes that by simply calling `bail!` instead of `println!`. As described here https://github.com/helix-editor/helix/pull/6792#issuecomment-1512080841 this slightly changes the formatting of the error message. I have therefore opted to remove the indentation from the failure message as that now looks a bit out of place
