### PR TITLE
Add support for showing all LSPs in --health

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -193,20 +193,17 @@ pub fn languages_all() -> std::io::Result<()> {
         match cmds.len() {
             0 => column("None", Color::Yellow),
             1 => check_binary(cmds.get(0).cloned()),
-            _ => {
-                let mut checks = cmds
-                    .iter()
-                    .map(|cmd| which::which(cmd).is_ok())
-                    .collect::<Vec<bool>>();
-                checks.sort_unstable();
-                checks.dedup();
-
-                if checks.len() == 2 {
-                    column("- Some", Color::Yellow);
-                } else if checks[0] {
-                    column("✓ All", Color::Green);
-                } else {
-                    column("✘ None", Color::Red);
+            n_configured => {
+                let n_available = cmds.iter().filter_map(|cmd| which::which(cmd).ok()).count();
+                match n_available {
+                    0 => column(&format!("✘ 0/{}", n_configured), Color::Red),
+                    n_available if n_available == n_configured => {
+                        column(&format!("✓ {}/{}", n_available, n_configured), Color::Green)
+                    }
+                    n_available => column(
+                        &format!("- {}/{}", n_available, n_configured),
+                        Color::Yellow,
+                    ),
                 }
             }
         };

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -195,16 +195,12 @@ pub fn languages_all() -> std::io::Result<()> {
             1 => check_binary(cmds.get(0).cloned()),
             n_configured => {
                 let n_available = cmds.iter().filter_map(|cmd| which::which(cmd).ok()).count();
-                match n_available {
-                    0 => column(&format!("✘ 0/{}", n_configured), Color::Red),
-                    n_available if n_available == n_configured => {
-                        column(&format!("✓ {}/{}", n_available, n_configured), Color::Green)
-                    }
-                    n_available => column(
-                        &format!("- {}/{}", n_available, n_configured),
-                        Color::Yellow,
-                    ),
-                }
+                let (icon, color) = match n_available {
+                    0 => ("✘", Color::Red),
+                    n_available if n_available == n_configured => ("✓", Color::Green),
+                    _ => ("-", Color::Yellow),
+                };
+                column(&format!("{} {}/{}", icon, n_available, n_configured), color);
             }
         };
     };

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -181,8 +181,8 @@ pub fn languages_all() -> std::io::Result<()> {
         .language
         .sort_unstable_by_key(|l| l.language_id.clone());
 
-    let check_binary = |cmd: Option<String>| match cmd {
-        Some(cmd) => match which::which(&cmd) {
+    let check_binary = |cmd: Option<&str>| match cmd {
+        Some(cmd) => match which::which(cmd) {
             Ok(_) => column(&format!("✓ {}", cmd), Color::Green),
             Err(_) => column(&format!("✘ {}", cmd), Color::Red),
         },
@@ -199,12 +199,12 @@ pub fn languages_all() -> std::io::Result<()> {
                 syn_loader_conf
                     .language_server
                     .get(&ls.name)
-                    .map(|config| config.command.clone())
+                    .map(|config| config.command.as_str())
             })
             .collect::<Vec<_>>();
-        check_binary(cmds.get(0).cloned());
+        check_binary(cmds.first().cloned());
 
-        let dap = lang.debugger.as_ref().map(|dap| dap.command.to_string());
+        let dap = lang.debugger.as_ref().map(|dap| dap.command.as_str());
         check_binary(dap);
 
         for ts_feat in TsFeature::all() {
@@ -219,7 +219,7 @@ pub fn languages_all() -> std::io::Result<()> {
         if cmds.len() > 1 {
             cmds.iter().skip(1).try_for_each(|cmd| {
                 column("", Color::Reset);
-                check_binary(Some(cmd.clone()));
+                check_binary(Some(cmd));
                 writeln!(stdout)
             })?;
         }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -268,16 +268,15 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
         }
     };
 
-    // TODO multiple language servers
-    probe_protocol(
-        "language server",
-        lang.language_servers.first().and_then(|ls| {
+    for ls in &lang.language_servers {
+        probe_protocol(
+            "language server",
             syn_loader_conf
                 .language_server
                 .get(&ls.name)
-                .map(|config| config.command.clone())
-        }),
-    )?;
+                .map(|config| config.command.clone()),
+        )?;
+    }
 
     probe_protocol(
         "debug adapter",

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -192,17 +192,13 @@ pub fn languages_all() -> std::io::Result<()> {
     for lang in &syn_loader_conf.language {
         column(&lang.language_id, Color::Reset);
 
-        let cmds = lang
-            .language_servers
-            .iter()
-            .filter_map(|ls| {
-                syn_loader_conf
-                    .language_server
-                    .get(&ls.name)
-                    .map(|config| config.command.as_str())
-            })
-            .collect::<Vec<_>>();
-        check_binary(cmds.first().cloned());
+        let mut cmds = lang.language_servers.iter().filter_map(|ls| {
+            syn_loader_conf
+                .language_server
+                .get(&ls.name)
+                .map(|config| config.command.as_str())
+        });
+        check_binary(cmds.next());
 
         let dap = lang.debugger.as_ref().map(|dap| dap.command.as_str());
         check_binary(dap);
@@ -216,13 +212,11 @@ pub fn languages_all() -> std::io::Result<()> {
 
         writeln!(stdout)?;
 
-        if cmds.len() > 1 {
-            cmds.iter().skip(1).try_for_each(|cmd| {
-                column("", Color::Reset);
-                check_binary(Some(cmd));
-                writeln!(stdout)
-            })?;
-        }
+        cmds.try_for_each(|cmd| {
+            column("", Color::Reset);
+            check_binary(Some(cmd));
+            writeln!(stdout)
+        })?;
     }
 
     Ok(())

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -283,9 +283,7 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
         lang.language_servers
             .iter()
             .filter_map(|ls| syn_loader_conf.language_server.get(&ls.name))
-            .map(|config| config.command.as_str())
-            .collect::<Vec<_>>()
-            .as_slice(),
+            .map(|config| config.command.as_str()),
     )?;
 
     probe_protocol(
@@ -301,12 +299,16 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
 }
 
 /// Display diagnostics about multiple LSPs and DAPs.
-fn probe_protocols(protocol_name: &str, server_cmds: &[&str]) -> std::io::Result<()> {
+fn probe_protocols<'a, I: Iterator<Item = &'a str> + 'a>(
+    protocol_name: &str,
+    server_cmds: I,
+) -> std::io::Result<()> {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
+    let mut server_cmds = server_cmds.peekable();
 
     write!(stdout, "Configured {}s:", protocol_name)?;
-    if server_cmds.is_empty() {
+    if server_cmds.peek().is_none() {
         writeln!(stdout, "{}", " None".yellow())?;
         return Ok(());
     }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -212,11 +212,11 @@ pub fn languages_all() -> std::io::Result<()> {
 
         writeln!(stdout)?;
 
-        cmds.try_for_each(|cmd| {
+        for cmd in cmds {
             column("", Color::Reset);
             check_binary(Some(cmd));
-            writeln!(stdout)
-        })?;
+            writeln!(stdout)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Hi there, today I had to debug an lsp configuration with multiple servers and came across this missing feature.
I wrote a quick implementation for the `--health <language>` subcommand, but now I'm stuck at `--health languages`.

In my machine `--health languages` doesn't fully show lang-servers' names and if I were to print all names one after another it would be pretty useless.

My idea was to check for the number of lang-servers and if there are more than one than the output could be something like (the names are pretty bad, I'm seeking better ideas):
```
✓ All (in green, it means all servers are ok)
- Some (in yellow, it means some servers are ok and some are not)
✘ None (in red, it means all servers are not ok)
```
Then for a more detailed output the user could use `--health <language>`.

Otherwise we could show every lang-server name in a different line, but I think it could become a little cumbersome to implement.

Let me know your thoughts!