### PR TITLE
Bail if no language servers support workspace symbols

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -442,6 +442,15 @@ pub fn symbol_picker(cx: &mut Context) {
 
 pub fn workspace_symbol_picker(cx: &mut Context) {
     let doc = doc!(cx.editor);
+    if doc
+        .language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols)
+        .count()
+        == 0
+    {
+        cx.editor
+            .set_error("No configured language server supports workspace symbols");
+        return;
+    }
 
     let get_symbols = move |pattern: String, editor: &mut Editor| {
         let doc = doc!(editor);


### PR DESCRIPTION
The behavior prior to this commit opened the picker and then showed the error. We can check the feature availability before performing the first query to prevent opening up the picker unnecessarily.