### PR TITLE
Update Nickel grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -664,7 +664,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nickel"
-source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "3a794388773f2424a97b2186828aa3fac4c66ce6" }
+source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "e1d9337864d209898a08c26b8cd4c2dd14c15148" }
 
 [[language]]
 name = "nix"


### PR DESCRIPTION
A recent change in Nickel breaks the existing grammar. This is a simple update of the query. The highlighting queries are still compatible.