### PR TITLE
Implement change picker

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -284,6 +284,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`                  |
 | `d`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                       |
 | `D`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`             |
+| `c`     | Open change picker                                                      | `change_picker`                            |
 | `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                            |
 | `a`     | Apply code action (**LSP**)                                             | `code_action`                              |
 | `h`     | Select symbol references (**LSP**)                                      | `select_references_to_symbol_under_cursor` |

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -222,6 +222,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "S" => workspace_symbol_picker,
             "d" => diagnostics_picker,
             "D" => workspace_diagnostics_picker,
+            "c" => change_picker,
             "a" => code_action,
             "'" => last_picker,
             "g" => { "Debug (experimental)" sticky=true


### PR DESCRIPTION
## What is this Pull Request about?
This pull request is introducing a new picker, which displays a list of all current changes in the current buffer.

## How can I try it?
The new picker can be accessed in `space` mode, by pressing `c`.

## How does it work?
1) If there are changes in the current file a picker with preview of the location where the selected hunk is will be displayed.
2) If there are no changes in the current file, the picker will not be displayed and a status message will be displayed instead.

## Visual preview

### Adds a new entry underneath the workspace diagnostics picker
![1692350940](https://github.com/helix-editor/helix/assets/4450312/a229c510-93de-437b-a349-2291ca4193c0)

### The change picker in action
![1692350891](https://github.com/helix-editor/helix/assets/4450312/a64d5636-2d2b-4a2b-8510-29968d54f676)

## Considerations
1. It will be really nice if we also have a workspace change picker. It will display a full overview of all changes in the current space. This can be bound to `<space>+C` for example. I think such features should be part of a future pull request.
2. In order to be consistent with the `]g` and `[g` motions, it would have been better to use `<space>+g` for the change picker, however that is currently occupied by the debug menu and I'm not sure if it is a good idea to change an existing default binding.