### PR TITLE
Add filename completer for shell prompt

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5401,7 +5401,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
         cx,
         prompt,
         Some('|'),
-        ui::completers::none,
+        ui::completers::filename,
         move |cx, input: &str, event: PromptEvent| {
             if event != PromptEvent::Validate {
                 return;


### PR DESCRIPTION
Fixes #6717 

## Things done in this PR
Added a completer for shell command using `!`, so we can have the same experience as `run-shell-command` where we complete using the filenames available.

## Evidence

https://github.com/helix-editor/helix/assets/13922607/c3cc3006-9a9e-4aaf-9de3-3bbeddccf387


