### PR TITLE
Add a mappable version of existing :reflow command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -389,6 +389,7 @@ impl MappableCommand {
         paste_primary_clipboard_before, "Paste primary clipboard before selections",
         indent, "Indent selection",
         unindent, "Unindent selection",
+        reflow, "Hard-wrap selection to given width",
         format_selections, "Format selection",
         join_selections, "Join lines inside selection",
         join_selections_space, "Join lines inside selection and select spaces",
@@ -4042,6 +4043,10 @@ fn unindent(cx: &mut Context) {
     let transaction = Transaction::change(doc.text(), changes.into_iter());
 
     doc.apply(&transaction, view.id);
+}
+
+fn reflow(cx: &mut Context) {
+    reflow_impl(cx.editor, cx.count);
 }
 
 fn format_selections(cx: &mut Context) {


### PR DESCRIPTION
https://github.com/helix-editor/helix/pull/2128 added the `reflow` command but I found I was not able to bind any keys to it because it was only added in the command (`:`) mode. This change adds a mappable command to call the existing reflow function. When used as a keymap, the count is used as the text width, with a missing or zero count triggering the existing original fallback default logic. This change does not set a default keybinding for the new reflow command to leave that decision up for discussion. I use `Alt-q` myself.