### PR TITLE
Add check for a non-zero value for tab width

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -48,6 +48,21 @@ where
         .transpose()
 }
 
+fn deserialize_tab_width<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    usize::deserialize(deserializer).and_then(|n| {
+        if n > 0 && n <= 16 {
+            Ok(n)
+        } else {
+            Err(serde::de::Error::custom(
+                "tab width must be a value from 1 to 16 inclusive",
+            ))
+        }
+    })
+}
+
 pub fn deserialize_auto_pairs<'de, D>(deserializer: D) -> Result<Option<AutoPairs>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -424,7 +439,8 @@ pub struct DebuggerQuirks {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IndentationConfiguration {
-    pub tab_width: std::num::NonZeroUsize,
+    #[serde(deserialize_with = "deserialize_tab_width")]
+    pub tab_width: usize,
     pub unit: String,
 }
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -48,6 +48,16 @@ where
         .transpose()
 }
 
+fn deserialize_tab_width<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    usize::deserialize(deserializer).and_then(|n| match n {
+        0 => Err(serde::de::Error::custom("tab width is zero")),
+        _ => Ok(n),
+    })
+}
+
 pub fn deserialize_auto_pairs<'de, D>(deserializer: D) -> Result<Option<AutoPairs>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -424,6 +434,7 @@ pub struct DebuggerQuirks {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IndentationConfiguration {
+    #[serde(deserialize_with = "deserialize_tab_width")]
     pub tab_width: usize,
     pub unit: String,
 }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -48,16 +48,6 @@ where
         .transpose()
 }
 
-fn deserialize_tab_width<'de, D>(deserializer: D) -> Result<usize, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    usize::deserialize(deserializer).and_then(|n| match n {
-        0 => Err(serde::de::Error::custom("tab width is zero")),
-        _ => Ok(n),
-    })
-}
-
 pub fn deserialize_auto_pairs<'de, D>(deserializer: D) -> Result<Option<AutoPairs>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -434,8 +424,7 @@ pub struct DebuggerQuirks {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IndentationConfiguration {
-    #[serde(deserialize_with = "deserialize_tab_width")]
-    pub tab_width: usize,
+    pub tab_width: std::num::NonZeroUsize,
     pub unit: String,
 }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1508,7 +1508,7 @@ impl Document {
     pub fn tab_width(&self) -> usize {
         self.language_config()
             .and_then(|config| config.indent.as_ref())
-            .map_or(4, |config| config.tab_width.into()) // fallback to 4 columns
+            .map_or(4, |config| config.tab_width) // fallback to 4 columns
     }
 
     // The width (in spaces) of a level of indentation.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1508,7 +1508,7 @@ impl Document {
     pub fn tab_width(&self) -> usize {
         self.language_config()
             .and_then(|config| config.indent.as_ref())
-            .map_or(4, |config| config.tab_width) // fallback to 4 columns
+            .map_or(4, |config| config.tab_width.into()) // fallback to 4 columns
     }
 
     // The width (in spaces) of a level of indentation.


### PR DESCRIPTION
Closes #7094. I think it is weird to set tab width to zero, so I added a custom deserialization function (a small wrapper that checks if the tab width value is zero).