### PR TITLE
Add rl and rla aliasses for reload and reload-all commands

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2560,14 +2560,14 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         },
         TypableCommand {
             name: "reload",
-            aliases: &[],
+            aliases: &["rl"],
             doc: "Discard changes and reload from the source file.",
             fun: reload,
             signature: CommandSignature::none(),
         },
         TypableCommand {
             name: "reload-all",
-            aliases: &[],
+            aliases: &["rla"],
             doc: "Discard changes and reload all documents from the source files.",
             fun: reload_all,
             signature: CommandSignature::none(),


### PR DESCRIPTION
Add `rl` and `rla` aliasses for `reload` and `reload-all` commands respectively.

Quick little addition as I find myself using those commands quite often lately and typing them out is too much of a hassle.