### PR TITLE
Clear completion when switching windows via click

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1073,6 +1073,7 @@ impl EditorView {
                 let editor = &mut cxt.editor;
 
                 if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
+                    let prev_view_id = view!(editor).id;
                     let doc = doc_mut!(editor, &view!(editor, view_id).doc);
 
                     if modifiers == KeyModifiers::ALT {
@@ -1080,6 +1081,10 @@ impl EditorView {
                         doc.set_selection(view_id, selection.push(Range::point(pos)));
                     } else {
                         doc.set_selection(view_id, Selection::point(pos));
+                    }
+
+                    if view_id != prev_view_id {
+                        self.clear_completion(editor);
                     }
 
                     editor.focus(view_id);


### PR DESCRIPTION
The completion component assumes that it operates on the same View but it's possible to break this assumption by switching windows through left-clicking. I believe we should clear the completion menu when switching windows to fix this.

This change fixes a panic for this scenario:

* Open a buffer with LSP completion available
* Split the window (for example `<C-w>v`)
* Enter insert mode and trigger the completion menu
* Select a completion candidate (for example with `<C-n>`)
* Switch to the original window by left-clicking in its area
* Enter insert mode and make edits (for example `o<backspace>`)

This will trip the `assert_eq` in Document::restore.