### PR TITLE
Add cargo feature that enables piping on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
+ "filedescriptor",
  "futures-core",
  "libc",
  "mio",
@@ -425,6 +426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -17,6 +17,7 @@ default = ["git"]
 unicode-lines = ["helix-core/unicode-lines"]
 integration = []
 git = ["helix-vcs/git"]
+macos-piping = ["crossterm/use-dev-tty"]
 
 [[bin]]
 name = "hx"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -211,7 +211,7 @@ impl Application {
             }
         } else if stdin().is_tty() || cfg!(feature = "integration") {
             editor.new_file(Action::VerticalSplit);
-        } else if cfg!(target_os = "macos") {
+        } else if cfg!(target_os = "macos") && !cfg!(feature = "macos-piping") {
             // On Linux and Windows, we allow the output of a command to be piped into the new buffer.
             // This doesn't currently work on macOS because of the following issue:
             //   https://github.com/crossterm-rs/crossterm/issues/500


### PR DESCRIPTION
Follow up to #5468. 

Since there have been understandable performance concerns around the tty polling implementation in the `crossterm` feature that enables piping on macos (https://github.com/crossterm-rs/crossterm/pull/735), this PR adds a feature flag to selectively enable this, so that we can conditionally compile it only for macos targets.