### PR TITLE
fix(comment): fix incorrect predicate

### DIFF
--- a/runtime/queries/comment/highlights.scm
+++ b/runtime/queries/comment/highlights.scm
@@ -28,10 +28,10 @@
 
 ; Error level tags
 ((tag (name) @error)
- (match? @error "^(BUG|FIXME|ISSUE|XXX)$"))
+ (#match? @error "^(BUG|FIXME|ISSUE|XXX)$"))
 
 ("text" @error
- (match? @error "^(BUG|FIXME|ISSUE|XXX)$"))
+ (#match? @error "^(BUG|FIXME|ISSUE|XXX)$"))
 
 (tag
  (name) @ui.text


### PR DESCRIPTION
These 2 captures were missing `#` so it's not working as intended

Was there any particular reason they were done as such?