### PR TITLE
fix(picker): duplicate entries in pickers

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2008,7 +2008,7 @@ fn make_search_word_bounded(cx: &mut Context) {
 }
 
 fn global_search(cx: &mut Context) {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     struct FileResult {
         path: PathBuf,
         /// 0 indexed lines
@@ -2581,6 +2581,7 @@ fn file_picker_in_current_directory(cx: &mut Context) {
 fn buffer_picker(cx: &mut Context) {
     let current = view!(cx.editor).doc;
 
+    #[derive(PartialEq)]
     struct BufferMeta {
         id: DocumentId,
         path: Option<PathBuf>,
@@ -2648,6 +2649,7 @@ fn buffer_picker(cx: &mut Context) {
 }
 
 fn jumplist_picker(cx: &mut Context) {
+    #[derive(PartialEq)]
     struct JumpMeta {
         id: DocumentId,
         path: Option<PathBuf>,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1027,10 +1027,21 @@ pub fn apply_workspace_edit(
     Ok(())
 }
 
+/// Removes duplicates from the vector, complexity - `O(n^2)`. If your type
+/// implements ([`Hash`] + [`Eq`]) or [`Ord`], you can use faster methods (e.g [`HashSet`]).
+pub fn remove_duplicates_bruteforce<T: PartialEq>(items: Vec<T>) -> Vec<T> {
+    items.into_iter().fold(Vec::new(), |mut accum, item| {
+        if !accum.contains(&item) {
+            accum.push(item);
+        }
+        accum
+    })
+}
+
 fn goto_impl(
     editor: &mut Editor,
     compositor: &mut Compositor,
-    locations: Vec<lsp::Location>,
+    mut locations: Vec<lsp::Location>,
     offset_encoding: OffsetEncoding,
 ) {
     let cwdir = helix_loader::current_working_dir();
@@ -1043,6 +1054,8 @@ fn goto_impl(
             editor.set_error("No definition found.");
         }
         _locations => {
+            // lsp::Location doesn't implement Ord or Hash. So we can't compare them faster than brute force
+            locations = remove_duplicates_bruteforce(locations);
             let picker = Picker::new(locations, cwdir, move |cx, location, action| {
                 jump_to_location(cx.editor, location, offset_encoding, action)
             })
@@ -1664,4 +1677,28 @@ fn compute_inlay_hints_for_view(
     );
 
     Some(callback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_duplicates_bruteforce() {
+        let tests = [
+            (vec![5, 4, 1], vec![5, 4, 1]),
+            (vec![1, 2, 3, 2, 1, 0], vec![1, 2, 3, 0]),
+            (vec![1, 1, 1, 2, 3], vec![1, 2, 3]),
+            (vec![], vec![]),
+        ];
+        for (test, expected) in tests {
+            assert_eq!(
+                remove_duplicates_bruteforce(test.clone()),
+                expected,
+                "{:?} without duplicates must be: {:?}",
+                test,
+                expected
+            );
+        }
+    }
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -99,12 +99,9 @@ impl ui::menu::Item for lsp::Location {
             .expect("Will only failed if allocating fail");
         res.into()
     }
-
-    fn as_partial_eq(&self) -> Option<&dyn PartialEq<Self>> {
-        Some(self as &dyn PartialEq<Self>)
-    }
 }
 
+#[derive(PartialEq)]
 struct SymbolInformationItem {
     symbol: lsp::SymbolInformation,
     offset_encoding: OffsetEncoding,
@@ -141,6 +138,7 @@ struct DiagnosticStyles {
     error: Style,
 }
 
+#[derive(PartialEq)]
 struct PickerDiagnostic {
     url: lsp::Url,
     diag: lsp::Diagnostic,
@@ -542,6 +540,7 @@ pub fn workspace_diagnostics_picker(cx: &mut Context) {
     cx.push_layer(Box::new(overlaid(picker)));
 }
 
+#[derive(PartialEq)]
 struct CodeActionOrCommandItem {
     lsp_item: lsp::CodeActionOrCommand,
     language_server_id: usize,
@@ -1047,7 +1046,6 @@ fn goto_impl(
             editor.set_error("No definition found.");
         }
         _locations => {
-            // lsp::Location doesn't implement Ord or Hash. So we can't compare them faster than brute force
             let picker = Picker::new(locations, cwdir, move |cx, location, action| {
                 jump_to_location(cx.editor, location, offset_encoding, action)
             })

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -29,6 +29,10 @@ pub trait Item {
         let label: String = self.format(data).cell_text().collect();
         label.into()
     }
+
+    fn as_partial_eq(&self) -> Option<&dyn PartialEq<Self>> {
+        None
+    }
 }
 
 impl Item for PathBuf {

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -14,7 +14,8 @@ use fuzzy_matcher::FuzzyMatcher;
 use helix_view::{graphics::Rect, Editor};
 use tui::layout::Constraint;
 
-pub trait Item {
+// PartialEq so we might deduplicate items (e.g in pickers)
+pub trait Item: PartialEq {
     /// Additional editor state that is used for label calculation.
     type Data;
 
@@ -28,10 +29,6 @@ pub trait Item {
     fn filter_text(&self, data: &Self::Data) -> Cow<str> {
         let label: String = self.format(data).cell_text().collect();
         label.into()
-    }
-
-    fn as_partial_eq(&self) -> Option<&dyn PartialEq<Self>> {
-        None
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -197,22 +197,13 @@ impl<T: Item + 'static> Picker<T> {
     /// Removes duplicates from picker options, complexity - `O(n^2)`.
     /// Pickers usually have no more than 10^5 entries, so it doesn't matter.
     fn options_dedup_bruteforce(&mut self) {
-        let items_len = self.options.len();
-        if items_len == 0 || self.options[0].as_partial_eq().is_none() {
-            return;
+        let mut unique_options = Vec::with_capacity(self.options.len());
+        for item in self.options.drain(..) {
+            if !unique_options.iter().any(|lhs| lhs == &item) {
+                unique_options.push(item);
+            }
         }
-        self.options =
-            self.options
-                .drain(..)
-                .fold(Vec::with_capacity(items_len), |mut accum, item| {
-                    if !accum
-                        .iter()
-                        .any(|lhs| lhs.as_partial_eq().unwrap().eq(&item))
-                    {
-                        accum.push(item);
-                    }
-                    accum
-                });
+        self.options = unique_options;
     }
 
     pub fn truncate_start(mut self, truncate_start: bool) -> Self {
@@ -1005,9 +996,6 @@ mod tests {
             type Data = ();
             fn format(&self, _data: &Self::Data) -> tui::widgets::Row {
                 self.to_string().into()
-            }
-            fn as_partial_eq(&self) -> Option<&dyn PartialEq<Self>> {
-                Some(self as &dyn PartialEq<Self>)
             }
         }
         let items = vec![0, 2, 1, 2, 1];


### PR DESCRIPTION
Closes #2286

Added `PartialEq` subtrait for `Item` trait. Wrote a method in `Picker impl` that deduplicates picker options using only the `PartialEq` trait. That's why the complexity is O(n^2), but I don't think it's a problem since pickers probably won't have more than 10^4 elements.

<details><summary>Note: I didn't do a `--force` push, so the first two commits in this pr are also valid solutions though quite different, but I think it's better.</summary>

1. 93303a825946d4c01583e4d7ce659768afa80853 _Only fixes duplicates in lsp pickers_. Removes duplicates from a list of items if they have the same filename and range. So if you have a line: 
``` rust
let mut q = 1; q = 2; q = 3;
```
it will show 3 entries in `goto_reference` picker anyway because these references have different `Range`.


2. 37f7b6d13ee527598d7eb3bb1d7231a3ced42512 Add `as_partial_eq` method to the `Item` trait with the default implementation. So we can deduplicate inside the picker initialization. With this approach, we simulate optional `PartialEq` trait for `Item` so that anyone who wants can make items comparable. This is both a terrible and a beautiful solution.

The first solution is still valid because right now only lsp pickers can return duplicates (e.g `gr` in rust macros). Though If you satisfy with second approach I can add `as_partial_eq` implementation for other items (just in case).
</details> 