### PR TITLE
Always visible statusline (under prompt)

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -84,18 +84,20 @@ separator = "│"
 mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
+under-prompt = true
 ```
 The `[editor.statusline]` key takes the following sub-keys:
 
-| Key           | Description | Default |
-| ---           | ---         | ---     |
-| `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name"]` |
-| `center`      | A list of elements aligned to the middle of the statusline | `[]` |
-| `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "position", "file-encoding"]` |
-| `separator`   | The character used to separate elements in the statusline | `"│"` |
-| `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
-| `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |
-| `mode.select` | The text shown in the `mode` element for select mode | `"SEL"` |
+| Key            | Description | Default |
+| ---            | ---         | ---     |
+| `left`         | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name"]` |
+| `center`       | A list of elements aligned to the middle of the statusline | `[]` |
+| `right`        | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "position", "file-encoding"]` |
+| `separator`    | The character used to separate elements in the statusline | `"│"` |
+| `mode.normal`  | The text shown in the `mode` element for normal mode | `"NOR"` |
+| `mode.insert`  | The text shown in the `mode` element for insert mode | `"INS"` |
+| `mode.select`  | The text shown in the `mode` element for select mode | `"SEL"` |
+| `under-prompt` | Whether the statusline is below the prompt when it appears (so it is always visible) | `false` |
 
 The following statusline elements can be configured:
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -212,11 +212,17 @@ impl EditorView {
 
         Self::render_diagnostics(doc, view, inner, surface, theme);
 
-        let statusline_area = view
-            .area
-            .clip_top(view.area.height.saturating_sub(1))
-            .clip_bottom(1); // -1 from bottom to remove commandline
-
+        // if we're not at the bottom of the screen, draw the statusline higher, otherwise
+        // it'll overlap with the next view
+        let statusline_area = if editor.config().statusline.under_prompt == true
+            && (viewport.bottom() - 1) == view.area.bottom()
+        {
+            view.area.clip_top(view.area.height)
+        } else {
+            view.area
+                .clip_top(view.area.height.saturating_sub(1))
+                .clip_bottom(1)
+        };
         let mut context =
             statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
 
@@ -1434,7 +1440,10 @@ impl Component for EditorView {
 
             surface.set_string(
                 area.x,
-                area.y + area.height.saturating_sub(1),
+                area.y
+                    + area
+                        .height
+                        .saturating_sub(cx.editor.config().statusline.under_prompt as u16 + 1),
                 status_msg,
                 style,
             );

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -375,7 +375,8 @@ impl Prompt {
 
         let completion_area = Rect::new(
             area.x,
-            (area.height - height).saturating_sub(1),
+            (area.height - height)
+                .saturating_sub(cx.editor.config().statusline.under_prompt as u16 + 1),
             area.width,
             height,
         );
@@ -450,7 +451,9 @@ impl Prompt {
             text.render(inner, surface, cx);
         }
 
-        let line = area.height - 1;
+        let line = area
+            .height
+            .saturating_sub(cx.editor.config().statusline.under_prompt as u16 + 1);
         // render buffer text
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
@@ -652,7 +655,8 @@ impl Component for Prompt {
     }
 
     fn cursor(&self, area: Rect, _editor: &Editor) -> (Option<Position>, CursorKind) {
-        let line = area.height as usize - 1;
+        let line = (area.height as usize)
+            .saturating_sub(_editor.config().statusline.under_prompt as usize + 1);
         (
             Some(Position::new(
                 area.y as usize + line,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -393,6 +393,8 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    // TODO name suggestions? always_visible?
+    pub under_prompt: bool,
 }
 
 impl Default for StatusLineConfig {
@@ -416,6 +418,7 @@ impl Default for StatusLineConfig {
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            under_prompt: false,
         }
     }
 }


### PR DESCRIPTION
Closes #5758
This PR is a duplicate of #5882 , but not stale.

For now, I quickly fixed it with a non-ideal config name and a strange code style that might be better commented out or simplified.
In #5882 I read that some want it to be a configurable option, some want a permanent layout. So I need to hear the "final" decision from the boss :smiley: 

Demo: https://asciinema.org/a/M3np9Q5K6c9OtShFhadtPASjT

TODO:
- [ ] Choose a better name (always-visible?)
- [ ] Default option true/false?
- [ ] More understandable code (is it understandable without comments? should I add comments? )
- [ ] Rework tests if these changes affect some