### PR TITLE
Add Fortran comment injections

### DIFF
--- a/runtime/queries/fortran/injections.scm
+++ b/runtime/queries/fortran/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Enables highlighting of notes like `@todo`, `@note`, `TODO`, `NOTE` in Fortran comments.