### PR TITLE
fix panic in inlay hint computation when view anchor is out of bounds

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1513,7 +1513,8 @@ fn compute_inlay_hints_for_view(
             // than computing all the hints for the full file (which could be dozens of time
             // longer than the view is).
             let view_height = view.inner_height();
-            let first_visible_line = doc_text.char_to_line(view.offset.anchor);
+            let first_visible_line =
+                doc_text.char_to_line(view.offset.anchor.min(doc_text.len_chars()));
             let first_line = first_visible_line.saturating_sub(view_height);
             let last_line = first_visible_line
                 .saturating_add(view_height.saturating_mul(2))


### PR DESCRIPTION
Fixes the crash from this comment https://github.com/helix-editor/helix/issues/6752#issuecomment-1517580073

Note that this crash is not the same crash that #6752 is about and was incorrectly reported there. The problem here is simply that `view.offset.anchor` was used directly with `char_to_line`, but the anchor can be out of bounds which causes a crash here. Everywhere else where the anchor is used we currently used `anchor.min(doc.len_char())` for that reason. This PR just adds that to the inlay hint computation too since we forgot about it there.
