### PR TITLE
Fix panic when line-number gutter's min-width is too large

### DIFF
--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, fmt::Write};
+use std::fmt::Write;
 
 use helix_core::syntax::LanguageServerFeature;
 
@@ -213,7 +213,7 @@ fn line_numbers_width(view: &View, doc: &Document) -> usize {
     let draw_last = text.line_to_byte(last_line) < text.len_bytes();
     let last_drawn = if draw_last { last_line + 1 } else { last_line };
     let digits = count_digits(last_drawn);
-    let n_min = min(
+    let n_min = std::cmp::min(
         view.gutters.line_numbers.min_width,
         (view.area.width - 4) as usize,
     );

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write;
+use std::{cmp::min, fmt::Write};
 
 use helix_core::syntax::LanguageServerFeature;
 
@@ -213,14 +213,10 @@ fn line_numbers_width(view: &View, doc: &Document) -> usize {
     let draw_last = text.line_to_byte(last_line) < text.len_bytes();
     let last_drawn = if draw_last { last_line + 1 } else { last_line };
     let digits = count_digits(last_drawn);
-    let n_min = if view.gutters.line_numbers.min_width > view.area.width as usize {
-        // currently subtracting 3 because there seems to be a value of 3 added on to
-        // whatever this function returns, not sure why this is the case and need
-        // clarification
-        (view.area.width - 3) as usize
-    } else {
-        view.gutters.line_numbers.min_width
-    };
+    let n_min = min(
+        view.gutters.line_numbers.min_width,
+        (view.area.width - 4) as usize,
+    );
     digits.max(n_min)
 }
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -213,7 +213,14 @@ fn line_numbers_width(view: &View, doc: &Document) -> usize {
     let draw_last = text.line_to_byte(last_line) < text.len_bytes();
     let last_drawn = if draw_last { last_line + 1 } else { last_line };
     let digits = count_digits(last_drawn);
-    let n_min = view.gutters.line_numbers.min_width;
+    let n_min = if view.gutters.line_numbers.min_width > view.area.width as usize {
+        // currently subtracting 3 because there seems to be a value of 3 added on to
+        // whatever this function returns, not sure why this is the case and need
+        // clarification
+        (view.area.width - 3) as usize
+    } else {
+        view.gutters.line_numbers.min_width
+    };
     digits.max(n_min)
 }
 


### PR DESCRIPTION
Attempted fix for #7154 

Trying to fix this as my first contribution, so this may be an incredibly stupid implementation. There was a 3 being added to whatever was returned from this function, and I was incredibly unsure where that was coming from. It was not coming from whatever the current gutter min width was, so I thought I would at least put this out there and see if anyone could give me some feedback :D 