### PR TITLE
Make '<C-j>' work like '<enter>' in most cases.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -36,7 +36,7 @@ use helix_view::{
     editor::{Action, CompleteAction},
     info::Info,
     input::KeyEvent,
-    keyboard::{KeyCode,KeyModifiers},
+    keyboard::{KeyCode, KeyModifiers},
     tree,
     view::View,
     Document, DocumentId, Editor, ViewId,
@@ -1262,9 +1262,10 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, extend: bo
             KeyEvent {
                 code: KeyCode::Enter,
                 ..
-            } | KeyEvent {
+            }
+            | KeyEvent {
                 code: KeyCode::Char('j'),
-                modifiers: KeyModifiers::CONTROL
+                modifiers: KeyModifiers::CONTROL,
             } =>
             // TODO: this isn't quite correct when CRLF is involved.
             // This hack will work in most cases, since documents don't
@@ -1419,9 +1420,10 @@ fn replace(cx: &mut Context) {
             KeyEvent {
                 code: KeyCode::Enter,
                 ..
-            } | KeyEvent {
+            }
+            | KeyEvent {
                 code: KeyCode::Char('j'),
-                modifiers: KeyModifiers::CONTROL
+                modifiers: KeyModifiers::CONTROL,
             } => Some(doc.line_ending.as_str()),
             KeyEvent {
                 code: KeyCode::Char(ch),
@@ -5148,9 +5150,10 @@ fn surround_add(cx: &mut Context) {
             KeyEvent {
                 code: KeyCode::Enter,
                 ..
-            } | KeyEvent {
+            }
+            | KeyEvent {
                 code: KeyCode::Char('j'),
-                modifiers: KeyModifiers::CONTROL
+                modifiers: KeyModifiers::CONTROL,
             } => (
                 doc.line_ending.as_str().into(),
                 doc.line_ending.as_str().into(),

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -280,7 +280,7 @@ impl<T: Item + 'static> Component for Menu<T> {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if let Some(selection) = self.selection() {
                     (self.callback_fn)(cx.editor, Some(selection), MenuEvent::Validate);
                     return EventResult::Consumed(close_fn);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -830,7 +830,7 @@ impl<T: Item + 'static> Component for Picker<T> {
                     (self.callback_fn)(ctx, option, Action::Load);
                 }
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if let Some(option) = self.selection() {
                     (self.callback_fn)(ctx, option, Action::Replace);
                 }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -564,7 +564,7 @@ impl Component for Prompt {
                     (self.callback_fn)(cx, &self.line, PromptEvent::Update);
                 }
             }
-            key!(Enter) => {
+            key!(Enter) | ctrl!('j') => {
                 if self.selection.is_some() && self.line.ends_with(std::path::MAIN_SEPARATOR) {
                     self.recalculate_completion(cx.editor);
                 } else {


### PR DESCRIPTION
Meant to partially fix #7076. This adds `<C-j>` as a substitute for `<enter>` in all non keybindable places.

The issue seems to be that crossterm expects the enter key to be presented to it as carriage return or a CSI function code when in raw mode (see [here](https://github.com/crossterm-rs/crossterm/blob/master/src/event/sys/unix/parse.rs#L99) for details). This seems like a reasonable assumption, as turning on raw mode turns ICRNL off. However, it seems like under some circumstances, some people's terminal drivers ends up sending newlines anyways.

I'll see if I can track down why this happens in my case, and submit a patch to crossterm if it is fixable. What is happening in my case may not be what is happening for other people though, and this patch should make helix usable even if crossterm fails to properly detect enter.