### PR TITLE
Consistent statusline spacing

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -92,9 +92,9 @@ The `[editor.statusline]` key takes the following sub-keys:
 
 | Key           | Description | Default |
 | ---           | ---         | ---     |
-| `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
+| `left`        | A list of elements aligned to the left of the statusline | `["spacer", "mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
 | `center`      | A list of elements aligned to the middle of the statusline | `[]` |
-| `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding"]` |
+| `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding", "spacer"]` |
 | `separator`   | The character used to separate elements in the statusline | `"│"` |
 | `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
 | `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -60,7 +60,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
-| `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
+| `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `true` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
@@ -92,13 +92,13 @@ The `[editor.statusline]` key takes the following sub-keys:
 
 | Key           | Description | Default |
 | ---           | ---         | ---     |
-| `left`        | A list of elements aligned to the left of the statusline | `["spacer", "mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
+| `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
 | `center`      | A list of elements aligned to the middle of the statusline | `[]` |
 | `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding", "spacer"]` |
 | `separator`   | The character used to separate elements in the statusline | `"│"` |
-| `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
-| `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |
-| `mode.select` | The text shown in the `mode` element for select mode | `"SEL"` |
+| `mode.normal` | The text shown in the `mode` element for normal mode | `" NOR "` |
+| `mode.insert` | The text shown in the `mode` element for insert mode | `" INS "` |
+| `mode.select` | The text shown in the `mode` element for select mode | `" SEL "` |
 
 The following statusline elements can be configured:
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -4,7 +4,6 @@ use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::Rect,
-    theme::Style,
     Document, Editor, View,
 };
 
@@ -58,25 +57,17 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
 
     surface.set_style(viewport.with_height(1), base_style);
 
-    let write_left = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.left, text, &base_style, style)
-    };
-    let write_center = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.center, text, &base_style, style)
-    };
-    let write_right = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.right, text, &base_style, style)
-    };
-
     // Left side of the status line.
 
     let config = context.editor.config();
 
     let element_ids = &config.statusline.left;
-    element_ids
+    context.parts.left = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_left));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     surface.set_spans(
         viewport.x,
@@ -88,10 +79,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Right side of the status line.
 
     let element_ids = &config.statusline.right;
-    element_ids
+    context.parts.right = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_right));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     surface.set_spans(
         viewport.x
@@ -106,10 +99,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Center of the status line.
 
     let element_ids = &config.statusline.center;
-    element_ids
+    context.parts.center = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_center));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     // Width of the empty space between the left and center area and between the center and right area.
     let spacing = 1u16;
@@ -126,17 +121,9 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     );
 }
 
-fn append(buffer: &mut Spans, text: String, base_style: &Style, style: Option<Style>) {
-    buffer.0.push(Span::styled(
-        text,
-        style.map_or(*base_style, |s| (*base_style).patch(s)),
-    ));
-}
-
-fn get_render_function<F>(element_id: StatusLineElementID) -> impl Fn(&mut RenderContext, F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn get_render_function<'a>(
+    element_id: StatusLineElementID,
+) -> impl Fn(&RenderContext) -> Spans<'a> {
     match element_id {
         helix_view::editor::StatusLineElement::Mode => render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
@@ -165,48 +152,35 @@ where
     }
 }
 
