### PR TITLE
build(tree-sitter): update javascript, typescript and tsx

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -563,7 +563,7 @@ args = { program = "{0}" }
 
 [[grammar]]
 name = "javascript"
-source = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "4a95461c4761c624f2263725aca79eeaefd36cad" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "f772967f7b7bc7c28f845be2420a38472b16a8ee" }
 
 [[language]]
 name = "jsx"
@@ -590,7 +590,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "typescript"
-source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259", subpath = "typescript" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf", subpath = "typescript" }
 
 [[language]]
 name = "tsx"
@@ -604,7 +604,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "tsx"
-source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259", subpath = "tsx" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf", subpath = "tsx" }
 
 [[language]]
 name = "css"

--- a/runtime/queries/_jsx/highlights.scm
+++ b/runtime/queries/_jsx/highlights.scm
@@ -4,9 +4,6 @@
 (jsx_opening_element ((identifier) @constructor
  (#match? @constructor "^[A-Z]")))
 
-; Handle the dot operator effectively - <My.Component>
-(jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
-
 (jsx_opening_element (identifier) @tag)
 
 ; Closing elements
@@ -15,9 +12,6 @@
 (jsx_closing_element ((identifier) @constructor
  (#match? @constructor "^[A-Z]")))
 
-; Handle the dot operator effectively - </My.Component>
-(jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
-
 (jsx_closing_element (identifier) @tag)
 
 ; Self-closing elements
@@ -25,9 +19,6 @@
 
 (jsx_self_closing_element ((identifier) @constructor
  (#match? @constructor "^[A-Z]")))
-
-; Handle the dot operator effectively - <My.Component />
-(jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
 (jsx_self_closing_element (identifier) @tag)
 
@@ -39,17 +30,14 @@
 ; Punctuation
 ; -----------
 
-; Handle attribute delimiter
+; Handle attribute delimiter (<Component color="red"/>)
 (jsx_attribute "=" @punctuation.delimiter)
 
 ; <Component>
 (jsx_opening_element ["<" ">"] @punctuation.bracket)
 
 ; </Component>
-(jsx_closing_element ["<" "/" ">"] @punctuation.bracket)
+(jsx_closing_element ["</" ">"] @punctuation.bracket)
 
 ; <Component />
-(jsx_self_closing_element ["<" "/" ">"] @punctuation.bracket)
-
-; <> ... </>
-(jsx_fragment ["<" "/" ">"] @punctuation.bracket)
+(jsx_self_closing_element ["<" "/>"] @punctuation.braket)

--- a/runtime/queries/_jsx/indents.scm
+++ b/runtime/queries/_jsx/indents.scm
@@ -1,5 +1,4 @@
 [
-  (jsx_fragment)
   (jsx_element)
   (jsx_self_closing_element)
 ] @indent

--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -109,7 +109,7 @@
 
 [
   ";"
-  "?."
+  (optional_chain) ; ?.
   "."
   ","
 ] @punctuation.delimiter


### PR DESCRIPTION
Closes #7845.

**Disclaimer**: _The quotations below show that this phrase is taken from the relevant upstream commit/pr. This is my first time using this format, so if it's not comfortable, let me know. Just want to provide some guidance to make the PR review as easy as possible (I spent a lot of time jumping between upstream commits and understanding the api changes)._

### Changes according to tree-sitter/tree-sitter-javascript@186f2adbf790552b354a9ba712341c7d48bdbccd:
* rename `?.` to `optional_chain`.
> Optional chaining property/array access and optional function calls now produce an `optional_chain` named field.

### Changes according to tree-sitter/tree-sitter-javascript@bb1f97b643b77fc1f082d621bf533b4b14cf0c3:
* Remove some queries with `nested_identifier`, 
> Made the Foo.Bar part in <Foo.Bar/> have the same parse tree as in const Component = Foo.Bar using aliases. We get the parse tree (member_expression (identifier) (property_identifier)) instead of (nested_identifier (identifier) (identifier))
* Remove deprecated `jsx_fragment` from indent query.
> Removed the special treatment of JSX fragments in the grammar.
* Count `</` and `/>` as a single token.
> Made </ and /> single tokens instead of two, makes more sense to me.