### PR TITLE
create separate timer for redraw requests

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -598,6 +598,9 @@ impl Application {
                     self.render().await;
                 }
             }
+            EditorEvent::Redraw => {
+                self.render().await;
+            }
             EditorEvent::IdleTimer => {
                 self.editor.clear_idle_timer();
                 self.handle_idle_timeout().await;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -918,7 +918,7 @@ pub struct Editor {
     pub auto_pairs: Option<AutoPairs>,
 
     pub idle_timer: Pin<Box<Sleep>>,
-    pub redraw_timer: Pin<Box<Sleep>>,
+    redraw_timer: Pin<Box<Sleep>>,
     last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -918,6 +918,7 @@ pub struct Editor {
     pub auto_pairs: Option<AutoPairs>,
 
     pub idle_timer: Pin<Box<Sleep>>,
+    pub redraw_timer: Pin<Box<Sleep>>,
     last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
 
@@ -963,6 +964,7 @@ pub enum EditorEvent {
     LanguageServerMessage((usize, Call)),
     DebuggerEvent(dap::Payload),
     IdleTimer,
+    Redraw,
 }
 
 #[derive(Debug, Clone)]
@@ -1053,6 +1055,7 @@ impl Editor {
             status_msg: None,
             autoinfo: None,
             idle_timer: Box::pin(sleep(conf.idle_timeout)),
+            redraw_timer: Box::pin(sleep(Duration::MAX)),
             last_motion: None,
             last_completion: None,
             config,
@@ -1753,12 +1756,16 @@ impl Editor {
                     if  !self.needs_redraw{
                         self.needs_redraw = true;
                         let timeout = Instant::now() + Duration::from_millis(33);
-                        if timeout < self.idle_timer.deadline(){
-                            self.idle_timer.as_mut().reset(timeout)
+                        if timeout < self.idle_timer.deadline() && timeout < self.redraw_timer.deadline(){
+                            self.redraw_timer.as_mut().reset(timeout)
                         }
                     }
                 }
 
+                _ = &mut self.redraw_timer  => {
+                    self.redraw_timer.as_mut().reset(Instant::now() + Duration::from_secs(86400 * 365 * 30));
+                    return EditorEvent::Redraw
+                }
                 _ = &mut self.idle_timer  => {
                     return EditorEvent::IdleTimer
                 }


### PR DESCRIPTION
The redraw handle was using the idle timeout to denounce redraw requests so far. I will openly admit that I didn't quite appreciate the importance of the idle timeout back when I wrote the diff gutter PR (as I was still new to the codebase). It didn't really matter back then because the diff gutter timing out is a very rare occurrence but with #7538 the redraw handle is now triggered quite commonly which essentially makes the idle-timeout setting useless.

This PR fixes that by simply adding a separate timer for the redraw handle. In the long term we may move away from using the idle-timeout for debouncing data model update (#8021) at which point it would be fine to switch back to the idle timeout. Until all of that (substantial) work is finished I think its a good idea to fix this in the meantime (especially looking toward the next release).