-fn render_mode<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_mode<'a>(context: &RenderContext) -> Spans<'a> {
     let visible = context.focused;
     let config = context.editor.config();
     let modenames = &config.statusline.mode;
-    write(
-        context,
-        format!(
-            " {} ",
-            if visible {
-                match context.editor.mode() {
-                    Mode::Insert => &modenames.insert,
-                    Mode::Select => &modenames.select,
-                    Mode::Normal => &modenames.normal,
-                }
-            } else {
-                // If not focused, explicitly leave an empty space instead of returning None.
-                "   "
-            }
-        ),
-        if visible && config.color_modes {
-            match context.editor.mode() {
-                Mode::Insert => Some(context.editor.theme.get("ui.statusline.insert")),
-                Mode::Select => Some(context.editor.theme.get("ui.statusline.select")),
-                Mode::Normal => Some(context.editor.theme.get("ui.statusline.normal")),
-            }
+    if visible {
+        let modename = match context.editor.mode() {
+            Mode::Insert => modenames.insert.clone(),
+            Mode::Select => modenames.select.clone(),
+            Mode::Normal => modenames.normal.clone(),
+        };
+        let style = match context.editor.mode() {
+            Mode::Insert => context.editor.theme.get("ui.statusline.insert"),
+            Mode::Select => context.editor.theme.get("ui.statusline.select"),
+            Mode::Normal => context.editor.theme.get("ui.statusline.normal"),
+        };
+        if config.color_modes {
+            Span::styled(modename, style).into()
         } else {
-            None
-        },
-    );
+            Span::raw(modename).into()
+        }
+    } else {
+        Spans::default()
+    }
 }
 
 // TODO think about handling multiple language servers
-fn render_lsp_spinner<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_lsp_spinner<'a>(context: &RenderContext) -> Spans<'a> {
     let language_server = context.doc.language_servers().next();
-    write(
-        context,
+    Span::raw(
         language_server
             .and_then(|srv| {
                 context
@@ -217,14 +191,11 @@ where
             // Even if there's no spinner; reserve its space to avoid elements frequently shifting.
             .unwrap_or(" ")
             .to_string(),
-        None,
-    );
+    )
+    .into()
 }
 
-fn render_diagnostics<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_diagnostics<'a>(context: &RenderContext) -> Spans<'a> {
     let (warnings, errors) = context
         .doc
         .shown_diagnostics()
@@ -238,29 +209,28 @@ where
             counts
         });
 
+    let mut output = Spans::default();
+
     if warnings > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
+            context.editor.theme.get("warning"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", warnings)));
     }
 
     if errors > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+            context.editor.theme.get("error"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", errors)));
     }
+
+    output
 }
 
-fn render_workspace_diagnostics<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_workspace_diagnostics<'a>(context: &RenderContext) -> Spans<'a> {
     let (warnings, errors) =
         context
             .editor
@@ -276,51 +246,49 @@ where
                 counts
             });
 
+    let mut output = Spans::default();
+
     if warnings > 0 || errors > 0 {
-        write(context, " W ".into(), None);
+        output.0.push(Span::raw(" W "));
     }
 
     if warnings > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
+            context.editor.theme.get("warning"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", warnings)));
     }
 
     if errors > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+            context.editor.theme.get("error"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", errors)));
     }
+
+    output
 }
 
-fn render_selections<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_selections<'a>(context: &RenderContext) -> Spans<'a> {
     let count = context.doc.selection(context.view.id).len();
-    write(
-        context,
-        format!(" {} sel{} ", count, if count == 1 { "" } else { "s" }),
-        None,
-    );
+    Span::raw(format!(
+        " {} sel{} ",
+        count,
+        if count == 1 { "" } else { "s" }
+    ))
+    .into()
 }
 
-fn render_primary_selection_length<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_primary_selection_length<'a>(context: &RenderContext) -> Spans<'a> {
     let tot_sel = context.doc.selection(context.view.id).primary().len();
-    write(
-        context,
-        format!(" {} char{} ", tot_sel, if tot_sel == 1 { "" } else { "s" }),
-        None,
-    );
+    Span::raw(format!(
+        " {} char{} ",
+        tot_sel,
+        if tot_sel == 1 { "" } else { "s" }
+    ))
+    .into()
 }
 
 fn get_position(context: &RenderContext) -> Position {
@@ -334,55 +302,33 @@ fn get_position(context: &RenderContext) -> Position {
     )
 }
 
-fn render_position<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_position<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
-    write(
-        context,
-        format!(" {}:{} ", position.row + 1, position.col + 1),
-        None,
-    );
+    Span::raw(format!(" {}:{} ", position.row + 1, position.col + 1)).into()
 }
 
-fn render_total_line_numbers<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_total_line_numbers<'a>(context: &RenderContext) -> Spans<'a> {
     let total_line_numbers = context.doc.text().len_lines();
-
-    write(context, format!(" {} ", total_line_numbers), None);
+    Span::raw(format!(" {} ", total_line_numbers)).into()
 }
 
