### PR TITLE
Add support for copilot

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -304,6 +304,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
+| `ui.virtual.diagnostics`    | Default style for inline diagnostics lines (notably control the background)                    |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
 | `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |

--- a/copilot.fish
+++ b/copilot.fish
@@ -1,5 +1,6 @@
 # Downloading Copilot lsp
 function clone_copilot_lsp
+    echo "*** Cloning the copilot lsp into /usr/local/bin ***"
     set -l url "https://github.com/github/copilot.vim"
     set -l folder_name "dist/"
     set -l temp_dir (mktemp -d)
@@ -23,6 +24,7 @@ end
 
 function create_copilot_exe
     set -l target_binary "/usr/local/bin/copilot"
+    echo "*** Creating an executable in /usr/local/bin to call the copilot lsp ***"
     if test -x $target_binary
         echo "The file '$target_binary' already exists. Delete this to re-install. Aborting."
         return
@@ -57,6 +59,7 @@ function oath
 end
 
 function auth
+    echo "*** Creating a github access-key file for copilot in ~/.config/github-copilot/hosts.json ***"
     set file_path ~/.config/github-copilot/hosts.json
     if test -e $file_path
         echo "Copilot access-key file $file_path already exists. Delete this to re-install/re-authenticate .Aborting."
@@ -101,6 +104,7 @@ end
 switch $argv[1]
     case --create-lsp
         clone_copilot_lsp
+        echo ""
         create_copilot_exe
     case --auth
         auth

--- a/copilot.fish
+++ b/copilot.fish
@@ -1,0 +1,110 @@
+# Downloading Copilot lsp
+function clone_copilot_lsp
+    set -l url "https://github.com/github/copilot.vim"
+    set -l folder_name "dist/"
+    set -l temp_dir (mktemp -d)
+
+    if test -d "/usr/local/bin/$folder_name"
+        echo "Folder '$folder_name' already exists in /usr/local/bin. Delete this to re-install. Aborting."
+        return 1
+    end
+
+    echo "Cloning repository from $url.."
+    if not git clone $url $temp_dir
+        echo "Failed to clone repository."
+    else if not sudo mv $temp_dir/$folder_name /usr/local/bin/$folder_name
+        echo "Failed to move $folder_name to /usr/local/bin."
+    end
+    echo "Moving $folder_name to /usr/local/bin.."
+
+    echo "Cleaning up..."
+    rm -rf $temp_dir
+end
+
+function create_copilot_exe
+    set -l target_binary "/usr/local/bin/copilot"
+    if test -x $target_binary
+        echo "The file '$target_binary' already exists. Delete this to re-install. Aborting."
+        return
+    end
+    echo '#! /usr/bin/env bash' > $target_binary
+    echo 'node /usr/local/bin/dist/agent.js' >> $target_binary
+    sudo chmod +x $target_binary
+    echo "The executable 'copilot' has been created at $target_binary"
+end
+
+# Auth
+function get_value 
+    set -l pairs (string split '&' $argv[1])
+    set -l kv_line (string match -r "$argv[2]=.*" $pairs)
+    echo (string split "=" $kv_line)[2]
+end
+
+function get_device_params
+    set -l payload '{ "scope": "read:user", "client_id": "Iv1.b507a08c87ecfe98" }'
+    set -l resp (curl -s -X POST "https://github.com/login/device/code" \
+        -H "Content-Type: application/json" \
+        -d $payload)
+    echo $resp
+end
+
+function oath 
+    set -l payload "{\"client_id\": \"Iv1.b507a08c87ecfe98\", \"device_code\": \"$argv[1]\", \"grant_type\": \"urn:ietf:params:oauth:grant-type:device_code\"}"
+    set -l resp (curl -s -X POST "https://github.com/login/oauth/access_token" \
+                    -H "Content-Type: application/json" \
+                    -d $payload)
+    echo $resp
+end
+
+function auth
+    set file_path ~/.config/github-copilot/hosts.json
+    if test -e $file_path
+        echo "Copilot access-key file $file_path already exists. Delete this to re-install/re-authenticate .Aborting."
+        return 1
+    end
+    
+    set device_params (get_device_params)
+    set device_code (get_value $device_params device_code)
+    set uri (get_value $device_params uri)
+    set uri (echo $uri | sed 's/%/\\\\x/g')
+    set user_code (get_value $device_params user_code)
+
+    echo -e "Go to $uri and enter the code $user_code"
+
+    while true 
+        set resp (oath $device_code)
+
+        set access_token (get_value $resp access_token)
+        set error (get_value $resp error)
+        if not test -z $access_token
+            mkdir -p ~/.config/github-copilot
+            echo "{\"github.com\":{\"oauth_token\":\"$access_token\"}}" > ~/.config/github-copilot/hosts.json
+            echo "Copilot access_token written to ~/.config/github-copilot/hosts.json"
+            return 0
+        else if not test -z error
+            echo $error
+        else 
+            echo "Bad response."
+            return 1
+        end
+        sleep 5
+    end
+end
+
+
+# Main 
+if not set -q argv[1]
+    echo "No argument provided. Use --create-lsp or --auth."
+    exit 1
+end
+
+switch $argv[1]
+    case --create-lsp
+        clone_copilot_lsp
+        create_copilot_exe
+    case --auth
+        auth
+    case '*'
+        echo "Unknown option: $argv[1]"
+        exit 1
+end

--- a/copilot.fish
+++ b/copilot.fish
@@ -28,7 +28,7 @@ function create_copilot_exe
         return
     end
     echo '#! /usr/bin/env bash' > $target_binary
-    echo 'node /usr/local/bin/dist/agent.js' >> $target_binary
+    echo 'node /usr/local/bin/dist/language-server.js' >>$target_binary
     sudo chmod +x $target_binary
     echo "The executable 'copilot' has been created at $target_binary"
 end

--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -4,7 +4,8 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Describes the severity level of a [`Diagnostic`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     Hint,
     Info,
@@ -23,6 +24,12 @@ impl Default for Severity {
 pub struct Range {
     pub start: usize,
     pub end: usize,
+}
+
+impl Range {
+    pub fn contains(self, pos: usize) -> bool {
+        (self.start..self.end).contains(&pos)
+    }
 }
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
@@ -69,5 +76,12 @@ slotmap::new_key_type! {
 impl fmt::Display for LanguageServerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+impl Diagnostic {
+    #[inline]
+    pub fn severity(&self) -> Severity {
+        self.severity.unwrap_or(Severity::Warning)
     }
 }

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -182,7 +182,7 @@ pub struct DocumentFormatter<'t> {
     line_pos: usize,
     exhausted: bool,
 
-    inline_anntoation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
+    inline_annotation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
 
     // softwrap specific
     /// The indentation of the current line
@@ -227,7 +227,7 @@ impl<'t> DocumentFormatter<'t> {
             word_buf: Vec::with_capacity(64),
             word_i: 0,
             line_pos: block_line_idx,
-            inline_anntoation_graphemes: None,
+            inline_annotation_graphemes: None,
         }
     }
 
@@ -237,7 +237,7 @@ impl<'t> DocumentFormatter<'t> {
     ) -> Option<(&'t str, Option<Highlight>)> {
         loop {
             if let Some(&mut (ref mut annotation, highlight)) =
-                self.inline_anntoation_graphemes.as_mut()
+                self.inline_annotation_graphemes.as_mut()
             {
                 if let Some(grapheme) = annotation.next() {
                     return Some((grapheme, highlight));
@@ -247,7 +247,7 @@ impl<'t> DocumentFormatter<'t> {
             if let Some((annotation, highlight)) =
                 self.annotations.next_inline_annotation_at(char_pos)
             {
-                self.inline_anntoation_graphemes = Some((
+                self.inline_annotation_graphemes = Some((
                     UnicodeSegmentation::graphemes(&*annotation.text, true),
                     highlight,
                 ))

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -10,6 +10,7 @@
 //! called a "block" and the caller must advance it as needed.
 
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem::replace;
 
@@ -41,6 +42,11 @@ impl GraphemeSource {
     /// Returns whether this grapheme is virtual inline text
     pub fn is_virtual(self) -> bool {
         matches!(self, GraphemeSource::VirtualText { .. })
+    }
+
+    pub fn is_eof(self) -> bool {
+        // all doc chars except the EOF char have non-zero codepoints
+        matches!(self, GraphemeSource::Document { codepoints: 0 })
     }
 
     pub fn doc_chars(self) -> usize {
@@ -117,6 +123,14 @@ impl<'a> GraphemeWithSource<'a> {
         self.grapheme.is_whitespace()
     }
 
+    fn is_newline(&self) -> bool {
+        matches!(self.grapheme, Grapheme::Newline)
+    }
+
+    fn is_eof(&self) -> bool {
+        self.source.is_eof()
+    }
+
     fn width(&self) -> usize {
         self.grapheme.width()
     }
@@ -135,6 +149,7 @@ pub struct TextFormat {
     pub wrap_indicator: Box<str>,
     pub wrap_indicator_highlight: Option<Highlight>,
     pub viewport_width: u16,
+    pub soft_wrap_at_text_width: bool,
 }
 
 // test implementation is basically only used for testing or when softwrap is always disabled
@@ -148,6 +163,7 @@ impl Default for TextFormat {
             wrap_indicator: Box::from(" "),
             viewport_width: 17,
             wrap_indicator_highlight: None,
+            soft_wrap_at_text_width: false,
         }
     }
 }
@@ -318,7 +334,25 @@ impl<'t> DocumentFormatter<'t> {
                 .change_position(visual_x, self.text_fmt.tab_width);
             word_width += grapheme.width();
         }
+        if let Some(grapheme) = &mut self.peeked_grapheme {
+            let visual_x = self.visual_pos.col + word_width;
+            grapheme
+                .grapheme
+                .change_position(visual_x, self.text_fmt.tab_width);
+        }
         word_width
+    }
+
+    fn peek_grapheme(&mut self, col: usize, char_pos: usize) -> Option<&GraphemeWithSource<'t>> {
+        if self.peeked_grapheme.is_none() {
+            self.peeked_grapheme = self.advance_grapheme(col, char_pos);
+        }
+        self.peeked_grapheme.as_ref()
+    }
+
+    fn next_grapheme(&mut self, col: usize, char_pos: usize) -> Option<GraphemeWithSource<'t>> {
+        self.peek_grapheme(col, char_pos);
+        self.peeked_grapheme.take()
     }
 
     fn advance_to_next_word(&mut self) {
@@ -326,32 +360,43 @@ impl<'t> DocumentFormatter<'t> {
         let mut word_width = 0;
         let mut word_chars = 0;
 
+        if self.exhausted {
+            return;
+        }
+
         loop {
-            // softwrap word if necessary
-            if word_width + self.visual_pos.col >= self.text_fmt.viewport_width as usize {
-                // wrapping this word would move too much text to the next line
-                // split the word at the line end instead
-                if word_width > self.text_fmt.max_wrap as usize {
-                    // Usually we stop accomulating graphemes as soon as softwrapping becomes necessary.
-                    // However if the last grapheme is multiple columns wide it might extend beyond the EOL.
-                    // The condition below ensures that this grapheme is not cutoff and instead wrapped to the next line
-                    if word_width + self.visual_pos.col > self.text_fmt.viewport_width as usize {
-                        self.peeked_grapheme = self.word_buf.pop();
-                    }
+            let mut col = self.visual_pos.col + word_width;
+            let char_pos = self.char_pos + word_chars;
+            match col.cmp(&(self.text_fmt.viewport_width as usize)) {
+                // The EOF char and newline chars are always selectable in helix. That means
+                // that wrapping happens "too-early" if a word fits a line perfectly. This
+                // is intentional so that all selectable graphemes are always visisble (and
+                // therefore the cursor never dissapears). However if the user manually set a
+                // lower softwrap width then this is underisable. Just increasing the viewport-
+                // width by one doesn't work because if a line is wrapped multiple times then
+                // some words may extend past the specified width.
+                //
+                // So we specialcase a word that ends exactly at linebounds and is followed
+                // by a newline/eof character here.
+                Ordering::Equal
+                    if self.text_fmt.soft_wrap_at_text_width
+                        && self.peek_grapheme(col, char_pos).map_or(false, |grapheme| {
+                            grapheme.is_newline() || grapheme.is_eof()
+                        }) => {}
+                Ordering::Equal if word_width > self.text_fmt.max_wrap as usize => return,
+                Ordering::Greater if word_width > self.text_fmt.max_wrap as usize => {
+                    self.peeked_grapheme = self.word_buf.pop();
                     return;
                 }
-
-                word_width = self.wrap_word();
+                Ordering::Equal | Ordering::Greater => {
+                    word_width = self.wrap_word();
+                    col = self.visual_pos.col + word_width;
+                }
+                Ordering::Less => (),
             }
 
-            let grapheme = if let Some(grapheme) = self.peeked_grapheme.take() {
-                grapheme
-            } else if let Some(grapheme) =
-                self.advance_grapheme(self.visual_pos.col + word_width, self.char_pos + word_chars)
-            {
-                grapheme
-            } else {
-                return;
+            let Some(grapheme) = self.next_grapheme(col, char_pos) else{
+                return
             };
             word_chars += grapheme.doc_chars();
 
@@ -376,7 +421,6 @@ impl<'t> DocumentFormatter<'t> {
     pub fn next_char_pos(&self) -> usize {
         self.char_pos
     }
-
     /// returns the visual position at the end of the last yielded grapheme
     pub fn next_visual_pos(&self) -> Position {
         self.visual_pos

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -23,18 +23,18 @@ impl<'t> DocumentFormatter<'t> {
         let viewport_width = self.text_fmt.viewport_width;
         let mut line = 0;
 
-        for (grapheme, pos) in self {
-            if pos.row != line {
+        for grapheme in self {
+            if grapheme.visual_pos.row != line {
                 line += 1;
-                assert_eq!(pos.row, line);
-                write!(res, "\n{}", ".".repeat(pos.col)).unwrap();
+                assert_eq!(grapheme.visual_pos.row, line);
+                write!(res, "\n{}", ".".repeat(grapheme.visual_pos.col)).unwrap();
                 assert!(
-                    pos.col <= viewport_width as usize,
+                    grapheme.visual_pos.col <= viewport_width as usize,
                     "softwrapped failed {}<={viewport_width}",
-                    pos.col
+                    grapheme.visual_pos.col
                 );
             }
-            write!(res, "{}", grapheme.grapheme).unwrap();
+            write!(res, "{}", grapheme.raw).unwrap();
         }
 
         res
@@ -48,7 +48,6 @@ fn softwrap_text(text: &str) -> String {
         &TextAnnotations::default(),
         0,
     )
-    .0
     .collect_to_str()
 }
 
@@ -106,7 +105,6 @@ fn overlay_text(text: &str, char_pos: usize, softwrap: bool, overlays: &[Overlay
         TextAnnotations::default().add_overlay(overlays, None),
         char_pos,
     )
-    .0
     .collect_to_str()
 }
 
@@ -143,7 +141,6 @@ fn annotate_text(text: &str, softwrap: bool, annotations: &[InlineAnnotation]) -
         TextAnnotations::default().add_inline_annotations(annotations, None),
         0,
     )
-    .0
     .collect_to_str()
 }
 
@@ -182,7 +179,6 @@ fn annotation_and_overlay() {
                 .add_overlay(overlay.as_slice(), None),
             0,
         )
-        .0
         .collect_to_str(),
         "fooo  bar "
     );

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -28,6 +28,11 @@ pub enum Grapheme<'a> {
 }
 
 impl<'a> Grapheme<'a> {
+    pub fn new_decoration(g: &'static str) -> Grapheme<'a> {
+        assert_ne!(g, "\t");
+        Grapheme::new(g.into(), 0, 0)
+    }
+
     pub fn new(g: GraphemeStr<'a>, visual_x: usize, tab_width: u16) -> Grapheme<'a> {
         match g {
             g if g == "\t" => Grapheme::Tab {

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -52,8 +52,8 @@ pub use {regex, tree_sitter};
 
 pub use graphemes::RopeGraphemes;
 pub use position::{
-    char_idx_at_visual_offset, coords_at_pos, pos_at_coords, visual_offset_from_anchor,
-    visual_offset_from_block, Position, VisualOffsetError,
+    char_idx_at_visual_offset, coords_at_pos, pos_at_coords, softwrapped_dimensions,
+    visual_offset_from_anchor, visual_offset_from_block, Position, VisualOffsetError,
 };
 #[allow(deprecated)]
 pub use position::{pos_at_visual_coords, visual_coords_at_pos};

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -171,6 +171,17 @@ pub fn visual_offset_from_block(
     (last_pos, block_start)
 }
 
+/// Returns the height of the given text when softwrapping
+pub fn softwrapped_dimensions(text: RopeSlice, text_fmt: &TextFormat) -> (usize, u16) {
+    let last_pos =
+        visual_offset_from_block(text, 0, usize::MAX, text_fmt, &TextAnnotations::default()).0;
+    if last_pos.row == 0 {
+        (1, last_pos.col as u16)
+    } else {
+        (last_pos.row + 1, text_fmt.viewport_width)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VisualOffsetError {
     PosBeforeAnchorRow,

--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, cmp::Ordering};
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
 
 use crate::{
     chars::char_is_line_ending,
@@ -14,6 +18,38 @@ use crate::{
 pub struct Position {
     pub row: usize,
     pub col: usize,
+}
+
+impl AddAssign for Position {
+    fn add_assign(&mut self, rhs: Self) {
+        self.row += rhs.row;
+        self.col += rhs.col;
+    }
+}
+
+impl SubAssign for Position {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.row -= rhs.row;
+        self.col -= rhs.col;
+    }
+}
+
+impl Sub for Position {
+    type Output = Position;
+
+    fn sub(mut self, rhs: Self) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl Add for Position {
+    type Output = Position;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
 }
 
 impl Position {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -373,7 +373,7 @@ enum LanguageServerFeatureConfiguration {
     Simple(String),
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LanguageServerFeatures {
     pub name: String,
     pub only: HashSet<LanguageServerFeature>,

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -333,7 +333,9 @@ impl<'a> TextAnnotations<'a> {
         layer: &'a [InlineAnnotation],
         highlight: Option<Highlight>,
     ) -> &mut Self {
-        self.inline_annotations.push((layer, highlight).into());
+        if !layer.is_empty() {
+            self.inline_annotations.push((layer, highlight).into());
+        }
         self
     }
 
@@ -348,7 +350,9 @@ impl<'a> TextAnnotations<'a> {
     /// If multiple layers contain overlay at the same position
     /// the overlay from the layer added last will be show.
     pub fn add_overlay(&mut self, layer: &'a [Overlay], highlight: Option<Highlight>) -> &mut Self {
-        self.overlays.push((layer, highlight).into());
+        if !layer.is_empty() {
+            self.overlays.push((layer, highlight).into());
+        }
         self
     }
 

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -1,8 +1,12 @@
 use std::cell::Cell;
+use std::cmp::Ordering;
+use std::fmt::Debug;
 use std::ops::Range;
+use std::ptr::NonNull;
 
+use crate::doc_formatter::FormattedGrapheme;
 use crate::syntax::Highlight;
-use crate::Tendril;
+use crate::{Position, Tendril};
 
 /// An inline annotation is continuous text shown
 /// on the screen before the grapheme that starts at
@@ -75,19 +79,98 @@ impl Overlay {
     }
 }
 
-/// Line annotations allow for virtual text between normal
-/// text lines. They cause `height` empty lines to be inserted
-/// below the document line that contains `anchor_char_idx`.
+/// Line annotations allow inserting virtual text lines between normal text
+/// lines.  These lines can be filled with text in the rendering code as their
+/// contents have no effect beyond visual appearance.
 ///
-/// These lines can be filled with text in the rendering code
-/// as their contents have no effect beyond visual appearance.
+/// The height of virtual text is usually not known ahead of time as virtual
+/// text often requires softwrapping. Furthermore the height of some virtual
+/// text like side-by-side diffs depends on the height of the text (again
+/// influenced by softwrap) and other virtual text. Therefore line annotations
+/// are computed on the fly instead of ahead of time like other annotations.
 ///
-/// To insert a line after a document line simply set
-/// `anchor_char_idx` to `doc.line_to_char(line_idx)`
-#[derive(Debug, Clone)]
-pub struct LineAnnotation {
-    pub anchor_char_idx: usize,
-    pub height: usize,
+/// The core of this trait `insert_virtual_lines` function. It is called at the
+/// end of every  visual line and allows the `LineAnnotation` to insert empty
+/// virtual lines. Apart from that the `LineAnnotation` trait has multiple
+/// methods that allow it to track anchors in the document.
+///
+/// When a new traversal of a document starts `reset_pos` is called. Afterwards
+/// the other functions are called with indices that are larger then the
+/// one passed to `reset_pos`. This allows performing a binary search (use
+/// `partition_point`) in `reset_pos` once and then to only look at the next
+/// anchor during each method call.
+///
+/// The `reset_pos`, `skip_conceal` and `process_anchor` functions all return a
+/// `char_idx` anchor. This anchor is stored when transversing the document and
+/// when the grapheme at the anchor is traversed the `process_anchor` function
+/// is called.
+///
+/// # Note
+///
+/// All functions only receive immutable references to `self`.
+/// `LineAnnotation`s that want to store an internal position or
+/// state of some kind should use `Cell`. Using interior mutability for
+/// caches is preferable as otherwise a lot of lifetimes become invariant
+/// which complicates APIs a lot.
+pub trait LineAnnotation {
+    /// Resets the internal position to `char_idx`. This function is called
+    //// when a new transveral of a document starts.
+    ///
+    /// All `char_idx` passed to `insert_virtual_lines` are strictly monotonically increasing
+    /// with the first `char_idx` greater or equal to the `char_idx`
+    /// passed to this function.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn reset_pos(&mut self, _char_idx: usize) -> usize {
+        usize::MAX
+    }
+
+    /// Called when a text is concealed that contains an anchor registered by this `LineAnnotation`
+    ///. In this case the line decorations  **must** ensure that virtual text anchored within that
+    /// char range is skipped.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// **after the end of conceal_end_char_idx**
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn skip_concealed_anchors(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.reset_pos(conceal_end_char_idx)
+    }
+
+    /// Process an anchor (horizontal position is provided) and returns the next anchor.
+    ///
+    /// # Returns
+    ///
+    /// The `char_idx` of the next anchor this `LineAnnotation` is interested in,
+    /// replaces the currently registered anchor. Return `usize::MAX` to ignore
+    fn process_anchor(&mut self, _grapheme: &FormattedGrapheme) -> usize {
+        usize::MAX
+    }
+
+    /// This function is called at the end of a visual line to insert virtual text
+    ///
+    /// # Returns
+    ///
+    /// The number of additional virtual lines to reserve
+    ///
+    /// # Note
+    ///
+    /// The `line_end_visual_pos` paramater indiciates the visual vertical distance
+    /// from the start of block where the transversal start.  This includes the offset
+    /// from other `LineAnnotations`. This allows inline annotations to consider
+    /// the height of the text and "align" two different documents (like for side
+    /// by side diffs).  These annotations that want to "align" two documents should
+    /// therefore be added last so that other virtual text is also considered while aligning
+    fn insert_virtual_lines(
+        &mut self,
+        line_end_char_idx: usize,
+        line_end_visual_pos: Position,
+        doc_line: usize,
+    ) -> Position;
 }
 
 #[derive(Debug)]
@@ -143,13 +226,67 @@ fn reset_pos<A, M>(layers: &[Layer<A, M>], pos: usize, get_pos: impl Fn(&A) -> u
     }
 }
 
+/// Safety: We store LineAnnotation in a NonNull pointer. This is necessary to work
+/// around an unfortunate inconsistency in rusts variance system that unnnecesarily
+/// makes the lifetime invariant if implemented with safe code. This makes the
+/// DocFormatter API very cumbersome/basically impossible to work with.
+///
+/// Normally object types dyn Foo + 'a so if we used Box<dyn LineAnnotation + 'a> below
+/// everything would be alright. However we want to use `Cell<Box<dyn LineAnnotation + 'a>>`
+/// to be able to call the mutable function on `LineAnnotation`. The problem is that
+/// some types like `Cell` make all their arguments invariant. This is important for soundness
+/// normally for the same reasons that &'a mut T is invariant over T
+/// (see <https://doc.rust-lang.org/nomicon/subtyping.html>). However for &'a mut (dyn Foo + 'b)
+/// there is a specical rule in the language to make 'b covariant (otherwise trait objects would be
+/// super annoying to use). See  <https://users.rust-lang.org/t/solved-variance-of-dyn-trait-a> for
+/// why this is sound. Sadly that rule doesn't apply to Cell<Box<(dyn Foo + 'a)>
+/// (or other invariant types like `UnsafeCell` or `*mut (dyn Foo + 'a)`).
+///
+/// We sidestep the problem by using `NonNull` which is covariant. In the specical case
+/// of trait objects this is sound (easily checked by adding a `PhantomData<&'a mut Foo + 'a)>` field).
+/// We don't need an explicit Cell type here because we never hand out any refereces
+/// to the trait objects so even without guarding mutable access to the pointer data behind a ``
+/// are covariant over 'a (or in other words it's a raw pointer, as long as we don't hand out
+/// references we are free to do whatever we want).
+struct RawBox<T: ?Sized>(NonNull<T>);
+
+impl<T: ?Sized> RawBox<T> {
+    /// Safety: Only a single mutable reference
+    /// created by this function may exist at a given time.
+    #[allow(clippy::mut_from_ref)]
+    unsafe fn get(&self) -> &mut T {
+        &mut *self.0.as_ptr()
+    }
+}
+impl<T: ?Sized> From<Box<T>> for RawBox<T> {
+    fn from(box_: Box<T>) -> Self {
+        // obviously safe because Box::into_raw never returns null
+        unsafe { Self(NonNull::new_unchecked(Box::into_raw(box_))) }
+    }
+}
+
+impl<T: ?Sized> Drop for RawBox<T> {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.0.as_ptr())) }
+    }
+}
+
 /// Annotations that change that is displayed when the document is render.
 /// Also commonly called virtual text.
