### PR TITLE
enhanced `surround_replace` to provide visual feedback

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5119,11 +5119,11 @@ fn surround_replace(cx: &mut Context) {
         let selection = selection.clone();
         let mut ranges: SmallVec<[Range; 1]> = SmallVec::new();
         // TODO: Use [`array_chunks`] once stabilized
-        change_pos.chunks_exact(2).for_each(|p| {
+        for p in change_pos.chunks_exact(2) {
             let [from, to] = *p else { unreachable!() };
             ranges.push(Range::point(from));
             ranges.push(Range::point(to));
-        });
+        }
         doc.set_selection(view.id, Selection::new(ranges, 0));
 
         cx.on_next_key(move |cx, event| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5118,16 +5118,13 @@ fn surround_replace(cx: &mut Context) {
         // Visual feedback
         let selection = selection.clone();
         let mut ranges: SmallVec<[Range; 1]> = SmallVec::new();
-        change_pos.chunks(2).for_each(|p| {
-            if p.len() == 2 {
-                let from = *p.first().unwrap();
-                let to = *p.get(1).unwrap();
-                ranges.push(Range::new(from, from + 1));
-                ranges.push(Range::new(to, to + 1));
-            }
+        // TODO: Use [`array_chunks`] once stabilized
+        change_pos.chunks_exact(2).for_each(|p| {
+            let [from, to] = *p else { unreachable!() };
+            ranges.push(Range::point(from));
+            ranges.push(Range::point(to));
         });
-        let feedback = Selection::new(ranges, 0);
-        doc.set_selection(view.id, feedback);
+        doc.set_selection(view.id, Selection::new(ranges, 0));
 
         cx.on_next_key(move |cx, event| {
             let (view, doc) = current!(cx.editor);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5117,21 +5117,10 @@ fn surround_replace(cx: &mut Context) {
 
         let selection = selection.clone();
         let ranges: SmallVec<[Range; 1]> = change_pos.iter().map(|&p| Range::point(p)).collect();
-        // TODO: Use [`array_chunks`] once stabilized
-        let primary_index = ranges
-            .chunks_exact(2)
-            .enumerate()
-            .find_map(|(i, pair)| {
-                let [from, to] = *pair else { unreachable!() };
-                // The cursor must be somewhere between both matches.
-                if Range::new(from.from(), to.to()).overlaps(&selection.primary()) {
-                    Some(i * 2)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(0);
-        doc.set_selection(view.id, Selection::new(ranges, primary_index));
+        doc.set_selection(
+            view.id,
+            Selection::new(ranges, selection.primary_index() * 2),
+        );
 
         cx.on_next_key(move |cx, event| {
             let (view, doc) = current!(cx.editor);


### PR DESCRIPTION
When the target character is pressed, the selection is temporarily updated to display the affected positions. It restores the original selection after the operation is cancelled or completed.