### PR TITLE
Fix unquoting arguments before passing to shell

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2154,7 +2154,10 @@ fn run_shell_command(
     }
 
     let shell = cx.editor.config().shell.clone();
-    let args = args.join(" ");
+    let args = args.into_iter()
+        .map(|arg| format!("'{}'", arg.trim()))
+        .collect::<Vec<String>>()
+        .join(" ");
 
     let callback = async move {
         let (output, success) = shell_impl_async(&shell, &args, None).await?;


### PR DESCRIPTION
#7453
Now quotes all arguments passed to the shell