### PR TITLE
Canonicalize LSP diagnostics path to resolve symlinks and match the document path

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -2,7 +2,7 @@ use arc_swap::{access::Map, ArcSwap};
 use futures_util::Stream;
 use helix_core::{
     diagnostic::{DiagnosticTag, NumberOrString},
-    path::get_relative_path,
+    path::{get_canonicalized_path, get_relative_path},
     pos_at_coords, syntax, Selection,
 };
 use helix_lsp::{
@@ -724,7 +724,11 @@ impl Application {
                         }
                     }
                     Notification::PublishDiagnostics(params) => {
-                        let path = match params.uri.to_file_path() {
+                        let path = match params
+                            .uri
+                            .to_file_path()
+                            .and_then(|path| get_canonicalized_path(&path).map_err(|_| ()))
+                        {
                             Ok(path) => path,
                             Err(_) => {
                                 log::error!("Unsupported file URI: {}", params.uri);


### PR DESCRIPTION
# Issue

When opening a file through a symlink, diagnostic info from the language server is discarded due to a mismatch between the LSP URL and the canonicalized path in `helix_view::Document`.

## Example

Consider the following project tree (example based on [cxx](https://github.com/dtolnay/cxx/tree/master)):

```
gen
├── Cargo.toml
└── src
    ├── lib.rs
    └── syntax -> ../../syntax
syntax
└── mod.rs
```

where `lib.rs` contains `mod syntax`.

If we open `gen/src/syntax/mod.rs` in helix, the path is canonicalized by `get_canonicalized_path` and it becomes an absolute path like `<...>/syntax/mod.rs`, since symlinks are resolved by `get_canonicalized_path` (in contrast to what is said in the comments in [helix-core/src/path.rs](https://github.com/helix-editor/helix/blob/master/helix-core/src/path.rs#L33), is this intended?). This canonicalized path is then stored in `helix_view::Document`.

However, when diagnostics are published by the language server, we get a URL that is turned into the path `<...>/gen/src/syntax/mod.rs`. Symlinks are not resolved and this path is not canonicalized. As a result, there is a mismatch between this path and the canonicalized path in `helix_view::Document`, and the diagnostics are not sent to the open document.

# Proposed Solution (this PR)

Canonicalize the path received from the language server to ensure that it matches the path stored in `helix_view::Document`. 

Please let me know if there are any problems with this PR!

P.S.: I believe this may have been a regression of https://github.com/helix-editor/helix/commit/d04288e0f3d292ce47fc0246bcbdc50a9d57ad5e, which might have changed the behavior of `get_canonicalized_path` to resolve symlinks, since `dunce::canonicalize` relies on `std::canonicalize` internally (on Linux/UNIX). Either way, canonicalizing the path sent by the language server using the same canonicalization method as done by this PR should resolve the current issue.