### PR TITLE
Refactor Nix flake to use crane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,110 +1,29 @@
 {
   "nodes": {
     "crane": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681175776,
-        "narHash": "sha256-7SsUy9114fryHAZ8p1L6G6YSu7jjz55FddEwa2U8XZc=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "445a3d222947632b5593112bb817850e8a9cf737",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "ref": "v0.12.1",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "dream2nix": {
       "inputs": {
-        "all-cabal-json": [
-          "nci"
-        ],
-        "crane": "crane",
-        "devshell": [
-          "nci"
-        ],
-        "drv-parts": "drv-parts",
         "flake-compat": "flake-compat",
-        "flake-parts": [
-          "nci",
-          "parts"
-        ],
-        "flake-utils-pre-commit": [
-          "nci"
-        ],
-        "ghc-utils": [
-          "nci"
-        ],
-        "gomod2nix": [
-          "nci"
-        ],
-        "mach-nix": [
-          "nci"
-        ],
-        "nix-pypi-fetcher": [
-          "nci"
+        "flake-utils": [
+          "flake-utils"
         ],
         "nixpkgs": [
-          "nci",
           "nixpkgs"
         ],
-        "nixpkgsV1": "nixpkgsV1",
-        "poetry2nix": [
-          "nci"
-        ],
-        "pre-commit-hooks": [
-          "nci"
-        ],
-        "pruned-racket-catalog": [
-          "nci"
+        "rust-overlay": [
+          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1683212002,
-        "narHash": "sha256-EObtqyQsv9v+inieRY5cvyCMCUI5zuU5qu+1axlJCPM=",
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "rev": "fbfb09d2ab5ff761d822dd40b4a1def81651d096",
+        "lastModified": 1688772518,
+        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "type": "github"
-      }
-    },
-    "drv-parts": {
-      "inputs": {
-        "flake-compat": [
-          "nci",
-          "dream2nix",
-          "flake-compat"
-        ],
-        "flake-parts": [
-          "nci",
-          "dream2nix",
-          "flake-parts"
-        ],
-        "nixpkgs": [
-          "nci",
-          "dream2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1680698112,
-        "narHash": "sha256-FgnobN/DvCjEsc0UAZEAdPLkL4IZi2ZMnu2K2bUaElc=",
-        "owner": "davhau",
-        "repo": "drv-parts",
-        "rev": "e8c2ec1157dc1edb002989669a0dbd935f430201",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davhau",
-        "repo": "drv-parts",
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -129,170 +48,58 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "mk-naked-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681286841,
-        "narHash": "sha256-3XlJrwlR0nBiREnuogoa5i1b4+w/XPe0z8bbrJASw0g=",
-        "owner": "yusdacra",
-        "repo": "mk-naked-shell",
-        "rev": "7612f828dd6f22b7fb332cc69440e839d7ffe6bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "yusdacra",
-        "repo": "mk-naked-shell",
-        "type": "github"
-      }
-    },
-    "nci": {
-      "inputs": {
-        "dream2nix": "dream2nix",
-        "mk-naked-shell": "mk-naked-shell",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "parts": "parts",
-        "rust-overlay": [
-          "rust-overlay"
-        ]
-      },
-      "locked": {
-        "lastModified": 1683699050,
-        "narHash": "sha256-UWKQpzVcSshB+sU2O8CCHjOSTQrNS7Kk9V3+UeBsJpg=",
-        "owner": "yusdacra",
-        "repo": "nix-cargo-integration",
-        "rev": "ed27173cd1b223f598343ea3c15aacb1d140feac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "yusdacra",
-        "repo": "nix-cargo-integration",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683408522,
-        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "lastModified": 1690272529,
+        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgsV1": {
-      "locked": {
-        "lastModified": 1678500271,
-        "narHash": "sha256-tRBLElf6f02HJGG0ZR7znMNFv/Uf7b2fFInpTHiHaSE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5eb98948b66de29f899c7fe27ae112a47964baf8",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-22.11",
-        "type": "indirect"
-      }
-    },
-    "parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nci",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nci": "nci",
+        "crane": "crane",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "parts": "parts_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1683771545,
-        "narHash": "sha256-we0GYcKTo2jRQGmUGrzQ9VH0OYAUsJMCsK8UkF+vZUA=",
+        "lastModified": 1690424156,
+        "narHash": "sha256-Bpml+L280tHTQpwpC5/BJbU4HSvEzMvW8IZ4gAXimhE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c57e210faf68e5d5386f18f1b17ad8365d25e4ed",
+        "rev": "f335a0213504c7e6481c359dc1009be9cf34432c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,166 +3,190 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
     };
-    nci = {
-      url = "github:yusdacra/nix-cargo-integration";
-      inputs.nixpkgs.follows = "nixpkgs";
+    crane = {
+      url = "github:ipetkov/crane";
       inputs.rust-overlay.follows = "rust-overlay";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
-    parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inp: let
-    mkRootPath = rel:
-      builtins.path {
-        path = "${toString ./.}/${rel}";
-        name = rel;
+  outputs = {
+    self,
+    nixpkgs,
+    crane,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [(import rust-overlay)];
       };
-    filteredSource = let
-      pathsToIgnore = [
-        ".envrc"
-        ".ignore"
-        ".github"
-        ".gitignore"
-        "logo.svg"
-        "logo_dark.svg"
-        "logo_light.svg"
-        "rust-toolchain.toml"
-        "rustfmt.toml"
-        "runtime"
-        "screenshot.png"
-        "book"
-        "contrib"
-        "docs"
-        "README.md"
-        "CHANGELOG.md"
-        "shell.nix"
-        "default.nix"
-        "grammars.nix"
-        "flake.nix"
-        "flake.lock"
-      ];
-      ignorePaths = path: type: let
-        inherit (inp.nixpkgs) lib;
-        # split the nix store path into its components
-        components = lib.splitString "/" path;
-        # drop off the `/nix/hash-source` section from the path
-        relPathComponents = lib.drop 4 components;
-        # reassemble the path components
-        relPath = lib.concatStringsSep "/" relPathComponents;
-      in
-        lib.all (p: ! (lib.hasPrefix p relPath)) pathsToIgnore;
-    in
-      builtins.path {
-        name = "helix-source";
-        path = toString ./.;
-        # filter out unnecessary paths
-        filter = ignorePaths;
-      };
-  in
-    inp.parts.lib.mkFlake {inputs = inp;} {
-      imports = [inp.nci.flakeModule inp.parts.flakeModules.easyOverlay];
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-        "i686-linux"
-      ];
-      perSystem = {
-        config,
-        pkgs,
-        lib,
-        ...
-      }: let
-        makeOverridableHelix = old: config: let
-          grammars = pkgs.callPackage ./grammars.nix config;
-          runtimeDir = pkgs.runCommand "helix-runtime" {} ''
-            mkdir -p $out
-            ln -s ${mkRootPath "runtime"}/* $out
-            rm -r $out/grammars
-            ln -s ${grammars} $out/grammars
-          '';
-          helix-wrapped =
-            pkgs.runCommand
-            old.name
-            {
-              inherit (old) pname version;
-              meta = old.meta or {};
-              passthru =
-                (old.passthru or {})
-                // {
-                  unwrapped = old;
-                };
-              nativeBuildInputs = [pkgs.makeWrapper];
-              makeWrapperArgs = config.makeWrapperArgs or [];
-            }
-            ''
-              cp -rs --no-preserve=mode,ownership ${old} $out
-              wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
-            '';
+      mkRootPath = rel:
+        builtins.path {
+          path = "${toString ./.}/${rel}";
+          name = rel;
+        };
+      filteredSource = let
+        pathsToIgnore = [
+          ".envrc"
+          ".ignore"
+          ".github"
+          ".gitignore"
+          "logo.svg"
+          "logo_dark.svg"
+          "logo_light.svg"
+          "rust-toolchain.toml"
+          "rustfmt.toml"
+          "runtime"
+          "screenshot.png"
+          "book"
+          "contrib"
+          "docs"
+          "README.md"
+          "CHANGELOG.md"
+          "shell.nix"
+          "default.nix"
+          "grammars.nix"
+          "flake.nix"
+          "flake.lock"
+        ];
+        ignorePaths = path: type: let
+          inherit (nixpkgs) lib;
+          # split the nix store path into its components
+          components = lib.splitString "/" path;
+          # drop off the `/nix/hash-source` section from the path
+          relPathComponents = lib.drop 4 components;
+          # reassemble the path components
+          relPath = lib.concatStringsSep "/" relPathComponents;
         in
-          helix-wrapped
-          // {
-            override = makeOverridableHelix old;
+          lib.all (p: ! (lib.hasPrefix p relPath)) pathsToIgnore;
+      in
+        builtins.path {
+          name = "helix-source";
+          path = toString ./.;
+          # filter out unnecessary paths
+          filter = ignorePaths;
+        };
+      makeOverridableHelix = old: config: let
+        grammars = pkgs.callPackage ./grammars.nix config;
+        runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+          mkdir -p $out
+          ln -s ${mkRootPath "runtime"}/* $out
+          rm -r $out/grammars
+          ln -s ${grammars} $out/grammars
+        '';
+        helix-wrapped =
+          pkgs.runCommand
+          old.name
+          {
+            inherit (old) pname version;
+            meta = old.meta or {};
             passthru =
-              helix-wrapped.passthru
+              (old.passthru or {})
               // {
-                wrapper = old: makeOverridableHelix old config;
+                unwrapped = old;
               };
-          };
-        stdenv =
-          if pkgs.stdenv.isLinux
-          then pkgs.stdenv
-          else pkgs.clangStdenv;
-        rustFlagsEnv =
-          if stdenv.isLinux
-          then ''$RUSTFLAGS -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment''
-          else "$RUSTFLAGS";
-      in {
-        nci.projects."helix-project".relPath = "";
-        nci.crates."helix-term" = {
-          overrides = {
-            add-meta.override = _: {meta.mainProgram = "hx";};
-            add-inputs.overrideAttrs = prev: {
-              buildInputs = (prev.buildInputs or []) ++ [stdenv.cc.cc.lib];
-            };
-            disable-grammar-builds = {
-              # disable fetching and building of tree-sitter grammars in the helix-term build.rs
-              HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-            };
-            disable-tests = {checkPhase = ":";};
-            set-stdenv.override = _: {inherit stdenv;};
-            set-filtered-src.override = _: {src = filteredSource;};
-          };
-        };
-
-        packages.helix-unwrapped = config.nci.outputs."helix-term".packages.release;
-        packages.helix-unwrapped-dev = config.nci.outputs."helix-term".packages.dev;
-        packages.helix = makeOverridableHelix config.packages.helix-unwrapped {};
-        packages.helix-dev = makeOverridableHelix config.packages.helix-unwrapped-dev {};
-        packages.default = config.packages.helix;
-
-        overlayAttrs = {
-          inherit (config.packages) helix;
-        };
-
-        devShells.default = config.nci.outputs."helix-project".devShell.overrideAttrs (old: {
-          nativeBuildInputs =
-            (old.nativeBuildInputs or [])
-            ++ (with pkgs; [lld_13 cargo-flamegraph rust-analyzer])
-            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) pkgs.cargo-tarpaulin)
-            ++ (lib.optional stdenv.isLinux pkgs.lldb)
-            ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreFoundation);
-          shellHook = ''
-            export HELIX_RUNTIME="$PWD/runtime"
-            export RUST_BACKTRACE="1"
-            export RUSTFLAGS="${rustFlagsEnv}"
+            nativeBuildInputs = [pkgs.makeWrapper];
+            makeWrapperArgs = config.makeWrapperArgs or [];
+          }
+          ''
+            cp -rs --no-preserve=mode,ownership ${old} $out
+            wrapProgram "$out/bin/hx" ''${makeWrapperArgs[@]} --set HELIX_RUNTIME "${runtimeDir}"
           '';
-        });
+      in
+        helix-wrapped
+        // {
+          override = makeOverridableHelix old;
+          passthru =
+            helix-wrapped.passthru
+            // {
+              wrapper = old: makeOverridableHelix old config;
+            };
+        };
+      stdenv =
+        if pkgs.stdenv.isLinux
+        then pkgs.stdenv
+        else pkgs.clangStdenv;
+      rustFlagsEnv =
+        if stdenv.isLinux
+        then ''$RUSTFLAGS -C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment''
+        else "$RUSTFLAGS";
+      rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+      commonArgs =
+        {
+          inherit stdenv;
+          src = filteredSource;
+          # disable fetching and building of tree-sitter grammars in the helix-term build.rs
+          HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+          buildInputs = [stdenv.cc.cc.lib];
+          # disable tests
+          doCheck = false;
+          meta.mainProgram = "hx";
+        }
+        // craneLib.crateNameFromCargoToml {cargoToml = ./helix-term/Cargo.toml;};
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+    in {
+      packages = {
+        helix-unwrapped = craneLib.buildPackage (commonArgs
+          // {
+            inherit cargoArtifacts;
+          });
+        helix = makeOverridableHelix self.packages.${system}.helix-unwrapped {};
+        default = self.packages.${system}.helix;
+      };
+
+      checks = {
+        # Build the crate itself
+        inherit (self.packages.${system}) helix;
+
+        clippy = craneLib.cargoClippy (commonArgs
+          // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+        fmt = craneLib.cargoFmt commonArgs;
+
+        doc = craneLib.cargoDoc (commonArgs
+          // {
+            inherit cargoArtifacts;
+          });
+
+        test = craneLib.cargoTest (commonArgs
+          // {
+            inherit cargoArtifacts;
+          });
+      };
+
+      devShells.default = pkgs.mkShell {
+        inputsFrom = builtins.attrValues self.checks.${system};
+        nativeBuildInputs = with pkgs;
+          [lld_13 cargo-flamegraph rust-analyzer]
+          ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) pkgs.cargo-tarpaulin)
+          ++ (lib.optional stdenv.isLinux pkgs.lldb)
+          ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreFoundation);
+        shellHook = ''
+          export HELIX_RUNTIME="$PWD/runtime"
+          export RUST_BACKTRACE="1"
+          export RUSTFLAGS="${rustFlagsEnv}"
+        '';
+      };
+    })
+    // {
+      overlays.default = final: prev: {
+        inherit (self.packages.${final.system}) helix;
       };
     };
 


### PR DESCRIPTION
This resolves a build issue with nci/dream2nix and git dependencies. We can keep most of the helix-specific parts of the flake, we just need to switch from configuring nci to calling craneLib functions.

We also switch to flake-utils from flake-parts:

* Using rust-overlay with flake-parts directly is unergonomic (see https://github.com/hercules-ci/flake-parts/discussions/83).
* Removing flake-parts reduces the overall dependencies: rust-overlay already depends on flake-utils.

Closes #7761