### PR TITLE
Properly handle case where last character in a cancelled command begins a new command

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -853,7 +853,8 @@ impl EditorView {
                         commands::insert::insert_char(cx, ch)
                     }
                 }
-                KeymapResult::Cancelled(pending) => {
+                KeymapResult::Cancelled(mut pending) => {
+                    let last_evt = pending.pop().unwrap();
                     for ev in pending {
                         match ev.char() {
                             Some(ch) => commands::insert::insert_char(cx, ch),
@@ -865,6 +866,14 @@ impl EditorView {
                                 }
                             }
                         }
+                    }
+                    match self.handle_keymap_event(Mode::Insert, cx, last_evt) {
+                        Some(KeymapResult::NotFound) => {
+                            if let Some(ch) = last_evt.char() {
+                                commands::insert::insert_char(cx, ch)
+                            }
+                        }
+                        _ => (),
                     }
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
This is per issue #6878 