### PR TITLE
fix UB in diff gutter

### DIFF
--- a/helix-vcs/src/diff/line_cache.rs
+++ b/helix-vcs/src/diff/line_cache.rs
@@ -20,8 +20,8 @@ use super::{MAX_DIFF_BYTES, MAX_DIFF_LINES};
 /// A cache that stores the `lines` of a rope as a vector.
 /// It allows safely reusing the allocation of the vec when updating the rope
 pub(crate) struct InternedRopeLines {
-    diff_base: Rope,
-    doc: Rope,
+    diff_base: Box<Rope>,
+    doc: Box<Rope>,
     num_tokens_diff_base: u32,
     interned: InternedInput<RopeSlice<'static>>,
 }
@@ -34,8 +34,8 @@ impl InternedRopeLines {
                 after: Vec::with_capacity(doc.len_lines()),
                 interner: Interner::new(diff_base.len_lines() + doc.len_lines()),
             },
-            diff_base,
-            doc,
+            diff_base: Box::new(diff_base),
+            doc: Box::new(doc),
             // will be populated by update_diff_base_impl
             num_tokens_diff_base: 0,
         };
@@ -44,19 +44,19 @@ impl InternedRopeLines {
     }
 
     pub fn doc(&self) -> Rope {
-        self.doc.clone()
+        Rope::clone(&*self.doc)
     }
 
     pub fn diff_base(&self) -> Rope {
-        self.diff_base.clone()
+        Rope::clone(&*self.diff_base)
     }
 
     /// Updates the `diff_base` and optionally the document if `doc` is not None
     pub fn update_diff_base(&mut self, diff_base: Rope, doc: Option<Rope>) {
         self.interned.clear();
-        self.diff_base = diff_base;
+        self.diff_base = Box::new(diff_base);
         if let Some(doc) = doc {
-            self.doc = doc
+            self.doc = Box::new(doc)
         }
         if !self.is_too_large() {
             self.update_diff_base_impl();
@@ -74,7 +74,7 @@ impl InternedRopeLines {
             .interner
             .erase_tokens_after(self.num_tokens_diff_base.into());
 
-        self.doc = doc;
+        self.doc = Box::new(doc);
         if self.is_too_large() {
             self.interned.after.clear();
         } else {


### PR DESCRIPTION
Fixes UB in the diff gutters that lead to crashes in rust 1.71.

See https://github.com/rust-lang/rust/issues/112171#issuecomment-1575573079

Note that this is a temporary fix that I will revert once I land the improvements described in the comment land in ropey. That could take a while tough, and we really don't want UB in the meantime.