### PR TITLE
Add require-git option

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -177,6 +177,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
         .max_depth(config.file_picker.max_depth)
+        .require_git(config.file_picker.require_git)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks));
 
     // We want to exclude files that the editor can't handle yet

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -190,6 +190,9 @@ pub struct FilePickerConfig {
     /// Enables reading `.git/info/exclude` files.
     /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to true.
     pub git_exclude: bool,
+    /// Enables use of local and global .gitignore files even if not in a git directory
+    /// Whether to require that the workspace is in a git repository for .gitignore parsing. Defaults to true.
+    pub require_git: bool,
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
@@ -206,6 +209,7 @@ impl Default for FilePickerConfig {
             git_ignore: true,
             git_global: true,
             git_exclude: true,
+            require_git: true,
             max_depth: None,
         }
     }


### PR DESCRIPTION
Adds a `require-git` config option to the file picker and uses it to determine whether the `ignore::WalkBuilder` requires the current directory to be a git directory or not.