### PR TITLE
fix off-by-one git-commit rulers

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1245,7 +1245,7 @@ roots = []
 file-types = ["COMMIT_EDITMSG"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
-rulers = [50, 72]
+rulers = [51, 73]
 text-width = 72
 
 [[grammar]]


### PR DESCRIPTION
Characters should maximally reside *inside* the ruler, not on top of it.

At least, that's my personal taste. Maybe the existing behavior is intentional?