### PR TITLE
Add Kaolin Dark, Light and Valley Dark themes

### DIFF
--- a/runtime/themes/kaolin-dark.toml
+++ b/runtime/themes/kaolin-dark.toml
@@ -1,0 +1,108 @@
+# Author : thlsrms <thlsrmsdev@gmail.com>
+
+# Original author: kaolin-dark by Ogden Webb: github.com/ogdenwebb/emacs-kaolin-themes
+# Kaolin Dark Theme - A dark jade theme inspired by Sierra.vim : github.com/AlessandroYorba/Sierra
+
+"attribute" = "constant"
+"keyword" = { fg = "hint" }
+"keyword.directive" = "info"
+"namespace" = "constant"
+"punctuation" = "fg0"
+"punctuation.delimiter" = "fg0"
+"operator" = "fg0"
+"special" = "constant"
+"variable.other.member" = { fg = "violet7", modifiers = ["italic"] }
+"variable" = "ultramarine4_dark"
+"variable.builtin" = "hint"
+"variable.parameter" = "ultramarine4_dark"
+"type" = "type"
+"type.builtin" = "info"
+"constructor" = { fg = "type" }
+"function" = { fg = "info" }
+"function.macro" = "constant"
+"function.builtin" = "selection0"
+"tag" = "#7aaaa5"
+"comment" = { fg = "gray0", modifiers = ["italic"] }
+"constant" = { fg = "constant" }
+"constant.builtin" = { fg = "info" }
+"string" = "hint"
+"constant.numeric" = "info"
+"constant.character.escape" = { fg = "hint", modifiers = ["bold"] }
+"label" = "constant"
+"module" = "info"
+
+"diff.plus" = "green0"
+"diff.delta" = "warn"
+"diff.minus" = "error"
+
+"warning" = "warn"
+"error" = "error"
+"info" = "info"
+"hint" = "hint"
+
+"diagnostic.error" = { underline = { style = "curl", color = "error" } }
+"diagnostic.warning" = { underline = { style = "curl", color = "warn" } }
+"diagnostic.info" = { underline = { style = "curl", color = "info" } }
+"diagnostic.hint" = { underline = { style = "curl", color = "hint" } }
+
+"ui.background" = { bg = "bg0" }
+"ui.linenr" = { fg = "gray0" }
+"ui.linenr.selected" = { fg = "gray1", modifiers = ["bold"] }
+"ui.cursorline" = { bg = "bg1" }
+"ui.cursorline.secondary" = { bg = "bg2" }
+"ui.cursorcolumn.primary" = { bg = "bg1" }
+"ui.cursorcolumn.secondary" = { bg = "bg2" }
+"ui.statusline" = { fg = "info", bg = "bg1" }
+"ui.statusline.normal" = { fg = "hint", bg = "bg1", modifiers = ["reversed", "bold"] }
+"ui.statusline.insert" = { fg = "green0", bg = "bg1", modifiers = ["reversed", "bold"] }
+"ui.statusline.select" = { fg = "ultramarine4_dark", bg = "bg1", modifiers = ["reversed", "bold"] }
+"ui.statusline.inactive" = { fg = "gray0", bg = "bg1" }
+"ui.popup" = { bg = "bg1" }
+"ui.window" = { fg= "bg1", bg = "bg0" }
+"ui.help" = { bg = "bg1", fg = "fg0" }
+"ui.text" = { fg = "fg1" }
+"ui.text.focus" = { fg = "selection0" }
+"ui.selection" = { bg = "selection1" }
+"ui.selection.primary" = { bg = "selection1" }
+"ui.cursor.primary" = { modifiers = ["reversed"] }
+"ui.cursor.match" = { fg = "bg1", bg = "ultramarine4_dark" }
+"ui.menu" = { fg = "fg0", bg = "bg1" }
+"ui.menu.selected" = { fg = "selection0", bg = "bg2", modifiers = ["bold"] }
+"ui.virtual.wrap" = "bg2"
+"ui.virtual.whitespace" = "fg1"
+"ui.virtual.indent-guide" = "bg2"
+"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.inlay-hint" = "gray1"
+"ui.virtual.inlay-hint.parameter" = { fg = "gray1", modifiers = ["dim"] }
+"ui.virtual.inlay-hint.type" = { fg = "gray1", modifiers = ["dim"] }
+"ui.debug.breakpoint" = "error"
+"ui.debug.active" = "warn"
+
+"markup.heading" = "info"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "warn", underline = { style = "line" } }
+"markup.link.text" = "selection0"
+"markup.raw" = "selection0"
+
+[palette]
+# kaolin-dark palette
+bg0 = "#18181b" # black1
+bg1 = "#222225" # black2
+bg2 = "#303035" # black4
+fg0 = "#e6e6e8" # white1
+fg1 = "#adadb9" # whiet4
+gray0 = "#545c5e" # gray3
+gray1 = "#919a9c" # gray9
+green0 = "#6fb593" # spring-green3
+selection0 = "#68f3ca" # aquamarine3
+selection1 = "#2e403b" # aquamarine6
+type = "#cd9575" # vermilion4
+hint = "#4d9391" # teal1
+info = "#80bcb6" # teal4
+warn = "#dbac66" # orange1
+error = "#cd5c60" # red1
+constant = "#ab98b5" # purple4
+ultramarine4_dark = "#968cc7"
+violet7 = "#766884"

