### PR TITLE
Add different background color for inactive panes

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -269,6 +269,7 @@ These scopes are used for theming the editor interface:
 | Key                               | Notes                                                                                          |
 | ---                               | ---                                                                                            |
 | `ui.background`                   |                                                                                                |
+| `ui.background.inactive`          | Background of unfocused document                                                               |
 | `ui.background.separator`         | Picker separator below input line                                                              |
 | `ui.cursor`                       |                                                                                                |
 | `ui.cursor.normal`                |                                                                                                |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -98,7 +98,7 @@ impl EditorView {
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
 
-        if !is_focused {
+        if !(is_focused && self.terminal_focused) {
             surface.set_style(area, theme.get("ui.background.inactive"))
         }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -98,6 +98,10 @@ impl EditorView {
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
 
+        if !is_focused {
+            surface.set_style(area, theme.get("ui.background.inactive"))
+        }
+
         if is_focused && config.cursorline {
             decorations.add_decoration(Self::cursorline(doc, view, theme));
         }


### PR DESCRIPTION
Adds a new theme key `ui.background.inactive` to control the background color of inactive panes.
This PR will not have any effect until the inactive color is defined, which I will leave to the theme maintainers.

Closes: https://github.com/helix-editor/helix/issues/1187