### PR TITLE
reduce stat calls during git discovery

### DIFF
--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -19,7 +19,7 @@ impl Git {
         let git_dir = path
             .ancestors()
             .find(|ancestor| ancestor.join(".git").exists())
-            .ok_or_else(|| anyhow!("No repostiory found at {path:?}"))?
+            .ok_or_else(|| anyhow!("No repository found at {path:?}"))?
             .join(".git");
 
         // custom open options


### PR DESCRIPTION
This should help with https://github.com/helix-editor/helix/issues/6867, I talked with @Byron and for our purposes checking `.git` should be enough and take less stat calls.

I still want to cache the repo lookup here eventually, but that needs some more considerations about resource cleanup (so we don't keep an infinite amout of repos open, probably some kind of LRU mechanism is needed). I also want to look into opening the repo asynchronously, but that's a bit awkward to synchronize, so I will look at that in a separate PR too.