### PR TITLE
Default yaml-language-server schema example in `languages.toml`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -867,6 +867,9 @@ indent = { tab-width = 2, unit = "  " }
 language-server = { command = "yaml-language-server", args = ["--stdio"] }
 injection-regex = "yml|yaml"
 
+[[language.config.yaml.schemas]]
+"https://json.schemastore.org/github-workflow.json" = ".github/workflows/*.{yml,yaml}"
+
 [[grammar]]
 name = "yaml"
 source = { git = "https://github.com/ikatyang/tree-sitter-yaml", rev = "0e36bed171768908f331ff7dff9d956bae016efb" }


### PR DESCRIPTION
Having an example in the `language.toml` on how to configure the default yaml language server with schemas will save someone else a good bit of tinkering time!
Especially since a major reason for a using the yaml language server is the schemas available.
Going digging through issues/discussions like: #5700 is an option, but a bit far removed from the `language.toml` already on your disk.

I decided on the Github Actions schema as that is unlikely to be polarizing, Helix is hosted on Github and makes use of Actions after all.