### PR TITLE
allow configuring diff gutter source

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -65,6 +65,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
+| `diff-source` | The source to use for diff operations (gutter, `:diffg`, `]g`, etc). Can be `git`, `file` (uses the contents of the file on disk), or `none`. | `git` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1283,10 +1283,12 @@ fn reload(
     }
 
     let scrolloff = cx.editor.config().scrolloff;
+    let diff_source = cx.editor.config().diff_source;
     let (view, doc) = current!(cx.editor);
-    doc.reload(view, &cx.editor.diff_provider).map(|_| {
-        view.ensure_cursor_in_view(doc, scrolloff);
-    })?;
+    doc.reload(view, &cx.editor.diff_provider, diff_source)
+        .map(|_| {
+            view.ensure_cursor_in_view(doc, scrolloff);
+        })?;
     if let Some(path) = doc.path() {
         cx.editor
             .language_servers
@@ -1324,6 +1326,7 @@ fn reload_all(
         .collect();
 
     for (doc_id, view_ids) in docs_view_ids {
+        let diff_source = cx.editor.config().diff_source;
         let doc = doc_mut!(cx.editor, &doc_id);
 
         // Every doc is guaranteed to have at least 1 view at this point.
@@ -1332,7 +1335,7 @@ fn reload_all(
         // Ensure that the view is synced with the document's history.
         view.sync_changes(doc);
 
-        doc.reload(view, &cx.editor.diff_provider)?;
+        doc.reload(view, &cx.editor.diff_provider, diff_source)?;
         if let Some(path) = doc.path() {
             cx.editor
                 .language_servers

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1284,7 +1284,7 @@ fn reload(
 
     let scrolloff = cx.editor.config().scrolloff;
     let (view, doc) = current!(cx.editor);
-    doc.reload(view, &cx.editor.diff_providers).map(|_| {
+    doc.reload(view, &cx.editor.diff_provider).map(|_| {
         view.ensure_cursor_in_view(doc, scrolloff);
     })?;
     if let Some(path) = doc.path() {
@@ -1332,7 +1332,7 @@ fn reload_all(
         // Ensure that the view is synced with the document's history.
         view.sync_changes(doc);
 
-        doc.reload(view, &cx.editor.diff_providers)?;
+        doc.reload(view, &cx.editor.diff_provider)?;
         if let Some(path) = doc.path() {
             cx.editor
                 .language_servers

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -7,8 +7,6 @@ use gix::objs::tree::EntryMode;
 use gix::sec::trust::DefaultForLevel;
 use gix::{Commit, ObjectId, Repository, ThreadSafeRepository};
 
-use crate::DiffProvider;
-
 #[cfg(test)]
 mod test;
 
@@ -59,10 +57,8 @@ impl Git {
 
         Ok(res)
     }
-}
 
-impl DiffProvider for Git {
-    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>> {
+    pub fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>> {
         debug_assert!(!file.exists() || file.is_file());
         debug_assert!(file.is_absolute());
 
@@ -101,7 +97,7 @@ impl DiffProvider for Git {
         Ok(data)
     }
 
-    fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+    pub fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
         debug_assert!(!file.exists() || file.is_file());
         debug_assert!(file.is_absolute());
         let repo_dir = file.parent().context("file has no parent directory")?;

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::Write, path::Path, process::Command};
 
 use tempfile::TempDir;
 
-use crate::{DiffProvider, Git};
+use crate::Git;
 
 fn exec_git_cmd(args: &str, git_dir: &Path) {
     let res = Command::new("git")

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -14,65 +14,14 @@ mod diff;
 
 pub use diff::{DiffHandle, Hunk};
 
-pub trait DiffProvider {
-    /// Returns the data that a diff should be computed against
-    /// if this provider is used.
-    /// The data is returned as raw byte without any decoding or encoding performed
-    /// to ensure all file encodings are handled correctly.
-    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>>;
-    fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>>;
-}
-
 #[doc(hidden)]
 pub struct Dummy;
-impl DiffProvider for Dummy {
-    fn get_diff_base(&self, _file: &Path) -> Result<Vec<u8>> {
+impl Dummy {
+    pub fn get_diff_base(&self, _file: &Path) -> Result<Vec<u8>> {
         bail!("helix was compiled without git support")
     }
 
-    fn get_current_head_name(&self, _file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+    pub fn get_current_head_name(&self, _file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
         bail!("helix was compiled without git support")
-    }
-}
-
-pub struct DiffProviderRegistry {
-    providers: Vec<Box<dyn DiffProvider>>,
-}
-
-impl DiffProviderRegistry {
-    pub fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>> {
-        self.providers
-            .iter()
-            .find_map(|provider| match provider.get_diff_base(file) {
-                Ok(res) => Some(res),
-                Err(err) => {
-                    log::info!("{err:#?}");
-                    log::info!("failed to open diff base for {}", file.display());
-                    None
-                }
-            })
-    }
-
-    pub fn get_current_head_name(&self, file: &Path) -> Option<Arc<ArcSwap<Box<str>>>> {
-        self.providers
-            .iter()
-            .find_map(|provider| match provider.get_current_head_name(file) {
-                Ok(res) => Some(res),
-                Err(err) => {
-                    log::info!("{err:#?}");
-                    log::info!("failed to obtain current head name for {}", file.display());
-                    None
-                }
-            })
-    }
-}
-
-impl Default for DiffProviderRegistry {
-    fn default() -> Self {
-        // currently only git is supported
-        // TODO make this configurable when more providers are added
-        let git: Box<dyn DiffProvider> = Box::new(Git);
-        let providers = vec![git];
-        DiffProviderRegistry { providers }
     }
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1618,6 +1618,9 @@ impl Document {
                     self.set_diff_base(self.text.clone());
                 }
             }
+            DiffSource::None => {
+                self.diff_handle = None;
+            }
         }
 
         self.version_control_head = match diff_provider.get_current_head_name(path) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -79,6 +79,7 @@ pub enum DiffSource {
     #[default]
     Git,
     File,
+    None,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
following up from #7805 

this implementation removes the diff provider cascading fallback behavior in favor of allowing the user to configure which diff provider to use (currently just `vcs`, `file`, or `none`). this should allow maintaining the current behavior in the normal case, but also allow using `:set diff-source file` to see a diff against the state of the file on disk.

this does not yet support per-buffer configuration of diff sources because helix doesn't really have a good mechanism for per-buffer configuration in general at the moment - it feels like something that would be easier to add once the more general feature exists.