### PR TITLE
Update tree-sitter-robot

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1567,7 +1567,7 @@ language-servers = [ "robotframework_ls" ]
 
 [[grammar]]
 name = "robot"
-source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "f1142bfaa6acfce95e25d2c6d18d218f4f533927" }
+source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "322e4cc65754d2b3fdef4f2f8a71e0762e3d13af" }
 
 [[language]]
 name = "r"

--- a/runtime/queries/robot/highlights.scm
+++ b/runtime/queries/robot/highlights.scm
@@ -1,7 +1,7 @@
 [
   (comment)
   (extra_text)
-] @comment.single
+] @comment
 
 [
   (section_header)

--- a/runtime/queries/robot/highlights.scm
+++ b/runtime/queries/robot/highlights.scm
@@ -1,21 +1,57 @@
-(comment) @comment
-(ellipses) @punctuation.delimiter
+[
+  (comment)
+  (extra_text)
+] @comment
 
-(section_header) @keyword
-(extra_text) @comment
-
-(setting_statement) @keyword
+[
+  (section_header)
+  (setting_statement)
+  (keyword_setting)
+  (test_case_setting)
+] @keyword
 
 (variable_definition (variable_name) @variable)
-
 (keyword_definition (name) @function)
-(keyword_definition (body (keyword_setting) @keyword))
+(test_case_definition (name) @function)
 
-(test_case_definition (name) @property)
+(keyword_invocation (keyword) @function.call)
+(ellipses) @punctuation.delimiter
 
-(keyword_invocation (keyword) @function)
+(text_chunk) @string
+(inline_python_expression) @string.special
+[
+  (scalar_variable)
+  (list_variable)
+  (dictionary_variable)
+] @variable
 
-(argument (text_chunk) @string)
-(argument (scalar_variable) @string.special)
-(argument (list_variable) @string.special)
-(argument (dictionary_variable) @string.special)
+; Control structures
+
+[
+  "FOR"
+  "IN"
+  "IN RANGE"
+  "IN ENUMERATE"
+  "IN ZIP"
+  (break_statement)
+  (continue_statement)
+] @repeat
+(for_statement "END" @repeat)
+
+"WHILE" @repeat
+(while_statement "END" @repeat)
+
+[
+  "IF"
+  "ELSE IF"
+] @conditional
+(if_statement "END" @conditional)
+(if_statement (else_statement "ELSE" @conditional))
+
+[
+  "TRY"
+  "EXCEPT"
+  "FINALLY"
+] @exception
+(try_statement "END" @exception)
+(try_statement (else_statement "ELSE" @exception))

--- a/runtime/queries/robot/highlights.scm
+++ b/runtime/queries/robot/highlights.scm
@@ -1,7 +1,7 @@
 [
   (comment)
   (extra_text)
-] @comment
+] @comment.single
 
 [
   (section_header)
@@ -14,7 +14,7 @@
 (keyword_definition (name) @function)
 (test_case_definition (name) @function)
 
-(keyword_invocation (keyword) @function.call)
+(keyword_invocation (keyword) @function)
 (ellipses) @punctuation.delimiter
 
 (text_chunk) @string
@@ -27,6 +27,8 @@
 
 ; Control structures
 
+"RETURN" @keyword.control.return
+
 [
   "FOR"
   "IN"
@@ -35,23 +37,23 @@
   "IN ZIP"
   (break_statement)
   (continue_statement)
-] @repeat
-(for_statement "END" @repeat)
+] @keyword.control.repeat
+(for_statement "END" @keyword.control.repeat)
 
-"WHILE" @repeat
-(while_statement "END" @repeat)
+"WHILE" @keyword.control.repeat
+(while_statement "END" @keyword.control.repeat)
 
 [
   "IF"
   "ELSE IF"
-] @conditional
-(if_statement "END" @conditional)
-(if_statement (else_statement "ELSE" @conditional))
+] @keyword.control.conditional
+(if_statement "END" @keyword.control.conditional)
+(if_statement (else_statement "ELSE" @keyword.control.conditional))
 
 [
   "TRY"
   "EXCEPT"
   "FINALLY"
-] @exception
-(try_statement "END" @exception)
-(try_statement (else_statement "ELSE" @exception))
+] @keyword.control.exception
+(try_statement "END" @keyword.control.exception)
+(try_statement (else_statement "ELSE" @keyword.control.exception))


### PR DESCRIPTION
Updates tree-sitter-robot to the newest version, and updates the syntax highlighting query.

~~Note: I wrote this highlights query for Neovim, and after a glance at the other highlights queries in Helix, I suspect you use different capture names. Neovim has a list of captures it supports for syntax highlighting: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights~~

~~I couldn't find anything similar for Helix. Please let me know if the query needs any modifications.~~