### PR TITLE
feat(toml): highlight table headers

### DIFF
--- a/runtime/queries/toml/highlights.scm
+++ b/runtime/queries/toml/highlights.scm
@@ -1,10 +1,23 @@
 ; Properties
 ;-----------
 
-[
+(table [
   (bare_key)
+  (dotted_key)
   (quoted_key)
-] @variable.other.member
+] @type)
+
+(table_array_element [
+  (bare_key)
+  (dotted_key)
+  (quoted_key)
+] @type)
+
+(pair [
+  (bare_key)
+  (dotted_key)
+  (quoted_key)
+] @variable.other.member)
 
 ; Literals
 ;---------


### PR DESCRIPTION
This highlights toml `[table]` headers differently, which matches GitHub (via [linguist](https://github.com/github-linguist/linguist)) and [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/toml/highlights.scm) (although this implementation overlooks some combinations of quoted and dotted keys).

Before |  After
:------:|:------:
![Before](https://github.com/helix-editor/helix/assets/19800529/91960da4-4757-4a3f-a1ac-94479b7846d3) | ![After](https://github.com/helix-editor/helix/assets/19800529/c7209b6d-3aa2-44f8-922d-ee14189c918d)

And for reference:
<details><summary>GitHub markdown</summary>
<p>

```toml
title = "TOML Example"

[table]
name = "Tom Preston-Werner"

["table"."dotted"]
enabled = true
ports = [8000, 8001, 8002]
dotted.key = { cpu = 79.5, case = 72.0 }
"quoted.key" = [["delta", "phi"], [3.14]]

[[table.dotted.array]]
ip = "10.0.0.1"
role = "frontend"

[bare]
[dot.ted]
["quoted"]

[[bare]]
[[dot.ted]]
[["quoted"]]
```

</p>
</details> 