-#[derive(Default, Debug, Clone)]
+#[derive(Default)]
 pub struct TextAnnotations<'a> {
     inline_annotations: Vec<Layer<'a, InlineAnnotation, Option<Highlight>>>,
     overlays: Vec<Layer<'a, Overlay, Option<Highlight>>>,
-    line_annotations: Vec<Layer<'a, LineAnnotation, ()>>,
+    line_annotations: Vec<(Cell<usize>, RawBox<dyn LineAnnotation + 'a>)>,
+}
+
+impl Debug for TextAnnotations<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextAnnotations")
+            .field("inline_annotations", &self.inline_annotations)
+            .field("overlays", &self.overlays)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> TextAnnotations<'a> {
@@ -157,9 +294,9 @@ impl<'a> TextAnnotations<'a> {
     pub fn reset_pos(&self, char_idx: usize) {
         reset_pos(&self.inline_annotations, char_idx, |annot| annot.char_idx);
         reset_pos(&self.overlays, char_idx, |annot| annot.char_idx);
-        reset_pos(&self.line_annotations, char_idx, |annot| {
-            annot.anchor_char_idx
-        });
+        for (next_anchor, layer) in &self.line_annotations {
+            next_anchor.set(unsafe { layer.get().reset_pos(char_idx) });
+        }
     }
 
     pub fn collect_overlay_highlights(
@@ -219,8 +356,9 @@ impl<'a> TextAnnotations<'a> {
     ///
     /// The line annotations **must be sorted** by their `char_idx`.
     /// Multiple line annotations with the same `char_idx` **are not allowed**.
-    pub fn add_line_annotation(&mut self, layer: &'a [LineAnnotation]) -> &mut Self {
-        self.line_annotations.push((layer, ()).into());
+    pub fn add_line_annotation(&mut self, layer: Box<dyn LineAnnotation + 'a>) -> &mut Self {
+        self.line_annotations
+            .push((Cell::new(usize::MAX), layer.into()));
         self
     }
 
@@ -250,21 +388,35 @@ impl<'a> TextAnnotations<'a> {
         overlay
     }
 
-    pub(crate) fn annotation_lines_at(&self, char_idx: usize) -> usize {
-        self.line_annotations
-            .iter()
-            .map(|layer| {
-                let mut lines = 0;
-                while let Some(annot) = layer.annotations.get(layer.current_index.get()) {
-                    if annot.anchor_char_idx == char_idx {
-                        layer.current_index.set(layer.current_index.get() + 1);
-                        lines += annot.height
-                    } else {
-                        break;
+    pub(crate) fn process_virtual_text_anchors(&self, grapheme: &FormattedGrapheme) {
+        for (next_anchor, layer) in &self.line_annotations {
+            loop {
+                match next_anchor.get().cmp(&grapheme.char_idx) {
+                    Ordering::Less => next_anchor
+                        .set(unsafe { layer.get().skip_concealed_anchors(grapheme.char_idx) }),
+                    Ordering::Equal => {
+                        next_anchor.set(unsafe { layer.get().process_anchor(grapheme) })
                     }
-                }
-                lines
-            })
-            .sum()
+                    Ordering::Greater => break,
+                };
+            }
+        }
+    }
+
+    pub(crate) fn virtual_lines_at(
+        &self,
+        char_idx: usize,
+        line_end_visual_pos: Position,
+        doc_line: usize,
+    ) -> usize {
+        let mut virt_off = Position::new(0, 0);
+        for (_, layer) in &self.line_annotations {
+            virt_off += unsafe {
+                layer
+                    .get()
+                    .insert_virtual_lines(char_idx, line_end_visual_pos + virt_off, doc_line)
+            };
+        }
+        virt_off.row
     }
 }

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -1,12 +1,11 @@
+use crate::doc_formatter::FormattedGrapheme;
+use crate::syntax::Highlight;
+use crate::{Position, Tendril};
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::ptr::NonNull;
-
-use crate::doc_formatter::FormattedGrapheme;
-use crate::syntax::Highlight;
-use crate::{Position, Tendril};
 
 /// An inline annotation is continuous text shown
 /// on the screen before the grapheme that starts at
@@ -422,5 +421,34 @@ impl<'a> TextAnnotations<'a> {
             };
         }
         virt_off.row
+    }
+}
+
+pub struct CopilotLineAnnotation {
+    doc_line: usize,
+    softwrap: usize,
+}
+
+impl CopilotLineAnnotation {
+    pub fn new(display_pos: Position, softwrap: usize) -> Box<Self> {
+        Box::new(CopilotLineAnnotation {
+            doc_line: display_pos.row,
+            softwrap,
+        })
+    }
+}
+
+impl LineAnnotation for CopilotLineAnnotation {
+    fn insert_virtual_lines(
+        &mut self,
+        _line_end_char_idx: usize,
+        _vertical_off: Position,
+        _doc_line: usize,
+    ) -> Position {
+        if self.doc_line != _doc_line {
+            return Position::new(0, 0);
+        }
+        self.doc_line = usize::MAX;
+        return Position::new(self.softwrap, 0);
     }
 }

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -5,6 +5,8 @@ use crate::{
     Call, Error, LanguageServerId, OffsetEncoding, Result,
 };
 
+use super::copilot_types;
+
 use helix_core::{find_workspace, syntax::LanguageServerFeature, ChangeSet, Rope};
 use helix_loader::VERSION_AND_GIT_HASH;
 use helix_stdx::path;
@@ -1521,6 +1523,19 @@ impl Client {
         })
     }
 
