### PR TITLE
Goto next/prev in last picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -35,7 +35,7 @@ use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
     editor::{Action, CompleteAction},
     info::Info,
-    input::KeyEvent,
+    input::{Event,  KeyEvent, KeyModifiers},
     keyboard::KeyCode,
     tree,
     view::View,
@@ -464,6 +464,8 @@ impl MappableCommand {
         goto_prev_test, "Goto previous test",
         goto_next_paragraph, "Goto next paragraph",
         goto_prev_paragraph, "Goto previous paragraph",
+        goto_next_in_last_picker, "Goto next in last picker",
+        goto_prev_in_last_picker, "Goto previous in last picker",
         dap_launch, "Launch debug target",
         dap_restart, "Restart debugging session",
         dap_toggle_breakpoint, "Toggle breakpoint",
@@ -3247,6 +3249,28 @@ fn goto_prev_diag(cx: &mut Context) {
         None => return,
     };
     doc.set_selection(view.id, selection);
+}
+
+fn goto_next_in_last_picker(cx: &mut Context) {
+    cx.callback = Some(Box::new(|compositor, cx| {
+        if let Some(picker) = &mut compositor.last_picker {
+            picker.handle_event( &Event::Key(KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::NONE }), cx);
+            picker.handle_event( &Event::Key(KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::NONE }), cx);
+        } else {
+            cx.editor.set_error("no last picker")
+        }
+    }));
+}
+
+fn goto_prev_in_last_picker(cx: &mut Context) {
+    cx.callback = Some(Box::new(|compositor, cx| {
+        if let Some(picker) = &mut compositor.last_picker {
+            picker.handle_event( &Event::Key(KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::NONE }), cx);
+            picker.handle_event( &Event::Key(KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::NONE }), cx);
+        } else {
+            cx.editor.set_error("no last picker")
+        }
+    }));
 }
 
 fn goto_first_change(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -115,6 +115,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "c" => goto_prev_comment,
             "T" => goto_prev_test,
             "p" => goto_prev_paragraph,
+            "[" => goto_prev_in_last_picker,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -128,6 +129,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "c" => goto_next_comment,
             "T" => goto_next_test,
             "p" => goto_next_paragraph,
+            "]" => goto_next_in_last_picker,
             "space" => add_newline_below,
         },
 


### PR DESCRIPTION
Hi, I am long time Vim user. I am tired of managing Vim plugins and configuration. Helix has a fantastic feature set out of the box and I would be happy to transition to it, however there are some features missing that are critical to my daily workflow.

One of them is being able to jump between global search results quickly. I discovered "last picker" but it  takes five key strokes to use it the way I would like to (`Space`, `'`, `Ctrl+n`, `Enter`). I would be happy to get it down to two.

I noticed in #1017  there were a suggestion to use `[p`, `]p`, I am proposing to use `[[` and `]]` as it is easy to type and would be useful for all picker types. 

I realize that proposed implementation is ugly and fragile. I am looking for guidance to improve it.