### PR TITLE
feat: display invisible chars inside selection

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -233,7 +233,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `nbsp`, `tab`, and `newline` | `"none"` |
+| `render` | Whether to render whitespace. May either be `"all"`, `"selection"` or `"none"`, or a table with sub-keys `space`, `nbsp`, `tab`, and `newline` | `"none"` |
 | `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad` | See example below |
 
 Example
@@ -245,7 +245,7 @@ render = "all"
 [editor.whitespace.render]
 space = "all"
 tab = "all"
-newline = "none"
+newline = "selection"
 
 [editor.whitespace.characters]
 space = "·"

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -651,8 +651,7 @@ pub enum WhitespaceRender {
 #[serde(rename_all = "kebab-case")]
 pub enum WhitespaceRenderValue {
     None,
-    // TODO
-    // Selection,
+    Selection,
     All,
 }
 
@@ -732,12 +731,13 @@ impl Default for IndentGuidesConfig {
 }
 
 /// Line ending configuration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LineEndingConfig {
     /// The platform's native line ending.
     ///
     /// `crlf` on Windows, otherwise `lf`.
+    #[default]
     Native,
     /// Line feed.
     LF,
@@ -752,12 +752,6 @@ pub enum LineEndingConfig {
     /// Next line.
     #[cfg(feature = "unicode-lines")]
     Nel,
-}
-
-impl Default for LineEndingConfig {
-    fn default() -> Self {
-        LineEndingConfig::Native
-    }
 }
 
 impl From<LineEndingConfig> for LineEnding {


### PR DESCRIPTION
Closes #1068
It appeared that #2208 is stale and would not be rebased on top of #5420. Though, if the author wakes up, you can close this PR without hesitation.

In general now it works fine: https://asciinema.org/a/vVQptp5dofjy3nz7CckwxjVFg

But I found one ~~bug~~ feature: I can't `set whitespace.render.<smth> <value>` only `set whitespace.render <value>`. This is related to master helix too. I don't know how to fix this at the moment (probably something with serde), but I would like to add this fix to the PR also

Code isn't the cleanest in the world, and I need to remove a lot of `clone` calls, maybe replace `String` with generic.