### PR TITLE
feat: add commands to yank current buffer filepath

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -10,7 +10,7 @@ use tui::widgets::Row;
 pub use typed::*;
 
 use helix_core::{
-    char_idx_at_visual_offset, comment,
+    char_idx_at_visual_offset, comment, coords_at_pos,
     doc_formatter::TextFormat,
     encoding, find_first_non_whitespace_char, find_workspace, graphemes,
     history::UndoKind,
@@ -382,6 +382,18 @@ impl MappableCommand {
         yank, "Yank selection",
         yank_to_clipboard, "Yank selections to clipboard",
         yank_to_primary_clipboard, "Yank selections to primary clipboard",
+        yank_absolute_filepath, "Yank the absolute filepath of the current buffer.",
+        yank_absolute_filepath_with_line, "Yank the absolute filepath with line number of the current buffer.",
+        yank_absolute_filepath_with_line_column, "Yank the absolute filepath with line and column numbers of the current buffer.",
+        yank_absolute_filepath_to_clipboard, "Yank the absolute filepath of the current buffer to the clipboard.",
+        yank_absolute_filepath_with_line_to_clipboard, "Yank the absolute filepath with line number of the current buffer to the clipboard.",
+        yank_absolute_filepath_with_line_column_to_clipboard, "Yank the absolute filepath with line and column numbers of the current buffer to the clipboard.",
+        yank_relative_filepath, "Yank the relative filepath of the current buffer.",
+        yank_relative_filepath_with_line, "Yank the relative filepath with line number of the current buffer.",
+        yank_relative_filepath_with_line_column, "Yank the relative filepath with line and column numbers of the current buffer.",
+        yank_relative_filepath_to_clipboard, "Yank the relative filepath of the current buffer to the clipboard.",
+        yank_relative_filepath_with_line_to_clipboard, "Yank the relative filepath and line number of the current buffer to the clipboard.",
+        yank_relative_filepath_with_line_column_to_clipboard, "Yank the relative filepath with line and column numbers of the current buffer to the clipboard.",
         yank_joined, "Join and yank selections",
         yank_joined_to_clipboard, "Join and yank selections to clipboard",
         yank_main_selection_to_clipboard, "Yank main selection to clipboard",
@@ -3899,6 +3911,154 @@ fn yank_main_selection_to_clipboard(cx: &mut Context) {
 fn yank_main_selection_to_primary_clipboard(cx: &mut Context) {
     yank_primary_selection_impl(cx.editor, '+');
     exit_select_mode(cx);
+}
+
+#[derive(Copy, Clone)]
+enum PathType {
+    Absolute,
+    Relative,
+}
+
+#[derive(Copy, Clone)]
+enum PathCursor {
+    Line,
+    LineColumn,
+}
+
+fn yank_filepath_impl(
+    editor: &mut Editor,
+    register: char,
+    path_type: PathType,
+    path_cursor: Option<PathCursor>,
+) {
+    let (view, doc) = current!(editor);
+    let relative_path = doc.relative_path();
+
+    let path = match path_type {
+        PathType::Absolute => doc.path(),
+        PathType::Relative => relative_path.as_ref(),
+    }
+    .map(|p| p.to_string_lossy());
+
+    if let Some(path) = path {
+        let mut path = path.to_string();
+
+        // Append line and column numbers to path
+        if let Some(path_cursor) = path_cursor {
+            let position = coords_at_pos(
+                doc.text().slice(..),
+                doc.selection(view.id)
+                    .primary()
+                    .cursor(doc.text().slice(..)),
+            );
+            path = match path_cursor {
+                PathCursor::Line => format!("{}:{}", path.to_string(), position.row + 1),
+                PathCursor::LineColumn => {
+                    format!(
+                        "{}:{}:{}",
+                        path.to_string(),
+                        position.row + 1,
+                        position.col + 1
+                    )
+                }
+            }
+        }
+
+        match editor.registers.write(register, vec![path.clone()]) {
+            Ok(_) => editor.set_status(format!("yanked {path} to register {register}")),
+            Err(err) => editor.set_error(err.to_string()),
+        }
+    } else {
+        editor.set_error("Current buffer has not yet been written to the filesystem".to_string());
+    }
+}
+
+fn yank_absolute_filepath(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Absolute,
+        None,
+    );
+}
+
+fn yank_absolute_filepath_with_line(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Absolute,
+        Some(PathCursor::Line),
+    );
+}
+
+fn yank_absolute_filepath_with_line_column(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Absolute,
+        Some(PathCursor::LineColumn),
+    );
+}
+
+fn yank_absolute_filepath_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(cx.editor, '*', PathType::Absolute, None);
+}
+
+fn yank_absolute_filepath_with_line_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(cx.editor, '*', PathType::Absolute, Some(PathCursor::Line));
+}
+
+fn yank_absolute_filepath_with_line_column_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        '*',
+        PathType::Absolute,
+        Some(PathCursor::LineColumn),
+    );
+}
+
+fn yank_relative_filepath(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Relative,
+        None,
+    );
+}
+
+fn yank_relative_filepath_with_line(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Relative,
+        Some(PathCursor::Line),
+    );
+}
+
+fn yank_relative_filepath_with_line_column(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        cx.register.unwrap_or('"'),
+        PathType::Relative,
+        Some(PathCursor::LineColumn),
+    );
+}
+
+fn yank_relative_filepath_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(cx.editor, '*', PathType::Relative, None);
+}
+
+fn yank_relative_filepath_with_line_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(cx.editor, '*', PathType::Relative, Some(PathCursor::Line));
+}
+
+fn yank_relative_filepath_with_line_column_to_clipboard(cx: &mut Context) {
+    yank_filepath_impl(
+        cx.editor,
+        '*',
+        PathType::Relative,
+        Some(PathCursor::LineColumn),
+    );
 }
 
 #[derive(Copy, Clone)]

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -895,6 +895,202 @@ fn theme(
     Ok(())
 }
 
