### PR TITLE
nix: add overlay for convenient package usage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
       };
   in
     inp.parts.lib.mkFlake {inputs = inp;} {
-      imports = [inp.nci.flakeModule];
+      imports = [inp.nci.flakeModule inp.parts.flakeModules.easyOverlay];
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
@@ -145,6 +145,10 @@
         packages.helix = makeOverridableHelix config.packages.helix-unwrapped {};
         packages.helix-dev = makeOverridableHelix config.packages.helix-unwrapped-dev {};
         packages.default = config.packages.helix;
+
+        overlayAttrs = {
+          inherit (config.packages) helix;
+        };
 
         devShells.default = config.nci.outputs."helix-project".devShell.overrideAttrs (old: {
           nativeBuildInputs =


### PR DESCRIPTION
This just adds an overlay to the nix flake to make it convenient to use helix.

It's not a big change. I'm adding it since a feature I really want to try was merged yesterday (multiple lsps).

@yusdacra @archseer when you have a moment.

closes #7042