### PR TITLE
fix(helix-lsp): don't panic when lsp capabilities aren't initialised

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -838,7 +838,7 @@ impl Client {
         new_text: &Rope,
         changes: &ChangeSet,
     ) -> Option<impl Future<Output = Result<()>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support document sync.
         let sync_capabilities = match capabilities.text_document_sync {
@@ -893,7 +893,7 @@ impl Client {
         text_document: lsp::TextDocumentIdentifier,
         text: &Rope,
     ) -> Option<impl Future<Output = Result<()>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         let include_text = match &capabilities.text_document_sync {
             Some(lsp::TextDocumentSyncCapability::Options(lsp::TextDocumentSyncOptions {
@@ -925,7 +925,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support completion.
         capabilities.completion_provider.as_ref()?;
@@ -951,7 +951,7 @@ impl Client {
         &self,
         completion_item: lsp::CompletionItem,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support resolving completion items.
         match capabilities.completion_provider {
@@ -969,7 +969,7 @@ impl Client {
         &self,
         code_action: lsp::CodeAction,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support resolving code action.
         match capabilities.completion_provider {
@@ -989,7 +989,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support signature help.
         capabilities.signature_help_provider.as_ref()?;
@@ -1013,7 +1013,7 @@ impl Client {
         range: lsp::Range,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         match capabilities.inlay_hint_provider {
             Some(
@@ -1038,7 +1038,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support hover.
         match capabilities.hover_provider {
@@ -1069,7 +1069,7 @@ impl Client {
         options: lsp::FormattingOptions,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Vec<lsp::TextEdit>>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support formatting.
         match capabilities.document_formatting_provider {
@@ -1117,7 +1117,7 @@ impl Client {
         options: lsp::FormattingOptions,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Vec<lsp::TextEdit>>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support range formatting.
         match capabilities.document_range_formatting_provider {
@@ -1147,7 +1147,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support document highlight.
         match capabilities.document_highlight_provider {
@@ -1200,7 +1200,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support goto-definition.
         match capabilities.definition_provider {
@@ -1221,7 +1221,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support goto-declaration.
         match capabilities.declaration_provider {
@@ -1246,7 +1246,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support goto-type-definition.
         match capabilities.type_definition_provider {
@@ -1270,7 +1270,7 @@ impl Client {
         position: lsp::Position,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support goto-definition.
         match capabilities.implementation_provider {
@@ -1295,7 +1295,7 @@ impl Client {
         include_declaration: bool,
         work_done_token: Option<lsp::ProgressToken>,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support goto-reference.
         match capabilities.references_provider {
@@ -1324,7 +1324,7 @@ impl Client {
         &self,
         text_document: lsp::TextDocumentIdentifier,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support document symbols.
         match capabilities.document_symbol_provider {
@@ -1346,7 +1346,7 @@ impl Client {
         text_document: lsp::TextDocumentIdentifier,
         position: lsp::Position,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         match capabilities.rename_provider {
             Some(lsp::OneOf::Right(lsp::RenameOptions {
@@ -1366,7 +1366,7 @@ impl Client {
 
     // empty string to get all symbols
     pub fn workspace_symbols(&self, query: String) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support workspace symbols.
         match capabilities.workspace_symbol_provider {
@@ -1389,7 +1389,7 @@ impl Client {
         range: lsp::Range,
         context: lsp::CodeActionContext,
     ) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the server does not support code actions.
         match capabilities.code_action_provider {
@@ -1442,7 +1442,7 @@ impl Client {
     }
 
     pub fn command(&self, command: lsp::Command) -> Option<impl Future<Output = Result<Value>>> {
-        let capabilities = self.capabilities.get().unwrap();
+        let capabilities = self.capabilities.get()?;
 
         // Return early if the language server does not support executing commands.
         capabilities.execute_command_provider.as_ref()?;


### PR DESCRIPTION
Some language servers don't 100% align with the spec and might start to send commands before the initialization has fully completed. In these cases, it's probably best for Helix not to panic entirely.

I'm not sure if this is the best version of this change (maybe logging a warning would be good), but it converts an outright panic into a no-op, similar to what a lot of the code does when the capability required isn't supported. Happy to work on this if needed.