### PR TITLE
Update everforest_dark.toml to add missing color definitions

### DIFF
--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -138,3 +138,7 @@ purple = "#d699b6"
 grey0 = "#7a8478"
 grey1 = "#859289"
 grey2 = "#9da9a0"
+
+statusline1 = "#a7c080"
+statusline2 = "#d3c6aa"
+statusline3 = "#e67e80"


### PR DESCRIPTION
everforest_dark had missing color definitions, and so the modes had no colors in the statusline, and the bufferline had no highlighting