### PR TITLE
Add language support for persistent library syntax

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -59,6 +59,7 @@
 | graphql | ✓ |  |  |  |
 | hare | ✓ |  |  |  |
 | haskell | ✓ | ✓ |  | `haskell-language-server-wrapper` |
+| haskell-persistent | ✓ |  |  |  |
 | hcl | ✓ |  | ✓ | `terraform-ls` |
 | heex | ✓ | ✓ |  | `elixir-ls` |
 | hosts | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -954,7 +954,6 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-haskell", rev = "98
 [[language]]
 name = "haskell-persistent"
 scope = "source.persistentmodels"
-injection-regex = "(persistWith|persistLowerCase|persistUpperCase)"
 file-types = ["persistentmodels"]
 roots = []
 comment-token = "--"

--- a/languages.toml
+++ b/languages.toml
@@ -952,6 +952,19 @@ name = "haskell"
 source = { git = "https://github.com/tree-sitter/tree-sitter-haskell", rev = "98fc7f59049aeb713ab9b72a8ff25dcaaef81087" }
 
 [[language]]
+name = "haskell-persistent"
+scope = "source.persistentmodels"
+injection-regex = "(persistWith|persistLowerCase|persistUpperCase)"
+file-types = ["persistentmodels"]
+roots = []
+comment-token = "--"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "haskell-persistent"
+source = { git = "https://github.com/MercuryTechnologies/tree-sitter-haskell-persistent", rev = "58a6ccfd56d9f1de8fb9f77e6c42151f8f0d0f3d" }
+
+[[language]]
 name = "purescript"
 scope = "source.purescript"
 injection-regex = "purescript"

--- a/runtime/queries/haskell-persistent/folds.scm
+++ b/runtime/queries/haskell-persistent/folds.scm
@@ -1,0 +1,3 @@
+[
+ (entity_definition)
+] @fold

--- a/runtime/queries/haskell-persistent/highlights.scm
+++ b/runtime/queries/haskell-persistent/highlights.scm
@@ -1,0 +1,37 @@
+;; ----------------------------------------------------------------------------
+;; Literals and comments
+
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+(char) @constant.character
+(string) @string
+(attribute_name) @attribute
+(attribute_exclamation_mark) @attribute
+
+(con_unit) @constant.builtin ; unit, as in ()
+
+(comment) @comment
+
+;; ----------------------------------------------------------------------------
+;; Keywords, operators, includes
+
+[
+  "Id"
+  "Primary"
+  "Foreign"
+  "deriving"
+] @keyword
+
+"=" @punctuation.delimiter
+
+;; ----------------------------------------------------------------------------
+;; Functions and variables
+
+(variable) @variable
+
+;; ----------------------------------------------------------------------------
+;; Types
+
+(type) @type
+
+(constructor) @constructor

--- a/runtime/queries/haskell-persistent/highlights.scm
+++ b/runtime/queries/haskell-persistent/highlights.scm
@@ -22,7 +22,7 @@
   "deriving"
 ] @keyword
 
-"=" @punctuation.delimiter
+"=" @operator
 
 ;; ----------------------------------------------------------------------------
 ;; Functions and variables

--- a/runtime/queries/haskell-persistent/locals.scm
+++ b/runtime/queries/haskell-persistent/locals.scm
@@ -1,0 +1,1 @@
+(fields (variable)) @local.definition

--- a/runtime/queries/haskell/injections.scm
+++ b/runtime/queries/haskell/injections.scm
@@ -2,5 +2,13 @@
  (#set! injection.language "comment"))
 
 (quasiquote
+ (quoter) @_quoter
+ ((quasiquote_body) @injection.content
+  (#match? @_quoter "(persistWith|persistLowerCase|persistUpperCase)")
+  (#set! injection.language "haskell-persistent")
+ )
+)
+
+(quasiquote
  (quoter) @injection.language
  (quasiquote_body) @injection.content)


### PR DESCRIPTION
This adds support for the language used by a [persistent](https://hackage.haskell.org/package/persistent) library to define the database models. This syntax is only used by one library, so I chose to prefix the language name with "haskell-" for specificity.

The haskell [injections query](https://github.com/helix-editor/helix/blob/master/runtime/queries/haskell/injections.scm) uses the name of the function that handles that content of the quasi-quote as the name of the language. The persistent library has three of them that I included into the `injection-regex`. 

<img width="989" alt="image" src="https://github.com/helix-editor/helix/assets/852150/d2c367a1-15fc-41fd-b4f3-d0f54bb52b14">
