### PR TITLE
Reformat with nightly rustfmt for better let-else formatting

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -106,12 +106,16 @@ fn find_pair(
         for close in
             iter::successors(node.next_sibling(), |node| node.next_sibling()).take(MATCH_LIMIT)
         {
-            let Some(open) = as_close_pair(doc, &close) else { continue; };
+            let Some(open) = as_close_pair(doc, &close) else {
+                continue;
+            };
             if find_pair_end(doc, Some(node), open, Backward).is_some() {
                 return doc.try_byte_to_char(close.start_byte()).ok();
             }
         }
-        let Some(parent) = node.parent() else { break; };
+        let Some(parent) = node.parent() else {
+            break;
+        };
         node = parent;
     }
     let node = tree.root_node().named_descendant_for_byte_range(pos, pos)?;

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -388,7 +388,10 @@ impl ChangeSet {
             }
 
             let Some((i, change)) = iter.next() else {
-                map!(|pos, _| (old_pos == pos).then_some(new_pos), self.changes.len());
+                map!(
+                    |pos, _| (old_pos == pos).then_some(new_pos),
+                    self.changes.len()
+                );
                 break;
             };
 

--- a/helix-loader/build.rs
+++ b/helix-loader/build.rs
@@ -40,7 +40,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     // If heads starts pointing at something else (different branch)
     // we need to return
     let head = Path::new(&git_dir).join("HEAD");
@@ -55,7 +57,9 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-    else{ return; };
+    else {
+        return;
+    };
     let head_ref = Path::new(&git_dir).join(head_ref);
     if head_ref.exists() {
         println!("cargo:rerun-if-changed={}", head_ref.display());

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -435,7 +435,7 @@ pub mod util {
             }
 
             let tabstops = tabstops.first().filter(|tabstops| !tabstops.is_empty());
-            let Some(tabstops) = tabstops else{
+            let Some(tabstops) = tabstops else {
                 // no tabstop normal mapping
                 mapped_selection.push(range);
                 continue;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -730,7 +730,8 @@ pub fn code_action(cx: &mut Context) {
 
                 // always present here
                 let action = action.unwrap();
-                let Some(language_server) = editor.language_server_by_id(action.language_server_id) else {
+                let Some(language_server) = editor.language_server_by_id(action.language_server_id)
+                else {
                     editor.set_error("Language Server disappeared");
                     return;
                 };
@@ -746,15 +747,20 @@ pub fn code_action(cx: &mut Context) {
                         // we support lsp "codeAction/resolve" for `edit` and `command` fields
                         let mut resolved_code_action = None;
                         if code_action.edit.is_none() || code_action.command.is_none() {
-                            if let Some(future) = language_server.resolve_code_action(code_action.clone()) {
+                            if let Some(future) =
+                                language_server.resolve_code_action(code_action.clone())
+                            {
                                 if let Ok(response) = helix_lsp::block_on(future) {
-                                    if let Ok(code_action) = serde_json::from_value::<CodeAction>(response) {
+                                    if let Ok(code_action) =
+                                        serde_json::from_value::<CodeAction>(response)
+                                    {
                                         resolved_code_action = Some(code_action);
                                     }
                                 }
                             }
                         }
-                        let resolved_code_action = resolved_code_action.as_ref().unwrap_or(code_action);
+                        let resolved_code_action =
+                            resolved_code_action.as_ref().unwrap_or(code_action);
 
                         if let Some(ref workspace_edit) = resolved_code_action.edit {
                             log::debug!("edit: {:?}", workspace_edit);
@@ -1186,7 +1192,8 @@ pub fn signature_help_impl(cx: &mut Context, invoked: SignatureHelpInvoked) {
         // Do not show the message if signature help was invoked
         // automatically on backspace, trigger characters, etc.
         if invoked == SignatureHelpInvoked::Manual {
-            cx.editor.set_error("No configured language server supports signature-help");
+            cx.editor
+                .set_error("No configured language server supports signature-help");
         }
         return;
     };
@@ -1411,7 +1418,8 @@ pub fn rename_symbol(cx: &mut Context) {
                     .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
                     .find(|ls| language_server_id.map_or(true, |id| id == ls.id()))
                 else {
-                    cx.editor.set_error("No configured language server supports symbol renaming");
+                    cx.editor
+                        .set_error("No configured language server supports symbol renaming");
                     return;
                 };
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1385,9 +1385,8 @@ fn lsp_workspace_command(
                 .map(|options| (ls.id(), options))
         })
     else {
-        cx.editor.set_status(
-             "No active language servers for this document support workspace commands",
-        );
+        cx.editor
+            .set_status("No active language servers for this document support workspace commands");
         return Ok(());
     };
 

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -144,7 +144,9 @@ impl Completion {
                         }
                     };
 
-                    let Some(range) = util::lsp_range_to_range(doc.text(), edit.range, offset_encoding) else{
+                    let Some(range) =
+                        util::lsp_range_to_range(doc.text(), edit.range, offset_encoding)
+                    else {
                         return Transaction::new(doc.text());
                     };
 
@@ -411,10 +413,18 @@ impl Completion {
             _ => return false,
         };
 
-        let Some(language_server) = cx.editor.language_server_by_id(current_item.language_server_id) else { return false; };
+        let Some(language_server) = cx
+            .editor
+            .language_server_by_id(current_item.language_server_id)
+        else {
+            return false;
+        };
 
         // This method should not block the compositor so we handle the response asynchronously.
-        let Some(future) = language_server.resolve_completion_item(current_item.item.clone()) else { return false; };
+        let Some(future) = language_server.resolve_completion_item(current_item.item.clone())
+        else {
+            return false;
+        };
 
         cx.callback(
             future,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -432,7 +432,7 @@ impl<T: Item + 'static> Picker<T> {
 
     fn handle_idle_timeout(&mut self, cx: &mut Context) -> EventResult {
         let Some((current_file, _)) = self.current_file(cx.editor) else {
-            return EventResult::Consumed(None)
+            return EventResult::Consumed(None);
         };
 
         // Try to find a document in the cache
@@ -459,11 +459,14 @@ impl<T: Item + 'static> Picker<T> {
                     let callback = move |editor: &mut Editor, compositor: &mut Compositor| {
                         let Some(syntax) = syntax else {
                             log::info!("highlighting picker item failed");
-                            return
+                            return;
                         };
-                        let Some(Overlay { content: picker, .. }) = compositor.find::<Overlay<Self>>() else {
+                        let Some(Overlay {
+                            content: picker, ..
+                        }) = compositor.find::<Overlay<Self>>()
+                        else {
                             log::info!("picker closed before syntax highlighting finished");
-                            return
+                            return;
                         };
                         // Try to find a document in the cache
                         let doc = match current_file {


### PR DESCRIPTION
As discussed in https://github.com/helix-editor/helix/pull/4443#discussion_r1271457803

I ran a format with rust nightly over the code, and fixed all issues where MSRV rustfmt would do something different (so that CI runs through).

I think this makes sense, since I often (and I'm sure I'm not the only one) reformat code with whatever rustfmt version I'm currently using, and this introduces a lot of changes that are unwanted compared to the actual change I was doing. This should at least minify this issue (two changes are still different with nightly rustfmt, the infamous comment in `helix-view/src/editor.rs` and a let else in a macro (which I formatted manually)).