### PR TITLE
Refactor register.rs

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1936,7 +1936,7 @@ fn search_selection(cx: &mut Context) {
         .join("|");
 
     let msg = format!("register '{}' set to '{}'", '/', &regex);
-    cx.editor.registers.push('/', regex);
+    cx.editor.registers.write('/', vec![regex]);
     cx.editor.set_status(msg);
 }
 
@@ -1965,7 +1965,7 @@ fn make_search_word_bounded(cx: &mut Context) {
     }
 
     let msg = format!("register '{}' set to '{}'", '/', &new_regex);
-    cx.editor.registers.push('/', new_regex);
+    cx.editor.registers.write('/', vec![new_regex]);
     cx.editor.set_status(msg);
 }
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -610,6 +610,7 @@ impl Component for Prompt {
                     .registers
                     .inner()
                     .iter()
+                    .filter(|(_, reg)| !reg.read().is_empty())
                     .map(|(ch, reg)| {
                         let content = reg
                             .read()

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -569,7 +569,7 @@ impl Component for Prompt {
                         if last_item != self.line {
                             // store in history
                             if let Some(register) = self.history_register {
-                                cx.editor.registers.push(register, self.line.clone());
+                                cx.editor.registers.write(register, vec![self.line.clone()]);
                             };
                         }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -43,6 +43,7 @@ pub use helix_core::diagnostic::Severity;
 pub use helix_core::register::Registers;
 use helix_core::{
     auto_pairs::AutoPairs,
+    register::{BlackHoleRegister, HistoryRegister},
     syntax::{self, AutoPairConfig, SoftWrap},
     Change,
 };
@@ -936,6 +937,12 @@ impl Editor {
         let conf = config.load();
         let auto_pairs = (&conf.auto_pairs).into();
 
+        let mut registers = Registers::default();
+        registers.set_register('/', Box::new(HistoryRegister::default()));
+        registers.set_register('"', Box::new(HistoryRegister::default()));
+        registers.set_register(':', Box::new(HistoryRegister::default()));
+        registers.set_register('_', Box::new(BlackHoleRegister::default()));
+
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;
 
@@ -962,7 +969,7 @@ impl Editor {
             theme_loader,
             last_theme: None,
             last_selection: None,
-            registers: Registers::default(),
+            registers,
             clipboard_provider: get_clipboard_provider(),
             status_msg: None,
             autoinfo: None,

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -71,6 +71,7 @@ impl Info {
         let body: Vec<_> = registers
             .inner()
             .iter()
+            .filter(|(_, reg)| !reg.read().is_empty())
             .map(|(ch, reg)| {
                 let content = reg
                     .read()


### PR DESCRIPTION
Background
---
I am planning to work on #2038 and #6039. which are both related to registers and clipboard. However, I think the two enhancement will be hard to implement without changing the design of registers, so I work on the register first.

Changes
---
Register become a trait, so different kinds of register can store in a single table, but handle input differently.
`SimpleRegister` is same as the original `Register`
`HistoryRegister` provide the old `Register::push()` function
`BlackHoleRegister` to avoid the "hardcode if" for the underscore(_) register
> For `HistoryRegister`
Before refactoring, `"`,`/`,`:`register was overwrite when yank (e.g`"/y`). After refactoring, it will become append instead of overwrite.