### PR TITLE
Recognize hidden justfiles

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2562,7 +2562,7 @@ source = { git = "https://github.com/lefp/tree-sitter-opencl", rev = "8e1d24a570
 [[language]]
 name = "just"
 scope = "source.just"
-file-types = ["justfile", "Justfile", "just"]
+file-types = ["justfile", "Justfile", ".justfile", ".Justfile"]
 injection-regex = "just"
 roots = []
 comment-token = "#"


### PR DESCRIPTION
Also removed `just` from the file types list as `just` does not recognize that. https://github.com/casey/just#quick-start, the 5th non-code paragraph