### PR TITLE
Update t32 language queries to version 2.2.1

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2688,7 +2688,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "t32"
-source = { git = "https://codeberg.org/xasc/tree-sitter-t32", rev = "1dd98248b01e4a3933c1b85b58bab0875e2ba437" }
+source = { git = "https://gitlab.com/xasc/tree-sitter-t32", rev = "6da5e3cbabd376b566d04282005e52ffe67ef74a" }
 
 [[language]]
 name = "webc"

--- a/runtime/queries/t32/highlights.scm
+++ b/runtime/queries/t32/highlights.scm
@@ -1,3 +1,28 @@
+; Operators in command and conditional HLL expressions
+(hll_comma_expression
+  "," @operator)
+
+(hll_conditional_expression
+  [
+   "?"
+   ":"
+] @operator)
+
+
+; Keywords, punctuation and operators
+[
+  "enum"
+  "struct"
+  "union"
+] @keyword.storage.type
+
+"sizeof" @keyword.operator
+
+[
+  "const"
+  "volatile"
+] @keyword.storage.modifier
+
 [
   "="
   "^^"
@@ -28,48 +53,88 @@
   "&"
   "->"
   "*"
+  "-="
+  "+="
+  "*="
+  "/="
+  "%="
+  "|="
+  "&="
+  "^="
+  ">>="
+  "<<="
+  "--"
+  "++"
 ] @operator
 
 [
- "("
- ")"
- "{"
- "}"
- "["
- "]"
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
 ] @punctuation.bracket
 
 [
   ","
   "."
-  ";"
 ] @punctuation.delimiter
 
-; Constants
+
+; Strings and others literal types
+(access_class) @constant.builtin
+
 [
-  (access_class)
   (address)
   (bitmask)
   (file_handle)
-  (frequency)
-  (time)
-] @constant.builtin
+  (integer)
+  (hll_number_literal)
+] @constant.numeric.integer
 
 [
   (float)
+  (frequency)
   (percentage)
+  (time)
 ] @constant.numeric.float
 
-(integer) @constant.numeric.integer
+[
+  (string)
+  (hll_string_literal)
+] @string
 
-(character) @constant.character
-
-; Strings
-(string) @string
+(hll_escape_sequence) @constant.character.escape
 
 (path) @string.special.path
-
 (symbol) @string.special.symbol
+
+[
+  (character)
+  (hll_char_literal)
+] @constant.character
+
+
+; Types in HLL expressions
+[
+  (hll_type_identifier)
+  (hll_type_descriptor)
+] @type
+
+(hll_type_qualifier) @keyword.storage.modifier
+
+(hll_primitive_type) @type.builtin
+
+
+; HLL call expressions
+(hll_call_expression
+  function: (hll_field_expression
+    field: (hll_field_identifier) @function))
+
+(hll_call_expression
+  function: (identifier) @function)
+
 
 ; Returns
 (
@@ -83,10 +148,12 @@
   (#match? @keyword.return "^[rR][eE][tT][uU][rR][nN]$")
 )
 
+
 ; Subroutine calls
 (subroutine_call_expression
   command: (identifier) @keyword
   subroutine: (identifier) @function)
+
 
 ; Subroutine blocks
 (subroutine_block
@@ -97,15 +164,17 @@
   label: (identifier) @function
   (block))
 
+
 ; Parameter declarations
 (parameter_declaration
   command: (identifier) @keyword
   (identifier)? @constant.builtin
   macro: (macro) @variable.parameter)
 
+
 ; Variables, constants and labels
-(macro) @variable
-(internal_c_variable) @variable
+(macro) @variable.builtin
+(trace32_hll_variable) @variable.builtin
 
 (
   (command_expression
@@ -116,16 +185,27 @@
 (labeled_expression
   label: (identifier) @label)
 
+(option_expression
+  (identifier) @constant.builtin)
+
+(format_expression
+  (identifier) @constant.builtin)
+
 (
- (argument_list (identifier) @constant.builtin)
- (#match? @constant.builtin "^[%/][a-zA-Z][a-zA-Z0-9.]*$")
+  (argument_list (identifier) @constant.builtin)
+  (#match? @constant.builtin "^[%/][a-zA-Z][a-zA-Z0-9.]*$")
 )
 (argument_list
-  (identifier) @constant)
+  (identifier) @constant.builtin)
+
 
 ; Commands
 (command_expression command: (identifier) @keyword)
 (macro_definition command: (identifier) @keyword)
+
+(call_expression
+  function: (identifier) @function.builtin)
+
 
 ; Control flow
 (if_block
@@ -138,8 +218,10 @@
 (repeat_block
   command: (identifier) @keyword.control.loop)
 
-(call_expression
-  function: (identifier) @function)
 
-(type_identifier) @type
+; HLL variables
+(identifier) @variable
+(hll_field_identifier) @variable.other.member
+
+
 (comment) @comment


### PR DESCRIPTION
Version 2.2.1 of the grammar adds extended support for HLL (C, C++,..) expressions. Quite a few node types were added, renamed or removed in the process.

This change brings the highlight queries in sync with the ones found in the repository of the grammar. The highlighting tests "look" okay after updating the queries.

Recently, Codeberg had some reliability issues. That is why the language is now using the mirror repository on GitLab as source instead.