### PR TITLE
Preview scratch buffers in jumplist picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2679,7 +2679,7 @@ fn jumplist_picker(cx: &mut Context) {
         |editor, meta| {
             let doc = &editor.documents.get(&meta.id)?;
             let line = meta.selection.primary().cursor_line(doc.text().slice(..));
-            Some((meta.path.clone()?.into(), Some((line, line))))
+            Some((meta.id.into(), Some((line, line))))
         },
     );
     cx.push_layer(Box::new(overlaid(picker)));


### PR DESCRIPTION
Fixes #7330.

There seems to be a fair bit of code duplication between `buffer_picker` and `jumplist_picker` which should maybe be factored out in the future...

![image](https://github.com/helix-editor/helix/assets/58790821/76dcc5f1-c917-4930-b457-66f610a8dabf)
