### PR TITLE
Save an undo checkpoint before paste in insert mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3948,6 +3948,10 @@ fn paste_impl(
         return;
     }
 
+    if mode == Mode::Insert {
+        doc.append_changes_to_history(view);
+    }
+
     let repeat = std::iter::repeat(
         // `values` is asserted to have at least one entry above.
         values


### PR DESCRIPTION
I often paste and find out that my clipboard didn't have what I expected on it. Previously, undoing the change (`u` in normal mode) would also undo everything else I added in insert mode which is usually too much.