### PR TITLE
highlight(matlab): Fix string's single-quote's color

### DIFF
--- a/runtime/queries/matlab/highlights.scm
+++ b/runtime/queries/matlab/highlights.scm
@@ -41,39 +41,6 @@
 
 (function_arguments (identifier) @variable.parameter)
 
-; Operators
-
-[
-  "+"
-  ".+"
-  "-"
-  ".*"
-  "*"
-  ".*"
-  "/"
-  "./"
-  "\\"
-  ".\\"
-  "^"
-  ".^"
-  "'"
-  ".'"
-  "|"
-  "&"
-  "?"
-  "@"
-  "<"
-  "<="
-  ">"
-  ">="
-  "=="
-  "~="
-  "="
-  "&&"
-  "||"
-  ":"
-] @operator
-
 ; Conditionals
 
 (if_statement [ "if" "end" ] @keyword.control.conditional)
@@ -106,11 +73,45 @@
 (formatting_sequence) @constant.character.escape
 (string) @string
 (number) @constant.numeric.float
+(unary_operator ["+" "-"] @constant.numeric.float)
 (boolean) @constant.builtin.boolean
 
 ; Comments
 
 [ (comment) (line_continuation) ] @comment.line
+
+; Operators
+
+[
+  "+"
+  ".+"
+  "-"
+  ".*"
+  "*"
+  ".*"
+  "/"
+  "./"
+  "\\"
+  ".\\"
+  "^"
+  ".^"
+  "'"
+  ".'"
+  "|"
+  "&"
+  "?"
+  "@"
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "~="
+  "="
+  "&&"
+  "||"
+  ":"
+] @operator
 
 ; Keywords
 


### PR DESCRIPTION
There are two small changes in the commit:

1. Fixes a priority error that makes single quotes highlight as operators even when delimiting strings (it should highlight as an operator only when it is used as the transpose operator).
2. Makes the sign in numbers like `-1` and `+2` have the same highlight as the numbers instead of highlighting as an operator. If you don't like this one I can remove it, no problem.