### PR TITLE
Improve and update the installation documentation

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -41,8 +41,6 @@ line.
 
 ## Linux, macOS, Windows and OpenBSD packaging status
 
-Helix is available for Linux, macOS and Windows via the official repositories listed below.
-
 [![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
 
 ## Linux
@@ -51,7 +49,7 @@ The following third party repositories are available:
 
 ### Ubuntu
 
-Helix is available via [Maveonair's PPA](https://launchpad.net/~maveonair/+archive/ubuntu/helix-editor):
+Add the `PPA` for Helix:
 
 ```sh
 sudo add-apt-repository ppa:maveonair/helix-editor
@@ -61,7 +59,7 @@ sudo apt install helix
 
 ### Fedora/RHEL
 
-Helix is available via `copr`:
+Enable the `COPR` repository for Helix:
 
 ```sh
 sudo dnf copr enable varlad/helix
@@ -92,8 +90,8 @@ If you are using a version of Nix without flakes enabled,
 
 ### AppImage
 
-Install Helix using [AppImage](https://appimage.org/).
-Download Helix AppImage from the [latest releases](https://github.com/helix-editor/helix/releases/latest) page.
+Install Helix using the Linux [AppImage](https://appimage.org/) format.
+Download the official Helix AppImage from the [latest releases](https://github.com/helix-editor/helix/releases/latest) page.
 
 ```sh
 chmod +x helix-*.AppImage # change permission for executable mode
@@ -143,33 +141,35 @@ pacman -S mingw-w64-ucrt-x86_64-helix
 
 ## Building from source
 
-Clone the repository:
+Requirements:
+
+- The [Rust toolchain](https://www.rust-lang.org/tools/install)
+- A c++14 compatible compiler to build the tree-sitter grammars, for example `gcc-c++`
+- If you are using the `musl-libc` standard library instead of `glibc` the following environment variable must be set during the build to ensure tree-sitter grammars can be loaded correctly:
+
+```sh
+RUSTFLAGS="-C target-feature=-crt-static"
+```
+
+1. Clone the repository:
 
 ```sh
 git clone https://github.com/helix-editor/helix
 cd helix
 ```
 
-Compile from source:
+2. Compile from source:
 
 ```sh
 cargo install --path helix-term --locked
 ```
 
 This command will create the `hx` executable and construct the tree-sitter
-grammars in the local `runtime` folder. To build the tree-sitter grammars requires
-a c++ compiler to be installed, for example `gcc-c++`.
-
-> 💡 If you are using the musl-libc instead of glibc the following environment variable must be set during the build
-> to ensure tree-sitter grammars can be loaded correctly:
->
-> ```sh
-> RUSTFLAGS="-C target-feature=-crt-static"
-> ```
+grammars in the local `runtime` folder.
 
 > 💡 Tree-sitter grammars can be fetched and compiled if not pre-packaged. Fetch
 > grammars with `hx --grammar fetch` (requires `git`) and compile them with
-> `hx --grammar build` (requires a C++ compiler). This will install them in
+> `hx --grammar build`. This will install them in
 > the `runtime` directory within the user's helix config directory (more
 > [details below](#multiple-runtime-directories)).
 

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -144,8 +144,10 @@ pacman -S mingw-w64-ucrt-x86_64-helix
 Requirements:
 
 - The [Rust toolchain](https://www.rust-lang.org/tools/install)
-- A c++14 compatible compiler to build the tree-sitter grammars, for example `gcc-c++`
-- If you are using the `musl-libc` standard library instead of `glibc` the following environment variable must be set during the build to ensure tree-sitter grammars can be loaded correctly:
+- The [Git version control system](https://git-scm.com/)
+- A c++14 compatible compiler to build the tree-sitter grammars, for example GCC or Clang
+
+If you are using the `musl-libc` standard library instead of `glibc` the following environment variable must be set during the build to ensure tree-sitter grammars can be loaded correctly:
 
 ```sh
 RUSTFLAGS="-C target-feature=-crt-static"
@@ -168,7 +170,7 @@ This command will create the `hx` executable and construct the tree-sitter
 grammars in the local `runtime` folder.
 
 > 💡 Tree-sitter grammars can be fetched and compiled if not pre-packaged. Fetch
-> grammars with `hx --grammar fetch` (requires `git`) and compile them with
+> grammars with `hx --grammar fetch` and compile them with
 > `hx --grammar build`. This will install them in
 > the `runtime` directory within the user's helix config directory (more
 > [details below](#multiple-runtime-directories)).


### PR DESCRIPTION
Before the release of 23.03.1, I wanted to address a few issues that have been bothering me and make some general improvements. 

Primarily, I corrected grammar and clarity issues, but I also added a new requirements section. Initially, we had agreed that this section was unnecessary as everyone knew that the Rust toolchain was mandatory. However, since a c++14 requirement was recently added, I included the Rust toolchain requirement in the new section as well. I think it is much better now as I also added the `If you are using the musl-libc...` section to the requirements up front, it made no sense to have it after you had tried to install Helix as it would have failed by then!

I think there was some debate about numbering `Clone the repository` and `compile from source`, but with the new requirements things seemed a bit harder to follow without them.