### PR TITLE
Improve wren support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -167,7 +167,7 @@
 | webc | ✓ |  |  |  |
 | wgsl | ✓ |  |  | `wgsl_analyzer` |
 | wit | ✓ |  | ✓ |  |
-| wren | ✓ | ✓ |  |  |
+| wren | ✓ | ✓ | ✓ |  |
 | xit | ✓ |  |  |  |
 | xml | ✓ |  | ✓ |  |
 | yaml | ✓ |  | ✓ | `yaml-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2704,7 +2704,7 @@ grammar = "html"
 
 [[grammar]]
 name = "wren"
-source = { git = "https://git.sr.ht/~jummit/tree-sitter-wren", rev = "7f576e8ccadac226f6a37cbefe95be3fee9f0a66"}
+source = { git = "https://git.sr.ht/~jummit/tree-sitter-wren", rev = "793d58266924e6efcc40e411663393e9d72bec87"}
 
 [[language]]
 name = "wren"

--- a/runtime/queries/wren/highlights.scm
+++ b/runtime/queries/wren/highlights.scm
@@ -1,11 +1,11 @@
-((identifier) @variable.builtin
+((name) @variable.builtin
  (#match? @variable.builtin "^(Bool|Class|Fiber|Fn|List|Map|Null|Num|Object|Range|Sequence|String|System)$"))
 
 (call_expression
-  (identifier) @function)
+  (name) @function)
 
 (method_definition
-  (identifier) @function.method)
+  (name) @function.method)
 
 ((parameter) @variable.parameter)
 
@@ -13,7 +13,9 @@
 (string) @string
 (raw_string) @string
 (number) @constant.numeric.integer
-(identifier) @variable
+(name) @variable
+(field) @variable
+(static_field) @variable
 (null) @constant.builtin
 (boolean) @constant.builtin.boolean
 

--- a/runtime/queries/wren/indents.scm
+++ b/runtime/queries/wren/indents.scm
@@ -1,0 +1,29 @@
+[
+	(list)
+	(map)
+	(call_body)
+	(parameter_list)
+	(call_expression)
+	(getter_definition)
+	(setter_definition)
+	(prefix_operator_definition)
+	(subscript_operator_definition)
+	(subscript_setter_definition)
+	(infix_operator_definition)
+	(method_definition)
+	(constructor)
+	(static_method_definition)
+	(static_getter_definition)
+	(attribute)
+	(conditional)
+	(class_body)
+	(if_statement)
+	(for_statement)
+	(while_statement)
+] @indent
+
+[
+	"}"
+	"]"
+	")"
+] @outdent

--- a/runtime/queries/wren/injections.scm
+++ b/runtime/queries/wren/injections.scm
@@ -1,0 +1,3 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#set! injection.include-children))

--- a/runtime/queries/wren/locals.scm
+++ b/runtime/queries/wren/locals.scm
@@ -1,0 +1,21 @@
+[
+	(method_definition)
+] @local.scope
+
+(name) @local.reference
+(field) @local.reference
+(static_field) @local.reference
+
+(for_statement
+	loop_variable: (name) @local.definition)
+
+(variable_definition
+	name: (name) @local.definition)
+
+(assignment
+	left: (field) @local.definition)
+
+(assignment
+	left: (static_field) @local.definition)
+
+(parameter) @local.definition

--- a/runtime/queries/wren/textobjects.scm
+++ b/runtime/queries/wren/textobjects.scm
@@ -1,6 +1,10 @@
 (class_definition
   (class_body) @class.inside) @class.around
 
+(call_expression
+  (call_body
+    (_) @function.inside) @function.around)
+
 (method_definition
   body: (_) @function.inside) @function.around
 


### PR DESCRIPTION
This uses the improved grammar and adds queries for indenting, injections and locals, plus overall improvements.

Maybe this isn't the right place to ask this, but is there a reason why only parameters are highlighted a different color using the locals queries?

Example:

```javascript
function test(a) {
  a // highlighted
  const b = 1
  b // not highlighted
}
```

I guess it's because it's less confusing?