### PR TITLE
Update EdgedDB (ESDL) grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2069,7 +2069,7 @@ roots = ["edgedb.toml"]
 
 [[grammar]]
 name ="esdl"
-source = { git = "https://github.com/greym0uth/tree-sitter-esdl", rev = "b840c8a8028127e0a7c6e6c45141adade2bd75cf" }
+source = { git = "https://github.com/greym0uth/tree-sitter-esdl", rev = "df83acc8cacd0cfb139eecee0e718dc32c4f92e2" }
 
 [[language]]
 name = "pascal"


### PR DESCRIPTION
This updates the esdl tree sitter grammar to the most recent version.

For context: Edgedb v3 came with some syntax changes which required an update to the tree sitter along with some other fixes.