### PR TITLE
Fix selection highlighting in remaining gruvbox derived themes

### DIFF
--- a/runtime/themes/gruvbox_dark_hard.toml
+++ b/runtime/themes/gruvbox_dark_hard.toml
@@ -4,8 +4,6 @@
 
 inherits = "gruvbox"
 
-"ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
-"ui.selection.primary" = { bg = "bg4", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { bg = "bg2" }
 

--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -4,8 +4,6 @@
 
 inherits = "gruvbox"
 
-"ui.selection" = { bg = "bg3", modifiers = ["reversed"] }
-"ui.selection.primary" = { bg = "bg4", modifiers = ["reversed"] }
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { bg = "bg2" }
 


### PR DESCRIPTION
Fix the problem already explained in #7126 for both `gruvbox_light` and
`gruvbox_dark_hard` themes by letting them use `ui.selection` related
configuration from the parent theme.

Closes #7126 