### PR TITLE
Update diagnostics correctly on LSP exit

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -964,6 +964,15 @@ impl Application {
                     Notification::Exit => {
                         self.editor.set_status("Language server exited");
 
+                        // LSPs may produce diagnostics for files that haven't been opened in helix,
+                        // we need to clear those and remove the entries from the list if this leads to
+                        // an empty diagnostic list for said files
+                        for diags in self.editor.diagnostics.values_mut() {
+                            diags.retain(|(_, lsp_id)| *lsp_id != server_id);
+                        }
+
+                        self.editor.diagnostics.retain(|_, diags| !diags.is_empty());
+
                         // Clear any diagnostics for documents with this server open.
                         let urls: Vec<_> = self
                             .editor

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -974,21 +974,8 @@ impl Application {
                         self.editor.diagnostics.retain(|_, diags| !diags.is_empty());
 
                         // Clear any diagnostics for documents with this server open.
-                        let urls: Vec<_> = self
-                            .editor
-                            .documents_mut()
-                            .filter_map(|doc| {
-                                if doc.supports_language_server(server_id) {
-                                    doc.clear_diagnostics(server_id);
-                                    doc.url()
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect();
-
-                        for url in urls {
-                            self.editor.diagnostics.remove(&url);
+                        for doc in self.editor.documents_mut() {
+                            doc.clear_diagnostics(server_id);
                         }
 
                         // Remove the language server from the registry.

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -275,7 +275,7 @@ where
             });
 
     if warnings > 0 || errors > 0 {
-        write(context, format!(" {} ", "W"), None);
+        write(context, " W ".into(), None);
     }
 
     if warnings > 0 {


### PR DESCRIPTION
LSPs can produce diagnostics for unopened documents, which previously made Helix increase the
workspace diagnostic count increase on each LSP restart.

There was also a bug in that if a document had diagnostics from two LSPs and one was exited, all
the diagnostics for all LSPs were cleared in `editor.diagnostics`, this has now been fixed.

Initially I was troubleshooting the ever increasing workspace count, that's why my first commit is a
small fix to the workspace diagnostics rendering code