### PR TITLE
Align view for background buffer  opened with `alt-ret`

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -234,9 +234,7 @@ fn jump_to_location(
     // we flip the range so that the cursor sits on the start of the symbol
     // (for example start of the function).
     doc.set_selection(view.id, Selection::single(new_range.head, new_range.anchor));
-    // We probably don't want to change the alignment of current file when we open new files in the background (Load).
-    // Except when the new file is the old file
-    if !matches!(action, Action::Load) || old_doc_id == doc.id() {
+    if View::change_align_view(action, old_doc_id, doc.id()) {
         align_view(doc, view, Align::Center);
     }
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -195,7 +195,6 @@ fn location_to_file_location(location: &lsp::Location) -> FileLocation {
     (path.into(), line)
 }
 
-// TODO: share with symbol picker(symbol.location)
 fn jump_to_location(
     editor: &mut Editor,
     location: &lsp::Location,
@@ -246,38 +245,13 @@ type SymbolPicker = Picker<SymbolInformationItem>;
 
 fn sym_picker(symbols: Vec<SymbolInformationItem>, current_path: Option<lsp::Url>) -> SymbolPicker {
     // TODO: drop current_path comparison and instead use workspace: bool flag?
-    Picker::new(symbols, current_path.clone(), move |cx, item, action| {
-        let (view, doc) = current!(cx.editor);
-        push_jump(view, doc);
-
-        if current_path.as_ref() != Some(&item.symbol.location.uri) {
-            let uri = &item.symbol.location.uri;
-            let path = match uri.to_file_path() {
-                Ok(path) => path,
-                Err(_) => {
-                    let err = format!("unable to convert URI to filepath: {}", uri);
-                    cx.editor.set_error(err);
-                    return;
-                }
-            };
-            if let Err(err) = cx.editor.open(&path, action) {
-                let err = format!("failed to open document: {}: {}", uri, err);
-                log::error!("{}", err);
-                cx.editor.set_error(err);
-                return;
-            }
-        }
-
-        let (view, doc) = current!(cx.editor);
-
-        if let Some(range) =
-            lsp_range_to_range(doc.text(), item.symbol.location.range, item.offset_encoding)
-        {
-            // we flip the range so that the cursor sits on the start of the symbol
-            // (for example start of the function).
-            doc.set_selection(view.id, Selection::single(range.head, range.anchor));
-            align_view(doc, view, Align::Center);
-        }
+    Picker::new(symbols, current_path, move |cx, item, action| {
+        jump_to_location(
+            cx.editor,
+            &item.symbol.location,
+            item.offset_encoding,
+            action,
+        );
     })
     .with_preview(move |_editor, item| Some(location_to_file_location(&item.symbol.location)))
     .truncate_start(false)
@@ -292,7 +266,7 @@ enum DiagnosticsFormat {
 fn diag_picker(
     cx: &Context,
     diagnostics: BTreeMap<lsp::Url, Vec<(lsp::Diagnostic, usize)>>,
-    current_path: Option<lsp::Url>,
+    _current_path: Option<lsp::Url>,
     format: DiagnosticsFormat,
 ) -> Picker<PickerDiagnostic> {
     // TODO: drop current_path comparison and instead use workspace: bool flag?
@@ -330,22 +304,12 @@ fn diag_picker(
                   offset_encoding,
               },
               action| {
-            if current_path.as_ref() == Some(url) {
-                let (view, doc) = current!(cx.editor);
-                push_jump(view, doc);
-            } else {
-                let path = url.to_file_path().unwrap();
-                cx.editor.open(&path, action).expect("editor.open failed");
-            }
-
-            let (view, doc) = current!(cx.editor);
-
-            if let Some(range) = lsp_range_to_range(doc.text(), diag.range, *offset_encoding) {
-                // we flip the range so that the cursor sits on the start of the symbol
-                // (for example start of the function).
-                doc.set_selection(view.id, Selection::single(range.head, range.anchor));
-                align_view(doc, view, Align::Center);
-            }
+            jump_to_location(
+                cx.editor,
+                &lsp::Location::new(url.clone(), diag.range),
+                *offset_encoding,
+                action,
+            )
         },
     )
     .with_preview(move |_editor, PickerDiagnostic { url, diag, .. }| {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -213,7 +213,6 @@ fn jump_to_location(
         }
     };
 
-    let old_doc_id = doc!(editor).id();
     let doc = match editor.open(&path, action) {
         Ok(id) => doc_mut!(editor, &id),
         Err(err) => {
@@ -234,7 +233,7 @@ fn jump_to_location(
     // we flip the range so that the cursor sits on the start of the symbol
     // (for example start of the function).
     doc.set_selection(view.id, Selection::single(new_range.head, new_range.anchor));
-    if View::change_align_view(action, old_doc_id, doc.id()) {
+    if action.align_view(view, doc.id()) {
         align_view(doc, view, Align::Center);
     }
 }

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -1,4 +1,5 @@
-#[cfg(feature = "integration")]
+// XXX remove before PR
+// #[cfg(feature = "integration")]
 mod test {
     mod helpers;
 

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -1,5 +1,4 @@
-// XXX remove before PR
-// #[cfg(feature = "integration")]
+#[cfg(feature = "integration")]
 mod test {
     mod helpers;
 
@@ -20,6 +19,7 @@ mod test {
     mod auto_pairs;
     mod commands;
     mod movement;
+    mod picker;
     mod prompt;
     mod splits;
 }

--- a/helix-term/tests/test/picker.rs
+++ b/helix-term/tests/test/picker.rs
@@ -37,7 +37,7 @@ async fn test_picker_alt_ret() -> anyhow::Result<()> {
     fs::write(&paths[1], "first\nsecond")?;
 
     log::debug!(
-        "created and writed two temporary files: {:?} & {:?}",
+        "created and wrote two temporary files: {:?} & {:?}",
         paths[0],
         paths[1]
     );

--- a/helix-term/tests/test/picker.rs
+++ b/helix-term/tests/test/picker.rs
@@ -1,0 +1,75 @@
+use std::fs;
+
+use helix_core::Range;
+use helix_loader::{current_working_dir, set_current_working_dir};
+use helix_view::{current_ref, editor::Action};
+use tempfile::{Builder, TempDir};
+
+use super::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_picker_alt_ret() -> anyhow::Result<()> {
+    // Create two files, open the first and run a global search for a word
+    // from the second file. Press <alt-ret> to have helix open the second file in the
+    // new buffer, but not change focus. Then check whether the word is highlighted
+    // correctly and the view of the first file has not changed.
+    let tmp_dir = TempDir::new()?;
+    set_current_working_dir(tmp_dir.path().into())?;
+
+    let mut app = AppBuilder::new().build()?;
+
+    log::debug!(
+        "set current working directory to {:?}",
+        current_working_dir()
+    );
+
+    // Add prefix so helix doesn't hide these files in a picker
+    let files = [
+        Builder::new().prefix("1").tempfile_in(&tmp_dir)?,
+        Builder::new().prefix("2").tempfile_in(&tmp_dir)?,
+    ];
+    fs::write(files[0].path(), "1\n2\n3\n4")?;
+    fs::write(files[1].path(), "first\nsecond")?;
+
+    log::debug!(
+        "created and writed two temporary files: {:?} & {:?}",
+        files[0].path(),
+        files[1].path()
+    );
+
+    // Manually open to save the offset, otherwise we won't be able to change the state in the Fn trait
+    app.editor.open(files[0].path(), Action::Replace)?;
+    let view_offset = current_ref!(app.editor).0.offset;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (Some("<space>/"), None),
+            (Some("second<ret>"), None),
+            (
+                Some("<A-ret><esc>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(app.editor);
+                    assert_eq!(doc.path().unwrap(), files[0].path());
+                    let select_ranges = doc.selection(view.id).ranges();
+                    assert_eq!(select_ranges[0], Range::new(0, 1));
+                    assert_eq!(view.offset, view_offset);
+                }),
+            ),
+            (
+                Some(":buffer<minus>next<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(app.editor);
+                    assert_eq!(doc.path().unwrap(), files[1].path());
+                    let select_ranges = doc.selection(view.id).ranges();
+                    assert_eq!(select_ranges.len(), 1);
+                    assert_eq!(select_ranges[0], Range::new(6, 12));
+                }),
+            ),
+        ],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/picker.rs
+++ b/helix-term/tests/test/picker.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use helix_core::Range;
+use helix_core::{path::get_canonicalized_path, Range};
 use helix_loader::{current_working_dir, set_current_working_dir};
 use helix_view::{current_ref, editor::Action};
 use tempfile::{Builder, TempDir};
@@ -28,13 +28,18 @@ async fn test_picker_alt_ret() -> anyhow::Result<()> {
         Builder::new().prefix("1").tempfile_in(&tmp_dir)?,
         Builder::new().prefix("2").tempfile_in(&tmp_dir)?,
     ];
-    fs::write(files[0].path(), "1\n2\n3\n4")?;
-    fs::write(files[1].path(), "first\nsecond")?;
+    let paths = files
+        .iter()
+        .map(|f| get_canonicalized_path(f.path()).unwrap())
+        .collect::<Vec<_>>();
+
+    fs::write(&paths[0], "1\n2\n3\n4")?;
+    fs::write(&paths[1], "first\nsecond")?;
 
     log::debug!(
         "created and writed two temporary files: {:?} & {:?}",
-        files[0].path(),
-        files[1].path()
+        paths[0],
+        paths[1]
     );
 
     // Manually open to save the offset, otherwise we won't be able to change the state in the Fn trait
@@ -50,7 +55,7 @@ async fn test_picker_alt_ret() -> anyhow::Result<()> {
                 Some("<A-ret><esc>"),
                 Some(&|app| {
                     let (view, doc) = current_ref!(app.editor);
-                    assert_eq!(doc.path().unwrap(), files[0].path());
+                    assert_eq!(doc.path().unwrap(), &paths[0]);
                     let select_ranges = doc.selection(view.id).ranges();
                     assert_eq!(select_ranges[0], Range::new(0, 1));
                     assert_eq!(view.offset, view_offset);
@@ -60,7 +65,7 @@ async fn test_picker_alt_ret() -> anyhow::Result<()> {
                 Some(":buffer<minus>next<ret>"),
                 Some(&|app| {
                     let (view, doc) = current_ref!(app.editor);
-                    assert_eq!(doc.path().unwrap(), files[1].path());
+                    assert_eq!(doc.path().unwrap(), &paths[1]);
                     let select_ranges = doc.selection(view.id).ranges();
                     assert_eq!(select_ranges.len(), 1);
                     assert_eq!(select_ranges[0], Range::new(6, 12));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -975,6 +975,13 @@ pub enum Action {
     VerticalSplit,
 }
 
+impl Action {
+    /// Whether to align the view to the cursor after executing this action
+    pub fn align_view(&self, view: &View, new_doc: DocumentId) -> bool {
+        !matches!((self, view.doc == new_doc), (Action::Load, false))
+    }
+}
+
 /// Error thrown on failed document closed
 pub enum CloseError {
     /// Document doesn't exist

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -1,7 +1,7 @@
 use crate::{
     align_view,
     document::DocumentInlayHints,
-    editor::{Action, GutterConfig, GutterType},
+    editor::{GutterConfig, GutterType},
     graphics::Rect,
     Align, Document, DocumentId, Theme, ViewId,
 };
@@ -312,13 +312,6 @@ impl View {
 
     pub fn is_cursor_in_view(&mut self, doc: &Document, scrolloff: usize) -> bool {
         self.offset_coords_to_in_view(doc, scrolloff).is_none()
-    }
-
-    /// Whether to change a view alignment of current file. You probably don't want to
-    /// change the alignment of current file when open new files in the background (Load).
-    /// Except when the new file is the old file
-    pub fn change_align_view(action: Action, old_id: DocumentId, new_id: DocumentId) -> bool {
-        !matches!((action, old_id == new_id), (Action::Load, false))
     }
 
     /// Estimates the last visible document line on screen.
@@ -1022,17 +1015,5 @@ mod tests {
             ),
             Some(7)
         );
-    }
-
-    #[test]
-    fn test_change_align_view() {
-        use std::num::NonZeroUsize;
-        let docs = [
-            DocumentId(NonZeroUsize::new(1).unwrap()),
-            DocumentId(NonZeroUsize::new(2).unwrap()),
-        ];
-        assert!(View::change_align_view(Action::Replace, docs[0], docs[1]));
-        assert!(View::change_align_view(Action::Load, docs[0], docs[0]));
-        assert!(!View::change_align_view(Action::Load, docs[0], docs[1]));
     }
 }


### PR DESCRIPTION
Closes #7673

Now if `alt-ret` is pressed, it opens the selected file and places the cursor on the selected line (if path contained a line number), but in the background (i. e the focused document remains unchanged).

- [x] All lsp pickers
- [x] Global search picker
- [x] Jump list picker