-fn render_position_percentage<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_position_percentage<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
     let maxrows = context.doc.text().len_lines();
-    write(
-        context,
-        format!("{}%", (position.row + 1) * 100 / maxrows),
-        None,
-    );
+    Span::raw(format!("{}%", (position.row + 1) * 100 / maxrows)).into()
 }
 
-fn render_file_encoding<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_encoding<'a>(context: &RenderContext) -> Spans<'a> {
     let enc = context.doc.encoding();
 
     if enc != encoding::UTF_8 {
-        write(context, format!(" {} ", enc.name()), None);
+        Span::raw(format!(" {} ", enc.name())).into()
+    } else {
+        Spans::default()
     }
 }
 
-fn render_file_line_ending<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_line_ending<'a>(context: &RenderContext) -> Spans<'a> {
     use helix_core::LineEnding::*;
     let line_ending = match context.doc.line_ending {
         Crlf => "CRLF",
@@ -401,22 +347,16 @@ where
         PS => "PS", // U+2029 -- ParagraphSeparator
     };
 
-    write(context, format!(" {} ", line_ending), None);
+    Span::raw(format!(" {} ", line_ending)).into()
 }
 
-fn render_file_type<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_type<'a>(context: &RenderContext) -> Spans<'a> {
     let file_type = context.doc.language_name().unwrap_or(DEFAULT_LANGUAGE_NAME);
 
-    write(context, format!(" {} ", file_type), None);
+    Span::raw(format!(" {} ", file_type)).into()
 }
 
-fn render_file_name<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_name<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let rel_path = context.doc.relative_path();
         let path = rel_path
@@ -426,13 +366,10 @@ where
         format!(" {} ", path)
     };
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_file_modification_indicator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_modification_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = (if context.doc.is_modified() {
         "[+]"
     } else {
@@ -440,26 +377,20 @@ where
     })
     .to_string();
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_read_only_indicator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_read_only_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = if context.doc.readonly {
         " [readonly] "
     } else {
         ""
     }
     .to_string();
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_file_base_name<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_base_name<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let rel_path = context.doc.relative_path();
         let path = rel_path
@@ -469,47 +400,37 @@ where
         format!(" {} ", path)
     };
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_separator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_separator<'a>(context: &RenderContext) -> Spans<'a> {
     let sep = &context.editor.config().statusline.separator;
 
-    write(
-        context,
+    Span::styled(
         sep.to_string(),
-        Some(context.editor.theme.get("ui.statusline.separator")),
-    );
+        context.editor.theme.get("ui.statusline.separator"),
+    )
+    .into()
 }
 
-fn render_spacer<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
-    write(context, String::from(" "), None);
+fn render_spacer<'a>(_context: &RenderContext) -> Spans<'a> {
+    Span::raw(" ").into()
 }
 
-fn render_version_control<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_version_control<'a>(context: &RenderContext) -> Spans<'a> {
     let head = context
         .doc
         .version_control_head()
         .unwrap_or_default()
         .to_string();
 
-    write(context, head, None);
+    Span::raw(head).into()
 }
 
-fn render_register<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_register<'a>(context: &RenderContext) -> Spans<'a> {
     if let Some(reg) = context.editor.selected_register {
-        write(context, format!(" reg={} ", reg), None)
+        Span::raw(format!(" reg={} ", reg)).into()
+    } else {
+        Spans::default()
     }
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -49,6 +49,17 @@ pub struct RenderBuffer<'a> {
     pub right: Spans<'a>,
 }
 
