### PR TITLE
Change operator color to brown in gruvbox theme

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -7,7 +7,7 @@
 "namespace" = "aqua1"
 "punctuation" = "orange1"
 "punctuation.delimiter" = "orange1"
-"operator" = "purple1"
+"operator" = "brown"
 "special" = "purple0"
 "variable.other.member" = "blue1"
 "variable" = "fg1"
@@ -105,3 +105,4 @@ aqua0 = "#689d6a"
 aqua1 = "#8ec07c"
 orange0 = "#d65d0e"
 orange1 = "#fe8019"
+brown = "#a52a2a" # https://www.w3schools.com/colors/color_tryit.asp?hex=a52a2a


### PR DESCRIPTION
This would help differentiating operators from constants and builtins.
We do this by adding new `brown` color to the palette and using it as
foreground color for operators.

Go based example:

Before:

![Screenshot from 2023-07-23 00-33-47](https://github.com/helix-editor/helix/assets/3425238/0fd824f8-de3c-43a0-b3a7-cd9a7541ac95)

After:

![Screenshot from 2023-07-23 00-33-16](https://github.com/helix-editor/helix/assets/3425238/58552d51-e3b4-454b-b946-eb677697f4eb)
