### PR TITLE
Update install.md to include packaging disclaimer

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -45,6 +45,7 @@ Download pre-built binaries from the
 line.
 
 ## Linux, macOS, Windows and OpenBSD packaging status
+Packages found outside the [GitHub Releases page](https://github.com/helix-editor/helix/releases) are outside the control of the Helix team. If you have an issue with a specific package, it may be necessary to contact the package maintainers.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
 


### PR DESCRIPTION
As part of https://github.com/helix-editor/helix/issues/7971 it was determined that a version of helix was compiled with a newer rust compiler version (which did not exist when 23.5 was released so the bug went unnoticed).