### PR TITLE
Break long sentence in book configuration footnote

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -131,8 +131,10 @@ The following statusline elements can be configured:
 | `goto-reference-include-declaration` | Include declaration in the goto references popup. | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
+
 [^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix.
-      Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances, please report any bugs you see so we can fix them!
+      Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances.
+      Please report any bugs you see so we can fix them!
 
 ### `[editor.cursor-shape]` Section
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -132,9 +132,7 @@ The following statusline elements can be configured:
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 
-[^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix.
-      Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances.
-      Please report any bugs you see so we can fix them!
+[^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix. Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances. Please report any bugs you see so we can fix them!
 
 ### `[editor.cursor-shape]` Section
 


### PR DESCRIPTION
Also, reduce overlong sentence, which also improves readability