### PR TITLE
add command line option to execute commands on editor startup

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -3,6 +3,8 @@ use helix_core::Position;
 use helix_view::tree::Layout;
 use std::path::{Path, PathBuf};
 
+use crate::keymap::MappableCommand;
+
 #[derive(Default)]
 pub struct Args {
     pub display_help: bool,
@@ -16,6 +18,7 @@ pub struct Args {
     pub verbosity: u64,
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
+    pub commands: Vec<MappableCommand>,
     pub files: Vec<(PathBuf, Position)>,
     pub working_directory: Option<PathBuf>,
 }
@@ -56,6 +59,16 @@ impl Args {
                 "-c" | "--config" => match argv.next().as_deref() {
                     Some(path) => args.config_file = Some(path.into()),
                     None => anyhow::bail!("--config must specify a path to read"),
+                },
+                "--command" => match argv.next().as_deref() {
+                    Some(command) => {
+                        let commands = command
+                            .split(',')
+                            .map(|s| s.parse())
+                            .collect::<Result<Vec<_>, _>>()?;
+                        args.commands.extend_from_slice(&commands)
+                    }
+                    None => anyhow::bail!("--command must specify a command to run"),
                 },
                 "--log" => match argv.next().as_deref() {
                     Some(path) => args.log_file = Some(path.into()),

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -74,12 +74,13 @@ fn quit(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
 
     ensure!(args.is_empty(), ":quit takes no arguments");
 
+    cx.block_try_flush_writes()?;
+
     // last view and we have unsaved changes
     if cx.editor.tree.views().count() == 1 {
         buffers_remaining_impl(cx.editor)?
     }
 
-    cx.block_try_flush_writes()?;
     cx.editor.close(view!(cx.editor).id);
 
     Ok(())


### PR DESCRIPTION
i'd like to be able to do things like alias a command to `helix --command file_picker` to immediately jump to picking a file, or set `GIT_EDITOR="helix --command insert_mode"` to simplify the process of writing commit messages. this isn't a hugely impactful feature, but it's pretty hard to do the things it allows without it. it is also a fairly common editor feature (basically the same as `vim -c` or `kak -e`).