### PR TITLE
Don't use word splitting during fuzzy matching

### DIFF
--- a/helix-core/src/fuzzy.rs
+++ b/helix-core/src/fuzzy.rs
@@ -1,6 +1,6 @@
 use std::ops::DerefMut;
 
-use nucleo::pattern::{AtomKind, CaseMatching, Pattern};
+use nucleo::pattern::{Atom, AtomKind, CaseMatching};
 use nucleo::Config;
 use parking_lot::Mutex;
 
@@ -32,12 +32,12 @@ pub fn fuzzy_match<T: AsRef<str>>(
     pattern: &str,
     items: impl IntoIterator<Item = T>,
     path: bool,
-) -> Vec<(T, u32)> {
+) -> Vec<(T, u16)> {
     let mut matcher = MATCHER.lock();
     matcher.config = Config::DEFAULT;
     if path {
         matcher.config.set_match_paths();
     }
-    let pattern = Pattern::new(pattern, CaseMatching::Smart, AtomKind::Fuzzy);
+    let pattern = Atom::new(pattern, CaseMatching::Smart, AtomKind::Fuzzy, false);
     pattern.match_list(items, &mut matcher)
 }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -5,7 +5,7 @@ use crate::{
     ctrl, key, shift,
 };
 use helix_core::fuzzy::MATCHER;
-use nucleo::pattern::{AtomKind, CaseMatching, Pattern};
+use nucleo::pattern::{Atom, AtomKind, CaseMatching};
 use nucleo::{Config, Utf32Str};
 use tui::{buffer::Buffer as Surface, widgets::Table};
 
@@ -94,13 +94,13 @@ impl<T: Item> Menu<T> {
         self.matches.clear();
         let mut matcher = MATCHER.lock();
         matcher.config = Config::DEFAULT;
-        let pattern = Pattern::new(pattern, CaseMatching::Ignore, AtomKind::Fuzzy);
+        let pattern = Atom::new(pattern, CaseMatching::Ignore, AtomKind::Fuzzy, false);
         let mut buf = Vec::new();
         let matches = self.options.iter().enumerate().filter_map(|(i, option)| {
             let text = option.filter_text(&self.editor_data);
             pattern
                 .score(Utf32Str::new(&text, &mut buf), &mut matcher)
-                .map(|score| (i as u32, score))
+                .map(|score| (i as u32, score as u32))
         });
         self.matches.extend(matches);
         self.matches


### PR DESCRIPTION
This fixes a regression introduced in the nulceo PR.

We used `Pattern::new` for fuzzy matching, however during the nulceo 0.2 release the definition of that function changed so that it also performs word splitting. That would mean that typing spaces would for example never close the completion popup. This PR fixes that by switching to `Atom::new` instead which is the right API for our use case (exactly the same as Pattern::new but does not perform word splitting).
