### PR TITLE
highlight(julia): Update tree-sitter-julia

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -805,7 +805,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "julia"
-source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "8fb38abff74652c4faddbf04d2d5bbbc6b4bae25" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "8e5ce1e5a96e8dfe0b0eee74633f5ba2766bf48b" }
 
 [[language]]
 name = "java"


### PR DESCRIPTION
Version 8fb38ab could fail to parse string literals that contained escape sequences, causing a crash.

This change updates to 8e5ce1e. Fixes #7309.

Syntax highlighting is broken after this update, working on updating queries for the changes in https://github.com/tree-sitter/tree-sitter-julia/pull/72.