### PR TITLE
Theme: Papercolor: Cleanup, linting and using inheritance

### DIFF
--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -1,7 +1,8 @@
 # Palette based on https://github.com/NLKNguyen/papercolor-theme
 # Author: Soc Virnyl Estela <socvirnyl.estela@gmail.com>
 
-"ui.linenr.selected" = { fg = "linenr_fg_selected" }
+"ui.linenr.selected" = { fg = "linenr_fg_selected", modifiers = ["bold"] }
+"ui.linenr" = { fg = "bright0" }
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
@@ -15,7 +16,7 @@
 "ui.statusline.inactive" = {bg="selection_foreground", fg="foreground"}
 "ui.virtual" = {fg = "linenr_fg_selected"}
 "ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.indent-guide" = { bg = "regular5" }
+"ui.virtual.indent-guide" = { fg = "bright0" }
 "ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
 "ui.cursor.match" = {bg = "bright0", fg = "regular0"}
 "ui.cursor" = {bg = "regular5", fg = "background"}
@@ -62,7 +63,6 @@
 "function.builtin" = { fg = "foreground", modifiers = ["bold"]}
 "function.macro" = { fg = "regular4", modifiers = ["bold"] }
 "comment" = { fg = "regular7", modifiers = ["dim"] }
-"ui.linenr" = { fg = "bright0" }
 "module" = "regular4"
 "constant" = "bright5"
 "constant.builtin" = "bright6"

--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -5,22 +5,26 @@
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_background", fg="selection_foreground"}
-"ui.cursorline" = {bg="cursorline_background"}
+"ui.selection" = {bg="selection_secondary_background", fg="selection_secondary_foreground"}
+"ui.selection.primary" = {bg="selection_background", fg="selection_foreground" }
 "ui.highlight" = {bg="cursorline_background"}
