### PR TITLE
Fix crash when cwd is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "cc",
+ "dunce",
  "etcetera",
  "libloading",
  "log",

--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -88,7 +88,7 @@ pub fn get_normalized_path(path: &Path) -> PathBuf {
 pub fn get_canonicalized_path(path: &Path) -> std::io::Result<PathBuf> {
     let path = expand_tilde(path);
     let path = if path.is_relative() {
-        std::env::current_dir().map(|current_dir| current_dir.join(path))?
+        helix_loader::current_working_dir().join(path)
     } else {
         path
     };
@@ -99,9 +99,7 @@ pub fn get_canonicalized_path(path: &Path) -> std::io::Result<PathBuf> {
 pub fn get_relative_path(path: &Path) -> PathBuf {
     let path = PathBuf::from(path);
     let path = if path.is_absolute() {
-        let cwdir = std::env::current_dir()
-            .map(|path| get_normalized_path(&path))
-            .expect("couldn't determine current directory");
+        let cwdir = get_normalized_path(&helix_loader::current_working_dir());
         get_normalized_path(&path)
             .strip_prefix(cwdir)
             .map(PathBuf::from)
@@ -142,7 +140,7 @@ pub fn get_relative_path(path: &Path) -> PathBuf {
 /// ```
 ///
 pub fn get_truncated_path<P: AsRef<Path>>(path: P) -> PathBuf {
-    let cwd = std::env::current_dir().unwrap_or_default();
+    let cwd = helix_loader::current_working_dir();
     let path = path
         .as_ref()
         .strip_prefix(cwd)

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -29,6 +29,7 @@ which = "4.4"
 cc = { version = "1" }
 threadpool = { version = "1.0" }
 tempfile = "3.6.0"
+dunce = "1.0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.8"

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -931,7 +931,7 @@ pub fn find_lsp_workspace(
     let mut file = if file.is_absolute() {
         file.to_path_buf()
     } else {
-        let current_dir = std::env::current_dir().expect("unable to determine current directory");
+        let current_dir = helix_loader::current_working_dir();
         current_dir.join(file)
     };
     file = path::get_normalized_path(&file);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -163,7 +163,7 @@ impl Application {
         } else if !args.files.is_empty() {
             let first = &args.files[0].0; // we know it's not empty
             if first.is_dir() {
-                std::env::set_current_dir(first).context("set current dir")?;
+                helix_loader::set_current_working_dir(first.clone())?;
                 editor.new_file(Action::VerticalSplit);
                 let picker = ui::file_picker(".".into(), &config.load().editor);
                 compositor.push(Box::new(overlaid(picker)));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2075,8 +2075,7 @@ fn global_search(cx: &mut Context) {
                     .binary_detection(BinaryDetection::quit(b'\x00'))
                     .build();
 
-                let search_root = std::env::current_dir()
-                    .expect("Global search error: Failed to get current dir");
+                let search_root = helix_loader::current_working_dir();
                 let dedup_symlinks = file_picker_config.deduplicate_links;
                 let absolute_root = search_root
                     .canonicalize()
@@ -2514,7 +2513,7 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
     cx.push_layer(Box::new(overlaid(picker)));
 }
 fn file_picker_in_current_directory(cx: &mut Context) {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("./"));
+    let cwd = helix_loader::current_working_dir();
     let picker = ui::file_picker(cwd, &cx.editor.config());
     cx.push_layer(Box::new(overlaid(picker)));
 }

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -217,7 +217,7 @@ pub fn dap_start_impl(
         }
     }
 
-    args.insert("cwd", to_value(std::env::current_dir().unwrap())?);
+    args.insert("cwd", to_value(helix_loader::current_working_dir())?);
 
     let args = to_value(args).unwrap();
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1033,7 +1033,7 @@ fn goto_impl(
     locations: Vec<lsp::Location>,
     offset_encoding: OffsetEncoding,
 ) {
-    let cwdir = std::env::current_dir().unwrap_or_default();
+    let cwdir = helix_loader::current_working_dir();
 
     match locations.as_slice() {
         [location] => {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1093,14 +1093,11 @@ fn change_current_directory(
             .as_ref(),
     );
 
-    if let Err(e) = std::env::set_current_dir(dir) {
-        bail!("Couldn't change the current working directory: {}", e);
-    }
+    helix_loader::set_current_working_dir(dir)?;
 
-    let cwd = std::env::current_dir().context("Couldn't get the new working directory")?;
     cx.editor.set_status(format!(
         "Current working directory is now {}",
-        cwd.display()
+        helix_loader::current_working_dir().display()
     ));
     Ok(())
 }
@@ -1114,7 +1111,7 @@ fn show_current_directory(
         return Ok(());
     }
 
-    let cwd = std::env::current_dir().context("Couldn't get the new working directory")?;
+    let cwd = helix_loader::current_working_dir();
     cx.editor
         .set_status(format!("Current working directory is {}", cwd.display()));
     Ok(())

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1112,8 +1112,13 @@ fn show_current_directory(
     }
 
     let cwd = helix_loader::current_working_dir();
-    cx.editor
-        .set_status(format!("Current working directory is {}", cwd.display()));
+    let message = format!("Current working directory is {}", cwd.display());
+
+    if cwd.exists() {
+        cx.editor.set_status(message);
+    } else {
+        cx.editor.set_error(format!("{} (deleted)", message));
+    }
     Ok(())
 }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -472,7 +472,7 @@ pub mod completers {
                 match path.parent() {
                     Some(path) if !path.as_os_str().is_empty() => path.to_path_buf(),
                     // Path::new("h")'s parent is Some("")...
-                    _ => std::env::current_dir().expect("couldn't determine current directory"),
+                    _ => helix_loader::current_working_dir(),
                 }
             };
 


### PR DESCRIPTION
Should solve #2527

I didn't figure out how to set an error on the editor from some places.

Where is was crashing before, it now relies on the scratch buffer instead.
In some other places (not related to buffer, like the `open` command or the global search ), I was able to generate a message or rely on the default value of the PathBuffer.

Let me know any improvements/suggestions you can see, I'll be more than happy to correct them :)