### PR TITLE
Border Styles in Themes

### DIFF
--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -1,5 +1,5 @@
 use crate::compositor::{Component, Context};
-use helix_view::graphics::{BorderStyle, Margin, Rect};
+use helix_view::graphics::{Margin, Rect};
 use helix_view::info::Info;
 use tui::buffer::Buffer as Surface;
 use tui::widgets::{Block, BorderType, Borders, Paragraph, Widget};
@@ -23,30 +23,20 @@ impl Component for Info {
         surface.clear_with(area, popup_style);
 
         // try to extract a border style from the ui.popup.info scope
-        let border_style = cx
+        // or fallback tot he default style used by this widget.
+        let border_type = cx
             .editor
             .theme
-            .try_extract("ui.popup.info", |s| s.border_style);
+            .find_map("ui.popup.info", |s| s.border_type)
+            .unwrap_or(BorderType::Plain);
 
-        // fallback to our default border style
-        let border_style = border_style.unwrap_or(BorderStyle::Plain);
+        let mut block = Block::default().title(self.title.as_str());
 
-        let block = if let BorderStyle::None = border_style {
-            Block::default().title(self.title.as_str())
-        } else {
-            let border_type = match border_style {
-                BorderStyle::Plain => BorderType::Plain,
-                BorderStyle::Rounded => BorderType::Rounded,
-                BorderStyle::Double => BorderType::Double,
-                BorderStyle::Thick => BorderType::Thick,
-                _ => unreachable!(),
-            };
-
-            Block::default()
-                .title(self.title.as_str())
+        if border_type != BorderType::None {
+            block = block
                 .borders(Borders::ALL)
                 .border_style(popup_style)
-                .border_type(border_type)
+                .border_type(border_type);
         };
 
         let margin = Margin::horizontal(1);

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -1,8 +1,8 @@
 use crate::compositor::{Component, Context};
-use helix_view::graphics::{Margin, Rect};
+use helix_view::graphics::{BorderStyle, Margin, Rect};
 use helix_view::info::Info;
 use tui::buffer::Buffer as Surface;
-use tui::widgets::{Block, Borders, Paragraph, Widget};
+use tui::widgets::{Block, BorderType, Borders, Paragraph, Widget};
 
 impl Component for Info {
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
@@ -22,10 +22,25 @@ impl Component for Info {
         ));
         surface.clear_with(area, popup_style);
 
-        let block = Block::default()
-            .title(self.title.as_str())
-            .borders(Borders::ALL)
-            .border_style(popup_style);
+        let border_style = popup_style.border_style.unwrap_or(BorderStyle::Plain);
+
+        let block = if let BorderStyle::None = border_style {
+            Block::default().title(self.title.as_str())
+        } else {
+            let border_type = match border_style {
+                BorderStyle::Plain => BorderType::Plain,
+                BorderStyle::Rounded => BorderType::Rounded,
+                BorderStyle::Double => BorderType::Double,
+                BorderStyle::Thick => BorderType::Thick,
+                _ => unreachable!(),
+            };
+
+            Block::default()
+                .title(self.title.as_str())
+                .borders(Borders::ALL)
+                .border_style(popup_style)
+                .border_type(border_type)
+        };
 
         let margin = Margin::horizontal(1);
         let inner = block.inner(area).inner(&margin);

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -22,7 +22,14 @@ impl Component for Info {
         ));
         surface.clear_with(area, popup_style);
 
-        let border_style = popup_style.border_style.unwrap_or(BorderStyle::Plain);
+        // try to extract a border style from the ui.popup.info scope
+        let border_style = cx
+            .editor
+            .theme
+            .try_extract("ui.popup.info", |s| s.border_style);
+
+        // fallback to our default border style
+        let border_style = border_style.unwrap_or(BorderStyle::Plain);
 
         let block = if let BorderStyle::None = border_style {
             Block::default().title(self.title.as_str())

--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use helix_core::syntax;
 use helix_view::graphics::{Margin, Rect, Style};
 use tui::buffer::Buffer;
-use tui::widgets::{BorderType, Paragraph, Widget, Wrap};
+use tui::widgets::{BorderLines, BorderType, Paragraph, Widget, Wrap};
 
 use crate::compositor::{Component, Compositor, Context};
 
@@ -80,7 +80,7 @@ impl Component for SignatureHelp {
         }
 
         let sep_style = Style::default();
-        let borders = BorderType::line_symbols(BorderType::Plain);
+        let borders = BorderLines::line_symbols(BorderType::Plain);
         for x in sig_text_area.left()..sig_text_area.right() {
             if let Some(cell) = surface.get_mut(x, sig_text_area.bottom()) {
                 cell.set_symbol(borders.horizontal).set_style(sep_style);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -14,7 +14,7 @@ use tui::{
     buffer::Buffer as Surface,
     layout::Constraint,
     text::{Span, Spans},
-    widgets::{Block, BorderType, Borders, Cell, Table},
+    widgets::{Block, BorderLines, BorderType, Borders, Cell, Table},
 };
 
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
@@ -758,7 +758,7 @@ impl<T: Item + 'static> Component for Picker<T> {
 
         // -- Separator
         let sep_style = cx.editor.theme.get("ui.background.separator");
-        let borders = BorderType::line_symbols(BorderType::Plain);
+        let borders = BorderLines::line_symbols(BorderType::Plain);
         for x in inner.left()..inner.right() {
             if let Some(cell) = surface.get_mut(x, inner.y + 1) {
                 cell.set_symbol(borders.horizontal).set_style(sep_style);

--- a/helix-tui/src/widgets/block.rs
+++ b/helix-tui/src/widgets/block.rs
@@ -4,21 +4,18 @@ use crate::{
     text::{Span, Spans},
     widgets::{Borders, Widget},
 };
+
+pub use helix_view::graphics::BorderType;
 use helix_view::graphics::{Rect, Style};
 
-/// Border render type. Defaults to [`BorderType::Plain`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum BorderType {
-    #[default]
-    Plain,
-    Rounded,
-    Double,
-    Thick,
+pub trait BorderLines {
+    fn line_symbols(self: Self) -> line::Set;
 }
 
-impl BorderType {
-    pub fn line_symbols(border_type: Self) -> line::Set {
-        match border_type {
+impl BorderLines for BorderType {
+    fn line_symbols(self: Self) -> line::Set {
+        match self {
+            Self::None => line::NORMAL, // TODO: lines made from spaces, just in case?
             Self::Plain => line::NORMAL,
             Self::Rounded => line::ROUNDED,
             Self::Double => line::DOUBLE,
@@ -125,7 +122,7 @@ impl<'a> Widget for Block<'a> {
             return;
         }
         buf.set_style(area, self.style);
-        let symbols = BorderType::line_symbols(self.border_type);
+        let symbols = BorderLines::line_symbols(self.border_type);
 
         // Sides
         if self.borders.intersects(Borders::LEFT) {

--- a/helix-tui/src/widgets/mod.rs
+++ b/helix-tui/src/widgets/mod.rs
@@ -15,7 +15,7 @@ mod paragraph;
 mod reflow;
 mod table;
 
-pub use self::block::{Block, BorderType};
+pub use self::block::{Block, BorderLines, BorderType};
 // pub use self::list::{List, ListItem, ListState};
 pub use self::paragraph::{Paragraph, Wrap};
 pub use self::table::{Cell, Row, Table, TableState};

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -302,16 +302,17 @@ impl From<Color> for crossterm::style::Color {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BorderStyle {
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BorderType {
     None,
+    #[default]
     Plain,
     Rounded,
     Double,
     Thick,
 }
 
-impl FromStr for BorderStyle {
+impl FromStr for BorderType {
     type Err = &'static str;
 
     fn from_str(style: &str) -> Result<Self, Self::Err> {
@@ -480,7 +481,7 @@ pub struct Style {
     pub underline_style: Option<UnderlineStyle>,
     pub add_modifier: Modifier,
     pub sub_modifier: Modifier,
-    pub border_style: Option<BorderStyle>,
+    pub border_type: Option<BorderType>,
 }
 
 impl Default for Style {
@@ -492,7 +493,7 @@ impl Default for Style {
             underline_style: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::empty(),
-            border_style: None,
+            border_type: None,
         }
     }
 }
@@ -507,7 +508,7 @@ impl Style {
             underline_style: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::all(),
-            border_style: None,
+            border_type: None,
         }
     }
 
@@ -611,8 +612,8 @@ impl Style {
         self
     }
 
-    pub fn border_style(mut self, border_style: BorderStyle) -> Style {
-        self.border_style = Some(border_style);
+    pub fn border_style(mut self, border_style: BorderType) -> Style {
+        self.border_type = Some(border_style);
         self
     }
 

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -612,7 +612,18 @@ impl Style {
         self
     }
 
-    pub fn border_style(mut self, border_style: BorderType) -> Style {
+    /// Changes the border type.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use helix_view::graphics::{BorderType, Style};
+    /// let style = Style::default().border_type(BorderType::None);
+    /// let diff = Style::default().border_type(BorderType::Plain);
+    /// let patched = style.patch(diff);
+    /// assert_eq!(patched.border_type, BorderType::Plain);
+    /// ```
+    pub fn border_type(mut self, border_style: BorderType) -> Style {
         self.border_type = Some(border_style);
         self
     }
@@ -635,6 +646,7 @@ impl Style {
         self.bg = other.bg.or(self.bg);
         self.underline_color = other.underline_color.or(self.underline_color);
         self.underline_style = other.underline_style.or(self.underline_style);
+        self.border_type = other.border_type.or(self.border_type);
 
         self.add_modifier.remove(other.sub_modifier);
         self.add_modifier.insert(other.add_modifier);

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -303,6 +303,30 @@ impl From<Color> for crossterm::style::Color {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BorderStyle {
+    None,
+    Plain,
+    Rounded,
+    Double,
+    Thick,
+}
+
+impl FromStr for BorderStyle {
+    type Err = &'static str;
+
+    fn from_str(style: &str) -> Result<Self, Self::Err> {
+        match style {
+            "none" => Ok(Self::None),
+            "plain" => Ok(Self::Plain),
+            "rounded" => Ok(Self::Rounded),
+            "double" => Ok(Self::Double),
+            "thick" => Ok(Self::Thick),
+            _ => Err("Invalid underline style"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnderlineStyle {
     Reset,
     Line,
@@ -456,6 +480,7 @@ pub struct Style {
     pub underline_style: Option<UnderlineStyle>,
     pub add_modifier: Modifier,
     pub sub_modifier: Modifier,
+    pub border_style: Option<BorderStyle>,
 }
 
 impl Default for Style {
@@ -467,6 +492,7 @@ impl Default for Style {
             underline_style: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::empty(),
+            border_style: None,
         }
     }
 }
@@ -481,6 +507,7 @@ impl Style {
             underline_style: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::all(),
+            border_style: None,
         }
     }
 
@@ -581,6 +608,11 @@ impl Style {
     pub fn remove_modifier(mut self, modifier: Modifier) -> Style {
         self.add_modifier.remove(modifier);
         self.sub_modifier.insert(modifier);
+        self
+    }
+
+    pub fn border_style(mut self, border_style: BorderStyle) -> Style {
+        self.border_style = Some(border_style);
         self
     }
 

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -488,7 +488,7 @@ impl ThemePalette {
                             }
                         }
                     }
-                    "border" => *style = style.border_style(Self::parse_border_style(&value)?),
+                    "border" => *style = style.border_type(Self::parse_border_style(&value)?),
                     _ => return Err(format!("Theme: invalid style attribute: {}", name)),
                 }
             }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer};
 use toml::{map::Map, Value};
 
-use crate::graphics::{BorderStyle, UnderlineStyle};
+use crate::graphics::{BorderType, UnderlineStyle};
 pub use crate::graphics::{Color, Modifier, Style};
 
 pub static DEFAULT_THEME_DATA: Lazy<Value> = Lazy::new(|| {
@@ -315,7 +315,7 @@ impl Theme {
 
     /// Extract a value from a style in a scope, falling back to dot seperated
     /// broader scopes.
-    pub fn try_extract<R, F>(&self, scope: &str, f: F) -> Option<R>
+    pub fn find_map<R, F>(&self, scope: &str, f: F) -> Option<R>
     where
         F: Fn(&Style) -> Option<R>,
     {
@@ -437,7 +437,7 @@ impl ThemePalette {
             .ok_or(format!("Theme: invalid modifier: {}", value))
     }
 
-    pub fn parse_border_style(value: &Value) -> Result<BorderStyle, String> {
+    pub fn parse_border_style(value: &Value) -> Result<BorderType, String> {
         value
             .as_str()
             .and_then(|s| s.parse().ok())

--- a/theme.toml
+++ b/theme.toml
@@ -49,7 +49,7 @@ label = "honey"
 "ui.linenr.selected" = { fg = "lilac" }
 "ui.statusline" = { fg = "lilac", bg = "revolver" }
 "ui.statusline.inactive" = { fg = "lavender", bg = "revolver" }
-"ui.popup" = { bg = "revolver" }
+"ui.popup" = { bg = "revolver", border = "rounded" }
 "ui.window" = { fg = "bossanova" }
 "ui.help" = { bg = "#7958DC", fg = "#171452" }
 


### PR DESCRIPTION
Added border styling support to themes. Currently only on `ui.popup.info` for preview.
Added support for extracting parts of a style in the scope-chains. This is used to resolve the 'border_type' value.

The theme TOML schema should allow for flexibility in the future by switching the meaning of the string to be a 'lines collection' theme lookup (like what happens for colours, and the palette definition).

I realize this adds more storage to the styles, and will only be used in a couple of scopes, but it should be fairly negligible.

Feedback is welcome, as this is my first contribution, and I am still trying to build a mental map of the codebase. 😄 