### PR TITLE
feat: make filename_impl walker configurable

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -441,7 +441,7 @@ pub mod completers {
     }
 
     // TODO: we could return an iter/lazy thing so it can fetch as many as it needs.
-    fn filename_impl<F>(_editor: &Editor, input: &str, filter_fn: F) -> Vec<Completion>
+    fn filename_impl<F>(editor: &Editor, input: &str, filter_fn: F) -> Vec<Completion>
     where
         F: Fn(&ignore::DirEntry) -> FileMatch,
     {
@@ -481,10 +481,14 @@ pub mod completers {
 
         let end = input.len()..;
 
+        let config = editor.config();
         let mut files: Vec<_> = WalkBuilder::new(&dir)
             .hidden(false)
             .follow_links(false) // We're scanning over depth 1
             .max_depth(Some(1))
+            .ignore(config.file_picker.ignore)
+            .git_ignore(config.file_picker.git_ignore)
+            .git_exclude(config.file_picker.git_exclude)
             .build()
             .filter_map(|file| {
                 file.ok().and_then(|entry| {


### PR DESCRIPTION
ref https://github.com/helix-editor/helix/issues/7715

couple of notes:
- I'm using file_picker config , is that a good idea or should filename have its own config (which will need duplicating FileConfig struct)
- Should I copy all the configs from https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs#L2094 I currently only added the options that impact performance 