--- a/runtime/themes/kaolin-light.toml
+++ b/runtime/themes/kaolin-light.toml
@@ -1,0 +1,60 @@
+# Author : thlsrms <thlsrmsdev@gmail.com>
+
+# Original author: kaolin-dark by Ogden Webb: github.com/ogdenwebb/emacs-kaolin-themes
+# Kaolin Light Theme - Light variant of the original Kaolin Dark Theme
+
+inherits = "kaolin-dark"
+
+"keyword.directive" = "selection0"
+"special" = "ultramarine1"
+"variable.other.member" = { fg = "constant", modifiers = ["italic"] }
+"variable" = "ultramarine1"
+"variable.parameter" = "constant"
+"type.builtin" = "selection0"
+"function" = { fg = "selection0" }
+"function.builtin" = "ultramarine1"
+"tag" = { fg = "hint", modifiers = ["italic"] }
+"constant.builtin" = { fg = "selection0" }
+"string" = "green0"
+"constant.numeric" = "selection0"
+"module" = "selection0"
+
+"ui.linenr.selected" = { fg = "green1", modifiers = ["bold"] }
+"ui.statusline" = { fg = "selection0", bg = "bg1" }
+"ui.statusline.normal" = { fg = "hint", bg = "bg1", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "warn", bg = "bg1", modifiers = ["reversed", "bold"] }
+"ui.statusline.select" = { fg = "constant", bg = "bg1", modifiers = ["reversed", "bold"] }
+"ui.text" = { fg = "fg0" }
+"ui.text.focus" = { fg = "green1", modifiers = ["bold"] }
+"ui.cursor.match" = { fg = "fg1", bg = "gray0" }
+"ui.menu.selected" = { fg = "green1", bg = "bg2", modifiers = ["bold"] }
+"ui.virtual.wrap" = "fg1"
+"ui.virtual.indent-guide" = "fg1"
+"ui.virtual.inlay-hint" = "gray0"
+"ui.virtual.inlay-hint.parameter" = { fg = "gray0", modifiers = ["italic"] }
+"ui.virtual.inlay-hint.type" = { fg = "gray0", modifiers = ["italic"] }
+
+"markup.heading" = { fg = "ultramarine1", modifiers = ["bold"] }
+"markup.link.url" = { fg = "info", underline = { style = "line" } }
+"markup.link.text" = "info"
+"markup.raw" = "constant"
+
+[palette]
+# kaolin-light palette
+bg0  = "#edeeeb" # kaolin-light-bg1
+bg1  = "#dfe1dc" # kaolin-light-bg2
+bg2  = "#d1d4cd" # kaolin-light-bg3
+fg0 = "#383e3f" # gray1
+fg1 = "#bebec4" # white4
+gray0 = "#7c878a" # gray7
+green0 = "#39854c" # erin2
+green1 = "#18a318" # green2
+selection0 = "#4c7a90" # azure4
+selection1 = "#d3e4f0" # azure9
+type = "#e36b3f" # vermilion3
+hint = "#13665f" # teal2
+info = "#3b84cc" # azure1
+warn = "#dbac66" # orange1
+error = "#e84c58" # red3
+constant = "#845A84" # magenta4
+ultramarine1 = "#6d46e3" # ultramarine1

