### PR TITLE
feat: Allow setting a menu name from config file

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -46,6 +46,11 @@ k = "scroll_down"
 m = ":run-shell-command make"
 c = ":run-shell-command cargo build"
 t = ":run-shell-command cargo test"
+
+# create a sub-menu with a name
+[keys.normal."space"]
+F.name = "Directory File Pickers"
+F.map = {f = "file_picker_in_current_buffer_directory", F = "file_picker_in_current_directory"}
 ```
 
 ## Special keys and modifiers


### PR DESCRIPTION
While it was possible to create sub-menus or other menus from a configuration file it was not possible to give those menus a name. This change lets you specify a name for the menu.