### PR TITLE
Switch MATLAB tree-sitter parser

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -88,7 +88,7 @@
 | markdoc | ✓ |  |  | `markdoc-ls` |
 | markdown | ✓ |  |  | `marksman` |
 | markdown.inline | ✓ |  |  |  |
-| matlab | ✓ |  |  |  |
+| matlab | ✓ | ✓ | ✓ |  |
 | mermaid | ✓ |  |  |  |
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |

--- a/languages.toml
+++ b/languages.toml
@@ -2285,7 +2285,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "matlab"
-source = { git = "https://github.com/mstanciu552/tree-sitter-matlab", rev = "2d5d3d5193718a86477d4335aba5b34e79147326" }
+source = { git = "https://github.com/acristoffers/tree-sitter-matlab", rev = "5a047c1572792ae943b51af7cf9307097b2fcce0" }
 
 [[language]]
 name = "ponylang"

--- a/runtime/queries/matlab/context.scm
+++ b/runtime/queries/matlab/context.scm
@@ -1,0 +1,41 @@
+(function_definition
+  (block (_) @context.end)
+) @context
+
+(while_statement
+  (block (_) @context.end)
+) @context
+
+(for_statement
+  (block (_) @context.end)
+) @context
+
+(if_statement
+  (block (_) @context.end)
+) @context
+
+(elseif_clause
+  (block (_) @context.end)
+) @context
+
+(else_clause
+  (block (_) @context.end)
+) @context
+
+(switch_statement) @context
+
+(case_clause
+  (block (_) @context.end)
+) @context
+
+(otherwise_clause
+  (block (_) @context.end)
+) @context
+
+(try_statement
+  "try"
+  (block (_) @context.end) @context
+  "end")
+(catch_clause
+  "catch"
+  (block (_) @context.end) @context)

--- a/runtime/queries/matlab/folds.scm
+++ b/runtime/queries/matlab/folds.scm
@@ -1,0 +1,11 @@
+[(if_statement)
+ (for_statement)
+ (while_statement)
+ (switch_statement)
+ (try_statement)
+ (function_definition)
+ (class_definition)
+ (enumeration)
+ (events)
+ (methods)
+ (properties)] @fold

--- a/runtime/queries/matlab/highlights.scm
+++ b/runtime/queries/matlab/highlights.scm
@@ -1,97 +1,127 @@
-  ; highlights.scm
+; Constants
 
-function_keyword: (function_keyword) @keyword.function
+(events (identifier) @constant)
+(attribute (identifier) @constant)
+
+"~" @constant.builtin
+
+; Fields/Properties
+
+(superclass "." (identifier) @variable.other.member)
+(property_name "." (identifier) @variable.other.member)
+(property name: (identifier) @variable.other.member)
+
+; Types
+
+(class_definition name: (identifier) @keyword.storage.type)
+(attributes (identifier) @constant)
+(enum . (identifier) @type.enum.variant)
+
+; Functions
 
 (function_definition
-function_name: (identifier) @function
-(end) @function)
+  "function" @keyword.function
+  name: (identifier) @function
+  [ "end" "endfunction" ]? @keyword.function)
 
-(parameter_list (identifier) @variable.parameter)
+(function_signature name: (identifier) @function)
+(function_call name: (identifier) @function)
+(handle_operator (identifier) @function)
+(validation_functions (identifier) @function)
+(command (command_name) @function.macro)
+(command_argument) @string
+(return_statement) @keyword.control.return
 
-[
-    "if"
-    "elseif"
-    "else"
-    "switch"
-    "case"
-    "otherwise"
-] @keyword.control.conditional
+; Assignments
 
-(if_statement (end) @keyword.control.conditional)
-(switch_statement (end) @keyword.control.conditional)
+(assignment left: (_) @variable)
+(multioutput_variable (_) @variable)
 
-["for" "while"] @keyword.control.repeat
-(for_statement (end) @keyword.control.repeat)
-(while_statement (end) @keyword.control.repeat)
+; Parameters
 
-["try" "catch"] @keyword.control.exception
-(try_statement (end) @keyword.control.exception)
+(function_arguments (identifier) @variable.parameter)
 
