### PR TITLE
Use prefix search on the line when navigating prompt history

### DIFF
--- a/helix-term/tests/test/prompt.rs
+++ b/helix-term/tests/test/prompt.rs
@@ -14,3 +14,23 @@ async fn test_history_completion() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_history_search() -> anyhow::Result<()> {
+    test_key_sequence(
+        &mut AppBuilder::new().build()?,
+        Some(":show<minus>directory<ret>:show<minus>clipboard<minus>provider<ret>:new<ret>:bc<ret>:sh<up><up><ret>"),
+        Some(&|app| {
+            assert!(&app
+                .editor
+                .get_status()
+                .unwrap()
+                .0
+                .starts_with("Current working dir"));
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
I've implemented a feature I've been missing in Helix for a while: (prefix) search in the prompt history based on the current line. This is a similar behaviour to what you'll find in many shells and REPLs.

For example, this allows the user to type `:o` and then search up and down through all the files they've opened previously.