### PR TITLE
Fix behaviour of matching when tree-sitter grammar is available

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -50,6 +50,10 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
     let tree = syntax.tree();
     let pos = doc.char_to_byte(pos);
 
+    if is_valid_bracket(doc.char(pos)) {
+        return find_matching_bracket_plaintext(doc, pos);
+    }
+
     let mut node = tree.root_node().named_descendant_for_byte_range(pos, pos)?;
 
     loop {
@@ -85,10 +89,7 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
 ///
 /// If no matching bracket is found, `None` is returned.
 #[must_use]
-pub fn find_matching_bracket_current_line_plaintext(
-    doc: &Rope,
-    cursor_pos: usize,
-) -> Option<usize> {
+pub fn find_matching_bracket_plaintext(doc: &Rope, cursor_pos: usize) -> Option<usize> {
     // Don't do anything when the cursor is not on top of a bracket.
     let bracket = doc.char(cursor_pos);
     if !is_valid_bracket(bracket) {
@@ -169,10 +170,10 @@ mod tests {
     fn test_find_matching_bracket_current_line_plaintext() {
         let assert = |input: &str, pos, expected| {
             let input = &Rope::from(input);
-            let actual = find_matching_bracket_current_line_plaintext(input, pos);
+            let actual = find_matching_bracket_plaintext(input, pos);
             assert_eq!(expected, actual.unwrap());
 
-            let actual = find_matching_bracket_current_line_plaintext(input, expected);
+            let actual = find_matching_bracket_plaintext(input, expected);
             assert_eq!(pos, actual.unwrap(), "expected symmetrical behaviour");
         };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4535,7 +4535,7 @@ fn match_brackets(cx: &mut Context) {
     let selection = doc.selection(view.id).clone().transform(|range| {
         let pos = range.cursor(text_slice);
         if let Some(matched_pos) = doc.syntax().map_or_else(
-            || match_brackets::find_matching_bracket_current_line_plaintext(text, pos),
+            || match_brackets::find_matching_bracket_plaintext(text, pos),
             |syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text, pos),
         ) {
             range.put_cursor(text_slice, matched_pos, is_select)


### PR DESCRIPTION
If the current character is a valid bracket, resort to plaintext matching. Otherwise, use regular tree-sitter node traversal.
This is a pragmatic solution that I propose, as addressing the tree-sitter grammars seems way more complex and tedious.
Why is believe this is acceptable? If the user is not on top of a valid bracket, regular operation will take place. It simply deals with the edge cases where the user _is on top_ of a bracket, which brings the unexpected behaviour that users complain about (see https://github.com/helix-editor/helix/issues/3357, https://github.com/helix-editor/helix/issues/5177)