### PR TITLE
Update tree-sitter-gleam, enable auto-format

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1541,10 +1541,11 @@ roots = ["gleam.toml"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "gleam" ]
+auto-format = true
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "ae79782c00656945db69641378e688cdb78d52c1" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "a59aadf3d7c11702cad244e7cd6b67b34ca9c16a" }
 
 [[language]]
 name = "ron"


### PR DESCRIPTION
Updates to the v0.30.4 release of tree-sitter-gleam which adds support for some new syntaxes added to the language. The changes are backwards compatible with the queries and we shouldn't need to add anything extra to the queries to cover the changes.

Also enables auto-format since the gleam language server supports it and gleam has a centralized formatter built into the compiler.