### PR TITLE
Only suggest automatic autocompletion after edit

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3182,6 +3182,11 @@ pub mod insert {
                 _ => return,
             }
         }
+        /* Only autocomplete on timer after the user has input character,
+        not when they are moving around the document. */
+        if doc.moved_since_changed() {
+            return;
+        }
         super::completion(cx);
     }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -883,6 +883,7 @@ impl Document {
 
     /// Select text within the [`Document`].
     pub fn set_selection(&mut self, view_id: ViewId, selection: Selection) {
+        self.moved_since_changed = true;
         // TODO: use a transaction?
         self.selections
             .insert(view_id, selection.ensure_invariants(self.text().slice(..)));

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1130,10 +1130,6 @@ impl Document {
         self.savepoints.push(savepoint_ref)
     }
 
-    pub fn register_insert_mode_movement(&mut self) {
-        self.moved_since_changed = true;
-    }
-
     fn earlier_later_impl(&mut self, view: &mut View, uk: UndoKind, earlier: bool) -> bool {
         let txns = if earlier {
             self.history.get_mut().earlier(uk)


### PR DESCRIPTION
When i move around in the document in insert mode i sometimes contemplate and wait a bit before continuing moving around. In this case i often get caught in an autocomplete dialogue and ends up changing the document without intention. I think it would be better to limit autocomplete to when a user has just changed the document, and not moved around.

I made a patch which made moving around with autocomplete enabled much more intuitive for me.
I guess it could be made an option if you don't want to change the default helix behaviour though.