### PR TITLE
Add description for 'ui.text.focus' in theme.md

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -296,7 +296,7 @@ These scopes are used for theming the editor interface:
 | `ui.window`                       | Borderlines separating splits                                                                  |
 | `ui.help`                         | Description box for commands                                                                   |
 | `ui.text`                         | Command prompts, popup text, etc.                                                              |
-| `ui.text.focus`                   |                                                                                                |
+| `ui.text.focus`                   | The currently selected line in the picker                                                      |
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |


### PR DESCRIPTION
Add a description for 'ui.text.foucs' saying that it styles the selected line in the picker, which is quite a prominent styling element I would say.

Took me some time to figure out which key it was since I couldn't find it in the docs.