### PR TITLE
Persist register selection in pending keymaps

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2705,6 +2705,9 @@ impl ui::menu::Item for MappableCommand {
 }
 
 pub fn command_palette(cx: &mut Context) {
+    let register = cx.register;
+    let count = cx.count;
+
     cx.callback = Some(Box::new(
         move |compositor: &mut Compositor, cx: &mut compositor::Context| {
             let keymap = compositor.find::<ui::EditorView>().unwrap().keymaps.map()
@@ -2722,8 +2725,8 @@ pub fn command_palette(cx: &mut Context) {
 
             let picker = Picker::new(commands, keymap, move |cx, command, _action| {
                 let mut ctx = Context {
-                    register: None,
-                    count: std::num::NonZeroUsize::new(1),
+                    register,
+                    count,
                     editor: cx.editor,
                     callback: None,
                     on_next_key_callback: None,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -943,6 +943,8 @@ impl EditorView {
                 self.handle_keymap_event(mode, cxt, event);
                 if self.keymaps.pending().is_empty() {
                     cxt.editor.count = None
+                } else {
+                    cxt.editor.selected_register = cxt.register.take();
                 }
             }
         }


### PR DESCRIPTION
Previously the register selection (via `"`) would be lost in the middle of any key sequence longer than one key. For example, `<space>f` would clear the register selection after the `<space>` making it inaccessible for the `file_picker` command.

This behavior does not currently have any effect in the default keymap but might affect custom keymaps. This change aligns the behavior of the register with count. Making this change allows propagating the register to the `command_palette` (see the child commit) or other pickers should we decide to use registers in those in the future. (Interactive global search for example.)