### PR TITLE
Add forth-lsp and update tree-sitter-forth

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -41,7 +41,7 @@
 | erlang | ✓ | ✓ |  | `erlang_ls` |
 | esdl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
-| forth | ✓ |  |  |  |
+| forth | ✓ |  |  | `forth-lsp` |
 | fortran | ✓ |  | ✓ | `fortls` |
 | gdscript | ✓ | ✓ | ✓ |  |
 | git-attributes | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -24,6 +24,7 @@ elm-language-server = { command = "elm-language-server" }
 elvish = { command = "elvish", args = ["-lsp"] }
 erlang-ls = { command = "erlang_ls" }
 forc = { command = "forc", args = ["lsp"] }
+forth-lsp = { command = "forth-lsp" }
 fortls = { command = "fortls", args = ["--lowercase_intrinsics"] }
 gleam = { command = "gleam", args = ["lsp"] }
 haskell-language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
@@ -2606,11 +2607,12 @@ injection-regex = "forth"
 file-types = ["fs", "forth", "fth", "4th"]
 roots = []
 comment-token = "\\"
+language-servers = [ "forth-lsp" ]
 indent = { tab-width = 3, unit = "   " }
 
 [[grammar]]
 name = "forth"
-source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "c6fae50a17763af827604627c0fa9e4604aaac0b" }
+source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "304ed77beb113e37af38b20ff14e3c37bf350d10" }
 
 [[language]]
 name = "t32"

--- a/runtime/queries/forth/highlights.scm
+++ b/runtime/queries/forth/highlights.scm
@@ -1,7 +1,6 @@
 ([(start_definition)(end_definition)] @keyword)
-([(lparen) (rparen)] @punctuation.bracket)
-((stack_effect_sep) @punctuation)
 ((number) @constant)
+((string) @string)
 ((word) @function)
 ((comment) @comment)
 ([(core)] @type)


### PR DESCRIPTION
Correctly identifies all non-whitespace identifiers as words, added numbers with various formats and in general a much more solid experience.

![image](https://github.com/helix-editor/helix/assets/721090/e8cf681a-7fe8-4b55-9894-653196eb7135)


