### PR TITLE
goto end of file if count is not present

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3105,33 +3105,35 @@ fn push_jump(view: &mut View, doc: &Document) {
 }
 
 fn goto_line(cx: &mut Context) {
-    if cx.count.is_some() {
-        let (view, doc) = current!(cx.editor);
-        push_jump(view, doc);
+	let (view, doc) = current!(cx.editor);
+	push_jump(view, doc);
 
-        goto_line_without_jumplist(cx.editor, cx.count);
-    }
+	goto_line_without_jumplist(cx.editor, cx.count);
 }
 
 fn goto_line_without_jumplist(editor: &mut Editor, count: Option<NonZeroUsize>) {
-    if let Some(count) = count {
-        let (view, doc) = current!(editor);
-        let text = doc.text().slice(..);
-        let max_line = if text.line(text.len_lines() - 1).len_chars() == 0 {
-            // If the last line is blank, don't jump to it.
-            text.len_lines().saturating_sub(2)
-        } else {
-            text.len_lines() - 1
-        };
-        let line_idx = std::cmp::min(count.get() - 1, max_line);
-        let pos = text.line_to_char(line_idx);
-        let selection = doc
-            .selection(view.id)
-            .clone()
-            .transform(|range| range.put_cursor(text, pos, editor.mode == Mode::Select));
+    let (view, doc) = current!(editor);
+    let text = doc.text().slice(..);
+    let max_line = if text.line(text.len_lines() - 1).len_chars() == 0 {
+        // If the last line is blank, don't jump to it.
+        text.len_lines().saturating_sub(2)
+    } else {
+        text.len_lines() - 1
+    };
 
-        doc.set_selection(view.id, selection);
-    }
+    let line_idx = if let Some(count) = count {
+        std::cmp::min(count.get() - 1, max_line)
+    } else {
+        max_line
+    };
+
+    let pos = text.line_to_char(line_idx);
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|range| range.put_cursor(text, pos, editor.mode == Mode::Select));
+
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_last_line(cx: &mut Context) {


### PR DESCRIPTION
Hello,

I'm not quite sure if this change is something wanted, but coming from vim, I'm _terribly_ missing this.

`G` is bound to `goto_line`. The change allows `goto_line` without count, therefore `G` without count results in going to the end of file.

The only thing I wasn't sure about is if there should be `push_jump` or not, but it seems more natural to always add current location to jumplist.

From vim docs:

> With a `count`, this command positions you at the given line number.  For example, "33G" puts you on line 33.  (...)
> With no argument, `G` positions you at the end of the file.
