### PR TITLE
Cursor’s position custom format support

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -81,21 +81,23 @@ left = ["mode", "spinner"]
 center = ["file-name"]
 right = ["diagnostics", "selections", "position", "file-encoding", "file-line-ending", "file-type"]
 separator = "│"
+position-format = "{column}:{line}/{lines_count}"
 mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
 ```
 The `[editor.statusline]` key takes the following sub-keys:
 
-| Key           | Description | Default |
-| ---           | ---         | ---     |
-| `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
-| `center`      | A list of elements aligned to the middle of the statusline | `[]` |
-| `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding"]` |
-| `separator`   | The character used to separate elements in the statusline | `"│"` |
-| `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
-| `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |
-| `mode.select` | The text shown in the `mode` element for select mode | `"SEL"` |
+| Key               | Description | Default |
+| ---               | ---         | ---     |
+| `left`            | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
+| `center`          | A list of elements aligned to the middle of the statusline | `[]` |
+| `right`           | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding"]` |
+| `separator`       | The character used to separate elements in the statusline | `"│"` |
+| `position-format` | The format of the position information. The first instances of `{line}`, `{column}` and `{lines_count}` will be replaced with the corresponding values. |
+| `mode.normal`     | The text shown in the `mode` element for normal mode | `"NOR"` |
+| `mode.insert`     | The text shown in the `mode` element for insert mode | `"INS"` |
+| `mode.select`     | The text shown in the `mode` element for select mode | `"SEL"` |
 
 The following statusline elements can be configured:
 
@@ -116,6 +118,7 @@ The following statusline elements can be configured:
 | `selections` | The number of active selections |
 | `primary-selection-length` | The number of characters currently in primary selection |
 | `position` | The cursor position |
+| `position-format` | The format used to display the position of the cursor (defaults to `""`, which is equivalent to `"{row}:{column}"`) |
 | `position-percentage` | The cursor position as a percentage of the total number of lines |
 | `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |
 | `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -339,11 +339,20 @@ where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
     let position = get_position(context);
-    write(
-        context,
-        format!(" {}:{} ", position.row + 1, position.col + 1),
-        None,
-    );
+    let total_line_numbers = context.doc.text().len_lines();
+
+    let res: String = match context.editor.config().statusline.position_format.as_str() {
+        "" => format!(" {}:{} ", position.row + 1, position.col + 1),
+        _ => {
+            let mut formatted: String = context.editor.config().statusline.position_format.clone();
+            formatted = formatted.replacen("{column}", &format!("{}", position.col + 1), 1);
+            formatted = formatted.replacen("{line}", &format!("{}", position.row + 1), 1);
+            formatted = formatted.replacen("{lines_count}", &format!("{}", total_line_numbers), 1);
+            formatted
+        }
+    };
+
+    write(context, res, None);
 }
 
 fn render_total_line_numbers<F>(context: &mut RenderContext, write: F)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -410,6 +410,7 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub position_format: String,
 }
 
 impl Default for StatusLineConfig {
@@ -434,6 +435,7 @@ impl Default for StatusLineConfig {
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            position_format: String::new(),
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #5049
The goal of this PR is to allow users to use a custom format to display the cursor’s position in a buffer.

## Solution

The solution used was mostly similar to the one proposed in the issue by @austinletson, except for one variation:

if a user specifies a format, the format string is, by definition, dynamic which prevents the use of the format! macro and can lead to a small hit in performance.
To prevent that, if no custom format is specified, the position of the cursor will be presented exactly as it was previously.

When a custom format has been specified, then the first instances (again, to limit any performance hit) of the format markers {column}, {line} and {lines_count}
are replaced with the appropriate values.

---

## Changelog

- Statusline: added custom cursor position format support

--- 
(First PR, I hope I did everything right!)