### PR TITLE
Add tree-sitter textobjects queries for bash

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | --- | --- |
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
-| bash | ✓ |  | ✓ | `bash-language-server` |
+| bash | ✓ | ✓ | ✓ | `bash-language-server` |
 | bass | ✓ |  |  | `bass` |
 | beancount | ✓ |  |  |  |
 | bibtex | ✓ |  |  | `texlab` |

--- a/runtime/queries/bash/textobjects.scm
+++ b/runtime/queries/bash/textobjects.scm
@@ -1,0 +1,9 @@
+(function_definition
+  body: (_) @function.inside) @function.around
+
+(command
+  argument: (_) @parameter.inside)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around


### PR DESCRIPTION
This implements function, (calling) argument and comment captures for use in the textobject selections in bash.

This also updates the generated docs after adding the textobjects for bash.