### PR TITLE
Configurable keymap ordering.

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -48,6 +48,12 @@ c = ":run-shell-command cargo build"
 t = ":run-shell-command cargo test"
 ```
 
+## Info box ordering
+
+Order of keybindings in config is preserved when displaying the respective info
+boxes. User defined keybindings take precedence over the built-in bindings,
+meaning that they are shown first.
+
 ## Special keys and modifiers
 
 Ctrl, Shift and Alt modifiers are encoded respectively with the prefixes

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -192,10 +192,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C-j" | "j" | "down" => jump_view_down,
             "C-k" | "k" | "up" => jump_view_up,
             "C-l" | "l" | "right" => jump_view_right,
-            "L" => swap_view_right,
-            "K" => swap_view_up,
             "H" => swap_view_left,
             "J" => swap_view_down,
+            "K" => swap_view_up,
+            "L" => swap_view_right,
             "n" => { "New split scratch buffer"
                 "C-s" | "s" => hsplit_new,
                 "C-v" | "v" => vsplit_new,
@@ -322,8 +322,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "C-a" => increment,
         "C-x" => decrement,
     });
-    let mut select = normal.clone();
-    select.merge_nodes(keymap!({ "Select mode"
+    let select = normal.clone().merge_nodes(keymap!({ "Select mode"
         "h" | "left" => extend_char_left,
         "j" | "down" => extend_visual_line_down,
         "k" | "up" => extend_visual_line_up,

--- a/helix-term/src/keymap/macros.rs
+++ b/helix-term/src/keymap/macros.rs
@@ -112,7 +112,7 @@ macro_rules! keymap {
                     _order.push(keymap!(@trie $value));
                 )+
             )*
-            let mut _node = $crate::keymap::KeyTrieNode::new($label, _map, _order);
+            let mut _node = $crate::keymap::KeyTrieNode::new(Some($label), _map, _order);
             $( _node.is_sticky = $sticky; )?
             $crate::keymap::KeyTrie::Node(_node)
         }

--- a/helix-term/src/keymap/macros.rs
+++ b/helix-term/src/keymap/macros.rs
@@ -106,10 +106,10 @@ macro_rules! keymap {
                     let _key = $key.parse::<::helix_view::input::KeyEvent>().unwrap();
                     let _duplicate = _map.insert(
                         _key,
-                        keymap!(@trie $value)
+                        _order.len()
                     );
                     assert!(_duplicate.is_none(), "Duplicate key found: {:?}", _duplicate.unwrap());
-                    _order.push(_key);
+                    _order.push(keymap!(@trie $value));
                 )+
             )*
             let mut _node = $crate::keymap::KeyTrieNode::new($label, _map, _order);

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -427,7 +427,7 @@ async fn test_write_utf_bom_file() -> anyhow::Result<()> {
 async fn edit_file_with_content(file_content: &[u8]) -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
 
-    file.as_file_mut().write_all(&file_content)?;
+    file.as_file_mut().write_all(file_content)?;
 
     helpers::test_key_sequence(
         &mut helpers::AppBuilder::new().build()?,

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -300,11 +300,9 @@ impl AppBuilder {
         self
     }
 
-    // Remove this attribute once `with_config` is used in a test:
-    #[allow(dead_code)]
     pub fn with_config(mut self, mut config: Config) -> Self {
         let keys = replace(&mut config.keys, helix_term::keymap::default());
-        merge_keys(&mut config.keys, keys);
+        config.keys = merge_keys(config.keys, keys);
         self.config = config;
         self
     }


### PR DESCRIPTION
Depends on #7214.
    
Makes it possible to declare the order in the config file. User order takes
precedence over pre-defined. (As requested by @GloopShlugger and @eugenesvk
in #5635.)
