### PR TITLE
Exclude config no_op bindings in command palette.

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -266,15 +266,12 @@ impl Keymap {
         // recursively visit all nodes in keymap
         fn map_node(cmd_map: &mut ReverseKeymap, node: &KeyTrie, keys: &mut Vec<KeyEvent>) {
             match node {
-                KeyTrie::MappableCommand(cmd) => match cmd {
-                    MappableCommand::Typable { name, .. } => {
+                KeyTrie::MappableCommand(cmd) => {
+                    let name = cmd.name();
+                    if name != "no_op" {
                         cmd_map.entry(name.into()).or_default().push(keys.clone())
                     }
-                    MappableCommand::Static { name, .. } => cmd_map
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(keys.clone()),
-                },
+                }
                 KeyTrie::Node(next) => {
                     for (key, trie) in &next.map {
                         keys.push(*key);

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -18,7 +18,7 @@ use std::{
 pub use default::default;
 use macros::key;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct KeyTrieNode {
     /// A label for keys coming under this node, like "Goto mode"
     name: String,
@@ -114,12 +114,6 @@ impl KeyTrieNode {
     /// Get a reference to the key trie node's order.
     pub fn order(&self) -> &[KeyEvent] {
         self.order.as_slice()
-    }
-}
-
-impl Default for KeyTrieNode {
-    fn default() -> Self {
-        Self::new("", HashMap::new(), Vec::new())
     }
 }
 

--- a/helix-term/src/keymap/macros.rs
+++ b/helix-term/src/keymap/macros.rs
@@ -81,7 +81,7 @@ macro_rules! alt {
 #[macro_export]
 macro_rules! keymap {
     (@trie $cmd:ident) => {
-        $crate::keymap::KeyTrie::Leaf($crate::commands::MappableCommand::$cmd)
+        $crate::keymap::KeyTrie::MappableCommand($crate::commands::MappableCommand::$cmd)
     };
 
     (@trie


### PR DESCRIPTION
My the top of my command palette currently looks like this 🙈

![2023-05-29-222146_screenshot](https://github.com/helix-editor/helix/assets/31696304/71416a6a-de0e-43f1-93ad-7230e697de56)

Depends on #7193 
