### PR TITLE
Make pasting replace the entire selection

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -113,7 +113,7 @@ impl Range {
     }
 
     /// `Direction::Backward` when head < anchor.
-    /// `Direction::Backward` otherwise.
+    /// `Direction::Forward` otherwise.
     #[inline]
     #[must_use]
     pub fn direction(&self) -> Direction {

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -163,11 +163,46 @@ async fn test_multi_selection_paste() -> anyhow::Result<()> {
             #(|ipsum)#
             #(|dolor)#
             "}),
+        "y;P",
+        platform_line(indoc! {"\
+            #[lorem|]#lorem
+            #(ipsum|)#ipsum
+            #(dolor|)#dolor
+            "}),
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_paste_replace() -> anyhow::Result<()> {
+    test((
+        platform_line(indoc! {"\
+            #[lorem|]# ipsum dolor
+            "}),
+        "yebp",
+        platform_line(indoc! {"\
+            lorem #[|lorem]# dolor
+            "}),
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_paste_linewise() -> anyhow::Result<()> {
+    test((
+        platform_line(indoc! {"\
+            #[lorem ipsum dolor\n|]#
+            dolor ipsum lorem
+            "}),
         "yp",
         platform_line(indoc! {"\
-            lorem#[|lorem]#
-            ipsum#(|ipsum)#
-            dolor#(|dolor)#
+            lorem ipsum dolor
+            #[lorem ipsum dolor\n|]#
+            dolor ipsum lorem
             "}),
     ))
     .await?;


### PR DESCRIPTION
Hey folks.

I don't think anyone asked for this, but it's an idea that would improve my productivity at least.

In vim, you can make a selection and then "p" to replace the selection with whatever you have yanked. I used to do this a ton in vim. It's one way to work around https://github.com/helix-editor/helix/issues/3001.

This PR makes non-linewise selections _replaced_ when pasting onto them.

[Kooha-2023-07-28-16-29-38.webm](https://github.com/helix-editor/helix/assets/2793160/e6bdd784-7d85-482c-90d1-32d9a5cfeba3)

This is a breaking change so I don't really expect a merge as-is. Just wanted to bring up the idea and do some legwork as well. One alternative could be to implement this as a separate command and bind it to, say, `a-p`.

Anyway let me know what you think. If you have time.