### PR TITLE
Fix TS freezing the editor

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -765,7 +765,11 @@ fn byte_range_to_str(range: std::ops::Range<usize>, source: RopeSlice) -> Cow<st
 }
 
 impl Syntax {
-    pub fn new(source: &Rope, config: Arc<HighlightConfiguration>, loader: Arc<Loader>) -> Self {
+    pub fn new(
+        source: &Rope,
+        config: Arc<HighlightConfiguration>,
+        loader: Arc<Loader>,
+    ) -> Option<Self> {
         let root_layer = LanguageLayer {
             tree: None,
             config,
@@ -790,11 +794,13 @@ impl Syntax {
             loader,
         };
 
-        syntax
-            .update(source, source, &ChangeSet::new(source))
-            .unwrap();
+        let res = syntax.update(source, source, &ChangeSet::new(source));
 
-        syntax
+        if res.is_err() {
+            log::error!("TS parser failed, disabeling TS for the current buffer: {res:?}");
+            return None;
+        }
+        Some(syntax)
     }
 
     pub fn update(
@@ -922,6 +928,7 @@ impl Syntax {
 
         PARSER.with(|ts_parser| {
             let ts_parser = &mut ts_parser.borrow_mut();
+            ts_parser.parser.set_timeout_micros(1000 * 500); // half a second is pretty generours
             let mut cursor = ts_parser.cursors.pop().unwrap_or_else(QueryCursor::new);
             // TODO: might need to set cursor range
             cursor.set_byte_range(0..usize::MAX);
@@ -2368,7 +2375,7 @@ mod test {
         let mut cursor = QueryCursor::new();
 
         let config = HighlightConfiguration::new(language, "", "", "").unwrap();
-        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader));
+        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader)).unwrap();
 
         let root = syntax.tree().root_node();
         let mut test = |capture, range| {
@@ -2439,7 +2446,7 @@ mod test {
             fn main() {}
         ",
         );
-        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader));
+        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader)).unwrap();
         let tree = syntax.tree();
         let root = tree.root_node();
         assert_eq!(root.kind(), "source_file");
@@ -2526,7 +2533,7 @@ mod test {
         let language = get_language(language_name).unwrap();
 
         let config = HighlightConfiguration::new(language, "", "", "").unwrap();
-        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader));
+        let syntax = Syntax::new(&source, Arc::new(config), Arc::new(loader)).unwrap();
 
         let root = syntax
             .tree()

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -72,7 +72,7 @@ fn test_treesitter_indent(file_name: &str, lang_scope: &str) {
 
     let language_config = loader.language_config_for_scope(lang_scope).unwrap();
     let highlight_config = language_config.highlight_config(&[]).unwrap();
-    let syntax = Syntax::new(&doc, highlight_config, std::sync::Arc::new(loader));
+    let syntax = Syntax::new(&doc, highlight_config, std::sync::Arc::new(loader)).unwrap();
     let indent_query = language_config.indent_query().unwrap();
     let text = doc.slice(..);
 

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -51,7 +51,7 @@ pub fn highlighted_code_block<'a>(
             language.into(),
         ))
         .and_then(|config| config.highlight_config(theme.scopes()))
