### PR TITLE
feat(command): select all siblings and children

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -14,6 +14,7 @@ use crate::{
 use helix_stdx::rope::{self, RopeSliceExt};
 use smallvec::{smallvec, SmallVec};
 use std::borrow::Cow;
+use tree_sitter::Node;
 
 /// A single selection range.
 ///
@@ -71,6 +72,12 @@ impl Range {
 
     pub fn point(head: usize) -> Self {
         Self::new(head, head)
+    }
+
+    pub fn from_node(node: Node, text: RopeSlice, direction: Direction) -> Self {
+        let from = text.byte_to_char(node.start_byte());
+        let to = text.byte_to_char(node.end_byte());
+        Range::new(from, to).with_direction(direction)
     }
 
     /// Start of the range.
@@ -375,6 +382,12 @@ impl Range {
         let first = graphemes.next();
         let second = graphemes.next();
         first.is_some() && second.is_none()
+    }
+
+    /// Converts this char range into an in order byte range, discarding
+    /// direction.
+    pub fn into_byte_range(&self, text: RopeSlice) -> (usize, usize) {
+        (text.char_to_byte(self.from()), text.char_to_byte(self.to()))
     }
 }
 
@@ -783,7 +796,9 @@ pub fn split_on_newline(text: RopeSlice, selection: &Selection) -> Selection {
         let mut start = sel_start;
 
         for line in sel.slice(text).lines() {
-            let Some(line_ending) = get_line_ending(&line) else { break };
+            let Some(line_ending) = get_line_ending(&line) else {
+                break;
+            };
             let line_end = start + line.len_chars();
             // TODO: retain range direction
             result.push(Range::new(start, line_end - line_ending.len_chars()));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -440,7 +440,8 @@ impl MappableCommand {
         shrink_selection, "Shrink selection to previously expanded syntax node",
         select_next_sibling, "Select next sibling in the syntax tree",
         select_prev_sibling, "Select previous sibling the in syntax tree",
-        select_all_siblings, "Select all siblings in the syntax tree",
+        select_all_siblings, "Select all siblings of the current node",
+        select_all_children, "Select all children of the current node",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save current selection to jumplist",
@@ -4989,6 +4990,23 @@ fn select_all_siblings(cx: &mut Context) {
     };
 
     cx.editor.apply_motion(motion);
+}
+
+fn select_all_children(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+
+        if let Some(syntax) = doc.syntax() {
+            let text = doc.text().slice(..);
+            let current_selection = doc.selection(view.id);
+            let selection =
+                object::select_all_children(syntax.tree(), text, current_selection.clone());
+            doc.set_selection(view.id, selection);
+        }
+    };
+
+    motion(cx.editor);
+    cx.editor.last_motion = Some(Motion(Box::new(motion)));
 }
 
 fn match_brackets(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -438,8 +438,9 @@ impl MappableCommand {
         reverse_selection_contents, "Reverse selections contents",
         expand_selection, "Expand selection to parent syntax node",
         shrink_selection, "Shrink selection to previously expanded syntax node",
-        select_next_sibling, "Select next sibling in syntax tree",
-        select_prev_sibling, "Select previous sibling in syntax tree",
+        select_next_sibling, "Select next sibling in the syntax tree",
+        select_prev_sibling, "Select previous sibling the in syntax tree",
+        select_all_siblings, "Select all siblings in the syntax tree",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save current selection to jumplist",
@@ -4972,6 +4973,22 @@ pub fn extend_parent_node_end(cx: &mut Context) {
 
 pub fn extend_parent_node_start(cx: &mut Context) {
     move_node_bound_impl(cx, Direction::Backward, Movement::Extend)
+}
+
+fn select_all_siblings(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+
+        if let Some(syntax) = doc.syntax() {
+            let text = doc.text().slice(..);
+            let current_selection = doc.selection(view.id);
+            let selection =
+                object::select_all_siblings(syntax.tree(), text, current_selection.clone());
+            doc.set_selection(view.id, selection);
+        }
+    };
+
+    cx.editor.apply_motion(motion);
 }
 
 fn match_brackets(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -87,6 +87,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "A-;" => flip_selections,
         "A-o" | "A-up" => expand_selection,
         "A-i" | "A-down" => shrink_selection,
+        "A-I" | "A-S-down" => select_all_children,
         "A-p" | "A-left" => select_prev_sibling,
         "A-n" | "A-right" => select_next_sibling,
         "A-e" => move_parent_node_end,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -91,6 +91,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "A-n" | "A-right" => select_next_sibling,
         "A-e" => move_parent_node_end,
         "A-b" => move_parent_node_start,
+        "A-a" => select_all_siblings,
 
         "%" => select_all,
         "x" => extend_line_below,

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -450,3 +450,154 @@ async fn test_smart_tab_move_parent_node_end() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn select_all_siblings() -> anyhow::Result<()> {
+    let tests = vec![
+        // basic tests
+        (
+            indoc! {r##"
+                let foo = bar(#[a|]#, b, c);
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let foo = bar(#[a|]#, #(b|)#, #(c|)#);
+            "##},
+        ),
+        (
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    2,
+                    3,
+                    4,
+                    5,
+                ];
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    #(2|)#,
+                    #(3|)#,
+                    #(4|)#,
+                    #(5|)#,
+                ];
+            "##},
+        ),
+        // direction is preserved
+        (
+            indoc! {r##"
+                let a = [
+                    #[|1]#,
+                    2,
+                    3,
+                    4,
+                    5,
+                ];
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let a = [
+                    #[|1]#,
+                    #(|2)#,
+                    #(|3)#,
+                    #(|4)#,
+                    #(|5)#,
+                ];
+            "##},
+        ),
+        // can't pick any more siblings - selection stays the same
+        (
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    #(2|)#,
+                    #(3|)#,
+                    #(4|)#,
+                    #(5|)#,
+                ];
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    #(2|)#,
+                    #(3|)#,
+                    #(4|)#,
+                    #(5|)#,
+                ];
+            "##},
+        ),
+        // each cursor does the sibling select independently
+        (
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    2,
+                    3,
+                    4,
+                    5,
+                ];
+
+                let b = [
+                    #("one"|)#,
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                ];
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    #(2|)#,
+                    #(3|)#,
+                    #(4|)#,
+                    #(5|)#,
+                ];
+
+                let b = [
+                    #("one"|)#,
+                    #("two"|)#,
+                    #("three"|)#,
+                    #("four"|)#,
+                    #("five"|)#,
+                ];
+            "##},
+        ),
+        // conflicting sibling selections get normalized. Here, the primary
+        // selection would choose every list item, but because the secondary
+        // range covers more than one item, the descendent is the entire list,
+        // which means the sibling is the assignment. The list item ranges just
+        // get normalized out since the list itself becomes selected.
+        (
+            indoc! {r##"
+                let a = [
+                    #[1|]#,
+                    2,
+                    #(3,
+                    4|)#,
+                    5,
+                ];
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let #(a|)# = #[[
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ]|]#;
+            "##},
+        ),
+    ];
+
+    for test in tests {
+        test_with_config(AppBuilder::new().with_file("foo.rs", None), test).await?;
+    }
+
+    Ok(())
+}

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -607,16 +607,16 @@ async fn select_all_children() -> anyhow::Result<()> {
     let tests = vec![
         // basic tests
         (
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let foo = bar#[(a, b, c)|]#;
-            "##}),
+            "##},
             "<A-I>",
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let foo = bar(#[a|]#, #(b|)#, #(c|)#);
-            "##}),
+            "##},
         ),
         (
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = #[[
                     1,
                     2,
@@ -624,9 +624,9 @@ async fn select_all_children() -> anyhow::Result<()> {
                     4,
                     5,
                 ]|]#;
-            "##}),
+            "##},
             "<A-I>",
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = [
                     #[1|]#,
                     #(2|)#,
@@ -634,11 +634,11 @@ async fn select_all_children() -> anyhow::Result<()> {
                     #(4|)#,
                     #(5|)#,
                 ];
-            "##}),
+            "##},
         ),
         // direction is preserved
         (
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = #[|[
                     1,
                     2,
@@ -646,9 +646,9 @@ async fn select_all_children() -> anyhow::Result<()> {
                     4,
                     5,
                 ]]#;
-            "##}),
+            "##},
             "<A-I>",
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = [
                     #[|1]#,
                     #(|2)#,
@@ -656,11 +656,11 @@ async fn select_all_children() -> anyhow::Result<()> {
                     #(|4)#,
                     #(|5)#,
                 ];
-            "##}),
+            "##},
         ),
         // can't pick any more children - selection stays the same
         (
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = [
                     #[1|]#,
                     #(2|)#,
@@ -668,9 +668,9 @@ async fn select_all_children() -> anyhow::Result<()> {
                     #(4|)#,
                     #(5|)#,
                 ];
-            "##}),
+            "##},
             "<A-I>",
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = [
                     #[1|]#,
                     #(2|)#,
@@ -678,11 +678,11 @@ async fn select_all_children() -> anyhow::Result<()> {
                     #(4|)#,
                     #(5|)#,
                 ];
-            "##}),
+            "##},
         ),
         // each cursor does the sibling select independently
         (
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = #[|[
                     1,
                     2,
@@ -698,9 +698,9 @@ async fn select_all_children() -> anyhow::Result<()> {
                     "four",
                     "five",
                 ]|)#;
-            "##}),
+            "##},
             "<A-I>",
-            helpers::platform_line(indoc! {r##"
+            indoc! {r##"
                 let a = [
                     #[|1]#,
                     #(|2)#,
@@ -716,7 +716,7 @@ async fn select_all_children() -> anyhow::Result<()> {
                     #("four"|)#,
                     #("five"|)#,
                 ];
-            "##}),
+            "##},
         ),
     ];
 


### PR DESCRIPTION
This adds two new related commands:

### `select_all_siblings`

Selects all siblings of the node under the cursor.

[![asciicast](https://asciinema.org/a/yt7SserYwGL7QJ3UGVAmhe60t.svg)](https://asciinema.org/a/yt7SserYwGL7QJ3UGVAmhe60t)

### `select_all_children`

Selects all children of the node under the cursor.

[![asciicast](https://asciinema.org/a/GiMx8a5uZMtbyXI0Zh8Z6CoDh.svg)](https://asciinema.org/a/GiMx8a5uZMtbyXI0Zh8Z6CoDh)

### `select_all_children_in_selection`

~~Selects all children of the node under the cursor, but only if the children are contained inside the starting selection.~~

Edit: saving this one for a future PR