### PR TITLE
Treat 'Vagrantfile' files as Ruby code

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -670,7 +670,7 @@ source = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "1b69
 name = "ruby"
 scope = "source.ruby"
 injection-regex = "ruby"
-file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder", "jb", "Podfile", "podspec"]
+file-types = ["rb", "rake", "rakefile", "irb", "gemfile", "gemspec", "Rakefile", "Gemfile", "rabl", "jbuilder", "jb", "Podfile", "podspec", "Vagrantfile"]
 shebangs = ["ruby"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
`Vagrantfile`s are configuration files for the [vagrant](https://www.vagrantup.com/) tool, and they are written in Ruby. Even as vagrant [is ported to Go](https://www.hashicorp.com/blog/toward-vagrant-3-0), `Vagrantfile`s [will be written in Ruby](https://developer.hashicorp.com/vagrant/docs/experimental/vagrant_go)

When a Vangrantfile is created, it starts with these lines:

```
# -*- mode: ruby -*-
# vi: set ft=ruby :
```

But since Helix (quite reasonably) doesn't change editor behavior based on file contents, adding this to `languages.toml` seems like a reasonable way to get this functionality.
