### PR TITLE
Correct JSON language server command

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -70,7 +70,7 @@
 | java | ✓ | ✓ |  | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jsdoc | ✓ |  |  |  |
-| json | ✓ |  | ✓ | `vscode-json-language-server` |
+| json | ✓ |  | ✓ | `vscode-json-languageserver` |
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ | `julia` |

--- a/languages.toml
+++ b/languages.toml
@@ -73,7 +73,7 @@ vhdl_ls = { command = "vhdl_ls", args = [] }
 vlang-language-server = { command = "v", args = ["ls"] }
 vscode-css-language-server = { command = "vscode-css-language-server", args = ["--stdio"], config = { "provideFormatter" = true }}
 vscode-html-language-server = { command = "vscode-html-language-server", args = ["--stdio"], config = { provideFormatter = true } }
-vscode-json-language-server =  { command = "vscode-json-language-server", args = ["--stdio"], config = { provideFormatter = true } }
+vscode-json-languageserver =  { command = "vscode-json-languageserver", args = ["--stdio"], config = { provideFormatter = true } }
 vuels = { command = "vue-language-server", args = ["--stdio"], config = { typescript = { tsdk = "node_modules/typescript/lib/" } } }
 wgsl_analyzer = { command = "wgsl_analyzer" }
 yaml-language-server = { command = "yaml-language-server", args = ["--stdio"] }


### PR DESCRIPTION
The executable name for the JSON language-server in `languages.toml` is incorrect.  This fixes that.

(See the [npm package listing](https://www.npmjs.com/package/vscode-json-languageserver))