+"ui.cursorline" = {bg="cursorline_background"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
 "ui.statusline.inactive" = {bg="selection_foreground", fg="foreground"}
+"ui.virtual" = {fg = "linenr_fg_selected"}
 "ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.ruler" = {bg="cursorline_background"}
-"ui.cursor.match" = {bg = "regular5", fg = "regular0"}
+"ui.virtual.indent-guide" = { bg = "regular5" }
+"ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
+"ui.cursor.match" = {bg = "bright0", fg = "regular0"}
 "ui.cursor" = {bg = "regular5", fg = "background"}
-"ui.window" = {bg = "#303030", fg = "bright2"}
+"ui.cursor.primary" = {bg = "foreground", fg = "background"}
+"ui.window" = {bg = "ui_window_bg", fg = "foreground"}
 "ui.help" = {bg = "background", fg = "bright2"}
-"ui.popup" = {bg = "#303030", fg = "bright6"}
-"ui.menu" = {bg = "#303030", fg = "bright6"}
-"ui.menu.selected" = {bg = "#C6C6C6", fg="selection_foreground"}
+"ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
+"ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
+"ui.menu.selected" = {bg = "selection_background", fg="selection_foreground"}
 
 "markup.heading" = { fg = "regular4", modifiers = ["bold"] }
 "markup.heading.1" = { fg = "bright2", modifiers = ["bold"] }
@@ -33,7 +37,7 @@
 "markup.bold" = { fg = "foreground", modifiers = ["bold"] }
 "markup.italic" = { fg = "bright0", modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "bright6", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "bright6", underline.style = "line" }
 "markup.link.text" = "bright2"
 "markup.link.label" = { fg = "regular2", modifiers = ["bold"] }
 "markup.raw" = "foreground"
@@ -52,12 +56,12 @@
 "variable.other.member" = "cyan"
 "variable.parameter" = "foreground"
 
-"special" = "#3E999F"
+"special" = "special"
 "function"  = "bright6"
 "constructor" = "regular4"
 "function.builtin" = { fg = "foreground", modifiers = ["bold"]}
 "function.macro" = { fg = "regular4", modifiers = ["bold"] }
-"comment" = { fg = "#686868", modifiers = ["dim"] }
+"comment" = { fg = "regular7", modifiers = ["dim"] }
 "ui.linenr" = { fg = "bright0" }
 "module" = "regular4"
 "constant" = "bright5"
@@ -97,14 +101,20 @@ bright0="#585858"
 bright1="#5faf5f"
 bright2="#afd700"
 bright3="#af87d7"
-bright4="#FFAF00"
+bright4="#ffaf00"
 bright5="#ff5faf"
 bright6="#00afaf"
 bright7="#5f8787"
 selection_foreground="#585858"
 selection_background="#8787AF"
+selection_secondary_background="#a1a1d6"
 cursorline_background="#303030"
 paper_bar_bg="#5F8787"
+linenr_fg_selected="#FFFF00"
+special="#3E999F"
+ui_window_bg="#444444"
+
+# 16 bit ANSI color names
 black="#1c1c1c"
 red="#af005f"
 green="#5faf00"
@@ -112,13 +122,12 @@ yellow="#d7af5f"
 blue="#5fafd7"
 magenta="#808080"
 cyan="#d7875f"
-gray="#d0d0d0"
+white="#d0d0d0"
+light-black="#585858"
 light-red="#5faf5f"
 light-green="#afd700"
 light-yellow="#af87d7"
-light-blue="#FFAF00"
+light-blue="#ffaf00"
 light-magenta="#ff5faf"
 light-cyan="#00afaf"
-light-gray="#5f8787"
-white="#808080"
-linenr_fg_selected="#FFFF00"
+light-white="#5f8787"

--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -1,134 +1,75 @@
 # Palette based on https://github.com/NLKNguyen/papercolor-theme
 # Author: Soc Virnyl Estela <socvirnyl.estela@gmail.com>
 
-"ui.linenr.selected" = { fg = "linenr_fg_selected", modifiers = ["bold"] }
-"ui.linenr" = { fg = "bright0" }
-"ui.background" = {bg="background"}
-"ui.text" = "foreground"
-"ui.text.focus" = { fg = "selection_bg", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_secondary_bg", fg="selection_secondary_fg"}
-"ui.selection.primary" = {bg="selection_bg", fg="selection_fg" }
-"ui.highlight" = {bg="cursorline_bg"}
-"ui.cursorline" = {bg="cursorline_bg"}
-"ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
-"ui.statusline.select" = {bg="background", fg="bright7"}
-"ui.statusline.normal" = {bg="background", fg="bright3"}
-"ui.statusline.inactive" = {bg="selection_fg", fg="foreground"}
-"ui.virtual" = {fg = "linenr_fg_selected"}
-"ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.indent-guide" = { fg = "bright0" }
-"ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
-"ui.cursor.match" = {bg = "bright0", fg = "regular0"}
-"ui.cursor" = {bg = "regular5", fg = "background"}
-"ui.cursor.primary" = {bg = "foreground", fg = "background"}
-"ui.window" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.help" = {bg = "background", fg = "bright2"}
-"ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu.selected" = {bg = "selection_bg", fg="selection_fg"}
-
-"markup.heading" = { fg = "regular4", modifiers = ["bold"] }
-"markup.heading.1" = { fg = "bright2", modifiers = ["bold"] }
-"markup.heading.2" = { fg = "bright5", modifiers = ["bold"] }
-"markup.heading.3" = { fg = "bright3", modifiers = ["bold"] }
-"markup.heading.4" = { fg = "bright5", modifiers = ["bold"] }
-"markup.heading.5" = { fg = "bright5", modifiers = ["bold"] }
-"markup.heading.6" = { fg = "bright5", modifiers = ["bold"] }
-"markup.list" = "bright3"
-"markup.bold" = { fg = "foreground", modifiers = ["bold"] }
-"markup.italic" = { fg = "bright0", modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "bright6", underline.style = "line" }
-"markup.link.text" = "bright2"
-"markup.link.label" = { fg = "regular2", modifiers = ["bold"] }
-"markup.raw" = "foreground"
-
-"string" = "foreground"
-"attribute" = "bright7"
-"keyword" = { fg = "regular4", modifiers = ["bold"]}
-"keyword.directive" = "regular4"
-"keyword.control.conditional" = "bright3"
-"keyword.function" = "regular4"
-"namespace" = "bright1"
-"type" = "bright2"
-"type.builtin" = { fg = "foreground", modifiers = ["bold"]}
-"variable" = "foreground"
-"variable.builtin" = "cyan"
-"variable.other.member" = "cyan"
-"variable.parameter" = "foreground"
-
-"special" = "special"
-"function"  = "bright6"
-"constructor" = "regular4"
-"function.builtin" = { fg = "foreground", modifiers = ["bold"]}
-"function.macro" = { fg = "regular4", modifiers = ["bold"] }
-"comment" = { fg = "regular7", modifiers = ["dim"] }
-"module" = "regular4"
-"constant" = "bright5"
-"constant.builtin" = "bright6"
-"constant.numeric" = "bright5"
-"constant.character.escape" = { fg = "foreground", modifiers = ["bold"]}
-"operator" = { fg = "regular4", modifiers = ["bold"]}
-
-"label" = { fg = "selection_bg", modifiers = ["bold", "italic"] }
-
-"diff.plus" = "regular2"
-"diff.delta" = "regular7"
-"diff.minus" = "regular1"
-
-"warning" = "bright4"
-"error" = "regular1"
-"info" = "bright4"
-
-"diagnostic.warning".underline = { color = "bright4", style = "curl" } 
-"diagnostic.error".underline = { color = "regular1", style = "curl" } 
-"diagnostic.info".underline = { color = "bright4", style = "curl" } 
-"diagnostic.hint".underline = { color = "bright4", style = "curl" } 
-
+inherits = "papercolor-light"
 
 [palette]
-background="#1c1c1c"
-foreground="#d0d0d0"
-regular0="#1c1c1c"
-regular1="#af005f"
-regular2="#5faf00"
-regular3="#d7af5f"
-regular4="#5fafd7"
-regular5="#808080"
-regular6="#d7875f"
-regular7="#d0d0d0"
-bright0="#585858"
-bright1="#5faf5f"
-bright2="#afd700"
-bright3="#af87d7"
-bright4="#ffaf00"
-bright5="#ff5faf"
-bright6="#00afaf"
-bright7="#5f8787"
+background = "#1c1c1c"
+foreground = "#d0d0d0"
 
-selection_fg="#585858"
-selection_bg="#8787AF"
-selection_secondary_bg="#a1a1d6"
-cursorline_bg="#303030"
-paper_bar_bg="#5F8787"
-linenr_fg_selected="#FFFF00"
-special="#3E999F"
-ui_window_bg="#444444"
+regular0 = "#1c1c1c" # color00 "Background"
+regular1 = "#af005f" # color01 "Negative"
+regular2 = "#5faf00" # color02 "Positive"
+regular3 = "#d7af5f" # color03 "Olive"
+regular4 = "#5fafd7" # color04 "Neutral" / Aqua
+regular5 = "#808080" # color05 "Comment"
+regular6 = "#d7875f" # color06 "Navy"
+regular7 = "#d0d0d0" # color07 "Foreground"
+bright0 = "#585858"  # color08 "Nontext"
+bright1 = "#5faf5f"  # color09 "Red"
+bright2 = "#afd700"  # color10 "Pink"
+bright3 = "#af87d7"  # color11 "Purple"
+bright4 = "#ffaf00"  # color12 "Accent"
+bright5 = "#ff5faf"  # color13 "Orange"
+bright6 = "#00afaf"  # color14 "Blue"
+bright7 = "#5f8787"  # color15 "Highlight"
+
+selection_fg = "#000000"
+selection_bg = "#8787af"
+selection_secondary_fg = "#333333"
+selection_secondary_bg = "#707097"
+special = "#3e999f"
+
+cursorline_bg = "#303030"
+cursorline_secondary_bg = "#2a2a2a"
+cursorcolumn_bg = "#303030"
+cursorcolumn_secondary_bg = "#2a2a2a"
+cursorlinenr_fg = "#ffff00"
+popupmenu_fg = "#c6c6c6"
+popupmenu_bg = "#303030"
+linenumber_fg = "#585858"
+vertsplit_fg = "#5f8787"
+statusline_active_fg = "#1c1c1c"
+statusline_active_bg = "#5f8787"
+statusline_inactive_fg = "#bcbcbc"
+statusline_inactive_bg = "#3a3a3a"
+todo_fg = "#ff8700"
+error_fg = "#af005f"
+error_bg = "#5f0000"
+matchparen_bg = "#4e4e4e"
+matchparen_fg = "#c6c6c6"
+wildmenu_fg = "#1c1c1c"
+wildmenu_bg = "#afd700"
+diffadd_fg = "#87d700"
+diffadd_bg = "#005f00"
+diffdelete_fg = "#af005f"
+diffdelete_bg = "#5f0000"
+diffchange_bg = "#005f5f"
 
 # 16 bit ANSI color names
-black="#1c1c1c"
-red="#af005f"
-green="#5faf00"
-yellow="#d7af5f"
-blue="#5fafd7"
-magenta="#808080"
-cyan="#d7875f"
-white="#d0d0d0"
-light-black="#585858"
-light-red="#5faf5f"
-light-green="#afd700"
-light-yellow="#af87d7"
-light-blue="#ffaf00"
-light-magenta="#ff5faf"
-light-cyan="#00afaf"
-light-white="#5f8787"
+black = "#1c1c1c"
+red = "#af005f"
+green = "#5faf00"
+yellow = "#d7af5f"
+blue = "#5fafd7"
+magenta = "#808080"
+cyan = "#d7875f"
+white = "#d0d0d0"
+light-black = "#585858"
+light-red = "#5faf5f"
+light-green = "#afd700"
+light-yellow = "#af87d7"
+light-blue = "#ffaf00"
+light-magenta = "#ff5faf"
+light-cyan = "#00afaf"
+light-white = "#5f8787"

--- a/runtime/themes/papercolor-dark.toml
+++ b/runtime/themes/papercolor-dark.toml
@@ -5,15 +5,15 @@
 "ui.linenr" = { fg = "bright0" }
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_secondary_background", fg="selection_secondary_foreground"}
-"ui.selection.primary" = {bg="selection_background", fg="selection_foreground" }
-"ui.highlight" = {bg="cursorline_background"}
-"ui.cursorline" = {bg="cursorline_background"}
+"ui.text.focus" = { fg = "selection_bg", modifiers = ["bold"]}
+"ui.selection" = {bg="selection_secondary_bg", fg="selection_secondary_fg"}
+"ui.selection.primary" = {bg="selection_bg", fg="selection_fg" }
+"ui.highlight" = {bg="cursorline_bg"}
+"ui.cursorline" = {bg="cursorline_bg"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
-"ui.statusline.inactive" = {bg="selection_foreground", fg="foreground"}
+"ui.statusline.inactive" = {bg="selection_fg", fg="foreground"}
 "ui.virtual" = {fg = "linenr_fg_selected"}
 "ui.virtual.whitespace" = { fg = "regular5" }
 "ui.virtual.indent-guide" = { fg = "bright0" }
@@ -25,7 +25,7 @@
 "ui.help" = {bg = "background", fg = "bright2"}
 "ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
 "ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu.selected" = {bg = "selection_background", fg="selection_foreground"}
+"ui.menu.selected" = {bg = "selection_bg", fg="selection_fg"}
 
 "markup.heading" = { fg = "regular4", modifiers = ["bold"] }
 "markup.heading.1" = { fg = "bright2", modifiers = ["bold"] }
@@ -70,10 +70,10 @@
 "constant.character.escape" = { fg = "foreground", modifiers = ["bold"]}
 "operator" = { fg = "regular4", modifiers = ["bold"]}
 
-"label" = { fg = "selection_background", modifiers = ["bold", "italic"] }
+"label" = { fg = "selection_bg", modifiers = ["bold", "italic"] }
 
 "diff.plus" = "regular2"
-"diff.delta" = "regular6"
+"diff.delta" = "regular7"
 "diff.minus" = "regular1"
 
 "warning" = "bright4"
@@ -105,10 +105,11 @@ bright4="#ffaf00"
 bright5="#ff5faf"
 bright6="#00afaf"
 bright7="#5f8787"
-selection_foreground="#585858"
-selection_background="#8787AF"
-selection_secondary_background="#a1a1d6"
-cursorline_background="#303030"
+
+selection_fg="#585858"
+selection_bg="#8787AF"
+selection_secondary_bg="#a1a1d6"
+cursorline_bg="#303030"
 paper_bar_bg="#5F8787"
 linenr_fg_selected="#FFFF00"
 special="#3E999F"

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -1,35 +1,124 @@
 # Palette based on https://github.com/NLKNguyen/papercolor-theme
 # Author: Soc Virnyl Estela <socvirnyl.estela@gmail.com>
 
-"ui.linenr.selected" = { fg = "linenr_fg_selected", modifiers = ["bold"] }
-"ui.linenr" = { fg = "bright0" }
-"ui.background" = {bg="background"}
+"ui.linenr.selected" = { fg = "cursorlinenr_fg", modifiers = ["bold"] }
+"ui.linenr" = { fg = "linenumber_fg" }
+"ui.background" = { bg = "background" }
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "selection_bg", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_secondary_bg", fg="selection_secondary_fg"}
-"ui.selection.primary" = {bg="selection_bg", fg="selection_fg" }
-"ui.highlight" = {bg="cursorline_bg"}
-"ui.cursorline" = {bg="cursorline_bg"}
-"ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
-"ui.statusline.select" = {bg="background", fg="bright7"}
-"ui.statusline.normal" = {bg="background", fg="bright3"}
-"ui.statusline.inactive" = {bg="bright0", fg="foreground"}
-"ui.virtual" = {fg = "linenr_fg_selected"}
-"ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.indent-guide" = { fg="bright0" }
-"ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
-"ui.cursor.match" = {bg = "bright0", fg = "regular0"}
-"ui.cursor" = {bg = "regular5", fg = "background"}
-"ui.cursor.primary" = {bg = "foreground", fg = "background"}
-"ui.window" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.help" = {bg = "background", fg = "bright2"}
-"ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu.selected" = {bg = "selection_bg", fg="selection_fg"}
+"ui.text.focus" = { fg = "selection_bg", modifiers = ["bold"] }
+"ui.selection" = { bg = "selection_secondary_bg", fg = "selection_secondary_fg" }
+"ui.selection.primary" = { bg = "selection_bg", fg = "selection_fg" }
+"ui.highlight" = { bg = "cursorline_bg" }
 
-"markup.heading" = { fg = "bright7", modifiers = ["bold"] }
+"ui.cursorline" = { bg = "cursorline_bg" }
+"ui.cursorline.secondary" = { bg = "cursorline_secondary_bg" }
+"ui.cursorcolumn" = { bg = "cursorline_bg" }
+"ui.cursorcolumn.secondary" = { bg = "cursorcolumn_secondary_bg" }
+
+"ui.statusline" = { bg = "statusline_active_bg", fg = "statusline_active_fg" }
+"ui.statusline.inactive" = { bg = "statusline_inactive_bg", fg = "statusline_inactive_fg" }
+"ui.statusline.normal" = { bg = "statusline_inactive_bg", fg = "bright6" }
+"ui.statusline.insert" = { bg = "statusline_inactive_bg", fg = "bright4" }
+"ui.statusline.select" = { bg = "statusline_inactive_bg", fg = "regular3" }
+"ui.statusline.separator" = { bg = "statusline_active_bg", fg = "statusline_active_bg" }
+
+"ui.virtual" = { fg = "cursorlinenr_fg" }
+"ui.virtual.whitespace" = { fg = "regular5" }
+"ui.virtual.indent-guide" = { fg = "bright0" }
+"ui.virtual.ruler" = { bg = "cursorline_secondary_bg", fg = "regular4" }
+"ui.cursor.match" = { bg = "matchparen_bg", fg = "matchparen_fg" }
+"ui.cursor" = { bg = "regular5", fg = "background" }
+"ui.cursor.primary" = { bg = "foreground", fg = "background" }
+"ui.window" = { fg = "vertsplit_fg" }
+"ui.help" = { bg = "wildmenu_bg", fg = "wildmenu_fg" }
+"ui.popup" = { bg = "popupmenu_bg", fg = "popupmenu_fg" }
+"ui.popup.info" = { bg = "popupmenu_bg", fg = "bright7", modifiers = ["bold"] }
+"ui.menu" = { bg = "popupmenu_bg", fg = "foreground" }
+"ui.menu.selected" = { bg = "selection_bg", fg = "selection_fg" }
+
+"warning" = "bright5"
+"error" = { bg = "error_bg", fg = "error_fg" }
+"info" = "todo_fg"
+
+"diagnostic.warning" = { fg = "bright0", modifiers = [
+  "dim",
+], underline = { color = "bright5", style = "curl" } }
+"diagnostic.error".underline = { color = "bright1", style = "curl" }
+"diagnostic.info".underline = { color = "bright4", style = "curl" }
+"diagnostic.hint".underline = { color = "bright6", style = "curl" }
+
+# Tree-sitter scopes for syntax highlighting
+"attribute" = "bright4"
+
+"type" = { fg = "bright2", modifiers = ["bold"] }
+"type.builtin" = { fg = "bright2", modifiers = ["bold"] }
+"type.enum" = { fg = "foreground" }
+"type.enum.variant" = { fg = "foreground" }
+
+"constructor" = "foreground"
+
+"constant" = "bright5"
+"constant.builtin" = "regular3"
+"constant.builtin.boolean" = { fg = "regular2", modifiers = ["bold"] }
+"constant.character.escape" = { fg = "bright3", modifiers = ["bold"] }
+"constant.character" = { fg = "regular3" }
+"constant.numeric" = "bright5"
+
+"string" = "regular3"
+"string.regexp" = "bright3"
+
+"comment" = { fg = "regular5", modifiers = ["italic"] }
+"comment.line" = { fg = "regular5", modifiers = ["italic"] }
+"comment.block" = { fg = "regular5", modifiers = ["italic"] }
+"comment.block.documentation" = { fg = "regular5", modifiers = ["bold"] }
+
+"variable" = "foreground"
+"variable.builtin" = "bright5"
+"variable.other.member" = "foreground"
+"variable.parameter" = "foreground"
+
+"label" = { fg = "selection_bg", modifiers = ["bold", "italic"] }
+
+"punctuation" = { fg = "foreground" }
+"punctuation.delimiter" = { fg = "regular4", modifiers = ["bold"] }
+"punctuation.bracket" = { fg = "foreground" }
+"punctuation.special" = { fg = "bright1", modifiers = ["bold"] }
+
+"keyword" = { fg = "bright2" }
+"keyword.control" = "bright1"
+"keyword.control.conditional" = { fg = "bright3", modifiers = ["bold"] }
+"keyword.control.repeat" = { fg = "bright3", modifiers = ["bold"] }
+"keyword.control.import" = { fg = "bright2" }
+"keyword.control.return" = { fg = "bright2" }
+"keyword.control.exception" = { fg = "bright1" }
+
+"keyword.operator" = { fg = "regular4", modifiers = ["bold"] }
+"keyword.directive" = "regular4"
+"keyword.function" = "bright2"
+"keyword.storage" = "bright2"
+"keyword.storage.type" = { fg = "regular4", modifiers = ["bold"] }
+"keyword.storage.modifier" = { fg = "regular6", modifiers = ["bold"] }
+"keyword.storage.modifier.ref" = { fg = "regular4", modifiers = ["bold"] }
+"keyword.special" = "bright1"
+
+"operator" = { fg = "regular4", modifiers = ["bold"] }
+
+"function" = { fg = "foreground" }
+"function.builtin" = { fg = "bright6" }
+"function.method" = { fg = "foreground" }
+"function.macro" = { fg = "regular3", modifiers = ["bold"] }
+"function.special" = { fg = "bright4" }
+
+"tag" = { fg = "regular4" }
+
+"namespace" = "bright6"
+
+"special" = "special"
+
+"markup.heading" = { fg = "bright4", modifiers = ["bold"] }
+"markup.heading.marker" = { fg = "bright2", modifiers = ["bold"] }
 "markup.heading.1" = { fg = "bright2", modifiers = ["bold"] }
-"markup.heading.2" = { fg = "bright4", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "bright5", modifiers = ["bold"] }
 "markup.heading.3" = { fg = "bright3", modifiers = ["bold"] }
 "markup.heading.4" = { fg = "bright4", modifiers = ["bold"] }
 "markup.heading.5" = { fg = "bright4", modifiers = ["bold"] }
@@ -38,95 +127,84 @@
 "markup.bold" = { fg = "foreground", modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "regular4", underline.style = "line"  }
+"markup.link.url" = { fg = "bright6", underline.style = "line" }
 "markup.link.text" = "bright2"
 "markup.link.label" = { fg = "regular2", modifiers = ["bold"] }
-"markup.raw" = "foreground"
+"markup.quote" = "regular4"
+# Both inline and block code
+"markup.raw" = "regular3"
 
-"string" = "foreground"
-"attribute" = "bright7"
-"keyword" = { fg = "regular4", modifiers = ["bold"]}
-"keyword.directive" = "regular1"
-"namespace" = "regular1"
-"type" = "bright2"
-"type.builtin" = { fg = "regular4", modifiers = ["bold"]}
-"variable" = "foreground"
-"variable.builtin" = "cyan"
-"variable.other.member" = "regular4"
-"variable.parameter" = "foreground"
-
-"special" = "special"
-"function"  = "bright1"
-"constructor" = "bright1"
-"function.builtin" = { fg = "regular4", modifiers = ["bold"]}
-"function.macro" = { fg = "regular1" }
-"comment" = { fg = "bright0", modifiers = ["dim"] }
-"module" = "regular1"
-"constant" = "regular3"
-"constant.builtin" = "regular3"
-"constant.numeric" = "bright4"
-"constant.character.escape" = { fg = "bright3", modifiers = ["bold"]}
-"operator" = { fg = "regular4", modifiers = ["bold"]}
-
-"label" = { fg = "selection_bg", modifiers = ["bold", "italic"] }
-
-"diff.plus" = "regular2"
-"diff.delta" = "regular7"
-"diff.minus" = "regular1"
-
-"warning" = "bright4"
-"error" = "regular1"
-"info" = "bright4"
-
-"diagnostic.warning".underline = { color = "bright4", style = "curl" } 
-"diagnostic.error".underline = { color = "regular1", style = "curl" } 
-"diagnostic.info".underline = { color = "bright4", style = "curl" } 
-"diagnostic.hint".underline = { color = "bright4", style = "curl" } 
+"diff.plus" = { bg = "diffadd_bg", fg = "diffadd_fg" }
+"diff.delta" = { bg = "diffchange_bg" }
+"diff.delta.moved" = { modifiers = ["italic"] }
+"diff.minus" = { bg = "diffdelete_bg", fg = "diffdelete_fg" }
 
 [palette]
-background="#eeeeee"
-foreground="#444444"
-regular0="#eeeeee"
-regular1="#af0000"
-regular2="#008700"
-regular3="#5f8700"
-regular4="#0087af"
-regular5="#878787"
-regular6="#005f87"
-regular7="#444444"
-bright0="#bcbcbc"
-bright1="#d70000"
-bright2="#d70087"
-bright3="#8700af"
-bright4="#d75f00"
-bright5="#d75f00"
-bright6="#005faf"
-bright7="#005f87"
+background = "#eeeeee"
+foreground = "#444444"
+regular0 = "#eeeeee"   # color00 "Background"
+regular1 = "#af0000"   # color01 "Negative"
+regular2 = "#008700"   # color02 "Positive"
+regular3 = "#5f8700"   # color03 "Olve"
+regular4 = "#0087af"   # color04 "Neutral" / Aqua
+regular5 = "#878787"   # color05 "Comment"
+regular6 = "#005f87"   # color06 "Navy"
+regular7 = "#444444"   # color07 "Foreground"
+bright0 = "#bcbcbc"    # color08 "Nontext"
+bright1 = "#d70000"    # color09 "Red"
+bright2 = "#d70087"    # color10 "Pink"
+bright3 = "#8700af"    # color11 "Purple"
+bright4 = "#d75f00"    # color12 "Accent"
+bright5 = "#d75f00"    # color13 "Orange"
+bright6 = "#005faf"    # color14 "Blue"
+bright7 = "#005f87"    # color15 "Highlight"
 
-selection_fg="#eeeeee"
-selection_secondary_fg="#d9d7d7"
-selection_bg="#0087af"
-selection_secondary_bg="#2c687a"
-cursorline_bg="#e4e4e4"
-paper_bar_bg="#005F87"
-linenr_fg_selected="#AF634D"
-special="#3E999F"
-ui_window_bg="#d0d0d0"
+selection_fg = "#eeeeee"
+selection_bg = "#0087af"
+selection_secondary_fg = "#d9d7d7"
+selection_secondary_bg = "#2c687a"
+special = "#3e999f"
+
+cursorline_bg = "#e4e4e4"
+cursorline_secondary_bg = "#eaeaea"
+cursorcolumn_bg = "#e4e4e4"
+cursorcolumn_secondary_bg = "#eaeaea"
+cursorlinenr_fg = "#af5f00"
+popupmenu_fg = "#444444"
+popupmenu_bg = "#d0d0d0"
+linenumber_fg = "#b2b2b2"
+vertsplit_fg = "#005f87"
+statusline_active_fg = "#e4e4e4"
+statusline_active_bg = "#005f87"
+statusline_inactive_fg = "#444444"
+statusline_inactive_bg = "#d0d0d0"
+todo_fg = "#00af5f"
+error_fg = "#af0000"
+error_bg = "#ffd7ff"
+matchparen_bg = "#c6c6c6"
+matchparen_fg = "#005f87"
+wildmenu_fg = "#444444"
+wildmenu_bg = "#ffff00"
+diffadd_fg = "#008700"
+diffadd_bg = "#afffaf"
+diffdelete_fg = "#af0000"
+diffdelete_bg = "#ffd7ff"
+diffchange_bg = "#ffd787"
 
 # 16 bit ANSI color names
-black="#eeeeee"
-red="#d70000"
-green="#008700"
-yellow="#5f8700"
-blue="#0087af"
-magenta="#878787"
-cyan="#005f87"
-white="#444444"
-light-black="#bcbcbc"
-light-red="#d70000"
-light-green="#d70087"
-light-yellow="#8700af"
-light-blue="#d75f00"
-light-magenta="#d75f00"
-light-cyan="#4c7a4d"
-light-white="#005faf"
+black = "#eeeeee"
+red = "#d70000"
+green = "#008700"
+yellow = "#5f8700"
+blue = "#0087af"
+magenta = "#878787"
+cyan = "#005f87"
+white = "#444444"
+light-black = "#bcbcbc"
+light-red = "#d70000"
+light-green = "#d70087"
+light-yellow = "#8700af"
+light-blue = "#d75f00"
+light-magenta = "#d75f00"
+light-cyan = "#4c7a4d"
+light-white = "#005faf"

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -5,11 +5,11 @@
 "ui.linenr" = { fg = "bright0" }
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_secondary_background", fg="selection_secondary_foreground"}
-"ui.selection.primary" = {bg="selection_background", fg="selection_foreground" }
-"ui.highlight" = {bg="cursorline_background"}
-"ui.cursorline" = {bg="cursorline_background"}
+"ui.text.focus" = { fg = "selection_bg", modifiers = ["bold"]}
+"ui.selection" = {bg="selection_secondary_bg", fg="selection_secondary_fg"}
+"ui.selection.primary" = {bg="selection_bg", fg="selection_fg" }
+"ui.highlight" = {bg="cursorline_bg"}
+"ui.cursorline" = {bg="cursorline_bg"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
@@ -25,7 +25,7 @@
 "ui.help" = {bg = "background", fg = "bright2"}
 "ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
 "ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
-"ui.menu.selected" = {bg = "selection_background", fg="selection_foreground"}
+"ui.menu.selected" = {bg = "selection_bg", fg="selection_fg"}
 
 "markup.heading" = { fg = "bright7", modifiers = ["bold"] }
 "markup.heading.1" = { fg = "bright2", modifiers = ["bold"] }
@@ -68,21 +68,20 @@
 "constant.character.escape" = { fg = "bright3", modifiers = ["bold"]}
 "operator" = { fg = "regular4", modifiers = ["bold"]}
 
-"label" = { fg = "selection_background", modifiers = ["bold", "italic"] }
+"label" = { fg = "selection_bg", modifiers = ["bold", "italic"] }
 
 "diff.plus" = "regular2"
-"diff.delta" = "bright0"
-"diff.minus" = "bright1"
+"diff.delta" = "regular7"
+"diff.minus" = "regular1"
 
 "warning" = "bright4"
 "error" = "regular1"
-"info" = "#ffaf00"
+"info" = "bright4"
 
 "diagnostic.warning".underline = { color = "bright4", style = "curl" } 
 "diagnostic.error".underline = { color = "regular1", style = "curl" } 
-"diagnostic.info".underline = { color = "#ffaf00", style = "curl" } 
-"diagnostic.hint".underline = { color = "#ffaf00", style = "curl" } 
-
+"diagnostic.info".underline = { color = "bright4", style = "curl" } 
+"diagnostic.hint".underline = { color = "bright4", style = "curl" } 
 
 [palette]
 background="#eeeeee"
@@ -104,11 +103,11 @@ bright5="#d75f00"
 bright6="#005faf"
 bright7="#005f87"
 
-selection_foreground="#eeeeee"
-selection_secondary_foreground="#d9d7d7"
-selection_background="#0087af"
-selection_secondary_background="#2c687a"
-cursorline_background="#e4e4e4"
+selection_fg="#eeeeee"
+selection_secondary_fg="#d9d7d7"
+selection_bg="#0087af"
+selection_secondary_bg="#2c687a"
+cursorline_bg="#e4e4e4"
 paper_bar_bg="#005F87"
 linenr_fg_selected="#AF634D"
 special="#3E999F"

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -5,22 +5,25 @@
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
-"ui.selection" = {bg="selection_background", fg="selection_foreground"}
+"ui.selection" = {bg="selection_secondary_background", fg="selection_secondary_foreground"}
+"ui.selection.primary" = {bg="selection_background", fg="selection_foreground" }
 "ui.highlight" = {bg="cursorline_background"}
 "ui.cursorline" = {bg="cursorline_background"}
 "ui.statusline" = {bg="paper_bar_bg", fg="regular0"}
 "ui.statusline.select" = {bg="background", fg="bright7"}
 "ui.statusline.normal" = {bg="background", fg="bright3"}
 "ui.statusline.inactive" = {bg="bright0", fg="foreground"}
-"ui.virtual" = "indent"
+"ui.virtual" = {fg = "linenr_fg_selected"}
 "ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.ruler" = {bg="cursorline_background"}
-"ui.cursor.match" = {bg = "regular5", fg = "regular0"}
+"ui.virtual.indent-guide" = { bg = "regular5" }
+"ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
+"ui.cursor.match" = {bg = "bright0", fg = "regular0"}
 "ui.cursor" = {bg = "regular5", fg = "background"}
-"ui.window" = {bg = "#D0D0D0", fg = "bright2"}
+"ui.cursor.primary" = {bg = "foreground", fg = "background"}
+"ui.window" = {bg = "ui_window_bg", fg = "foreground"}
 "ui.help" = {bg = "background", fg = "bright2"}
-"ui.popup" = {bg = "#D0D0D0", fg = "bright7"}
-"ui.menu" = {bg = "#D0D0D0", fg = "bright7"}
+"ui.popup" = {bg = "ui_window_bg", fg = "foreground"}
+"ui.menu" = {bg = "ui_window_bg", fg = "foreground"}
 "ui.menu.selected" = {bg = "selection_background", fg="selection_foreground"}
 
 "markup.heading" = { fg = "bright7", modifiers = ["bold"] }
@@ -34,9 +37,9 @@
 "markup.bold" = { fg = "foreground", modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "regular4", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "regular4", underline.style = "line"  }
 "markup.link.text" = "bright2"
-"markup.link.label" = { fg = "regular7", modifiers = ["bold"] }
+"markup.link.label" = { fg = "regular2", modifiers = ["bold"] }
 "markup.raw" = "foreground"
 
 "string" = "foreground"
@@ -51,18 +54,18 @@
 "variable.other.member" = "regular4"
 "variable.parameter" = "foreground"
 
-"special" = "#3E999F"
+"special" = "special"
 "function"  = "bright1"
 "constructor" = "bright1"
 "function.builtin" = { fg = "regular4", modifiers = ["bold"]}
 "function.macro" = { fg = "regular1" }
 "comment" = { fg = "bright0", modifiers = ["dim"] }
 "ui.linenr" = { fg = "bright0" }
-"module" = "#af0000"
-"constant" = "#5f8700"
-"constant.builtin" = "#5f8700"
-"constant.numeric" = "#d75f00"
-"constant.character.escape" = { fg = "#8700af", modifiers = ["bold"]}
+"module" = "regular1"
+"constant" = "regular3"
+"constant.builtin" = "regular3"
+"constant.numeric" = "bright4"
+"constant.character.escape" = { fg = "bright3", modifiers = ["bold"]}
 "operator" = { fg = "regular4", modifiers = ["bold"]}
 
 "label" = { fg = "selection_background", modifiers = ["bold", "italic"] }
@@ -73,12 +76,12 @@
 
 "warning" = "bright4"
 "error" = "regular1"
-"info" = "#FFAF00"
+"info" = "#ffaf00"
 
 "diagnostic.warning".underline = { color = "bright4", style = "curl" } 
 "diagnostic.error".underline = { color = "regular1", style = "curl" } 
-"diagnostic.info".underline = { color = "#FFAF00", style = "curl" } 
-"diagnostic.hint".underline = { color = "#FFAF00", style = "curl" } 
+"diagnostic.info".underline = { color = "#ffaf00", style = "curl" } 
+"diagnostic.hint".underline = { color = "#ffaf00", style = "curl" } 
 
 
 [palette]
@@ -91,19 +94,27 @@ regular3="#5f8700"
 regular4="#0087af"
 regular5="#878787"
 regular6="#005f87"
-regular7="#764e37"
+regular7="#444444"
 bright0="#bcbcbc"
 bright1="#d70000"
 bright2="#d70087"
 bright3="#8700af"
 bright4="#d75f00"
 bright5="#d75f00"
-bright6="#4c7a5d"
-bright7="#005faf"
+bright6="#005faf"
+bright7="#005f87"
+
 selection_foreground="#eeeeee"
+selection_secondary_foreground="#d9d7d7"
 selection_background="#0087af"
+selection_secondary_background="#2c687a"
 cursorline_background="#fdfdfd"
 paper_bar_bg="#005F87"
+linenr_fg_selected="#AF634D"
+special="#3E999F"
+ui_window_bg="#d0d0d0"
+
+# 16 bit ANSI color names
 black="#eeeeee"
 red="#d70000"
 green="#008700"
@@ -111,13 +122,12 @@ yellow="#5f8700"
 blue="#0087af"
 magenta="#878787"
 cyan="#005f87"
-gray="#764e37"
+white="#444444"
+light-black="#bcbcbc"
 light-red="#d70000"
 light-green="#d70087"
 light-yellow="#8700af"
 light-blue="#d75f00"
 light-magenta="#d75f00"
 light-cyan="#4c7a4d"
-light-gray="#005faf"
-white="#444444"
-linenr_fg_selected="#AF634D"
+light-white="#005faf"

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -1,7 +1,8 @@
 # Palette based on https://github.com/NLKNguyen/papercolor-theme
 # Author: Soc Virnyl Estela <socvirnyl.estela@gmail.com>
 
-"ui.linenr.selected" = { fg = "linenr_fg_selected" }
+"ui.linenr.selected" = { fg = "linenr_fg_selected", modifiers = ["bold"] }
+"ui.linenr" = { fg = "bright0" }
 "ui.background" = {bg="background"}
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "selection_background", modifiers = ["bold"]}
@@ -15,7 +16,7 @@
 "ui.statusline.inactive" = {bg="bright0", fg="foreground"}
 "ui.virtual" = {fg = "linenr_fg_selected"}
 "ui.virtual.whitespace" = { fg = "regular5" }
-"ui.virtual.indent-guide" = { bg = "regular5" }
+"ui.virtual.indent-guide" = { fg="bright0" }
 "ui.virtual.ruler" = {bg = "bright0", fg="bright4"}
 "ui.cursor.match" = {bg = "bright0", fg = "regular0"}
 "ui.cursor" = {bg = "regular5", fg = "background"}
@@ -60,7 +61,6 @@
 "function.builtin" = { fg = "regular4", modifiers = ["bold"]}
 "function.macro" = { fg = "regular1" }
 "comment" = { fg = "bright0", modifiers = ["dim"] }
-"ui.linenr" = { fg = "bright0" }
 "module" = "regular1"
 "constant" = "regular3"
 "constant.builtin" = "regular3"
@@ -108,7 +108,7 @@ selection_foreground="#eeeeee"
 selection_secondary_foreground="#d9d7d7"
 selection_background="#0087af"
 selection_secondary_background="#2c687a"
-cursorline_background="#fdfdfd"
+cursorline_background="#e4e4e4"
 paper_bar_bg="#005F87"
 linenr_fg_selected="#AF634D"
 special="#3E999F"


### PR DESCRIPTION
Started out as just fixing the lints, ended up being a bit more substantial overhaul.

Primary changes:

*  Unify dark and light variants to share everything except palette
    * Enables using `inherits` feature
* Extend original Papercolor with multi-cursor color variations
    * Add indication for primary cursor
    * Make cursor visible from selection

Minor changes:

* Add more and align existing scopes with Vim plugin papercolor
* Match UI elements closer to original

## Light 
### Old
![image](https://github.com/helix-editor/helix/assets/2083498/e0c080f7-05f5-43b7-8149-bdca6aeeb15c)
### New
![image](https://github.com/helix-editor/helix/assets/2083498/7ceda74f-4553-4998-a0b3-69783f7f79f2)
### Vim
![image](https://github.com/helix-editor/helix/assets/2083498/3c73c774-9fd8-474d-9b7c-adb9b36b9f4f)

## Dark
### Old
![image](https://github.com/helix-editor/helix/assets/2083498/0296afbe-6751-47f6-afe7-8efbb6d9b069)
### New
![image](https://github.com/helix-editor/helix/assets/2083498/94fb8f19-d357-49f8-b5b3-9c4bd3318141)
### Vim
![image](https://github.com/helix-editor/helix/assets/2083498/b55d2e81-b612-4d74-8461-2e15b4dfbd68)

For both light and dark Vim screenshots, the cursor should be filled in, just like in Helix. Due to loss of focus when taking screenshots we get the boxed in letter variant instead. 
