### PR TITLE
Allow configuring enhanced keyboard protocol detection

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -62,6 +62,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
+| `enhanced-keyboard-protocol` | Set to `true` to force enabling the enhanced keyboard protocol or `false` to disable. When omitted, the host terminal is queried to detect support | none |
 
 ### `[editor.statusline]` Section
 

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -18,14 +18,29 @@ pub struct Viewport {
 }
 
 #[derive(Debug)]
+pub enum FeatureToggle {
+    Enable,
+    Disable,
+    Detect,
+}
+
+#[derive(Debug)]
 pub struct Config {
     pub enable_mouse_capture: bool,
+    pub enable_enhanced_keyboard_protocol: FeatureToggle,
 }
 
 impl From<EditorConfig> for Config {
     fn from(config: EditorConfig) -> Self {
+        let enable_enhanced_keyboard_protocol = match config.enhanced_keyboard_protocol {
+            Some(true) => FeatureToggle::Enable,
+            Some(false) => FeatureToggle::Disable,
+            None => FeatureToggle::Detect,
+        };
+
         Self {
             enable_mouse_capture: config.mouse,
+            enable_enhanced_keyboard_protocol,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -284,6 +284,9 @@ pub struct Config {
     pub soft_wrap: SoftWrap,
     /// Workspace specific lsp ceiling dirs
     pub workspace_lsp_roots: Vec<PathBuf>,
+    /// Whether to force enabling or disabling support for the enhanced keyboard protocol.
+    /// Set to `None` to automatically detect support by querying the host terminal.
+    pub enhanced_keyboard_protocol: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -759,6 +762,7 @@ impl Default for Config {
             text_width: 80,
             completion_replace: false,
             workspace_lsp_roots: Vec::new(),
+            enhanced_keyboard_protocol: None,
         }
     }
 }


### PR DESCRIPTION
This can be used to force Helix to enable or disable support for the enhanced (Kitty) keyboard protocol. Force disabling support can be useful if you rely on ambiguous escape codes (C-[ is suprisingly popular). Force enabling this can be useful to avoid any overhead of the automatic detection, though this is usually unnoticeably small.

This fixes https://github.com/helix-editor/helix/issues/6551 but I think the proper way to support that workflow is to enable rebinding Escape in remaining places (#5505). I'll open this so anyone who wants to can use the changes but I'm not sure this should actually be merged.