### PR TITLE
Add a more file types for R

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1324,7 +1324,7 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-git-rebase", rev 
 name = "regex"
 scope = "source.regex"
 injection-regex = "regex"
-file-types = ["regex"]
+file-types = ["regex", ".Rbuildignore"]
 roots = []
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -715,7 +715,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-ruby", rev = "206c7
 name = "bash"
 scope = "source.bash"
 injection-regex = "(shell|bash|zsh|sh)"
-file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", ".zimrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild", "bazelrc", ".bash_aliases"]
+file-types = ["sh", "bash", "zsh", ".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile", ".zshenv", ".zlogin", ".zlogout", ".zprofile", ".zshrc", ".zimrc", "APKBUILD", "PKGBUILD", "eclass", "ebuild", "bazelrc", ".bash_aliases", "Renviron", ".Renviron"]
 shebangs = ["sh", "bash", "dash", "zsh"]
 roots = []
 comment-token = "#"
@@ -756,7 +756,7 @@ source = { git = "https://github.com/gbprod/tree-sitter-twig", rev = "807b293fec
 name = "latex"
 scope = "source.tex"
 injection-regex = "tex"
-file-types = ["tex", "sty", "cls"]
+file-types = ["tex", "sty", "cls", "Rd"]
 roots = []
 comment-token = "%"
 language-servers = [ "texlab" ]
@@ -1555,7 +1555,7 @@ source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "f1142bfaa6
 name = "r"
 scope = "source.r"
 injection-regex = "(r|R)"
-file-types = ["r", "R"]
+file-types = ["r", "R", ".Rprofile", "Rprofile.site"]
 shebangs = ["r", "R"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
Registers extra R ecosystem files

- `.Rprofile` & `Rprofile.site` files, which are configured in R
- `Renviron` & `.Renviron` files, which are [GNU configuration files](https://www.gnu.org/prep/standards/html_node/Configuration.html), a syntax that is a subset of the existing `bash` syntax
- `Rd` documentation files, which use `infotex`, a subset of LaTeX
- `.Rbuildignore` (sort of like a `.gitignore` for R packages), which is defined as `regex`s

Quite a few files in the R ecosystem use the Debian Control File (DCF) format, but there isn't an existing language to couple that to, so I'll leave that for a separate PR.

(using [R administration guide as reference](https://cran.r-project.org/doc/manuals/R-admin.html))