### PR TITLE
CI: Remove the aarch64 appimage build steps from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Build AppImage
         shell: bash
-        if: matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-linux'
+        if: matrix.build == 'x86_64-linux'
         run: |
           # Required as of 22.x https://github.com/AppImage/AppImageKit/wiki/FUSE
           sudo add-apt-repository universe
@@ -263,7 +263,7 @@ jobs:
               mv bins-$platform/hx$exe $pkgname
               chmod +x $pkgname/hx$exe
 
-              if [[ "$platform" = "aarch64-linux" || "$platform" = "x86_64-linux" ]]; then
+              if [[ "$platform" = "x86_64-linux" ]]; then
                   mv bins-$platform/helix-*.AppImage* dist/
               fi
 


### PR DESCRIPTION
The steps mistakenly produce a x86_64 appimage and call it aarch64. linuxdeploy doesn't currently support producing aarch64 appimages so we should just remove these steps for aarch64-linux.

Closes #5237