### PR TITLE
feat: first-line-regex to detect languages

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -58,7 +58,7 @@ These configuration keys are available:
 | `injection-regex`     | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
 | `file-types`          | The filetypes of the language, for example `["yml", "yaml"]`. See the file-type detection section below. |
 | `shebangs`            | The interpreters from the shebang line, for example `["sh", "bash"]` |
-| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple ["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"] |
+| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple ["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"] (strace) |
 | `roots`               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -58,7 +58,7 @@ These configuration keys are available:
 | `injection-regex`     | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
 | `file-types`          | The filetypes of the language, for example `["yml", "yaml"]`. See the file-type detection section below. |
 | `shebangs`            | The interpreters from the shebang line, for example `["sh", "bash"]` |
-| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple ["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"] (strace) |
+| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple `["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"]` (strace) |
 | `roots`               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -58,7 +58,7 @@ These configuration keys are available:
 | `injection-regex`     | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
 | `file-types`          | The filetypes of the language, for example `["yml", "yaml"]`. See the file-type detection section below. |
 | `shebangs`            | The interpreters from the shebang line, for example `["sh", "bash"]` |
-| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple `["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"]` (strace) |
+| `first-line-regexs`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple `["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"]` (strace) |
 | `roots`               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -58,6 +58,7 @@ These configuration keys are available:
 | `injection-regex`     | regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential [language injection][treesitter-language-injection] site. |
 | `file-types`          | The filetypes of the language, for example `["yml", "yaml"]`. See the file-type detection section below. |
 | `shebangs`            | The interpreters from the shebang line, for example `["sh", "bash"]` |
