### PR TITLE
Maintain the current cursor's position and view in the vsplit/hsplit commands too

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4636,17 +4636,19 @@ fn transpose_view(cx: &mut Context) {
     cx.editor.transpose_view()
 }
 
-// split helper, clear it later
-fn split(cx: &mut Context, action: Action) {
-    let (view, doc) = current!(cx.editor);
+/// Open a new split in the given direction specified by the action.
+///
+/// Maintain the current view (both the cursor's position and view in document).
+fn split_helper(editor: &mut Editor, action: Action) {
+    let (view, doc) = current!(editor);
     let id = doc.id();
     let selection = doc.selection(view.id).clone();
     let offset = view.offset;
 
-    cx.editor.switch(id, action);
+    editor.switch(id, action);
 
     // match the selection in the previous view
-    let (view, doc) = current!(cx.editor);
+    let (view, doc) = current!(editor);
     doc.set_selection(view.id, selection);
     // match the view scroll offset (switch doesn't handle this fully
     // since the selection is only matched after the split)
@@ -4654,7 +4656,7 @@ fn split(cx: &mut Context, action: Action) {
 }
 
 fn hsplit(cx: &mut Context) {
-    split(cx, Action::HorizontalSplit);
+    split_helper(&mut cx.editor, Action::HorizontalSplit);
 }
 
 fn hsplit_new(cx: &mut Context) {
@@ -4662,7 +4664,7 @@ fn hsplit_new(cx: &mut Context) {
 }
 
 fn vsplit(cx: &mut Context) {
-    split(cx, Action::VerticalSplit);
+    split_helper(&mut cx.editor, Action::VerticalSplit);
 }
 
 fn vsplit_new(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1506,10 +1506,8 @@ fn vsplit(
         return Ok(());
     }
 
-    let id = view!(cx.editor).doc;
-
     if args.is_empty() {
-        cx.editor.switch(id, Action::VerticalSplit);
+        split_helper(&mut cx.editor, Action::VerticalSplit);
     } else {
         for arg in args {
             cx.editor
@@ -1529,10 +1527,8 @@ fn hsplit(
         return Ok(());
     }
 
-    let id = view!(cx.editor).doc;
-
     if args.is_empty() {
-        cx.editor.switch(id, Action::HorizontalSplit);
+        split_helper(&mut cx.editor, Action::HorizontalSplit);
     } else {
         for arg in args {
             cx.editor


### PR DESCRIPTION
First of all, thanks for this editor; it's all I've ever wanted from nvim, without the configuration hassle.

I've been quite surprised to discover today that doing `C-w C-v` would keep the current cursor's position and view in document, while the `:vsplit` command would not do that and reset the cursor to the top of the screen. This PR implements a consistent behavior in both cases, which is that of `C-w C-v` which I personally find more pleasant.