### PR TITLE
Add command to merge non-consecutive ranges

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -111,7 +111,8 @@
 | `s`                   | Select all regex matches inside selections                        | `select_regex`                       |
 | `S`                   | Split selection into sub selections on regex matches              | `split_selection`                    |
 | `Alt-s`               | Split selection on newlines                                       | `split_selection_on_newline`         |
-| `Alt-_ `              | Merge consecutive selections                                      | `merge_consecutive_selections`       |
+| `Alt-minus`           | Merge selections                                                  | `merge_selections`                   |
+| `Alt-_`               | Merge consecutive selections                                      | `merge_consecutive_selections`       |
 | `&`                   | Align selection in columns                                        | `align_selections`                   |
 | `_`                   | Trim whitespace from the selection                                | `trim_selections`                    |
 | `;`                   | Collapse selection onto a single cursor                           | `collapse_selection`                 |

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -522,6 +522,16 @@ impl Selection {
         self
     }
 
+    // Replaces ranges with one spanning from leftmost to rightmost selection
+    pub fn merge_ranges(mut self) -> Self {
+        if !self.ranges.is_empty() {
+            let merged_range = self.ranges.iter().fold(self.ranges[0], |a, b| a.merge(*b));
+            self.ranges = smallvec![merged_range];
+            self.primary_index = 0;
+        }
+        self
+    }
+
     // Merges all ranges that are consecutive
     pub fn merge_consecutive_ranges(mut self) -> Self {
         let mut primary = self.ranges[self.primary_index];

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -522,14 +522,14 @@ impl Selection {
         self
     }
 
-    // Replaces ranges with one spanning from leftmost to rightmost selection
+    /// Replaces ranges with one spanning from first to last range.
     pub fn merge_ranges(self) -> Self {
         let first = self.ranges.first().unwrap();
         let last = self.ranges.last().unwrap();
         Selection::new(smallvec![first.merge(*last)], 0)
     }
 
-    // Merges all ranges that are consecutive
+    /// Merges all ranges that are consecutive.
     pub fn merge_consecutive_ranges(mut self) -> Self {
         let mut primary = self.ranges[self.primary_index];
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -523,13 +523,10 @@ impl Selection {
     }
 
     // Replaces ranges with one spanning from leftmost to rightmost selection
-    pub fn merge_ranges(mut self) -> Self {
-        if !self.ranges.is_empty() {
-            let merged_range = self.ranges.iter().fold(self.ranges[0], |a, b| a.merge(*b));
-            self.ranges = smallvec![merged_range];
-            self.primary_index = 0;
-        }
-        self
+    pub fn merge_ranges(self) -> Self {
+        let first = self.ranges.first().unwrap();
+        let last = self.ranges.last().unwrap();
+        Selection::new(smallvec![first.merge(*last)], 0)
     }
 
     // Merges all ranges that are consecutive

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -274,6 +274,7 @@ impl MappableCommand {
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
         split_selection_on_newline, "Split selection on newlines",
+        merge_selections, "Merge selections",
         merge_consecutive_selections, "Merge consecutive selections",
         search, "Search for regex pattern",
         rsearch, "Reverse search for regex pattern",
@@ -1737,6 +1738,12 @@ fn split_selection_on_newline(cx: &mut Context) {
     static REGEX: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\r\n|[\n\r\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}]").unwrap());
     let selection = selection::split_on_matches(text, doc.selection(view.id), &REGEX);
+    doc.set_selection(view.id, selection);
+}
+
+fn merge_selections(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let selection = doc.selection(view.id).clone().merge_ranges();
     doc.set_selection(view.id, selection);
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -79,6 +79,7 @@ pub fn default() -> HashMap<Mode, Keymap> {
 
         "s" => select_regex,
         "A-s" => split_selection_on_newline,
+        "A-minus" => merge_selections,
         "A-_" => merge_consecutive_selections,
         "S" => split_selection,
         ";" => collapse_selection,


### PR DESCRIPTION
Situations may arise in which you want to extend your selection up to a search result, or simply select everything between two or more cursors.

<img alt="before" title="before" src="https://github.com/helix-editor/helix/assets/18398499/02587068-71c9-40e4-a234-0201e2dd1647">
<img alt="before" title="before" src="https://github.com/helix-editor/helix/assets/18398499/2d4841ae-3d4d-4796-88a9-75a1e9db13bc">

Currently there is no mechanism for this other than badly abusing `goto_last_modification` as a poor man's mark.[^1]
`merge_selections` combines all current ranges into a single range spanning from the first selection in the buffer to the last.

Now you can search in visual mode for the token you want to select up to, then hit `Alt-minus` (since `Alt-_` could already merge consecutive selections).

[helix_merge_ranges_macro_demo](https://github.com/helix-editor/helix/assets/18398499/728e9fad-2a8a-43b8-8d4f-46f1bf13df28)

[^1]: [How to select "until next occurrence"? - Reddit](https://www.reddit.com/r/HelixEditor/comments/13i527h/how_to_select_until_next_occurence/)