### PR TITLE
chore: add additional ignore file highlights

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1380,7 +1380,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 name = "git-ignore"
 scope = "source.gitignore"
 roots = []
-file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore"]
+file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore", "CODEOWNERS"]
 injection-regex = "git-ignore"
 comment-token = "#"
 grammar = "gitignore"

--- a/languages.toml
+++ b/languages.toml
@@ -1380,7 +1380,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 name = "git-ignore"
 scope = "source.gitignore"
 roots = []
-file-types = [".gitignore", ".gitignore_global"]
+file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore"]
 injection-regex = "git-ignore"
 comment-token = "#"
 grammar = "gitignore"


### PR DESCRIPTION
Various files use the same syntax highlighting as `.gitignore` and similarly tell different tools what files/folders to ignore. Update the languages files so that other ignore type files use the same highlighting gitignore. The files added are:

- .ignore
- .prettierignore
- .eslintignore
- .npmignore

Resolves: #8089