### PR TITLE
book: Rename Arch Linux's repository from `community` to `extra`

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -6,7 +6,7 @@
 - [Linux](#linux)
   - [Ubuntu](#ubuntu)
   - [Fedora/RHEL](#fedorarhel)
-  - [Arch Linux community](#arch-linux-community)
+  - [Arch Linux extra](#arch-linux-extra)
   - [NixOS](#nixos)
   - [Flatpak](#flatpak)
   - [AppImage](#appimage)
@@ -70,9 +70,9 @@ sudo dnf copr enable varlad/helix
 sudo dnf install helix
 ```
 
-### Arch Linux community
+### Arch Linux extra
 
-Releases are available in the `community` repository:
+Releases are available in the `extra` repository:
 
 ```sh
 sudo pacman -S helix


### PR DESCRIPTION
After the https://archlinux.org/news/git-migration-completed/