### PR TITLE
Nord Theme: Fix missing ui text focus, use undercurls for diagnostics

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -15,14 +15,14 @@
 "constructor" = "nord8"
 
 # Diagnostics
-"diagnostic" = "nord13"
-"diagnostic.error" = "nord11"
+"diagnostic" = { underline = { color = "nord13", style = "curl" } }
+"diagnostic.error" = { underline = { color = "nord11", style = "curl" } }
 "error" = "nord11"
-"diagnostic.hint" = "nord10"
+"diagnostic.hint" = { underline = { color = "nord10", style = "curl" } }
 "hint" = "nord10"
-"diagnostic.info" = "nord8"
+"diagnostic.info" = { underline = { color = "nord8", style = "curl" } }
 "info" = "nord8"
-"diagnostic.warning" = "nord13"
+"diagnostic.warning" = { underline = { color = "nord13", style = "curl" } }
 "warning" = "nord13"
 
 # Diffs
@@ -100,6 +100,7 @@
 "ui.popup" = { bg = "nord1" }
 "ui.popup.info" = { bg = "nord1" }
 "ui.help" = { bg = "nord1" }
+"ui.text.focus" = { fg = "nord8", bg = "nord2" }
 
 # Gutter
 "ui.gutter" = "nord5"


### PR DESCRIPTION
During a refactor of the theme the ui text focus was removed (accidentally?) which makes the picker much less easy to read. The diagnostic undercurls had also been removed in the refactor so added them back.
Before:
![before-nord](https://github.com/helix-editor/helix/assets/1215953/39ef9775-4972-4061-9587-48aafcd6c479)
After:
![after-nord](https://github.com/helix-editor/helix/assets/1215953/6ad0ab07-cef6-4ad3-9ba3-762ca88c53f0)

