### PR TITLE
Register systemd files as ini

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2233,7 +2233,26 @@ grammar = "bash"
 [[language]]
 name = "ini"
 scope = "source.ini"
-file-types = ["ini"]
+file-types = [
+  "ini",
+  # Systemd unit files
+  "service",
+  "automount",
+  "device",
+  "mount",
+  "path",
+  "service",
+  "slice",
+  "socket",
+  "swap",
+  "target",
+  "timer",
+  # Podman quadlets
+  "container",
+  "volume",
+  "kube",
+  "network"
+]
 injection-regex = "ini"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
Howdy yall,
I edit a lot of systemd files, which are the INI format, and upon opening helix I constantly have to `:set-language`. I was wondering if it would be okay to add them to the ini file types.
- [Systemd unit files](https://www.man7.org/linux/man-pages/man5/systemd.unit.5.html)
- [Podman quadlet systemd units](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)