### PR TITLE
goto_file: file path resolution relative to either the workspace or the current file

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1192,11 +1192,15 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
     for sel in paths {
         let p = sel.trim();
         if !p.is_empty() {
-            let path = &rel_path.join(p);
+            let mut path = PathBuf::from(p);
+            if !path.exists() {
+                path = rel_path.join(p);
+            }
+
             if path.is_dir() {
-                let picker = ui::file_picker(path.into(), &cx.editor.config());
+                let picker = ui::file_picker(path, &cx.editor.config());
                 cx.push_layer(Box::new(overlaid(picker)));
-            } else if let Err(e) = cx.editor.open(path, action) {
+            } else if let Err(e) = cx.editor.open(&path, action) {
                 cx.editor.set_error(format!("Open file failed: {:?}", e));
             }
         }


### PR DESCRIPTION
I'm currently working on a LaTeX project with the following structure:

![1282085](https://github.com/helix-editor/helix/assets/46726554/da9a367e-3ba7-4a28-917d-dffbc84ff731)

The LaTeX compiler (I'm using `xelatex`) interprets paths relative to the main.tex file (which is at the root of the folder in this case). So even in `background/chapters/main.tex`, I can't just type `./ssl.tex`. Since the PR that implement relative paths in `goto_file_impl`, if I type `mim` (match inside the brackets) and then `gf` in one of the input statements on the left, helix will open the file `chapters/background/chapters/background/file.tex`. So to select the file I need now takes extra keystrokes.

This PR makes `goto_file_impl` first check if it can find the file relative to the current working directory, and if it doesn't exist, open it relative to the currently opened file.