### PR TITLE
Add ability to configure the file modification indicator

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -64,6 +64,8 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
+| `file-modification-indicator` | The indicator to show whether the file is modified (appears when there are unsaved changes) | `[+]` |
+
 
 ### `[editor.statusline]` Section
 
@@ -105,7 +107,6 @@ The following statusline elements can be configured:
 | `spinner` | A progress spinner indicating LSP activity |
 | `file-name` | The path/name of the opened file |
 | `file-base-name` | The basename of the opened file |
-| `file-modification-indicator` | The indicator to show whether the file is modified (a `[+]` appears when there are unsaved changes) |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |
 | `total-line-numbers` | The total line numbers of the opened file |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -552,7 +552,16 @@ impl EditorView {
                 bufferline_inactive
             };
 
-            let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
+            let text = format!(
+                " {}{} ",
+                fname,
+                if doc.is_modified() {
+                    editor.config().file_modification_indicator.to_string()
+                } else {
+                    "".to_string()
+                }
+            );
+
             let used_width = viewport.x.saturating_sub(x);
             let rem_width = surface.area.width.saturating_sub(used_width);
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -432,8 +432,9 @@ fn render_file_modification_indicator<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
+    let indicator = &context.editor.config().file_modification_indicator;
     let title = (if context.doc.is_modified() {
-        "[+]"
+        indicator
     } else {
         "   "
     })

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -288,6 +288,8 @@ pub struct Config {
     pub workspace_lsp_roots: Vec<PathBuf>,
     /// Which line ending to choose for new documents. Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
     pub default_line_ending: LineEndingConfig,
+    /// String to display when the file is modified. Defaults to `[+]`.
+    pub file_modification_indicator: String,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -819,6 +821,7 @@ impl Default for Config {
             completion_replace: false,
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
+            file_modification_indicator: String::from("[+]"),
         }
     }
 }


### PR DESCRIPTION
Relates to the second request in #7481.

Previously the file modification indicator was documented under [[editor.statusline]](https://docs.helix-editor.com/configuration.html#editorstatusline-section), but the way I have it currently, the configuration will change the file modification indicator on both the buffer line AND the status line. I've put it there as it's more of a general editor change. Wondering if there are any opinions on whether:

A - The configurable indicator should control both the buffer and status line indicator (current)
B - The configurable indicator should only be for the buffer line and the status line default [+] should remain
C - They should be independently configurable 

I've also made the assumption that someone may the entire indicator configurable, rather than just the character(s) inside the [].