### PR TITLE
Rename reset to default

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -70,7 +70,7 @@ over it and is merged into the default palette.
 
 | Color Name      |
 | ---             |
-| `reset`         |
+| `default`       |
 | `black`         |
 | `red`           |
 | `green`         |

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -359,7 +359,7 @@ impl Default for ThemePalette {
     fn default() -> Self {
         Self {
             palette: hashmap! {
-                "reset".to_string() => Color::Reset,
+                "default".to_string() => Color::Reset,
                 "black".to_string() => Color::Black,
                 "red".to_string() => Color::Red,
                 "green".to_string() => Color::Green,


### PR DESCRIPTION
This PR addresses the comment presented on https://github.com/helix-editor/helix/pull/8083

- Use `default` instead of `reset`, as this is the conventional name for ANSI codes 39/49. The word `reset` should be reserved for ANSI code `0`, which resets both fg and bg colors at once, while also removing all modifiers. While the code uses the value name `Reset`, this is misleading and should not leak into the user space.