### PR TITLE
Add Flathub to the list of Linux third party repositories

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -8,6 +8,7 @@
   - [Fedora/RHEL](#fedorarhel)
   - [Arch Linux community](#arch-linux-community)
   - [NixOS](#nixos)
+  - [Flatpak](#flatpak)
   - [AppImage](#appimage)
 - [macOS](#macos)
   - [Homebrew Core](#homebrew-core)
@@ -18,6 +19,9 @@
   - [MSYS2](#msys2)
 - [Building from source](#building-from-source)
   - [Configuring Helix's runtime files](#configuring-helixs-runtime-files)
+    - [Linux and macOS](#linux-and-macos)
+    - [Windows](#windows)
+    - [Multiple runtime directories](#multiple-runtime-directories)
   - [Validating the installation](#validating-the-installation)
   - [Configure the desktop shortcut](#configure-the-desktop-shortcut)
 <!--toc:end-->
@@ -87,6 +91,15 @@ accepts the new settings on first use.
 If you are using a version of Nix without flakes enabled,
 [install Cachix CLI](https://docs.cachix.org/installation) and use
 `cachix use helix` to configure Nix to use cached outputs when possible.
+
+### Flatpak
+
+Helix is available on [Flathub](https://flathub.org/en-GB/apps/com.helix_editor.Helix):
+
+```sh
+flatpak install flathub com.helix_editor.Helix
+flatpak run com.helix_editor.Helix
+```
 
 ### AppImage
 


### PR DESCRIPTION
I added Flathub to address a comment in https://github.com/helix-editor/helix/issues/6993

When updating the TOC it picked up that some subheadings from another PR had not been added, so they are now included.