### PR TITLE
fix syntax highlights in dynamic picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -474,9 +474,13 @@ impl<T: Item + 'static> Picker<T> {
                             log::info!("highlighting picker item failed");
                             return;
                         };
-                        let Some(Overlay {
-                            content: picker, ..
-                        }) = compositor.find::<Overlay<Self>>()
+                        let picker = match compositor.find::<Overlay<Self>>() {
+                            Some(Overlay { content, .. }) => Some(content),
+                            None => compositor
+                                .find::<Overlay<DynamicPicker<T>>>()
+                                .map(|overlay| &mut overlay.content.file_picker),
+                        };
+                        let Some(picker) = picker
                         else {
                             log::info!("picker closed before syntax highlighting finished");
                             return;


### PR DESCRIPTION
Closes #8205

This bug was caused by us only looking for the normal picker (but not the dyn picker) component in the compositor when doing syntax highlighting. This was a regression caused by #7028.
