### PR TITLE
feat(health): show info about multiple lsp/dap binaries

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -8,7 +8,7 @@ pub struct Args {
     pub display_help: bool,
     pub display_version: bool,
     pub health: bool,
-    pub health_arg: Option<String>,
+    pub health_arg: Vec<String>,
     pub load_tutor: bool,
     pub fetch_grammars: bool,
     pub build_grammars: bool,
@@ -42,7 +42,10 @@ impl Args {
                 },
                 "--health" => {
                     args.health = true;
-                    args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));
+                    // Helix exists after printin health so we don't care about files
+                    while let Some(item) = argv.next_if(|opt| !opt.starts_with('-')) {
+                        args.health_arg.push(item);
+                    }
                 }
                 "-g" | "--grammar" => match argv.next().as_deref() {
                     Some("fetch") => args.fetch_grammars = true,

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -42,7 +42,7 @@ impl Args {
                 },
                 "--health" => {
                     args.health = true;
-                    // Helix exists after printin health so we don't care about files
+                    // Treat all arguments after `--health' as language names
                     while let Some(item) = argv.next_if(|opt| !opt.starts_with('-')) {
                         args.health_arg.push(item);
                     }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -276,7 +276,6 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
         }
     };
 
-    // TODO multiple language servers
     probe_protocol(
         "language server",
         lang.language_servers
@@ -358,9 +357,10 @@ pub fn print_health(health_args: Vec<String>) -> std::io::Result<()> {
         print_all()?;
         return Ok(());
     }
+
     for (idx, health_arg) in health_args.into_iter().enumerate() {
         if idx != 0 {
-            // Empty line
+            // New line
             let mut stdout = std::io::stdout().lock();
             writeln!(stdout)?;
         }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -328,17 +328,31 @@ fn probe_treesitter_feature(lang: &str, feature: TsFeature) -> std::io::Result<(
     Ok(())
 }
 
-pub fn print_health(health_arg: Option<String>) -> std::io::Result<()> {
-    match health_arg.as_deref() {
-        Some("languages") => languages_all()?,
-        Some("clipboard") => clipboard()?,
-        None | Some("all") => {
-            general()?;
-            clipboard()?;
-            writeln!(std::io::stdout().lock())?;
-            languages_all()?;
+pub fn print_health(health_args: Vec<String>) -> std::io::Result<()> {
+    fn print_all() -> std::io::Result<()> {
+        general()?;
+        clipboard()?;
+        writeln!(std::io::stdout().lock())?;
+        languages_all()?;
+        Ok(())
+    }
+
+    if health_args.is_empty() {
+        print_all()?;
+        return Ok(());
+    }
+    for (idx, health_arg) in health_args.into_iter().enumerate() {
+        if idx != 0 {
+            // Empty line
+            let mut stdout = std::io::stdout().lock();
+            writeln!(stdout)?;
         }
-        Some(lang) => language(lang.to_string())?,
+        match health_arg.as_str() {
+            "languages" => languages_all()?,
+            "clipboard" => clipboard()?,
+            "all" => print_all()?,
+            lang => language(lang.into())?,
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
This PR introduces two changes:
1. Add support for multiple health arguments. E.g, `hx --health rust ruby` (05d1f94)
2. Show information about all lsp/dap binaries when `hx --health` or `hx --health <lang>` (5c4b873)

It doesn't close any existing issues afaik, but removes some TODOs introduced in #2507.
If you are not happy with the first change, I can rebase the branch to contain only the second.

[asciinema](https://asciinema.org/a/ZMlHi5XpJ8iHpEfgzdRxOL4zp)