### PR TITLE
Replace `*.cabal` in Haskell `roots` with `cabal.project`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -875,7 +875,7 @@ name = "haskell"
 scope = "source.haskell"
 injection-regex = "haskell"
 file-types = ["hs", "hs-boot"]
-roots = ["Setup.hs", "stack.yaml", "*.cabal"]
+roots = ["Setup.hs", "stack.yaml", "cabal.project"]
 comment-token = "--"
 language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
`roots` doesn't support wildcards. As such this root is dropped, and `cabal.project` is added, which is probably the best we can do for Cabal-based projects for now.