### PR TITLE
Fix next/prev tree-sitter inconsistency

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -509,8 +509,7 @@ pub fn goto_treesitter_object(
     count: usize,
 ) -> Range {
     let get_range = move |range: Range| -> Option<Range> {
-        let left_pos = slice.char_to_byte(range.cursor(slice));
-        let right_pos = slice.char_to_byte(range.from());
+        let byte_pos = slice.char_to_byte(range.cursor(slice));
 
         let cap_name = |t: TextObject| format!("{}.{}", object_name, t);
         let mut cursor = QueryCursor::new();
@@ -527,10 +526,10 @@ pub fn goto_treesitter_object(
 
         let node = match dir {
             Direction::Forward => nodes
-                .filter(|n| n.start_byte() > left_pos)
+                .filter(|n| n.start_byte() > byte_pos)
                 .min_by_key(|n| (n.start_byte(), Reverse(n.end_byte())))?,
             Direction::Backward => nodes
-                .filter(|n| n.end_byte() < right_pos)
+                .filter(|n| n.end_byte() < byte_pos)
                 .max_by_key(|n| (n.end_byte(), Reverse(n.start_byte())))?,
         };
 


### PR DESCRIPTION
Fixes #7223 
Before there where different results going to next or previous due to sorting not dealing with multiple captures that start/end at the same pos. I chose to prefer longer matches.

