### PR TITLE
highlight(matlab): Better UTF-8 handling.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2285,7 +2285,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "matlab"
-source = { git = "https://github.com/acristoffers/tree-sitter-matlab", rev = "4029fa791ddadd555c6a371a4e882ef1735d868c" }
+source = { git = "https://github.com/acristoffers/tree-sitter-matlab", rev = "676117eafa64afedc8380a921a77cd9f2244bc6b" }
 
 [[language]]
 name = "ponylang"


### PR DESCRIPTION
Me again. The "fuzzer" found problems in the code that caused hangs and sigsegvs. They were related mostly to baddly handled UTF-8 chars in my code (and the sigsegv came from the stdlib O.o). Now fixed. It now ran for 1 hour without finding any more problems so hopefully there's nothing like that anymore.