### PR TITLE
Remove Ubuntu PPA from docs

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -51,16 +51,6 @@ line.
 
 The following third party repositories are available:
 
-### Ubuntu
-
-Add the `PPA` for Helix:
-
-```sh
-sudo add-apt-repository ppa:maveonair/helix-editor
-sudo apt update
-sudo apt install helix
-```
-
 ### Fedora/RHEL
 
 Enable the `COPR` repository for Helix:
@@ -113,7 +103,7 @@ Download the official Helix AppImage from the [latest releases](https://github.c
 chmod +x helix-*.AppImage # change permission for executable mode
 ./helix-*.AppImage # run helix
 ```
- 
+
 ## macOS
 
 ### Homebrew Core
@@ -207,7 +197,7 @@ Or, create a symlink in `~/.config/helix` that links to the source code director
 ln -Ts $PWD/runtime ~/.config/helix/runtime
 ```
 
-If the above command fails to create a symbolic link because the file exists either move `~/.config/helix/runtime` to a new location or delete it, then run the symlink command above again. 
+If the above command fails to create a symbolic link because the file exists either move `~/.config/helix/runtime` to a new location or delete it, then run the symlink command above again.
 
 #### Windows
 


### PR DESCRIPTION
Hi all

**Description**
Unfortunately, I have to abandon my Ubuntu PPA for Helix. The reason for this decision is that every time a new version comes out, the whole build pipeline in Canonical's Launchpad completely breaks down, mainly because there is no internet connection during the build process and the way grammars are built changes.

After a few hours of debugging, I've concluded this time that it's best to remove the PPA from the documentation, since I can't keep up with deploying the latest version fast enough - which I think every user of Helix deserves, since it's such a great text editor!

In the event that someone wants to take over the PPA from me, I am happy to provide the instructions as I have done in the past.

**What's been change**
- Removed Ubuntu PPA installation details from docs