### PR TITLE
Expose "reset" color value in themes

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -70,6 +70,7 @@ over it and is merged into the default palette.
 
 | Color Name      |
 | ---             |
+| `reset`         |
 | `black`         |
 | `red`           |
 | `green`         |

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -359,6 +359,7 @@ impl Default for ThemePalette {
     fn default() -> Self {
         Self {
             palette: hashmap! {
+                "reset".to_string() => Color::Reset,
                 "black".to_string() => Color::Black,
                 "red".to_string() => Color::Red,
                 "green".to_string() => Color::Green,


### PR DESCRIPTION
Seems like this was a pretty trivial fix, but please let me know if you spot anything obviously wrong here.

I tested it and it seemed like you could pretty easily modify `reset` to whatever you want and have it show up in your theme.