### PR TITLE
Rename till commands

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -43,7 +43,7 @@
 | `E`                   | Move next WORD end                                 | `move_next_long_word_end`   |
 | `t`                   | Find 'till next char                               | `find_till_char`            |
 | `f`                   | Find next char                                     | `find_next_char`            |
-| `T`                   | Find 'till previous char                           | `till_prev_char`            |
+| `T`                   | Find 'till previous char                           | `find_till_prev_char`       |
 | `F`                   | Find previous char                                 | `find_prev_char`            |
 | `G`                   | Go to line number `<n>`                            | `goto_line`                 |
 | `Alt-.`               | Repeat last motion (`f`, `t` or `m`)               | `repeat_last_motion`        |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -41,7 +41,7 @@
 | `W`                   | Move next WORD start                               | `move_next_long_word_start` |
 | `B`                   | Move previous WORD start                           | `move_prev_long_word_start` |
 | `E`                   | Move next WORD end                                 | `move_next_long_word_end`   |
-| `t`                   | Find 'till next char                               | `find_till_char`            |
+| `t`                   | Find 'till next char                               | `find_till_next_char`       |
 | `f`                   | Find next char                                     | `find_next_char`            |
 | `T`                   | Find 'till previous char                           | `find_till_prev_char`       |
 | `F`                   | Find previous char                                 | `find_prev_char`            |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -250,7 +250,9 @@ impl MappableCommand {
         // TODO: remove `find_till_char` with version 23.03 + X
         find_till_char, "Move till next occurrence of char [DEPRECATED]",
         find_next_char, "Move to next occurrence of char",
-        extend_till_char, "Extend till next occurrence of char",
+        extend_till_next_char, "Extend till next occurrence of char",
+        // TODO: remove `extend_till_char` with version 23.03 + X
+        extend_till_char, "Extend till next occurrence of char [DEPRECATED]",
         extend_next_char, "Extend to next occurrence of char",
         find_till_prev_char, "Move till previous occurrence of char",
         // TODO: remove `till_prev_char` with version 23.03 + X
@@ -1357,8 +1359,13 @@ fn find_next_char(cx: &mut Context) {
     will_find_char(cx, find_next_char_impl, true, false)
 }
 
-fn extend_till_char(cx: &mut Context) {
+fn extend_till_next_char(cx: &mut Context) {
     will_find_char(cx, find_next_char_impl, false, true)
+}
+
+// todo: remove `extend_till_char` with version 23.03 + X
+fn extend_till_char(cx: &mut Context) {
+    extend_till_next_char(cx)
 }
 
 fn extend_next_char(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -250,7 +250,9 @@ impl MappableCommand {
         find_next_char, "Move to next occurrence of char",
         extend_till_char, "Extend till next occurrence of char",
         extend_next_char, "Extend to next occurrence of char",
-        till_prev_char, "Move till previous occurrence of char",
+        find_till_prev_char, "Move till previous occurrence of char",
+        // TODO: remove `till_prev_char` with version 23.03 + X
+        till_prev_char, "Move till previous occurrence of char [DEPRECATED]",
         find_prev_char, "Move to previous occurrence of char",
         extend_till_prev_char, "Extend till previous occurrence of char",
         extend_prev_char, "Extend to previous occurrence of char",
@@ -1356,8 +1358,13 @@ fn extend_next_char(cx: &mut Context) {
     will_find_char(cx, find_next_char_impl, true, true)
 }
 
-fn till_prev_char(cx: &mut Context) {
+fn find_till_prev_char(cx: &mut Context) {
     will_find_char(cx, find_prev_char_impl, false, false)
+}
+
+// todo: remove `till_prev_char` with version 23.03 + X
+fn till_prev_char(cx: &mut Context) {
+    find_till_prev_char(cx)
 }
 
 fn find_prev_char(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -246,7 +246,9 @@ impl MappableCommand {
         extend_next_long_word_start, "Extend to start of next long word",
         extend_prev_long_word_start, "Extend to start of previous long word",
         extend_next_long_word_end, "Extend to end of next long word",
-        find_till_char, "Move till next occurrence of char",
+        find_till_next_char, "Move till next occurrence of char",
+        // TODO: remove `find_till_char` with version 23.03 + X
+        find_till_char, "Move till next occurrence of char [DEPRECATED]",
         find_next_char, "Move to next occurrence of char",
         extend_till_char, "Extend till next occurrence of char",
         extend_next_char, "Extend to next occurrence of char",
@@ -1342,8 +1344,13 @@ fn find_prev_char_impl(
     }
 }
 
-fn find_till_char(cx: &mut Context) {
+fn find_till_next_char(cx: &mut Context) {
     will_find_char(cx, find_next_char_impl, false, false)
+}
+
+// todo: remove `find_till_char` with version 23.03 + X
+fn find_till_char(cx: &mut Context) {
+    find_till_next_char(cx)
 }
 
 fn find_next_char(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -338,7 +338,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "n" => extend_search_next,
         "N" => extend_search_prev,
 
-        "t" => extend_till_char,
+        "t" => extend_till_next_char,
         "f" => extend_next_char,
         "T" => extend_till_prev_char,
         "F" => extend_prev_char,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -13,7 +13,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "t" => find_till_char,
         "f" => find_next_char,
-        "T" => till_prev_char,
+        "T" => find_till_prev_char,
         "F" => find_prev_char,
         "r" => replace,
         "R" => replace_with_yanked,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -11,7 +11,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
         "k" | "up" => move_visual_line_up,
         "l" | "right" => move_char_right,
 
-        "t" => find_till_char,
+        "t" => find_till_next_char,
         "f" => find_next_char,
         "T" => find_till_prev_char,
         "F" => find_prev_char,


### PR DESCRIPTION
Fixes #6929

This renames the till commands `find_till_char`, `extend_till_char`, and `till_prev_char` to `find_till_next_char`, `extend_till_next_char`, and `find_till_prev_char`.

Currently, this keeps the existing commands intact as aliases to the renamed ones, adding "[DEPRECATED]" to the description and a TODO comments for scheduled removal after [TBD] versions (with current version being 23.03).

Opening to gather feedback.