### PR TITLE
Update the Nord theme to follow the Nord style guide

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -1,133 +1,180 @@
-# Author : RayGervais<raygervais@hotmail.ca>
+# Nord (Dark Ambiance) port for Helix (https://helix-editor.com/)
+# https://docs.helix-editor.com/themes.html
+# https://www.nordtheme.com/docs/colors-and-palettes
 
-"ui.linenr.selected" = "nord4"
-"ui.cursorline.primary" = { bg = "nord1" }
-"ui.text.focus" = { fg = "nord8", modifiers = ["bold"] }
-"ui.menu" = { fg = "nord6", bg = "nord1" }
-"ui.menu.selected" = { fg = "nord8", bg = "nord2" }
-"ui.virtual.ruler" = { bg = "nord1" }
+## SYNTAX HIGHLIGHTING
 
-"info" = "nord8"
-"hint" = "nord8"
-
-# Polar Night
-# nord0 - background color
-"ui.background" = { bg = "nord0" }
-
-"ui.statusline.inactive" = { fg = "nord8", bg = "nord1" }
-"ui.statusline.normal" = { fg = "nord0", bg = "nord8" }
-"ui.statusline.insert" = { fg = "nord0", bg = "nord13" }
-"ui.statusline.select" = { fg = "nord0", bg = "nord15" }
-
-
-# nord1 - status bars, panels, modals, autocompletion
-"ui.statusline" = { fg = "nord4", bg = "nord1" }
-"ui.popup" = { bg = "nord1" }
-"ui.window" = { bg = "nord1" }
-"ui.help" = { bg = "nord1", fg = "nord4" }
-
-# nord2 - active line, highlighting
-"ui.selection" = { bg = "nord2" }
-"ui.cursor.match" = { bg = "nord2" }
-
-# nord3 - comments, invisible/non-printable characters
-"comment" = { fg = "nord3_bright", modifiers = ["italic"] }
-"ui.linenr" = "nord3_bright"
-"ui.virtual.whitespace" = "nord3_bright"
-"ui.virtual.inlay-hint" = { fg = "nord3_bright" }
-
-
-# Snow Storm
-# nord4 - cursor, variables, constants, attributes, fields
-"ui.cursor.primary" = { fg = "nord4", modifiers = ["reversed"] }
-"attribute" = "nord4"
-"variable" = "nord4"
-"constant" = "nord4"
-"variable.builtin" = "nord4"
-"constant.builtin" = "nord4"
-"namespace" = "nord4"
-
-# nord5 - subtle UI text
-
-# nord6 - base text, punctuation
-"ui.text" = "nord6"
-"punctuation" = "nord6"
-
-# Frost
-# nord7 - classes, types, primitives
-"type" = "nord7"
-"type.builtin" = "nord7"
-"label" = "nord7"
-
-# nord8 - declaration, methods, routines
-"constructor" = "nord8"
-"function" = "nord8"
-"function.macro" = "nord8"
-"function.builtin" = "nord8"
-
-# nord9 - operator, tags, units, punctuations
-"punctuation.delimiter" = "nord9"
-"operator" = "nord9"
-"variable.other.member" = "nord9"
-
-# nord10 - keywords, special
-"keyword" = "nord10"
-"keyword.directive" = "nord10"
-"variable.parameter" = "nord10"
-
-# Aurora
-# nord11 - error
-"error" = "nord11"
-
-# nord12 - annotations, decorators
-"special" = "nord12"
-"module" = "nord12"
-
-# nord13 - warnings, escape characters, regex
-"warning" = "nord13"
+# Constants
+"constant" = "nord4" 
+"constant.builtin" = "nord9"
+"constant.builtin.boolean" = "nord9"
+"constant.builtin.character" = "nord15"
 "constant.character.escape" = "nord13"
-
-# nord14 - strings
-"string" = "nord14"
-
-# nord15 - integer, floating point
+"constant.macro" = "nord9"
 "constant.numeric" = "nord15"
+"constructor" = "nord8"
 
