### PR TITLE
Recognise `.gir` as XML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2146,7 +2146,7 @@ source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d1
 name = "xml"
 scope = "source.xml"
 injection-regex = "xml"
-file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg", "xsd", "gml", "xaml"]
+file-types = ["xml", "mobileconfig", "plist", "xib", "storyboard", "svg", "xsd", "gml", "xaml", "gir"]
 indent = { tab-width = 2, unit = "  " }
 roots = []
 


### PR DESCRIPTION
GIR is a file format used by [GObject Introspection][1] to store machine-readable API metadata of GObject libraries.

Example: [`GObject-2.0.gir`](https://github.com/gtk-rs/gir-files/blob/43cac7495ff5daa303fcd5e360644a3b0a4cd4c3/GObject-2.0.gir)

[1]: https://gi.readthedocs.io/