### PR TITLE
match pairs which don't form a standalone TS node

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -64,9 +64,12 @@ fn find_pair(syntax: &Syntax, doc: &Rope, pos: usize, traverse_parents: bool) ->
                 if end_byte == pos {
                     return Some(start_char);
                 }
+
                 // We return the end char if the cursor is either on the start char
                 // or at some arbitrary position between start and end char.
-                return Some(end_char);
+                if traverse_parents || start_byte == pos {
+                    return Some(end_char);
+                }
             }
         }
         // this node itselt wasn't a pair but maybe its siblings are

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4535,8 +4535,8 @@ fn match_brackets(cx: &mut Context) {
     let selection = doc.selection(view.id).clone().transform(|range| {
         let pos = range.cursor(text_slice);
         if let Some(matched_pos) = doc.syntax().map_or_else(
-            || match_brackets::find_matching_bracket_current_line_plaintext(text, pos),
-            |syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text, pos),
+            || match_brackets::find_matching_bracket_plaintext(text.slice(..), pos),
+            |syntax| match_brackets::find_matching_bracket_fuzzy(syntax, text.slice(..), pos),
         ) {
             range.put_cursor(text_slice, matched_pos, is_select)
         } else {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -501,7 +501,9 @@ impl EditorView {
             use helix_core::match_brackets;
             let pos = doc.selection(view.id).primary().cursor(text);
 
-            if let Some(pos) = match_brackets::find_matching_bracket(syntax, doc.text(), pos) {
+            if let Some(pos) =
+                match_brackets::find_matching_bracket(syntax, doc.text().slice(..), pos)
+            {
                 // ensure col is on screen
                 if let Some(highlight) = theme.find_scope_index_exact("ui.cursor.match") {
                     return vec![(highlight, pos..pos + 1)];


### PR DESCRIPTION
Closes #3357
Closes #5177

These issues where caused by us requiring pairs to form a standalone TS node. This change looks at the sibling nodes (so still within the same node) to also find pairs formed by siblings. Syntax trees are usually much wider than deep, so I introduced a fairy aggressive limit on the number of examined nodes. Usually pairs form immediate siblings and looking at additional siblings is just done to handle weird grammars (and comments). The limit does lead to missing some matches but those cases are so rare that it's worth the improved performance IMO.
