### PR TITLE
Support use of the SUPER key as a modifier

### DIFF
--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -158,7 +158,7 @@ pub(crate) mod keys {
 impl fmt::Display for KeyEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "{}{}{}",
+            "{}{}{}{}",
             if self.modifiers.contains(KeyModifiers::SHIFT) {
                 "S-"
             } else {
@@ -171,6 +171,11 @@ impl fmt::Display for KeyEvent {
             },
             if self.modifiers.contains(KeyModifiers::CONTROL) {
                 "C-"
+            } else {
+                ""
+            },
+            if self.modifiers.contains(KeyModifiers::SUPER) {
+                "X-"
             } else {
                 ""
             },
@@ -392,6 +397,7 @@ impl std::str::FromStr for KeyEvent {
                 "S" => KeyModifiers::SHIFT,
                 "A" => KeyModifiers::ALT,
                 "C" => KeyModifiers::CONTROL,
+                "X" => KeyModifiers::SUPER,
                 _ => return Err(anyhow!("Invalid key modifier '{}-'", token)),
             };
 
@@ -489,6 +495,8 @@ impl From<crossterm::event::KeyEvent> for KeyEvent {
                 modifiers,
             }
         } else {
+            log::debug!("Received KeyEvent: code = {:?}, modifiers = {:?}", code, modifiers);
+
             Self {
                 code: code.into(),
                 modifiers: modifiers.into(),

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -7,6 +7,7 @@ bitflags! {
         const SHIFT = 0b0000_0001;
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
+        const SUPER = 0b0000_1000;
         const NONE = 0b0000_0000;
     }
 }
@@ -26,6 +27,9 @@ impl From<KeyModifiers> for crossterm::event::KeyModifiers {
         }
         if key_modifiers.contains(KeyModifiers::ALT) {
             result.insert(CKeyModifiers::ALT);
+        }
+        if key_modifiers.contains(KeyModifiers::SUPER) {
+            result.insert(CKeyModifiers::SUPER);
         }
 
         result
@@ -47,6 +51,9 @@ impl From<crossterm::event::KeyModifiers> for KeyModifiers {
         }
         if val.contains(CKeyModifiers::ALT) {
             result.insert(KeyModifiers::ALT);
+        }
+        if val.contains(CKeyModifiers::SUPER) {
+            result.insert(KeyModifiers::SUPER);
         }
 
         result


### PR DESCRIPTION
This allows creating custom keybindings using the super key (command on macOS, Windows/Linux key otherwise). It uses `X` as the key name as `C` is already taken.

I originally did this on my local helix build and purely for myself, but I decided I might as well open a PR for it in case others find it useful. 
