### PR TITLE
feat: add a config option to exclude declaration from LSP references

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -128,6 +128,7 @@ The following statusline elements can be configured:
 | `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 | `snippets`      | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |
+| `goto-reference-include-declaration` | Include declaration in the goto references popup. | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 [^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix.

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1167,6 +1167,7 @@ impl Client {
         &self,
         text_document: lsp::TextDocumentIdentifier,
         position: lsp::Position,
+        include_declaration: bool,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
         let capabilities = self.capabilities.get().unwrap();
@@ -1183,7 +1184,7 @@ impl Client {
                 position,
             },
             context: lsp::ReferenceContext {
-                include_declaration: true,
+                include_declaration,
             },
             work_done_progress_params: lsp::WorkDoneProgressParams { work_done_token },
             partial_result_params: lsp::PartialResultParams {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1078,9 +1078,9 @@ pub fn goto_implementation(cx: &mut Context) {
 }
 
 pub fn goto_reference(cx: &mut Context) {
+    let config = cx.editor.config();
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
-    let config = cx.editor.config.load();
     let offset_encoding = language_server.offset_encoding();
 
     let pos = doc.position(view.id, offset_encoding);

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1080,7 +1080,7 @@ pub fn goto_implementation(cx: &mut Context) {
 pub fn goto_reference(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
-    let editor_cfg = cx.editor.config.load();
+    let config = cx.editor.config.load();
     let offset_encoding = language_server.offset_encoding();
 
     let pos = doc.position(view.id, offset_encoding);
@@ -1088,7 +1088,7 @@ pub fn goto_reference(cx: &mut Context) {
     let future = match language_server.goto_reference(
         doc.identifier(),
         pos,
-        editor_cfg.lsp.goto_reference_include_declaration,
+        config.lsp.goto_reference_include_declaration,
         None,
     ) {
         Some(future) => future,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1080,11 +1080,17 @@ pub fn goto_implementation(cx: &mut Context) {
 pub fn goto_reference(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let language_server = language_server!(cx.editor, doc);
+    let editor_cfg = cx.editor.config.load();
     let offset_encoding = language_server.offset_encoding();
 
     let pos = doc.position(view.id, offset_encoding);
 
-    let future = match language_server.goto_reference(doc.identifier(), pos, None) {
+    let future = match language_server.goto_reference(
+        doc.identifier(),
+        pos,
+        editor_cfg.lsp.goto_reference_include_declaration,
+        None,
+    ) {
         Some(future) => future,
         None => {
             cx.editor

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -354,6 +354,8 @@ pub struct LspConfig {
     pub display_inlay_hints: bool,
     /// Whether to enable snippet support
     pub snippets: bool,
+    /// Whether to include declaration in the goto reference query
+    pub goto_reference_include_declaration: bool,
 }
 
 impl Default for LspConfig {
@@ -365,6 +367,7 @@ impl Default for LspConfig {
             display_signature_help_docs: true,
             display_inlay_hints: false,
             snippets: true,
+            goto_reference_include_declaration: true,
         }
     }
 }


### PR DESCRIPTION
Fixes: #5344
