### PR TITLE
Create new command to open docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
+ "open",
  "pulldown-cmark",
  "serde",
  "serde_json",
@@ -1414,6 +1415,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1623,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "open"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16814a067484415fda653868c9be0ac5f2abd2ef5d951082a5f2fe1b3662944"
+dependencies = [
+ "is-wsl",
+ "pathdiff",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1654,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -81,3 +81,4 @@
 | `:run-shell-command`, `:sh` | Run a shell command |
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
+| `:docs-open` | Opens the helix documentation in the default web browser |

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -66,6 +66,9 @@ serde = { version = "1.0", features = ["derive"] }
 grep-regex = "0.1.11"
 grep-searcher = "0.1.11"
 
+# for the :docs-open command
+open = "4.1.0"
+
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 libc = "0.2.144"

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -8,8 +8,11 @@ use super::*;
 use helix_core::{encoding, shellwords::Shellwords};
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::editor::{Action, CloseError, ConfigEvent};
+use open::that as open_that;
 use serde_json::Value;
 use ui::completers::{self, Completer};
+
+const HELIX_DOCS_URL: &str = "https://docs.helix-editor.com";
 
 #[derive(Clone)]
 pub struct TypableCommand {
@@ -2230,6 +2233,23 @@ fn clear_register(
     Ok(())
 }
 
+fn docs_open(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+    if let Err(e) = open_that(HELIX_DOCS_URL) {
+        // this fails in WSL
+        bail!("Could not open web browser: {}", e);
+    } else {
+        cx.editor.set_status("Documentation opened in browser");
+        return Ok(());
+    }
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         TypableCommand {
             name: "quit",
@@ -2804,6 +2824,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             fun: clear_register,
             signature: CommandSignature::none(),
         },
+        TypableCommand {
+            name: "docs-open",
+            aliases: &[],
+            doc: "Opens the helix documentation in the default web browser",
+            fun: docs_open,
+            signature: CommandSignature::none()
+        }
     ];
 
 pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableCommand>> =


### PR DESCRIPTION
# what
This PR introduces a new command (`:docs-open`) which opens the helix documentation at https://docs.helix-editor.com/ in the default web browser
# why
I found it convenient when writing the config file and looking up some commands (still learning the keymappings).
# notes
The implementation is straightforward but introduces a [new dependency](https://docs.rs/open/4.1.0/open/index.html).
I found that the command only works if helix is run on the native OS, and WSL does not work.
The error message it displays under that condition is verbose and could be shortened for simplicity's sake - suggestions are welcome.