### PR TITLE
LSP: Forcefully shutdown uninitialized servers

### DIFF
--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -353,6 +353,11 @@ impl Transport {
             }
         }
 
+        fn is_shutdown(payload: &Payload) -> bool {
+            use lsp_types::request::{Request, Shutdown};
+            matches!(payload, Payload::Request { value: jsonrpc::MethodCall { method, .. }, .. } if method == Shutdown::METHOD)
+        }
+
         // TODO: events that use capabilities need to do the right thing
 
         loop {
@@ -391,7 +396,10 @@ impl Transport {
                 }
                 msg = client_rx.recv() => {
                     if let Some(msg) = msg {
-                        if is_pending && !is_initialize(&msg) {
+                        if is_pending && is_shutdown(&msg) {
+                            log::info!("Language server not initialized, shutting down");
+                            break;
+                        } else if is_pending && !is_initialize(&msg) {
                             // ignore notifications
                             if let Payload::Notification(_) = msg {
                                 continue;


### PR DESCRIPTION
The LSP spec has this to say about initialize:

> The initialize request is sent as the first request from the client to the server. If the server receives a request or notification before the initialize request it should act as follows: ...

> Notifications should be dropped, except for the exit notification. This will allow the exit of a server without an initialize request.

> Until the server has responded to the `initialize` request with an `InitializeResult`, the client must not send any additional requests or notifications to the server.

(https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize)

The spec is not really explicit about how to handle this scenario. Before a client sends the 'initialize' request we are allowed to send an 'exit' notification, but after 'initialize' we can't send any requests (like shutdown) or notifications (like exit). So my intepretation is that we should forcefully close the server in this state.

This matches the behavior of Neovim's built-in LSP client:
https://github.com/neovim/neovim/blob/5ceb2238d3685255cd517ca87fd7edae9ed88811/runtime/lua/vim/lsp.lua#L1610-L1628

This is a rough edge for ltex-ls which has a long start-up time. Some configure ltex-ls for git-commits for spell-checking and it's possible to finish writing your commit message, `:wq` and have the shutdown request time out before the server is initialized.

Closes https://github.com/helix-editor/helix/issues/7446
Closes https://github.com/helix-editor/helix/issues/7211

Also see https://github.com/helix-editor/helix/issues/5732. I think it would be fine in practice to also send an exit notification here but the spec is explicit that other requests/notifications are not allowed after 'initialize'.
