### PR TITLE
Don't crash when getcwd fails

### DIFF
--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -101,7 +101,7 @@ pub fn get_relative_path(path: &Path) -> PathBuf {
     let path = if path.is_absolute() {
         let cwdir = std::env::current_dir()
             .map(|path| get_normalized_path(&path))
-            .expect("couldn't determine current directory");
+            .unwrap_or_default();
         get_normalized_path(&path)
             .strip_prefix(cwdir)
             .map(PathBuf::from)


### PR DESCRIPTION
This can happen e.g. when you lose access to the filesystem

get_relative_path() already returns absolute paths when the input isn't under the working directory, so we just return absolute paths in this case too.