### PR TITLE
Explain how to enter Select mode in keymap

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -25,6 +25,8 @@
 
 ## Normal mode
 
+Normal mode is the default mode when you launch helix. Return to it from other modes by typing `Escape`.
+
 ### Movement
 
 > NOTE: Unlike Vim, `f`, `F`, `t` and `T` are not confined to the current line.
@@ -337,7 +339,7 @@ These mappings are in the style of [vim-unimpaired](https://github.com/tpope/vim
 
 ## Insert mode
 
-The default mode. Return to it by typing `Escape`.
+Accessed by typing `i` in [normal mode](#normal-mode).
 
 Insert mode bindings are minimal by default. Helix is designed to
 be a modal editor, and this is reflected in the user experience and internal

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -337,6 +337,8 @@ These mappings are in the style of [vim-unimpaired](https://github.com/tpope/vim
 
 ## Insert mode
 
+The default mode. Return to it by typing `Escape`.
+
 Insert mode bindings are minimal by default. Helix is designed to
 be a modal editor, and this is reflected in the user experience and internal
 mechanics. Changes to the text are only saved for undos when
@@ -389,6 +391,8 @@ end = "no_op"
 ```
 
 ## Select / extend mode
+
+Accessed by typing `v` in [normal mode](#normal-mode).
 
 Select mode echoes Normal mode, but changes any movements to extend
 selections rather than replace them. Goto motions are also changed to


### PR DESCRIPTION
I was struggling to find the hotkey for entering select mode by search, and noticed that the other modes had a leading paragraph after their headings with how to enter them. I added the same for Select and Insert mode.