### PR TITLE
Add asm (assembler) language support based on tree-sitter-asm

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -1,5 +1,6 @@
 | Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Default LSP |
 | --- | --- | --- | --- | --- |
+| asm | ✓ |  |  |  |
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ |  | ✓ | `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2474,10 +2474,23 @@ name = "po"
 source = { git = "https://github.com/erasin/tree-sitter-po", rev = "417cee9abb2053ed26b19e7de972398f2da9b29e" }
 
 [[language]]
+name = "asm"
+scope = "source.asm"
+injection-regex = "asm"
+file-types = ["s", "S"]
+comment-token = "#"
+indent = { tab-width = 8, unit = "        " }
+roots = []
+
+[[grammar]]
+name = "asm"
+source = { git = "https://github.com/rush-rs/tree-sitter-asm.git", rev = "36dc26acc7818920de2e103e20a9f42358caf926" }
+
+[[language]]
 name = "nasm"
 scope = "source.nasm"
-file-types = ["asm", "s", "S", "nasm"]
-injection-regex = "n?asm"
+file-types = ["asm", "nasm"]
+injection-regex = "nasm"
 roots = []
 comment-token = ";"
 indent = { tab-width = 8, unit = "        " }

--- a/runtime/queries/asm/highlights.scm
+++ b/runtime/queries/asm/highlights.scm
@@ -1,0 +1,54 @@
+; Copyright (c) 2023 RubixDev
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+
+; This file is provided in the rush-rs/tree-sitter-asm repo
+
+; General
+(label (ident) @label)
+(reg) @variable.builtin
+(meta
+  kind: (_) @function.builtin)
+(instruction
+  kind: (_) @function.call)
+
+; Comments
+(line_comment) @comment @spell
+
+; Literals
+(int) @number
+(float) @number
+(string) @string
+
+; Keywords
+[
+  "byte"
+  "word"
+  "dword"
+  "qword"
+  "ptr"
+  "rel"
+] @keyword
+
+; Operators & Punctuation
+["+" "-" "*"] @operator
+
+["(" ")" "[" "]"]  @punctuation.bracket
+
+["," ":"] @punctuation.delimiter


### PR DESCRIPTION
The tree-sitter-asm syntax is more suitable for generic assembly language, including GNU assembler syntax, than the NASM-specific one.

This changes extensions for NASM so that asm syntax is used for ".s" and ".S" files, which are commonly used with the GNU assembler, and ".asm" and ".nasm" for NASM which are more commonly used with that.

---

The only thing I'm not sure about is tree-sitter-asm had highlight queries in the package already, so I just copied those but appended the LICENSE file to the beginning. Since it's MIT license I hope this is not a problem, but unfortunately I'm not the author of tree-sitter-asm so I can't help you with that. It would probably be more ideal if helix could also include highlight queries from git while building the grammars rather than having to be in the main helix repo.