### PR TITLE
Fix `:log-open` when `--log` is specified

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -11,19 +11,23 @@ static RUNTIME_DIRS: once_cell::sync::Lazy<Vec<PathBuf>> =
 
 static CONFIG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
 
+static LOG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
+
 pub fn initialize_config_file(specified_file: Option<PathBuf>) {
-    let config_file = specified_file.unwrap_or_else(|| {
-        let config_dir = config_dir();
-
-        if !config_dir.exists() {
-            std::fs::create_dir_all(&config_dir).ok();
-        }
-
-        config_dir.join("config.toml")
-    });
-
-    // We should only initialize this value once.
+    let config_file = specified_file.unwrap_or_else(default_config_file);
     CONFIG_FILE.set(config_file).ok();
+}
+
+pub fn initialize_log_file(specified_file: Option<PathBuf>) {
+    let log_file = specified_file.unwrap_or_else(default_log_file);
+    LOG_FILE.set(log_file).ok();
+}
+
+pub fn ensure_config_dir() {
+    let config_dir = config_dir();
+    if !config_dir.exists() {
+        std::fs::create_dir_all(&config_dir).ok();
+    }
 }
 
 /// A list of runtime directories from highest to lowest priority
@@ -121,11 +125,15 @@ pub fn cache_dir() -> PathBuf {
     path
 }
 
+pub fn default_config_file() -> PathBuf {
+    config_dir().join("config.toml")
+}
+
 pub fn config_file() -> PathBuf {
     CONFIG_FILE
         .get()
         .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| config_dir().join("config.toml"))
+        .unwrap_or_else(default_config_file)
 }
 
 pub fn workspace_config_file() -> PathBuf {
@@ -136,8 +144,15 @@ pub fn lang_config_file() -> PathBuf {
     config_dir().join("languages.toml")
 }
 
-pub fn log_file() -> PathBuf {
+pub fn default_log_file() -> PathBuf {
     cache_dir().join("helix.log")
+}
+
+pub fn log_file() -> PathBuf {
+    LOG_FILE
+        .get()
+        .map(|path| path.to_path_buf())
+        .unwrap_or_else(default_log_file)
 }
 
 /// Merge two TOML documents, merging values from `right` onto `left`

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -109,7 +109,6 @@ FLAGS:
         return Ok(0);
     }
 
-    helix_loader::ensure_config_dir();
     helix_loader::initialize_config_file(args.config_file.clone());
     helix_loader::initialize_log_file(args.log_file.clone());
 

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -4,9 +4,8 @@ use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
 use helix_term::config::{Config, ConfigLoadError};
-use std::path::PathBuf;
 
-fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
+fn setup_logging(verbosity: u64) -> Result<()> {
     let mut base_config = fern::Dispatch::new();
 
     base_config = match verbosity {
@@ -27,7 +26,7 @@ fn setup_logging(logpath: PathBuf, verbosity: u64) -> Result<()> {
                 message
             ))
         })
-        .chain(fern::log_file(logpath)?);
+        .chain(fern::log_file(helix_loader::log_file())?);
 
     base_config.chain(file_config).apply()?;
 
@@ -41,12 +40,6 @@ fn main() -> Result<()> {
 
 #[tokio::main]
 async fn main_impl() -> Result<i32> {
-    let logpath = helix_loader::log_file();
-    let parent = logpath.parent().unwrap();
-    if !parent.exists() {
-        std::fs::create_dir_all(parent).ok();
-    }
-
     let help = format!(
         "\
 {} {}
@@ -78,7 +71,7 @@ FLAGS:
         VERSION_AND_GIT_HASH,
         env!("CARGO_PKG_AUTHORS"),
         env!("CARGO_PKG_DESCRIPTION"),
-        logpath.display(),
+        helix_loader::default_log_file().display(),
     );
 
     let args = Args::parse_args().context("could not parse arguments")?;
@@ -116,15 +109,11 @@ FLAGS:
         return Ok(0);
     }
 
-    let logpath = args.log_file.as_ref().cloned().unwrap_or(logpath);
-    setup_logging(logpath, args.verbosity).context("failed to initialize logging")?;
-
-    let config_dir = helix_loader::config_dir();
-    if !config_dir.exists() {
-        std::fs::create_dir_all(&config_dir).ok();
-    }
-
+    helix_loader::ensure_config_dir();
     helix_loader::initialize_config_file(args.config_file.clone());
+    helix_loader::initialize_log_file(args.log_file.clone());
+
+    setup_logging(args.verbosity).context("failed to initialize logging")?;
 
     let config = match Config::load_default() {
         Ok(config) => config,


### PR DESCRIPTION
The command always opened the default log file path. The path can be customized passing the `--log` optional argument. When this is the case the `open-log` command should respect it.