### PR TITLE
Detect tmux clipboard provider on macOS

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -73,9 +73,14 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
 
 #[cfg(target_os = "macos")]
 pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
-    use crate::env::binary_exists;
+    use crate::env::{binary_exists, env_var_is_set};
 
-    if binary_exists("pbcopy") && binary_exists("pbpaste") {
+    if env_var_is_set("TMUX") && binary_exists("tmux") {
+        command_provider! {
+            paste => "tmux", "save-buffer", "-";
+            copy => "tmux", "load-buffer", "-w", "-";
+        }
+    } else if binary_exists("pbcopy") && binary_exists("pbpaste") {
         command_provider! {
             paste => "pbpaste";
             copy => "pbcopy";


### PR DESCRIPTION
Currently, only `pbcopy` and `pbpaste` are allowed as clipboard provider on macOS, seemingly without good reasons.

When SSH-ing into a macOS server, there's no way to yank to the client clipboard, even inside a tmux session, as Helix refuses to use tmux as clipboard provider on macOS, and the default provider (`pbcopy`) does not pass the content to SSH clients.

This PR adds the same tmux test to macOS.