-        .map(|config| Syntax::new(&rope, config, Arc::clone(&config_loader)));
+        .and_then(|config| Syntax::new(&rope, config, Arc::clone(&config_loader)));
 
     let syntax = match syntax {
         Some(s) => s,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1,7 +1,9 @@
 use crate::{
     alt,
-    compositor::{Component, Compositor, Context, Event, EventResult},
-    ctrl, key, shift,
+    compositor::{self, Component, Compositor, Context, Event, EventResult},
+    ctrl,
+    job::Callback,
+    key, shift,
     ui::{
         self,
         document::{render_document, LineDecoration, LinePos, TextRenderer},
@@ -9,7 +11,7 @@ use crate::{
         EditorView,
     },
 };
-use futures_util::future::BoxFuture;
+use futures_util::{future::BoxFuture, FutureExt};
 use tui::{
     buffer::Buffer as Surface,
     layout::Constraint,
@@ -26,7 +28,7 @@ use std::{collections::HashMap, io::Read, path::PathBuf};
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::{
     movement::Direction, text_annotations::TextAnnotations,
-    unicode::segmentation::UnicodeSegmentation, Position,
+    unicode::segmentation::UnicodeSegmentation, Position, Syntax,
 };
 use helix_view::{
     editor::Action,
@@ -122,7 +124,7 @@ impl Preview<'_, '_> {
     }
 }
 
-impl<T: Item> FilePicker<T> {
+impl<T: Item + 'static> FilePicker<T> {
     pub fn new(
         options: Vec<T>,
         editor_data: T::Data,
@@ -208,29 +210,67 @@ impl<T: Item> FilePicker<T> {
     }
 
     fn handle_idle_timeout(&mut self, cx: &mut Context) -> EventResult {
+        let Some((current_file, _)) = self.current_file(cx.editor) else {
+            return EventResult::Consumed(None)
+        };
+
         // Try to find a document in the cache
-        let doc = self
-            .current_file(cx.editor)
-            .and_then(|(path, _range)| match path {
-                PathOrId::Id(doc_id) => Some(doc_mut!(cx.editor, &doc_id)),
-                PathOrId::Path(path) => match self.preview_cache.get_mut(&path) {
-                    Some(CachedPreview::Document(doc)) => Some(doc),
-                    _ => None,
-                },
-            });
+        let doc = match &current_file {
+            PathOrId::Id(doc_id) => doc_mut!(cx.editor, doc_id),
+            PathOrId::Path(path) => match self.preview_cache.get_mut(path) {
+                Some(CachedPreview::Document(ref mut doc)) => doc,
+                _ => return EventResult::Consumed(None),
+            },
+        };
+
+        let mut callback: Option<compositor::Callback> = None;
 
         // Then attempt to highlight it if it has no language set
-        if let Some(doc) = doc {
-            if doc.language_config().is_none() {
+        if doc.language_config().is_none() {
+            if let Some(language_config) = doc.detect_language_config(&cx.editor.syn_loader) {
+                doc.language = Some(language_config.clone());
+                let text = doc.text().clone();
                 let loader = cx.editor.syn_loader.clone();
-                doc.detect_language(loader);
+                let job = tokio::task::spawn_blocking(move || {
+                    let syntax = language_config
+                        .highlight_config(&loader.scopes())
+                        .and_then(|highlight_config| Syntax::new(&text, highlight_config, loader));
+                    let callback = move |editor: &mut Editor, compositor: &mut Compositor| {
+                        let Some(syntax) = syntax else {
+                            log::info!("highlighting picker item failed");
+                            return
+                        };
+                        log::info!("hmm1");
+                        let Some(Overlay { content: picker, .. }) = compositor.find::<Overlay<Self>>() else {
+                            log::info!("picker closed before syntax highlighting finished");
+                            return
+                        };
+                        log::info!("hmm2");
+                        // Try to find a document in the cache
+                        let doc = match current_file {
+                            PathOrId::Id(doc_id) => doc_mut!(editor, &doc_id),
+                            PathOrId::Path(path) => match picker.preview_cache.get_mut(&path) {
+                                Some(CachedPreview::Document(ref mut doc)) => doc,
+                                _ => return,
+                            },
+                        };
+                        log::info!("yay");
+                        doc.syntax = Some(syntax);
+                    };
+                    Callback::EditorCompositor(Box::new(callback))
+                });
+                let tmp: compositor::Callback = Box::new(move |_, ctx| {
+                    ctx.jobs
+                        .callback(job.map(|res| res.map_err(anyhow::Error::from)))
+                });
+                callback = Some(Box::new(tmp))
             }
-
-            // QUESTION: do we want to compute inlay hints in pickers too ? Probably not for now
-            // but it could be interesting in the future
         }
 
-        EventResult::Consumed(None)
+        // QUESTION: do we want to compute inlay hints in pickers too ? Probably not for now
+        // but it could be interesting in the future
+
+        EventResult::Consumed(callback)
     }
 }
 
@@ -372,6 +412,10 @@ impl<T: Item + 'static> Component for FilePicker<T> {
         };
         self.picker.required_size((picker_width, height))?;
         Some((width, height))
+    }
+
+    fn id(&self) -> Option<&'static str> {
+        Some("file-picker")
     }
 }
 
@@ -945,17 +989,16 @@ impl<T: Item + Send + 'static> Component for DynamicPicker<T> {
 
         cx.jobs.callback(async move {
             let new_options = new_options.await?;
-            let callback =
-                crate::job::Callback::EditorCompositor(Box::new(move |editor, compositor| {
-                    // Wrapping of pickers in overlay is done outside the picker code,
-                    // so this is fragile and will break if wrapped in some other widget.
-                    let picker = match compositor.find_id::<Overlay<DynamicPicker<T>>>(Self::ID) {
-                        Some(overlay) => &mut overlay.content.file_picker.picker,
-                        None => return,
-                    };
-                    picker.set_options(new_options);
-                    editor.reset_idle_timer();
-                }));
+            let callback = Callback::EditorCompositor(Box::new(move |editor, compositor| {
+                // Wrapping of pickers in overlay is done outside the picker code,
+                // so this is fragile and will break if wrapped in some other widget.
+                let picker = match compositor.find_id::<Overlay<DynamicPicker<T>>>(Self::ID) {
+                    Some(overlay) => &mut overlay.content.file_picker.picker,
+                    None => return,
+                };
+                picker.set_options(new_options);
+                editor.reset_idle_timer();
+            }));
             anyhow::Ok(callback)
         });
         EventResult::Consumed(None)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -240,12 +240,10 @@ impl<T: Item + 'static> FilePicker<T> {
                             log::info!("highlighting picker item failed");
                             return
                         };
-                        log::info!("hmm1");
                         let Some(Overlay { content: picker, .. }) = compositor.find::<Overlay<Self>>() else {
                             log::info!("picker closed before syntax highlighting finished");
                             return
                         };
-                        log::info!("hmm2");
                         // Try to find a document in the cache
                         let doc = match current_file {
                             PathOrId::Id(doc_id) => doc_mut!(editor, &doc_id),
@@ -254,7 +252,6 @@ impl<T: Item + 'static> FilePicker<T> {
                                 _ => return,
                             },
                         };
