### PR TITLE
chore: update scala tree-sitter grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1229,7 +1229,7 @@ language-servers = [ "metals" ]
 
 [[grammar]]
 name = "scala"
-source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "f6bbf35de41653b409ca9a3537a154f2b095ef64" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "23d21310fe4ab4b3273e7a6810e781224a3e7fe1" }
 
 [[language]]
 name = "dockerfile"

--- a/runtime/queries/scala/locals.scm
+++ b/runtime/queries/scala/locals.scm
@@ -1,0 +1,29 @@
+(template_body) @local.scope
+(lambda_expression) @local.scope
+
+
+(function_declaration
+      name: (identifier) @local.definition) @local.scope
+
+(function_definition
+      name: (identifier) @local.definition)
+
+(parameter
+  name: (identifier) @local.definition)
+
+(binding
+  name: (identifier) @local.definition)
+
+(val_definition
+  pattern: (identifier) @local.definition)
+
+(var_definition
+  pattern: (identifier) @local.definition)
+
+(val_declaration
+  name: (identifier) @local.definition)
+
+(var_declaration
+  name: (identifier) @local.definition)
+
+(identifier) @local.reference


### PR DESCRIPTION
Update to a new Scala tree-sitter grammar revision, because the current one lags behind by quite a bit:

https://github.com/tree-sitter/tree-sitter-scala/commits/master