### PR TITLE
Auto-format specified by language is now opt-in [#7868]

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -333,8 +333,13 @@ fn write_impl(
     let jobs = &mut cx.jobs;
     let (view, doc) = current!(cx.editor);
     let path = path.map(AsRef::as_ref);
+    let language_auto_fmt = if let Some(language_config) = doc.language_config() {
+        language_config.auto_format
+    } else {
+        editor_auto_fmt
+    };
 
-    let fmt = if editor_auto_fmt {
+    let fmt = if language_auto_fmt {
         doc.auto_format().map(|fmt| {
             let callback = make_format_callback(
                 doc.id(),
@@ -692,7 +697,12 @@ pub fn write_all_impl(
                 current_view.id
             };
 
-            let fmt = if auto_format {
+            let language_auto_fmt = if let Some(language_config) = doc.language_config() {
+                language_config.auto_format
+            } else {
+                auto_format
+            };
+            let fmt = if language_auto_fmt {
                 doc.auto_format().map(|fmt| {
                     let callback = make_format_callback(
                         doc.id(),


### PR DESCRIPTION
# Objective

Fixes #7868
The auto-format parameter when specified by language could disable the auto-formatting when it was globally activated. However when the auto-formatting was disabled globally there was no way to override that parameter for an individual language.

## Solution

This PR changes that, such that if auto-format is turned off globally *but* turned on for the language, the auto-formatting will be done on save.

| Global | Language | Current Behaviour | New Behaviour |
| ------ | -------- | ----------------- | ------------- |
| True   | True     | True              | True          |
| True   | False    | False             | False         |
| False  | True     | **False**         | **True**      |
| False  | False    | False             | False         |

## Changelog

### Changed

- Auto-format: can now be opted-in per language when globally deactivated