### PR TITLE
Add .star as starlark file extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1915,7 +1915,7 @@ source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569
 name = "starlark"
 scope = "source.starlark"
 injection-regex = "(starlark|bzl|bazel)"
-file-types = ["bzl", "bazel", "BUILD"]
+file-types = ["bzl", "bazel", "BUILD", "star"]
 roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }


### PR DESCRIPTION
In addition to the other defined extensions, `.star` is a frequently used extension for starlark files. This can be demonstrated through a cursory search of github for files ending in `.star` here: https://github.com/search?q=path%3A%2F.star%24%2F&type=code