### PR TITLE
re-add indent and textobject queries for perl

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -112,7 +112,7 @@
 | pascal | ✓ | ✓ |  | `pasls` |
 | passwd | ✓ |  |  |  |
 | pem | ✓ |  |  |  |
-| perl | ✓ |  | ✓ | `perlnavigator` |
+| perl | ✓ | ✓ | ✓ | `perlnavigator` |
 | php | ✓ | ✓ | ✓ | `intelephense` |
 | po | ✓ | ✓ |  |  |
 | pod | ✓ |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -112,7 +112,7 @@
 | pascal | ✓ | ✓ |  | `pasls` |
 | passwd | ✓ |  |  |  |
 | pem | ✓ |  |  |  |
-| perl | ✓ |  |  | `perlnavigator` |
+| perl | ✓ |  | ✓ | `perlnavigator` |
 | php | ✓ | ✓ | ✓ | `intelephense` |
 | po | ✓ | ✓ |  |  |
 | pod | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1119,7 +1119,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "perl"
-source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "ed21ecbcc128a6688770ebafd3ef68a1c9bc1ea9" }
+source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "9f3166800d40267fa68ed8273e96baf74f390517" }
 
 [[language]]
 name = "pod"

--- a/runtime/queries/perl/indents.scm
+++ b/runtime/queries/perl/indents.scm
@@ -1,0 +1,29 @@
+[
+  (block)
+  (conditional_statement)
+  (loop_statement)
+  (cstyle_for_statement)
+  (for_statement)
+  (elsif)
+  (array_element_expression)
+  (hash_element_expression)
+  (coderef_call_expression)
+  (anonymous_slice_expression)
+  (slice_expression)
+  (keyval_expression)
+  (anonymous_array_expression)
+  (anonymous_hash_expression)
+  (stub_expression)
+  (func0op_call_expression)
+  (func1op_call_expression)
+  (map_grep_expression)
+  (function_call_expression)
+  (method_call_expression)
+  (attribute)
+] @indent
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent

--- a/runtime/queries/perl/textobjects.scm
+++ b/runtime/queries/perl/textobjects.scm
@@ -1,0 +1,14 @@
+(subroutine_declaration_statement
+  body: (_) @function.inside) @function.around
+(anonymous_subroutine_expression
+  body: (_) @function.inside) @function.around
+
+(package_statement) @class.around
+(package_statement
+  (block) @class.inside)
+
+(list_expression
+  (_) @parameter.inside)
+
+(comment) @comment.around
+(pod) @comment.around


### PR DESCRIPTION
followup from https://github.com/helix-editor/helix/pull/7644#issuecomment-1637390250

opening this as a draft because it depends on some minor tweaks to the grammar itself that i'm working on here https://github.com/tree-sitter-perl/tree-sitter-perl/pull/110, but wanted to make sure the changes don't get lost