### PR TITLE
markdown.inline: Add `injection.combined` to html tag

### DIFF
--- a/runtime/queries/markdown.inline/injections.scm
+++ b/runtime/queries/markdown.inline/injections.scm
@@ -1,4 +1,7 @@
 
-((html_tag) @injection.content (#set! injection.language "html") (#set! injection.include-unnamed-children))
+((html_tag) @injection.content 
+  (#set! injection.language "html") 
+  (#set! injection.include-unnamed-children)
+  (#set! injection.combined))
 
 ((latex_block) @injection.content (#set! injection.language "latex") (#set! injection.include-unnamed-children))


### PR DESCRIPTION
Problem: Closing tags for markdown is sometimes not highlighted 
Solution: Add `injection.combined` to create a valid syntax tree for highlighting

Similar to #5265, but for markdown inline
