### PR TITLE
support diff gutters for non-vcs files

### DIFF
--- a/helix-vcs/src/file.rs
+++ b/helix-vcs/src/file.rs
@@ -1,0 +1,39 @@
+use std::{io::Read, sync::Arc};
+
+use anyhow::bail;
+use arc_swap::ArcSwap;
+
+use crate::DiffProvider;
+
+pub struct File;
+
+const MAX_SIZE: usize = 10 * 1024 * 1024;
+const READ_SIZE: usize = 8 * 1024;
+
+impl DiffProvider for File {
+    fn get_diff_base(&self, file: &std::path::Path) -> anyhow::Result<Vec<u8>> {
+        let mut fh = std::fs::File::open(file)?;
+        let mut contents = vec![];
+        loop {
+            let mut chunk = [0; READ_SIZE];
+            let bytes = fh.read(&mut chunk)?;
+            if bytes == 0 {
+                break;
+            }
+            if contents.len() + bytes > MAX_SIZE {
+                bail!("file too long");
+            }
+            contents.extend_from_slice(&chunk[..bytes]);
+        }
+        Ok(contents)
+    }
+
+    fn get_current_head_name(
+        &self,
+        _file: &std::path::Path,
+    ) -> anyhow::Result<std::sync::Arc<arc_swap::ArcSwap<Box<str>>>> {
+        Ok(Arc::new(ArcSwap::from_pointee(
+            "(file)".to_string().into_boxed_str(),
+        )))
+    }
+}

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -7,6 +7,7 @@ pub use git::Git;
 #[cfg(not(feature = "git"))]
 pub use Dummy as Git;
 
+mod file;
 #[cfg(feature = "git")]
 mod git;
 
@@ -72,7 +73,8 @@ impl Default for DiffProviderRegistry {
         // currently only git is supported
         // TODO make this configurable when more providers are added
         let git: Box<dyn DiffProvider> = Box::new(Git);
-        let providers = vec![git];
+        let file: Box<dyn DiffProvider> = Box::new(file::File);
+        let providers = vec![git, file];
         DiffProviderRegistry { providers }
     }
 }


### PR DESCRIPTION
fixes #6571 

i'm not sure if the file size limitation is necessary (it doesn't exist for git diffs) but i added it because files in git repositories tend to be relatively small (git in general doesn't handle large files particularly well), and using a text editor to open enormous log files is a pretty common operation.