### PR TITLE
Copy desktop and icon files to Nix output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,6 @@
           ".ignore"
           ".github"
           ".gitignore"
-          "logo.svg"
           "logo_dark.svg"
           "logo_light.svg"
           "rust-toolchain.toml"
@@ -51,7 +50,6 @@
           "runtime"
           "screenshot.png"
           "book"
-          "contrib"
           "docs"
           "README.md"
           "CHANGELOG.md"
@@ -142,6 +140,12 @@
         helix-unwrapped = craneLib.buildPackage (commonArgs
           // {
             inherit cargoArtifacts;
+            postInstall = ''
+              mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps $out/share/icons/hicolor/256x256/apps
+              cp contrib/Helix.desktop $out/share/applications
+              cp logo.svg $out/share/icons/hicolor/scalable/apps/helix.svg
+              cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
+            '';
           });
         helix = makeOverridableHelix self.packages.${system}.helix-unwrapped {};
         default = self.packages.${system}.helix;


### PR DESCRIPTION
Copy `contrib/Helix.desktop`, `logo.svg` and `contrib/helix.png` to the Nix output.

This allows nix (or home-manager) users to have their XDG desktop set up without manually copying these files.