+fn yank_absolute_filepath(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Absolute,
+        None,
+    );
+    Ok(())
+}
+
+fn yank_absolute_filepath_with_line(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Absolute,
+        Some(PathCursor::Line),
+    );
+    Ok(())
+}
+
+fn yank_absolute_filepath_with_line_column(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Absolute,
+        Some(PathCursor::LineColumn),
+    );
+    Ok(())
+}
+
+fn yank_absolute_filepath_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(cx.editor, '*', PathType::Absolute, None);
+    Ok(())
+}
+
+fn yank_absolute_filepath_with_line_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(cx.editor, '*', PathType::Absolute, Some(PathCursor::Line));
+    Ok(())
+}
+
+fn yank_absolute_filepath_with_line_column_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        '*',
+        PathType::Absolute,
+        Some(PathCursor::LineColumn),
+    );
+    Ok(())
+}
+
+fn yank_relative_filepath(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Relative,
+        None,
+    );
+    Ok(())
+}
+
+fn yank_relative_filepath_with_line(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Relative,
+        Some(PathCursor::Line),
+    );
+    Ok(())
+}
+
+fn yank_relative_filepath_with_line_column(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        cx.editor.selected_register.unwrap_or('"'),
+        PathType::Relative,
+        Some(PathCursor::LineColumn),
+    );
+    Ok(())
+}
+
+fn yank_relative_filepath_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(cx.editor, '*', PathType::Relative, None);
+    Ok(())
+}
+
+fn yank_relative_filepath_with_line_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(cx.editor, '*', PathType::Relative, Some(PathCursor::Line));
+    Ok(())
+}
+
+fn yank_relative_filepath_with_line_column_to_clipboard(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    yank_filepath_impl(
+        cx.editor,
+        '*',
+        PathType::Relative,
+        Some(PathCursor::LineColumn),
+    );
+    Ok(())
+}
+
 fn yank_main_selection_to_clipboard(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -2535,6 +2731,48 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         signature: CommandSignature::none(),
     },
     TypableCommand {
+        name: "yank-filepath-absolute",
+        aliases: &[],
+        doc: "Yank the absolute filepath of the current document.",
+        fun: yank_absolute_filepath,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "yank-filepath-absolute-line",
+        aliases: &[],
+        doc: "Yank the absolute filepath and line number of the current document.",
+        fun: yank_absolute_filepath_with_line,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "yank-filepath-absolute-line-column",
+        aliases: &[],
+        doc: "Yank the absolute filepath, line and column numbers of the current document.",
+        fun: yank_absolute_filepath_with_line_column,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "yank-filepath-relative",
+        aliases: &[],
+        doc: "Yank the relative filepath of the current document.",
+        fun: yank_relative_filepath,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "yank-filepath-relative-line",
+        aliases: &[],
+        doc: "Yank the relative filepath and line number of the current document.",
+        fun: yank_relative_filepath_with_line,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "yank-filepath-relative-line-column",
+        aliases: &[],
+        doc: "Yank the relative filepath, line and column numbers of the current document.",
+        fun: yank_relative_filepath_with_line_column,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
         name: "clipboard-yank",
         aliases: &[],
         doc: "Yank main selection into system clipboard.",
@@ -2553,6 +2791,48 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Yank main selection into system primary clipboard.",
         fun: yank_main_selection_to_primary_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-absolute",
+        aliases: &[],
+        doc: "Yank the absolute filepath of the current document into the system clipboard.",
+        fun: yank_absolute_filepath_to_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-absolute-line",
+        aliases: &[],
+        doc: "Yank the absolute filepath and line number of the current document into the system clipboard.",
+        fun: yank_absolute_filepath_with_line_to_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-absolute-line-column",
+        aliases: &[],
+        doc: "Yank the absolute filepath, line and column numbers of the current document into the system clipboard.",
+        fun: yank_absolute_filepath_with_line_column_to_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-relative",
+        aliases: &[],
+        doc: "Yank the relative filepath of the current document into the system clipboard.",
+        fun: yank_relative_filepath_to_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-relative-line",
+        aliases: &[],
+        doc: "Yank the relative filepath and line number of the current document into the system clipboard.",
+        fun: yank_relative_filepath_with_line_to_clipboard,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "clipboard-yank-filepath-relative-line-column",
+        aliases: &[],
+        doc: "Yank the relative filepath, line and column numbers of the current document into the system clipboard.",
+        fun: yank_relative_filepath_with_line_column_to_clipboard,
         signature: CommandSignature::none(),
     },
     TypableCommand {


### PR DESCRIPTION
Closes #2985

## What

This PR adds a series of commands to enable the user to yank the current buffer's filepath to a specified register, or the clipboard. Per the referenced issue thread, there have been distinct commands created to allow the user to retrieve the following combinations:

- absolute path
- absolute path + line number
- absolute path + line and column numbers
- relative path
- relative path + line number
- relative path + line and column numbers

Each of the above combinations have been created as `Static` and `Typable` commands, so they can be mapped to a key by the user, or invoked with the `:` command mode. 

The general `yank_*_filepath` implementations will write to the current selected register, whereas the more specific `*_to_clipboard` commands will write to the system clipboard directly. Having both retains the flexibility for these commands to be used within Helix, while also enabling easier export of the values outside of Helix, i.e. some examples from issue thread:

- run `git blame` externally on current file
- share specific line/column reference with colleague, e.g. better leverage this functionality: 
```
hx some/file/path.ext:row:col
```

## Additional context

### Naming

I welcome any suggestions for improvements to the naming. I tried to keep it verbose enough to differentiate between each combination easily, yet concise enough to not be _too_ long... but naming is hard. 

As for `TypableCommand` aliases, I considered a few, but was not sufficiently convinced of their value to add any of them. Some ideas I had:

- `abs`: yank absolute filepath
- `rel`: yank relative filepath
- `line`: yank relative filepath with line
- `col`: yank relative filepath with line and column numbers
- `cpa`: yank absolute path to clipboard
- `yfa`: yank absolute filepath to clipboard
- etc

In most of these cases, it seemed easier to me to just start typing the full command and then `<tab>` to the desired command, than to remember all the shorthand variants.

### Primary clipboard

I noticed that the `yank` implementations have dedicated functions for yanking to the primary clipboard in addition to the system clipboard. As there were already quite a few command combinations being added, I skipped adding these `primary-` specific ones, mainly for 2 reasons:

- I believe the general `yank_*_filepath` static commands could be user-mapped to a key and used in combination with setting the `+` register in advance to yank them to the primary clipboard. Although, it doesn't appear possible to do that with a `TypedCommand`.
- I'm not entirely sure when this primary clipboard would be used/want to be used for this feature vs using the system clipboard...

However, I am also happy to add these additional `primary-` command combos, if desired.

### Keymappings

I considered adding some default keymappings (as suggested in the original issue thread) to make these commands more readily accessible to users. I decided against it for now as these can always be configured by each user per their needs/preference and I am not sure how strict the project is in general about extending the default keymapping.

For those curious/wanting this feature, I was thinking of adding something like this to the "space" category:

```
"." => { "Yank filepath to clipboard"
  "a" => yank_absolute_filepath_to_clipboard,
  "r" => yank_relative_filepath_to_clipboard,
  "l" => yank_relative_filepath_with_line_to_clipboard,
  "c" => yank_relative_filepath_with_line_column_to_clipboard,
},
```
I can add this to the PR if there's a general consensus that they would be good additions, but can also be done as a follow up PR. 