### PR TITLE
Add ability to customize colors for inactive, active modified, and inactive modified buffers on the bufferline

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -269,6 +269,10 @@ These scopes are used for theming the editor interface:
 | ---                               | ---                                                                                            |
 | `ui.background`                   |                                                                                                |
 | `ui.background.separator`         | Picker separator below input line                                                              |
+| `ui.bufferline.active`            |                                                                                                |
+| `ui.bufferline.active.modified`   |                                                                                                |
+| `ui.bufferline.inactive`          |                                                                                                |
+| `ui.bufferline.inactive.modified` |                                                                                                |
 | `ui.cursor`                       |                                                                                                |
 | `ui.cursor.normal`                |                                                                                                |
 | `ui.cursor.insert`                |                                                                                                |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -529,10 +529,20 @@ impl EditorView {
             .try_get("ui.bufferline.active")
             .unwrap_or_else(|| editor.theme.get("ui.statusline.active"));
 
+        let bufferline_active_modified = editor
+            .theme
+            .try_get("ui.bufferline.active.modified")
+            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline.active").unwrap_or_else(|| editor.theme.get("ui.statusline.active")));
+
         let bufferline_inactive = editor
             .theme
-            .try_get("ui.bufferline")
-            .unwrap_or_else(|| editor.theme.get("ui.statusline.inactive"));
+            .try_get("ui.bufferline.inactive")
+            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline").unwrap_or_else(|| editor.theme.get("ui.statusline.inactive")));
+
+        let bufferline_inactive_modified = editor
+            .theme
+            .try_get("ui.bufferline.inactive.modified")
+            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline").unwrap_or_else(|| editor.theme.get("ui.statusline.inactive")));
 
         let mut x = viewport.x;
         let current_doc = view!(editor).doc;
@@ -547,7 +557,13 @@ impl EditorView {
                 .unwrap_or_default();
 
             let style = if current_doc == doc.id() {
-                bufferline_active
+                if doc.is_modified() { 
+                    bufferline_active_modified 
+                } else {
+                    bufferline_active
+                }
+            } else if doc.is_modified() { 
+                bufferline_inactive_modified 
             } else {
                 bufferline_inactive
             };

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -532,17 +532,32 @@ impl EditorView {
         let bufferline_active_modified = editor
             .theme
             .try_get("ui.bufferline.active.modified")
-            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline.active").unwrap_or_else(|| editor.theme.get("ui.statusline.active")));
+            .unwrap_or_else(|| {
+                editor
+                    .theme
+                    .try_get("ui.bufferline.active")
+                    .unwrap_or_else(|| editor.theme.get("ui.statusline.active"))
+            });
 
         let bufferline_inactive = editor
             .theme
             .try_get("ui.bufferline.inactive")
-            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline").unwrap_or_else(|| editor.theme.get("ui.statusline.inactive")));
+            .unwrap_or_else(|| {
+                editor
+                    .theme
+                    .try_get("ui.bufferline")
+                    .unwrap_or_else(|| editor.theme.get("ui.statusline.inactive"))
+            });
 
         let bufferline_inactive_modified = editor
             .theme
             .try_get("ui.bufferline.inactive.modified")
-            .unwrap_or_else(|| editor.theme.try_get("ui.bufferline").unwrap_or_else(|| editor.theme.get("ui.statusline.inactive")));
+            .unwrap_or_else(|| {
+                editor
+                    .theme
+                    .try_get("ui.bufferline")
+                    .unwrap_or_else(|| editor.theme.get("ui.statusline.inactive"))
+            });
 
         let mut x = viewport.x;
         let current_doc = view!(editor).doc;
@@ -557,13 +572,13 @@ impl EditorView {
                 .unwrap_or_default();
 
             let style = if current_doc == doc.id() {
-                if doc.is_modified() { 
-                    bufferline_active_modified 
+                if doc.is_modified() {
+                    bufferline_active_modified
                 } else {
                     bufferline_active
                 }
-            } else if doc.is_modified() { 
-                bufferline_inactive_modified 
+            } else if doc.is_modified() {
+                bufferline_inactive_modified
             } else {
                 bufferline_inactive
             };


### PR DESCRIPTION
Resolves #7481. Preserve default behavior for ui.bufferline.inactive but add ability to customize. Add ui.bufferline.* entries to the themes book.

Tested with github_dark.toml.
<img width="284" alt="image" src="https://github.com/helix-editor/helix/assets/18293679/02c13d32-f97a-4781-bda8-e5555e456d36">

editor.rs active
<img width="415" alt="image" src="https://github.com/helix-editor/helix/assets/18293679/0470341f-9c0c-43ce-a48b-80368bc37e22">

Both modified, editor.rs active
<img width="414" alt="image" src="https://github.com/helix-editor/helix/assets/18293679/e3f84ef2-7967-474a-b65b-c41fd0780259">