### PR TITLE
Recognise XAML files as XML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2140,7 +2140,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg", "xsd", "gml"]
+file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg", "xsd", "gml", "xaml"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
XAML files are types of XML files that are used quite a bit in UI development, so it would be handy to recognise them.