### PR TITLE
Disable auto-pairing ` in OCaml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -886,7 +886,6 @@ indent = { tab-width = 2, unit = "  " }
 '{' = '}'
 '[' = ']'
 '"' = '"'
-'`' = '`'
 
 [[grammar]]
 name = "ocaml"
@@ -907,7 +906,6 @@ indent = { tab-width = 2, unit = "  " }
 '{' = '}'
 '[' = ']'
 '"' = '"'
-'`' = '`'
 
 [[grammar]]
 name = "ocaml-interface"


### PR DESCRIPTION
Similar to what was done in #6381, the backquote in OCaml can be used in the beginning of a constructor (<code>type t = [`Foo]</code>) and should not be auto-paired.