### PR TITLE
Prevent GraphemeStrs created from Strings from leaking

### DIFF
--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -481,7 +481,7 @@ impl<'a> From<String> for GraphemeStr<'a> {
         let ptr = Box::into_raw(g.into_bytes().into_boxed_slice()) as *mut u8;
         GraphemeStr {
             ptr: unsafe { NonNull::new_unchecked(ptr) },
-            len: i32::try_from(len).unwrap() as u32,
+            len: (i32::try_from(len).unwrap() as u32) | Self::MASK_OWNED,
             phantom: PhantomData,
         }
     }


### PR DESCRIPTION
I noticed that the `From<String>` impl of `GraphemeStr` doesn't set the high bit on `self.len`.  My understanding is that this would mean that the backing memory for the string will not get dropped when the `GraphemeStr` is dropped. This PR fixes the that by setting the high bit during conversion.