### PR TITLE
Add config for diagnostics messages

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -29,7 +29,6 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-// use helix_tui::layout::Alignment;
 use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
@@ -684,8 +683,7 @@ impl EditorView {
                     Some(Severity::Info) => info,
                     Some(Severity::Hint) => hint,
                 });
-            let msg = format!("{}\n", diagnostic.message).to_owned();
-            let text = Text::styled(msg, style);
+            let text = Text::styled(&diagnostic.message, style);
             lines.extend(text.lines);
             let code = diagnostic.code.as_ref().map(|x| match x {
                 NumberOrString::Number(n) => format!("({n})"),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -263,6 +263,8 @@ pub struct Config {
     pub statusline: StatusLineConfig,
     /// Shape for cursor in each mode
     pub cursor_shape: CursorShapeConfig,
+    /// Configuration of the diagnostics rendering
+    pub diagnostics: DiagnosticsConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
     pub true_color: bool,
     /// Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative. Defaults to `false`.
@@ -434,6 +436,26 @@ impl Default for StatusLineConfig {
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct DiagnosticsConfig {
+    pub top_margin: u16,
+    pub right_margin: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl Default for DiagnosticsConfig {
+    fn default() -> Self {
+        Self {
+            top_margin: 1,
+            right_margin: 0,
+            width: 100,
+            height: 15,
         }
     }
 }
@@ -824,6 +846,7 @@ impl Default for Config {
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),
+            diagnostics: DiagnosticsConfig::default(),
             true_color: false,
             undercurl: false,
             search: SearchConfig::default(),


### PR DESCRIPTION
I think we need a way to make the diagnostics display configurable. By default, the messages are right on the edge of the screen and can be hard to read when the messages get too long.

Here are the defaults (current behavior):
```toml
[editor.diagnostics]
top-margin = 1
right-margin = 0
width = 100
height = 15
```

Which will look something like this:
<img width="1361" alt="image" src="https://github.com/helix-editor/helix/assets/16892444/0a9a65b3-f424-405b-b259-44cf37acadea">


Here is how it can be adjusted:
```toml
[editor.diagnostics]
top-margin = 1
right-margin = 2
width = 100
height = 15
```

which will look like this:
<img width="1361" alt="image" src="https://github.com/helix-editor/helix/assets/16892444/be398975-02db-4942-a45c-4d0139cbb8f9">

Further possibilities could be an `align` property to align left if desired, or perhaps a way to truncate each of the messages to a max of N characters for extremely long messages that would be intrusive.