### PR TITLE
return early if soft wrap is disabled

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -62,7 +62,7 @@ pub fn move_vertically_visual(
     annotations: &mut TextAnnotations,
 ) -> Range {
     if !text_fmt.soft_wrap {
-        move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
+        return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
     annotations.clear_line_annotations();
     let pos = range.cursor(slice);


### PR DESCRIPTION
Change to use the result of move_vertically if soft wrap is disabled

In reading the helix code, I wondered if not using the result of move_vertically was not the intent.
If you do not need this change, please feel free to CLOSE it!