### PR TITLE
Scroll cursor and page together (neovim-like scrolling)

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -53,8 +53,8 @@ Normal mode is the default mode when you launch helix. Return to it from other m
 | `End`                 | Move to the end of the line                        | `goto_line_end`             |
 | `Ctrl-b`, `PageUp`    | Move page up                                       | `page_up`                   |
 | `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                 |
-| `Ctrl-u`              | Move half page up                                  | `half_page_up`              |
-| `Ctrl-d`              | Move half page down                                | `half_page_down`            |
+| `Ctrl-u`              | Move cursor and page half page up                  | `page_cursor_half_up`       |
+| `Ctrl-d`              | Move cursor and page half page down                | `page_cursor_half_down`     |
 | `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`              |
 | `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`             |
 | `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`            |
@@ -182,18 +182,18 @@ normal mode) is persistent and can be exited using the escape key. This is
 useful when you're simply looking over text and not actively editing it.
 
 
-| Key                  | Description                                               | Command             |
-| -----                | -----------                                               | -------             |
-| `z`, `c`             | Vertically center the line                                | `align_view_center` |
-| `t`                  | Align the line to the top of the screen                   | `align_view_top`    |
-| `b`                  | Align the line to the bottom of the screen                | `align_view_bottom` |
-| `m`                  | Align the line to the middle of the screen (horizontally) | `align_view_middle` |
-| `j`, `down`          | Scroll the view downwards                                 | `scroll_down`       |
-| `k`, `up`            | Scroll the view upwards                                   | `scroll_up`         |
-| `Ctrl-f`, `PageDown` | Move page down                                            | `page_down`         |
-| `Ctrl-b`, `PageUp`   | Move page up                                              | `page_up`           |
-| `Ctrl-d`             | Move half page down                                       | `half_page_down`    |
-| `Ctrl-u`             | Move half page up                                         | `half_page_up`      |
+| Key                  | Description                                               | Command                 |
+| -----                | -----------                                               | -------                 |
+| `z`, `c`             | Vertically center the line                                | `align_view_center`     |
+| `t`                  | Align the line to the top of the screen                   | `align_view_top`        |
+| `b`                  | Align the line to the bottom of the screen                | `align_view_bottom`     |
+| `m`                  | Align the line to the middle of the screen (horizontally) | `align_view_middle`     |
+| `j`, `down`          | Scroll the view downwards                                 | `scroll_down`           |
+| `k`, `up`            | Scroll the view upwards                                   | `scroll_up`             |
+| `Ctrl-f`, `PageDown` | Move page down                                            | `page_down`             |
+| `Ctrl-b`, `PageUp`   | Move page up                                              | `page_up`               |
+| `Ctrl-u`             | Move cursor and page half page up                         | `page_cursor_half_up`   |
+| `Ctrl-d`             | Move cursor and page half page down                       | `page_cursor_half_down` |
 
 #### Goto mode
 

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -64,6 +64,7 @@ pub fn move_vertically_visual(
     if !text_fmt.soft_wrap {
         return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
+    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
 
     // Compute the current position's 2d coordinates.
@@ -111,6 +112,7 @@ pub fn move_vertically(
     text_fmt: &TextFormat,
     annotations: &mut TextAnnotations,
 ) -> Range {
+    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
     let line_idx = slice.char_to_line(pos);
     let line_start = slice.line_to_char(line_idx);

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -64,6 +64,28 @@ pub fn move_vertically_visual(
     if !text_fmt.soft_wrap {
         return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
+    annotations.clear_line_annotations();
+
+    return _move_vertically_visual(
+        slice,
+        range,
+        dir,
+        count,
+        behaviour,
+        text_fmt,
+        annotations,
+    );
+}
+
+pub fn _move_vertically_visual(
+    slice: RopeSlice,
+    range: Range,
+    dir: Direction,
+    count: usize,
+    behaviour: Movement,
+    text_fmt: &TextFormat,
+    annotations: &mut TextAnnotations
+) -> Range {
     let pos = range.cursor(slice);
 
     // Compute the current position's 2d coordinates.
@@ -111,6 +133,7 @@ pub fn move_vertically(
     text_fmt: &TextFormat,
     annotations: &mut TextAnnotations,
 ) -> Range {
+    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
     let line_idx = slice.char_to_line(pos);
     let line_start = slice.line_to_char(line_idx);

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -64,7 +64,6 @@ pub fn move_vertically_visual(
     if !text_fmt.soft_wrap {
         return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
-    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
 
     // Compute the current position's 2d coordinates.
@@ -112,7 +111,6 @@ pub fn move_vertically(
     text_fmt: &TextFormat,
     annotations: &mut TextAnnotations,
 ) -> Range {
-    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
     let line_idx = slice.char_to_line(pos);
     let line_start = slice.line_to_char(line_idx);

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -64,28 +64,6 @@ pub fn move_vertically_visual(
     if !text_fmt.soft_wrap {
         return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
-    annotations.clear_line_annotations();
-
-    return _move_vertically_visual(
-        slice,
-        range,
-        dir,
-        count,
-        behaviour,
-        text_fmt,
-        annotations,
-    );
-}
-
-pub fn _move_vertically_visual(
-    slice: RopeSlice,
-    range: Range,
-    dir: Direction,
-    count: usize,
-    behaviour: Movement,
-    text_fmt: &TextFormat,
-    annotations: &mut TextAnnotations
-) -> Range {
     let pos = range.cursor(slice);
 
     // Compute the current position's 2d coordinates.
@@ -133,7 +111,6 @@ pub fn move_vertically(
     text_fmt: &TextFormat,
     annotations: &mut TextAnnotations,
 ) -> Range {
-    annotations.clear_line_annotations();
     let pos = range.cursor(slice);
     let line_idx = slice.char_to_line(pos);
     let line_start = slice.line_to_char(line_idx);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1542,7 +1542,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
         };
         // TODO: When inline diagnostics gets merged- 1. move_vertically_visual removes
         // line annotations/diagnostics so the cursor may jump further than the view.
-        // 2. If the cursor lands on a complete line of virtual text, the cursor will 
+        // 2. If the cursor lands on a complete line of virtual text, the cursor will
         // jump a different distance than the view.
         let selection = doc.selection(view.id).clone().transform(|range| {
             move_vertically_visual(
@@ -1558,7 +1558,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
         doc.set_selection(view.id, selection);
         return;
     }
-    
+
     let mut head;
     match direction {
         Forward => {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -276,6 +276,10 @@ impl MappableCommand {
         page_down, "Move page down",
         half_page_up, "Move half page up",
         half_page_down, "Move half page down",
+        page_cursor_up, "Move page and cursor up",
+        page_cursor_down, "Move page and cursor down",
+        page_cursor_half_up, "Move page and cursor half up",
+        page_cursor_half_down, "Move page and cursor half down",
         select_all, "Select whole document",
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
@@ -1652,6 +1656,30 @@ fn half_page_down(cx: &mut Context) {
     let view = view!(cx.editor);
     let offset = view.inner_height() / 2;
     scroll(cx, offset, Direction::Forward);
+}
+
+fn page_cursor_up(cx: &mut Context) {
+    let view = view!(cx.editor);
+    let offset = view.inner_height();
+    scroll_page_and_cursor(cx, offset, Direction::Backward);
+}
+
+fn page_cursor_down(cx: &mut Context) {
+    let view = view!(cx.editor);
+    let offset = view.inner_height();
+    scroll_page_and_cursor(cx, offset, Direction::Forward);
+}
+
+fn page_cursor_half_up(cx: &mut Context) {
+    let view = view!(cx.editor);
+    let offset = view.inner_height() / 2;
+    scroll_page_and_cursor(cx, offset, Direction::Backward);
+}
+
+fn page_cursor_half_down(cx: &mut Context) {
+    let view = view!(cx.editor);
+    let offset = view.inner_height() / 2;
+    scroll_page_and_cursor(cx, offset, Direction::Forward);
 }
 
 #[allow(deprecated)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -595,6 +595,7 @@ fn move_impl(cx: &mut Context, move_fn: MoveFn, dir: Direction, behaviour: Movem
     let text = doc.text().slice(..);
     let text_fmt = doc.text_format(view.inner_area(doc).width, None);
     let mut annotations = view.text_annotations(doc, None);
+    annotations.clear_line_annotations();
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         move_fn(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -18,7 +18,7 @@ use helix_core::{
     indent::IndentStyle,
     line_ending::{get_line_ending_of_str, line_end_char_index, str_is_line_ending},
     match_brackets,
-    movement::{self, move_vertically_visual, _move_vertically_visual, Direction},
+    movement::{self, move_vertically_visual, Direction},
     object, pos_at_coords,
     regex::{self, Regex, RegexBuilder},
     search::{self, CharMatcher},
@@ -599,6 +599,7 @@ fn move_impl(cx: &mut Context, move_fn: MoveFn, dir: Direction, behaviour: Movem
     let text = doc.text().slice(..);
     let text_fmt = doc.text_format(view.inner_area(doc).width, None);
     let mut annotations = view.text_annotations(doc, None);
+    annotations.clear_line_annotations();
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         move_fn(
@@ -1543,7 +1544,7 @@ pub fn scroll_page_and_cursor(cx: &mut Context, offset: usize, direction: Direct
     }
 
     let selection = doc.selection(view.id).clone().transform(|range| {
-            _move_vertically_visual(
+            move_vertically_visual(
                 doc_text,
                 range,
                 direction,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -599,7 +599,6 @@ fn move_impl(cx: &mut Context, move_fn: MoveFn, dir: Direction, behaviour: Movem
     let text = doc.text().slice(..);
     let text_fmt = doc.text_format(view.inner_area(doc).width, None);
     let mut annotations = view.text_annotations(doc, None);
-    annotations.clear_line_annotations();
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         move_fn(

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1549,7 +1549,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
                 doc_text,
                 range,
                 direction,
-                offset.abs() as usize,
+                offset.unsigned_abs(),
                 movement,
                 &text_fmt,
                 &mut annotations,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1542,6 +1542,10 @@ pub fn scroll_page_and_cursor(cx: &mut Context, offset: usize, direction: Direct
         offset += scrolloff - cursor_pos.row + 1;
     }
 
+    // TODO: When inline diagnostics gets merged- 1. move_vertically_visual removes
+    // line annotations/diagnostics so the cursor may jump further than the view.
+    // 2. If the cursor lands on a complete line of virtual text, the cursor will 
+    // jump a different distance than the view.
     let selection = doc.selection(view.id).clone().transform(|range| {
             move_vertically_visual(
                 doc_text,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -18,7 +18,7 @@ use helix_core::{
     indent::IndentStyle,
     line_ending::{get_line_ending_of_str, line_end_char_index, str_is_line_ending},
     match_brackets,
-    movement::{self, move_vertically_visual, Direction},
+    movement::{self, move_vertically_visual, _move_vertically_visual, Direction},
     object, pos_at_coords,
     regex::{self, Regex, RegexBuilder},
     search::{self, CharMatcher},
@@ -599,7 +599,6 @@ fn move_impl(cx: &mut Context, move_fn: MoveFn, dir: Direction, behaviour: Movem
     let text = doc.text().slice(..);
     let text_fmt = doc.text_format(view.inner_area(doc).width, None);
     let mut annotations = view.text_annotations(doc, None);
-    annotations.clear_line_annotations();
 
     let selection = doc.selection(view.id).clone().transform(|range| {
         move_fn(
@@ -1544,7 +1543,7 @@ pub fn scroll_page_and_cursor(cx: &mut Context, offset: usize, direction: Direct
     }
 
     let selection = doc.selection(view.id).clone().transform(|range| {
-            move_vertically_visual(
+            _move_vertically_visual(
                 doc_text,
                 range,
                 direction,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -178,8 +178,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "esc" => normal_mode,
         "C-b" | "pageup" => page_up,
         "C-f" | "pagedown" => page_down,
-        "C-u" => half_page_up,
-        "C-d" => half_page_down,
+        "C-u" => page_cursor_half_up,
+        "C-d" => page_cursor_half_down,
 
         "C-w" => { "Window"
             "C-w" | "w" => rotate_view,
@@ -287,8 +287,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" | "backspace" => half_page_up,
-            "C-d" | "space" => half_page_down,
+            "C-u" => page_cursor_half_up,
+            "C-d" => page_cursor_half_down,
 
             "/" => search,
             "?" => rsearch,
@@ -304,9 +304,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" | "backspace" => half_page_up,
-            "C-d" | "space" => half_page_down,
-
+            "C-u" => page_cursor_half_up,
+            "C-d" => page_cursor_half_down,
             "/" => search,
             "?" => rsearch,
             "n" => search_next,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -287,8 +287,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" => page_cursor_half_up,
-            "C-d" => page_cursor_half_down,
+            "C-u" | "backspace" => page_cursor_half_up,
+            "C-d" | "space" => page_cursor_half_down,
 
             "/" => search,
             "?" => rsearch,
@@ -304,8 +304,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" | "down" => scroll_down,
             "C-b" | "pageup" => page_up,
             "C-f" | "pagedown" => page_down,
-            "C-u" => page_cursor_half_up,
-            "C-d" => page_cursor_half_down,
+            "C-u" | "backspace" => page_cursor_half_up,
+            "C-d" | "space" => page_cursor_half_down,
+
             "/" => search,
             "?" => rsearch,
             "n" => search_next,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1139,7 +1139,7 @@ impl EditorView {
                 }
 
                 let offset = config.scroll_lines.unsigned_abs();
-                commands::scroll(cxt, offset, direction);
+                commands::scroll(cxt, offset, direction, false);
 
                 cxt.editor.tree.focus = current_view;
                 cxt.editor.ensure_cursor_in_view(current_view);


### PR DESCRIPTION
Solves #7639 - adds a new scroll function so that the cursor and page jump by the same distance vertically. Assigns this to C-u and C-d, similar to neovim. 

The consistent distance between cursor and view top would break if the cursor were to land on a whole line of virtual text- the cursor would be placed on the closest non-virtual text above where it landed. Meaning the view and cursor would not have jumped the same vertical distance. 
This should be pretty rare though- unless you are using #6417 and have a ton of error messages. I could refactor this nvim-scroll function though- to first calculate how many lines the cursor jumped (eg the cursor tried to jump by half a page but could only jump by half a page -1 line due to virtual text) and then move the view by exactly this number. This would change the behaviour at the bottom of the page a bit also.

This nvim-scroll function respects the cursor's column throughout scrolls which I think is nice, I will make a pr for the `scroll` function to have the same.

Closes #7639 