### PR TITLE
languages: add gemini

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -45,6 +45,7 @@
 | fortran | ✓ |  | ✓ | `fortls` |
 | fsharp | ✓ |  |  | `fsautocomplete` |
 | gdscript | ✓ | ✓ | ✓ |  |
+| gemini | ✓ |  |  |  |
 | git-attributes | ✓ |  |  |  |
 | git-commit | ✓ | ✓ |  |  |
 | git-config | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2794,3 +2794,13 @@ roots = []
 [[grammar]]
 name = "strace"
 source = { git = "https://github.com/sigmaSd/tree-sitter-strace", rev = "a0f6c50ae4087a9299f055d0f30fe94fd98189a4" }
+
+[[language]]
+name = "gemini"
+scope = "source.gmi"
+file-types = ["gmi"]
+roots = []
+
+[[grammar]]
+name = "gemini"
+source = { git = "https://git.sr.ht/~sfr/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }

--- a/runtime/queries/gemini/highlights.scm
+++ b/runtime/queries/gemini/highlights.scm
@@ -1,0 +1,26 @@
+(link) @punctuation.bracket
+(link 
+  label: (text) @markup.link.label)
+(link
+  uri: (uri) @markup.link.url)
+
+[
+  (start_pre)
+  (pre)
+  (end_pre)
+] @markup.raw.block
+(start_pre
+  alt: (text) @label)
+
+(heading1
+  (text) @markup.heading.1) @markup.heading.marker
+(heading2
+  (text) @markup.heading.2) @markup.heading.marker
+(heading3
+  (text) @markup.heading.3) @markup.heading.marker
+
+(ulist
+  (indicator) @markup.list.unnumbered) 
+(quote
+  (indicator) @markup.quote
+  (text) @markup.italic)


### PR DESCRIPTION
`text/gemini` is the canonical content type of the gemini protocol.
[cheatsheet](https://gemini.circumlunar.space/docs/gemtext.gmi), [specification](https://gemini.circumlunar.space/docs/specification.gmi), [tree-sitter grammar i wrote](https://git.sr.ht/~sfr/tree-sitter-gemini)

![23-08-26-223021](https://github.com/helix-editor/helix/assets/57151943/bc14b70a-ffbe-4e4f-8a2d-9dad296c74f9)
