### PR TITLE
Remove unused items.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,10 +6,6 @@ Some suggestions to get started:
 
 - You can look at the [good first issue][good-first-issue] label on the issue tracker.
 - Help with packaging on various distributions needed!
-- To use print debugging to the [Helix log file][log-file], you must:
-  * Print using `log::info!`, `warn!`, or `error!`. (`log::info!("helix!")`)
-  * Pass the appropriate verbosity level option for the desired log level. (`hx -v <file>` for info, more `v`s for higher verbosity)
-  * Want to display the logs in a separate file instead of using the `:log-open` command in your compiled Helix editor? Start your debug version with `cargo run -- --log foo.log` and in a new terminal use `tail -f foo.log`
 - Instead of running a release version of Helix, while developing you may want to run in debug mode with `cargo run` which is way faster to compile
 - Looking for even faster compile times? Give a try to [mold](https://github.com/rui314/mold)
 - If your preferred language is missing, integrating a tree-sitter grammar for
@@ -18,6 +14,29 @@ Some suggestions to get started:
 
 We provide an [architecture.md][architecture.md] that should give you
 a good overview of the internals.
+
+## Logging
+
+To use print debugging to the [Helix log file][log-file], you must:
+1. Emit log events by calling `log::<event>!()`, e.g. `log::info!("{}", x)`.
+2. Set the log level before starting Helix. This can be done by passing the -v flag where more `v`'s imply a higher verbosity level, e.g. `hx -vvv`. The `HELIX_LOG_LEVEL` env variable can alternatively be set to override any defaults/provided verbosity flags.
+
+| `log::<event>!` | Number of `v`s in CLI command | `$HELIX_LOG_LEVEL` |
+| ---             | ---                           | ---                |
+| -               | -                             | "OFF"              |
+| `error!`        | 0                             | "ERROR"            |
+| `warn!`         | 0                             | "WARN"             |
+| `info!`         | 1                             | "INFO"             |
+| `debug!`        | 2                             | "DEBUG"            |
+| `trace!`        | > 3                           | "TRACE"            |
+
+Logs can then be viewed by opening the log file from helix with `:log-open`. It is also possible to output the log contents directly to the `std out` by running something akin to:
+
+```bash
+  cargo run -- --log foo.log
+  # And in another terminal
+  tail --follow foo.log
+```
 
 # Auto generated documentation
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -77,7 +77,9 @@ impl Application {
         syn_loader_conf: syntax::Configuration,
     ) -> Result<Self, Error> {
         #[cfg(feature = "integration")]
-        crate::log::setup_logging(std::io::stdout(), None).unwrap();
+        // Unwrap will be error error if logging system has been
+        // initialized by another test.
+        let _ = crate::log::setup_logging(std::io::stdout(), None);
 
         use helix_view::editor::Action;
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -463,7 +463,7 @@ impl Application {
                 // https://github.com/neovim/neovim/issues/12322
                 // https://github.com/neovim/neovim/pull/13084
                 for retries in 1..=10 {
-                    match self.claim_term().await {
+                    match self.claim_term() {
                         Ok(()) => break,
                         Err(err) if retries == 10 => panic!("Failed to claim terminal: {}", err),
                         Err(_) => continue,
@@ -1082,7 +1082,7 @@ impl Application {
         }
     }
 
-    async fn claim_term(&mut self) -> std::io::Result<()> {
+    fn claim_term(&mut self) -> std::io::Result<()> {
         let terminal_config = self.config.load().editor.clone().into();
         self.terminal.claim(terminal_config)
     }
@@ -1098,7 +1098,7 @@ impl Application {
     }
 
     pub async fn run(&mut self) -> Result<i32, Error> {
-        self.claim_term().await?;
+        self.claim_term()?;
 
         // Exit the alternate screen and disable raw mode before panicking
         let hook = std::panic::take_hook();

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -28,6 +28,7 @@ use crate::{
     ui::{self, overlay::overlaid},
 };
 
+use core::panic;
 use log::{debug, error, warn};
 use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 
@@ -1101,13 +1102,12 @@ impl Application {
         self.claim_term()?;
 
         // Exit the alternate screen and disable raw mode before panicking
-        let hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             // We can't handle errors properly inside this closure.  And it's
             // probably not a good idea to `unwrap()` inside a panic handler.
             // So we just ignore the `Result`.
             let _ = TerminalBackend::force_restore();
-            hook(info);
+            std::panic::take_hook()(info);
         }));
 
         self.event_loop(&mut EventStream::new()).await;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -33,7 +33,10 @@ use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 
 use anyhow::{Context, Error};
 
-use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
+use crossterm::{
+    event::{Event as CrosstermEvent, EventStream},
+    tty::IsTty,
+};
 #[cfg(not(windows))]
 use {signal_hook::consts::signal, signal_hook_tokio::Signals};
 #[cfg(windows)]
@@ -1094,10 +1097,7 @@ impl Application {
         self.terminal.restore(terminal_config)
     }
 
-    pub async fn run<S>(&mut self, input_stream: &mut S) -> Result<i32, Error>
-    where
-        S: Stream<Item = crossterm::Result<crossterm::event::Event>> + Unpin,
-    {
+    pub async fn run(&mut self) -> Result<i32, Error> {
         self.claim_term().await?;
 
         // Exit the alternate screen and disable raw mode before panicking
@@ -1110,7 +1110,7 @@ impl Application {
             hook(info);
         }));
 
-        self.event_loop(input_stream).await;
+        self.event_loop(&mut EventStream::new()).await;
 
         let close_errs = self.close().await;
 

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -43,11 +43,6 @@ pub trait Component: Any + AnyComponent {
     }
     // , args: ()
 
-    /// Should redraw? Useful for saving redraw cycles if we know component didn't change.
-    fn should_update(&self) -> bool {
-        true
-    }
-
     /// Render the component onto the provided surface.
     fn render(&mut self, area: Rect, frame: &mut Surface, ctx: &mut Context);
 

--- a/helix-term/src/help.rs
+++ b/helix-term/src/help.rs
@@ -1,0 +1,38 @@
+use helix_loader::VERSION_AND_GIT_HASH;
+use once_cell::sync::Lazy;
+
+pub static HELP_MESSAGE: Lazy<String> = Lazy::new(|| {
+    format!(
+        "\
+{} {}
+{}
+{}
+
+USAGE:
+    hx [FLAGS] [files]...
+
+ARGS:
+    <files>...    Sets the input file to use, position can also be specified via file[:row[:col]]
+
+FLAGS:
+    -h, --help                     Prints help information
+    --tutor                        Loads the tutorial
+    --health [CATEGORY]            Checks for potential errors in editor setup
+                                   CATEGORY can be a language or one of 'clipboard', 'languages'
+                                   or 'all'. 'all' is the default if not specified.
+    -g, --grammar {{fetch|build}}    Fetches or builds tree-sitter grammars listed in languages.toml
+    -c, --config <file>            Specifies a file to use for configuration
+    -v                             Increases logging verbosity each use for up to 3 times
+    --log <file>                   Specifies a file to use for logging
+                                   (default file: {})
+    -V, --version                  Prints version information
+    --vsplit                       Splits all given files vertically into different windows
+    --hsplit                       Splits all given files horizontally into different windows
+",
+        env!("CARGO_PKG_NAME"),
+        VERSION_AND_GIT_HASH,
+        env!("CARGO_PKG_AUTHORS"),
+        env!("CARGO_PKG_DESCRIPTION"),
+        helix_loader::default_log_file().display(),
+    )
+});

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -85,13 +85,6 @@ impl Jobs {
         }
     }
 
-    pub async fn next_job(&mut self) -> Option<anyhow::Result<Option<Callback>>> {
-        tokio::select! {
-            event = self.futures.next() => {  event }
-            event = self.wait_futures.next() => { event }
-        }
-    }
-
     pub fn add(&self, j: Job) {
         if j.wait {
             self.wait_futures.push(j.future);

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -56,10 +56,6 @@ impl Jobs {
         Self::default()
     }
 
-    pub fn spawn<F: Future<Output = anyhow::Result<()>> + Send + 'static>(&mut self, f: F) {
-        self.add(Job::new(f));
-    }
-
     pub fn callback<F: Future<Output = anyhow::Result<Callback>> + Send + 'static>(
         &mut self,
         f: F,

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod compositor;
 pub mod config;
 pub mod health;
+pub mod help;
 pub mod job;
 pub mod keymap;
 pub mod ui;

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod help;
 pub mod job;
 pub mod keymap;
+pub mod log;
 pub mod ui;
 use std::path::Path;
 

--- a/helix-term/src/log.rs
+++ b/helix-term/src/log.rs
@@ -1,0 +1,43 @@
+use anyhow::anyhow;
+use log::LevelFilter;
+
+pub fn setup_logging<T: Into<fern::Output>>(
+    output: T,
+    verbosity: Option<u64>,
+) -> anyhow::Result<()> {
+    fern::Dispatch::new()
+        .level(get_log_level(verbosity)?)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{} {} [{}] {}",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .chain(output)
+        .apply()
+        .map_err(|error| anyhow!(error))
+}
+
+fn get_log_level(verbosity: Option<u64>) -> anyhow::Result<LevelFilter> {
+    if let Ok(env_log_level) = std::env::var("HELIX_LOG_LEVEL") {
+        return env_log_level
+            .parse::<LevelFilter>()
+            .map_err(|error| anyhow!(error));
+    }
+
+    if let Some(verbosity) = verbosity {
+        let log_level = match verbosity {
+            0 => LevelFilter::Warn,
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
+            _3_or_more => LevelFilter::Trace,
+        };
+
+        Ok(log_level)
+    } else {
+        Ok(LevelFilter::Info)
+    }
+}

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Error, Result};
-use crossterm::event::EventStream;
 use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
@@ -81,6 +80,6 @@ async fn main() -> Result<()> {
     let mut app = Application::new(args, config, syn_loader_conf)
         .context("unable to create new application")?;
 
-    let exit_code = app.run(&mut EventStream::new()).await?;
+    let exit_code = app.run().await?;
     std::process::exit(exit_code)
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -7,13 +7,8 @@ use helix_term::config::{Config, ConfigLoadError};
 use helix_term::help::HELP_MESSAGE;
 use helix_term::log::setup_logging;
 
-fn main() -> Result<()> {
-    let exit_code = main_impl()?;
-    std::process::exit(exit_code);
-}
-
 #[tokio::main]
-async fn main_impl() -> Result<i32> {
+async fn main() -> Result<()> {
     let args = Args::parse_args().context("could not parse arguments")?;
 
     helix_loader::initialize_config_file(args.config_file.clone());
@@ -44,12 +39,12 @@ async fn main_impl() -> Result<i32> {
 
     if args.fetch_grammars {
         helix_loader::grammar::fetch_grammars()?;
-        return Ok(0);
+        std::process::exit(0);
     }
 
     if args.build_grammars {
         helix_loader::grammar::build_grammars(None)?;
-        return Ok(0);
+        std::process::exit(0);
     }
 
     setup_logging(
@@ -87,6 +82,5 @@ async fn main_impl() -> Result<i32> {
         .context("unable to create new application")?;
 
     let exit_code = app.run(&mut EventStream::new()).await?;
-
-    Ok(exit_code)
+    std::process::exit(exit_code)
 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -4,6 +4,7 @@ use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
 use helix_term::config::{Config, ConfigLoadError};
+use helix_term::help::HELP_MESSAGE;
 
 fn setup_logging(verbosity: u64) -> Result<()> {
     let mut base_config = fern::Dispatch::new();
@@ -40,40 +41,6 @@ fn main() -> Result<()> {
 
 #[tokio::main]
 async fn main_impl() -> Result<i32> {
-    let help = format!(
-        "\
-{} {}
-{}
-{}
-
-USAGE:
-    hx [FLAGS] [files]...
-
-ARGS:
-    <files>...    Sets the input file to use, position can also be specified via file[:row[:col]]
-
-FLAGS:
-    -h, --help                     Prints help information
-    --tutor                        Loads the tutorial
-    --health [CATEGORY]            Checks for potential errors in editor setup
-                                   CATEGORY can be a language or one of 'clipboard', 'languages'
-                                   or 'all'. 'all' is the default if not specified.
-    -g, --grammar {{fetch|build}}    Fetches or builds tree-sitter grammars listed in languages.toml
-    -c, --config <file>            Specifies a file to use for configuration
-    -v                             Increases logging verbosity each use for up to 3 times
-    --log <file>                   Specifies a file to use for logging
-                                   (default file: {})
-    -V, --version                  Prints version information
-    --vsplit                       Splits all given files vertically into different windows
-    --hsplit                       Splits all given files horizontally into different windows
-",
-        env!("CARGO_PKG_NAME"),
-        VERSION_AND_GIT_HASH,
-        env!("CARGO_PKG_AUTHORS"),
-        env!("CARGO_PKG_DESCRIPTION"),
-        helix_loader::default_log_file().display(),
-    );
-
     let args = Args::parse_args().context("could not parse arguments")?;
 
     helix_loader::initialize_config_file(args.config_file.clone());
@@ -81,7 +48,7 @@ FLAGS:
 
     // Help has a higher priority and should be handled separately.
     if args.display_help {
-        print!("{}", help);
+        print!("{}", *HELP_MESSAGE);
         std::process::exit(0);
     }
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -19,9 +19,6 @@ use helix_lsp::{lsp, util, OffsetEncoding};
 
 impl menu::Item for CompletionItem {
     type Data = ();
-    fn sort_text(&self, data: &Self::Data) -> Cow<str> {
-        self.filter_text(data)
-    }
 
     #[inline]
     fn filter_text(&self, _data: &Self::Data) -> Cow<str> {

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -20,11 +20,6 @@ pub trait Item {
 
     fn format(&self, data: &Self::Data) -> Row;
 
-    fn sort_text(&self, data: &Self::Data) -> Cow<str> {
-        let label: String = self.format(data).cell_text().collect();
-        label.into()
-    }
-
     fn filter_text(&self, data: &Self::Data) -> Cow<str> {
         let label: String = self.format(data).cell_text().collect();
         label.into()

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -266,7 +266,7 @@ impl<T: Item + 'static> Picker<T> {
             // then we can score the filtered set.
             self.matches.retain_mut(|pmatch| {
                 let option = &self.options[pmatch.index];
-                let text = option.sort_text(&self.editor_data);
+                let text = option.filter_text(&self.editor_data);
 
                 match query.fuzzy_match(&text, &self.matcher) {
                     Some(s) => {


### PR DESCRIPTION
I'm trying to understand how application rendering works and noticed that there were some items that were not being utilized in practice.

This search wasn't systematic, in the sense that there is probably more dead code present that hasn't caught by clippy.
Finding the rest would require the use of less liberal visibility constraints, but that would require large codebase refactors that aren't really viable right now.

PR depends on https://github.com/helix-editor/helix/pull/7591. I could, if asked for, cherry-pick out the commits to master resolve the conflicts.