### PR TITLE
feat: add todo.txt tree-sitter

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -149,6 +149,7 @@
 | tablegen | ✓ | ✓ | ✓ |  |
 | task | ✓ |  |  |  |
 | tfvars | ✓ |  | ✓ | `terraform-ls` |
+| todotxt | ✓ |  |  |  |
 | toml | ✓ |  |  | `taplo` |
 | tsq | ✓ |  |  |  |
 | tsx | ✓ | ✓ | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2736,3 +2736,14 @@ indent = { tab-width = 4, unit = "    " }
 name = "unison"
 source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "98c4e8bc5c9f5989814a720457cf36963cf4043d" }
 
+[[language]]
+name = "todotxt"
+scope = "text.todotxt"
+file-types = [{ suffix = ".todo.txt" }, "todotxt"]
+roots = []
+formatter = { command = "sort" }
+auto-format = true
+
+[[grammar]]
+name = "todotxt"
+source = { git = "https://github.com/arnarg/tree-sitter-todotxt", rev = "0207f6a4ab6aeafc4b091914d31d8235049a2578" }

--- a/runtime/queries/todotxt/highlights.scm
+++ b/runtime/queries/todotxt/highlights.scm
@@ -1,0 +1,6 @@
+(done_task) @comment
+(task (priority) @keyword)
+(task (date) @comment)
+(task (kv) @comment)
+(task (project) @string)
+(task (context) @type)


### PR DESCRIPTION
Add support for todo.txt ([docs](https://github.com/todotxt/todo.txt), [website](http://todotxt.org/)).

Since i often use todo.txt for organizing and markdown is already included i wanted to offer upstreaming my config.

The official file extension is `.todo.txt`, but that doesn't work with helix (and a bunch of other editors) due to the recognition prioritization, therefore i also added the alternative `.todotxt` extension.

This uses the same tree-sitter as [neovim](https://github.com/nvim-treesitter/nvim-treesitter/pull/2594).