### PR TITLE
Add line-number option always-relative (#6240)

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -44,7 +44,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `middle-click-paste` | Middle click paste support | `true` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step | `3` |
 | `shell` | Shell to use when running external commands | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
-| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `absolute` |
+| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers. `always-relative` shows relative line numbers in every mode | `absolute` |
 | `cursorline` | Highlight all lines with a cursor | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -562,6 +562,9 @@ pub enum LineNumber {
     /// If focused and in normal/select mode, show relative line number to the primary cursor.
     /// If unfocused or in insert mode, show absolute line number.
     Relative,
+
+    /// Always show relative line number to the primary cursor.
+    AlwaysRelative,
 }
 
 impl std::str::FromStr for LineNumber {
@@ -571,7 +574,10 @@ impl std::str::FromStr for LineNumber {
         match s.to_lowercase().as_str() {
             "absolute" | "abs" => Ok(Self::Absolute),
             "relative" | "rel" => Ok(Self::Relative),
-            _ => anyhow::bail!("Line number can only be `absolute` or `relative`."),
+            "always-relative" | "arel" => Ok(Self::AlwaysRelative),
+            _ => anyhow::bail!(
+                "Line number can only be `absolute`, `relative`, or `always-relative`."
+            ),
         }
     }
 }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -175,9 +175,8 @@ pub fn line_numbers<'doc>(
             } else {
                 use crate::{document::Mode, editor::LineNumber};
 
-                let relative = line_number == LineNumber::Relative
-                    && mode != Mode::Insert
-                    && is_focused
+                let relative = (line_number == LineNumber::AlwaysRelative
+                    || (line_number == LineNumber::Relative && mode != Mode::Insert && is_focused))
                     && current_line != line;
 
                 let display_num = if relative {


### PR DESCRIPTION
As proposed in the discussion #6240, I added an option `always-relative` to show relative line-numbers in every mode to stop distracting visual jumps.

I mentioned it in the documentation.

Since this is my first PR, just let me know if it needs further tweaks :)