### PR TITLE
fix formatting in the rust textobject query file

### DIFF
--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -1,5 +1,8 @@
 (function_item
-  body: (_) @function.inside) @function.around(closure_expression body: (_) @function.inside) @function.around
+  body: (_) @function.inside) @function.around
+
+(closure_expression
+  body: (_) @function.inside) @function.around
 
 (struct_item
   body: (_) @class.inside) @class.around


### PR DESCRIPTION
looks like two lines were unintentionally joined - it doesn't appear to affect the functionality, but it's confusing to read