+fn join_with_spaces<'a, I: Iterator<Item = Span<'a>>>(iter: I) -> Spans<'a> {
+    let mut spans = Vec::new();
+    for elem in iter {
+        if !spans.is_empty() {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(elem);
+    }
+    spans.into()
+}
+
 pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface) {
     let base_style = if context.focused {
         context.editor.theme.get("ui.statusline")
@@ -63,12 +74,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     let config = context.editor.config();
 
     let element_ids = &config.statusline.left;
-    context.parts.left = element_ids
-        .iter()
-        .map(|element_id| get_render_function(*element_id))
-        .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>()
-        .into();
+    context.parts.left = join_with_spaces(
+        element_ids
+            .iter()
+            .map(|element_id| get_render_function(*element_id))
+            .flat_map(|render| render(context).0),
+    );
 
     surface.set_spans(
         viewport.x,
@@ -80,12 +91,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Right side of the status line.
 
     let element_ids = &config.statusline.right;
-    context.parts.right = element_ids
-        .iter()
-        .map(|element_id| get_render_function(*element_id))
-        .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>()
-        .into();
+    context.parts.right = join_with_spaces(
+        element_ids
+            .iter()
+            .map(|element_id| get_render_function(*element_id))
+            .flat_map(|render| render(context).0),
+    );
 
     surface.set_spans(
         viewport.x
@@ -100,12 +111,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Center of the status line.
 
     let element_ids = &config.statusline.center;
-    context.parts.center = element_ids
-        .iter()
-        .map(|element_id| get_render_function(*element_id))
-        .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>()
-        .into();
+    context.parts.center = join_with_spaces(
+        element_ids
+            .iter()
+            .map(|element_id| get_render_function(*element_id))
+            .flat_map(|render| render(context).0),
+    );
 
     // Width of the empty space between the left and center area and between the center and right area.
     let spacing = 1u16;
@@ -408,7 +419,7 @@ fn render_separator<'a>(context: &RenderContext) -> Spans<'a> {
 }
 
 fn render_spacer<'a>(_context: &RenderContext) -> Spans<'a> {
-    Span::raw(" ").into()
+    Span::raw("").into()
 }
 
 fn render_version_control<'a>(context: &RenderContext) -> Spans<'a> {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -424,7 +424,6 @@ impl Default for StatusLineConfig {
 
         Self {
             left: vec![
-                E::Spacer,
                 E::Mode,
                 E::Spinner,
                 E::FileName,
@@ -457,9 +456,9 @@ pub struct ModeConfig {
 impl Default for ModeConfig {
     fn default() -> Self {
         Self {
-            normal: String::from("NOR"),
-            insert: String::from("INS"),
-            select: String::from("SEL"),
+            normal: String::from(" NOR "),
+            insert: String::from(" INS "),
+            select: String::from(" SEL "),
         }
     }
 }
@@ -845,7 +844,7 @@ impl Default for Config {
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),
-            color_modes: false,
+            color_modes: true,
             soft_wrap: SoftWrap {
                 enable: Some(false),
                 ..SoftWrap::default()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -424,6 +424,7 @@ impl Default for StatusLineConfig {
 
         Self {
             left: vec![
+                E::Spacer,
                 E::Mode,
                 E::Spinner,
                 E::FileName,
@@ -437,6 +438,7 @@ impl Default for StatusLineConfig {
                 E::Register,
                 E::Position,
                 E::FileEncoding,
+                E::Spacer,
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),


### PR DESCRIPTION
Statusline elements used to have inconsistent spacing due to each element having to pad itself without knowledge of surrounding elements.

<img alt="Inconsistent spacing" src="https://github.com/helix-editor/helix/assets/18398499/8cca6179-4593-47e6-8a7f-acfe6c7e89c8">

 - `mode`, `selections`, `file-name` and `position` are padded, the rest are not
 - `file-modification-indicator` reserves space for itself, `spinner` and `diagnostics` do not

This PR fixes these spacing inconsistencies.

<img alt="Consistent spacing" src="https://github.com/helix-editor/helix/assets/18398499/f06f7848-b500-4901-b5de-a5ed0328d116">

 - No elements pad themselves
 - No elements reserve empty space
 - The statusline pads everything
 - The `spacer` element has been repurposed to join multiple spacers, e.g. to pad the ends of the statusline

The render functions of statusline elements previously used an ad-hoc `write` callback to blit `Spans` directly to the `Surface` of the statusline. This callback has been removed. Now each render function has to return the `Spans` it wants to display, which the renderer of the statusline collects, intersperses with spaces, then blits to the surface.