### PR TITLE
Fix: #7502

### DIFF
--- a/helix-core/src/register.rs
+++ b/helix-core/src/register.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Register {
     name: char,
     values: Vec<String>,
@@ -36,9 +36,9 @@ impl Register {
 }
 
 /// Currently just wraps a `HashMap` of `Register`s
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Registers {
-    inner: HashMap<char, Register>,
+    pub inner: HashMap<char, Register>,
 }
 
 impl Registers {

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -61,7 +61,7 @@ impl Info {
             .map(|(ch, reg)| {
                 let content = reg
                     .read()
-                    .get(0)
+                    .last()
                     .and_then(|s| s.lines().next())
                     .unwrap_or_default();
                 (ch.to_string(), content)
@@ -71,5 +71,32 @@ impl Info {
         let mut infobox = Self::new("Registers", &body);
         infobox.width = 30; // copied content could be very long
         infobox
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helix_core::register::Register;
+    use once_cell::sync::Lazy;
+
+    const REGISTER_VALUE_1_MOCK: &str = "value_1";
+    const REGISTER_VALUE_2_MOCK: &str = "value_2";
+    static REGISTERS_MOCK: Lazy<Registers> = Lazy::new(|| Registers {
+        inner: [(
+            '/',
+            Register::new_with_values('/', vec![REGISTER_VALUE_1_MOCK.to_string()]),
+        )]
+        .into(),
+    });
+
+    #[test]
+    fn infobox_shows_latest_value() {
+        let mut registers = (*REGISTERS_MOCK).clone();
+        registers.push('/', REGISTER_VALUE_2_MOCK.to_string());
+
+        assert!(Info::from_registers(&registers)
+            .text
+            .contains(REGISTER_VALUE_2_MOCK));
     }
 }


### PR DESCRIPTION
The fix itself was a one-liner, but I added a test for it anyway. I'm interested in working on register histories, so I might as well get started with setting up the necessary test scaffolding here.

The test was placed in `info.rs` because `Register` is in core, which can't have `helix-view` as a dependency. Not being able to place it in `registers.rs` forced me to make the `inner` field public. Maybe we should discuss if it would be appropriate to move `Register`(s) to `helix-view`.  
