### PR TITLE
fix(docs): Remove `config` from language configuration docs

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -64,7 +64,6 @@ These configuration keys are available:
 | `comment-token`       | The token to use as a comment-token                           |
 | `indent`              | The indent to use. Has sub keys `unit` (the text inserted into the document when indenting; usually set to N spaces or `"\t"` for tabs) and `tab-width` (the number of spaces rendered for a tab) |
 | `language-servers`    | The Language Servers used for this language. See below for more information in the section [Configuring Language Servers for a language](#configuring-language-servers-for-a-language)   |
-| `config`              | Language Server configuration                                 |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set, defaults to `editor.text-width`   |


### PR DESCRIPTION
Aligns docs with https://github.com/helix-editor/helix/pull/2507/files#diff-e78218ec4fe8cd27d4141d6d1077b4e929f734f03e97dcadfcc82f03d9ed661cL88-L90 

Fixes #7081