--- a/runtime/themes/kaolin-valley-dark.toml
+++ b/runtime/themes/kaolin-valley-dark.toml
@@ -1,0 +1,73 @@
+# Author : thlsrms <thlsrmsdev@gmail.com>
+
+# Original author: kaolin-valley-dark by Ogden Webb: github.com/ogdenwebb/emacs-kaolin-themes
+# Kaolin Valley Dark Theme - Colorful Kaolin theme with brown background
+
+inherits = "kaolin-dark"
+
+"attribute" = "fg1"
+"keyword" = { fg = "teal3" }
+"keyword.directive" = "green0"
+"operator" = "teal3"
+"special" = "ultramarine3"
+"variable.other.member" = { fg = "selection0", modifiers = ["italic"] }
+"variable" = "constant"
+"variable.builtin" = "teal3"
+"variable.parameter" = "constant"
+"type.builtin" = "aquamarine3"
+"function" = { fg = "valley-dark-fn" }
+"function.macro" = "valley-dark-fn"
+"function.builtin" = "aquamarine3"
+"tag" = "green0"
+"constant.builtin" = { fg = "aquamarine3" }
+"string" = "fg1"
+"constant.numeric" = "aquamarine3"
+"constant.character.escape" = "fg1"
+"label" = "ultramarine3"
+"module" = "green0"
+
+"diff.delta" = "type"
+
+"ui.linenr.selected" = { fg = "warn", modifiers = ["bold"] }
+"ui.statusline" = { fg = "fg0", bg = "bg1" }
+"ui.statusline.normal" = { fg = "warn", bg = "bg1", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "hint", bg = "bg1", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "constant", bg = "bg1", modifiers = ["bold"] }
+"ui.text.focus" = { fg = "selection0", bg = "bg1" }
+"ui.cursor.match" = { fg = "bg0", bg = "selection0" }
+"ui.menu" = { fg = "fg1", bg = "bg1" }
+"ui.menu.selected" = { fg = "selection0", bg = "bg1", modifiers = ["bold"] }
+"ui.virtual.wrap" = "gray1"
+"ui.virtual.whitespace" = "gray1"
+"ui.virtual.indent-guide" = "gray1"
+"ui.virtual.ruler" = { bg = "bg2" }
+"ui.virtual.inlay-hint" = "gray0"
+"ui.virtual.inlay-hint.parameter" = { fg = "gray0", modifiers = ["italic"] }
+"ui.virtual.inlay-hint.type" = { fg = "gray0", modifiers = ["italic"] }
+
+"markup.heading" = "type"
+"markup.link.url" = { fg = "constant", modifiers = ["underlined"] }
+"markup.link.text" = "valley-dark-fn"
+
+[palette]
+# kaolin-valley-dark palette
+bg0 = "#262221" # valley-dark-bg1
+bg1 = "#2e2a29" # valley-dark-bg2
+bg2 = "#383030" # valley-dark-bg4
+fg0 = "#eee6d3" # amber9
+fg1 = "#cea2ca" # magenta3
+gray0 = "#635c4a" # valley-dark-comment
+gray1 = "#52413f" # brown2
+green0 = "#91f368" # harlequin3
+selection0 = "#ee7042" # vermilion3
+selection1 = "#402e2e" # red6
+type = "#eed891" # amber3
+hint = "#6bd9db" # cyan3
+info = "#41b0f3" # capri3
+warn = "#cfb05f" # amber1
+error = "#e84c58" # red3
+constant = "#ef6787" # crimson3
+valley-dark-fn = "#7ed7e6"
+teal3 = "#49bdb0"
+aquamarine3 = "#53e6b5"
+ultramarine3 = "#9587dd"


### PR DESCRIPTION
Hi, I tried porting these variations based on the original [Kaolin themes](https://github.com/ogdenwebb/emacs-kaolin-themes) palette:

<details>
  <summary>Kaolin Dark</Summary>
  <br>

  ![kaolin-dark](https://github.com/helix-editor/helix/assets/70434673/da0ab3f8-261f-466a-9290-187e5624ff4b)
</details>

<details>
  <summary>Kaolin Light</Summary>
  <br>
  
  ![kaolin-light](https://github.com/helix-editor/helix/assets/70434673/834acc8f-2a15-41a6-bc3f-ad40c16d24a5)
</details>

<details>
  <summary>Kaolin Valley Dark</Summary>
  <br>
  
  ![kaolin-valley-dark](https://github.com/helix-editor/helix/assets/70434673/e055dd64-59ca-45f8-af26-b3d379577b72)
</details>