### PR TITLE
use redraw handle for debouncing LSP messages

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1703,7 +1703,7 @@ impl Editor {
                 _ = self.redraw_handle.0.notified() => {
                     if  !self.needs_redraw{
                         self.needs_redraw = true;
-                        let timeout = Instant::now() + Duration::from_millis(96);
+                        let timeout = Instant::now() + Duration::from_millis(33);
                         if timeout < self.idle_timer.deadline(){
                             self.idle_timer.as_mut().reset(timeout)
                         }


### PR DESCRIPTION
See https://github.com/helix-editor/helix/pull/7373#issuecomment-1616716678 for prior discussion

Fixes helix not redrawing after receiving messages from the LSP by replacing the existing (buggy) special-purpose deboucing with using the redraw handle that was added as part of #3890 
