### PR TITLE
Fix various typos

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -962,7 +962,7 @@ impl Syntax {
         let res = syntax.update(source, source, &ChangeSet::new(source));
 
         if res.is_err() {
-            log::error!("TS parser failed, disabeling TS for the current buffer: {res:?}");
+            log::error!("TS parser failed, disabling TS for the current buffer: {res:?}");
             return None;
         }
         Some(syntax)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1206,7 +1206,7 @@ impl Document {
                     transaction.changes(),
                 );
                 if res.is_err() {
-                    log::error!("TS parser failed, disabeling TS for the current buffer: {res:?}");
+                    log::error!("TS parser failed, disabling TS for the current buffer: {res:?}");
                     self.syntax = None;
                 }
             }

--- a/runtime/themes/jellybeans.toml
+++ b/runtime/themes/jellybeans.toml
@@ -22,7 +22,7 @@
 
 "constant.builtin.boolean" = "yellow"
 "constant.character" = "yellow"
-"constant.characted.escape" = "red_error"
+"constant.character.escape" = "red_error"
 "constant.numeric" = "dark_orange"
 "string" = "dark_green"
 "string.regexp" = "light_purple"

--- a/runtime/themes/molokai.toml
+++ b/runtime/themes/molokai.toml
@@ -13,7 +13,7 @@ inherits = "monokai"
 "keyword.storage.modifier" = { fg = "#fd971f", modifiers = ["italic"] }
 "label" = "#e6db74"
 "operator" = "keyword"
-"punctuation.delimeter" = "#8f8f8f"
+"punctuation.delimiter" = "#8f8f8f"
 "type" = "light-blue"
 "variable.builtin" = { fg = "#ae81ff", modifiers = ["bold"] }
 "tag.builtin" = { fg = "#ae81ff", modifiers = ["bold"] }

--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -125,7 +125,7 @@
 "keyword.control.exception" = { fg = "magenta" } # `try`, `catch`, `raise`/`throw` and related.
 "keyword.operator" = { fg = "fg2", modifiers = ["bold"] } # 'or', 'and', 'in'.
 "keyword.directive" = { fg = "pink-bright" } # Preprocessor directives (#if in C...).
-"keyword.function" = { fg = "red" } # The keyword to define a funtion: 'def', 'fun', 'fn'.
+"keyword.function" = { fg = "red" } # The keyword to define a function: 'def', 'fun', 'fn'.
 "keyword.storage" = { fg = "magenta" } # Keywords describing how things are stored
 "keyword.storage.type" = { fg = "magenta" } #  The type of something, class, function, var, let, etc.
 "keyword.storage.modifier" = { fg = "yellow" } # Storage modifiers like static, mut, const, ref, etc.
@@ -183,6 +183,6 @@ bg4            = "#39506d" # Conceal, border fg
 fg0            = "#d6d6d7" # Lighter fg
 fg1            = "#cdcecf" # Default fg
 fg2            = "#aeafb0" # Darker fg (status line)
-fg3            = "#71839b" # Darker fg (line numbers, fold colums)
+fg3            = "#71839b" # Darker fg (line numbers, fold columns)
 sel0           = "#2b3b51" # Popup bg, visual selection bg
 sel1           = "#3c5372" # Popup sel bg, search bg

--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -100,14 +100,14 @@
 
 'variable' = { fg = "white" }  # Variable names.
 'variable.builtin' = { } # Language reserved variables: `this`, `self`, `super`, etc.
-'variable.parameter' = { } # Funtion parameters.
+'variable.parameter' = { } # Function parameters.
 'variable.other.member' = { } # Fields of composite data types (e.g. structs, unions).
 'variable.function' = { } # ?
 
 'label' = { fg = "purple" } # Loop labels in rust.
 
 'punctuation' =  { fg = "yellow", modifiers = ["bold"] } # (){}[]:;,.
-# 'punctuation.delimeter' = { fg = "yellow" } # Commas and colons.
+# 'punctuation.delimiter' = { fg = "yellow" } # Commas and colons.
 # 'punctuation.bracket' = { fg = "yellow" } # Parentheses, angle brackets, etc.
 
 'keyword' = { fg = "pink", modifiers = ["bold"] } # Language reserved keywords.
@@ -119,7 +119,7 @@
 'keyword.control.exception' = {fg = "pink", modifiers = ["bold"] } # 'raise' in python.
 'keyword.operator' = { } # 'or', 'and', 'in'.
 'keyword.directive' = { fg = "purple" } # Preprocessor directives (#if in C).
-'keyword.function' = { } # The keyword to define a funtion: 'def', 'fun', 'fn'.
+'keyword.function' = { } # The keyword to define a function: 'def', 'fun', 'fn'.
 
 'operator' = { fg = "pink", modifiers = ["bold"] } # Logical (&&, ||) and - I assume - Mathematical (+, %) operators
 

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -89,7 +89,7 @@
 "comment" = { fg = "muted", modifiers = ["italic"]}
 # "comment.line" = ""
 # "comment.block" = ""
-# "comment.block.documenation" = ""
+# "comment.block.documentation" = ""
 
 "variable" = "text"
 "variable.builtin" = "love"


### PR DESCRIPTION
Various typos, found using [typos-cli](https://github.com/crate-ci/typos). This actually modifies the molokai and jellybeans themes as some keys were incorrect (but the changes "look" correct).