### PR TITLE
Allow clipboard paste with multiple selection

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -794,6 +794,12 @@ pub struct Breakpoint {
     pub log_message: Option<String>,
 }
 
+#[derive(Debug, Default)]
+pub struct ClipboardContent {
+    pub contents: Vec<String>,
+    pub hash: Option<u64>,
+}
+
 use futures_util::stream::{Flatten, Once};
 
 pub struct Editor {
@@ -823,7 +829,7 @@ pub struct Editor {
     pub breakpoints: HashMap<PathBuf, Vec<Breakpoint>>,
 
     pub clipboard_provider: Box<dyn ClipboardProvider>,
-
+    pub last_clipboard: [ClipboardContent; 2],
     pub syn_loader: Arc<syntax::Loader>,
     pub theme_loader: Arc<theme::Loader>,
     /// last_theme is used for theme previews. We store the current theme here,
@@ -964,6 +970,7 @@ impl Editor {
             last_selection: None,
             registers: Registers::default(),
             clipboard_provider: get_clipboard_provider(),
+            last_clipboard: Default::default(),
             status_msg: None,
             autoinfo: None,
             idle_timer: Box::pin(sleep(conf.idle_timeout)),


### PR DESCRIPTION
Allow pasting content with multiple selection if two requirement is fulfill:
1. The content is yank from same instance.
2. No other application overwrite the clipboard in that period. (unless the exact same string is copied or hash collision occurs)

Tested and working:
- wl-paste+wl-copy
- clipboard-win
- termcode

Not tested:
- pbpaste+pbcopy (mac)
- xclip
- xsel
- win32yank.exe
- termux-clipboard-set
- tmux