### PR TITLE
chores: run `cargo fmt`, fix Clippy warnings

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -106,12 +106,16 @@ fn find_pair(
         for close in
             iter::successors(node.next_sibling(), |node| node.next_sibling()).take(MATCH_LIMIT)
         {
-            let Some(open) = as_close_pair(doc, &close) else { continue; };
+            let Some(open) = as_close_pair(doc, &close) else {
+                continue;
+            };
             if find_pair_end(doc, Some(node), open, Backward).is_some() {
                 return doc.try_byte_to_char(close.start_byte()).ok();
             }
         }
-        let Some(parent) = node.parent() else { break; };
+        let Some(parent) = node.parent() else {
+            break;
+        };
         node = parent;
     }
     let node = tree.root_node().named_descendant_for_byte_range(pos, pos)?;

--- a/helix-core/src/shellwords.rs
+++ b/helix-core/src/shellwords.rs
@@ -285,7 +285,7 @@ mod test {
             Cow::from("$#%^@"),
             Cow::from("%^&(%^"),
             Cow::from(")(*&^%"),
-            Cow::from(r#"a\\b"#),
+            Cow::from(r"a\\b"),
             //last ' just changes to quoted but since we dont have anything after it, it should be ignored
         ];
         assert_eq!(expected, result);

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -353,7 +353,9 @@ impl ChangeSet {
             macro_rules! map {
                 ($map: expr, $i: expr) => {
                     loop {
-                        let Some((pos, assoc)) = positions.peek_mut() else { return; };
+                        let Some((pos, assoc)) = positions.peek_mut() else {
+                                                return;
+                                            };
                         if **pos < old_pos {
                             // Positions are not sorted, revert to the last Operation that
                             // contains this position and continue iterating from there.
@@ -380,7 +382,10 @@ impl ChangeSet {
                             debug_assert!(old_pos <= **pos, "Reverse Iter across changeset works");
                             continue 'outer;
                         }
-                        let Some(new_pos) = $map(**pos, *assoc) else { break; };
+                        #[allow(clippy::redundant_closure_call)]
+                                            let Some(new_pos) = $map(**pos, *assoc) else {
+                                                break;
+                                            };
                         **pos = new_pos;
                         positions.next();
                     }
@@ -388,7 +393,10 @@ impl ChangeSet {
             }
 
             let Some((i, change)) = iter.next() else {
-                map!(|pos, _| (old_pos == pos).then_some(new_pos), self.changes.len());
+                map!(
+                    |pos, _| (old_pos == pos).then_some(new_pos),
+                    self.changes.len()
+                );
                 break;
             };
 

--- a/helix-loader/build.rs
+++ b/helix-loader/build.rs
@@ -40,7 +40,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     // If heads starts pointing at something else (different branch)
     // we need to return
     let head = Path::new(&git_dir).join("HEAD");
@@ -55,7 +57,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     let head_ref = Path::new(&git_dir).join(head_ref);
     if head_ref.exists() {
         println!("cargo:rerun-if-changed={}", head_ref.display());

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -434,7 +434,7 @@ pub mod util {
             }
 
             let tabstops = tabstops.first().filter(|tabstops| !tabstops.is_empty());
-            let Some(tabstops) = tabstops else{
+            let Some(tabstops) = tabstops else {
                 // no tabstop normal mapping
                 mapped_selection.push(range);
                 continue;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -785,7 +785,7 @@ fn goto_buffer(editor: &mut Editor, direction: Direction) {
             let iter = editor.documents.keys();
             let mut iter = iter.rev().skip_while(|id| *id != &current);
             iter.next(); // skip current item
-            iter.next().or_else(|| editor.documents.keys().rev().next())
+            iter.next().or_else(|| editor.documents.keys().next_back())
         }
     }
     .unwrap();

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -730,7 +730,8 @@ pub fn code_action(cx: &mut Context) {
 
                 // always present here
                 let action = action.unwrap();
-                let Some(language_server) = editor.language_server_by_id(action.language_server_id) else {
+                let Some(language_server) = editor.language_server_by_id(action.language_server_id)
+                else {
                     editor.set_error("Language Server disappeared");
                     return;
                 };
@@ -1173,7 +1174,8 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
         // Do not show the message if signature help was invoked
         // automatically on backspace, trigger characters, etc.
         if invoked == SignatureHelpInvoked::Manual {
-            cx.editor.set_error("No configured language server supports signature-help");
+            cx.editor
+                .set_error("No configured language server supports signature-help");
         }
         return;
     };
@@ -1398,7 +1400,8 @@ pub fn rename_symbol(cx: &mut Context) {
                     .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
                     .find(|ls| language_server_id.map_or(true, |id| id == ls.id()))
                 else {
-                    cx.editor.set_error("No configured language server supports symbol renaming");
+                    cx.editor
+                        .set_error("No configured language server supports symbol renaming");
                     return;
                 };
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1372,9 +1372,8 @@ fn lsp_workspace_command(
                 .map(|options| (ls.id(), options))
         })
     else {
-        cx.editor.set_status(
-             "No active language servers for this document support workspace commands",
-        );
+        cx.editor
+            .set_status("No active language servers for this document support workspace commands");
         return Ok(());
     };
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -144,7 +144,9 @@ impl Completion {
                         }
                     };
 
-                    let Some(range) = util::lsp_range_to_range(doc.text(), edit.range, offset_encoding) else{
+                    let Some(range) =
+                        util::lsp_range_to_range(doc.text(), edit.range, offset_encoding)
+                    else {
                         return Transaction::new(doc.text());
                     };
 
@@ -411,10 +413,18 @@ impl Completion {
             _ => return false,
         };
 
-        let Some(language_server) = cx.editor.language_server_by_id(current_item.language_server_id) else { return false; };
+        let Some(language_server) = cx
+            .editor
+            .language_server_by_id(current_item.language_server_id)
+        else {
+            return false;
+        };
 
         // This method should not block the compositor so we handle the response asynchronously.
-        let Some(future) = language_server.resolve_completion_item(current_item.item.clone()) else { return false; };
+        let Some(future) = language_server.resolve_completion_item(current_item.item.clone())
+        else {
+            return false;
+        };
 
         cx.callback(
             future,

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -273,7 +273,7 @@ impl Markdown {
                             Arc::clone(&self.config_loader),
                             None,
                         );
-                        lines.extend(tui_text.lines.into_iter());
+                        lines.extend(tui_text.lines);
                     } else {
                         let style = if let Some(Tag::Heading(level, ..)) = tags.last() {
                             match level {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -432,7 +432,7 @@ impl<T: Item + 'static> Picker<T> {
 
     fn handle_idle_timeout(&mut self, cx: &mut Context) -> EventResult {
         let Some((current_file, _)) = self.current_file(cx.editor) else {
-            return EventResult::Consumed(None)
+            return EventResult::Consumed(None);
         };
 
         // Try to find a document in the cache
@@ -459,11 +459,14 @@ impl<T: Item + 'static> Picker<T> {
                     let callback = move |editor: &mut Editor, compositor: &mut Compositor| {
                         let Some(syntax) = syntax else {
                             log::info!("highlighting picker item failed");
-                            return
+                            return;
                         };
-                        let Some(Overlay { content: picker, .. }) = compositor.find::<Overlay<Self>>() else {
+                        let Some(Overlay {
+                            content: picker, ..
+                        }) = compositor.find::<Overlay<Self>>()
+                        else {
                             log::info!("picker closed before syntax highlighting finished");
-                            return
+                            return;
                         };
                         // Try to find a document in the cache
                         let doc = match current_file {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -734,10 +734,12 @@ impl Default for IndentGuidesConfig {
 /// Line ending configuration.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum LineEndingConfig {
     /// The platform's native line ending.
     ///
     /// `crlf` on Windows, otherwise `lf`.
+    #[default]
     Native,
     /// Line feed.
     LF,
@@ -752,12 +754,6 @@ pub enum LineEndingConfig {
     /// Next line.
     #[cfg(feature = "unicode-lines")]
     Nel,
-}
-
-impl Default for LineEndingConfig {
-    fn default() -> Self {
-        LineEndingConfig::Native
-    }
 }
 
 impl From<LineEndingConfig> for LineEnding {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -535,7 +535,7 @@ impl Tree {
             id
         } else {
             // extremely crude, take the last item
-            let (key, _) = self.traverse().rev().next().unwrap();
+            let (key, _) = self.traverse().next_back().unwrap();
             key
         }
     }


### PR DESCRIPTION
`cargo fmt` recently learned to format `let else` blocks, and reformats a few of them.

Two of the clippy warnings look like false positives, most of the rest were fixed with `cargo clippy --fix`.

I ran everything with `+nightly`, but am not sure which version actually ran because of `rust-toolchain.toml`.