### PR TITLE
Nord theme: Update ruler to set bg instead of fg

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -125,7 +125,7 @@
 # Virtual/invisable text
 "ui.virtual.indent-guide" = "nord3"
 "ui.virtual.inlay-hint" = { fg = "nord3", modifiers = ["italic"] }
-"ui.virtual.ruler" = "nord3"
+"ui.virtual.ruler" = { bg = "nord1" }
 "ui.virtual.whitespace" = "nord3"
 "ui.virtual.wrap" = "nord3"
 


### PR DESCRIPTION
The new nord theme sets the `fg` value of `"ui.virtual.ruler"` instead of the `bg`, which makes it really hard to see where the ruler actually is.
Also, this should make it more consistent with the other themes. (they all set `bg`)

note: Changed it to `nord1` because that's what nord-vim uses for [`ColorColumn`](https://github.com/nordtheme/vim/blob/main/colors/nord.vim#L131)

before:
![image](https://github.com/helix-editor/helix/assets/32709291/fcc9de3d-4155-4b71-ac8f-1599404dbe02)


after:
![image](https://github.com/helix-editor/helix/assets/32709291/5dd816c9-2736-4a9d-8bed-cec42563e5b3)