### PR TITLE
Fix warnings from clippy

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -397,15 +397,10 @@ mod test {
 
         let selections: SmallVec<[Range; 1]> = spec
             .match_indices('^')
-            .into_iter()
             .map(|(i, _)| Range::point(i))
             .collect();
 
-        let expectations: Vec<usize> = spec
-            .match_indices('_')
-            .into_iter()
-            .map(|(i, _)| i)
-            .collect();
+        let expectations: Vec<usize> = spec.match_indices('_').map(|(i, _)| i).collect();
 
         (rope, Selection::new(selections, 0), expectations)
     }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -188,7 +188,7 @@ impl<'de> Deserialize<'de> for FileType {
             {
                 match map.next_entry::<String, String>()? {
                     Some((key, suffix)) if key == "suffix" => Ok(FileType::Suffix(
-                        suffix.replace('/', &std::path::MAIN_SEPARATOR.to_string()),
+                        suffix.replace('/', std::path::MAIN_SEPARATOR_STR),
                     )),
                     Some((key, _value)) => Err(serde::de::Error::custom(format!(
                         "unknown key in `file-types` list: {}",

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -187,9 +187,12 @@ impl<'de> Deserialize<'de> for FileType {
                 M: serde::de::MapAccess<'de>,
             {
                 match map.next_entry::<String, String>()? {
-                    Some((key, suffix)) if key == "suffix" => Ok(FileType::Suffix(
-                        suffix.replace('/', std::path::MAIN_SEPARATOR_STR),
-                    )),
+                    Some((key, suffix)) if key == "suffix" => Ok(FileType::Suffix({
+                        // FIXME: use `suffix.replace('/', std::path::MAIN_SEPARATOR_STR)`
+                        //        if MSRV is updated to 1.68
+                        let mut seperator = [0; 1];
+                        suffix.replace('/', std::path::MAIN_SEPARATOR.encode_utf8(&mut seperator))
+                    })),
                     Some((key, _value)) => Err(serde::de::Error::custom(format!(
                         "unknown key in `file-types` list: {}",
                         key

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -209,6 +209,24 @@ pub fn merge_toml_values(left: toml::Value, right: toml::Value, merge_depth: usi
     }
 }
 
+/// Finds the current workspace folder.
+/// Used as a ceiling dir for LSP root resolution, the filepicker and potentially as a future filewatching root
+///
+/// This function starts searching the FS upward from the CWD
+/// and returns the first directory that contains either `.git` or `.helix`.
+/// If no workspace was found returns (CWD, true).
+/// Otherwise (workspace, false) is returned
+pub fn find_workspace() -> (PathBuf, bool) {
+    let current_dir = std::env::current_dir().expect("unable to determine current directory");
+    for ancestor in current_dir.ancestors() {
+        if ancestor.join(".git").exists() || ancestor.join(".helix").exists() {
+            return (ancestor.to_owned(), false);
+        }
+    }
+
+    (current_dir, true)
+}
+
 #[cfg(test)]
 mod merge_toml_tests {
     use std::str;
@@ -280,22 +298,4 @@ mod merge_toml_tests {
             &vec![Value::String("lsp".into())]
         )
     }
-}
-
-/// Finds the current workspace folder.
-/// Used as a ceiling dir for LSP root resolution, the filepicker and potentially as a future filewatching root
-///
-/// This function starts searching the FS upward from the CWD
-/// and returns the first directory that contains either `.git` or `.helix`.
-/// If no workspace was found returns (CWD, true).
-/// Otherwise (workspace, false) is returned
-pub fn find_workspace() -> (PathBuf, bool) {
-    let current_dir = std::env::current_dir().expect("unable to determine current directory");
-    for ancestor in current_dir.ancestors() {
-        if ancestor.join(".git").exists() || ancestor.join(".helix").exists() {
-            return (ancestor.to_owned(), false);
-        }
-    }
-
-    (current_dir, true)
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -103,7 +103,7 @@ impl EditorView {
 
         // Set DAP highlights, if needed.
         if let Some(frame) = editor.current_stack_frame() {
-            let dap_line = frame.line.saturating_sub(1) as usize;
+            let dap_line = frame.line.saturating_sub(1);
             let style = theme.get("ui.highlight.frameline");
             let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
                 if pos.doc_line != dap_line {

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -442,7 +442,7 @@ impl Buffer {
         let mut x_offset = x as usize;
         let max_offset = min(self.area.right(), width.saturating_add(x));
         let mut start_index = self.index_of(x, y);
-        let mut index = self.index_of(max_offset as u16, y);
+        let mut index = self.index_of(max_offset, y);
 
         let content_width = spans.width();
         let truncated = content_width > width as usize;

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -68,7 +68,7 @@ macro_rules! command_provider {
 
 #[cfg(windows)]
 pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
-    Box::new(provider::WindowsProvider::default())
+    Box::<provider::WindowsProvider>::default()
 }
 
 #[cfg(target_os = "macos")]

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -689,7 +689,7 @@ pub struct WhitespaceCharacters {
 impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
-            space: '·',   // U+00B7
+            space: '·',    // U+00B7
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -689,7 +689,7 @@ pub struct WhitespaceCharacters {
 impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
-            space: '·',    // U+00B7
+            space: '·',   // U+00B7
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -728,12 +728,11 @@ mod test {
         tree.focus = l0;
         let view = View::new(DocumentId::default(), GutterConfig::default());
         tree.split(view, Layout::Vertical);
-        let l2 = tree.focus;
 
         // Tree in test
         // | L0  | L2 |    |
         // |    L1    | R0 |
-        tree.focus = l2;
+        let l2 = tree.focus;
         assert_eq!(Some(l0), tree.find_split_in_direction(l2, Direction::Left));
         assert_eq!(Some(l1), tree.find_split_in_direction(l2, Direction::Down));
         assert_eq!(Some(r0), tree.find_split_in_direction(l2, Direction::Right));


### PR DESCRIPTION

I found clippy complained a lot and thus fix them.

<details>                                                                                                                                                                                         <summary>cargo clippy --workspace --all-targets</summary>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           

```rust
helix $ cargo clippy --workspace --all-targets
warning: items were found after the testing module
   --> helix-loader\src\lib.rs:213:1
    |
213 | / mod merge_toml_tests {
214 | |     use std::str;
215 | |
216 | |     use super::merge_toml_values;
...   |
300 | |     (current_dir, true)
301 | | }
    | |_^
    |
    = help: move the items to before the testing module was defined
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#items_after_test_module
    = note: `#[warn(clippy::items_after_test_module)]` on by default

    Checking helix-core v0.6.0 (E:\Rust\helix\helix-core)
warning: `helix-loader` (lib test) generated 1 warning
   Compiling helix-term v0.6.0 (E:\Rust\helix\helix-term)
warning: taking a reference on `std::path::MAIN_SEPARATOR` conversion to `String`
   --> helix-core\src\syntax.rs:191:45
    |
191 |                         suffix.replace('/', &std::path::MAIN_SEPARATOR.to_string()),
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `std::path::MAIN_SEPARATOR_STR`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_main_separator_str
    = note: `#[warn(clippy::manual_main_separator_str)]` on by default

warning: `helix-core` (lib) generated 1 warning (run `cargo clippy --fix --lib -p helix-core` to apply 1 suggestion)
    Checking helix-lsp v0.6.0 (E:\Rust\helix\helix-lsp)
    Checking helix-vcs v0.6.0 (E:\Rust\helix\helix-vcs)
    Checking helix-dap v0.6.0 (E:\Rust\helix\helix-dap)
warning: useless conversion to the same type: `std::str::MatchIndices<'_, char>`
   --> helix-core\src\surround.rs:398:48
    |
398 |           let selections: SmallVec<[Range; 1]> = spec
    |  ________________________________________________^
399 | |             .match_indices('^')
400 | |             .into_iter()
    | |________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default
help: consider removing `.into_iter()`
    |
398 ~         let selections: SmallVec<[Range; 1]> = spec
399 +             .match_indices('^')
    |

warning: useless conversion to the same type: `std::str::MatchIndices<'_, char>`
   --> helix-core\src\surround.rs:404:40
    |
404 |           let expectations: Vec<usize> = spec
    |  ________________________________________^
405 | |             .match_indices('_')
406 | |             .into_iter()
    | |________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
    |
404 ~         let expectations: Vec<usize> = spec
405 +             .match_indices('_')
    |

warning: `helix-core` (lib test) generated 3 warnings (1 duplicate) (run `cargo clippy --fix --lib -p helix-core --tests` to apply 2 suggestions)
    Checking helix-view v0.6.0 (E:\Rust\helix\helix-view)
warning: `Box::new(_)` of default value
  --> helix-view\src\clipboard.rs:71:5
   |
71 |     Box::new(provider::WindowsProvider::default())
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::<WindowsProvider>::default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#box_default
   = note: `#[warn(clippy::box_default)]` on by default

warning: use of `default` to create a unit struct
  --> helix-view\src\clipboard.rs:71:39
   |
71 |     Box::new(provider::WindowsProvider::default())
   |                                       ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `#[warn(clippy::default_constructed_unit_structs)]` on by default

warning: `helix-view` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p helix-view` to apply 2 suggestions)
    Checking helix-tui v0.6.0 (E:\Rust\helix\helix-tui)
warning: casting to the same type is unnecessary (`u16` -> `u16`)
   --> helix-tui\src\buffer.rs:445:39
    |
445 |         let mut index = self.index_of(max_offset as u16, y);
    |                                       ^^^^^^^^^^^^^^^^^ help: try: `max_offset`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: `helix-tui` (lib) generated 1 warning (run `cargo clippy --fix --lib -p helix-tui` to apply 1 suggestion)
warning: `helix-tui` (lib test) generated 1 warning (1 duplicate)
error: this looks like you are trying to swap `l2` and `tree.focus`
   --> helix-view\src\tree.rs:731:9
    |
731 | /         let l2 = tree.focus;
732 | |
733 | |         // Tree in test
734 | |         // | L0  | L2 |    |
735 | |         // |    L1    | R0 |
736 | |         tree.focus = l2;
    | |_______________________^ help: try: `std::mem::swap(&mut l2, &mut tree.focus)`
    |
    = note: or maybe you should use `std::mem::replace`?
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#almost_swapped
    = note: `#[deny(clippy::almost_swapped)]` on by default

warning: `helix-view` (lib test) generated 2 warnings (2 duplicates)
error: could not compile `helix-view` (lib test) due to previous error; 2 warnings emitted
warning: build failed, waiting for other jobs to finish...
warning: casting to the same type is unnecessary (`usize` -> `usize`)
   --> helix-term\src\ui\editor.rs:106:28
    |
106 |             let dap_line = frame.line.saturating_sub(1) as usize;
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `frame.line.saturating_sub(1)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: `helix-term` (lib) generated 1 warning (run `cargo clippy --fix --lib -p helix-term` to apply 1 suggestion)
warning: `helix-term` (lib test) generated 1 warning (1 duplicate)
```

</details>