### PR TITLE
Check for 'git' before fetching/building grammars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "threadpool",
  "toml",
  "tree-sitter",
+ "which",
 ]
 
 [[package]]

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -21,6 +21,7 @@ etcetera = "0.8"
 tree-sitter = "0.20"
 once_cell = "1.18"
 log = "0.4"
+which = "4.4"
 
 # TODO: these two should be on !wasm32 only
 

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -85,7 +85,16 @@ pub fn get_language(name: &str) -> Result<Language> {
     Ok(language)
 }
 
+fn ensure_git_is_available() -> Result<()> {
+    match which::which("git") {
+        Ok(_cmd) => Ok(()),
+        Err(err) => Err(anyhow::anyhow!("'git' could not be found ({err})")),
+    }
+}
+
 pub fn fetch_grammars() -> Result<()> {
+    ensure_git_is_available()?;
+
     // We do not need to fetch local grammars.
     let mut grammars = get_grammar_configs()?;
     grammars.retain(|grammar| !matches!(grammar.source, GrammarSource::Local { .. }));
@@ -145,6 +154,8 @@ pub fn fetch_grammars() -> Result<()> {
 }
 
 pub fn build_grammars(target: Option<String>) -> Result<()> {
+    ensure_git_is_available()?;
+
     let grammars = get_grammar_configs()?;
     println!("Building {} grammars", grammars.len());
     let results = run_parallel(grammars, move |grammar| {


### PR DESCRIPTION
Previously the error message for this potential failure-case was confusing: "no such file or directory". `hx -g fetch`, `hx -g build` and the helix-term builder should bail early if the git binary is not available.