### PR TITLE
Use `std::io::IsTerminal` (stabilized in 1.70) over `crossterm` implementation.

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -31,14 +31,14 @@ use crate::{
 use log::{debug, error, warn};
 use std::{
     collections::btree_map::Entry,
-    io::{stdin, stdout},
+    io::{stdin, stdout, IsTerminal},
     path::Path,
     sync::Arc,
 };
 
 use anyhow::{Context, Error};
 
-use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
+use crossterm::event::Event as CrosstermEvent;
 #[cfg(not(windows))]
 use {signal_hook::consts::signal, signal_hook_tokio::Signals};
 #[cfg(windows)]
@@ -209,7 +209,7 @@ impl Application {
                 let (view, doc) = current!(editor);
                 align_view(doc, view, Align::Center);
             }
-        } else if stdin().is_tty() || cfg!(feature = "integration") {
+        } else if stdin().is_terminal() || cfg!(feature = "integration") {
             editor.new_file(Action::VerticalSplit);
         } else if cfg!(target_os = "macos") {
             // On Linux and Windows, we allow the output of a command to be piped into the new buffer.

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -1,11 +1,10 @@
 use crossterm::{
     style::{Color, Print, Stylize},
-    tty::IsTty,
 };
 use helix_core::config::{default_syntax_loader, user_syntax_loader};
 use helix_loader::grammar::load_runtime_file;
 use helix_view::clipboard::get_clipboard_provider;
-use std::io::Write;
+use std::io::{Write, IsTerminal};
 
 #[derive(Copy, Clone)]
 pub enum TsFeature {
@@ -153,7 +152,7 @@ pub fn languages_all() -> std::io::Result<()> {
 
     let terminal_cols = crossterm::terminal::size().map(|(c, _)| c).unwrap_or(80);
     let column_width = terminal_cols as usize / headings.len();
-    let is_terminal = std::io::stdout().is_tty();
+    let is_terminal = std::io::stdout().is_terminal();
 
     let column = |item: &str, color: Color| {
         let mut data = format!(

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -1,10 +1,8 @@
-use crossterm::{
-    style::{Color, Print, Stylize},
-};
+use crossterm::style::{Color, Print, Stylize};
 use helix_core::config::{default_syntax_loader, user_syntax_loader};
 use helix_loader::grammar::load_runtime_file;
 use helix_view::clipboard::get_clipboard_provider;
-use std::io::{Write, IsTerminal};
+use std::io::{IsTerminal, Write};
 
 #[derive(Copy, Clone)]
 pub enum TsFeature {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -704,7 +704,7 @@ pub struct WhitespaceCharacters {
 impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
-            space: '·',    // U+00B7
+            space: '·',   // U+00B7
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE
@@ -732,12 +732,13 @@ impl Default for IndentGuidesConfig {
 }
 
 /// Line ending configuration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LineEndingConfig {
     /// The platform's native line ending.
     ///
     /// `crlf` on Windows, otherwise `lf`.
+    #[default]
     Native,
     /// Line feed.
     LF,
@@ -752,12 +753,6 @@ pub enum LineEndingConfig {
     /// Next line.
     #[cfg(feature = "unicode-lines")]
     Nel,
-}
-
-impl Default for LineEndingConfig {
-    fn default() -> Self {
-        LineEndingConfig::Native
-    }
 }
 
 impl From<LineEndingConfig> for LineEnding {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.70.0"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
https://github.com/crossterm-rs/crossterm/pull/794