-# markup
-"markup.heading" = "nord8"
-"markup.list" = "nord9"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.text" = "nord8"
-"markup.raw" = "nord7"
+# Diagnostics
+"diagnostic" = "nord13"
+"diagnostic.error" = "nord11"
+"error" = "nord11"
+"diagnostic.hint" = "nord10"
+"hint" = "nord10"
+"diagnostic.info" = "nord8"
+"info" = "nord8"
+"diagnostic.warning" = "nord13"
+"warning" = "nord13"
 
-# lsp diagnostics
-"diagnostic.error" = { underline = { color = "nord11", style = "curl" } }
-"diagnostic.warning" = { underline = { color = "nord13", style = "curl" } }
-"diagnostic.info" = { underline = { color = "nord8", style = "curl" } }
-"diagnostic.hint" = { underline = { color = "nord8", style = "curl" } }
-
-# vcs
-"diff.plus" = "nord14"
-"diff.delta" = "nord12"
+# Diffs
+"diff.delta" = "nord13"
 "diff.minus" = "nord11"
+"diff.plus" = "nord14"
+
+# Functions
+"function" = "nord8"
+"function.builtin" = "nord7"
+"function.method" = "nord8"
+"function.macro" = "nord9"
+"function.special" = "nord9"
+
+# Git
+"git.delta.moved" = "nord12"
+
+# Keywords
+"keyword" = "nord9"
+"keyword.control.conditional" = "nord9"
+"keyword.control.exception" = "nord9"
+"keyword.control.repeat" = "nord9"
+"keyword.directive" = "nord9"
+"keyword.function" = "nord9"
+"keyword.operator" = "nord9"
+"keyword.return" = "nord9"
+"keyword.storage.modifier" = "nord9"
+"keyword.storage.type" = "nord7"
+
+# Punctuation
+"punctuation" = "nord6"
+"punctuation.bracket" = "nord6"
+"punctuation.delimiter" = "nord6"
+"punctuation.special" = "nord9"
+
+# Strings
+"string" = "nord14"
+"string.escape" = "nord13"
+"string.regex" = "nord13"
+"string.special" = "nord13"
+
+# Types
+"type" = "nord4"
+"type.builtin" = "nord7"
+
+# Variables
+"variable" = "nord4"
+"variable.builint" = "nord9"
+"variable.other.member" = "nord4"
+"variable.parameter" = "nord8"
+"attribute" = "nord4"
+
+# Misc.
+"label" = "nord7"
+"namespace" = "nord4"
+"operator" = "nord9"
+"special" = "nord4"
+"tag" = "nord4"
+"comment" = { fg = "nord3_bright", modifiers = ["italic"] }
+
+## EDITOR UI COLORS
+
+"ui.background" = { bg = "nord0" }
+"ui.text" = "nord4"
+"ui.window" = "nord1"
+
+# Debug
+"ui.debug.active" = "nord13"
+"ui.debug.breakpoint" = "nord11"
+
+# Popus and menus
+"ui.menu" = { bg = "nord1" }
+"ui.menu.scroll" = { fg = "nord4", bg = "nord3" }
+"ui.menu.selected" = { fg = "nord8", bg = "nord2" }
+"ui.popup" = { bg = "nord1" }
+"ui.popup.info" = { bg = "nord1" }
+"ui.help" = { bg = "nord1" }
+
+# Gutter
+"ui.gutter" = "nord5"
+"ui.linenr" = "nord3"
+"ui.linenr.selected" = "nord5"
+
+# Cursor
+"ui.cursor" = { fg = "nord4", modifiers = [ "reversed" ] }
+"ui.cursorcolumn.primary" = { bg = "nord1" }
+"ui.cursorline.primary" = { bg = "nord1" }
+
+"ui.selection" = { bg = "nord2" }
+"ui.highlight" = { fg = "nord8", bg = "nord2" }
+
+# Statusline
+"ui.statusline" = {  bg = "nord1" }
+"ui.statusline.inactive" = { fg = "nord8", bg = "nord1" }
+"ui.statusline.insert" = { fg = "nord1", bg = "nord6" }
+"ui.statusline.normal" = { fg = "nord1", bg = "nord8" }
+"ui.statusline.select" = { fg = "nord1", bg = "nord7" }
+"ui.statusline.separator" = "nord3"
+
+# Virtual/invisable text
+"ui.virtual.indent-guide" = "nord3"
+"ui.virtual.inlay-hint" = { fg = "nord3", modifiers = ["italic"] }
+"ui.virtual.ruler" = "nord3"
+"ui.virtual.whitespace" = "nord3"
+"ui.virtual.wrap" = "nord3"
+
+# Bufferline
+"ui.bufferline" = { fg = "nord5", bg = "nord1" }
+"ui.bufferline.active" = { fg = "nord6", bg = "nord2", underline = { color = "nord8", style = "line" }, modifiers = [ "italic" ] }
 
 [palette]
