### PR TITLE
Fix for saving from insert mode

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -834,6 +834,10 @@ impl EditorView {
         cxt.editor.autoinfo = self.keymaps.sticky().map(|node| node.infobox());
 
         let mut execute_command = |command: &commands::MappableCommand| {
+            let doc = doc_mut!(cxt.editor);
+            let view = view_mut!(cxt.editor);
+            doc.append_changes_to_history(view);
+
             command.execute(cxt);
             helix_event::dispatch(PostCommand { command, cx: cxt });
 


### PR DESCRIPTION
Fixes #6513, fixes #3501, addresses #1583. This somewhat changes the granularity of the undo history: but keeps the preciseness. While adding to the undo history on a save may not seem idiomatic conceptually at first: I think it's the best way to address the issue, because 1) saving a file is somewhat of a "finishing" action and 2) comparing the undo history with the current state of a file is quite a nice way to check if something has been modified and I would prefer not to mess with it.

I also added e2a877432ce7f75eba60d5dd579e5a0ab45b73e8 because I stumbled across it while tracking down this issue and thought that having a separate history entry for a raw paste before any manipulation of it would be desirable. I'd be fine rolling it back but that also propagating to history makes more sense to me.