### PR TITLE
Highlight Dart 3 `sealed` and `base` keywords

### DIFF
--- a/runtime/queries/dart/highlights.scm
+++ b/runtime/queries/dart/highlights.scm
@@ -219,6 +219,7 @@
     "operator"
     "part"
     "required"
+    "sealed"
     "set"
     "show"
     "static"
@@ -230,7 +231,7 @@
 
 ; when used as an identifier:
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^(abstract|as|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|set|static|typedef)$"))
+ (#match? @variable.builtin "^(abstract|as|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|sealed|set|static|typedef)$"))
 
 ; Error
 (ERROR) @error

--- a/runtime/queries/dart/highlights.scm
+++ b/runtime/queries/dart/highlights.scm
@@ -200,6 +200,7 @@
     "async"
     "async*"
     "await"
+    "base"
     "class"
     "covariant"
     "deferred"
@@ -231,7 +232,7 @@
 
 ; when used as an identifier:
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^(abstract|as|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|sealed|set|static|typedef)$"))
+ (#match? @variable.builtin "^(abstract|as|base|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|sealed|set|static|typedef)$"))
 
 ; Error
 (ERROR) @error


### PR DESCRIPTION
Dart 3 introduces new `sealed` and `base` class modifiers, but they are not properly highlighted in Helix. This PR fixes that by adding them to the keyword list.