+| `first-line-regex`    | A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file, for exmaple ["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"] |
 | `roots`               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | `auto-format`         | Whether to autoformat this language when saving               |
 | `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -112,7 +112,7 @@ pub struct LanguageConfiguration {
     pub shebangs: Vec<String>, // interpreter(s) associated with language
     #[serde(default, skip_serializing, deserialize_with = "deserialize_regex_vec")]
     pub first_line_regexs: Vec<Regex>, // interpreter(s) associated with the first line of the document
-    pub roots: Vec<String>,        // these indicate project roots <.git, Cargo.toml>
+    pub roots: Vec<String>, // these indicate project roots <.git, Cargo.toml>
     pub comment_token: Option<String>,
     pub text_width: Option<usize>,
     pub soft_wrap: Option<SoftWrap>,
@@ -868,15 +868,15 @@ impl Loader {
 
         configuration_id.and_then(|&id| self.language_configs.get(id).cloned())
     }
-    
+
     pub fn language_config_for_first_line_regex(
         &self,
         source: RopeSlice,
     ) -> Option<Arc<LanguageConfiguration>> {
         let line = Cow::from(source.line(0));
-        for (regex,id) in &self.language_config_ids_by_first_line_regex {
+        for (regex, id) in &self.language_config_ids_by_first_line_regex {
             if regex.0.is_match(&line) {
-                return self.language_configs.get(*id).cloned()
+                return self.language_configs.get(*id).cloned();
             }
         }
         None

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -111,7 +111,7 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub shebangs: Vec<String>, // interpreter(s) associated with language
     #[serde(default, skip_serializing, deserialize_with = "deserialize_regex_vec")]
-    pub first_line_regexs: Vec<Regex>, // interpreter(s) associated with the first line of the document
+    pub first_line_regexs: Vec<Regex>, // regex patterns that will be tested against the first line of a file in order to determine whether this language applies to the file
     pub roots: Vec<String>, // these indicate project roots <.git, Cargo.toml>
     pub comment_token: Option<String>,
     pub text_width: Option<usize>,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -875,7 +875,6 @@ impl Loader {
     ) -> Option<Arc<LanguageConfiguration>> {
         let line = Cow::from(source.line(0));
         for (regex,id) in &self.language_config_ids_by_first_line_regex {
-            dbg!(&regex,&id,&regex.0.is_match(&line));
             if regex.0.is_match(&line) {
                 return self.language_configs.get(*id).cloned()
             }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -798,7 +798,7 @@ impl Loader {
             for first_line_regex in &config.first_line_regexs {
                 loader
                     .language_config_ids_by_first_line_regex
-                    .push((first_line_regex.clone().into(), language_id));
+                    .push((first_line_regex.clone(), language_id));
             }
 
             loader.language_configs.push(Arc::new(config));

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -858,8 +858,7 @@ impl Loader {
         self.language_config_ids_by_first_line_regex
             .iter()
             .find(|(regex, _)| regex.is_match(&line))
-            .map(|(_, id)| self.language_configs.get(*id).cloned())
-            .flatten()
+            .and_then(|(_, id)| self.language_configs.get(*id).cloned())
     }
 
     pub fn language_config_for_scope(&self, scope: &str) -> Option<Arc<LanguageConfiguration>> {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -855,12 +855,11 @@ impl Loader {
         source: RopeSlice,
     ) -> Option<Arc<LanguageConfiguration>> {
         let line = Cow::from(source.line(0));
-        for (regex, id) in &self.language_config_ids_by_first_line_regex {
-            if regex.is_match(&line) {
-                return self.language_configs.get(*id).cloned();
-            }
-        }
-        None
+        self.language_config_ids_by_first_line_regex
+            .iter()
+            .find(|(regex, _)| regex.is_match(&line))
+            .map(|(_, id)| self.language_configs.get(*id).cloned())
+            .flatten()
     }
 
     pub fn language_config_for_scope(&self, scope: &str) -> Option<Arc<LanguageConfiguration>> {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2807,4 +2807,61 @@ mod test {
         let results = load_runtime_file("rust", "does-not-exist");
         assert!(results.is_err());
     }
+
+    #[test]
+    fn test_detect_file_with_first_line_regex() {
+        let loader = Loader::new(Configuration {
+            language: vec![LanguageConfiguration {
+                language_id: "strace".into(),
+                language_server_language_id: None,
+                scope: "scope.strace".into(),
+                file_types: vec![],
+                shebangs: vec![],
+                first_line_regexs: vec![
+                    Regex::new("execve").unwrap(),
+                    Regex::new("^[0-9:.]* *execve").unwrap(),
+                ],
+                roots: vec![],
+                comment_token: None,
+                text_width: None,
+                soft_wrap: None,
+                auto_format: false,
+                formatter: None,
+                diagnostic_severity: Severity::Info,
+                grammar: None,
+                injection_regex: None,
+                highlight_config: OnceCell::new(),
+                language_servers: vec![],
+                indent: None,
+                indent_query: OnceCell::new(),
+                textobject_query: OnceCell::new(),
+                debugger: None,
+                auto_pairs: None,
+                rulers: None,
+                workspace_lsp_roots: None,
+            }],
+            language_server: HashMap::new(),
+        });
+        assert!(loader
+            .language_config_for_first_line_regex(
+                ["execve", "arch_prctl(0x3001"].join("\n").as_str().into()
+            )
+            .is_some());
+        assert!(loader
+            .language_config_for_first_line_regex(
+                ["447845 execve", "arch_prctl(0x3001"]
+                    .join("\n")
+                    .as_str()
+                    .into()
+            )
+            .is_some());
+        assert!(loader
+            .language_config_for_first_line_regex(
+                ["random", "arch_prctl(0x3001"].join("\n").as_str().into()
+            )
+            .is_none());
+        assert!(loader
+            .language_config_for_first_line_regex(["random", "execve"].join("\n").as_str().into())
+            .is_none());
+    }
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -940,7 +940,6 @@ impl Document {
             .language_config_for_file_name(self.path.as_ref()?)
             .or_else(|| config_loader.language_config_for_shebang(self.text().slice(..)))
             .or_else(|| config_loader.language_config_for_first_line_regex(self.text().slice(..)))
-
     }
 
     /// Detect the indentation used in the file, or otherwise defaults to the language indentation

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -939,6 +939,8 @@ impl Document {
         config_loader
             .language_config_for_file_name(self.path.as_ref()?)
             .or_else(|| config_loader.language_config_for_shebang(self.text().slice(..)))
+            .or_else(|| config_loader.language_config_for_first_line_regex(self.text().slice(..)))
+
     }
 
     /// Detect the indentation used in the file, or otherwise defaults to the language indentation


### PR DESCRIPTION
Add a new method to detect a language: first-line-regex

This is taken from tree sitter https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-detection (there is also content-regex)

Vim also have something similar

This is useful for files that usually don't have an extension but have a known layout: strace output, tree sitter tests, etc..