### PR TITLE
Add support for packaging Helix as a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ target
 helix-term/rustfmt.toml
 result
 runtime/grammars
+
+# Snapcraft artifacts
+*.snap
+/parts/
+/prime/
+/stage/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: hx
+base: core22
+adopt-info: helix
+license: MPL-2.0
+source-code: https://github.com/helix-editor/helix
+issues: https://github.com/helix-editor/helix/issues
+
+title: Helix
+website: https://helix-editor.com
+summary: Helix is a modal text editor inspired by Vim and Kakoune
+description: |
+  * Vim-like modal editing
+  * Multiple selections
+  * Built-in language server support
+  * Smart, incremental syntax highlighting and code editing via tree-sitter
+  * Written in Rust
+
+  New to Helix? Read the [docs](https://docs.helix-editor.com/)!
+  Coming from Vim? Read about the [differences](https://github.com/helix-editor/helix/wiki/Differences-from#vim)!
+  Want answers to common questions? Check the [FAQ](https://github.com/helix-editor/helix/wiki/FAQ)!
+
+
+grade: stable
+confinement: classic
+
+apps:
+  hx:
+    command: bin/hx
+
+parts:
+  helix:
+    source: .
+    plugin: rust
+    rust-path: [helix-term]
+
+    override-pull: |
+      craftctl default
+      craftctl set version="$(git describe --tags --always)"
+
+    build-packages: [cargo, rustc, g++]
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      craftctl default
+
+      # Strip executables
+      find . -type f -executable -exec strip -s {} \;
+
+      # Copy runtime to install dir
+      cp -r "${CRAFT_PART_BUILD}/runtime" "${CRAFT_PART_INSTALL}/bin/"
+      rm -r "${CRAFT_PART_INSTALL}/bin/runtime/grammars/sources"


### PR DESCRIPTION
This commit primarily adds a `snapcraft.yaml` file for packaging Helix as a snap.

As noted in the linked issues, currently both `hx` and `helix` are reserved names in the Global Snap Store (with `hx` being the preferred package name). However, this can usually be remedied by contacting the store team. In the case that neither can be used, we should be able to create a snap with a name like `helix-editor` and simply advise users to alias (`snap alias helix-editor hx`, for example) to enable invoking Helix as normal.

Additionally, we'll have to request that the snap be allowed to be uploaded with "Classic" confinement (which essentially allows it to run unconfined) as this is pretty much necessary for a general-purpose text editor.

Of course, if this commit were to be merged, it also brings with it a question of who will maintain the package builds.
The ideal situation would, of course, be that the Helix team, at the very least, own the account to which the snap is associated, while also giving select users publishing rights (as "Collaborators" in the Snapcraft Dashboard). If, however, you all don't want to undertake this, I'll gladly maintain the snap myself with your blessing. Should the time ever come that I was no longer willing/able to maintain the snap, or you wished to maintain it yourself, the snap's ownership could be transferred to a Helix-owned account.

I'm marking this PR as a draft until there's a concrete plan in place for where the snap will reside (should you want to merge in the first place), and discussion with the Snap store team has occurred.

Let me know what you think!

closes #2171
closes #2180