-nord0 = "#2e3440"
-nord1 = "#3b4252"
-nord2 = "#434c5e"
-# we use a brighter nord3 based on discussion here:
-# https://github.com/arcticicestudio/nord/issues/94
-nord3_bright = "#616e88"
-nord4 = "#d8dee9"
-nord6 = "#eceff4"
-nord7 = "#8fbcbb"
-nord8 = "#88c0d0"
-nord9 = "#81a1c1"
-nord10 = "#5e81ac"
-nord11 = "#bf616a"
-nord12 = "#d08770"
-nord13 = "#ebcb8b"
-nord14 = "#a3be8c"
-nord15 = "#b48ead"
+# Polar Night is made up of four darker colors that are commonly used for base elements like backgrounds or text color in bright ambiance designs.
+#
+# The origin color or the Polar Night palette
+nord0 = "#2e3440" 
+# A brighter shade color based on nord0
+nord1 = "#3B4252" 
+# An even more brighter shade color of nord0
+nord2 = "#434C5E" 
+# The brightest shade color based on nord0
+nord3 = "#4C566A" 
+# 10% brighter for comments, see https://github.com/nordtheme/nord/issues/94
+nord3_bright = "#616e88" 
+
+# Snow Storm is made up of three bright colors that are commonly used for text colors or base UI elements in bright ambiance designs.
+# The origin color or the Snow Storm palette
+nord4 = "#D8DEE9" 
+# A brighter shade color of nord4
+nord5 = "#E5E9F0" 
+# The brightest shade color based on nord4
+nord6 = "#ECEFF4" 
+
+# Frost can be described as the heart palette of Nord, a group of four bluish colors that are commonly used for primary UI component and text highlighting and essential code syntax elements.
+#
+# A calm and highly contrasted color reminiscent of frozen polar water
+nord7 = "#8FBCBB" 
+# The bright and shiny primary accent color reminiscent of pure and clear ice
+nord8 = "#88C0D0" 
+# A more darkened and less saturated color reminiscent of arctic waters
+nord9 = "#81A1C1" 
+# A dark and intensive color reminiscent of the deep arctic ocean
+ nord10 = "#5E81AC" 
+
+# Aurora consists of five colorful components reminiscent of the "Aurora borealis", sometimes referred to as polar lights or northern lights.
+#
+# Red
+nord11 = "#BF616A" 
+# Orange
+nord12 = "#D08770" 
+# Yellow
+nord13 = "#EBCB8B" 
+# Green
+nord14 = "#A3BE8C" 
+# Purple
+nord15 = "#B48EAD" 


### PR DESCRIPTION
This rewrites the entire Nord theme to make it follow the [upstream style guide](https://www.nordtheme.com/docs/colors-and-palettes). The current Nord theme does not follow the style guide and also does not look like any of the official ports. The [nord.vim](https://www.nordtheme.com/ports/vim) port was used as a guide when the nord style guide was unclear. This looks much more similar to the other Nord ports,  and also improves the
contrast of code compared to the old theme.

<img width="1430" alt="helix_nord_theme_comparison" src="https://github.com/helix-editor/helix/assets/83884198/67964d4c-9561-49ab-a75d-296a5c0ecd9f">