+    pub fn copilot_completion(
+        &self,
+        document: copilot_types::Document,
+    ) -> impl Future<Output = Result<Option<copilot_types::CompletionResponse>>> {
+        let params = copilot_types::CompletionRequestParams { doc: document };
+        let request = self.call::<copilot_types::CompletionRequest>(params);
+
+        async move {
+            let json = request.await?;
+            let response: Option<copilot_types::CompletionResponse> = serde_json::from_value(json)?;
+            Ok(response)
+        }
+    }
     pub fn command(&self, command: lsp::Command) -> Option<impl Future<Output = Result<Value>>> {
         let capabilities = self.capabilities.get().unwrap();
 

--- a/helix-lsp/src/copilot_types.rs
+++ b/helix-lsp/src/copilot_types.rs
@@ -1,0 +1,60 @@
+use lsp_types::{request::Request, Position, Range};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum CompletionRequest {}
+
+#[derive(Serialize, Deserialize)]
+pub struct CompletionRequestParams {
+    pub doc: Document,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Document {
+    pub tab_size: usize,
+    pub insert_spaces: bool,
+    pub path: String,
+    pub indent_size: usize,
+    pub version: u32,
+    pub relative_path: String,
+    pub language_id: String,
+    pub position: Position,
+    pub source: String,
+    pub uri: String,
+}
+
+impl Request for CompletionRequest {
+    type Params = CompletionRequestParams;
+    type Result = Option<CompletionResponse>;
+    const METHOD: &'static str = "getCompletionsCycling";
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompletionResponse {
+    pub completions: Vec<Completion>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Completion {
+    uuid: String,
+    pub range: Range,
+    pub display_text: String,
+    pub position: Position,
+    doc_version: Option<usize>,
+    point: Option<usize>,
+    region: Option<(usize, usize)>,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct DocCompletion {
+    pub text: String,
+    pub lsp_range: Range,
+
+    pub display_text: String,
+    pub display_coords: helix_core::Position,
+    pub additional_softwrap: usize,
+    pub doc_version: usize,
+}

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -1,4 +1,5 @@
 mod client;
+pub mod copilot_types;
 pub mod file_event;
 mod file_operations;
 pub mod jsonrpc;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -290,7 +290,7 @@ impl Application {
         self.compositor.render(area, surface, &mut cx);
         let (pos, kind) = self.compositor.cursor(area, &self.editor);
         // reset cursor cache
-        self.editor.cursor_cache.set(None);
+        self.editor.cursor_cache.reset();
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
         self.terminal.draw(pos, kind).unwrap();

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -771,7 +771,7 @@ impl Application {
                                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
                                         params
                                             .diagnostics
-                                            .sort_unstable_by_key(|d| (d.severity, d.range.start));
+                                            .sort_by_key(|d| (d.severity, d.range.start));
                                     }
                                     for source in &lang_conf.persistent_diagnostic_sources {
                                         let new_diagnostics = params
@@ -812,9 +812,8 @@ impl Application {
 
                         // Sort diagnostics first by severity and then by line numbers.
                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
-                        diagnostics.sort_unstable_by_key(|(d, server_id)| {
-                            (d.severity, d.range.start, *server_id)
-                        });
+                        diagnostics
+                            .sort_by_key(|(d, server_id)| (d.severity, d.range.start, *server_id));
 
                         if let Some(doc) = doc {
                             let diagnostic_of_language_server_and_not_in_unchanged_sources =

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -134,7 +134,7 @@ impl Application {
         let area = terminal.size().expect("couldn't get terminal size");
         let mut compositor = Compositor::new(area);
         let config = Arc::new(ArcSwap::from_pointee(config));
-        let handlers = handlers::setup(config.clone());
+        let handlers = handlers::setup(config.clone(), args.enable_copilot);
         let mut editor = Editor::new(
             area,
             theme_loader.clone(),

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Default)]
 pub struct Args {
+    pub enable_copilot: bool,
     pub display_help: bool,
     pub display_version: bool,
     pub health: bool,
@@ -30,6 +31,7 @@ impl Args {
 
         while let Some(arg) = argv.next() {
             match arg.as_str() {
+                "-a" => args.enable_copilot = true,
                 "--" => break, // stop parsing at this point treat the remaining as files
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6123,16 +6123,16 @@ fn copilot_apply_completion(cx: &mut Context) {
 
 fn copilot_show_completion(cx: &mut Context) {
     let (_, doc) = current!(cx.editor);
-    if let Some(copilot) = doc.copilot.as_mut() {
-        copilot.should_render = true;
-    }
+    doc.copilot.show_completion();
 }
 
 fn copilot_toggle_auto_render(cx: &mut Context) {
-    cx.editor.auto_render_copilot = !cx.editor.auto_render_copilot;
+    let (_, doc) = current!(cx.editor);
+    let auto_render = doc.copilot.toggle_auto_render();
+
     cx.editor.set_status(format!(
         "copilot-auto-render = {}",
-        cx.editor.auto_render_copilot
+        auto_render,
     ));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1688,7 +1688,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     let doc_text = doc.text().slice(..);
     let viewport = view.inner_area(doc);
     let text_fmt = doc.text_format(viewport.width, None);
-    let mut annotations = view.text_annotations(&*doc, None);
+    let annotations = view.text_annotations(&*doc, None);
     (view.offset.anchor, view.offset.vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         view.offset.anchor,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -249,7 +249,9 @@ impl MappableCommand {
 
     #[rustfmt::skip]
     static_commands!(
-        apply_copilot_completion, "Apply a copilot completion",
+        copilot_apply_completion, "Apply a copilot completion",
+        copilot_show_completion, "Show the copilot completion",
+        copilot_toggle_auto_render, "Toggle the automatic rendering of copilot completions",
         no_op, "Do nothing",
         move_char_left, "Move left",
         move_char_right, "Move right",
@@ -6114,9 +6116,24 @@ fn jump_to_label(cx: &mut Context, labels: Vec<Range>, behaviour: Movement) {
     });
 }
 
-fn apply_copilot_completion(cx: &mut Context) {
+fn copilot_apply_completion(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    doc.apply_copilot(view.id);
+    doc.apply_copilot_completion(view.id);
+}
+
+fn copilot_show_completion(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    if let Some(copilot) = doc.copilot.as_mut() {
+        copilot.should_render = true;
+    }
+}
+
+fn copilot_toggle_auto_render(cx: &mut Context) {
+    cx.editor.auto_render_copilot = !cx.editor.auto_render_copilot;
+    cx.editor.set_status(format!(
+        "copilot-auto-render = {}",
+        cx.editor.auto_render_copilot
+    ));
 }
 
 fn jump_to_word(cx: &mut Context, behaviour: Movement) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -249,6 +249,7 @@ impl MappableCommand {
 
     #[rustfmt::skip]
     static_commands!(
+        apply_copilot_completion, "Apply a copilot completion",
         no_op, "Do nothing",
         move_char_left, "Move left",
         move_char_right, "Move right",
@@ -1688,7 +1689,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     let doc_text = doc.text().slice(..);
     let viewport = view.inner_area(doc);
     let text_fmt = doc.text_format(viewport.width, None);
-    let annotations = view.text_annotations(&*doc, None);
+    let mut annotations = view.text_annotations(&*doc, None);
     (view.offset.anchor, view.offset.vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         view.offset.anchor,
@@ -1718,6 +1719,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
                 &mut annotations,
             )
         });
+        drop(annotations);
         doc.set_selection(view.id, selection);
         return;
     }
@@ -6110,6 +6112,11 @@ fn jump_to_label(cx: &mut Context, labels: Vec<Range>, behaviour: Movement) {
             }
         });
     });
+}
+
+fn apply_copilot_completion(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    doc.apply_copilot(view.id);
 }
 
 fn jump_to_word(cx: &mut Context, behaviour: Movement) {

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -7,6 +7,7 @@ use crate::config::Config;
 use crate::events;
 use crate::handlers::auto_save::AutoSaveHandler;
 use crate::handlers::completion::CompletionHandler;
+use crate::handlers::copilot::CopilotHandler;
 use crate::handlers::signature_help::SignatureHelpHandler;
 
 pub use completion::trigger_auto_completion;
@@ -14,23 +15,31 @@ pub use helix_view::handlers::Handlers;
 
 mod auto_save;
 pub mod completion;
+mod copilot;
 mod signature_help;
 
-pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
+pub fn setup(config: Arc<ArcSwap<Config>>, enable_copilot: bool) -> Handlers {
     events::register();
 
     let completions = CompletionHandler::new(config).spawn();
     let signature_hints = SignatureHelpHandler::new().spawn();
     let auto_save = AutoSaveHandler::new().spawn();
+    let copilot = if enable_copilot {
+        Some(CopilotHandler::new().spawn())
+    } else {
+        None
+    };
 
     let handlers = Handlers {
         completions,
         signature_hints,
         auto_save,
+        copilot,
     };
 
     completion::register_hooks(&handlers);
     signature_help::register_hooks(&handlers);
     auto_save::register_hooks(&handlers);
+    copilot::try_register_hooks(&handlers);
     handlers
 }

--- a/helix-term/src/handlers/copilot.rs
+++ b/helix-term/src/handlers/copilot.rs
@@ -1,0 +1,182 @@
+use std::time::Duration;
+use helix_core::{coords_at_pos, softwrapped_dimensions, Rope};
+use helix_event::{
+    cancelable_future, cancelation, register_hook, send_blocking, CancelRx, CancelTx,
+};
+use helix_lsp::copilot_types::DocCompletion;
+use helix_lsp::util::{lsp_pos_to_pos, lsp_range_to_range};
+use helix_view::document::{Copilot, Mode};
+use helix_view::Editor;
+use tokio::time::Instant;
+use crate::events::{OnModeSwitch, PostCommand, PostInsertChar};
+use crate::handlers::Handlers;
+use helix_view::{handlers::lsp::CopilotEvent, DocumentId};
+use crate::job::{dispatch, dispatch_blocking};
+
+pub struct CopilotHandler {
+    doc_id: Option<DocumentId>,
+    cancel: Option<CancelTx>,
+}
+
+impl CopilotHandler {
+    pub fn new() -> Self {
+        Self {
+            doc_id: None,
+            cancel: None,
+        }
+    }
+}
+
+impl helix_event::AsyncHook for CopilotHandler {
+    type Event = CopilotEvent;
+    fn handle_event(
+        &mut self,
+        event: Self::Event,
+        _: Option<Instant>,
+    ) -> Option<Instant> {
+        match event {
+            CopilotEvent::RequestCompletion { doc_id } => {
+                self.doc_id = Some(doc_id);
+                self.cancel.take();
+                Some(Instant::now() + Duration::from_millis(100))
+            }
+            CopilotEvent::CancelInFlightCompletion => {
+                self.cancel.take();
+                None
+            }
+        }
+    }
+
+    fn finish_debounce(&mut self) {
+        let Some(doc_id) = self.doc_id else {return;};
+        let (tx, rx) = cancelation();
+        self.cancel = Some(tx);
+
+        dispatch_blocking(move |editor, _| {
+            copilot_completion(editor, doc_id, rx);
+        });
+    }
+}
+
+fn copilot_completion(editor: &mut Editor, doc_id: DocumentId, cancel: CancelRx) {
+    let (view, doc) = current_ref!(editor);
+    if doc.id() != doc_id {
+        return;
+    }
+
+    let Some(copilot_ls) = doc
+        .language_servers()
+        .filter(|ls| ls.name() == "copilot")
+        .next()
+    else { return; };
+    let offset_encoding = copilot_ls.offset_encoding();
+
+    let copilot_future = if let Some(copilot_doc) = doc.copilot_document(view.id, offset_encoding) {
+        copilot_ls.copilot_completion(copilot_doc)
+    } else {
+        return;
+    };
+
+    tokio::spawn(async move {
+        if let Some(item) = cancelable_future(copilot_future, cancel).await {
+            if let Ok(Some(completion_reponse)) = item {
+                dispatch(move |editor, _| {
+                    let completions = if completion_reponse.completions.len() > 0 {
+                        completion_reponse.completions
+                    } else {
+                        return;
+                    };
+
+                    let (view, doc) = current!(editor);
+                    let doc_completion = completions
+                        .into_iter()
+                        .filter_map(|completion| {
+                            /*
+                            NOTE:
+                            The computation below is neccesary because:
+
+                            1. If we're typing the string ' let x = Vec::From(*);' where * is cursor position, copilot will sometimes respond with the
+                            completion '[1,2,3]' where '[1,2,3]' is to be inserted between the two brackets. It will not give any other information about 
+                            the first line. In this case, we cannot only render the virtual text '[1,2,3]' (rendering virtual text has no effect on the position 
+                            of the doc's non-virtual text (it will not cause ');' to move rightwards).
+                            Hence we need to calculate what the whole first line will look like post applying copilot's completion.
+
+                            2. We also need to calculate what the whole first line will look like post applying the completion in order to calculate the number of 
+                            additional lines needed for first line's softwrap. Eg ' let x = String::From(*);' may not require softwrapping, but 
+                            ' let x = String::From([1,2,3]);'  may do. 
+
+                            The remaining additional lines that copilot may insert will not be interleaved with the doc's text, so the above problems are only relevant 
+                            to the completion's first line
+                            */
+                            let txt_fmt = doc.text_format(view.inner_width(&doc), None);
+
+                            let Some(range) = lsp_range_to_range(doc.text(), completion.range, offset_encoding) else {return None;};
+                            let (start_coords, end_coords) = (coords_at_pos(doc.text().slice(..).into(), range.anchor), coords_at_pos(doc.text().slice(..).into(), range.head));
+
+                            let display_pos =
+                                lsp_pos_to_pos(doc.text(), completion.position, offset_encoding)?;
+                            let display_coords =
+                                coords_at_pos(doc.text().slice(..).into(), display_pos);
+
+                            let line_idx = doc.text().char_to_line(display_pos);
+                            let mut line_rope = Rope::from(doc.text().get_line(line_idx)?);
+                            let pre_insert_softwrap =
+                                softwrapped_dimensions(line_rope.slice(..), &txt_fmt).0;
+
+                            line_rope.remove(start_coords.col..end_coords.col);
+                            line_rope.insert(start_coords.col, &completion.text);
+                            let post_insert_softwrap =
+                                softwrapped_dimensions(line_rope.slice(..), &txt_fmt).0;
+                            
+                            Some(DocCompletion {
+                                text: completion.text,
+                                lsp_range: completion.range,
+                                display_text: line_rope.to_string(),
+                                display_coords,
+                                additional_softwrap: post_insert_softwrap - pre_insert_softwrap,
+                                doc_version: doc.version() as usize,
+                            })
+                        })
+                        .collect::<Vec<DocCompletion>>();
+
+                    doc.copilot = Some(Copilot {
+                        completions: doc_completion,
+                        idx: 0,
+                        offset_encoding,
+                    });
+                })
+                .await;
+            }
+        }
+    });
+}
+
+pub(super) fn try_register_hooks(handlers: &Handlers) {
+    let Some(copilot_handler) = handlers.copilot.clone() else {return;};
+
+    register_hook!(move |event: &mut PostCommand<'_, '_>| {
+        let (_, doc) = current!(event.cx.editor);
+        doc.clear_copilot_completions();
+        Ok(())
+    });
+
+    let tx = copilot_handler.clone();
+    register_hook!(move |event: &mut OnModeSwitch<'_, '_>| {
+        let (_, doc) = current!(event.cx.editor);
+        doc.clear_copilot_completions();
+        if event.old_mode == Mode::Insert {
+            send_blocking(&tx, CopilotEvent::CancelInFlightCompletion);
+        } else if event.new_mode == Mode::Insert {
+            send_blocking(&tx, CopilotEvent::RequestCompletion { doc_id: doc.id() });
+        }
+        Ok(())
+    });
+
+    let tx = copilot_handler.clone();
+    register_hook!(move |event: &mut PostInsertChar<'_, '_>| {
+        let (_, doc) = current!(event.cx.editor);
+        doc.clear_copilot_completions();
+        send_blocking(&tx, CopilotEvent::RequestCompletion { doc_id: doc.id() });
+        Ok(())
+    });
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -80,6 +80,7 @@ FLAGS:
 
     helix_loader::initialize_config_file(args.config_file.clone());
     helix_loader::initialize_log_file(args.log_file.clone());
+    helix_core::config::initialize_enable_copilot(args.enable_copilot);
 
     // Help has a higher priority and should be handled separately.
     if args.display_help {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -448,14 +448,10 @@ impl Component for Completion {
         // ---
         // option.documentation
 
-        let (view, doc) = current!(cx.editor);
-        let language = doc.language_name().unwrap_or("");
-        let text = doc.text().slice(..);
-        let cursor_pos = doc.selection(view.id).primary().cursor(text);
-        let coords = view
-            .screen_coords_at_pos(doc, text, cursor_pos)
-            .expect("cursor must be in view");
+        let Some(coords) = cx.editor.cursor().0 else { return };
         let cursor_pos = coords.row as u16;
+        let (_, doc) = current!(cx.editor);
+        let language = doc.language_name().unwrap_or("");
 
         let markdowned = |lang: &str, detail: Option<&str>, doc: Option<&str>| {
             let md = match (detail, doc) {

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -182,21 +182,18 @@ pub fn render_text<'t>(
     line_decorations: &mut [Box<dyn LineDecoration + '_>],
     translated_positions: &mut [TranslatedPosition],
 ) {
-    let (
-        Position {
-            row: mut row_off, ..
-        },
-        mut char_pos,
-    ) = visual_offset_from_block(
+    let mut row_off = visual_offset_from_block(
         text,
         offset.anchor,
         offset.anchor,
         text_fmt,
         text_annotations,
-    );
+    )
+    .0
+    .row;
     row_off += offset.vertical_offset;
 
-    let (mut formatter, mut first_visible_char_idx) =
+    let mut formatter =
         DocumentFormatter::new_at_prev_checkpoint(text, text_fmt, text_annotations, offset.anchor);
     let mut syntax_styles = StyleIter {
         text_style: renderer.text_style,
@@ -229,19 +226,19 @@ pub fn render_text<'t>(
     let mut overlay_style_span = overlay_styles
         .next()
         .unwrap_or_else(|| (Style::default(), usize::MAX));
+    let mut first_visible_char_idx = formatter.next_char_pos();
 
     loop {
         // formattter.line_pos returns to line index of the next grapheme
         // so it must be called before formatter.next
-        let doc_line = formatter.line_pos();
-        let Some((grapheme, mut pos)) = formatter.next() else {
-            let mut last_pos = formatter.visual_pos();
+        let Some(mut grapheme) = formatter.next() else {
+            let mut last_pos = formatter.next_visual_pos();
             if last_pos.row >= row_off {
                 last_pos.col -= 1;
                 last_pos.row -= row_off;
                 // check if any positions translated on the fly (like cursor) are at the EOF
                 translate_positions(
-                    char_pos + 1,
+                    text.len_chars() + 1,
                     first_visible_char_idx,
                     translated_positions,
                     text_fmt,
@@ -253,46 +250,56 @@ pub fn render_text<'t>(
         };
 
         // skip any graphemes on visual lines before the block start
-        if pos.row < row_off {
-            if char_pos >= syntax_style_span.1 {
-                syntax_style_span = if let Some(syntax_style_span) = syntax_styles.next() {
-                    syntax_style_span
+        // if pos.row < row_off {
+        //     if char_pos >= syntax_style_span.1 {
+        //         syntax_style_span = if let Some(syntax_style_span) = syntax_styles.next() {
+        //             syntax_style_span
+        //         } else {
+        //             break;
+        //         }
+        //     }
+        //     if char_pos >= overlay_style_span.1 {
+        //         overlay_style_span = if let Some(overlay_style_span) = overlay_styles.next() {
+        //             overlay_style_span
+        if grapheme.visual_pos.row < row_off {
+            if grapheme.char_idx >= style_span.1 {
+                style_span = if let Some(style_span) = styles.next() {
+                    style_span
                 } else {
                     break;
-                }
-            }
-            if char_pos >= overlay_style_span.1 {
-                overlay_style_span = if let Some(overlay_style_span) = overlay_styles.next() {
-                    overlay_style_span
+                };    
+                overlay_span = if let Some(overlay_span) = overlays.next() {
+                    overlay_span
                 } else {
                     break;
-                }
+                };
             }
-            char_pos += grapheme.doc_chars();
-            first_visible_char_idx = char_pos + 1;
+            first_visible_char_idx = formatter.next_char_pos();
             continue;
         }
-        pos.row -= row_off;
+        grapheme.visual_pos.row -= row_off;
 
         // if the end of the viewport is reached stop rendering
-        if pos.row as u16 >= renderer.viewport.height {
+        if grapheme.visual_pos.row as u16 >= renderer.viewport.height + renderer.offset.row as u16 {
             break;
         }
 
         // apply decorations before rendering a new line
-        if pos.row as u16 != last_line_pos.visual_line {
-            if pos.row > 0 {
-                renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
+        if grapheme.visual_pos.row as u16 != last_line_pos.visual_line {
+            if grapheme.visual_pos.row > 0 {
+                // draw indent guides for the last line
+                renderer
+                    .draw_indent_guides(last_line_indent_level, last_line_pos.visual_line as u16);
                 is_in_indent_area = true;
                 for line_decoration in &mut *line_decorations {
-                    line_decoration.render_foreground(renderer, last_line_pos, char_pos);
+                    line_decoration.render_foreground(renderer, last_line_pos, grapheme.char_idx);
                 }
             }
             last_line_pos = LinePos {
-                first_visual_line: doc_line != last_line_pos.doc_line,
-                doc_line,
-                visual_line: pos.row as u16,
-                start_char_idx: char_pos,
+                first_visual_line: grapheme.line_idx != last_line_pos.doc_line,
+                doc_line: grapheme.line_idx,
+                visual_line: grapheme.visual_pos.row as u16,
+                start_char_idx: grapheme.char_idx,
             };
             for line_decoration in &mut *line_decorations {
                 line_decoration.render_background(renderer, last_line_pos);
@@ -300,26 +307,25 @@ pub fn render_text<'t>(
         }
 
         // acquire the correct grapheme style
-        while char_pos >= syntax_style_span.1 {
+        while  grapheme.char_idx >= syntax_style_span.1 {
             syntax_style_span = syntax_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
-        while char_pos >= overlay_style_span.1 {
+        while  grapheme.char_idx >= overlay_style_span.1 {
             overlay_style_span = overlay_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
-        char_pos += grapheme.doc_chars();
 
         // check if any positions translated on the fly (like cursor) has been reached
         translate_positions(
-            char_pos,
+            formatter.next_char_pos(),
             first_visible_char_idx,
             translated_positions,
             text_fmt,
             renderer,
-            pos,
+            grapheme.visual_pos,
         );
 
         let (syntax_style, overlay_style) =
@@ -335,27 +341,37 @@ pub fn render_text<'t>(
 
         let is_virtual = grapheme.is_virtual();
         renderer.draw_grapheme(
+<<<<<<< HEAD
             grapheme.grapheme,
             GraphemeStyle {
                 syntax_style,
                 overlay_style,
             },
             is_virtual,
+||||||| parent of 5e32edd8 (track char_idx in DocFormatter)
+            grapheme.grapheme,
+            grapheme_style,
+            virt,
+=======
+            grapheme.raw,
+            grapheme_style,
+            virt,
+>>>>>>> 5e32edd8 (track char_idx in DocFormatter)
             &mut last_line_indent_level,
             &mut is_in_indent_area,
-            pos,
+            grapheme.visual_pos,
         );
     }
 
     renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
     for line_decoration in &mut *line_decorations {
-        line_decoration.render_foreground(renderer, last_line_pos, char_pos);
+        line_decoration.render_foreground(renderer, last_line_pos, formatter.next_char_pos());
     }
 }
 
 #[derive(Debug)]
 pub struct TextRenderer<'a> {
-    pub surface: &'a mut Surface,
+    surface: &'a mut Surface,
     pub text_style: Style,
     pub whitespace_style: Style,
     pub indent_guide_char: String,

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -117,7 +117,7 @@ pub fn render_document(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn render_text<'t>(
+pub fn render_text(
     renderer: &mut TextRenderer,
     text: RopeSlice<'_>,
     anchor: usize,
@@ -348,6 +348,46 @@ impl<'a> TextRenderer<'a> {
             viewport,
             offset,
         }
+    }
+    /// Draws a single `grapheme` at the current render position with a specified `style`.
+    pub fn draw_decoration_grapheme(
+        &mut self,
+        grapheme: Grapheme,
+        mut style: Style,
+        mut row: u16,
+        col: u16,
+    ) -> bool {
+        if (row as usize) < self.offset.row
+            || row >= self.viewport.height
+            || col >= self.viewport.width
+        {
+            return false;
+        }
+        row -= self.offset.row as u16;
+        let is_whitespace = grapheme.is_whitespace();
+
+        // TODO is it correct to apply the whitspace style to all unicode white spaces?
+        if is_whitespace {
+            style = style.patch(self.whitespace_style);
+        }
+
+        let grapheme = match grapheme {
+            Grapheme::Tab { width } => {
+                let grapheme_tab_width = char_to_byte_idx(&self.virtual_tab, width);
+                &self.virtual_tab[..grapheme_tab_width]
+            }
+            Grapheme::Other { ref g } if g == "\u{00A0}" => " ",
+            Grapheme::Other { ref g } => g,
+            Grapheme::Newline => " ",
+        };
+
+        self.surface.set_string(
+            self.viewport.x + col,
+            self.viewport.y + row,
+            grapheme,
+            style,
+        );
+        true
     }
 
     /// Draws a single `grapheme` at the current render position with a specified `style`.

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -300,12 +300,12 @@ pub fn render_text<'t>(
         }
 
         // acquire the correct grapheme style
-        if char_pos >= syntax_style_span.1 {
+        while char_pos >= syntax_style_span.1 {
             syntax_style_span = syntax_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
-        if char_pos >= overlay_style_span.1 {
+        while char_pos >= overlay_style_span.1 {
             overlay_style_span = overlay_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -12,26 +12,10 @@ use helix_view::editor::{WhitespaceConfig, WhitespaceRenderValue};
 use helix_view::graphics::Rect;
 use helix_view::theme::Style;
 use helix_view::view::ViewPosition;
-use helix_view::Document;
-use helix_view::Theme;
+use helix_view::{Document, Theme};
 use tui::buffer::Buffer as Surface;
 
-pub trait LineDecoration {
-    fn render_background(&mut self, _renderer: &mut TextRenderer, _pos: LinePos) {}
-    fn render_foreground(
-        &mut self,
-        _renderer: &mut TextRenderer,
-        _pos: LinePos,
-        _end_char_idx: usize,
-    ) {
-    }
-}
-
-impl<F: FnMut(&mut TextRenderer, LinePos)> LineDecoration for F {
-    fn render_background(&mut self, renderer: &mut TextRenderer, pos: LinePos) {
-        self(renderer, pos)
-    }
-}
+use crate::ui::text_decorations::DecorationManager;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum StyleIterKind {
@@ -98,14 +82,7 @@ pub struct LinePos {
     pub doc_line: usize,
     /// Vertical offset from the top of the inner view area
     pub visual_line: u16,
-    /// The first char index of this visual line.
-    /// Note that if the visual line is entirely filled by
-    /// a very long inline virtual text then this index will point
-    /// at the next (non-virtual) char after this visual line
-    pub start_char_idx: usize,
 }
-
-pub type TranslatedPosition<'a> = (usize, Box<dyn FnMut(&mut TextRenderer, Position) + 'a>);
 
 #[allow(clippy::too_many_arguments)]
 pub fn render_document(
@@ -117,84 +94,46 @@ pub fn render_document(
     syntax_highlight_iter: impl Iterator<Item = HighlightEvent>,
     overlay_highlight_iter: impl Iterator<Item = HighlightEvent>,
     theme: &Theme,
-    line_decoration: &mut [Box<dyn LineDecoration + '_>],
-    translated_positions: &mut [TranslatedPosition],
+    decorations: DecorationManager,
 ) {
-    let mut renderer = TextRenderer::new(surface, doc, theme, offset.horizontal_offset, viewport);
+    let mut renderer = TextRenderer::new(
+        surface,
+        doc,
+        theme,
+        Position::new(offset.vertical_offset, offset.horizontal_offset),
+        viewport,
+    );
     render_text(
         &mut renderer,
         doc.text().slice(..),
-        offset,
+        offset.anchor,
         &doc.text_format(viewport.width, Some(theme)),
         doc_annotations,
         syntax_highlight_iter,
         overlay_highlight_iter,
         theme,
-        line_decoration,
-        translated_positions,
+        decorations,
     )
-}
-
-fn translate_positions(
-    char_pos: usize,
-    first_visible_char_idx: usize,
-    translated_positions: &mut [TranslatedPosition],
-    text_fmt: &TextFormat,
-    renderer: &mut TextRenderer,
-    pos: Position,
-) {
-    // check if any positions translated on the fly (like cursor) has been reached
-    for (char_idx, callback) in &mut *translated_positions {
-        if *char_idx < char_pos && *char_idx >= first_visible_char_idx {
-            // by replacing the char_index with usize::MAX large number we ensure
-            // that the same position is only translated once
-            // text will never reach usize::MAX as rust memory allocations are limited
-            // to isize::MAX
-            *char_idx = usize::MAX;
-
-            if text_fmt.soft_wrap {
-                callback(renderer, pos)
-            } else if pos.col >= renderer.col_offset
-                && pos.col - renderer.col_offset < renderer.viewport.width as usize
-            {
-                callback(
-                    renderer,
-                    Position {
-                        row: pos.row,
-                        col: pos.col - renderer.col_offset,
-                    },
-                )
-            }
-        }
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn render_text<'t>(
     renderer: &mut TextRenderer,
-    text: RopeSlice<'t>,
-    offset: ViewPosition,
+    text: RopeSlice<'_>,
+    anchor: usize,
     text_fmt: &TextFormat,
     text_annotations: &TextAnnotations,
     syntax_highlight_iter: impl Iterator<Item = HighlightEvent>,
     overlay_highlight_iter: impl Iterator<Item = HighlightEvent>,
     theme: &Theme,
-    line_decorations: &mut [Box<dyn LineDecoration + '_>],
-    translated_positions: &mut [TranslatedPosition],
+    mut decorations: DecorationManager,
 ) {
-    let mut row_off = visual_offset_from_block(
-        text,
-        offset.anchor,
-        offset.anchor,
-        text_fmt,
-        text_annotations,
-    )
-    .0
-    .row;
-    row_off += offset.vertical_offset;
+    let row_off = visual_offset_from_block(text, anchor, anchor, text_fmt, text_annotations)
+        .0
+        .row;
 
     let mut formatter =
-        DocumentFormatter::new_at_prev_checkpoint(text, text_fmt, text_annotations, offset.anchor);
+        DocumentFormatter::new_at_prev_checkpoint(text, text_fmt, text_annotations, anchor);
     let mut syntax_styles = StyleIter {
         text_style: renderer.text_style,
         active_highlights: Vec::with_capacity(64),
@@ -216,8 +155,8 @@ pub fn render_text<'t>(
         first_visual_line: false,
         doc_line: usize::MAX,
         visual_line: u16::MAX,
-        start_char_idx: usize::MAX,
     };
+    let mut last_line_end = 0;
     let mut is_in_indent_area = true;
     let mut last_line_indent_level = 0;
     let mut syntax_style_span = syntax_styles
@@ -226,58 +165,20 @@ pub fn render_text<'t>(
     let mut overlay_style_span = overlay_styles
         .next()
         .unwrap_or_else(|| (Style::default(), usize::MAX));
-    let mut first_visible_char_idx = formatter.next_char_pos();
+    let mut reached_view_top = false;
 
     loop {
-        // formattter.line_pos returns to line index of the next grapheme
-        // so it must be called before formatter.next
-        let Some(mut grapheme) = formatter.next() else {
-            let mut last_pos = formatter.next_visual_pos();
-            if last_pos.row >= row_off {
-                last_pos.col -= 1;
-                last_pos.row -= row_off;
-                // check if any positions translated on the fly (like cursor) are at the EOF
-                translate_positions(
-                    text.len_chars() + 1,
-                    first_visible_char_idx,
-                    translated_positions,
-                    text_fmt,
-                    renderer,
-                    last_pos,
-                );
-            }
-            break;
-        };
+        let Some(mut grapheme) = formatter.next() else { break };
 
         // skip any graphemes on visual lines before the block start
-        // if pos.row < row_off {
-        //     if char_pos >= syntax_style_span.1 {
-        //         syntax_style_span = if let Some(syntax_style_span) = syntax_styles.next() {
-        //             syntax_style_span
-        //         } else {
-        //             break;
-        //         }
-        //     }
-        //     if char_pos >= overlay_style_span.1 {
-        //         overlay_style_span = if let Some(overlay_style_span) = overlay_styles.next() {
-        //             overlay_style_span
         if grapheme.visual_pos.row < row_off {
-            if grapheme.char_idx >= style_span.1 {
-                style_span = if let Some(style_span) = styles.next() {
-                    style_span
-                } else {
-                    break;
-                };    
-                overlay_span = if let Some(overlay_span) = overlays.next() {
-                    overlay_span
-                } else {
-                    break;
-                };
-            }
-            first_visible_char_idx = formatter.next_char_pos();
             continue;
         }
         grapheme.visual_pos.row -= row_off;
+        if !reached_view_top {
+            decorations.prepare_for_rendering(grapheme.char_idx);
+            reached_view_top = true;
+        }
 
         // if the end of the viewport is reached stop rendering
         if grapheme.visual_pos.row as u16 >= renderer.viewport.height + renderer.offset.row as u16 {
@@ -286,87 +187,67 @@ pub fn render_text<'t>(
 
         // apply decorations before rendering a new line
         if grapheme.visual_pos.row as u16 != last_line_pos.visual_line {
-            if grapheme.visual_pos.row > 0 {
+            // we initiate doc_line with usize::MAX because no file
+            // can reach that size (memory allocations are limited to isize::MAX)
+            // initially there is no "previous" line (so doc_line is set to usize::MAX)
+            // in that case we don't need to draw indent guides/virtual text
+            if last_line_pos.doc_line != usize::MAX {
                 // draw indent guides for the last line
-                renderer
-                    .draw_indent_guides(last_line_indent_level, last_line_pos.visual_line as u16);
+                renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
                 is_in_indent_area = true;
-                for line_decoration in &mut *line_decorations {
-                    line_decoration.render_foreground(renderer, last_line_pos, grapheme.char_idx);
-                }
+                decorations.render_virtual_lines(renderer, last_line_pos, last_line_end)
             }
             last_line_pos = LinePos {
                 first_visual_line: grapheme.line_idx != last_line_pos.doc_line,
                 doc_line: grapheme.line_idx,
                 visual_line: grapheme.visual_pos.row as u16,
-                start_char_idx: grapheme.char_idx,
             };
-            for line_decoration in &mut *line_decorations {
-                line_decoration.render_background(renderer, last_line_pos);
-            }
+            decorations.decorate_line(renderer, last_line_pos);
         }
 
         // acquire the correct grapheme style
-        while  grapheme.char_idx >= syntax_style_span.1 {
+        while grapheme.char_idx >= syntax_style_span.1 {
             syntax_style_span = syntax_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
-        while  grapheme.char_idx >= overlay_style_span.1 {
+        while grapheme.char_idx >= overlay_style_span.1 {
             overlay_style_span = overlay_styles
                 .next()
                 .unwrap_or((Style::default(), usize::MAX));
         }
 
-        // check if any positions translated on the fly (like cursor) has been reached
-        translate_positions(
-            formatter.next_char_pos(),
-            first_visible_char_idx,
-            translated_positions,
-            text_fmt,
-            renderer,
-            grapheme.visual_pos,
-        );
-
-        let (syntax_style, overlay_style) =
-            if let GraphemeSource::VirtualText { highlight } = grapheme.source {
-                let mut style = renderer.text_style;
-                if let Some(highlight) = highlight {
-                    style = style.patch(theme.highlight(highlight.0))
-                }
-                (style, Style::default())
-            } else {
-                (syntax_style_span.0, overlay_style_span.0)
-            };
-
-        let is_virtual = grapheme.is_virtual();
-        renderer.draw_grapheme(
-<<<<<<< HEAD
-            grapheme.grapheme,
+        let grapheme_style = if let GraphemeSource::VirtualText { highlight } = grapheme.source {
+            let mut style = renderer.text_style;
+            if let Some(highlight) = highlight {
+                style = style.patch(theme.highlight(highlight.0));
+            }
             GraphemeStyle {
-                syntax_style,
-                overlay_style,
-            },
-            is_virtual,
-||||||| parent of 5e32edd8 (track char_idx in DocFormatter)
-            grapheme.grapheme,
-            grapheme_style,
-            virt,
-=======
+                syntax_style: style,
+                overlay_style: Style::default(),
+            }
+        } else {
+            GraphemeStyle {
+                syntax_style: syntax_style_span.0,
+                overlay_style: overlay_style_span.0,
+            }
+        };
+        decorations.decorate_grapheme(renderer, &grapheme);
+
+        let virt = grapheme.is_virtual();
+        let grapheme_width = renderer.draw_grapheme(
             grapheme.raw,
             grapheme_style,
             virt,
->>>>>>> 5e32edd8 (track char_idx in DocFormatter)
             &mut last_line_indent_level,
             &mut is_in_indent_area,
             grapheme.visual_pos,
         );
+        last_line_end = grapheme.visual_pos.col + grapheme_width;
     }
 
     renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
-    for line_decoration in &mut *line_decorations {
-        line_decoration.render_foreground(renderer, last_line_pos, formatter.next_char_pos());
-    }
+    decorations.render_virtual_lines(renderer, last_line_pos, last_line_end)
 }
 
 #[derive(Debug)]
@@ -385,8 +266,8 @@ pub struct TextRenderer<'a> {
     pub indent_width: u16,
     pub starting_indent: usize,
     pub draw_indent_guides: bool,
-    pub col_offset: usize,
     pub viewport: Rect,
+    pub offset: Position,
 }
 
 pub struct GraphemeStyle {
@@ -399,7 +280,7 @@ impl<'a> TextRenderer<'a> {
         surface: &'a mut Surface,
         doc: &Document,
         theme: &Theme,
-        col_offset: usize,
+        offset: Position,
         viewport: Rect,
     ) -> TextRenderer<'a> {
         let editor_config = doc.config.load();
@@ -454,8 +335,8 @@ impl<'a> TextRenderer<'a> {
             virtual_tab,
             whitespace_style: theme.get("ui.virtual.whitespace"),
             indent_width,
-            starting_indent: col_offset / indent_width as usize
-                + (col_offset % indent_width as usize != 0) as usize
+            starting_indent: offset.col / indent_width as usize
+                + (offset.col % indent_width as usize != 0) as usize
                 + editor_config.indent_guides.skip_levels as usize,
             indent_guide_style: text_style.patch(
                 theme
@@ -465,7 +346,7 @@ impl<'a> TextRenderer<'a> {
             text_style,
             draw_indent_guides: editor_config.indent_guides.render,
             viewport,
-            col_offset,
+            offset,
         }
     }
 
@@ -477,9 +358,13 @@ impl<'a> TextRenderer<'a> {
         is_virtual: bool,
         last_indent_level: &mut usize,
         is_in_indent_area: &mut bool,
-        position: Position,
-    ) {
-        let cut_off_start = self.col_offset.saturating_sub(position.col);
+        mut position: Position,
+    ) -> usize {
+        if position.row < self.offset.row {
+            return 0;
+        }
+        position.row -= self.offset.row;
+        let cut_off_start = self.offset.col.saturating_sub(position.col);
         let is_whitespace = grapheme.is_whitespace();
 
         // TODO is it correct to apply the whitespace style to all unicode white spaces?
@@ -511,12 +396,11 @@ impl<'a> TextRenderer<'a> {
             Grapheme::Newline => &self.newline,
         };
 
-        let in_bounds = self.col_offset <= position.col
-            && position.col < self.viewport.width as usize + self.col_offset;
+        let in_bounds = self.column_in_bounds(position.col + width - 1);
 
         if in_bounds {
             self.surface.set_string(
-                self.viewport.x + (position.col - self.col_offset) as u16,
+                self.viewport.x + (position.col - self.offset.col) as u16,
                 self.viewport.y + position.row as u16,
                 grapheme,
                 style,
@@ -536,31 +420,96 @@ impl<'a> TextRenderer<'a> {
             *last_indent_level = position.col;
             *is_in_indent_area = false;
         }
+
+        width
+    }
+
+    pub fn column_in_bounds(&self, colum: usize) -> bool {
+        self.offset.col <= colum && colum < self.viewport.width as usize + self.offset.col
     }
 
     /// Overlay indentation guides ontop of a rendered line
     /// The indentation level is computed in `draw_lines`.
     /// Therefore this function must always be called afterwards.
-    pub fn draw_indent_guides(&mut self, indent_level: usize, row: u16) {
-        if !self.draw_indent_guides {
+    pub fn draw_indent_guides(&mut self, indent_level: usize, mut row: u16) {
+        if !self.draw_indent_guides || self.offset.row > row as usize {
             return;
         }
+        row -= self.offset.row as u16;
 
         // Don't draw indent guides outside of view
         let end_indent = min(
             indent_level,
             // Add indent_width - 1 to round up, since the first visible
             // indent might be a bit after offset.col
-            self.col_offset + self.viewport.width as usize + (self.indent_width as usize - 1),
+            self.offset.col + self.viewport.width as usize + (self.indent_width as usize - 1),
         ) / self.indent_width as usize;
 
         for i in self.starting_indent..end_indent {
-            let x = (self.viewport.x as usize + (i * self.indent_width as usize) - self.col_offset)
+            let x = (self.viewport.x as usize + (i * self.indent_width as usize) - self.offset.col)
                 as u16;
             let y = self.viewport.y + row;
             debug_assert!(self.surface.in_bounds(x, y));
             self.surface
                 .set_string(x, y, &self.indent_guide_char, self.indent_guide_style);
         }
+    }
+
+    pub fn set_string(&mut self, x: u16, y: u16, string: impl AsRef<str>, style: Style) {
+        if (y as usize) < self.offset.row {
+            return;
+        }
+        self.surface
+            .set_string(x, y + self.viewport.y, string, style)
+    }
+
+    pub fn set_stringn(
+        &mut self,
+        x: u16,
+        y: u16,
+        string: impl AsRef<str>,
+        width: usize,
+        style: Style,
+    ) {
+        if (y as usize) < self.offset.row {
+            return;
+        }
+        self.surface
+            .set_stringn(x, y + self.viewport.y, string, width, style);
+    }
+
+    /// Sets the style of an area **within the text viewport* this accounts
+    /// both for the renderers vertical offset and its viewport
+    pub fn set_style(&mut self, mut area: Rect, style: Style) {
+        area = area.clip_top(self.offset.row as u16);
+        area.y += self.viewport.y;
+        self.surface.set_style(area, style);
+    }
+
+    /// Sets the style of an area **within the text viewport* this accounts
+    /// both for the renderers vertical offset and its viewport
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_string_truncated(
+        &mut self,
+        x: u16,
+        y: u16,
+        string: &str,
+        width: usize,
+        style: impl Fn(usize) -> Style, // Map a grapheme's string offset to a style
+        ellipsis: bool,
+        truncate_start: bool,
+    ) -> (u16, u16) {
+        if (y as usize) < self.offset.row {
+            return (x, y);
+        }
+        self.surface.set_string_truncated(
+            x,
+            y + self.viewport.y,
+            string,
+            width,
+            style,
+            ellipsis,
+            truncate_start,
+        )
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -185,6 +185,12 @@ impl EditorView {
                 primary_cursor,
             });
         }
+        decorations.add_decoration(InlineDiagnostics::new(
+            doc,
+            theme,
+            primary_cursor,
+            config.lsp.inline_diagnostics.clone(),
+        ));
         render_document(
             surface,
             inner,
@@ -210,7 +216,9 @@ impl EditorView {
             }
         }
 
-        Self::render_diagnostics(doc, view, inner, surface, theme);
+        if config.lsp.display_diagnostic_message {
+            Self::render_diagnostics(doc, view, inner, surface, theme);
+        }
 
         let statusline_area = view
             .area

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -27,11 +27,12 @@ use helix_view::{
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
-    Document, Editor, Theme, View,
+    view, Document, Editor, Theme, View,
 };
 use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
+use super::text_decorations::CopilotDecoration;
 
 pub struct EditorView {
     pub keymaps: Keymaps,
@@ -185,12 +186,22 @@ impl EditorView {
                 primary_cursor,
             });
         }
-        decorations.add_decoration(InlineDiagnostics::new(
+
+        decorations.add_decoration(CopilotDecoration::new(
             doc,
-            theme,
-            primary_cursor,
-            config.lsp.inline_diagnostics.clone(),
+            doc.text_format(view.inner_width(doc), Some(&editor.theme)),
+            theme.get("ui.get.focused"),
         ));
+
+        if config.lsp.inline_diagnostics.enabled {
+            decorations.add_decoration(InlineDiagnostics::new(
+                doc,
+                theme,
+                primary_cursor,
+                config.lsp.inline_diagnostics.clone(),
+            ));
+        }
+
         render_document(
             surface,
             inner,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -12,6 +12,7 @@ mod prompt;
 mod spinner;
 mod statusline;
 mod text;
+mod text_decorations;
 
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -6,7 +6,8 @@ use crate::{
     key, shift,
     ui::{
         self,
-        document::{render_document, LineDecoration, LinePos, TextRenderer},
+        document::{render_document, LinePos, TextRenderer},
+        text_decorations::DecorationManager,
         EditorView,
     },
 };
@@ -759,7 +760,7 @@ impl<T: Item + 'static> Picker<T> {
                 }
                 overlay_highlights = Box::new(helix_core::syntax::merge(overlay_highlights, spans));
             }
-            let mut decorations: Vec<Box<dyn LineDecoration>> = Vec::new();
+            let mut decorations = DecorationManager::default();
 
             if let Some((start, end)) = range {
                 let style = cx
@@ -771,14 +772,14 @@ impl<T: Item + 'static> Picker<T> {
                     if (start..=end).contains(&pos.doc_line) {
                         let area = Rect::new(
                             renderer.viewport.x,
-                            renderer.viewport.y + pos.visual_line,
+                            pos.visual_line,
                             renderer.viewport.width,
                             1,
                         );
-                        renderer.surface.set_style(area, style)
+                        renderer.set_style(area, style)
                     }
                 };
-                decorations.push(Box::new(draw_highlight))
+                decorations.add_decoration(draw_highlight);
             }
 
             render_document(
@@ -791,8 +792,7 @@ impl<T: Item + 'static> Picker<T> {
                 syntax_highlights,
                 overlay_highlights,
                 &cx.editor.theme,
-                &mut decorations,
-                &mut [],
+                decorations,
             );
         }
     }

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -46,7 +46,7 @@ impl<T: Component> Popup<T> {
         Self {
             contents,
             position: None,
-            position_bias: Open::Below,
+            position_bias: Open::Above,
             area: Rect::new(0, 0, 0, 0),
             scroll_half_pages: 0,
             auto_close: false,

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -1,0 +1,173 @@
+use std::cmp::Ordering;
+
+use helix_core::doc_formatter::FormattedGrapheme;
+use helix_core::Position;
+use helix_view::editor::CursorCache;
+
+use crate::ui::document::{LinePos, TextRenderer};
+
+pub use diagnostics::InlineDiagnostics;
+
+mod diagnostics;
+
+/// Decorations are the primary mechanisim for extending the text rendering.
+///
+/// Any on-screen element which is anchored to the rendered text in some form should
+/// be implemented using this trait. Translating char positions to
+/// on-screen positions can be expensive and should not be done during rendering.
+/// Instead such translations are performed on the fly while the text is being rendered.
+/// The results are provided to this trait
+///
+/// To reserve space for virtual text lines (which is then filled by this trait) emit appropriate
+/// [`LineAnnotation`](helix_core::text_annotations::LineAnnotation) in [`helix_view::View::text_annotations`]
+pub trait Decoration {
+    /// Called **before** a **visual** line is rendered. A visual line does not
+    /// necessairly correspond to a single line in a document as soft wrapping can
+    /// spread a single document line across multiple visual lines.
+    ///
+    /// This function is called before text is rendered as any decorations should
+    /// never overlap the document text. That means that setting the forground color
+    /// here is (essentially) useless as the text color is overwritten by the
+    /// rendered text. This -ofcourse- doesn't apply when rendering inside virtual lines
+    /// below the line reserved by `LineAnnotation`s. e as no text will be rendered here.
+    fn decorate_line(&mut self, _renderer: &mut TextRenderer, _pos: LinePos) {}
+
+    /// Called **after** a **visual** line is rendered. A visual line does not
+    /// necessairly correspond to a single line in a document as soft wrapping can
+    /// spread a single document line across multiple visual lines.
+    ///
+    /// This function is called after text is rendered so that decorations can collect
+    /// horizontal positions on the line (see [`Decoration::decorate_grapheme`]) first and
+    /// use those positions` while rendering
+    /// virtual text.
+    /// That means that setting the forground color
+    /// here is (essentially) useless as the text color is overwritten by the
+    /// rendered text. This -ofcourse- doesn't apply when rendering inside virtual lines
+    /// below the line reserved by `LineAnnotation`s. e as no text will be rendered here.
+    /// **Note**: To avoid overlapping decorations in the virtual lines, each decoration
+    /// must return the number of virtual text lines it has taken up. Each `Decoration` recieves
+    /// an offset `virt_off` based on these return values where it can render virtual text:
+    ///
+    /// That means that a `render_line` implementation that returns `X` can render virtual text
+    /// in the following area:
+    /// ``` no-compile
+    /// let start = inner.y + pos.virtual_line + virt_off;
+    /// start .. start + X
+    /// ````
+    fn render_virt_lines(
+        &mut self,
+        _renderer: &mut TextRenderer,
+        _pos: LinePos,
+        _virt_off: Position,
+    ) -> Position {
+        Position::new(0, 0)
+    }
+
+    fn reset_pos(&mut self, _pos: usize) -> usize {
+        usize::MAX
+    }
+
+    fn skip_concealed_anchor(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.reset_pos(conceal_end_char_idx)
+    }
+
+    /// This function is called **before** the grapheme at `char_idx` is rendered.
+    ///
+    /// # Returns
+    /// The next
+    fn decorate_grapheme(
+        &mut self,
+        _renderer: &mut TextRenderer,
+        _grapheme: &FormattedGrapheme,
+    ) -> usize {
+        usize::MAX
+    }
+}
+
+impl<F: FnMut(&mut TextRenderer, LinePos)> Decoration for F {
+    fn decorate_line(&mut self, renderer: &mut TextRenderer, pos: LinePos) {
+        self(renderer, pos);
+    }
+}
+
+#[derive(Default)]
+pub struct DecorationManager<'a> {
+    decorations: Vec<(Box<dyn Decoration + 'a>, usize)>,
+}
+
+impl<'a> DecorationManager<'a> {
+    pub fn add_decoration(&mut self, decoration: impl Decoration + 'a) {
+        self.decorations.push((Box::new(decoration), 0));
+    }
+
+    pub fn prepare_for_rendering(&mut self, first_visible_char: usize) {
+        for (decoration, next_position) in &mut self.decorations {
+            *next_position = decoration.reset_pos(first_visible_char)
+        }
+    }
+
+    pub fn decorate_grapheme(&mut self, renderer: &mut TextRenderer, grapheme: &FormattedGrapheme) {
+        for (decoration, hook_char_idx) in &mut self.decorations {
+            loop {
+                match (*hook_char_idx).cmp(&grapheme.char_idx) {
+                    // this grapheme has been concealed or we are at the first grapheme
+                    Ordering::Less => {
+                        *hook_char_idx = decoration.skip_concealed_anchor(grapheme.char_idx)
+                    }
+                    Ordering::Equal => {
+                        *hook_char_idx = decoration.decorate_grapheme(renderer, grapheme)
+                    }
+                    Ordering::Greater => break,
+                }
+            }
+        }
+    }
+
+    pub fn decorate_line(&mut self, renderer: &mut TextRenderer, pos: LinePos) {
+        for (decoration, _) in &mut self.decorations {
+            decoration.decorate_line(renderer, pos);
+        }
+    }
+
+    pub fn render_virtual_lines(
+        &mut self,
+        renderer: &mut TextRenderer,
+        pos: LinePos,
+        line_width: usize,
+    ) {
+        let mut virt_off = Position::new(1, line_width); // start at 1 so the line is never overwritten
+        for (decoration, _) in &mut self.decorations {
+            virt_off += decoration.render_virt_lines(renderer, pos, virt_off);
+        }
+    }
+}
+
+/// Cursor rendering is done externally so all the cursor decoration
+/// does is save the position of primary cursor
+pub struct Cursor<'a> {
+    pub cache: &'a CursorCache,
+    pub primary_cursor: usize,
+}
+impl Decoration for Cursor<'_> {
+    fn reset_pos(&mut self, pos: usize) -> usize {
+        if pos <= self.primary_cursor {
+            self.primary_cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn decorate_grapheme(
+        &mut self,
+        renderer: &mut TextRenderer,
+        grapheme: &FormattedGrapheme,
+    ) -> usize {
+        if renderer.column_in_bounds(grapheme.visual_pos.col)
+            && renderer.offset.row < grapheme.visual_pos.row
+        {
+            let position = grapheme.visual_pos - renderer.offset;
+            self.cache.set(Some(position));
+        }
+        usize::MAX
+    }
+}

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -1,0 +1,286 @@
+use std::cmp::Ordering;
+
+use helix_core::diagnostic::Severity;
+use helix_core::doc_formatter::{DocumentFormatter, FormattedGrapheme};
+use helix_core::graphemes::Grapheme;
+use helix_core::text_annotations::TextAnnotations;
+use helix_core::{Diagnostic, Position};
+use helix_view::annotations::diagnostics::{InlineDiagnosticAccumulator, InlineDiagnosticsConfig};
+
+use helix_view::theme::Style;
+use helix_view::{Document, Theme};
+
+use crate::ui::document::{LinePos, TextRenderer};
+use crate::ui::text_decorations::Decoration;
+
+#[derive(Debug)]
+struct Styles {
+    hint: Style,
+    info: Style,
+    warning: Style,
+    error: Style,
+}
+
+impl Styles {
+    fn new(theme: &Theme) -> Styles {
+        Styles {
+            hint: theme.get("hint"),
+            info: theme.get("info"),
+            warning: theme.get("warning"),
+            error: theme.get("error"),
+        }
+    }
+
+    fn severity_style(&self, severity: Severity) -> Style {
+        match severity {
+            Severity::Hint => self.hint,
+            Severity::Info => self.info,
+            Severity::Warning => self.warning,
+            Severity::Error => self.error,
+        }
+    }
+}
+
+pub struct InlineDiagnostics<'a> {
+    state: InlineDiagnosticAccumulator<'a>,
+    styles: Styles,
+}
+
+impl<'a> InlineDiagnostics<'a> {
+    pub fn new(
+        doc: &'a Document,
+        theme: &Theme,
+        cursor: usize,
+        config: InlineDiagnosticsConfig,
+    ) -> Self {
+        InlineDiagnostics {
+            state: InlineDiagnosticAccumulator::new(cursor, doc, config),
+            styles: Styles::new(theme),
+        }
+    }
+}
+
+const BL_CORNER: &str = "┘";
+const TR_CORNER: &str = "┌";
+const BR_CORNER: &str = "└";
+const STACK: &str = "├";
+const MULTI: &str = "┴";
+const HOR_BAR: &str = "─";
+const VER_BAR: &str = "│";
+
+struct Renderer<'a, 'b> {
+    renderer: &'a mut TextRenderer<'b>,
+    first_row: u16,
+    row: u16,
+    config: &'a InlineDiagnosticsConfig,
+    styles: &'a Styles,
+}
+
+impl Renderer<'_, '_> {
+    fn draw_decoration(&mut self, g: &'static str, severity: Severity, col: u16) {
+        self.draw_decoration_at(g, severity, col, self.row)
+    }
+
+    fn draw_decoration_at(&mut self, g: &'static str, severity: Severity, col: u16, row: u16) {
+        self.renderer.draw_decoration_grapheme(
+            Grapheme::new_decoration(g),
+            self.styles.severity_style(severity),
+            row,
+            col,
+        );
+    }
+
+    fn draw_eol_diagnostic(&mut self, diag: &Diagnostic, row: u16, col: usize) -> u16 {
+        let style = self.styles.severity_style(diag.severity());
+        let width = self.renderer.viewport.width;
+        if !self.renderer.column_in_bounds(col + 1) {
+            return 0;
+        }
+        let col = (col - self.renderer.offset.col) as u16;
+        let (new_col, _) = self.renderer.set_string_truncated(
+            self.renderer.viewport.x + col + 1,
+            row,
+            &diag.message,
+            width.saturating_sub(col + 1) as usize,
+            |_| style,
+            true,
+            false,
+        );
+        new_col - col
+    }
+
+    fn draw_diagnostic(&mut self, diag: &Diagnostic, col: u16, next_severity: Option<Severity>) {
+        let severity = diag.severity();
+        let (sym, sym_severity) = if let Some(next_severity) = next_severity {
+            (STACK, next_severity.max(severity))
+        } else {
+            (BR_CORNER, severity)
+        };
+        self.draw_decoration(sym, sym_severity, col);
+        for i in 0..self.config.prefix_len {
+            self.draw_decoration(HOR_BAR, severity, col + i + 1);
+        }
+
+        let text_col = col + self.config.prefix_len + 1;
+        let text_fmt = self.config.text_fmt(text_col, self.renderer.viewport.width);
+        let annotations = TextAnnotations::default();
+        let formatter = DocumentFormatter::new_at_prev_checkpoint(
+            diag.message.as_str().trim().into(),
+            &text_fmt,
+            &annotations,
+            0,
+        );
+        let mut last_row = 0;
+        let style = self.styles.severity_style(severity);
+        for grapheme in formatter {
+            last_row = grapheme.visual_pos.row;
+            self.renderer.draw_decoration_grapheme(
+                grapheme.raw,
+                style,
+                self.row + grapheme.visual_pos.row as u16,
+                text_col + grapheme.visual_pos.col as u16,
+            );
+        }
+        self.row += 1;
+        // height is last_row + 1 and extra_rows is height - 1
+        let extra_lines = last_row;
+        if let Some(next_severity) = next_severity {
+            for _ in 0..extra_lines {
+                self.draw_decoration(VER_BAR, next_severity, col);
+                self.row += 1;
+            }
+        } else {
+            self.row += extra_lines as u16;
+        }
+    }
+
+    fn draw_multi_diagnostics(&mut self, stack: &mut Vec<(&Diagnostic, u16)>) {
+        let Some(&(last_diag, last_anchor)) = stack.last() else { return };
+        let start = self
+            .config
+            .max_diagnostic_start(self.renderer.viewport.width);
+
+        if last_anchor <= start {
+            return;
+        }
+        let mut severity = last_diag.severity();
+        let mut last_anchor = last_anchor;
+        self.draw_decoration(BL_CORNER, severity, last_anchor);
+        let mut stacked_diagnostics = 1;
+        for &(diag, anchor) in stack.iter().rev().skip(1) {
+            let sym = match anchor.cmp(&start) {
+                Ordering::Less => break,
+                Ordering::Equal => STACK,
+                Ordering::Greater => MULTI,
+            };
+            stacked_diagnostics += 1;
+            severity = severity.max(diag.severity());
+            let old_severity = severity;
+            if anchor == last_anchor && severity == old_severity {
+                continue;
+            }
+            for col in (anchor + 1)..last_anchor {
+                self.draw_decoration(HOR_BAR, old_severity, col)
+            }
+            self.draw_decoration(sym, severity, anchor);
+            last_anchor = anchor;
+        }
+
+        // if no diagnostic anchor was found exactly at the start of the
+        // diagnostic text  draw an upwards corner and ensure the last piece
+        // of the line is not missing
+        if last_anchor != start {
+            for col in (start + 1)..last_anchor {
+                self.draw_decoration(HOR_BAR, severity, col)
+            }
+            self.draw_decoration(TR_CORNER, severity, start)
+        }
+        self.row += 1;
+        let stacked_diagnostics = &stack[stack.len() - stacked_diagnostics..];
+
+        for (i, (diag, _)) in stacked_diagnostics.iter().rev().enumerate() {
+            let next_severity = stacked_diagnostics[..stacked_diagnostics.len() - i - 1]
+                .iter()
+                .map(|(diag, _)| diag.severity())
+                .max();
+            self.draw_diagnostic(diag, start, next_severity);
+        }
+
+        stack.truncate(stack.len() - stacked_diagnostics.len());
+    }
+
+    fn draw_diagnostics(&mut self, stack: &mut Vec<(&Diagnostic, u16)>) {
+        let mut stack = stack.drain(..).rev().peekable();
+        let mut last_anchor = self.renderer.viewport.width;
+        while let Some((diag, anchor)) = stack.next() {
+            if anchor != last_anchor {
+                for row in self.first_row..self.row {
+                    self.draw_decoration_at(VER_BAR, diag.severity(), anchor, row);
+                }
+            }
+            let next_severity = stack.peek().and_then(|&(diag, next_anchor)| {
+                (next_anchor == anchor).then_some(diag.severity())
+            });
+            self.draw_diagnostic(diag, anchor, next_severity);
+            last_anchor = anchor;
+        }
+    }
+}
+
+impl Decoration for InlineDiagnostics<'_> {
+    fn render_virt_lines(
+        &mut self,
+        renderer: &mut TextRenderer,
+        pos: LinePos,
+        virt_off: Position,
+    ) -> Position {
+        let mut col_off = 0;
+        let filter = self.state.filter();
+        let eol_diagnostic = self
+            .state
+            .stack
+            .iter()
+            .filter(|(diag, _)| !filter.matches(diag.severity()))
+            .max_by_key(|(diagnostic, _)| diagnostic.severity);
+        if let Some((eol_diagnostic, _)) = eol_diagnostic {
+            let mut renderer = Renderer {
+                renderer,
+                first_row: pos.visual_line,
+                row: pos.visual_line,
+                config: &self.state.config,
+                styles: &self.styles,
+            };
+            col_off = renderer.draw_eol_diagnostic(eol_diagnostic, pos.visual_line, virt_off.col);
+        }
+
+        self.state.compute_line_diagnostics();
+        let mut renderer = Renderer {
+            renderer,
+            first_row: pos.visual_line + virt_off.row as u16,
+            row: pos.visual_line + virt_off.row as u16,
+            config: &self.state.config,
+            styles: &self.styles,
+        };
+        renderer.draw_multi_diagnostics(&mut self.state.stack);
+        renderer.draw_diagnostics(&mut self.state.stack);
+        let horizontal_off = renderer.row - renderer.first_row;
+        Position::new(horizontal_off as usize, col_off as usize)
+    }
+
+    fn reset_pos(&mut self, pos: usize) -> usize {
+        self.state.reset_pos(pos)
+    }
+
+    fn skip_concealed_anchor(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.state.skip_concealed(conceal_end_char_idx)
+    }
+
+    fn decorate_grapheme(
+        &mut self,
+        renderer: &mut TextRenderer,
+        grapheme: &FormattedGrapheme,
+    ) -> usize {
+        self.state
+            .proccess_anchor(grapheme, renderer.viewport.width, renderer.offset.col)
+    }
+}

--- a/helix-view/src/annotations.rs
+++ b/helix-view/src/annotations.rs
@@ -1,0 +1,1 @@
+pub mod diagnostics;

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -1,0 +1,305 @@
+use helix_core::diagnostic::Severity;
+use helix_core::doc_formatter::{FormattedGrapheme, TextFormat};
+use helix_core::text_annotations::LineAnnotation;
+use helix_core::{softwrapped_dimensions, Diagnostic, Position};
+use serde::{Deserialize, Serialize};
+
+use crate::Document;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct SeverityFilter(Box<[Severity]>);
+
+impl<'de> Deserialize<'de> for SeverityFilter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case", deny_unknown_fields, untagged)]
+        enum Helper {
+            AtLeast(Severity),
+            OneOf(Box<[Severity]>),
+        }
+        let severities = match Helper::deserialize(deserializer)? {
+            Helper::AtLeast(min) => {
+                let mut severities = vec![
+                    Severity::Error,
+                    Severity::Warning,
+                    Severity::Info,
+                    Severity::Hint,
+                ];
+                severities.retain(|&it| it >= min);
+                severities.into_boxed_slice()
+            }
+            Helper::OneOf(severities) => severities,
+        };
+        Ok(SeverityFilter(severities))
+    }
+}
+
+impl SeverityFilter {
+    pub fn matches(&self, severity: Severity) -> bool {
+        self.0.contains(&severity)
+    }
+    pub fn disabled(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct InlineDiagnosticsConfig {
+    pub cursor_line: SeverityFilter,
+    pub other_lines: SeverityFilter,
+    pub min_diagnostic_width: u16,
+    pub prefix_len: u16,
+    pub max_wrap: u16,
+    pub max_diagnostics: usize,
+}
+
+impl InlineDiagnosticsConfig {
+    // last column where to start diagnostics
+    // every diagnostics that start afterwards will be displayed with a "backwards
+    // line" to ensure they are still rendered with `min_diagnostic_widht`. If `width`
+    // it too small to display diagnostics with atleast `min_diagnostic_width` space
+    // (or inline diagnostics are displed) `None` is returned. In that case inline
+    // diagnostics should not be shown
+    pub fn enable(&self, width: u16) -> bool {
+        let disabled = matches!(
+            self,
+            Self {
+                cursor_line: SeverityFilter(cursor_line),
+                other_lines: SeverityFilter(other_lines),
+                ..
+            } if cursor_line.is_empty() && other_lines.is_empty()
+        );
+        !disabled && width >= self.min_diagnostic_width + self.prefix_len
+    }
+
+    pub fn max_diagnostic_start(&self, width: u16) -> u16 {
+        width - self.min_diagnostic_width - self.prefix_len
+    }
+
+    pub fn text_fmt(&self, anchor_col: u16, width: u16) -> TextFormat {
+        let width = if anchor_col > self.max_diagnostic_start(width) {
+            self.min_diagnostic_width
+        } else {
+            width - anchor_col - self.prefix_len
+        };
+
+        TextFormat {
+            soft_wrap: true,
+            tab_width: 4,
+            max_wrap: self.max_wrap.min(width / 4),
+            max_indent_retain: 0,
+            wrap_indicator: "".into(),
+            wrap_indicator_highlight: None,
+            viewport_width: width,
+            soft_wrap_at_text_width: true,
+        }
+    }
+}
+
+impl Default for InlineDiagnosticsConfig {
+    fn default() -> Self {
+        InlineDiagnosticsConfig {
+            cursor_line: SeverityFilter(Box::new([Severity::Warning, Severity::Error])),
+            other_lines: SeverityFilter(Box::default()),
+            min_diagnostic_width: 40,
+            prefix_len: 1,
+            max_wrap: 20,
+            max_diagnostics: 20,
+        }
+    }
+}
+
+pub struct InlineDiagnosticAccumulator<'a> {
+    idx: usize,
+    doc: &'a Document,
+    pub stack: Vec<(&'a Diagnostic, u16)>,
+    pub config: InlineDiagnosticsConfig,
+    cursor: usize,
+    cursor_line: bool,
+}
+
+impl<'a> InlineDiagnosticAccumulator<'a> {
+    pub fn new(cursor: usize, doc: &'a Document, config: InlineDiagnosticsConfig) -> Self {
+        InlineDiagnosticAccumulator {
+            idx: 0,
+            doc,
+            stack: Vec::new(),
+            config,
+            cursor,
+            cursor_line: false,
+        }
+    }
+
+    pub fn reset_pos(&mut self, char_idx: usize) -> usize {
+        self.idx = 0;
+        self.clear();
+        self.skip_concealed(char_idx)
+    }
+
+    pub fn skip_concealed(&mut self, conceal_end_char_idx: usize) -> usize {
+        let diagnostics = &self.doc.diagnostics[self.idx..];
+        let idx = diagnostics.partition_point(|diag| diag.range.start < conceal_end_char_idx);
+        self.idx += idx;
+        self.next_anchor(conceal_end_char_idx)
+    }
+
+    pub fn next_anchor(&self, current_char_idx: usize) -> usize {
+        let next_diag_start = self
+            .doc
+            .diagnostics
+            .get(self.idx)
+            .map_or(usize::MAX, |diag| diag.range.start);
+        if (current_char_idx..next_diag_start).contains(&self.cursor) {
+            self.cursor
+        } else {
+            next_diag_start
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.cursor_line = false;
+        self.stack.clear();
+    }
+
+    fn process_anchor_impl(
+        &mut self,
+        grapheme: &FormattedGrapheme,
+        width: u16,
+        horizontal_off: usize,
+    ) -> bool {
+        // TODO: doing the cursor tracking here works well but is somewhat
+        // duplicate effort/tedious maybe centrilize this somehwere?
+        // In the DocFormatter?
+        if grapheme.char_idx == self.cursor {
+            self.cursor_line = true;
+            if self
+                .doc
+                .diagnostics
+                .get(self.idx)
+                .map_or(true, |diag| diag.range.start != grapheme.char_idx)
+            {
+                return false;
+            }
+        }
+
+        let Some(anchor_col) = grapheme.visual_pos.col.checked_sub(horizontal_off) else {
+            return true
+        };
+        if anchor_col >= width as usize {
+            return true;
+        }
+
+        for diag in &self.doc.diagnostics[self.idx..] {
+            if diag.range.start != grapheme.char_idx {
+                break;
+            }
+            self.stack.push((diag, anchor_col as u16));
+            self.idx += 1;
+        }
+        false
+    }
+
+    pub fn proccess_anchor(
+        &mut self,
+        grapheme: &FormattedGrapheme,
+        width: u16,
+        horizontal_off: usize,
+    ) -> usize {
+        if self.process_anchor_impl(grapheme, width, horizontal_off) {
+            self.idx += self.doc.diagnostics[self.idx..]
+                .iter()
+                .take_while(|diag| diag.range.start == grapheme.char_idx)
+                .count();
+        }
+        self.next_anchor(grapheme.char_idx + 1)
+    }
+
+    pub fn filter(&self) -> &SeverityFilter {
+        if self.cursor_line {
+            &self.config.cursor_line
+        } else {
+            &self.config.other_lines
+        }
+    }
+
+    pub fn compute_line_diagnostics(&mut self) {
+        let filter = if self.cursor_line {
+            self.cursor_line = false;
+            &self.config.cursor_line
+        } else {
+            &self.config.other_lines
+        };
+        self.stack
+            .retain(|(diag, _)| filter.matches(diag.severity()));
+        self.stack.truncate(self.config.max_diagnostics)
+    }
+
+    pub fn has_multi(&self, width: u16) -> bool {
+        self.stack.last().map_or(false, |&(_, anchor)| {
+            anchor > self.config.max_diagnostic_start(width)
+        })
+    }
+}
+
+pub(crate) struct InlineDiagnostics<'a> {
+    state: InlineDiagnosticAccumulator<'a>,
+    width: u16,
+    horizontal_off: usize,
+}
+
+impl<'a> InlineDiagnostics<'a> {
+    #[allow(clippy::new_ret_no_self)]
+    pub(crate) fn new(
+        doc: &'a Document,
+        cursor: usize,
+        width: u16,
+        horizontal_off: usize,
+        config: InlineDiagnosticsConfig,
+    ) -> Box<dyn LineAnnotation + 'a> {
+        Box::new(InlineDiagnostics {
+            state: InlineDiagnosticAccumulator::new(cursor, doc, config),
+            width,
+            horizontal_off,
+        })
+    }
+}
+
+impl LineAnnotation for InlineDiagnostics<'_> {
+    fn reset_pos(&mut self, char_idx: usize) -> usize {
+        self.state.reset_pos(char_idx)
+    }
+
+    fn skip_concealed_anchors(&mut self, conceal_end_char_idx: usize) -> usize {
+        self.state.skip_concealed(conceal_end_char_idx)
+    }
+
+    fn process_anchor(&mut self, grapheme: &FormattedGrapheme) -> usize {
+        self.state
+            .proccess_anchor(grapheme, self.width, self.horizontal_off)
+    }
+
+    fn insert_virtual_lines(
+        &mut self,
+        _line_end_char_idx: usize,
+        _line_end_visual_pos: Position,
+        _doc_line: usize,
+    ) -> Position {
+        self.state.compute_line_diagnostics();
+        let multi = self.state.has_multi(self.width);
+        let diagostic_height: usize = self
+            .state
+            .stack
+            .drain(..)
+            .map(|(diag, anchor)| {
+                let text_fmt = self.state.config.text_fmt(anchor, self.width);
+                softwrapped_dimensions(diag.message.as_str().trim().into(), &text_fmt).0
+            })
+            .sum();
+        Position::new(multi as usize + diagostic_height, 0)
+    }
+}

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -50,6 +50,7 @@ impl SeverityFilter {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct InlineDiagnosticsConfig {
+    pub enabled: bool,
     pub cursor_line: SeverityFilter,
     pub other_lines: SeverityFilter,
     pub min_diagnostic_width: u16,
@@ -104,6 +105,7 @@ impl InlineDiagnosticsConfig {
 impl Default for InlineDiagnosticsConfig {
     fn default() -> Self {
         InlineDiagnosticsConfig {
+            enabled: false,
             cursor_line: SeverityFilter(Box::new([Severity::Warning, Severity::Error])),
             other_lines: SeverityFilter(Box::default()),
             min_diagnostic_width: 40,

--- a/helix-view/src/copilot.rs
+++ b/helix-view/src/copilot.rs
@@ -1,0 +1,76 @@
+use helix_lsp::{copilot_types::DocCompletion, OffsetEncoding};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+static GLOBAL_AUTO_RENDER: once_cell::sync::OnceCell<Arc<Mutex<bool>>> = once_cell::sync::OnceCell::new();
+
+#[derive(Clone, Debug)]
+pub struct Copilot {
+    completion_response: Option<(Vec<DocCompletion>, OffsetEncoding)> ,
+    render: Render
+}
+
+#[derive(Clone, Debug)]
+struct Render {
+    global_auto_render: Arc<Mutex<bool>>,
+    should_render: Option<usize>,
+}
+
+impl Render {
+    pub fn reset(& mut self) {
+        let lock = self.global_auto_render.lock();
+        self.should_render = if *lock {Some(0)} else {None};
+    }
+    pub fn should_not_render(&mut self) {
+        self.should_render = None;
+    }
+ }
+
+impl Copilot {
+    pub fn new(editor_auto_render: bool) -> Copilot {
+        let global_auto_render_completion = GLOBAL_AUTO_RENDER.get_or_init(|| Arc::new(Mutex::new(editor_auto_render))).clone();
+
+        return Self {
+            completion_response: None,
+            render: Render { 
+                global_auto_render: global_auto_render_completion,
+                should_render: None
+            }
+        }
+    }
+
+    pub fn delete_state_and_reset_should_render(&mut self) {
+        self.render.reset();
+        self.completion_response = None;
+    }
+
+    pub fn delete_state_and_should_not_render(&mut self) {
+        self.render.should_not_render();
+        self.completion_response = None;
+    }
+
+    pub fn show_completion(&mut self) {
+        self.render.should_render = Some(0);
+    }
+
+    pub fn fill_with_completions(&mut self, completions: Vec<DocCompletion>, offset_encoding: OffsetEncoding) {
+       self.completion_response = Some((completions, offset_encoding));
+    }
+
+    pub fn get_completion_if_should_render(&self) -> Option<&DocCompletion> {
+        let idx = self.render.should_render?;
+        let completions = &self.completion_response.as_ref()?.0;
+        completions.get(idx)
+    }
+
+    pub fn offset_encoding(&self) -> Option<OffsetEncoding> {
+        Some(self.completion_response.as_ref()?.1)
+    }
+
+    pub fn toggle_auto_render(&self) -> bool {
+       let mut lock = self.render.global_auto_render.lock(); 
+       *lock = !(*lock);
+       return *lock;
+    }
+
+}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1939,7 +1939,7 @@ impl Document {
             .language_config()
             .and_then(|config| config.text_width)
             .unwrap_or(config.text_width);
-        let soft_wrap_at_text_width = self
+        let mut soft_wrap_at_text_width = self
             .language_config()
             .and_then(|config| {
                 config
@@ -1950,12 +1950,13 @@ impl Document {
             .or(config.soft_wrap.wrap_at_text_width)
             .unwrap_or(false);
         if soft_wrap_at_text_width {
-            // We increase max_line_len by 1 because softwrap considers the newline character
-            // as part of the line length while the "typical" expectation is that this is not the case.
-            // In particular other commands like :reflow do not count the line terminator.
-            // This is technically inconsistent for the last line as that line never has a line terminator
-            // but having the last visual line exceed the width by 1 seems like a rare edge case.
-            viewport_width = viewport_width.min(text_width as u16 + 1)
+            // if the viewport is smaller than the specified
+            // width then this setting has no effcet
+            if text_width >= viewport_width as usize {
+                soft_wrap_at_text_width = false;
+            } else {
+                viewport_width = text_width as u16;
+            }
         }
         let config = self.config.load();
         let editor_soft_wrap = &config.soft_wrap;
@@ -1992,6 +1993,7 @@ impl Document {
             wrap_indicator_highlight: theme
                 .and_then(|theme| theme.find_scope_index("ui.virtual.wrap"))
                 .map(Highlight),
+            soft_wrap_at_text_width,
         }
     }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -40,6 +40,7 @@ use helix_core::{
     ChangeSet, Diagnostic, LineEnding, Rope, RopeBuilder, Selection, Syntax, Transaction,
 };
 
+use crate::copilot::Copilot;
 use crate::editor::Config;
 use crate::events::{DocumentDidChange, SelectionDidChange};
 use crate::{DocumentId, Editor, Theme, View, ViewId};
@@ -129,16 +130,8 @@ pub enum DocumentOpenError {
     IoError(#[from] io::Error),
 }
 
-#[derive(Clone, Debug)]
-pub struct Copilot {
-    pub should_render: bool,
-    pub completions: Vec<DocCompletion>,
-    pub idx: usize,
-    pub offset_encoding: OffsetEncoding,
-}
-
 pub struct Document {
-    pub copilot: Option<Copilot>,
+    pub copilot: Copilot,
     pub(crate) id: DocumentId,
     text: Rope,
     selections: HashMap<ViewId, Selection>,
@@ -649,46 +642,25 @@ use helix_lsp::{copilot_types, Client, LanguageServerId, LanguageServerName};
 use url::Url;
 
 impl Document {
-    pub fn clear_copilot_completions(&mut self) {
-        self.copilot = None;
-    }
-
     pub fn get_copilot_completion_for_rendering(&self) -> Option<&DocCompletion> {
-        let Some(copilot) = self.copilot.as_ref() else {
-            return None;
-        };
-        if !copilot.should_render {
-            return None;
-        }
+        let completion = self.copilot.get_completion_if_should_render()?;
 
-        let completion = copilot.completions.get(copilot.idx)?;
         if self.version as usize != completion.doc_version {
             return None;
         }
-        return Some(completion);
+        Some(completion)
     }
 
-    pub fn apply_copilot_completion(&mut self, view_id: ViewId) {
-        if let None = self.get_copilot_completion_for_rendering() {
-            return;
-        }
-        let Some(copilot) = self.copilot.as_ref() else {
-            return;
-        };
-
-        let Some(completion) = copilot.completions.get(copilot.idx) else {
-            return;
-        };
-        if completion.doc_version != self.version as usize {
-            return;
-        }
+     pub fn apply_copilot_completion(&mut self, view_id: ViewId) {
+        let Some(completion) = self.copilot.get_completion_if_should_render() else { return; };
+        let Some(offset_encoding) = self.copilot.offset_encoding() else { return; };
 
         let edit = lsp::TextEdit {
             range: completion.lsp_range,
             new_text: completion.text.clone(),
         };
         let transaction =
-            generate_transaction_from_edits(self.text(), vec![edit], copilot.offset_encoding);
+            generate_transaction_from_edits(self.text(), vec![edit], offset_encoding);
 
         self.apply(&transaction, view_id);
     }
@@ -702,9 +674,10 @@ impl Document {
         let line_ending = config.load().default_line_ending.into();
         let changes = ChangeSet::new(text.slice(..));
         let old_state = None;
+        let copilot_auto_render = config.load().copilot_auto_render;
 
         Self {
-            copilot: None,
+            copilot: Copilot::new(copilot_auto_render),
             id: DocumentId::default(),
             path: None,
             encoding,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -129,8 +129,9 @@ pub enum DocumentOpenError {
     IoError(#[from] io::Error),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Copilot {
+    pub should_render: bool,
     pub completions: Vec<DocCompletion>,
     pub idx: usize,
     pub offset_encoding: OffsetEncoding,
@@ -653,8 +654,12 @@ impl Document {
     }
 
     pub fn get_copilot_completion_for_rendering(&self) -> Option<&DocCompletion> {
-        let Some(copilot) = self.copilot.as_ref() else {return None;};
-        if !copilot.should_render {return None;}
+        let Some(copilot) = self.copilot.as_ref() else {
+            return None;
+        };
+        if !copilot.should_render {
+            return None;
+        }
 
         let completion = copilot.completions.get(copilot.idx)?;
         if self.version as usize != completion.doc_version {
@@ -663,10 +668,17 @@ impl Document {
         return Some(completion);
     }
 
-     pub fn apply_copilot_completion(&mut self, view_id: ViewId) {
-        if let None = self.get_copilot_completion_for_rendering() {return;}
-        let Some(copilot) = self.copilot.as_ref() else {return;};
-        let Some(completion) = copilot.completions.get(copilot.idx) else {return;};
+    pub fn apply_copilot_completion(&mut self, view_id: ViewId) {
+        if let None = self.get_copilot_completion_for_rendering() {
+            return;
+        }
+        let Some(copilot) = self.copilot.as_ref() else {
+            return;
+        };
+
+        let Some(completion) = copilot.completions.get(copilot.idx) else {
+            return;
+        };
         if completion.doc_version != self.version as usize {
             return;
         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -652,25 +652,21 @@ impl Document {
         self.copilot = None;
     }
 
-    pub fn get_copilot_completion(&self) -> Option<&DocCompletion> {
-        let Some(copilot) = self.copilot.as_ref() else {
-            return None;
-        };
-        let completion = copilot.completions.get(copilot.idx)?;
+    pub fn get_copilot_completion_for_rendering(&self) -> Option<&DocCompletion> {
+        let Some(copilot) = self.copilot.as_ref() else {return None;};
+        if !copilot.should_render {return None;}
 
+        let completion = copilot.completions.get(copilot.idx)?;
         if self.version as usize != completion.doc_version {
             return None;
         }
         return Some(completion);
     }
 
-    pub fn apply_copilot(&mut self, view_id: ViewId) {
-        let Some(copilot) = self.copilot.as_ref() else {
-            return;
-        };
-        let Some(completion) = copilot.completions.get(copilot.idx) else {
-            return;
-        };
+     pub fn apply_copilot_completion(&mut self, view_id: ViewId) {
+        if let None = self.get_copilot_completion_for_rendering() {return;}
+        let Some(copilot) = self.copilot.as_ref() else {return;};
+        let Some(completion) = copilot.completions.get(copilot.idx) else {return;};
         if completion.doc_version != self.version as usize {
             return;
         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -99,7 +99,6 @@ impl Serialize for Mode {
         serializer.collect_str(self)
     }
 }
-
 /// A snapshot of the text of a document that we want to write out to disk
 #[derive(Debug, Clone)]
 pub struct DocumentSavedEvent {
@@ -1321,8 +1320,12 @@ impl Document {
                 true
             });
 
-            self.diagnostics.sort_unstable_by_key(|diagnostic| {
-                (diagnostic.range, diagnostic.severity, diagnostic.provider)
+            self.diagnostics.sort_by_key(|diagnostic| {
+                (
+                    diagnostic.range,
+                    diagnostic.severity,
+                    diagnostic.provider,
+                )
             });
 
             // Update the inlay hint annotations' positions, helping ensure they are displayed in the proper place
@@ -1897,8 +1900,12 @@ impl Document {
             });
         }
         self.diagnostics.extend(diagnostics);
-        self.diagnostics.sort_unstable_by_key(|diagnostic| {
-            (diagnostic.range, diagnostic.severity, diagnostic.provider)
+        self.diagnostics.sort_by_key(|diagnostic| {
+            (
+                diagnostic.range,
+                diagnostic.severity,
+                diagnostic.provider,
+            )
         });
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1070,10 +1070,10 @@ pub struct Editor {
     /// This cache is only a performance optimization to
     /// avoid calculating the cursor position multiple
     /// times during rendering and should not be set by other functions.
-    pub cursor_cache: Cell<Option<Option<Position>>>,
     pub handlers: Handlers,
 
     pub mouse_down_range: Option<Range>,
+    pub cursor_cache: CursorCache,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1188,9 +1188,9 @@ impl Editor {
             exit_code: 0,
             config_events: unbounded_channel(),
             needs_redraw: false,
-            cursor_cache: Cell::new(None),
             handlers,
             mouse_down_range: None,
+            cursor_cache: CursorCache::default(),
         }
     }
 
@@ -1983,15 +1983,7 @@ impl Editor {
     pub fn cursor(&self) -> (Option<Position>, CursorKind) {
         let config = self.config();
         let (view, doc) = current_ref!(self);
-        let cursor = doc
-            .selection(view.id)
-            .primary()
-            .cursor(doc.text().slice(..));
-        let pos = self
-            .cursor_cache
-            .get()
-            .unwrap_or_else(|| view.screen_coords_at_pos(doc, doc.text().slice(..), cursor));
-        if let Some(mut pos) = pos {
+        if let Some(mut pos) = self.cursor_cache.get(view, doc) {
             let inner = view.inner_area(doc);
             pos.col += inner.x as usize;
             pos.row += inner.y as usize;
@@ -2184,5 +2176,30 @@ fn try_restore_indent(doc: &mut Document, view: &mut View) {
                 (line_start_pos, pos, None)
             });
         doc.apply(&transaction, view.id);
+    }
+}
+
+#[derive(Default)]
+pub struct CursorCache(Cell<Option<Option<Position>>>);
+
+impl CursorCache {
+    pub fn get(&self, view: &View, doc: &Document) -> Option<Position> {
+        if let Some(pos) = self.0.get() {
+            return pos;
+        }
+
+        let text = doc.text().slice(..);
+        let cursor = doc.selection(view.id).primary().cursor(text);
+        let res = view.screen_coords_at_pos(doc, text, cursor);
+        self.set(res);
+        res
+    }
+
+    pub fn set(&self, cursor_pos: Option<Position>) {
+        self.0.set(Some(cursor_pos))
+    }
+
+    pub fn reset(&self) {
+        self.0.set(None)
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1013,7 +1013,6 @@ pub struct Breakpoint {
 use futures_util::stream::{Flatten, Once};
 
 pub struct Editor {
-    pub auto_render_copilot: bool,
     /// Current editing mode.
     pub mode: Mode,
     pub tree: Tree,
@@ -1164,7 +1163,6 @@ impl Editor {
         area.height -= 1;
 
         Self {
-            auto_render_copilot: conf.copilot_auto_render,
             mode: Mode::Normal,
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -449,7 +449,7 @@ impl Default for LspConfig {
             snippets: true,
             goto_reference_include_declaration: true,
             inline_diagnostics: InlineDiagnosticsConfig::default(),
-            display_diagnostic_message: false,
+            display_diagnostic_message: true,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,5 +1,6 @@
 use crate::{
     align_view,
+    annotations::diagnostics::InlineDiagnosticsConfig,
     document::{
         DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
     },
@@ -431,6 +432,10 @@ pub struct LspConfig {
     pub snippets: bool,
     /// Whether to include declaration in the goto reference query
     pub goto_reference_include_declaration: bool,
+    /// Display diagnostic on the same line they occur automatically.
+    /// Also called "error lens"-style diagnostics, in reference to the popular VSCode extension.
+    pub inline_diagnostics: InlineDiagnosticsConfig,
+    pub display_diagnostic_message: bool,
 }
 
 impl Default for LspConfig {
@@ -443,6 +448,8 @@ impl Default for LspConfig {
             display_inlay_hints: false,
             snippets: true,
             goto_reference_include_declaration: true,
+            inline_diagnostics: InlineDiagnosticsConfig::default(),
+            display_diagnostic_message: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -245,6 +245,7 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
+    pub copilot_auto_render: bool,
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
     /// Number of lines to scroll at once. Defaults to 3
@@ -934,6 +935,7 @@ pub enum PopupBorderConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            copilot_auto_render: true,
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,
@@ -1011,6 +1013,7 @@ pub struct Breakpoint {
 use futures_util::stream::{Flatten, Once};
 
 pub struct Editor {
+    pub auto_render_copilot: bool,
     /// Current editing mode.
     pub mode: Mode,
     pub tree: Tree,
@@ -1161,6 +1164,7 @@ impl Editor {
         area.height -= 1;
 
         Self {
+            auto_render_copilot: conf.copilot_auto_render,
             mode: Mode::Normal,
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -18,6 +18,7 @@ pub struct Handlers {
     pub completions: Sender<lsp::CompletionEvent>,
     pub signature_hints: Sender<lsp::SignatureHelpEvent>,
     pub auto_save: Sender<AutoSaveEvent>,
+    pub copilot: Option<Sender<lsp::CopilotEvent>>,
 }
 
 impl Handlers {

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -18,7 +18,7 @@ pub struct Handlers {
     pub completions: Sender<lsp::CompletionEvent>,
     pub signature_hints: Sender<lsp::SignatureHelpEvent>,
     pub auto_save: Sender<AutoSaveEvent>,
-    pub copilot: Option<Sender<lsp::CopilotEvent>>,
+    pub copilot: Option<Sender<lsp::CopilotRequestCompletionEvent>>,
 }
 
 impl Handlers {

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -4,6 +4,11 @@ use crate::{DocumentId, ViewId};
 use helix_lsp::util::generate_transaction_from_edits;
 use helix_lsp::{lsp, OffsetEncoding};
 
+pub enum CopilotEvent {
+    RequestCompletion { doc_id: DocumentId },
+    CancelInFlightCompletion,
+}
+
 pub enum CompletionEvent {
     /// Auto completion was triggered by typing a word char
     AutoTrigger {

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -4,10 +4,7 @@ use crate::{DocumentId, ViewId};
 use helix_lsp::util::generate_transaction_from_edits;
 use helix_lsp::{lsp, OffsetEncoding};
 
-pub enum CopilotEvent {
-    RequestCompletion { doc_id: DocumentId },
-    CancelInFlightCompletion,
-}
+pub struct CopilotRequestCompletionEvent;
 
 pub enum CompletionEvent {
     /// Auto completion was triggered by typing a word char

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod macros;
 
+pub mod annotations;
 pub mod base64;
 pub mod clipboard;
 pub mod document;

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -17,6 +17,7 @@ pub mod register;
 pub mod theme;
 pub mod tree;
 pub mod view;
+pub mod copilot;
 
 use std::num::NonZeroUsize;
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -393,11 +393,6 @@ impl View {
         text: RopeSlice,
         pos: usize,
     ) -> Option<Position> {
-        if pos < self.offset.anchor {
-            // Line is not visible on screen
-            return None;
-        }
-
         let viewport = self.inner_area(doc);
         let text_fmt = doc.text_format(viewport.width, None);
         let annotations = self.text_annotations(doc, None);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -11,7 +11,7 @@ use helix_core::{
     char_idx_at_visual_offset,
     doc_formatter::TextFormat,
     syntax::Highlight,
-    text_annotations::TextAnnotations,
+    text_annotations::{CopilotLineAnnotation, TextAnnotations},
     visual_offset_from_anchor, visual_offset_from_block, Position, RopeSlice, Selection,
     Transaction,
     VisualOffsetError::{PosAfterMaxRow, PosBeforeAnchorRow},
@@ -465,7 +465,7 @@ impl View {
         };
         let width = self.inner_width(doc);
         let config = doc.config.load();
-        if config.lsp.inline_diagnostics.enable(width) {
+        if config.lsp.inline_diagnostics.enable(width) && config.lsp.inline_diagnostics.enabled {
             let config = config.lsp.inline_diagnostics.clone();
             let cursor = doc
                 .selection(self.id)
@@ -477,6 +477,13 @@ impl View {
                 width,
                 self.offset.horizontal_offset,
                 config,
+            ));
+        }
+
+        if let Some(completion) = doc.get_copilot_completion_for_rendering() {
+            text_annotations.add_line_annotation(CopilotLineAnnotation::new(
+                completion.display_coords,
+                completion.additional_softwrap,
             ));
         }
 

--- a/languages.toml
+++ b/languages.toml
@@ -20,6 +20,7 @@ cl-lsp = { command = "cl-lsp", args = [ "stdio" ] }
 clangd = { command = "clangd" }
 clojure-lsp = { command = "clojure-lsp" }
 cmake-language-server = { command = "cmake-language-server" }
+copilot = { command = "copilot", args = ["--stdio"]}
 crystalline = { command = "crystalline", args = ["--stdio"] }
 cs = { command = "cs", args = ["launch", "--contrib", "smithy-language-server", "--", "0"] }
 csharp-ls = { command = "csharp-ls" }


### PR DESCRIPTION
Builds on the multiple-lsp pr - #2507 , adding the ability to use copilot, will solve #4037 . 

I don't think that copilot should be built into the core, I think it should be a plugin, but this will do until the plugin system arrives?

You need copilot on the your path, download it from [copilot.vim](https://github.com/github/copilot.vim/tree/release/copilot/dist) and make it executable.

Then in languages.toml eg - 
```
[language-server.copilot]
command = "copilot"
args = ["--stdio"]

[[language]]
name = "rust"
language-servers = ["rust-analyzer", "copilot"]
```
The copilot server actually handles authentication, so all you need is a key in ~/.config/github-copilot , if you've used copilot in another editor you'll have this key so dont need to do anything.

How it works- 
I've added additional state to the Document struct. When the document changes, we spawn a thread that sends a completion request to the copilot server, and then stores the response in this new document state.

Then when you press C-n, if we have a response in the doc's copilot-state, translate the CopilotCompletionResponse to a vec of transactions, then push the CopilotPicker component. 
Then cycle through the transactions using C-n, C-m, this just works by undoing and applying the transactions. Then Enter to simply leave the picker, or Esc to undo the current transaction then leave.  

We could remove the additional document state and send the request and receive the completion response upon launching the picker, but this is slower (adds the time between finishing typing and pressing C-n, which is a good fraction of time taken to send+receive the completionResponse).

What I'll add next is the ability for the picker to be receive new completions upon being launched. For example you type '// function to sum vec of ints', then very quickly press C-n, we may not have received the completion before we launch the picker, so the picker needs to see these new transactions after it has launched- atm you would have to C-n again to relaunch the picker.

Also would be nice for the picker to view the completions in a different color before accepting, similar to other editor copilot plugins.

Also need to add additional types to copilot_types, for things like the logs that the copilot-lsp sends, which arent lsp standard.

