### PR TITLE
feat: pest language server support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -51,6 +51,7 @@ openscad-lsp = { command = "openscad-lsp", args = ["--stdio"] }
 pasls = { command = "pasls", args = [] }
 pbkit = { command = "pb", args = [ "lsp" ] }
 perlnavigator = { command = "perlnavigator", args= ["--stdio"] }
+pest-language-server = { command = "pest-language-server" }
 prisma-language-server = { command = "prisma-language-server", args = ["--stdio"] }
 purescript-language-server = { command = "purescript-language-server", args = ["--stdio"] }
 pylsp = { command = "pylsp" }
@@ -1116,6 +1117,20 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "perl"
 source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "ed21ecbcc128a6688770ebafd3ef68a1c9bc1ea9" }
+
+[[language]]
+name = "pest"
+scope = "source.pest"
+file-types = ["pest"]
+roots = []
+comment-token = "//"
+language-servers = [ "pest-language-server" ]
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
 
 [[language]]
 name = "racket"


### PR DESCRIPTION
support for the [pest](https://pest.rs) language server: https://github.com/pest-parser/pest-ide-tools 

tested and working. i'll be back when we have a tree sitter grammar, we only have textmate for now unfortunately.