### PR TITLE
Avoid extra indentation on Go switches

### DIFF
--- a/runtime/queries/go/indents.scm
+++ b/runtime/queries/go/indents.scm
@@ -14,8 +14,6 @@
   (argument_list)
   (field_declaration_list)
   (block)
-  (type_switch_statement)
-  (expression_switch_statement)
   (var_declaration)
 ] @indent
 
@@ -24,5 +22,19 @@
   ")"
 ] @outdent
 
-((_ "}" @outdent) @outer (#not-kind-eq? @outer "select_statement"))
-(communication_case) @extend
+; Switches and selects aren't indented, only their case bodies are.
+; Outdent all closing braces except those closing switches or selects.
+(
+    (_ "}" @outdent) @outer
+    (#not-kind-eq? @outer "select_statement")
+    (#not-kind-eq? @outer "type_switch_statement")
+    (#not-kind-eq? @outer "expression_switch_statement")
+)
+
+; Starting a line after a new case should indent.
+[
+  (communication_case)
+  (expression_case)
+  (default_case)
+  (type_case)
+] @extend


### PR DESCRIPTION
(see commit message)

Fixes #6772.