### PR TITLE
Remove path completions for `:new` command

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2408,9 +2408,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["n"],
         doc: "Create a new scratch buffer.",
         fun: new_file,
-        // TODO: This seems to complete with a filename, but doesn't use that filename to
-        //       set the path of the newly created buffer.
-        signature: CommandSignature::positional(&[completers::filename]),
+        signature: CommandSignature::none(),
     },
     TypableCommand {
         name: "format",


### PR DESCRIPTION
Since the argument of `:new` is never used, the completion might be confusing for user.