### PR TITLE
Update soft-wrap indicator in gruvbox.toml and themes derived from it

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -61,6 +61,7 @@
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.ruler" = { bg = "bg1" }
 "ui.virtual.inlay-hint" = { fg = "gray1" }
+"ui.virtual.wrap" = { fg = "bg2" }
 
 "diagnostic.warning" = { underline = { color = "orange1", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }


### PR DESCRIPTION
Hi!

I find the default brightness of the soft-wrap indicator to be too distracting. This dims it quite a bit, bringing it down almost to the background level.

Could such a change be considered for merging? I personally think it has a positive impact on the quality of gruvbox-derived themes.