-                        log::info!("yay");
                         doc.syntax = Some(syntax);
                     };
                     Callback::EditorCompositor(Box::new(callback))

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -141,9 +141,9 @@ pub struct Document {
     /// The document's default line ending.
     pub line_ending: LineEnding,
 
-    syntax: Option<Syntax>,
+    pub syntax: Option<Syntax>,
     /// Corresponding language scope name. Usually `source.<lang>`.
-    pub(crate) language: Option<Arc<LanguageConfiguration>>,
+    pub language: Option<Arc<LanguageConfiguration>>,
 
     /// Pending changes since last history commit.
     changes: ChangeSet,
@@ -856,12 +856,20 @@ impl Document {
 
     /// Detect the programming language based on the file type.
     pub fn detect_language(&mut self, config_loader: Arc<syntax::Loader>) {
-        if let Some(path) = &self.path {
-            let language_config = config_loader
-                .language_config_for_file_name(path)
-                .or_else(|| config_loader.language_config_for_shebang(self.text()));
-            self.set_language(language_config, Some(config_loader));
-        }
+        self.set_language(
+            self.detect_language_config(&config_loader),
+            Some(config_loader),
+        );
+    }
+
+    /// Detect the programming language based on the file type.
+    pub fn detect_language_config(
+        &self,
+        config_loader: &syntax::Loader,
+    ) -> Option<Arc<helix_core::syntax::LanguageConfiguration>> {
+        config_loader
+            .language_config_for_file_name(self.path.as_ref()?)
+            .or_else(|| config_loader.language_config_for_shebang(self.text()))
     }
 
     /// Detect the indentation used in the file, or otherwise defaults to the language indentation


### PR DESCRIPTION
Fixes #6697
Closes #338

This PR addresses TS syntax highlighting freezing the UI loop in two separate ways:
* It uses the parser timeout mechanism in TS to limit all TS parsing to 500ms. If parsing exceeds 500ms, its canceled and TS is automatically disabled for that buffer. This is preferable to a fixed size limit (as suggested in #338) as it takes different CPU speeds/grammar speeds into account (and future optimizations in the parser/TS). If parsing takes longer than 500ms the editor always feels laggy.
* In the picker syntax highlighting is now performed in a background thread to avoid micro stutters in the UI (if trying to move after a short a delay)