### PR TITLE
Add ltex-ls language server

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -46,7 +46,7 @@
 | fsharp | ✓ |  |  | `fsautocomplete` |
 | gdscript | ✓ | ✓ | ✓ |  |
 | git-attributes | ✓ |  |  |  |
-| git-commit | ✓ | ✓ |  | `ltex-ls` |
+| git-commit | ✓ | ✓ |  |  |
 | git-config | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -46,7 +46,7 @@
 | fsharp | ✓ |  |  | `fsautocomplete` |
 | gdscript | ✓ | ✓ | ✓ |  |
 | git-attributes | ✓ |  |  |  |
-| git-commit | ✓ | ✓ |  |  |
+| git-commit | ✓ | ✓ |  | `ltex-ls` |
 | git-config | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1294,7 +1294,6 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 rulers = [51, 73]
 text-width = 72
-language-servers = [ "ltex-ls" ]
 
 [[grammar]]
 name = "git-commit"

--- a/languages.toml
+++ b/languages.toml
@@ -1293,6 +1293,7 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 rulers = [51, 73]
 text-width = 72
+language-servers = [ "ltex-ls" ]
 
 [[grammar]]
 name = "git-commit"

--- a/languages.toml
+++ b/languages.toml
@@ -37,6 +37,7 @@ jsonnet-language-server = { command = "jsonnet-language-server", args= ["-t", "-
 julia = { command = "julia", timeout = 60, args = [ "--startup-file=no", "--history-file=no", "--quiet", "-e", "using LanguageServer; runserver()", ] }
 kotlin-language-server = { command = "kotlin-language-server" }
 lean = { command = "lean", args = [ "--server" ] }
+ltex-ls = { command = "ltex-ls" }
 markdoc-ls = { command = "markdoc-ls", args = ["--stdio"] }
 marksman = { command = "marksman", args = ["server"] }
 metals = { command = "metals", config = { "isHttpEnabled" = true } }


### PR DESCRIPTION
`ltex-ls` now supports spelling and grammar correction for git-commit files, so I think it makes sense to support it by default. Everyone could benefit from it as Helix has no built-in spelling/grammar checker.

![Screenshot from 2023-08-05 13-50-58](https://github.com/helix-editor/helix/assets/12832280/9494e68b-78a0-4a8b-9ce9-3e54b453819f)
