### PR TITLE
Remove `tree-sitter-cabal`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2467,10 +2467,6 @@ roots = ["cabal.project", "Setup.hs"]
 indent = { tab-width = 2, unit = "  " }
 comment-token = "--"
 
-[[grammar]]
-name = "cabal"
-source = { git = "https://gitlab.com/magus/tree-sitter-cabal", rev = "7d5fa6887ae05a0b06d046f1e754c197c8ad869b" }
-
 [[language]]
 name = "hurl"
 scope = "source.hurl"


### PR DESCRIPTION
I think I added this prematurely. The upstream parser isn't mature enough, and segfaults on quite a few routine edits of `.cabal` files (e.g., those generated by `hpack`, or files with merge conflicts). I think we should drop this until it's more mature.