### PR TITLE
Fix underflow when repeating a completion that has a negative shift position

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -907,8 +907,9 @@ impl EditorView {
                                 let text = doc.text().slice(..);
                                 let cursor = doc.selection(view.id).primary().cursor(text);
 
-                                let shift_position =
-                                    |pos: usize| -> usize { pos + cursor - trigger_offset };
+                                let shift_position = |pos: usize| -> usize {
+                                    (pos + cursor).saturating_sub(trigger_offset)
+                                };
 
                                 let tx = Transaction::change(
                                     doc.text(),


### PR DESCRIPTION
While rewriting #2608 I have had a panic, when repeating a completion edit at the beginning of a buffer, with a negative start range, this should fix the issue...