### PR TITLE
Auto indent change if selection is linewise

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2319,10 +2319,11 @@ fn begin_by_a_whole_line(selection: &Selection, text: &Rope) -> bool {
     for range in selection.ranges() {
         // If at least a full line is selected (strange require 2).
         if range.slice(text.slice(..)).len_lines() >= 2 {
-            // If in the begin of the selection is at the begining of a line.
-            let (start_line, _) = range.line_range(text.slice(..));
+            // If the start of the selection is at the start of a line and the end at the end of a line.
+            let (start_line, end_line) = range.line_range(text.slice(..));
             let start = text.line_to_char(start_line);
-            if start == range.anchor {
+            let end = text.line_to_char((end_line + 1).min(text.len_lines()));
+            if start == range.anchor && end == range.head {
                 return true;
             }
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2315,14 +2315,14 @@ enum Operation {
     Change,
 }
 
-fn only_whole_lines(selection: &Selection, text: &Rope) -> bool {
+fn selection_is_linewise(selection: &Selection, text: &Rope) -> bool {
     selection.ranges().iter().all(|range| {
-        // If not at least a full line is selected (strange require 2).
-        if range.slice(text.slice(..)).len_lines() < 2 {
+        let text = text.slice(..);
+        if range.slice(text).len_lines() < 2 {
             return false;
         }
         // If the start of the selection is at the start of a line and the end at the end of a line.
-        let (start_line, end_line) = range.line_range(text.slice(..));
+        let (start_line, end_line) = range.line_range(text);
         let start = text.line_to_char(start_line);
         let end = text.line_to_char((end_line + 1).min(text.len_lines()));
         start == range.from() && end == range.to()
@@ -2333,7 +2333,7 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
     let (view, doc) = current!(cx.editor);
 
     let selection = doc.selection(view.id);
-    let only_whole_lines = only_whole_lines(selection, doc.text());
+    let only_whole_lines = selection_is_linewise(selection, doc.text());
 
     if cx.register != Some('_') {
         // first yank the selection

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2325,7 +2325,7 @@ fn only_whole_lines(selection: &Selection, text: &Rope) -> bool {
         let (start_line, end_line) = range.line_range(text.slice(..));
         let start = text.line_to_char(start_line);
         let end = text.line_to_char((end_line + 1).min(text.len_lines()));
-        start == range.anchor && end == range.head
+        start == range.from() && end == range.to()
     })
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -296,8 +296,6 @@ impl MappableCommand {
         delete_selection, "Delete selection",
         delete_selection_noyank, "Delete selection without yanking",
         change_selection, "Change selection",
-        change_selection_with_indent, "Change selection and place the cursor at the appropriated indent",
-        change_selection_with_indent_noyank, "Change selection without yanking and place the cursor at the appropriated indent",
         change_selection_noyank, "Change selection without yanking",
         collapse_selection, "Collapse selection into single cursor",
         flip_selections, "Flip selection cursor and anchor",
@@ -2315,7 +2313,6 @@ fn shrink_to_line_bounds(cx: &mut Context) {
 enum Operation {
     Delete,
     Change,
-    ChangeWithIndent,
 }
 
 fn only_whole_lines(selection: &Selection, text: &Rope) -> bool {
@@ -2357,9 +2354,6 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
             exit_select_mode(cx);
         }
         Operation::Change => {
-            enter_insert_mode(cx);
-        }
-        Operation::ChangeWithIndent => {
             if only_whole_lines {
                 open_above(cx);
             } else {
@@ -2431,15 +2425,6 @@ fn change_selection(cx: &mut Context) {
 fn change_selection_noyank(cx: &mut Context) {
     cx.register = Some('_');
     delete_selection_impl(cx, Operation::Change);
-}
-
-fn change_selection_with_indent(cx: &mut Context) {
-    delete_selection_impl(cx, Operation::ChangeWithIndent);
-}
-
-fn change_selection_with_indent_noyank(cx: &mut Context) {
-    cx.register = Some('_');
-    delete_selection_impl(cx, Operation::ChangeWithIndent);
 }
 
 fn collapse_selection(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2316,7 +2316,7 @@ enum Operation {
 }
 
 fn only_whole_lines(selection: &Selection, text: &Rope) -> bool {
-    selection.ranges().into_iter().all(|range| {
+    selection.ranges().iter().all(|range| {
         // If not at least a full line is selected (strange require 2).
         if range.slice(text.slice(..)).len_lines() < 2 {
             return false;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -296,6 +296,8 @@ impl MappableCommand {
         delete_selection, "Delete selection",
         delete_selection_noyank, "Delete selection without yanking",
         change_selection, "Change selection",
+        change_selection_with_indent, "Change selection and place the cursor at the appropriated indent",
+        change_selection_with_indent_noyank, "Change selection without yanking and place the cursor at the appropriated indent",
         change_selection_noyank, "Change selection without yanking",
         collapse_selection, "Collapse selection into single cursor",
         flip_selections, "Flip selection cursor and anchor",
@@ -2313,6 +2315,7 @@ fn shrink_to_line_bounds(cx: &mut Context) {
 enum Operation {
     Delete,
     Change,
+    ChangeWithIndent,
 }
 
 fn only_whole_lines(selection: &Selection, text: &Rope) -> bool {
@@ -2354,6 +2357,9 @@ fn delete_selection_impl(cx: &mut Context, op: Operation) {
             exit_select_mode(cx);
         }
         Operation::Change => {
+            enter_insert_mode(cx);
+        }
+        Operation::ChangeWithIndent => {
             if only_whole_lines {
                 open_above(cx);
             } else {
@@ -2425,6 +2431,15 @@ fn change_selection(cx: &mut Context) {
 fn change_selection_noyank(cx: &mut Context) {
     cx.register = Some('_');
     delete_selection_impl(cx, Operation::Change);
+}
+
+fn change_selection_with_indent(cx: &mut Context) {
+    delete_selection_impl(cx, Operation::ChangeWithIndent);
+}
+
+fn change_selection_with_indent_noyank(cx: &mut Context) {
+    cx.register = Some('_');
+    delete_selection_impl(cx, Operation::ChangeWithIndent);
 }
 
 fn collapse_selection(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2316,8 +2316,7 @@ enum Operation {
 }
 
 fn begin_by_a_whole_line(selection: &Selection, text: &Rope) -> bool {
-    if selection.ranges().len() == 1 {
-        let range = selection.ranges()[0];
+    for range in selection.ranges() {
         // If at least a full line is selected (strange require 2).
         if range.slice(text.slice(..)).len_lines() >= 2 {
             // If in the begin of the selection is at the begining of a line.


### PR DESCRIPTION
This make `c` auto indent if the selection begins by a whole line. 

I inspired from the other functions in `command.rs`.  I'm not sure if the implementation is very good, all the text editing functions in the code base are new to me.


Resolve https://github.com/helix-editor/helix/discussions/4507 https://github.com/helix-editor/helix/discussions/2783

|before|after|
|----|-----|
|![before_1](https://github.com/helix-editor/helix/assets/56633664/37fa684b-7605-4fcf-a1db-449c9c637b53)|![before_1](https://github.com/helix-editor/helix/assets/56633664/37fa684b-7605-4fcf-a1db-449c9c637b53)|
|![before_2](https://github.com/helix-editor/helix/assets/56633664/7bff72e5-3400-4cbb-95b2-5ea49305c669)|![after_2](https://github.com/helix-editor/helix/assets/56633664/8364f271-b6e7-4fb2-aa81-7fb9dac078cd)|

This also works if multiple lines are selected. Otherwise it behaves exactly as before.

## Why not use a custom key bindings for this?

For me if you select a whole line and go to insert mod with `c`, you want the auto indentation behavior all of the time. 

This is also consistent  with the Vim `V c` or `cc`  behavior.

This PR aims to be a QOL improvement, in the same spirit than https://github.com/helix-editor/helix/pull/5837