### PR TITLE
Theme Pop-Dark: Increase Diagnostics clarity

### DIFF
--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -1,13 +1,14 @@
 # Pop Dark theme for the Helix Editor
 # Author: workingj<workingj@pm.me>
+# Author : Eric Correia <correia.eh@gmail.com>
 # Repo: https://github.com/workingJ/helix-pop-theme
 # Version: 1.0
 # This theme is based on Nathaniel Webb's VSCodePopTheme <https://github.com/ArtisanByteCrafter/VSCodePopTheme>
 
-info = { fg = 'yellowH', bg = 'brownD' }
-hint = { fg = 'brownD', bg = 'yellowH', modifiers = ['bold'] }
-warning = { fg = 'brownD', bg = 'orangeW', modifiers = ['bold'] }
-error = { fg = 'brownD', bg = 'redE', modifiers = ['bold'] }
+info = { fg = 'brownD' }
+hint = { fg = 'yellowH', modifiers = ['bold'] }
+warning = { fg = 'orangeW', modifiers = ['bold'] }
+error = { fg = 'redE', modifiers = ['bold'] }
 'diagnostic.info'.underline = { color = 'yellowH', style = 'curl' } 
 'diagnostic.hint'.underline = { color = 'yellowH', style = 'curl' } 
 'diagnostic.warning'.underline = { color = 'orangeW', style = 'curl' } 

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -1,6 +1,5 @@
 # Pop Dark theme for the Helix Editor
 # Author: workingj<workingj@pm.me>
-# Author : Eric Correia <correia.eh@gmail.com>
 # Repo: https://github.com/workingJ/helix-pop-theme
 # Version: 1.0
 # This theme is based on Nathaniel Webb's VSCodePopTheme <https://github.com/ArtisanByteCrafter/VSCodePopTheme>


### PR DESCRIPTION
This PR is meant to make the hover diagnostics more legible by inverting the background and foreground color settings for `info`, `warning`, `hint`, and `error`. 

Previously, it was not clear the status level of each item in the diagnostics picker. These changes fix that as well.
Before:
<img width="1920" alt="Screenshot 2023-07-21 at 10 01 55 PM" src="https://github.com/helix-editor/helix/assets/4412771/78e7022b-8b21-4c8f-91af-f64fe9b1a578">


After:
<img width="1913" alt="Screenshot 2023-07-21 at 10 06 04 PM" src="https://github.com/helix-editor/helix/assets/4412771/5a3a5b94-a95b-4aeb-9b68-ae5fa8e6802e">

