### PR TITLE
Add support for configuring clipboard used for mouse yank

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -41,6 +41,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 |--|--|---------|
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
+| `mouse_yank_clipboard` | Which clipboard to use for mouse yanks. Can be `primary` or `system` | `primary` |
 | `middle-click-paste` | Middle click paste support | `true` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step | `3` |
 | `shell` | Shell to use when running external commands | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1172,7 +1172,15 @@ impl EditorView {
                     return EventResult::Ignored(None);
                 }
 
-                commands::MappableCommand::yank_main_selection_to_primary_clipboard.execute(cxt);
+                match config.mouse_yank_clipboard {
+                    helix_view::editor::MouseYankClipboard::Primary => {
+                        commands::MappableCommand::yank_main_selection_to_primary_clipboard
+                            .execute(cxt);
+                    }
+                    helix_view::editor::MouseYankClipboard::System => {
+                        commands::MappableCommand::yank_main_selection_to_clipboard.execute(cxt);
+                    }
+                }
 
                 EventResult::Consumed(None)
             }
@@ -1206,8 +1214,16 @@ impl EditorView {
                 }
 
                 if modifiers == KeyModifiers::ALT {
-                    commands::MappableCommand::replace_selections_with_primary_clipboard
-                        .execute(cxt);
+                    match config.mouse_yank_clipboard {
+                        helix_view::editor::MouseYankClipboard::Primary => {
+                            commands::MappableCommand::replace_selections_with_primary_clipboard
+                                .execute(cxt);
+                        }
+                        helix_view::editor::MouseYankClipboard::System => {
+                            commands::MappableCommand::replace_selections_with_clipboard
+                                .execute(cxt);
+                        }
+                    }
 
                     return EventResult::Consumed(None);
                 }
@@ -1216,7 +1232,15 @@ impl EditorView {
                     let doc = doc_mut!(editor, &view!(editor, view_id).doc);
                     doc.set_selection(view_id, Selection::point(pos));
                     cxt.editor.focus(view_id);
-                    commands::MappableCommand::paste_primary_clipboard_before.execute(cxt);
+
+                    match config.mouse_yank_clipboard {
+                        helix_view::editor::MouseYankClipboard::Primary => {
+                            commands::MappableCommand::paste_primary_clipboard_before.execute(cxt);
+                        }
+                        helix_view::editor::MouseYankClipboard::System => {
+                            commands::MappableCommand::paste_clipboard_before.execute(cxt);
+                        }
+                    }
 
                     return EventResult::Consumed(None);
                 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -219,6 +219,8 @@ pub struct Config {
     pub scroll_lines: isize,
     /// Mouse support. Defaults to true.
     pub mouse: bool,
+    /// Which clipboard to use for mouse yank.
+    pub mouse_yank_clipboard: MouseYankClipboard,
     /// Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
     pub shell: Vec<String>,
     /// Line number mode.
@@ -600,6 +602,16 @@ pub enum LineNumber {
     Relative,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MouseYankClipboard {
+    /// Mouse yanks to primary clipboard
+    Primary,
+
+    /// Mouse yanks to system clipboard
+    System,
+}
+
 impl std::str::FromStr for LineNumber {
     type Err = anyhow::Error;
 
@@ -805,6 +817,7 @@ impl Default for Config {
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,
+            mouse_yank_clipboard: MouseYankClipboard::Primary,
             shell: if cfg!(windows) {
                 vec!["cmd".to_owned(), "/C".to_owned()]
             } else {


### PR DESCRIPTION
Adds mouse_yank_clipboard configuration option under the editor section:

[editor]
mouse-yank-clipboard = "system" / "primary" (default "primary")

This affects the following actions:
- Selecting text with mouse will yank to configured clipboard
- Pasting with middle mouse button will use configured clipboard
- Replacing selected text with ALT+middle mouse button will use configured clipboard

Without this option Helix will fallback to current behavior of using the primary clipboard for the above mentioned actions.

Fixes  #6642.