### PR TITLE
Add register statusline element

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -117,6 +117,7 @@ The following statusline elements can be configured:
 | `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |
 | `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |
 | `version-control` | The current branch name or detached commit hash of the opened workspace |
+| `register` | The current selected register |
 
 ### `[editor.lsp]` Section
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -160,6 +160,7 @@ where
         helix_view::editor::StatusLineElement::Separator => render_separator,
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
+        helix_view::editor::StatusLineElement::Register => render_register,
     }
 }
 
@@ -488,4 +489,13 @@ where
         .to_string();
 
     write(context, head, None);
+}
+
+fn render_register<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    if let Some(reg) = context.editor.selected_register {
+        write(context, format!(" reg={} ", reg), None)
+    }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -403,7 +403,13 @@ impl Default for StatusLineConfig {
                 E::FileModificationIndicator,
             ],
             center: vec![],
-            right: vec![E::Diagnostics, E::Selections, E::Position, E::FileEncoding],
+            right: vec![
+                E::Diagnostics,
+                E::Selections,
+                E::Register,
+                E::Position,
+                E::FileEncoding,
+            ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
         }
@@ -484,6 +490,9 @@ pub enum StatusLineElement {
 
     /// Current version control information
     VersionControl,
+
+    /// Indicator for selected register
+    Register,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs


### PR DESCRIPTION
Resolves issue #1585 by adding a status message when a register is selected with the `select_register` command, similar to the message produced when starting to record a macro. Additionally, an indicator appears on the right with the selected register.