### PR TITLE
Fix Clone definition for Injector

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -156,7 +156,7 @@ impl<T: Item> Clone for Injector<T> {
         Injector {
             dst: self.dst.clone(),
             editor_data: self.editor_data.clone(),
-            shutown: Arc::new(AtomicBool::new(false)),
+            shutown: self.shutown.clone(),
         }
     }
 }


### PR DESCRIPTION
Injectors detect that a Picker has been shut down / removed by checking the shutdown atomic bool (which is shared with the Picker instance and is set to `true` on Picker's Drop). Cloning Injector should create more references to the Picker's atomic bool rather than creating new ones. This should fix global search so that the WalkBuilder halts when the picker is dropped.