### PR TITLE
Save an undo checkpoint before accepting completion

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -292,6 +292,8 @@ impl Completion {
                     };
                     // if more text was entered, remove it
                     doc.restore(view, &savepoint, true);
+                    // save an undo checkpoint before the completion
+                    doc.append_changes_to_history(view);
                     let transaction = item_to_transaction(
                         doc,
                         view.id,


### PR DESCRIPTION
See https://github.com/helix-editor/helix/issues/7643#issuecomment-1642740855

When you accidentally accept the wrong completion candidate and then go to normal mode and undo, the whole insert is undone which feels like too much. We can save an undo checkpoint when accepting a completion of the text before the completion takes effect so that the undo window is smaller.

I'm not sure if this is too granular or not: if you use completions frequently this can introduce many undo points.