### PR TITLE
languages: add editorconfig

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -30,6 +30,7 @@
 | dockerfile | ✓ |  |  | `docker-langserver` |
 | dot | ✓ |  |  | `dot-language-server` |
 | dtd | ✓ |  |  |  |
+| editorconfig | ✓ |  |  |  |
 | edoc | ✓ |  |  |  |
 | eex | ✓ |  |  |  |
 | ejs | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2804,3 +2804,14 @@ roots = []
 [[grammar]]
 name = "gemini"
 source = { git = "https://git.sr.ht/~sfr/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
+
+[[language]]
+name = "editorconfig"
+scope = "source.editorconfig"
+file-types = [".editorconfig"]
+comment-token = "#"
+roots = []
+
+[[grammar]]
+name = "editorconfig"
+source = { git = "https://git.sr.ht/~sfr/tree-sitter-editorconfig", rev = "1f0d15cede8bbc0e2317fa83896ef3c600ffd82d" }

--- a/runtime/queries/editorconfig/highlights.scm
+++ b/runtime/queries/editorconfig/highlights.scm
@@ -1,0 +1,6 @@
+(boolean) @constant.builtin
+(comment) @comment
+[ (string) (name) ] @string
+(number) @number
+
+[ "[" "]" "," ] @punctuation.bracket


### PR DESCRIPTION
note that this is unrelated to #279; this is simply a highlighting grammar for .editorconfig files, which i felt was useful regardless.

[homepage](https://editorconfig.org), [specification](https://spec.editorconfig.org/), [tree-sitter grammar i wrote](https://git.sr.ht/~sfr/tree-sitter-editorconfig)