### PR TITLE
Docs: specify that language-server table must be before language and grammar array

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -99,8 +99,8 @@ with the following priorities:
 
 Language servers are configured separately in the table `language-server` in the same file as the languages `languages.toml`
 
-> 💡 Due to limitations of toml anything in the ``language-server`` table must
-> be specified before the ``[[language]]`` and ``[[grammar]]`` arrays of tables.
+> 💡 Due to limitations of TOML, anything in the `language-server` table must
+> be specified before the `[[language]]` and `[[grammar]]` arrays of tables.
 
 For example:
 

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -99,6 +99,9 @@ with the following priorities:
 
 Language servers are configured separately in the table `language-server` in the same file as the languages `languages.toml`
 
+> 💡 Due to limitations of toml anything in the ``language-server`` table must
+> be specified before the ``[[language]]`` and ``[[grammar]]`` arrays of tables.
+
 For example:
 
 ```toml


### PR DESCRIPTION
Due to a limitation in toml, when specifying the new config  for language servers from #2507 because they are just tables they must be put before the arrays of tables (language and grammar). I have seen a couple issues and matrix questions pop up where people didn't know this and put the language server configuration after the language config and then nothing happens, #7149 and https://github.com/helix-editor/helix/discussions/7101#discussioncomment-5962068. If we think there is going to be more arrays of tables in the future we could make the message more general but I think this way is more clear. I couldn't find any official documentation about this behaviour of toml but I am pretty sure it is the case.