### PR TITLE
Fix open windows path with spaces in prompt

### DIFF
--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -165,7 +165,7 @@ pub fn get_truncated_path<P: AsRef<Path>>(path: P) -> PathBuf {
 pub fn remove_quotes_from_windows_path(path: &Path) -> PathBuf {
     if cfg!(windows) {
         // remove double quotes from paths from Windows
-        PathBuf::from(path.to_string_lossy().replace("\"", ""))
+        PathBuf::from(path.to_string_lossy().replace('\"', ""))
     } else {
         path.to_path_buf()
     }

--- a/helix-core/src/path.rs
+++ b/helix-core/src/path.rs
@@ -160,3 +160,13 @@ pub fn get_truncated_path<P: AsRef<Path>>(path: P) -> PathBuf {
     ret.push(file);
     ret
 }
+
+/// Removes double quotes from Windows paths, otherwise returns path unchanged.
+pub fn remove_quotes_from_windows_path(path: &Path) -> PathBuf {
+    if cfg!(windows) {
+        // remove double quotes from paths from Windows
+        PathBuf::from(path.to_string_lossy().replace("\"", ""))
+    } else {
+        path.to_path_buf()
+    }
+}

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -110,6 +110,7 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
     for arg in args {
         let (path, pos) = args::parse_file(arg);
         let path = helix_core::path::expand_tilde(&path);
+        let path = helix_core::path::remove_quotes_from_windows_path(&path);
         // If the path is a directory, open a file picker on that directory and update the status
         // message
         if let Ok(true) = std::fs::canonicalize(&path).map(|p| p.is_dir()) {
@@ -1096,6 +1097,8 @@ fn change_current_directory(
             .as_ref()
             .as_ref(),
     );
+
+    let dir = helix_core::path::remove_quotes_from_windows_path(&dir);
 
     helix_loader::set_current_working_dir(dir)?;
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -407,6 +407,7 @@ pub mod completers {
 
         let is_tilde = input == "~";
         let path = helix_core::path::expand_tilde(Path::new(input));
+        let path = helix_core::path::remove_quotes_from_windows_path(&path);
 
         let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
             (path, None)


### PR DESCRIPTION
This allows Windows paths to be opened using the prompt if the path has a space in it (#5921).  Right now for `:cd` or `:open`, if a path has spaces you must type the entire path manually between quotes.  The prompt autocomplete currently puts quotes between folders or files with spaces, but it 1. is not separated properly in shellwords, 2. cannot be opened  with quotes in the middle of a path, and 3. puts the separator before the closing quote which breaks the file list builder.

The " characters need to be stripped out from the string if they are in the middle of the path. It is possible to use a path surrounded with doublequotes, and I originally wanted to rewrite the argument to add a " at the beginning of the argument when a file or folder with spaces is selected, but I ended up with too hacky of a solution using shellwords in the change_completion_selection function.  I think if there were an ergonomic way to do this, I'd much prefer to do it that way. 

I was tempted to add the bit that strips out the quotes in expand_tilde 😅. Not sure if there's a better way to do this.

The caveat with this fix is it still will not work if you start the path with " (i.e. typing :cd "C:\"Program Files"" will not work). Entering :cd "C:\Program Files" does work but the autocomplete prompts will not work. I had issues maintainly compatibility with other tests and #4098 when trying to get this to work in shellwords.  Maybe it could be worked around by checking if the argument starts with with " but then we run into the same issue above of determining where the argument begins.