### PR TITLE
Add text objects for protobuf

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -115,7 +115,7 @@
 | ponylang | ✓ | ✓ | ✓ |  |
 | prisma | ✓ |  |  | `prisma-language-server` |
 | prolog |  |  |  | `swipl` |
-| protobuf | ✓ |  | ✓ | `bufls`, `pb` |
+| protobuf | ✓ | ✓ | ✓ | `bufls`, `pb` |
 | prql | ✓ |  |  |  |
 | purescript | ✓ |  |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | `pylsp` |

--- a/runtime/queries/protobuf/textobjects.scm
+++ b/runtime/queries/protobuf/textobjects.scm
@@ -1,0 +1,14 @@
+(rpc) @function.inside
+(rpc) @function.around
+
+(rpc
+    (enumMessageType) @parameter.inside)
+
+(message
+    (messageBody) @class.inside) @class.around
+
+(service
+    (serviceBody) @class.inside) @class.around
+
+(comment) @comment.inside
+(comment)+ @comment.around


### PR DESCRIPTION
* `service` and `message` are type objects
* `rpc`s are functions, both `around` and `inside` selects entire line (as they have no body)
* identifiers within `rpc`s are parameters, although pretty useless as there can only be one