### PR TITLE
Skip rendering gutters when gutter width exceeds view width

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -163,15 +163,18 @@ impl EditorView {
             Box::new(highlights)
         };
 
-        Self::render_gutter(
-            editor,
-            doc,
-            view,
-            view.area,
-            theme,
-            is_focused,
-            &mut line_decorations,
-        );
+        let gutter_overflow = view.gutter_offset(doc) == 0;
+        if !gutter_overflow {
+            Self::render_gutter(
+                editor,
+                doc,
+                view,
+                view.area,
+                theme,
+                is_focused,
+                &mut line_decorations,
+            );
+        }
 
         if is_focused {
             let cursor = doc

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -187,11 +187,17 @@ impl View {
     }
 
     pub fn gutter_offset(&self, doc: &Document) -> u16 {
-        self.gutters
+        let total_width = self
+            .gutters
             .layout
             .iter()
             .map(|gutter| gutter.width(self, doc) as u16)
-            .sum()
+            .sum();
+        if total_width < self.area.width {
+            total_width
+        } else {
+            0
+        }
     }
 
     //


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/7154
Setting `gutters.line-numbers.min-width` to a value higher than `terminal_width * terminal_height` led to index out of bounds.  
My approach was to have the width of `LineNumbers` be capped at 90% of the viewport size. Everything works as expected until the threshold is reached, when `min_width` is set to default value.

https://github.com/helix-editor/helix/assets/83179501/6f4b82a2-3c02-49c9-adf0-24683ccedbe6

