### PR TITLE
Add an editor option for keeping completion placeholders.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -55,6 +55,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
+| `completion-keep-placeholders` | Set to `true` to keep snippet placeholders when accepting completions. | `false` |
 | `auto-info` | Whether to display info boxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -112,6 +112,8 @@ impl Completion {
     ) -> Self {
         let preview_completion_insert = editor.config().preview_completion_insert;
         let replace_mode = editor.config().completion_replace;
+        let keep_placeholders = editor.config().completion_keep_placeholders;
+
         // Sort completion items according to their preselect status (given by the LSP server)
         items.sort_by_key(|item| !item.item.preselect.unwrap_or(false));
 
@@ -298,7 +300,7 @@ impl Completion {
                         &item.item,
                         offset_encoding,
                         trigger_offset,
-                        false,
+                        keep_placeholders,
                         replace_mode,
                     );
                     doc.apply(&transaction, view.id);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -257,6 +257,8 @@ pub struct Config {
     /// Whether to instruct the LSP to replace the entire word when applying a completion
     /// or to only insert new text
     pub completion_replace: bool,
+    /// Keep snippet placeholders when accepting completions. Defaults to `false`.
+    pub completion_keep_placeholders: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
@@ -797,6 +799,7 @@ impl Default for Config {
             idle_timeout: Duration::from_millis(400),
             preview_completion_insert: true,
             completion_trigger_len: 2,
+            completion_keep_placeholders: false,
             auto_info: true,
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),


### PR DESCRIPTION
I keep finding myself having to retype them again.

Possibly relevant commit: https://github.com/helix-editor/helix/commit/ba24cfe9125eda97346e3ceee42686fb9f46046f