### PR TITLE
Always reset cursor correctly on exit.

### DIFF
--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -65,20 +65,6 @@ where
     viewport: Viewport,
 }
 
-impl<B> Drop for Terminal<B>
-where
-    B: Backend,
-{
-    fn drop(&mut self) {
-        // Attempt to restore the cursor state
-        if self.cursor_kind == CursorKind::Hidden {
-            if let Err(err) = self.show_cursor(CursorKind::Block) {
-                eprintln!("Failed to show the cursor: {}", err);
-            }
-        }
-    }
-}
-
 impl<B> Terminal<B>
 where
     B: Backend,


### PR DESCRIPTION
This is intended to be a fix for #7404. I was able to replicate on MacOS by setting Terminal.app's default cursor to something other than Block, and then binding a key to `:quit` as described in the issue. Via debugging, I found that `Terminal::restore` actually does reset the cursor correctly regardless of if a keybind is used or if `:quit` is used.
However, the cursor gets set back to `CursorKind::Block` when the process exits if a keybinding was used.

It turns out that the `Drop` impl for `Terminal` will put the cursor back in block mode if `terminal.cursor_kind` is `Hidden`. Via debugging, I found that this was not the case if `:quit` was used but was the case if the keybind was used.

My understanding is that either `Terminal::restore` or `TerminalBackend::force_restore` will be called before exit, and both reset the cursor. Thus it seems to me that the `Drop` impl for `Terminal` is redundant and does not have the information needed to do the reset properly. Thus this PR removes the `Drop` impl.