### PR TITLE
Add title box to `Picker`

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -228,6 +228,15 @@ Search specific options.
 | `smart-case` | Enable smart case regex searching (case-insensitive unless pattern contains upper case characters) | `true` |
 | `wrap-around`| Whether the search should wrap after depleting the matches | `true` |
 
+
+### `[editor.picker]` Section
+
+Picker specific options.
+
+| Key | Description | Default |
+|--|--|---------|
+| `title` | Weather to draw picker's titlebox | `true` |
+
 ### `[editor.whitespace]` Section
 
 Options for rendering whitespace with visible characters. Use `:set whitespace.render all` to temporarily enable visible whitespace.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -235,7 +235,7 @@ Picker specific options.
 
 | Key | Description | Default |
 |--|--|---------|
-| `title` | Weather to draw picker's titlebox | `true` |
+| `picker-title` | Renders a title for the opening picker. Can be `never`, `center`, `inline`, `inline-border` or `prompt` | `never` |
 
 ### `[editor.whitespace]` Section
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2211,7 +2211,9 @@ fn global_search(cx: &mut Context) {
 
                 cx.jobs.callback(async move {
                     let call = move |_: &mut Editor, compositor: &mut Compositor| {
+                        let picker_title = String::from("Global Search");
                         let picker = Picker::with_stream(
+                            picker_title,
                             picker,
                             injector,
                             move |cx, FileResult { path, line_num }, action| {
@@ -2680,7 +2682,8 @@ fn buffer_picker(cx: &mut Context) {
     // mru
     items.sort_unstable_by_key(|item| std::cmp::Reverse(item.focused_at));
 
-    let picker = Picker::new(items, (), |cx, meta, action| {
+    let picker_title = String::from("Buffer List");
+    let picker = Picker::new(picker_title, items, (), |cx, meta, action| {
         cx.editor.switch(meta.id, action);
     })
     .with_preview(|editor, meta| {
@@ -2757,7 +2760,9 @@ fn jumplist_picker(cx: &mut Context) {
         }
     };
 
+    let picker_title = String::from("Jumplist Picker");
     let picker = Picker::new(
+        picker_title,
         cx.editor
             .tree
             .views()
@@ -2834,32 +2839,38 @@ pub fn command_palette(cx: &mut Context) {
                 }
             }));
 
-            let picker = Picker::new(commands, keymap, move |cx, command, _action| {
-                let mut ctx = Context {
-                    register,
-                    count,
-                    editor: cx.editor,
-                    callback: None,
-                    on_next_key_callback: None,
-                    jobs: cx.jobs,
-                };
-                let focus = view!(ctx.editor).id;
+            let picker_title = String::from("Command Palette");
+            let picker = Picker::new(
+                picker_title,
+                commands,
+                keymap,
+                move |cx, command, _action| {
+                    let mut ctx = Context {
+                        register,
+                        count,
+                        editor: cx.editor,
+                        callback: None,
+                        on_next_key_callback: None,
+                        jobs: cx.jobs,
+                    };
+                    let focus = view!(ctx.editor).id;
 
-                command.execute(&mut ctx);
+                    command.execute(&mut ctx);
 
-                if ctx.editor.tree.contains(focus) {
-                    let config = ctx.editor.config();
-                    let mode = ctx.editor.mode();
-                    let view = view_mut!(ctx.editor, focus);
-                    let doc = doc_mut!(ctx.editor, &view.doc);
+                    if ctx.editor.tree.contains(focus) {
+                        let config = ctx.editor.config();
+                        let mode = ctx.editor.mode();
+                        let view = view_mut!(ctx.editor, focus);
+                        let doc = doc_mut!(ctx.editor, &view.doc);
 
-                    view.ensure_cursor_in_view(doc, config.scrolloff);
+                        view.ensure_cursor_in_view(doc, config.scrolloff);
 
-                    if mode != Mode::Insert {
-                        doc.append_changes_to_history(view);
+                        if mode != Mode::Insert {
+                            doc.append_changes_to_history(view);
+                        }
                     }
-                }
-            });
+                },
+            );
             compositor.push(Box::new(overlaid(picker)));
         },
     ));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2209,9 +2209,26 @@ fn global_search(cx: &mut Context) {
                         });
                 });
 
+                let user_entered_regex = regex.to_string();
+                let case_sensitive = if smart_case {
+                    user_entered_regex
+                        .chars()
+                        .find(|char| char.is_ascii_uppercase())
+                        .is_some()
+                } else {
+                    true
+                };
                 cx.jobs.callback(async move {
                     let call = move |_: &mut Editor, compositor: &mut Compositor| {
-                        let picker_title = String::from("Global Search");
+                        let picker_title = format!(
+                            "Global Search: '{}' {}",
+                            regex.to_string(),
+                            if case_sensitive {
+                                "[Case Sensitive]"
+                            } else {
+                                "[Case Insensitive]"
+                            }
+                        );
                         let picker = Picker::with_stream(
                             picker_title,
                             picker,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2213,8 +2213,7 @@ fn global_search(cx: &mut Context) {
                 let case_sensitive = if smart_case {
                     user_entered_regex
                         .chars()
-                        .find(|char| char.is_ascii_uppercase())
-                        .is_some()
+                        .any(|char| char.is_ascii_uppercase())
                 } else {
                     true
                 };
@@ -2222,7 +2221,7 @@ fn global_search(cx: &mut Context) {
                     let call = move |_: &mut Editor, compositor: &mut Compositor| {
                         let picker_title = format!(
                             "Global Search: '{}' {}",
-                            regex.to_string(),
+                            regex,
                             if case_sensitive {
                                 "[Case Sensitive]"
                             } else {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -73,9 +73,13 @@ fn thread_picker(
             let debugger = debugger!(editor);
 
             let thread_states = debugger.thread_states.clone();
-            let picker = Picker::new(threads, thread_states, move |cx, thread, _action| {
-                callback_fn(cx.editor, thread)
-            })
+            let picker_title = String::from("Thread Picker");
+            let picker = Picker::new(
+                picker_title,
+                threads,
+                thread_states,
+                move |cx, thread, _action| callback_fn(cx.editor, thread),
+            )
             .with_preview(move |editor, thread| {
                 let frames = editor.debugger.as_ref()?.stack_frames.get(&thread.id)?;
                 let frame = frames.get(0)?;
@@ -268,7 +272,9 @@ pub fn dap_launch(cx: &mut Context) {
 
     let templates = config.templates.clone();
 
+    let picker_title = String::from("DAP Picker");
     cx.push_layer(Box::new(overlaid(Picker::new(
+        picker_title,
         templates,
         (),
         |cx, template, _action| {
@@ -730,7 +736,8 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
 
     let frames = debugger.stack_frames[&thread_id].clone();
 
-    let picker = Picker::new(frames, (), move |cx, frame, _action| {
+    let picker_title = String::from("DAP Stack Frame Picker");
+    let picker = Picker::new(picker_title, frames, (), move |cx, frame, _action| {
         let debugger = debugger!(cx.editor);
         // TODO: this should be simpler to find
         let pos = debugger.stack_frames[&thread_id]

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -296,8 +296,26 @@ fn diag_picker(
         warning: cx.editor.theme.get("warning"),
         error: cx.editor.theme.get("error"),
     };
+    let mut informations = 0;
+    let mut warnings = 0;
+    let mut errors = 0;
+    let mut hints = 0;
 
-    let picker_title = String::from("Diagnostics Picker");
+    flat_diag
+        .iter()
+        .filter_map(|i| i.diag.severity)
+        .for_each(|severity| match severity {
+            DiagnosticSeverity::INFORMATION => informations += 1,
+            DiagnosticSeverity::WARNING => warnings += 1,
+            DiagnosticSeverity::ERROR => errors += 1,
+            DiagnosticSeverity::HINT => hints += 1,
+            _ => (),
+        });
+
+    let picker_title = format!(
+        "Diagnostics: [{} E] [{} W] [{} I] [{} H]",
+        errors, warnings, informations, hints,
+    );
     Picker::new(
         picker_title,
         flat_diag,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -242,14 +242,20 @@ type SymbolPicker = Picker<SymbolInformationItem>;
 
 fn sym_picker(symbols: Vec<SymbolInformationItem>, current_path: Option<lsp::Url>) -> SymbolPicker {
     // TODO: drop current_path comparison and instead use workspace: bool flag?
-    Picker::new(symbols, current_path, move |cx, item, action| {
-        jump_to_location(
-            cx.editor,
-            &item.symbol.location,
-            item.offset_encoding,
-            action,
-        );
-    })
+    let picker_title = String::from("Symbol Picker");
+    Picker::new(
+        picker_title,
+        symbols,
+        current_path,
+        move |cx, item, action| {
+            jump_to_location(
+                cx.editor,
+                &item.symbol.location,
+                item.offset_encoding,
+                action,
+            );
+        },
+    )
     .with_preview(move |_editor, item| Some(location_to_file_location(&item.symbol.location)))
     .truncate_start(false)
 }
@@ -291,7 +297,9 @@ fn diag_picker(
         error: cx.editor.theme.get("error"),
     };
 
+    let picker_title = String::from("Diagnostics Picker");
     Picker::new(
+        picker_title,
         flat_diag,
         (styles, format),
         move |cx,
@@ -1029,9 +1037,15 @@ fn goto_impl(
             editor.set_error("No definition found.");
         }
         _locations => {
-            let picker = Picker::new(locations, cwdir, move |cx, location, action| {
-                jump_to_location(cx.editor, location, offset_encoding, action)
-            })
+            let picker_title = String::from("Goto Picker");
+            let picker = Picker::new(
+                picker_title,
+                locations,
+                cwdir,
+                move |cx, location, action| {
+                    jump_to_location(cx.editor, location, offset_encoding, action)
+                },
+            )
             .with_preview(move |_editor, location| Some(location_to_file_location(location)));
             compositor.push(Box::new(overlaid(picker)));
         }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1388,9 +1388,11 @@ fn lsp_workspace_command(
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
                 move |_editor: &mut Editor, compositor: &mut Compositor| {
-                    let picker = ui::Picker::new(commands, (), move |cx, command, _action| {
-                        execute_lsp_command(cx.editor, language_server_id, command.clone());
-                    });
+                    let picker_title = String::from("LSP Workspace Commands");
+                    let picker =
+                        ui::Picker::new(picker_title, commands, (), move |cx, command, _action| {
+                            execute_lsp_command(cx.editor, language_server_id, command.clone());
+                        });
                     compositor.push(Box::new(overlaid(picker)))
                 },
             ));

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -199,16 +199,22 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
     });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
-    let picker = Picker::new(Vec::new(), root, move |cx, path: &PathBuf, action| {
-        if let Err(e) = cx.editor.open(path, action) {
-            let err = if let Some(err) = e.source() {
-                format!("{}", err)
-            } else {
-                format!("unable to open \"{}\"", path.display())
-            };
-            cx.editor.set_error(err);
-        }
-    })
+    let picker_title = String::from("File Picker");
+    let picker = Picker::new(
+        picker_title,
+        Vec::new(),
+        root,
+        move |cx, path: &PathBuf, action| {
+            if let Err(e) = cx.editor.open(path, action) {
+                let err = if let Some(err) = e.source() {
+                    format!("{}", err)
+                } else {
+                    format!("unable to open \"{}\"", path.display())
+                };
+                cx.editor.set_error(err);
+            }
+        },
+    )
     .with_preview(|_editor, path| Some((path.clone().into(), None)));
     let injector = picker.injector();
     std::thread::spawn(move || {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -199,7 +199,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
     });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
-    let picker_title = String::from("File Picker");
+    let picker_title = format!("Files in {:?}", root.as_os_str());
     let picker = Picker::new(
         picker_title,
         Vec::new(),

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -800,16 +800,11 @@ impl<T: Item + 'static> Picker<T> {
 
         // add connecting characters to picker's top border
         let borders = BorderType::line_symbols(BorderType::Plain);
-        surface.set_string(
-            area.x,
-            area.y + 2,
-            borders.horizontal_up.to_string(),
-            Style::default(),
-        );
+        surface.set_string(area.x, area.y + 2, borders.horizontal_up, Style::default());
         surface.set_string(
             area.x + area.width - 1,
             area.y + 2,
-            borders.horizontal_up.to_string(),
+            borders.horizontal_up,
             Style::default(),
         );
     }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -785,35 +785,32 @@ impl<T: Item + 'static> Picker<T> {
         let text_style = cx.editor.theme.get("ui.text");
         surface.clear_with(area, background);
 
-        // don't like this but the lifetime sucks
-        let block = Block::default().borders(Borders::ALL);
-
-        // calculate the inner area inside the box
-        let borders = BorderType::line_symbols(BorderType::Plain);
+        // render the border
+        let block = Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT);
         block.render(area, surface);
+
+        // render the title text
         surface.set_string(
-            area.x,
+            // Add two for spacing for border box and margin
+            area.x + 2,
             area.y + 1,
-            format!("{} {}  ", borders.vertical, self.title.clone()),
+            &self.title,
             text_style,
         );
-        surface.set_string(
-            area.x + area.width - 1,
-            area.y + 1,
-            borders.vertical.to_string(),
-            text_style,
-        );
+
+        // add connecting characters to picker's top border
+        let borders = BorderType::line_symbols(BorderType::Plain);
         surface.set_string(
             area.x,
             area.y + 2,
             borders.horizontal_up.to_string(),
-            text_style,
+            Style::default(),
         );
         surface.set_string(
             area.x + area.width - 1,
             area.y + 2,
             borders.horizontal_up.to_string(),
-            text_style,
+            Style::default(),
         );
     }
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -845,15 +845,19 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             self.render_preview(preview_area, surface, cx);
         }
 
-        // Add four for margin and bounding box edges
-        let title_width = self.title.len() as u16 + 4;
-        let area_to_clip = area.width - title_width;
-        let mut title_area = area
-            .clip_left(area_to_clip / 2)
-            .clip_right(area_to_clip / 2)
-            .with_height(TITLE_BOX_HEIGHT);
-        title_area.y -= TITLE_BOX_HEIGHT;
-        self.render_title(title_area, surface, cx);
+        let render_title = area.y >= TITLE_BOX_HEIGHT;
+
+        if render_title {
+            // Add four for margin and bounding box edges
+            let title_width = self.title.len() as u16 + 4;
+            let area_to_clip = area.width - title_width;
+            let mut title_area = area
+                .clip_left(area_to_clip / 2)
+                .clip_right(area_to_clip / 2)
+                .with_height(TITLE_BOX_HEIGHT);
+            title_area.y -= TITLE_BOX_HEIGHT;
+            self.render_title(title_area, surface, cx);
+        }
     }
 
     fn handle_event(&mut self, event: &Event, ctx: &mut Context) -> EventResult {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -837,21 +837,22 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             area.width
         };
 
-        let picker_area = area.with_width(picker_width).clip_top(TITLE_BOX_HEIGHT);
+        let picker_area = area.with_width(picker_width);
         self.render_picker(picker_area, surface, cx);
 
         if render_preview {
-            let preview_area = area.clip_left(picker_width).clip_top(TITLE_BOX_HEIGHT);
+            let preview_area = area.clip_left(picker_width);
             self.render_preview(preview_area, surface, cx);
         }
 
         // Add four for margin and bounding box edges
         let title_width = self.title.len() as u16 + 4;
         let area_to_clip = area.width - title_width;
-        let title_area = area
+        let mut title_area = area
             .clip_left(area_to_clip / 2)
             .clip_right(area_to_clip / 2)
             .with_height(TITLE_BOX_HEIGHT);
+        title_area.y -= TITLE_BOX_HEIGHT;
         self.render_title(title_area, surface, cx);
     }
 
@@ -954,7 +955,7 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
         let inner = block.inner(area);
 
         // prompt area
-        let area = inner.clip_left(1).with_height(1 + TITLE_BOX_HEIGHT);
+        let area = inner.clip_left(1).with_height(1);
 
         self.prompt.cursor(area, editor)
     }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -39,7 +39,7 @@ use helix_core::{
     Syntax,
 };
 use helix_view::{
-    editor::Action,
+    editor::{Action, PickerTitle},
     graphics::{CursorKind, Margin, Modifier, Rect},
     theme::Style,
     view::ViewPosition,
@@ -838,7 +838,7 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
         }
 
         let editor_config = cx.editor.config.load();
-        let render_title = editor_config.picker.title && area.y >= TITLE_BOX_HEIGHT;
+        let render_title = editor_config.picker != PickerTitle::Never && area.y >= TITLE_BOX_HEIGHT;
 
         if render_title {
             // Add four for margin and bounding box edges

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -777,6 +777,39 @@ impl<T: Item + 'static> Picker<T> {
             );
         }
     }
+
+    fn render_title(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        // -- Render the frame:
+        // clear area
+        let background = cx.editor.theme.get("ui.background");
+        let text_style = cx.editor.theme.get("ui.text");
+        surface.clear_with(area, background);
+
+        // don't like this but the lifetime sucks
+        let block = Block::default().borders(Borders::ALL);
+
+        // calculate the inner area inside the box
+        let borders = BorderType::line_symbols(BorderType::Plain);
+        block.render(area, surface);
+        surface.set_string(
+            area.x,
+            area.y + 1,
+            format!("{}{}{0}", borders.vertical, self.title.clone()),
+            text_style,
+        );
+        surface.set_string(
+            area.x,
+            area.y + 2,
+            borders.horizontal_up.to_string(),
+            text_style,
+        );
+        surface.set_string(
+            area.x + area.width - 1,
+            area.y + 2,
+            borders.horizontal_up.to_string(),
+            text_style,
+        );
+    }
 }
 
 impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
@@ -805,6 +838,15 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             let preview_area = area.clip_left(picker_width).clip_top(TITLE_BOX_HEIGHT);
             self.render_preview(preview_area, surface, cx);
         }
+
+        // Add two extra for the left and right edges in the bounding box
+        let title_width = self.title.len() as u16 + 2;
+        let area_to_clip = area.width - title_width;
+        let title_area = area
+            .clip_left(area_to_clip / 2)
+            .clip_right(area_to_clip / 2)
+            .with_height(TITLE_BOX_HEIGHT);
+        self.render_title(title_area, surface, cx);
     }
 
     fn handle_event(&mut self, event: &Event, ctx: &mut Context) -> EventResult {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -824,7 +824,7 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
         //        | title |
         // +------+--+ +--+------+
         // |prompt   | |preview  |
-        // +---------+ |         |
+        // |---------| |         |
         // |picker   | |         |
         // |         | |         |
         // +---------+ +---------+

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -886,7 +886,7 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             self.render_preview(preview_area, surface, cx);
         }
 
-        let title_render_mode = cx.editor.config.load().picker;
+        let title_render_mode = cx.editor.config.load().picker_title;
         self.render_title(title_render_mode, area, surface, cx);
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -794,7 +794,7 @@ impl<T: Item + 'static> Picker<T> {
         surface.set_string(
             area.x,
             area.y + 1,
-            format!("{}{}{0}", borders.vertical, self.title.clone()),
+            format!("{} {} {0}", borders.vertical, self.title.clone()),
             text_style,
         );
         surface.set_string(
@@ -839,8 +839,8 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             self.render_preview(preview_area, surface, cx);
         }
 
-        // Add two extra for the left and right edges in the bounding box
-        let title_width = self.title.len() as u16 + 2;
+        // Add four for margin and bounding box edges
+        let title_width = self.title.len() as u16 + 4;
         let area_to_clip = area.width - title_width;
         let title_area = area
             .clip_left(area_to_clip / 2)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -50,6 +50,7 @@ pub const ID: &str = "picker";
 use super::{menu::Item, overlay::Overlay};
 
 pub const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
+pub const TITLE_BOX_HEIGHT: u16 = 2;
 /// Biggest file size to preview in bytes
 pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
 
@@ -780,7 +781,9 @@ impl<T: Item + 'static> Picker<T> {
 
 impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        // +---------+ +---------+
+        //        +-------+
+        //        | title |
+        // +------+--+ +--+------+
         // |prompt   | |preview  |
         // +---------+ |         |
         // |picker   | |         |
@@ -795,11 +798,11 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             area.width
         };
 
-        let picker_area = area.with_width(picker_width);
+        let picker_area = area.with_width(picker_width).clip_top(TITLE_BOX_HEIGHT);
         self.render_picker(picker_area, surface, cx);
 
         if render_preview {
-            let preview_area = area.clip_left(picker_width);
+            let preview_area = area.clip_left(picker_width).clip_top(TITLE_BOX_HEIGHT);
             self.render_preview(preview_area, surface, cx);
         }
     }
@@ -903,7 +906,7 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
         let inner = block.inner(area);
 
         // prompt area
-        let area = inner.clip_left(1).with_height(1);
+        let area = inner.clip_left(1).with_height(1 + TITLE_BOX_HEIGHT);
 
         self.prompt.cursor(area, editor)
     }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -782,7 +782,7 @@ impl<T: Item + 'static> Picker<T> {
         // -- Render the frame:
         // clear area
         let background = cx.editor.theme.get("ui.background");
-        let text_style = cx.editor.theme.get("ui.text");
+        let text_style = cx.editor.theme.get("ui.text").add_modifier(Modifier::BOLD);
         surface.clear_with(area, background);
 
         // render the border

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -827,7 +827,27 @@ impl<T: Item + 'static> Picker<T> {
                     Style::default(),
                 );
             }
-            _ => (),
+            PickerTitle::Inline => surface.set_string(area.x + 1, area.y, &self.title, text_style),
+            PickerTitle::InlineBorder => {
+                let mut area = area.with_width(title_width).with_height(2);
+                area.y -= 1;
+
+                surface.clear_with(area, background);
+
+                let block = Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT);
+                block.render(area, surface);
+
+                surface.set_string(area.x + 2, area.y + 1, &self.title, text_style);
+
+                surface.set_string(
+                    area.x + title_width - 1,
+                    area.y + 1,
+                    borders.bottom_left,
+                    Style::default(),
+                );
+            }
+            PickerTitle::Prompt => cx.editor.set_status(self.title.clone()),
+            PickerTitle::Never => (),
         }
     }
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -201,6 +201,9 @@ pub struct Picker<T: Item> {
     read_buffer: Vec<u8>,
     /// Given an item in the picker, return the file path and line number to display.
     file_fn: Option<FileCallback<T>>,
+
+    /// Title for the picker box
+    title: String,
 }
 
 impl<T: Item + 'static> Picker<T> {
@@ -220,6 +223,7 @@ impl<T: Item + 'static> Picker<T> {
     }
 
     pub fn new(
+        title: String,
         options: Vec<T>,
         editor_data: T::Data,
         callback_fn: impl Fn(&mut Context, &T, Action) + 'static,
@@ -237,6 +241,7 @@ impl<T: Item + 'static> Picker<T> {
             }
         }
         Self::with(
+            title,
             matcher,
             Arc::new(editor_data),
             Arc::new(AtomicBool::new(false)),
@@ -245,14 +250,22 @@ impl<T: Item + 'static> Picker<T> {
     }
 
     pub fn with_stream(
+        title: String,
         matcher: Nucleo<T>,
         injector: Injector<T>,
         callback_fn: impl Fn(&mut Context, &T, Action) + 'static,
     ) -> Self {
-        Self::with(matcher, injector.editor_data, injector.shutown, callback_fn)
+        Self::with(
+            title,
+            matcher,
+            injector.editor_data,
+            injector.shutown,
+            callback_fn,
+        )
     }
 
     fn with(
+        title: String,
         matcher: Nucleo<T>,
         editor_data: Arc<T::Data>,
         shutdown: Arc<AtomicBool>,
@@ -280,6 +293,7 @@ impl<T: Item + 'static> Picker<T> {
             preview_cache: HashMap::new(),
             read_buffer: Vec::with_capacity(1024),
             file_fn: None,
+            title,
         }
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -793,6 +793,10 @@ impl<T: Item + 'static> Picker<T> {
             PickerTitle::Center => {
                 const TITLE_BOX_HEIGHT: u16 = 2;
 
+                if area.y < TITLE_BOX_HEIGHT || area.width <= title_width + 1 {
+                    return;
+                }
+
                 // Compute area for title rendering
                 let area_to_clip = area.width - title_width;
                 let mut area = area
@@ -829,6 +833,9 @@ impl<T: Item + 'static> Picker<T> {
             }
             PickerTitle::Inline => surface.set_string(area.x + 1, area.y, &self.title, text_style),
             PickerTitle::InlineBorder => {
+                if area.width <= title_width {
+                    return;
+                }
                 let mut area = area.with_width(title_width).with_height(2);
                 area.y -= 1;
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -837,7 +837,8 @@ impl<T: Item + 'static + Send + Sync> Component for Picker<T> {
             self.render_preview(preview_area, surface, cx);
         }
 
-        let render_title = area.y >= TITLE_BOX_HEIGHT;
+        let editor_config = cx.editor.config.load();
+        let render_title = editor_config.picker.title && area.y >= TITLE_BOX_HEIGHT;
 
         if render_title {
             // Add four for margin and bounding box edges

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -794,7 +794,13 @@ impl<T: Item + 'static> Picker<T> {
         surface.set_string(
             area.x,
             area.y + 1,
-            format!("{} {} {0}", borders.vertical, self.title.clone()),
+            format!("{} {}  ", borders.vertical, self.title.clone()),
+            text_style,
+        );
+        surface.set_string(
+            area.x + area.width - 1,
+            area.y + 1,
+            borders.vertical.to_string(),
             text_style,
         );
         surface.set_string(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -272,7 +272,7 @@ pub struct Config {
     pub search: SearchConfig,
     /// Picker configuration
     #[serde(default)]
-    pub picker: PickerTitle,
+    pub picker_title: PickerTitle,
     pub lsp: LspConfig,
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
@@ -846,7 +846,7 @@ impl Default for Config {
             true_color: false,
             undercurl: false,
             search: SearchConfig::default(),
-            picker: PickerTitle::default(),
+            picker_title: PickerTitle::default(),
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -270,6 +270,9 @@ pub struct Config {
     /// Search configuration.
     #[serde(default)]
     pub search: SearchConfig,
+    /// Picker configuration
+    #[serde(default)]
+    pub picker: PickerConfig,
     pub lsp: LspConfig,
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
@@ -400,6 +403,19 @@ pub struct SearchConfig {
     pub smart_case: bool,
     /// Whether the search should wrap after depleting the matches. Default to true.
     pub wrap_around: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    /// Title: Weather to render title for the picker
+    pub title: bool,
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        Self { title: true }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -827,6 +843,7 @@ impl Default for Config {
             true_color: false,
             undercurl: false,
             search: SearchConfig::default(),
+            picker: PickerConfig::default(),
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -272,7 +272,7 @@ pub struct Config {
     pub search: SearchConfig,
     /// Picker configuration
     #[serde(default)]
-    pub picker: PickerConfig,
+    pub picker: PickerTitle,
     pub lsp: LspConfig,
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
@@ -405,17 +405,20 @@ pub struct SearchConfig {
     pub wrap_around: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
-pub struct PickerConfig {
-    /// Title: Weather to render title for the picker
-    pub title: bool,
-}
-
-impl Default for PickerConfig {
-    fn default() -> Self {
-        Self { title: true }
-    }
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PickerTitle {
+    /// Don't render the title
+    #[default]
+    Never,
+    /// Render on top of picker box
+    Center,
+    /// Render inline with the picker's border
+    Inline,
+    /// Render inline with the picker's border
+    InlineBorder,
+    /// Render title in the prompt line
+    Prompt,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -843,7 +846,7 @@ impl Default for Config {
             true_color: false,
             undercurl: false,
             search: SearchConfig::default(),
-            picker: PickerConfig::default(),
+            picker: PickerTitle::default(),
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),


### PR DESCRIPTION
Fixes #8139  
The current implementation of the picker doesn't display any context information about what it's displaying.  
This PR adds a `title` field to the `Picker` struct and implements the necessary logic for proper rendering of the title box based on the config option `PickerTitle`.  
```rust
pub struct Picker<T: Item> {
...
    /// Title for the picker box
    title: String,
}
```
```rust
pub enum PickerTitle {
    /// Don't render the title
    #[default]
    Never,
    /// Render on top of picker box
    Center,
    /// Render inline with the picker's border
    Inline,
    /// Render inline with the picker's border
    InlineBorder,
    /// Render title in the prompt line
    Prompt,
}
```
This changes the rendering of a picker as follows:
```md

                `inline`                 `inline-border`           `center`

                                                                  +-------+
                                  +-------+                       | title |
         +-title-+-+ +---------+  | title +-+ +---------+  +------+--+ +--+------+
         | prompt  | | preview |  | prompt  | | preview |  | prompt  | | preview |
         |---------| |         |  |---------| |         |  |---------| |         |
         | picker  | |         |  | picker  | |         |  | picker  | |         |
         |         | |         |  |         | |         |  |         | |         |
         |         | |         |  |         | |         |  |         | |         |
         |         | |         |  |         | |         |  |         | |         |
         |         | |         |  |         | |         |  |         | |         |
         |         | |         |  |         | |         |  |         | |         |
         +---------+ +---------+  +---------+ +---------+  +---------+ +---------+
```
The `title` is exposed to the caller via `Picker::new()` and `Picker::with_stream()` functions.
I have added the following as the titles for now:
| Caller | Title | Dynamic |
| -| :-: | :---: |
|`global_search`|**Global Search: '`user_entered_regex`' [`case_sensitive`]** | :heavy_check_mark:|
|`buffer_picker`|**Buffer List** | |
|`jumplist_picker`|**Jumplist List** | |
|`command_palette`|**Command Palette** | |
|`file_picker`|**Files in: `current working directory`** | :heavy_check_mark: |
|`sym_picker`|**Symbol Picker** | |
|`diag_picker`|**Diagnostics: [`errors` E] [`warnings` W] [`informations` I] [`hints` H]** | :heavy_check_mark: |
|`lsp_workspace_command`|**LSP Workspace Commands**| |
|`goto_impl`|**Goto Picker**| |
|`thread_picker`|**Thread Picker**| |
|`dap_launch`|**DAP Picker**| |
|`dap_switch_stack_frame`|**DAP Stack Frame Picker**| |

## Screenshots
### Changes to Picker:
![image](https://github.com/helix-editor/helix/assets/83179501/12bc04a8-81dc-467d-9b1c-15ffdd0129af)
### File Picker:
![image](https://github.com/helix-editor/helix/assets/83179501/04778f11-f8be-43a3-807a-d0b9cdfb4994)
### Global Search Picker:
![image](https://github.com/helix-editor/helix/assets/83179501/c12e83ce-f024-45a2-b357-22d24c0db93d)
### Diagnostics Picker:
![image](https://github.com/helix-editor/helix/assets/83179501/8e7f3ece-b8c2-4393-a529-0a44c2e3d547)

## Videos
### Dynamic Titles:
https://github.com/helix-editor/helix/assets/83179501/ea3c3441-feb1-4d2c-ad80-739b8eb99187
### Rendering Options:
https://github.com/helix-editor/helix/assets/83179501/6ae20ae0-bbdf-499b-9f34-0f393d6873fd


