### PR TITLE
proposal: support matching inside string literals

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -117,9 +117,6 @@ fn find_pair(
         node = parent;
     }
     let node = tree.root_node().named_descendant_for_byte_range(pos, pos)?;
-    if node.child_count() != 0 {
-        return None;
-    }
     let node_start = doc.byte_to_char(node.start_byte());
     find_matching_bracket_plaintext(doc.byte_slice(node.byte_range()), pos_ - node_start)
         .map(|pos| pos + node_start)

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -47,8 +47,10 @@ pub fn find_matching_bracket(syntax: &Syntax, doc: RopeSlice, pos: usize) -> Opt
 //
 // If no surrounding scope is found, the function returns `None`.
 #[must_use]
-pub fn find_matching_bracket_fuzzy(syntax: &Syntax, doc: RopeSlice, pos: usize) -> Option<usize> {
-    find_pair(syntax, doc, pos, true)
+pub fn find_matching_bracket_fuzzy(syntax: &Syntax, doc: RopeSlice, pos_: usize) -> Option<usize> {
+    let pos = doc.char_to_byte(pos_);
+    let traverse_parents = !is_valid_bracket(doc.char(pos));
+    find_pair(syntax, doc, pos_, traverse_parents)
 }
 
 fn find_pair(


### PR DESCRIPTION
Matching is in much better shape than what it used to, but there are still really counter-intuitive issues such as: https://github.com/helix-editor/helix/issues/2110 This patch proposes two changes:

- `find_matching_bracket_fuzzy` should not traverse parents if already on a valid bracket, this was not being respected as traverse parents was always set to `true`, probably an overlook after the refactor introduced in https://github.com/helix-editor/helix/pull/7242

- Finally I propose a change: plain-text search should run even if the node has children. Why? In https://github.com/helix-editor/helix/issues/2110, when on top of the inner brackets, when inspecting the tree-sitter scopes you will notice it's a string literal node with 2 escape sequence child nodes, therefore plain-text matching never runs, and the user is confused. I also regularly run into similar issues on my day-to-day, as I work with YAMLs that have interpolation inside strings (eg `something: "anything {{ version }}"`) but for some reason the node has a children (so 1 > 0) and again I can never match the inner `{`.

In general, the first fix is desirable: if you are lucky to be on top of a matching bracket inside a tree-site node without children, you would never be able to match anyway, because it would be traversing the parents and very likely there will be a matching node somewhere in the parent nodes, so I really think the first should stay no matter what. And this is really bad, because the highlight would correctly pick the inner match, and then when running `mm` it would behave differently and match something on the parent hierarchy.

I'm not an expert on the code-base and the issues you've run into in general, but I'd like to believe removing the constraint should make the majority of the users happy (I see there are still a few issues open about weird `mm` behaviour, I hope to address all of them here) and it would be very weird to run into performance problems for most of the people doing regular editing.
