### PR TITLE
fix(commands.rs): remove check for empty line from indent() function

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3994,10 +3994,6 @@ fn indent(cx: &mut Context) {
     let transaction = Transaction::change(
         doc.text(),
         lines.into_iter().filter_map(|line| {
-            let is_blank = doc.text().line(line).chunks().all(|s| s.trim().is_empty());
-            if is_blank {
-                return None;
-            }
             let pos = doc.text().line_to_char(line);
             Some((pos, pos, Some(indent.clone())))
         }),


### PR DESCRIPTION
refs #4505

There is a check for empty line, however this check is probably useless, as one can indent to desired space without any text present and then start typing, having it offers no benefit