### PR TITLE
Highlight query improvements for java and typescript

### DIFF
--- a/runtime/queries/java/highlights.scm
+++ b/runtime/queries/java/highlights.scm
@@ -13,8 +13,6 @@
 (marker_annotation
   name: (identifier) @attribute)
 
-"@" @operator
-
 ; Types
 
 (interface_declaration
@@ -47,6 +45,9 @@
   (floating_point_type)
   (void_type)
 ] @type.builtin
+
+(type_arguments
+  (wildcard "?" @type.builtin))
 
 ; Variables
 
@@ -86,6 +87,84 @@
 
 (line_comment) @comment
 (block_comment) @comment
+
+; Punctuation
+
+[
+  "::"
+  "."
+  ";"
+  ","
+] @punctuation.delimiter
+
+[
+  "@"
+  "..."
+] @punctuation.special
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(type_arguments
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(type_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+; Operators
+
+[
+  "="
+  ">"
+  "<"
+  "!"
+  "~"
+  "?"
+  ":"
+  "->"
+  "=="
+  ">="
+  "<="
+  "!="
+  "&&"
+  "||"
+  "++"
+  "--"
+  "+"
+  "-"
+  "*"
+  "/"
+  "&"
+  "|"
+  "^"
+  "%"
+  "<<"
+  ">>"
+  ">>>"
+  "+="
+  "-="
+  "*="
+  "/="
+  "&="
+  "|="
+  "^="
+  "%="
+  "<<="
+  ">>="
+  ">>>="
+] @operator
 
 ; Keywords
 

--- a/runtime/queries/typescript/highlights.scm
+++ b/runtime/queries/typescript/highlights.scm
@@ -5,7 +5,6 @@
 
 (ambient_declaration "global" @namespace)
 
-
 ; Variables
 
 (required_parameter (identifier) @variable.parameter)
@@ -21,8 +20,6 @@
 (property_signature "?" @punctuation.special)
 
 (conditional_type ["?" ":"] @operator)
-
-
 
 ; Keywords
 
@@ -50,16 +47,22 @@
   "readonly"
 ] @keyword.storage.modifier
 
-; inherits: ecma
-
 ; Types
 
 (type_identifier) @type
 (predefined_type) @type.builtin
 
 (type_arguments
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(type_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))
@@ -75,3 +78,5 @@
 (template_type
   "${" @punctuation.special
   "}" @punctuation.special) @embedded
+
+; inherits: ecma


### PR DESCRIPTION
## Java

Java highlights were completely missing punctuation and operator highlights. This PR adds them based on the JSE 20 language spec. Changes include:

- Add punctuation according to the [spec](https://docs.oracle.com/javase/specs/jls/se20/html/jls-3.html#jls-3.12) (see "3.11. Separators"). I defined `@` and `...` as special punctuation because those are somewhat different to the regular punctuation symbols.
- Add operators according to the [spec](https://docs.oracle.com/javase/specs/jls/se20/html/jls-3.html#jls-3.12) (see "3.12. Operators").
- Highlight the wildcard type argument `?` as a type instead of as an operator, in the context of type arguments, according to the [spec](https://docs.oracle.com/javase/specs/jls/se20/html/jls-4.html#d5e3254) (see "4.5.1. Type Arguments of Parameterized Types").

## Typescript

The symbols `<` and `>` where being highlighted as operators in the context of type arguments, and the highlight for type parameters was missing. Changes include:

- Move the `; inherits: ecma` statement to the bottom of the file so that the operator highlights in there don't override the highlight of `<` and `>` for type arguments and parameters (and any type highlight really).
- Add highlight for `<` and `>` in the context of type parameters.