### PR TITLE
Fix style overwriting in table rows with multiple cells

### DIFF
--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -450,11 +450,11 @@ impl<'a> Table<'a> {
             } else {
                 col
             };
+            if is_selected {
+                buf.set_style(table_row_area, self.highlight_style);
+            }
             let mut col = table_row_start_col;
             for (width, cell) in columns_widths.iter().zip(table_row.cells.iter()) {
-                if is_selected {
-                    buf.set_style(table_row_area, self.highlight_style);
-                }
                 render_cell(
                     buf,
                     cell,


### PR DESCRIPTION
This is a fix for a subtle bug in the styling of cells in a table: only the last Cell in the selected Row will display fuzzy-matching highlights.

The simplest way to reproduce the bug is to open up the buffer picker. Inputting a buffer ID number or a flag which is present like * should highlight matched characters with your theme's 'ui.text.focus' scope, but the styles are not applied.

The issue is that the block moved in this commit was called per-cell but operates on the whole row's area, so the call in the last cell would overwrite all prior cells. The block must be moved outside the for-loop over the cells.

| Before | After |
|---|---|
| ![before](https://github.com/helix-editor/helix/assets/21230295/0c2e639f-7d0b-43b4-83d4-7122e078a1c8) | ![after](https://github.com/helix-editor/helix/assets/21230295/c3058aeb-cdfa-4862-89a2-af41e00fcb22) |

