### PR TITLE
allow for higher F keys to be used

### DIFF
--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -379,7 +379,7 @@ impl std::str::FromStr for KeyEvent {
             function if function.len() > 1 && function.starts_with('F') => {
                 let function: String = function.chars().skip(1).collect();
                 let function = str::parse::<u8>(&function)?;
-                (function > 0 && function < 13)
+                (function > 0 && function < 25)
                     .then_some(KeyCode::F(function))
                     .ok_or_else(|| anyhow!("Invalid function key '{}'", function))?
             }
@@ -682,7 +682,7 @@ mod test {
 
     #[test]
     fn parsing_nonsensical_keys_fails() {
-        assert!(str::parse::<KeyEvent>("F13").is_err());
+        assert!(str::parse::<KeyEvent>("F25").is_err());
         assert!(str::parse::<KeyEvent>("F0").is_err());
         assert!(str::parse::<KeyEvent>("aaa").is_err());
         assert!(str::parse::<KeyEvent>("S-S-a").is_err());


### PR DESCRIPTION
As mentioned in #7669, windows allows for higher function keys than F12.
Additionally, custom keyboard firmwares like ZMK support up to F24 https://zmk.dev/docs/codes/keyboard-keypad#f-keys