### PR TITLE
Syntax-highlight regex prompts

### DIFF
--- a/helix-core/src/history.rs
+++ b/helix-core/src/history.rs
@@ -72,8 +72,8 @@ impl Default for History {
             revisions: vec![Revision {
                 parent: 0,
                 last_child: None,
-                transaction: Transaction::from(ChangeSet::new(&Rope::new())),
-                inversion: Transaction::from(ChangeSet::new(&Rope::new())),
+                transaction: Transaction::from(ChangeSet::new("".into())),
+                inversion: Transaction::from(ChangeSet::new("".into())),
                 timestamp: Instant::now(),
             }],
             current: 0,

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -1,3 +1,4 @@
+use ropey::RopeSlice;
 use smallvec::SmallVec;
 
 use crate::{Range, Rope, Selection, Tendril};
@@ -42,7 +43,7 @@ impl ChangeSet {
     }
 
     #[must_use]
-    pub fn new(doc: &Rope) -> Self {
+    pub fn new(doc: RopeSlice) -> Self {
         let len = doc.len_chars();
         Self {
             changes: Vec::new(),
@@ -485,7 +486,7 @@ impl Transaction {
     /// Create a new, empty transaction.
     pub fn new(doc: &Rope) -> Self {
         Self {
-            changes: ChangeSet::new(doc),
+            changes: ChangeSet::new(doc.slice(..)),
             selection: None,
         }
     }
@@ -946,9 +947,9 @@ mod test {
     #[test]
     fn combine_with_empty() {
         let empty = Rope::from("");
-        let a = ChangeSet::new(&empty);
+        let a = ChangeSet::new(empty.slice(..));
 
-        let mut b = ChangeSet::new(&empty);
+        let mut b = ChangeSet::new(empty.slice(..));
         b.insert("a".into());
 
         let changes = a.compose(b);
@@ -962,9 +963,9 @@ mod test {
         const TEST_CASE: &str = "Hello, これはヘリックスエディターです！";
 
         let empty = Rope::from("");
-        let a = ChangeSet::new(&empty);
+        let a = ChangeSet::new(empty.slice(..));
 
-        let mut b = ChangeSet::new(&empty);
+        let mut b = ChangeSet::new(empty.slice(..));
         b.insert(TEST_CASE.into());
 
         let changes = a.compose(b);

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -72,9 +72,9 @@ fn test_treesitter_indent(file_name: &str, lang_scope: &str) {
 
     let language_config = loader.language_config_for_scope(lang_scope).unwrap();
     let highlight_config = language_config.highlight_config(&[]).unwrap();
-    let syntax = Syntax::new(&doc, highlight_config, std::sync::Arc::new(loader)).unwrap();
-    let indent_query = language_config.indent_query().unwrap();
     let text = doc.slice(..);
+    let syntax = Syntax::new(text, highlight_config, std::sync::Arc::new(loader)).unwrap();
+    let indent_query = language_config.indent_query().unwrap();
 
     for i in 0..doc.len_lines() {
         let line = text.line(i);

--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -62,7 +62,7 @@ impl Component for SignatureHelp {
         });
 
         let sig_text = crate::ui::markdown::highlighted_code_block(
-            self.signature.clone(),
+            &self.signature,
             &self.language,
             Some(&cx.editor.theme),
             Arc::clone(&self.config_loader),
@@ -109,7 +109,7 @@ impl Component for SignatureHelp {
         let max_text_width = (viewport.0 - PADDING).min(120);
 
         let signature_text = crate::ui::markdown::highlighted_code_block(
-            self.signature.clone(),
+            &self.signature,
             &self.language,
             None,
             Arc::clone(&self.config_loader),

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -10,7 +10,7 @@ use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag};
 
 use helix_core::{
     syntax::{self, HighlightEvent, InjectionLanguageMarker, Syntax},
-    Rope,
+    RopeSlice,
 };
 use helix_view::{
     graphics::{Margin, Rect, Style},
@@ -45,13 +45,13 @@ pub fn highlighted_code_block<'a>(
         None => return styled_multiline_text(text, code_style),
     };
 
-    let rope = Rope::from(text.as_ref());
+    let ropeslice = RopeSlice::from(text);
     let syntax = config_loader
         .language_configuration_for_injection_string(&InjectionLanguageMarker::Name(
             language.into(),
         ))
         .and_then(|config| config.highlight_config(theme.scopes()))
-        .and_then(|config| Syntax::new(&rope, config, Arc::clone(&config_loader)));
+        .and_then(|config| Syntax::new(ropeslice, config, Arc::clone(&config_loader)));
 
     let syntax = match syntax {
         Some(s) => s,
@@ -59,7 +59,7 @@ pub fn highlighted_code_block<'a>(
     };
 
     let highlight_iter = syntax
-        .highlight_iter(rope.slice(..), None, None)
+        .highlight_iter(ropeslice, None, None)
         .map(|e| e.unwrap());
     let highlight_iter: Box<dyn Iterator<Item = HighlightEvent>> =
         if let Some(spans) = additional_highlight_spans {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -17,7 +17,7 @@ use helix_view::{
     Theme,
 };
 
-fn styled_multiline_text<'a>(text: String, style: Style) -> Text<'a> {
+fn styled_multiline_text<'a>(text: &str, style: Style) -> Text<'a> {
     let spans: Vec<_> = text
         .lines()
         .map(|line| Span::styled(line.to_string(), style))
@@ -27,7 +27,7 @@ fn styled_multiline_text<'a>(text: String, style: Style) -> Text<'a> {
 }
 
 pub fn highlighted_code_block<'a>(
-    text: String,
+    text: &str,
     language: &str,
     theme: Option<&Theme>,
     config_loader: Arc<syntax::Loader>,
@@ -267,7 +267,7 @@ impl Markdown {
                             CodeBlockKind::Indented => "",
                         };
                         let tui_text = highlighted_code_block(
-                            text.to_string(),
+                            &text,
                             language,
                             theme,
                             Arc::clone(&self.config_loader),

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -151,7 +151,8 @@ pub fn regex_prompt(
                 }
             }
         },
-    );
+    )
+    .with_language("regex", std::sync::Arc::clone(&cx.editor.syn_loader));
     // Calculate initial completion
     prompt.recalculate_completion(cx.editor);
     // prompt

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -142,9 +142,6 @@ pub fn regex_prompt(
                                 };
 
                                 cx.jobs.callback(callback);
-                            } else {
-                                // Update
-                                // TODO: mark command line as error
                             }
                         }
                     }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -453,9 +453,9 @@ impl<T: Item + 'static> Picker<T> {
                 let text = doc.text().clone();
                 let loader = cx.editor.syn_loader.clone();
                 let job = tokio::task::spawn_blocking(move || {
-                    let syntax = language_config
-                        .highlight_config(&loader.scopes())
-                        .and_then(|highlight_config| Syntax::new(&text, highlight_config, loader));
+                    let syntax = language_config.highlight_config(&loader.scopes()).and_then(
+                        |highlight_config| Syntax::new(text.slice(..), highlight_config, loader),
+                    );
                     let callback = move |editor: &mut Editor, compositor: &mut Compositor| {
                         let Some(syntax) = syntax else {
                             log::info!("highlighting picker item failed");

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -476,7 +476,7 @@ impl Prompt {
             }
         } else if let Some((language, loader)) = self.language.as_ref() {
             let mut text: ui::text::Text = crate::ui::markdown::highlighted_code_block(
-                self.line.clone(),
+                &self.line,
                 language,
                 Some(&cx.editor.theme),
                 loader.clone(),

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,7 +1,9 @@
 use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
+use helix_core::syntax;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
+use std::sync::Arc;
 use std::{borrow::Cow, ops::RangeFrom};
 use tui::buffer::Buffer as Surface;
 use tui::widgets::{Block, Borders, Widget};
@@ -32,6 +34,7 @@ pub struct Prompt {
     callback_fn: CallbackFn,
     pub doc_fn: DocFn,
     next_char_handler: Option<PromptCharHandler>,
+    language: Option<(&'static str, Arc<syntax::Loader>)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -83,6 +86,7 @@ impl Prompt {
             callback_fn: Box::new(callback_fn),
             doc_fn: Box::new(|_| None),
             next_char_handler: None,
+            language: None,
         }
     }
 
@@ -91,6 +95,11 @@ impl Prompt {
         self.line = line;
         self.cursor = cursor;
         self.recalculate_completion(editor);
+        self
+    }
+
+    pub fn with_language(mut self, language: &'static str, loader: Arc<syntax::Loader>) -> Self {
+        self.language = Some((language, loader));
         self
     }
 
@@ -456,30 +465,28 @@ impl Prompt {
         // render buffer text
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
-        let (input, is_suggestion): (Cow<str>, bool) = if self.line.is_empty() {
-            // latest value in the register list
-            match self
+        let line_area = area.clip_left(self.prompt.len() as u16).clip_top(line);
+        if self.line.is_empty() {
+            // Show the most recently entered value as a suggestion.
+            if let Some(suggestion) = self
                 .history_register
                 .and_then(|reg| cx.editor.registers.last(reg))
-                .map(|entry| entry.into())
             {
-                Some(value) => (value, true),
-                None => (Cow::from(""), false),
+                surface.set_string(line_area.x, line_area.y, suggestion, suggestion_color);
             }
+        } else if let Some((language, loader)) = self.language.as_ref() {
+            let mut text: ui::text::Text = crate::ui::markdown::highlighted_code_block(
+                self.line.clone(),
+                language,
+                Some(&cx.editor.theme),
+                loader.clone(),
+                None,
+            )
+            .into();
+            text.render(line_area, surface, cx);
         } else {
-            (self.line.as_str().into(), false)
-        };
-
-        surface.set_string(
-            area.x + self.prompt.len() as u16,
-            area.y + line,
-            &input,
-            if is_suggestion {
-                suggestion_color
-            } else {
-                prompt_color
-            },
-        );
+            surface.set_string(line_area.x, line_area.y, self.line.clone(), prompt_color);
+        }
     }
 }
 

--- a/runtime/queries/regex/highlights.scm
+++ b/runtime/queries/regex/highlights.scm
@@ -50,4 +50,4 @@
   ])
 
 (class_character) @constant.character
-(pattern_character) @string
+(ERROR) @error


### PR DESCRIPTION
<img src="https://github.com/helix-editor/helix/assets/21230295/ea3c7229-f47c-4a1a-b007-9de3c78b518e" width="60%" />



We can re-use the code-block highlighting function from the markdown component to highlight regex prompts with tree-sitter-regex. To make this change a little cheaper, we switch some functions from taking `&Rope`s to `RopeSlice`s (see 50557c62747e076e0c35f72c396e20d48d4e9052's message).