### PR TITLE
Add commands for movement by subwords

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -1074,6 +1074,178 @@ mod test {
     }
 
     #[test]
+    fn test_behaviour_when_moving_to_start_of_next_sub_words() {
+        let tests = [
+            (
+                "NextSubwordStart",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 11)),
+                ],
+            ),
+            (
+                "next_subword_start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "Next_Subword_Start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "NEXT_SUBWORD_START",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "next subword start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "Next Subword Start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "NEXT SUBWORD START",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 5)),
+                    (1, Range::new(4, 4), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "next__subword__start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 6)),
+                    (1, Range::new(4, 4), Range::new(4, 6)),
+                    (1, Range::new(5, 5), Range::new(6, 15)),
+                ],
+            ),
+            (
+                "Next__Subword__Start",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 6)),
+                    (1, Range::new(4, 4), Range::new(4, 6)),
+                    (1, Range::new(5, 5), Range::new(6, 15)),
+                ],
+            ),
+            (
+                "NEXT__SUBWORD__START",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 6)),
+                    (1, Range::new(4, 4), Range::new(4, 6)),
+                    (1, Range::new(5, 5), Range::new(6, 15)),
+                ],
+            ),
+        ];
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_next_sub_word_start(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
+
+    #[test]
+    fn test_behaviour_when_moving_to_end_of_next_sub_words() {
+        let tests = [
+            (
+                "NextSubwordEnd",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 11)),
+                ],
+            ),
+            (
+                "next subword end",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "Next Subword End",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "NEXT SUBWORD END",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "next_subword_end",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "Next_Subword_End",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "NEXT_SUBWORD_END",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 12)),
+                ],
+            ),
+            (
+                "next__subword__end",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 13)),
+                    (1, Range::new(5, 5), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "Next__Subword__End",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 13)),
+                    (1, Range::new(5, 5), Range::new(5, 13)),
+                ],
+            ),
+            (
+                "NEXT__SUBWORD__END",
+                vec![
+                    (1, Range::new(0, 0), Range::new(0, 4)),
+                    (1, Range::new(4, 4), Range::new(4, 13)),
+                    (1, Range::new(5, 5), Range::new(5, 13)),
+                ],
+            ),
+        ];
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_next_sub_word_end(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
+
+    #[test]
     fn test_behaviour_when_moving_to_start_of_next_long_words() {
         let tests = [
             ("Basic forward motion stops at the first space",
@@ -1237,6 +1409,92 @@ mod test {
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
                 let range = move_prev_word_start(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
+
+    #[test]
+    fn test_behaviour_when_moving_to_start_of_previous_sub_words() {
+        let tests = [
+            (
+                "PrevSubwordEnd",
+                vec![
+                    (1, Range::new(13, 13), Range::new(14, 11)),
+                    (1, Range::new(11, 11), Range::new(11, 4)),
+                ],
+            ),
+            (
+                "prev subword end",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "Prev Subword End",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "PREV SUBWORD END",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "prev_subword_end",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "Prev_Subword_End",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "PREV_SUBWORD_END",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 13)),
+                    (1, Range::new(12, 12), Range::new(13, 5)),
+                ],
+            ),
+            (
+                "prev__subword__end",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 15)),
+                    (1, Range::new(13, 13), Range::new(14, 6)),
+                    (1, Range::new(14, 14), Range::new(15, 6)),
+                ],
+            ),
+            (
+                "Prev__Subword__End",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 15)),
+                    (1, Range::new(13, 13), Range::new(14, 6)),
+                    (1, Range::new(14, 14), Range::new(15, 6)),
+                ],
+            ),
+            (
+                "PREV__SUBWORD__END",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 15)),
+                    (1, Range::new(13, 13), Range::new(14, 6)),
+                    (1, Range::new(14, 14), Range::new(15, 6)),
+                ],
+            ),
+        ];
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_prev_sub_word_start(Rope::from(sample).slice(..), begin, count);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }
@@ -1500,6 +1758,92 @@ mod test {
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
                 let range = move_prev_word_end(Rope::from(sample).slice(..), begin, count);
+                assert_eq!(range, expected_end, "Case failed: [{}]", sample);
+            }
+        }
+    }
+
+    #[test]
+    fn test_behaviour_when_moving_to_end_of_previous_sub_words() {
+        let tests = [
+            (
+                "PrevSubwordEnd",
+                vec![
+                    (1, Range::new(13, 13), Range::new(14, 11)),
+                    (1, Range::new(11, 11), Range::new(11, 4)),
+                ],
+            ),
+            (
+                "prev subword end",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "Prev Subword End",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "PREV SUBWORD END",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "prev_subword_end",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "Prev_Subword_End",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "PREV_SUBWORD_END",
+                vec![
+                    (1, Range::new(15, 15), Range::new(16, 12)),
+                    (1, Range::new(12, 12), Range::new(12, 4)),
+                ],
+            ),
+            (
+                "prev__subword__end",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 13)),
+                    (1, Range::new(13, 13), Range::new(13, 4)),
+                    (1, Range::new(14, 14), Range::new(15, 13)),
+                ],
+            ),
+            (
+                "Prev__Subword__End",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 13)),
+                    (1, Range::new(13, 13), Range::new(13, 4)),
+                    (1, Range::new(14, 14), Range::new(15, 13)),
+                ],
+            ),
+            (
+                "PREV__SUBWORD__END",
+                vec![
+                    (1, Range::new(17, 17), Range::new(18, 13)),
+                    (1, Range::new(13, 13), Range::new(13, 4)),
+                    (1, Range::new(14, 14), Range::new(15, 13)),
+                ],
+            ),
+        ];
+
+        for (sample, scenario) in tests {
+            for (count, begin, expected_end) in scenario.into_iter() {
+                let range = move_prev_sub_word_end(Rope::from(sample).slice(..), begin, count);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -249,6 +249,10 @@ impl MappableCommand {
         move_prev_long_word_start, "Move to start of previous long word",
         move_next_long_word_end, "Move to end of next long word",
         move_prev_long_word_end, "Move to end of previous long word",
+        move_next_sub_word_start, "Move to start of next sub word",
+        move_prev_sub_word_start, "Move to start of previous sub word",
+        move_next_sub_word_end, "Move to end of next sub word",
+        move_prev_sub_word_end, "Move to end of previous sub word",
         move_parent_node_end, "Move to end of the parent node",
         move_parent_node_start, "Move to beginning of the parent node",
         extend_next_word_start, "Extend to start of next word",
@@ -259,6 +263,10 @@ impl MappableCommand {
         extend_prev_long_word_start, "Extend to start of previous long word",
         extend_next_long_word_end, "Extend to end of next long word",
         extend_prev_long_word_end, "Extend to end of prev long word",
+        extend_next_sub_word_start, "Extend to start of next sub word",
+        extend_prev_sub_word_start, "Extend to start of previous sub word",
+        extend_next_sub_word_end, "Extend to end of next sub word",
+        extend_prev_sub_word_end, "Extend to end of prev sub word",
         extend_parent_node_end, "Extend to end of the parent node",
         extend_parent_node_start, "Extend to beginning of the parent node",
         find_till_char, "Move till next occurrence of char",
@@ -1094,6 +1102,22 @@ fn move_next_long_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_long_word_end)
 }
 
+fn move_next_sub_word_start(cx: &mut Context) {
+    move_word_impl(cx, movement::move_next_sub_word_start)
+}
+
+fn move_prev_sub_word_start(cx: &mut Context) {
+    move_word_impl(cx, movement::move_prev_sub_word_start)
+}
+
+fn move_prev_sub_word_end(cx: &mut Context) {
+    move_word_impl(cx, movement::move_prev_sub_word_end)
+}
+
+fn move_next_sub_word_end(cx: &mut Context) {
+    move_word_impl(cx, movement::move_next_sub_word_end)
+}
+
 fn goto_para_impl<F>(cx: &mut Context, move_fn: F)
 where
     F: Fn(RopeSlice, Range, usize, Movement) -> Range + 'static,
@@ -1305,6 +1329,22 @@ fn extend_prev_long_word_end(cx: &mut Context) {
 
 fn extend_next_long_word_end(cx: &mut Context) {
     extend_word_impl(cx, movement::move_next_long_word_end)
+}
+
+fn extend_next_sub_word_start(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_next_sub_word_start)
+}
+
+fn extend_prev_sub_word_start(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_prev_sub_word_start)
+}
+
+fn extend_prev_sub_word_end(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_prev_sub_word_end)
+}
+
+fn extend_next_sub_word_end(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_next_sub_word_end)
 }
 
 /// Separate branch to find_char designed only for `<ret>` char.


### PR DESCRIPTION
This PR adds commands that enable movement within subwords that are snake_cased or camelCased, as previously proposed in discussion https://github.com/helix-editor/helix/discussions/5463. Subwords are delimited by underscores and by transitions from lowercase to uppercase.

The commands are named `{move,extend}_{next,prev}_sub_word_{start,end}`. This PR doesn't add any keybinds.

Example usage (`|` characters indicate cursor):

- `|f|oo bar baz` -> move next sub word -> `|foo |bar baz`
- `|f|oo_bar_baz` -> move next sub word -> `|foo_|bar_baz`
- `|f|ooBarBaz` -> move next sub word -> `|foo|BarBaz`

Example keybinds:
```toml
[keys.normal]
W = 'move_next_sub_word_start'
B = 'move_prev_sub_word_start'
E = 'move_next_sub_word_end'

[keys.select]
W = 'extend_next_sub_word_start'
B = 'extend_prev_sub_word_start'
E = 'extend_next_sub_word_end'
```