### PR TITLE
use rust 1.68 in rust-toolchain.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install stable toolchain
-        uses: helix-editor/rust-toolchain@v1
-        with:
-          profile: minimal
-          override: true
 
+      - name: Remove rust-toolchain.toml file
+        run: rm rust-toolchain.toml
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@1.65
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
@@ -35,6 +35,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Remove rust-toolchain.toml file
+        run: rm rust-toolchain.toml
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@1.65
@@ -65,6 +68,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Remove rust-toolchain.toml file
+        run: rm rust-toolchain.toml
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@1.65
         with:
@@ -90,6 +96,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Remove rust-toolchain.toml file
+        run: rm rust-toolchain.toml
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@1.65
 
@@ -103,6 +112,7 @@ jobs:
 
       - name: Check uncommitted documentation changes
         run: |
+          git restore rust-toolchain.toml
           git diff
           git diff-files --quiet \
             || (echo "Run 'cargo xtask docgen', commit the changes and push again" \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.68.0"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
fixes the problem found in https://github.com/helix-editor/helix/pull/7814#issuecomment-1666514270 which was an existing problem in helix that could occur while file-walking, this occured due to a bug in rust which was fixed and in included in the 1.68 release. This pr only updates the rust-toolchain.toml so that users building from source won't encounter this bug, but our msrv is still 1.65 which is what we check in CI. As before releases are still built with the latest rust stable so nothing needs to change there.