### PR TITLE
Cli --working-path option added to helix-term

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -169,6 +169,10 @@ impl Application {
                 let picker = ui::file_picker(".".into(), &config.load().editor);
                 compositor.push(Box::new(overlaid(picker)));
             } else {
+                match args.working_path {
+                    Some(path) => helix_loader::set_current_working_dir(path.clone())?,
+                    None => log::warn!("invalid working path given"),
+                }
                 let nr_of_files = args.files.len();
                 for (i, (file, pos)) in args.files.into_iter().enumerate() {
                     if file.is_dir() {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,7 +17,7 @@ pub struct Args {
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
     pub files: Vec<(PathBuf, Position)>,
-    pub working_path: Option<String>,
+    pub working_path: Option<PathBuf>,
 }
 
 impl Args {
@@ -61,7 +61,7 @@ impl Args {
                     None => anyhow::bail!("--log must specify a path to write"),
                 },
                 "-w" | "--working-path" => match argv.next().as_deref() {
-                    Some(path) => args.working_path = Some(path.into()),
+                    Some(path) => args.working_path = if Path::new(path).exists() {Some(PathBuf::from(path))} else {None},
                     None => anyhow::bail!("--working-path must specify an initial working directory"),
                 },
                 arg if arg.starts_with("--") => {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
     pub files: Vec<(PathBuf, Position)>,
+    pub working_path: Option<String>,
 }
 
 impl Args {
@@ -58,6 +59,10 @@ impl Args {
                 "--log" => match argv.next().as_deref() {
                     Some(path) => args.log_file = Some(path.into()),
                     None => anyhow::bail!("--log must specify a path to write"),
+                },
+                "-w" | "--working-path" => match argv.next().as_deref() {
+                    Some(path) => args.working_path = Some(path.into()),
+                    None => anyhow::bail!("--working-path must specify an initial working directory"),
                 },
                 arg if arg.starts_with("--") => {
                     anyhow::bail!("unexpected double dash argument: {}", arg)

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -66,6 +66,7 @@ FLAGS:
     -V, --version                  Prints version information
     --vsplit                       Splits all given files vertically into different windows
     --hsplit                       Splits all given files horizontally into different windows
+    -w, --working-path <path>      Specify an initial working directory
 ",
         env!("CARGO_PKG_NAME"),
         VERSION_AND_GIT_HASH,


### PR DESCRIPTION
You can now use -w or --working-path to set the current working path of the hx editor from command line.

Similar to these other editors [here](https://docs.godotengine.org/en/stable/tutorials/editor/external_editor.html)
example:
`hx -w ~/helix/helix-term/ -- src/args.rs src/application.rs`
confirm it works by checking your current working directory from inside the editor with `:pwd`