### PR TITLE
add move_prev_long_word_end and extend_prev_long_word_end commands

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1382,6 +1382,11 @@ mod test {
             ("    Jumping to end of a word preceded by whitespace",
                 vec![(1, Range::new(0, 0), Range::new(0, 11))]),
 
+            // // Why do we want this behavior?  The current behavior fails this
+            // // test, but seems better and more consistent.
+            // (" Starting from a boundary advances the anchor",
+            //     vec![(1, Range::new(0, 0), Range::new(1, 9))]),
+
             ("Previous anchor is irrelevant for end of word motion",
                 vec![(1, Range::new(12, 2), Range::new(2, 8))]),
             ("Identifiers_with_underscores are considered a single word",

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1373,20 +1373,6 @@ mod test {
     #[test]
     fn test_behaviour_when_moving_to_end_of_next_long_words() {
         let tests = [
-            // todo: add tests for `move_prev_long_word_end`
-       ];
-
-        for (sample, scenario) in tests {
-            for (count, begin, expected_end) in scenario.into_iter() {
-                let range = move_next_long_word_end(Rope::from(sample).slice(..), begin, count);
-                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
-            }
-        }
-    }
-
-    #[test]
-    fn test_behaviour_when_moving_to_end_of_prev_long_words() {
-        let tests = [
             ("Basic forward motion from the start of a word to the end of it",
                 vec![(1, Range::new(0, 0), Range::new(0, 5))]),
             ("Basic forward motion from the end of a word to the end of the next",
@@ -1451,6 +1437,20 @@ mod test {
                 vec![
                     (1, Range::new(0, 0), Range::new(0, 7)),
                 ]),
+        ];
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_next_long_word_end(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
+
+    #[test]
+    fn test_behaviour_when_moving_to_end_of_prev_long_words() {
+        let tests = [
+            // todo: add tests for `move_prev_long_word_end`
         ];
 
         for (sample, scenario) in tests {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -239,6 +239,7 @@ impl MappableCommand {
         move_next_long_word_start, "Move to start of next long word",
         move_prev_long_word_start, "Move to start of previous long word",
         move_next_long_word_end, "Move to end of next long word",
+        move_prev_long_word_end, "Move to end of previous long word",
         extend_next_word_start, "Extend to start of next word",
         extend_prev_word_start, "Extend to start of previous word",
         extend_next_word_end, "Extend to end of next word",
@@ -246,6 +247,7 @@ impl MappableCommand {
         extend_next_long_word_start, "Extend to start of next long word",
         extend_prev_long_word_start, "Extend to start of previous long word",
         extend_next_long_word_end, "Extend to end of next long word",
+        extend_prev_long_word_end, "Extend to end of prev long word",
         find_till_char, "Move till next occurrence of char",
         find_next_char, "Move to next occurrence of char",
         extend_till_char, "Extend till next occurrence of char",
@@ -1062,6 +1064,10 @@ fn move_prev_long_word_start(cx: &mut Context) {
     move_word_impl(cx, movement::move_prev_long_word_start)
 }
 
+fn move_prev_long_word_end(cx: &mut Context) {
+    move_word_impl(cx, movement::move_prev_long_word_end)
+}
+
 fn move_next_long_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_long_word_end)
 }
@@ -1217,6 +1223,10 @@ fn extend_next_long_word_start(cx: &mut Context) {
 
 fn extend_prev_long_word_start(cx: &mut Context) {
     extend_word_impl(cx, movement::move_prev_long_word_start)
+}
+
+fn extend_prev_long_word_end(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_prev_long_word_end)
 }
 
 fn extend_next_long_word_end(cx: &mut Context) {


### PR DESCRIPTION
Fixes #6904

Adds the `move_prev_long_word_end` and `extend_prev_long_word_end` commands.

Tests are adapted from `test_behaviour_when_moving_to_start_of_previous_long_words` of the `move_prev_long_word_start` command, please double check if these are correct.

Here's a quick config to test the new commands with the keybinding `A-W`, together with `A-w` for the already existing but by default unbound `move_prev_word_end`.

```toml
[keys.normal]
A-w = "move_prev_word_end"
A-W = "move_prev_long_word_end"

[keys.select]
A-w = "extend_prev_word_end"
A-W = "extend_prev_long_word_end"
```

