### PR TITLE
Add LSP parent module command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -352,6 +352,7 @@ impl MappableCommand {
         goto_previous_buffer, "Goto previous buffer",
         goto_line_end_newline, "Goto newline at line end",
         goto_first_nonwhitespace, "Goto first non-blank in line",
+        goto_parent_module, "Goto parent module",
         trim_selections, "Trim whitespace from selections",
         extend_to_line_start, "Extend to line start",
         extend_to_first_nonwhitespace, "Extend to first non-blank in line",

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1650,3 +1650,27 @@ fn compute_inlay_hints_for_view(
 
     Some(callback)
 }
+
+pub fn goto_parent_module(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let language_server = language_server!(cx.editor, doc);
+    let offset_encoding = language_server.offset_encoding();
+
+    if !language_server.supports_parent_module() {
+        cx.editor
+            .set_error("Language server does not support experimental parent module command");
+        return;
+    }
+
+    let pos = doc.position(view.id, offset_encoding);
+
+    if let Some(future) = language_server.parent_module(doc.identifier(), pos) {
+        cx.callback(
+            future,
+            move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
+                let items = to_locations(response);
+                goto_impl(editor, compositor, items, offset_encoding);
+            },
+        )
+    }
+}

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -48,6 +48,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
             "y" => goto_type_definition,
             "r" => goto_reference,
             "i" => goto_implementation,
+            "u" => goto_parent_module,
             "t" => goto_window_top,
             "c" => goto_window_center,
             "b" => goto_window_bottom,


### PR DESCRIPTION
This adds the `experimental/parentModule` command that is supported by Rust Analyzer. 

I've bound it as a default keybind to `gu` for the moniker "go up". Feel free to suggest changing or removing this keybind since it's not something that will be supported across most LSPs. 

Proposal for this experimental command: https://github.com/microsoft/language-server-protocol/issues/1002


https://github.com/helix-editor/helix/assets/10239377/72bac496-3265-4ab2-9490-c3292dcbb620

