### PR TITLE
book: Install helix declaratively from nixpkgs on NixOS

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -82,7 +82,10 @@ in the AUR, which builds the master branch.
 
 ### NixOS
 
-Helix is available as a [flake](https://nixos.wiki/wiki/Flakes) in the project
+Helix is available in [nixpkgs](https://github.com/nixos/nixpkgs) through the `helix` attribute,
+the unstable channel usually carries the latest release.
+
+Helix is also available as a [flake](https://nixos.wiki/wiki/Flakes) in the project
 root. Use `nix develop` to spin up a reproducible development shell. Outputs are
 cached for each push to master using [Cachix](https://www.cachix.org/). The
 flake is configured to automatically make use of this cache assuming the user


### PR DESCRIPTION
This is really the most simple way, and helix is well maintained in nixpkgs.

The flake solution is overly complicated for newcomers to NixOS, as I just
witnessed on our support room. Copying/adapting/understanding that
expression is far easier.