### PR TITLE
Add linewise-paste config option

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -232,6 +232,8 @@ pub struct Config {
     pub gutters: GutterConfig,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
+    /// Linewise paste support. Defaults to true.
+    pub linewise_paste: bool,
     /// Automatic insertion of pairs to parentheses, brackets,
     /// etc. Optionally, this can be a list of 2-tuples to specify a
     /// global list of characters to pair. Defaults to true.
@@ -790,6 +792,7 @@ impl Default for Config {
             cursorcolumn: false,
             gutters: GutterConfig::default(),
             middle_click_paste: true,
+            linewise_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
             auto_format: true,


### PR DESCRIPTION
Current behaviour of `paste` commands is to detect a line ending and perform the linewise paste. This prevents pasting text (that contains a line ending) in the middle of another line. By toggling `linewise-paste` config option user can control this behaviour.

Example:

I have a line `bc\n` in a default register and I want to paste it in the middle of line `a d`, I place cursor on `d` and type `P` (to paste before)

If `linewise-paste` is set to `true` (current default), the result will be:
```
bc
a d
```

 If `linewise-paste` is set to `false`, the result will be:
```
a bc
d
```