### PR TITLE
Use crossterm cursor when terminal loses focus

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -158,6 +158,7 @@ impl EditorView {
                     view,
                     theme,
                     &config.cursor_shape,
+                    self.terminal_focused,
                 ),
             );
             let focused_view_elements = Self::highlight_focused_view_elements(view, doc, theme);
@@ -420,6 +421,7 @@ impl EditorView {
         view: &View,
         theme: &Theme,
         cursor_shape_config: &CursorShapeConfig,
+        is_terminal_focused: bool,
     ) -> Vec<(usize, std::ops::Range<usize>)> {
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id);
@@ -490,13 +492,17 @@ impl EditorView {
                         cursor_start
                     };
                 spans.push((selection_scope, range.anchor..selection_end));
-                if !selection_is_primary || cursor_is_block {
+                // add block cursors
+                // skip primary cursor if terminal is unfocused - crossterm cursor is used in that case
+                if !selection_is_primary || (cursor_is_block && is_terminal_focused) {
                     spans.push((cursor_scope, cursor_start..range.head));
                 }
             } else {
                 // Reverse case.
                 let cursor_end = next_grapheme_boundary(text, range.head);
-                if !selection_is_primary || cursor_is_block {
+                // add block cursors
+                // skip primary cursor if terminal is unfocused - crossterm cursor is used in that case
+                if !selection_is_primary || (cursor_is_block && is_terminal_focused) {
                     spans.push((cursor_scope, range.head..cursor_end));
                 }
                 // non block cursors look like they exclude the cursor
@@ -1520,8 +1526,15 @@ impl Component for EditorView {
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
         match editor.cursor() {
-            // All block cursors are drawn manually
-            (pos, CursorKind::Block) => (pos, CursorKind::Hidden),
+            // all block cursors are drawn manually
+            (pos, CursorKind::Block) => {
+                if self.terminal_focused {
+                    (pos, CursorKind::Hidden)
+                } else {
+                    // use crossterm cursor when terminal loses focus
+                    (pos, CursorKind::Underline)
+                }
+            }
             cursor => cursor,
         }
     }


### PR DESCRIPTION
All but the documents block cursor change their shape to a box outline if the terminal loses focus. I am missing that feature because (depending on your window manager) it can be hard to tell which editor has focus if you have multiple open at the same time. Because the custom rendered block cursor is just the background color of the respective char it is no possible to achieve the same behavior (display as outline).

Therefore I created a proof of concept for the custom block cursor to change its color when the terminal window loses focus. 

If the theme does not define a color for the unfocused cursor (e.g. `ui.cursor.primary.unfocused`) it should calculate the color by faking transparency of the cursor. Therefore it tries to get the background color and the cursor color and mix them.

Currently I have 2 main problems with the color calculation: 

- I do not know how to get the RGB values of a named color (e.g. yellow) but I need those to calculate the "transparent" cursor color
- Some themes (e.g. default) do not define a cursor color (Style.bg is None). There are default colors defined but I do not know how I can query them.
- I also tried to use the DIM modifier but it did not seem to have any effect (atleast in alacritty). I forgot to create a commit for that but if desired I could reimpl. that to analyze why it did not work.

The current implementation works well with some themes, e.g. gruvbox, catpuccin_*, emacs.


Another questions that should be discussed:

- If the feature gets accepted, should it be the default? 
  - I think yes because all other cursors have this behavior