### PR TITLE
correctly map unsorted positions

### DIFF
--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -339,7 +339,7 @@ impl ChangeSet {
     /// in `O(N+M)` instead of `O(NM)`. This function also handles unsorted/
     /// partially sorted lists. However, in that case worst case complexity is
     /// again `O(MN)`.  For lists that are often/mostly sorted (like the end of diagnostic ranges)
-    /// performanc is usally close to `O(N + M)`
+    /// performance is usally close to `O(N + M)`
     pub fn update_positions<'a>(&self, positions: impl Iterator<Item = (&'a mut usize, Assoc)>) {
         use Operation::*;
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1197,7 +1197,7 @@ impl Document {
                 if let Some(data) = Rc::get_mut(annotations) {
                     changes.update_positions(
                         data.iter_mut()
-                            .map(|diagnostic| (&mut diagnostic.char_idx, Assoc::After)),
+                            .map(|annotation| (&mut annotation.char_idx, Assoc::After)),
                     );
                 }
             };


### PR DESCRIPTION
Fixes #7468
Fixes #7470


#7408 caused cashes because it assumed that all positions that are mapped with `update_position` are sorted. This is almost always the case. Except for the **end** of diagnostics. Diagnostics are sorted by their start position (and only if start positions are equal by end position). That caused various crashes. This is not a problem for selections since they are non-overlapping so ends re always sorted. 

This PR addresses that by allowing `update_positions` to backtrack in case if encounters an unsorted position. That does mean that the position mapping isn't quite linear anymore for diagnostics ends. However, this shouldn't really be an issue in practice as most diagnostics don't overlap, so the performance impact should be quite small in practice. 
