### PR TITLE
Fix off-by-one in select symbol references

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1484,7 +1484,7 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
             };
             let (view, doc) = current!(editor);
             let text = doc.text();
-            let pos = doc.selection(view.id).primary().head;
+            let pos = doc.selection(view.id).primary().cursor(text.slice(..));
 
             // We must find the range that contains our primary cursor to prevent our primary cursor to move
             let mut primary_index = 0;


### PR DESCRIPTION
This merge request fixes an off-by-one error in `select_references_to_symbol_under_cursor`.

When finding the range which contains the head of the current primary selection (so that this range will be the new primary selection), using the `head` field of the primary selection leads to the correct range being missed when `head > anchor` and the cursor is on the final character of the range, since `Range::contains`'s `pos` parameter seems to refer to the position of a character since it is non-inclusive. Using the `cursor` method fixes this since it returns the position of the character under the cursor.