### PR TITLE
Add vim-like jump to textobject

### DIFF
--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -225,7 +225,7 @@ fn textobject_pair_surround_impl(
     count: usize,
 ) -> Range {
     let pair_pos = match ch {
-        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
+        Some(ch) => surround::find_nth_textobject_pairs_pos(slice, ch, range, count),
         // Automatically find the closest surround pairs
         None => surround::find_nth_closest_pairs_pos(slice, range, count),
     };
@@ -503,11 +503,13 @@ mod test {
             (
                 "simple (single) surround pairs",
                 vec![
-                    (3, Inside, (3, 3), '(', 1),
+                    (20, Inside, (20, 20), '(', 1),
+                    (3, Inside, (8, 14), '(', 1),
                     (7, Inside, (8, 14), ')', 1),
                     (10, Inside, (8, 14), '(', 1),
                     (14, Inside, (8, 14), ')', 1),
-                    (3, Around, (3, 3), '(', 1),
+                    (20, Around, (20, 20), '(', 1),
+                    (3, Around, (7, 15), '(', 1),
                     (7, Around, (7, 15), ')', 1),
                     (10, Around, (7, 15), '(', 1),
                     (14, Around, (7, 15), ')', 1),
@@ -516,11 +518,13 @@ mod test {
             (
                 "samexx 'single' surround pairs",
                 vec![
-                    (3, Inside, (3, 3), '\'', 1),
+                    (20, Inside, (20, 20), '(', 1),
+                    (3, Inside, (8, 14), '\'', 1),
                     (7, Inside, (7, 7), '\'', 1),
                     (10, Inside, (8, 14), '\'', 1),
                     (14, Inside, (14, 14), '\'', 1),
-                    (3, Around, (3, 3), '\'', 1),
+                    (20, Around, (20, 20), '(', 1),
+                    (3, Around, (7, 15), '\'', 1),
                     (7, Around, (7, 7), '\'', 1),
                     (10, Around, (7, 15), '\'', 1),
                     (14, Around, (14, 14), '\'', 1),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -452,6 +452,8 @@ impl MappableCommand {
         surround_delete, "Surround delete",
         select_textobject_around, "Select around object",
         select_textobject_inner, "Select inside object",
+        select_textobject_around_vim_like, "Select around object",
+        select_textobject_inner_vim_like, "Select inside object",
         goto_next_function, "Goto next function",
         goto_prev_function, "Goto previous function",
         goto_next_class, "Goto next type definition",
@@ -5011,14 +5013,22 @@ fn goto_prev_test(cx: &mut Context) {
 }
 
 fn select_textobject_around(cx: &mut Context) {
-    select_textobject(cx, textobject::TextObject::Around);
+    select_textobject(cx, textobject::TextObject::Around, false);
 }
 
 fn select_textobject_inner(cx: &mut Context) {
-    select_textobject(cx, textobject::TextObject::Inside);
+    select_textobject(cx, textobject::TextObject::Inside, false);
 }
 
-fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
+fn select_textobject_around_vim_like(cx: &mut Context) {
+    select_textobject(cx, textobject::TextObject::Around, true);
+}
+
+fn select_textobject_inner_vim_like(cx: &mut Context) {
+    select_textobject(cx, textobject::TextObject::Inside, true);
+}
+
+fn select_textobject(cx: &mut Context, objtype: textobject::TextObject, vim_like: bool) {
     let count = cx.count();
 
     cx.on_next_key(move |cx, event| {
@@ -5080,9 +5090,9 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         ),
                         'g' => textobject_change(range),
                         // TODO: cancel new ranges if inconsistent surround matches across lines
-                        ch if !ch.is_ascii_alphanumeric() => {
-                            textobject::textobject_pair_surround(text, range, objtype, ch, count)
-                        }
+                        ch if !ch.is_ascii_alphanumeric() => textobject::textobject_pair_surround(
+                            text, range, objtype, ch, count, vim_like,
+                        ),
                         _ => range,
                     }
                 });

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -104,6 +104,14 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "a" => select_textobject_around,
             "i" => select_textobject_inner,
         },
+        "M" => { "Match"
+            "m" => match_brackets,
+            "s" => surround_add,
+            "r" => surround_replace,
+            "d" => surround_delete,
+            "a" => select_textobject_around_vim_like,
+            "i" => select_textobject_inner_vim_like,
+        },
         "[" => { "Left bracket"
             "d" => goto_prev_diag,
             "D" => goto_first_diag,


### PR DESCRIPTION
Support matching the nearest textobject even in cases where the cursor is outside it, like in vim. Examples:
1. `this is (some text)`, assume the cursor is in the start of the line - `mi(` will select `some text`.
2. 
    ```python
    dict(
        key1="val1",
        key2="val2",
    )
    ```
    when the cursor is somewhere on `key2` and `mi"` is pressed, `val2` will be selected (unlike the current behavior which selects `,\nkey2=`)

see more examples in the test cases.

In order to avoid the ambiguity in example 2, surrounding pairs of the same character (like quotes) are only supported in the current line. This also matches the behavior of vim and vim-surround.