### PR TITLE
Add better error message for file save failure due to parent not existing

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -808,7 +808,7 @@ impl Document {
                     if force {
                         std::fs::DirBuilder::new().recursive(true).create(parent)?;
                     } else {
-                        bail!("can't save file, parent directory does not exist");
+                        bail!("can't save file, parent directory does not exist (use :w! to create it)");
                     }
                 }
             }


### PR DESCRIPTION
Fixes #5229

had to google to workout how to save with parents (and found that issue) so thought it would be worth fixing it for others