### PR TITLE
Update tree-sitter-git-commit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1296,7 +1296,7 @@ text-width = 72
 
 [[grammar]]
 name = "git-commit"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "db88cffa3952dd2328b741af5d0fc69bdb76704f" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev = "6f193a66e9aa872760823dff020960c6cedc37b3" }
 
 [[language]]
 name = "diff"


### PR DESCRIPTION
This fixes a problem parsing the "On branch _branch_" part of the commit comment when the branch contains a slash. See https://github.com/the-mikedavis/tree-sitter-git-commit/issues/12