### PR TITLE
Add `insert-final-newline` config option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -64,7 +64,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
-| `insert-final-newline` | Whether to automatically insert a final newline on write if missing | `false` |
+| `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `false` |
 
 ### `[editor.statusline]` Section
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -64,6 +64,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
+| `insert-final-newline` | Whether to automatically insert a final newline on write if missing | `false` |
 
 ### `[editor.statusline]` Section
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -64,7 +64,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
-| `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `false` |
+| `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -461,6 +461,31 @@ async fn test_write_insert_final_newline_unchanged_if_not_missing() -> anyhow::R
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_write_insert_final_newline_unchanged_if_missing_and_false() -> anyhow::Result<()> {
+    let mut file = tempfile::NamedTempFile::new()?;
+    let mut app = helpers::AppBuilder::new()
+        .with_config(Config {
+            editor: helix_view::editor::Config {
+                insert_final_newline: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .with_file(file.path(), None)
+        .with_input_text("#[t|]#he quiet rain continued through the night")
+        .build()?;
+
+    test_key_sequence(&mut app, Some(":w<ret>"), None, false).await?;
+
+    helpers::assert_file_has_content(
+        file.as_file_mut(),
+        "the quiet rain continued through the night",
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_write_all_insert_final_newline_add_if_missing_and_modified() -> anyhow::Result<()> {
     let mut file1 = tempfile::NamedTempFile::new()?;
     let mut file2 = tempfile::NamedTempFile::new()?;

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -350,7 +350,7 @@ pub fn assert_file_has_content(file: &mut File, content: &str) -> anyhow::Result
 
     let mut file_content = String::new();
     file.read_to_string(&mut file_content)?;
-    assert_eq!(content, file_content);
+    assert_eq!(file_content, content);
 
     Ok(())
 }

--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -62,9 +62,9 @@ async fn test_split_write_quit_all() -> anyhow::Result<()> {
     )
     .await?;
 
-    helpers::assert_file_has_content(file1.as_file_mut(), "hello1")?;
-    helpers::assert_file_has_content(file2.as_file_mut(), "hello2")?;
-    helpers::assert_file_has_content(file3.as_file_mut(), "hello3")?;
+    helpers::assert_file_has_content(file1.as_file_mut(), &platform_line("hello1"))?;
+    helpers::assert_file_has_content(file2.as_file_mut(), &platform_line("hello2"))?;
+    helpers::assert_file_has_content(file3.as_file_mut(), &platform_line("hello3"))?;
 
     Ok(())
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -287,7 +287,7 @@ pub struct Config {
     pub workspace_lsp_roots: Vec<PathBuf>,
     /// Which line ending to choose for new documents. Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
     pub default_line_ending: LineEndingConfig,
-    /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `false`.
+    /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
@@ -844,7 +844,7 @@ impl Default for Config {
             completion_replace: false,
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
-            insert_final_newline: false,
+            insert_final_newline: true,
             smart_tab: Some(SmartTabConfig::default()),
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -287,7 +287,7 @@ pub struct Config {
     pub workspace_lsp_roots: Vec<PathBuf>,
     /// Which line ending to choose for new documents. Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
     pub default_line_ending: LineEndingConfig,
-    /// Whether to automatically insert a final newline on write if missing. Defaults to `false`.
+    /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `false`.
     pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -287,6 +287,8 @@ pub struct Config {
     pub workspace_lsp_roots: Vec<PathBuf>,
     /// Which line ending to choose for new documents. Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
     pub default_line_ending: LineEndingConfig,
+    /// Whether to automatically insert a final newline on write if missing. Defaults to `false`.
+    pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
 }
@@ -842,6 +844,7 @@ impl Default for Config {
             completion_replace: false,
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
+            insert_final_newline: false,
             smart_tab: Some(SmartTabConfig::default()),
         }
     }


### PR DESCRIPTION
This resolves #4274 with the implementation largely based off of #5435
and also addresses the review from @the-mikedavis on that PR.

The option name is from EditorConfig's `insert_final_newline`, which is
also used by VS Code as `files.insertFinalNewline`.

We match Vim's behavior in that :w will add the newline to unmodified
files but :wa will not; see #1760. Tests are included for this.

Co-authored-by: Xalfer <64538944+Xalfer@users.noreply.github.com>
