### PR TITLE
language-server: add tailwindcss language-server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -63,6 +63,7 @@ sourcekit-lsp = { command = "sourcekit-lsp" }
 svelteserver = { command = "svelteserver", args = ["--stdio"] }
 svlangserver = { command = "svlangserver", args = [] }
 swipl = { command = "swipl", args = [ "-g", "use_module(library(lsp_server))", "-g", "lsp_server:main", "-t", "halt", "--", "stdio" ] }
+tailwindcss = { command = "tailwindcss-language-server", args = ["--stdio"], config = { } }
 taplo = { command = "taplo", args = ["lsp", "stdio"] }
 terraform-ls = { command = "terraform-ls", args = ["serve"] }
 texlab = { command = "texlab" }


### PR DESCRIPTION
Just adding the tailwind css language server for convenience.
(now that multiple language servers are enabled, this is going to be great for usage with svelte files for example (or any of the other js frameworks).