### PR TITLE
Add Odin comment injections

### DIFF
--- a/runtime/queries/odin/injections.scm
+++ b/runtime/queries/odin/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This enables highlighting of `@note`, `TODO`, etc in comments.