### PR TITLE
LSP: Discard publishDiagnostic from uninitialized servers

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -746,7 +746,12 @@ impl Application {
                                 return;
                             }
                         };
-                        let offset_encoding = language_server!().offset_encoding();
+                        let language_server = language_server!();
+                        if !language_server.is_initialized() {
+                            log::error!("Discarding publishDiagnostic notification sent by an uninitialized server: {}", language_server.name());
+                            return;
+                        }
+                        let offset_encoding = language_server.offset_encoding();
                         let doc = self.editor.document_by_path_mut(&path).filter(|doc| {
                             if let Some(version) = params.version {
                                 if version != doc.version() {


### PR DESCRIPTION
The spec explicitly disallows publishDiagnostic to be sent before the initialize response:

> ... the server is not allowed to send any requests or notifications to the client until it has responded with an InitializeResult ...

(https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize)

But if a non-compliant server sends this we currently panic because we '.expect()' the server capabilities to be known to fetch the position encoding. Instead of panicking we can discard the notification and log the non-compliant behavior.

See #7466