### PR TITLE
Update languages.toml for Nickel

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -577,7 +577,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nickel"
-source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "9d83db400b6c11260b9106f131f93ddda8131933" }
+source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "3a794388773f2424a97b2186828aa3fac4c66ce6" }
 
 [[language]]
 name = "nix"

--- a/languages.toml
+++ b/languages.toml
@@ -575,6 +575,12 @@ comment-token = "#"
 language-server = { command = "nls" }
 indent = { tab-width = 2, unit = "  " }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+
 [[grammar]]
 name = "nickel"
 source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "3a794388773f2424a97b2186828aa3fac4c66ce6" }

--- a/runtime/queries/nickel/highlights.scm
+++ b/runtime/queries/nickel/highlights.scm
@@ -20,7 +20,7 @@
 )
 
 (record_operand (atom (ident) @variable))
-(let_expr
+(let_in_block
   "let" @keyword
   "rec"? @keyword
   pat: (pattern
@@ -53,7 +53,7 @@
 (interpolation_end) @punctuation.bracket
 
 ["forall" "default" "doc"] @keyword
-["if" "then" "else" "switch"] @keyword.control.conditional
+["if" "then" "else" "match"] @keyword.control.conditional
 "import" @keyword.control.import
 
 (infix_expr

--- a/runtime/queries/nickel/indents.scm
+++ b/runtime/queries/nickel/indents.scm
@@ -1,7 +1,7 @@
 [
   (fun_expr)
   (let_expr)
-  (switch_expr)
+  (match_expr)
   (ite_expr)
 
   (uni_record)

--- a/runtime/queries/nickel/injections.scm
+++ b/runtime/queries/nickel/injections.scm
@@ -1,0 +1,3 @@
+(annot_atom doc: (static_string)
+            @injection.content
+            (#set! injection.language "markdown"))


### PR DESCRIPTION
Update the revision of `tree-sitter-nickel` and copy over the highlighting queries. Also, adjust the `auto-pairs` configuration, since `'` isn't a paired delimiter in Nickel.