### PR TITLE
helix-core/surround: `Syntax` aware

### DIFF
--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -7,9 +7,9 @@ use crate::chars::{categorize_char, char_is_whitespace, CharCategory};
 use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
 use crate::line_ending::rope_is_line_ending;
 use crate::movement::Direction;
-use crate::surround;
 use crate::syntax::LanguageConfiguration;
 use crate::Range;
+use crate::{surround, Syntax};
 
 fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, long: bool) -> usize {
     use CharCategory::{Eol, Whitespace};
@@ -199,25 +199,28 @@ pub fn textobject_paragraph(
 }
 
 pub fn textobject_pair_surround(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     ch: char,
     count: usize,
 ) -> Range {
-    textobject_pair_surround_impl(slice, range, textobject, Some(ch), count)
+    textobject_pair_surround_impl(syntax, slice, range, textobject, Some(ch), count)
 }
 
 pub fn textobject_pair_surround_closest(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     count: usize,
 ) -> Range {
-    textobject_pair_surround_impl(slice, range, textobject, None, count)
+    textobject_pair_surround_impl(syntax, slice, range, textobject, None, count)
 }
 
 fn textobject_pair_surround_impl(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
@@ -225,7 +228,7 @@ fn textobject_pair_surround_impl(
     count: usize,
 ) -> Range {
     let pair_pos = match ch {
-        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
+        Some(ch) => surround::find_nth_pairs_pos(syntax, slice, ch, range, count),
         // Automatically find the closest surround pairs
         None => surround::find_nth_closest_pairs_pos(slice, range, count),
     };
@@ -574,7 +577,8 @@ mod test {
             let slice = doc.slice(..);
             for &case in scenario {
                 let (pos, objtype, expected_range, ch, count) = case;
-                let result = textobject_pair_surround(slice, Range::point(pos), objtype, ch, count);
+                let result =
+                    textobject_pair_surround(None, slice, Range::point(pos), objtype, ch, count);
                 assert_eq!(
                     result,
                     expected_range.into(),


### PR DESCRIPTION
Prior to this change, attempting to replace the double quotes in `" asdf "` would fail with "Cursor on ambiguous surround pair".

Now, after running e.g. `:set-language rust` in a file with the contents `" asdf "`, it is now possible to replace the double quotes with `mr` as you could with any other pair.

This change essentially makes any pair that you can use `mm` on to go to the matching pair also able to be replaced with `mr` or deleted with `md` (whether they be built-in, or provided by a tree-sitter grammar).

---

I would like to add tests for this, but I don't know how I should go about doing this (specifically, creating e.g. a Rust tree-sitter `Syntax` instance). I noticed one instance in `helix-core/tests/indent.rs`, but....  it seemed kinda heavy-weight. I'd be happy to use that approach, but I'm hoping to learn about something that's less verbose. Suggestions / examples appreciated :)