### PR TITLE
Change dark_plus inlay-hints colors to more pleasant colors

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -89,7 +89,7 @@
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
 "ui.virtual.indent-guide" = { fg = "dark_gray4" }
-"ui.virtual.inlay-hint" = { fg = "dark_gray"}
+"ui.virtual.inlay-hint" = { fg = "dark_gray5"}
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }
@@ -114,6 +114,7 @@ dark_gray = "#858585"
 dark_gray2 = "#1e1e1e"
 dark_gray3 = "#282828"
 dark_gray4 = "#404040"
+dark_gray5 = "#8b949e"
 blue = "#007acc"
 blue2 = "#569CD6"
 blue3 = "#6796E6"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -89,7 +89,7 @@
 "ui.virtual.whitespace" = { fg = "dark_gray" }
 "ui.virtual.ruler" = { bg = "borders" }
 "ui.virtual.indent-guide" = { fg = "dark_gray4" }
-"ui.virtual.inlay-hint" = { fg = "white", bg = "#444444" }
+"ui.virtual.inlay-hint" = { fg = "dark_gray"}
 
 "warning" = { fg = "gold2" }
 "error" = { fg = "red" }


### PR DESCRIPTION
A little change to the `dark_plus` theme.

- Before:
![2023-07-12T17:48:17,965895541+01:00](https://github.com/helix-editor/helix/assets/73954836/0501a6a4-8144-4842-baeb-53f9afec2f5b)

- After:
![2023-07-12T17:48:02,745411692+01:00](https://github.com/helix-editor/helix/assets/73954836/63ea37cf-35ff-4804-baa5-affa2d769fe4)
