### PR TITLE
Add config option for instant completion entry preview.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -52,6 +52,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant | `400` |
+| `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
 | `auto-info` | Whether to display info boxes | `true` |

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -110,6 +110,7 @@ impl Completion {
         start_offset: usize,
         trigger_offset: usize,
     ) -> Self {
+        let preview_completion_insert = editor.config().preview_completion_insert;
         let replace_mode = editor.config().completion_replace;
         // Sort completion items according to their preselect status (given by the LSP server)
         items.sort_by_key(|item| !item.item.preselect.unwrap_or(false));
@@ -230,7 +231,7 @@ impl Completion {
 
             match event {
                 PromptEvent::Abort => {}
-                PromptEvent::Update => {
+                PromptEvent::Update if preview_completion_insert => {
                     // Update creates "ghost" transactions which are not sent to the
                     // lsp server to avoid messing up re-requesting completions. Once a
                     // completion has been selected (with tab, c-n or c-p) it's always accepted whenever anything
@@ -263,6 +264,7 @@ impl Completion {
                     );
                     doc.apply_temporary(&transaction, view.id);
                 }
+                PromptEvent::Update => {}
                 PromptEvent::Validate => {
                     if let Some(CompleteAction::Selected { savepoint }) =
                         editor.last_completion.take()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -251,6 +251,8 @@ pub struct Config {
         deserialize_with = "deserialize_duration_millis"
     )]
     pub idle_timeout: Duration,
+    /// Whether to insert the completion suggestion on hover. Defaults to true.
+    pub preview_completion_insert: bool,
     pub completion_trigger_len: u8,
     /// Whether to instruct the LSP to replace the entire word when applying a completion
     /// or to only insert new text
@@ -737,6 +739,7 @@ impl Default for Config {
             auto_format: true,
             auto_save: false,
             idle_timeout: Duration::from_millis(400),
+            preview_completion_insert: true,
             completion_trigger_len: 2,
             auto_info: true,
             file_picker: FilePickerConfig::default(),


### PR DESCRIPTION
This PR adds the config option `preview_completion_insert` which controls the insertion behavior of autocompletion.
Currently, Helix inserts the selected completion entry instantly into the document (reversible with c-c), this behavior is a personal preference though and should be configurable, as I prefer it to only insert on confirmation.

The new option defaults to true, thus the default behavior is not changed.