### PR TITLE
Unify logging and expand its documentation in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,10 +6,6 @@ Some suggestions to get started:
 
 - You can look at the [good first issue][good-first-issue] label on the issue tracker.
 - Help with packaging on various distributions needed!
-- To use print debugging to the [Helix log file][log-file], you must:
-  * Print using `log::info!`, `warn!`, or `error!`. (`log::info!("helix!")`)
-  * Pass the appropriate verbosity level option for the desired log level. (`hx -v <file>` for info, more `v`s for higher verbosity)
-  * Want to display the logs in a separate file instead of using the `:log-open` command in your compiled Helix editor? Start your debug version with `cargo run -- --log foo.log` and in a new terminal use `tail -f foo.log`
 - Instead of running a release version of Helix, while developing you may want to run in debug mode with `cargo run` which is way faster to compile
 - Looking for even faster compile times? Give a try to [mold](https://github.com/rui314/mold)
 - If your preferred language is missing, integrating a tree-sitter grammar for
@@ -18,6 +14,29 @@ Some suggestions to get started:
 
 We provide an [architecture.md][architecture.md] that should give you
 a good overview of the internals.
+
+## Logging
+
+To use print debugging to the [Helix log file][log-file], you must:
+1. Emit log events by calling `log::<event>!()`, e.g. `log::info!("{}", x)`.
+2. Set the log level before starting Helix. This can be done by passing the -v flag where more `v`'s imply a higher verbosity level, e.g. `hx -vvv`. The `HELIX_LOG_LEVEL` env variable can alternatively be set to override any defaults/provided verbosity flags.
+
+| `log::<event>!` | Number of `v`s in CLI command | `$HELIX_LOG_LEVEL` |
+| ---             | ---                           | ---                |
+| -               | -                             | "OFF"              |
+| `error!`        | 0                             | "ERROR"            |
+| `warn!`         | 0                             | "WARN"             |
+| `info!`         | 1                             | "INFO"             |
+| `debug!`        | 2                             | "DEBUG"            |
+| `trace!`        | > 3                           | "TRACE"            |
+
+Logs can then be viewed by opening the log file from helix with `:log-open`. It is also possible to output the log contents directly to the `std out` by running something akin to:
+
+```bash
+  cargo run -- --log foo.log
+  # And in another terminal
+  tail --follow foo.log
+```
 
 # Auto generated documentation
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -77,7 +77,9 @@ impl Application {
         syn_loader_conf: syntax::Configuration,
     ) -> Result<Self, Error> {
         #[cfg(feature = "integration")]
-        crate::log::setup_logging(std::io::stdout(), None).unwrap();
+        // Unwrap will be error error if logging system has been
+        // initialized by another test.
+        let _ = crate::log::setup_logging(std::io::stdout(), None);
 
         use helix_view::editor::Action;
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -33,7 +33,10 @@ use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 
 use anyhow::{Context, Error};
 
-use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
+use crossterm::{
+    event::{Event as CrosstermEvent, EventStream},
+    tty::IsTty,
+};
 #[cfg(not(windows))]
 use {signal_hook::consts::signal, signal_hook_tokio::Signals};
 #[cfg(windows)]
@@ -1094,10 +1097,7 @@ impl Application {
         self.terminal.restore(terminal_config)
     }
 
-    pub async fn run<S>(&mut self, input_stream: &mut S) -> Result<i32, Error>
-    where
-        S: Stream<Item = crossterm::Result<crossterm::event::Event>> + Unpin,
-    {
+    pub async fn run(&mut self) -> Result<i32, Error> {
         self.claim_term().await?;
 
         // Exit the alternate screen and disable raw mode before panicking
@@ -1110,7 +1110,7 @@ impl Application {
             hook(info);
         }));
 
-        self.event_loop(input_stream).await;
+        self.event_loop(&mut EventStream::new()).await;
 
         let close_errs = self.close().await;
 

--- a/helix-term/src/help.rs
+++ b/helix-term/src/help.rs
@@ -1,0 +1,38 @@
+use helix_loader::VERSION_AND_GIT_HASH;
+use once_cell::sync::Lazy;
+
+pub static HELP_MESSAGE: Lazy<String> = Lazy::new(|| {
+    format!(
+        "\
+{} {}
+{}
+{}
+
+USAGE:
+    hx [FLAGS] [files]...
+
+ARGS:
+    <files>...    Sets the input file to use, position can also be specified via file[:row[:col]]
+
+FLAGS:
+    -h, --help                     Prints help information
+    --tutor                        Loads the tutorial
+    --health [CATEGORY]            Checks for potential errors in editor setup
+                                   CATEGORY can be a language or one of 'clipboard', 'languages'
+                                   or 'all'. 'all' is the default if not specified.
+    -g, --grammar {{fetch|build}}    Fetches or builds tree-sitter grammars listed in languages.toml
+    -c, --config <file>            Specifies a file to use for configuration
+    -v                             Increases logging verbosity each use for up to 3 times
+    --log <file>                   Specifies a file to use for logging
+                                   (default file: {})
+    -V, --version                  Prints version information
+    --vsplit                       Splits all given files vertically into different windows
+    --hsplit                       Splits all given files horizontally into different windows
+",
+        env!("CARGO_PKG_NAME"),
+        VERSION_AND_GIT_HASH,
+        env!("CARGO_PKG_AUTHORS"),
+        env!("CARGO_PKG_DESCRIPTION"),
+        helix_loader::default_log_file().display(),
+    )
+});

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod compositor;
 pub mod config;
 pub mod health;
+pub mod help;
 pub mod job;
 pub mod keymap;
 pub mod ui;

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod help;
 pub mod job;
 pub mod keymap;
+pub mod log;
 pub mod ui;
 use std::path::Path;
 

--- a/helix-term/src/log.rs
+++ b/helix-term/src/log.rs
@@ -1,0 +1,43 @@
+use anyhow::anyhow;
+use log::LevelFilter;
+
+pub fn setup_logging<T: Into<fern::Output>>(
+    output: T,
+    verbosity: Option<u64>,
+) -> anyhow::Result<()> {
+    fern::Dispatch::new()
+        .level(get_log_level(verbosity)?)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{} {} [{}] {}",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .chain(output)
+        .apply()
+        .map_err(|error| anyhow!(error))
+}
+
+fn get_log_level(verbosity: Option<u64>) -> anyhow::Result<LevelFilter> {
+    if let Ok(env_log_level) = std::env::var("HELIX_LOG_LEVEL") {
+        return env_log_level
+            .parse::<LevelFilter>()
+            .map_err(|error| anyhow!(error));
+    }
+
+    if let Some(verbosity) = verbosity {
+        let log_level = match verbosity {
+            0 => LevelFilter::Warn,
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
+            _3_or_more => LevelFilter::Trace,
+        };
+
+        Ok(log_level)
+    } else {
+        Ok(LevelFilter::Info)
+    }
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Error, Result};
-use crossterm::event::EventStream;
 use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
@@ -81,6 +80,6 @@ async fn main() -> Result<()> {
     let mut app = Application::new(args, config, syn_loader_conf)
         .context("unable to create new application")?;
 
-    let exit_code = app.run(&mut EventStream::new()).await?;
+    let exit_code = app.run().await?;
     std::process::exit(exit_code)
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -7,13 +7,8 @@ use helix_term::config::{Config, ConfigLoadError};
 use helix_term::help::HELP_MESSAGE;
 use helix_term::log::setup_logging;
 
-fn main() -> Result<()> {
-    let exit_code = main_impl()?;
-    std::process::exit(exit_code);
-}
-
 #[tokio::main]
-async fn main_impl() -> Result<i32> {
+async fn main() -> Result<()> {
     let args = Args::parse_args().context("could not parse arguments")?;
 
     helix_loader::initialize_config_file(args.config_file.clone());
@@ -44,12 +39,12 @@ async fn main_impl() -> Result<i32> {
 
     if args.fetch_grammars {
         helix_loader::grammar::fetch_grammars()?;
-        return Ok(0);
+        std::process::exit(0);
     }
 
     if args.build_grammars {
         helix_loader::grammar::build_grammars(None)?;
-        return Ok(0);
+        std::process::exit(0);
     }
 
     setup_logging(
@@ -87,6 +82,5 @@ async fn main_impl() -> Result<i32> {
         .context("unable to create new application")?;
 
     let exit_code = app.run(&mut EventStream::new()).await?;
-
-    Ok(exit_code)
+    std::process::exit(exit_code)
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -4,6 +4,7 @@ use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
 use helix_term::config::{Config, ConfigLoadError};
+use helix_term::help::HELP_MESSAGE;
 
 fn setup_logging(verbosity: u64) -> Result<()> {
     let mut base_config = fern::Dispatch::new();
@@ -40,40 +41,6 @@ fn main() -> Result<()> {
 
 #[tokio::main]
 async fn main_impl() -> Result<i32> {
-    let help = format!(
-        "\
-{} {}
-{}
-{}
-
-USAGE:
-    hx [FLAGS] [files]...
-
-ARGS:
-    <files>...    Sets the input file to use, position can also be specified via file[:row[:col]]
-
-FLAGS:
-    -h, --help                     Prints help information
-    --tutor                        Loads the tutorial
-    --health [CATEGORY]            Checks for potential errors in editor setup
-                                   CATEGORY can be a language or one of 'clipboard', 'languages'
-                                   or 'all'. 'all' is the default if not specified.
-    -g, --grammar {{fetch|build}}    Fetches or builds tree-sitter grammars listed in languages.toml
-    -c, --config <file>            Specifies a file to use for configuration
-    -v                             Increases logging verbosity each use for up to 3 times
-    --log <file>                   Specifies a file to use for logging
-                                   (default file: {})
-    -V, --version                  Prints version information
-    --vsplit                       Splits all given files vertically into different windows
-    --hsplit                       Splits all given files horizontally into different windows
-",
-        env!("CARGO_PKG_NAME"),
-        VERSION_AND_GIT_HASH,
-        env!("CARGO_PKG_AUTHORS"),
-        env!("CARGO_PKG_DESCRIPTION"),
-        helix_loader::default_log_file().display(),
-    );
-
     let args = Args::parse_args().context("could not parse arguments")?;
 
     helix_loader::initialize_config_file(args.config_file.clone());
@@ -81,7 +48,7 @@ FLAGS:
 
     // Help has a higher priority and should be handled separately.
     if args.display_help {
-        print!("{}", help);
+        print!("{}", *HELP_MESSAGE);
         std::process::exit(0);
     }
 


### PR DESCRIPTION
Makes it also possible to provide the `HELIX_LOG_LEVEL` env var that was previously only available in the integration test suite. Also did some minor clean up in main.rs if that's ok.