### PR TITLE
Fix search highlighting for the default docs theme

### DIFF
--- a/book/custom.css
+++ b/book/custom.css
@@ -164,7 +164,7 @@ code.hljs {
   --searchresults-header-fg: #5f5f71;
   --searchresults-border-color: #5c5c68;
   --searchresults-li-bg: #242430;
-  --search-mark-bg: #acff5;
+  --search-mark-bg: #a2cff5;
 }
 
 .colibri .content .header {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,9 +29,15 @@ files, run
 cargo xtask docgen
 ```
 
-inside the project. We use [xtask][xtask] as an ad-hoc task runner and
-thus do not require any dependencies other than `cargo` (You don't have
-to `cargo install` anything either).
+inside the project. We use [xtask][xtask] as an ad-hoc task runner.
+
+To preview the book itself, install [mdbook][mdbook]. Then, run
+
+```shell
+mdbook serve book
+```
+
+and visit [http://localhost:3000](http://localhost:3000).
 
 # Testing
 
@@ -58,4 +64,5 @@ The current MSRV and future changes to the MSRV are listed in the [Firefox docum
 [architecture.md]: ./architecture.md
 [docs]: https://docs.helix-editor.com/
 [xtask]: https://github.com/matklad/cargo-xtask
+[mdbook]: https://rust-lang.github.io/mdBook/guide/installation.html
 [helpers.rs]: ../helix-term/tests/test/helpers.rs


### PR DESCRIPTION
Closes #8214

Also adds some documentation on how to preview book changes. Is running mdBook something we'd like to use xtask for in the future?