### PR TITLE
Fix keymap select / extend mode anchor link

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -15,7 +15,7 @@
       - [Popup](#popup)
     - [Unimpaired](#unimpaired)
 - [Insert mode](#insert-mode)
-- [Select / extend mode](#select-extend-mode)
+- [Select / extend mode](#select--extend-mode)
 - [Picker](#picker)
 - [Prompt](#prompt)
 


### PR DESCRIPTION
This fixes a broken anchor tag in the Keymap page's table of contents.