-(function_definition end: (end) @keyword)
-
-["return" "break" "continue"] @keyword.return
-
-(
-(identifier) @constant.builtin
-(#any-of? @constant.builtin "true" "false")
-)
-
-(
-    (identifier) @constant.builtin
-    (#eq? @constant.builtin "end")
-)
-
-;; Punctuations
-
-[";" ","] @punctuation.special
-(argument_list "," @punctuation.delimiter)
-(vector_definition ["," ";"] @punctuation.delimiter)
-(cell_definition ["," ";"] @punctuation.delimiter)
-":" @punctuation.delimiter
-(parameter_list "," @punctuation.delimiter)
-(return_value "," @punctuation.delimiter)
-
-; ;; Brackets
+; Operators
 
 [
- "("
- ")"
- "["
- "]"
- "{"
- "}"
-] @punctuation.bracket
-
-;; Operators
-"=" @operator
-(operation [ ">"
-            "<"
-            "=="
-            "<="
-            ">="
-            "=<"
-            "=>"
-            "~="
-            "*"
-            ".*"
-            "/"
-            "\\"
-            "./"
-            "^"
-            ".^"
-            "+"] @operator)
-
-;; boolean operator
-[
-    "&&"
-    "||"
+  "+"
+  ".+"
+  "-"
+  ".*"
+  "*"
+  ".*"
+  "/"
+  "./"
+  "\\"
+  ".\\"
+  "^"
+  ".^"
+  "'"
+  ".'"
+  "|"
+  "&"
+  "?"
+  "@"
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "~="
+  "="
+  "&&"
+  "||"
+  ":"
 ] @operator
 
-;; Number
-(number) @constant.numeric
+; Conditionals
 
-;; String
+(if_statement [ "if" "end" ] @keyword.control.conditional)
+(elseif_clause "elseif" @keyword.control.conditional)
+(else_clause "else" @keyword.control.conditional)
+(switch_statement [ "switch" "end" ] @keyword.control.conditional)
+(case_clause "case" @keyword.control.conditional)
+(otherwise_clause "otherwise" @keyword.control.conditional)
+(break_statement) @keyword.control.conditional
+
+; Repeats
+
+(for_statement [ "for" "parfor" "end" ] @keyword.control.repeat)
+(while_statement [ "while" "end" ] @keyword.control.repeat)
+(continue_statement) @keyword.control.repeat
+
+; Exceptions
+
+(try_statement [ "try" "end" ] @keyword.control.exception)
+(catch_clause "catch" @keyword.control.exception)
+
+; Punctuation
+
+[ ";" "," "." ] @punctuation.delimiter
+[ "(" ")" "[" "]" "{" "}" ] @punctuation.bracket
+
+; Literals
+
+(escape_sequence) @constant.character.escape
+(formatting_sequence) @constant.character.escape
 (string) @string
+(number) @constant.numeric.float
+(boolean) @constant.builtin.boolean
 
-;; Comment
-(comment) @comment
+; Comments
+
+[ (comment) (line_continuation) ] @comment.line
+
+; Keywords
+
+"classdef" @keyword.storage.type
+[
+  "arguments"
+  "end"
+  "enumeration"
+  "events"
+  "global"
+  "methods"
+  "persistent"
+  "properties"
+] @keyword

--- a/runtime/queries/matlab/indents.scm
+++ b/runtime/queries/matlab/indents.scm
@@ -1,0 +1,23 @@
+[
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (switch_statement)
+  (try_statement)
+  (function_definition)
+  (class_definition)
+  (enumeration)
+  (events)
+  (methods)
+  (properties)
+] @indent
+
+[
+  (elseif_clause)
+  (else_clause)
+  (case_clause)
+  (otherwise_clause)
+  (catch_clause)
+] @indent @extend
+
+[ "end" ] @outdent

--- a/runtime/queries/matlab/injections.scm
+++ b/runtime/queries/matlab/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/matlab/locals.scm
+++ b/runtime/queries/matlab/locals.scm
@@ -1,0 +1,19 @@
+(function_definition name: (identifier) @local.definition ?) @local.scope
+(function_arguments (identifier)* @local.definition)
+
+(lambda (arguments (identifier) @local.definition)) @local.scope
+
+(assignment left: ((function_call
+                     name: (identifier) @local.definition)))
+(assignment left: ((field_expression . [(function_call
+                                          name: (identifier) @local.definition)
+                                        (identifier) @local.definition])))
+(assignment left: (_) @local.definition)
+(assignment (multioutput_variable (_) @local.definition))
+
+(iterator . (identifier) @local.definition)
+(global_operator (identifier) @local.definition)
+(persistent_operator (identifier) @local.definition)
+(catch_clause (identifier) @local.definition)
+
+(identifier) @local.reference

--- a/runtime/queries/matlab/textobjects.scm
+++ b/runtime/queries/matlab/textobjects.scm
@@ -1,0 +1,9 @@
+(arguments ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+(function_arguments ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(lambda expression: (_) @function.inside) @function.around
+(function_definition (block) @function.inside) @function.around
+
+(class_definition) @class.inside @class.around
+
+(comment) @comment.inside @comment.around


### PR DESCRIPTION
Product of #7386.

I believe I got the highlight right, or at least now I get a nice rainbow-vomit when using the `doom_acario_dark` theme. And no more quirks.

Textobjects and indents were tested and are inline with what I found in other grammars. That is to say "could you please take a look at the indents because I think it is broken, but it is defined the same as other languages so I don't know if it's broken or if it's just me who doesn't know how this editor works".

 I simply copied the other queries and did not adapt them or anything. I not even know if helix supports them.

![image](https://github.com/helix-editor/helix/assets/2191364/0b368c1e-8656-40e2-9b1a-a53228d38594)
