### PR TITLE
[chore] Remove unnecessary `Err` from `get_canonicalized_path`

### DIFF
--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -85,7 +85,7 @@ pub fn get_normalized_path(path: &Path) -> PathBuf {
 ///
 /// This function is used instead of `std::fs::canonicalize` because we don't want to verify
 /// here if the path exists, just normalize it's components.
-pub fn get_canonicalized_path(path: &Path) -> std::io::Result<PathBuf> {
+pub fn get_canonicalized_path(path: &Path) -> PathBuf {
     let path = expand_tilde(path);
     let path = if path.is_relative() {
         helix_loader::current_working_dir().join(path)
@@ -93,7 +93,7 @@ pub fn get_canonicalized_path(path: &Path) -> std::io::Result<PathBuf> {
         path
     };
 
-    Ok(get_normalized_path(path.as_path()))
+    get_normalized_path(path.as_path())
 }
 
 pub fn get_relative_path(path: &Path) -> PathBuf {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -160,7 +160,7 @@ impl Application {
             let path = helix_loader::runtime_file(Path::new("tutor"));
             editor.open(&path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
-            doc_mut!(editor).set_path(None)?;
+            doc_mut!(editor).set_path(None);
         } else if !args.files.is_empty() {
             let first = &args.files[0].0; // we know it's not empty
             if first.is_dir() {
@@ -554,16 +554,7 @@ impl Application {
         let bytes = doc_save_event.text.len_bytes();
 
         if doc.path() != Some(&doc_save_event.path) {
-            if let Err(err) = doc.set_path(Some(&doc_save_event.path)) {
-                log::error!(
-                    "error setting path for doc '{:?}': {}",
-                    doc.path(),
-                    err.to_string(),
-                );
-
-                self.editor.set_error(err.to_string());
-                return;
-            }
+            doc.set_path(Some(&doc_save_event.path));
 
             let loader = self.editor.syn_loader.clone();
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1679,7 +1679,7 @@ fn tutor(
     let path = helix_loader::runtime_file(Path::new("tutor"));
     cx.editor.open(&path, Action::Replace)?;
     // Unset path to prevent accidentally saving to the original tutor file.
-    doc_mut!(cx.editor).set_path(None)?;
+    doc_mut!(cx.editor).set_path(None);
     Ok(())
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -51,12 +51,12 @@ pub enum PathOrId {
 }
 
 impl PathOrId {
-    fn get_canonicalized(self) -> std::io::Result<Self> {
+    fn get_canonicalized(self) -> Self {
         use PathOrId::*;
-        Ok(match self {
-            Path(path) => Path(helix_core::path::get_canonicalized_path(&path)?),
+        match self {
+            Path(path) => Path(helix_core::path::get_canonicalized_path(&path)),
             Id(id) => Id(id),
-        })
+        }
     }
 }
 
@@ -375,7 +375,7 @@ impl<T: Item + 'static> Picker<T> {
     fn current_file(&self, editor: &Editor) -> Option<FileLocation> {
         self.selection()
             .and_then(|current| (self.file_fn.as_ref()?)(editor, current))
-            .and_then(|(path_or_id, line)| path_or_id.get_canonicalized().ok().zip(Some(line)))
+            .and_then(|(path_or_id, line)| Some(path_or_id.get_canonicalized()).zip(Some(line)))
     }
 
     /// Get (cached) preview for a given path. If a document corresponding

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -375,7 +375,7 @@ impl<T: Item + 'static> Picker<T> {
     fn current_file(&self, editor: &Editor) -> Option<FileLocation> {
         self.selection()
             .and_then(|current| (self.file_fn.as_ref()?)(editor, current))
-            .and_then(|(path_or_id, line)| Some(path_or_id.get_canonicalized()).zip(Some(line)))
+            .map(|(path_or_id, line)| (path_or_id.get_canonicalized(), line))
     }
 
     /// Get (cached) preview for a given path. If a document corresponding

--- a/helix-term/tests/test/picker.rs
+++ b/helix-term/tests/test/picker.rs
@@ -30,7 +30,7 @@ async fn test_picker_alt_ret() -> anyhow::Result<()> {
     ];
     let paths = files
         .iter()
-        .map(|f| get_canonicalized_path(f.path()).unwrap())
+        .map(|f| get_canonicalized_path(f.path()))
         .collect::<Vec<_>>();
 
     fs::write(&paths[0], "1\n2\n3\n4")?;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -708,7 +708,7 @@ impl Document {
         let mut doc = Self::from(rope, Some((encoding, has_bom)), config);
 
         // set the path and try detecting the language
-        doc.set_path(Some(path))?;
+        doc.set_path(Some(path));
         if let Some(loader) = config_loader {
             doc.detect_language(loader);
         }
@@ -853,7 +853,7 @@ impl Document {
         let text = self.text().clone();
 
         let path = match path {
-            Some(path) => helix_core::path::get_canonicalized_path(&path)?,
+            Some(path) => helix_core::path::get_canonicalized_path(&path),
             None => {
                 if self.path.is_none() {
                     bail!("Can't save with no path set!");
@@ -1047,18 +1047,14 @@ impl Document {
         self.encoding
     }
 
-    pub fn set_path(&mut self, path: Option<&Path>) -> Result<(), std::io::Error> {
-        let path = path
-            .map(helix_core::path::get_canonicalized_path)
-            .transpose()?;
+    pub fn set_path(&mut self, path: Option<&Path>) {
+        let path = path.map(helix_core::path::get_canonicalized_path);
 
         // if parent doesn't exist we still want to open the document
         // and error out when document is saved
         self.path = path;
 
         self.detect_readonly();
-
-        Ok(())
     }
 
     /// Set the programming language for the file and load associated data (e.g. highlighting)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1436,7 +1436,7 @@ impl Editor {
 
     // ??? possible use for integration tests
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, Error> {
-        let path = helix_core::path::get_canonicalized_path(path)?;
+        let path = helix_core::path::get_canonicalized_path(path);
         let id = self.document_by_path(&path).map(|doc| doc.id);
 
         let id = if let Some(id) = id {


### PR DESCRIPTION
Following function never fails but returns a `Result`.
https://github.com/helix-editor/helix/blob/01a1e5ec2a8c5b81da1360746dad0a96cd88ae8e/helix-core/src/path.rs#L88-L97

This change just fixes this and all the callers of this function.


History:
Previously the function returned a `Result` as it had to rely on `std::env::current_dir` which could fail. But in https://github.com/helix-editor/helix/commit/8afc0282f28e73cf78d1bd7b11d78fd853ae2036 we started relying on `helix_loader::current_working_dir` which consumes the `Err` already.