### PR TITLE
Allow indent-guides to be enable in languages.toml

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -117,6 +117,9 @@ pub struct LanguageConfiguration {
 
     pub grammar: Option<String>, // tree-sitter grammar name, defaults to language_id
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent_guides: Option<IndentGuidesConfig>, // override global indent_guides
+
     // content_regex
     #[serde(default, skip_serializing, deserialize_with = "deserialize_regex")]
     pub injection_regex: Option<Regex>,
@@ -154,6 +157,24 @@ pub struct LanguageConfiguration {
     /// Hardcoded LSP root directories relative to the workspace root, like `examples` or `tools/fuzz`.
     /// Falling back to the current working directory if none are configured.
     pub workspace_lsp_roots: Option<Vec<PathBuf>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct IndentGuidesConfig {
+    pub render: bool,
+    pub character: char,
+    pub skip_levels: u8,
+}
+
+impl Default for IndentGuidesConfig {
+    fn default() -> Self {
+        Self {
+            skip_levels: 0,
+            render: false,
+            character: '│',
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -331,6 +331,10 @@ impl<'a> TextRenderer<'a> {
         viewport: Rect,
     ) -> TextRenderer<'a> {
         let editor_config = doc.config.load();
+        let indent_guides_config = doc
+            .language_config()
+            .and_then(|config| config.indent_guides.as_ref())
+            .unwrap_or(&editor_config.indent_guides);
         let WhitespaceConfig {
             render: ws_render,
             characters: ws_chars,
@@ -368,7 +372,7 @@ impl<'a> TextRenderer<'a> {
 
         TextRenderer {
             surface,
-            indent_guide_char: editor_config.indent_guides.character.into(),
+            indent_guide_char: indent_guides_config.character.into(),
             newline,
             nbsp,
             space,
@@ -378,14 +382,14 @@ impl<'a> TextRenderer<'a> {
             indent_width,
             starting_indent: col_offset / indent_width as usize
                 + (col_offset % indent_width as usize != 0) as usize
-                + editor_config.indent_guides.skip_levels as usize,
+                + indent_guides_config.skip_levels as usize,
             indent_guide_style: text_style.patch(
                 theme
                     .try_get("ui.virtual.indent-guide")
                     .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
             ),
             text_style,
-            draw_indent_guides: editor_config.indent_guides.render,
+            draw_indent_guides: indent_guides_config.render,
             viewport,
             col_offset,
         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -42,7 +42,7 @@ use anyhow::{anyhow, bail, Error};
 pub use helix_core::diagnostic::Severity;
 use helix_core::{
     auto_pairs::AutoPairs,
-    syntax::{self, AutoPairConfig, SoftWrap},
+    syntax::{self, AutoPairConfig, IndentGuidesConfig, SoftWrap},
     Change, LineEnding, NATIVE_LINE_ENDING,
 };
 use helix_core::{Position, Selection};
@@ -730,24 +730,6 @@ impl Default for WhitespaceCharacters {
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE
             tabpad: ' ',
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
-pub struct IndentGuidesConfig {
-    pub render: bool,
-    pub character: char,
-    pub skip_levels: u8,
-}
-
-impl Default for IndentGuidesConfig {
-    fn default() -> Self {
-        Self {
-            skip_levels: 0,
-            render: false,
-            character: '│',
         }
     }
 }


### PR DESCRIPTION
Closes #8054

Allow configuring indent guides at the language level to override the global setting:
```toml
[[language]]
name = "python"
indent-guides = { render = true, character = "▏", skip-levels = 1 }
```