### PR TITLE
Fix: better selection color in Ferra

### DIFF
--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -48,8 +48,7 @@
 "ui.text.focus" = { fg = "ferra_coral" }
 "ui.menu" = { fg = "ferra_blush", bg = "ferra_ash" }
 "ui.menu.selected" = { fg = "ferra_coral", bg = "ferra_ash" }
-"ui.selection" = { bg = "ferra_umber", fg = "ferra_night" }
-"ui.selection.primary" = { bg = "ferra_night", fg = "ferra_umber" }
+"ui.selection" = { bg = "ferra_umber" }
 "ui.virtual" = { fg = "ferra_bark" }
 "ui.virtual.whitespace" = { fg = "ferra_bark" }
 "ui.virtual.ruler" = { bg = "ferra_ash" }


### PR DESCRIPTION
This is just a tiny update for the selection color in Ferra theme.  

Currently the selection color is hard to read:
<img width="428" alt="Screenshot 2023-05-25 at 16 39 31" src="https://github.com/helix-editor/helix/assets/2248455/80e3d788-caae-43db-a548-e42d343d407e">

This has now been updated to the below image:
<img width="436" alt="Screenshot 2023-05-25 at 16 39 41" src="https://github.com/helix-editor/helix/assets/2248455/43d04494-688a-41ae-ae7c-d3016f9467df">


