### PR TITLE
[theme] add cyan_light theme

### DIFF
--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -10,7 +10,7 @@
 "constant" = "darker_blue"
 "constant.builtin.boolean" = "blue"
 "constant.character" = "blue"
-"constant.character.escape" = "blue"
+"constant.character.escape" = "dark_red"
 "constant.numeric" = "blue"
 
 "string" = "green"

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -10,7 +10,7 @@
 "constant" = "darker_blue"
 "constant.builtin.boolean" = "blue"
 "constant.character" = "blue"
-"constant.characted.escape" = "blue"
+"constant.character.escape" = "blue"
 "constant.numeric" = "blue"
 
 "string" = "green"

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -63,7 +63,7 @@
 
 # ui specific
 "ui.background" = { bg = "shade00" }
-"ui.cursor" = { bg = "shade03" }
+"ui.cursor" = { bg = "shade02" }
 "ui.cursor.primary" = { bg = "cursor_blue" }
 "ui.cursor.match" = { fg = "shade00", bg = "shade04" }
 "ui.cursor.primary.select" = { bg = "light_purple" }

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -90,11 +90,11 @@
 "ui.window" = { bg = "shade00", fg = "shade04" }
 "ui.help" = { fg = "shade06", bg = "shade01" }
 "ui.text" = "shade05"
-"ui.text.focus" = { fg = "shade05", bg = "diff_green" }
+"ui.text.focus" = { fg = "shade07", bg = "light_blue" }
 "ui.virtual" = "shade03"
 "ui.virtual.ruler" = { bg = "shade04" }
 "ui.menu" = { fg = "shade05", bg = "shade01" }
-"ui.menu.selected" = { fg = "shade00", bg = "light_blue" }
+"ui.menu.selected" = { fg = "shade07", bg = "light_blue" }
 
 "hint" = "shade04"
 "info" = "light_blue"

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -1,0 +1,151 @@
+# An approximation/port of the Cyan Light Theme from Jetbrains
+# 
+# Original Color Scheme here https://plugins.jetbrains.com/plugin/12102-cyan-light-theme
+
+"attribute" = "blue"
+"type" = "shade07"
+"type.enum.variant" = "purple"
+"constructor" = "shade07"
+
+"constant" = "darker_blue"
+"constant.builtin.boolean" = "blue"
+"constant.character" = "blue"
+"constant.characted.escape" = "blue"
+"constant.numeric" = "blue"
+
+"string" = "green"
+"string.regexp" = "blue"
+"string.special" = { fg = "dark_red", modifiers = ["underlined"] }
+
+"comment" = "comment_gray"
+
+"variable" = "green_blue"
+"variable.builtin" = { fg = "darker_blue" }
+"variable.parameter" = "purple"
+"variable.other.member" = "purple"
+
+"label" = { fg = "darker_blue", modifiers = ["underlined"] }
+"punctuation" = "shade06"
+
+"keyword" = "darker_blue"
+"keyword.control.exception" = "darker_blue"
+
+"operator" = "shade06"
+
+"function" = "shade07"
+"function.macro" = "yellow"
+"function.builtin" = { fg = "shade07", modifiers = ["italic"] }
+"function.special" = "dark_red"
+"function.method" = "dark_yellow"
+
+"tag" = "darker_blue"
+"special" = "shade06"
+"namespace" = "darker_blue"
+
+"markup.bold" = { fg = "shade06", modifiers = ["bold"] }
+"markup.italic" = { fg = "shade06", modifiers = ["italic"] }
+"markup.strikethrough" = { fg = "shade06", modifiers = ["crossed_out"] }
+"markup.heading" = { fg = "purple" }
+"markup.list" = "darker_blue"
+"markup.list.numbered" = "darker_blue"
+"markup.list.unnumbered" = "darker_blue"
+"markup.link.url" = "shade06"
+"markup.link.text" = { fg = "dark_blue", modifiers = ['underlined'] }
+"markup.link.label" = "dark_blue"
+"markup.quote" = "green"
+"markup.raw" = "green"
+"markup.raw.inline" = "green"
+"markup.raw.block" = "green"
+
+"diff.plus" = "diff_green"
+"diff.minus" = "diff_red"
+"diff.delta" = "diff_blue"
+
+# ui specific
+"ui.background" = { bg = "shade00" }
+"ui.cursor" = { bg = "shade03" }
+"ui.cursor.primary" = { bg = "cursor_blue" }
+"ui.cursor.match" = { fg = "shade00", bg = "shade04" }
+"ui.cursor.primary.select" = { bg = "light_purple" }
+"ui.cursor.primary.insert" = { bg = "light_green" }
+
+"ui.selection" = { bg = "lighter_blue" }
+"ui.selection.primary" = { bg = "lighter_blue" }
+
+"ui.highlight" = { bg = "faint_blue" }
+"ui.cursorline.primary" = { bg = "faint_blue" }
+
+"ui.linenr" = { fg = "shade03" }
+"ui.linenr.selected" = { fg = "shade04", bg = "faint_blue", modifiers = [
+    "bold",
+] }
+
+"ui.statusline" = { fg = "shade06", bg = "shade02" }
+"ui.statusline.inactive" = { fg = "shade04", bg = "shade01" }
+"ui.statusline.normal" = { fg = "shade00", bg = "blue" }
+"ui.statusline.insert" = { fg = "shade00", bg = "green" }
+"ui.statusline.select" = { fg = "shade00", bg = "purple" }
+
+"ui.popup" = { bg = "shade01", fg = "shade04" }
+"ui.window" = { bg = "shade00", fg = "shade04" }
+"ui.help" = { fg = "shade06", bg = "shade01" }
+"ui.text" = "shade05"
+"ui.text.focus" = { fg = "shade05", bg = "diff_green" }
+"ui.virtual" = "shade03"
+"ui.virtual.ruler" = { bg = "shade04" }
+"ui.menu" = { fg = "shade05", bg = "shade01" }
+"ui.menu.selected" = { fg = "shade00", bg = "light_blue" }
+
+"hint" = "shade04"
+"info" = "light_blue"
+"warning" = "orange"
+"error" = "red"
+"diagnostic" = { modifiers = [] }
+"diagnostic.hint" = { underline = { color = "shade04", style = "line" } }
+"diagnostic.info" = { underline = { color = "light_blue", style = "line" } }
+"diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+
+[palette]
+shade00 = "#f2f3f7"
+shade01 = "#dadde8"
+shade02 = "#c1c6d9"
+shade03 = "#a9b0ca"
+shade04 = "#525c85"
+shade05 = "#434b6c"
+shade06 = "#343a54"
+shade07 = "#25293c"
+
+background = "#f2f3f7"
+foreground = "#25293c"
+
+comment_gray = "#808080"
+
+diff_blue = "#C3D6E8"
+faint_blue = "#E8Eef1"
+lighter_blue = "#d0eaff"
+light_blue = "#99ccff"
+cursor_blue = "#80bfff"
+blue = "#0073E6"
+dark_blue = "#185b93"
+darker_blue = "#000080"
+
+
+purple = "#660E7A"
+light_purple = "#ED9CFF"
+
+diff_green = "#C9DEC1"
+green = "#00733B"
+light_green = "#5DCE87"
+green_blue = "#458383"
+
+
+yellow = "#808000"
+dark_yellow = "#7A7A43"
+
+light_orange = "#f9c881"
+orange = "#F49810"
+
+diff_red = "#EBBCBC"
+red = "#d90016"
+dark_red = "#7F0000"


### PR DESCRIPTION
👋🏼  Hi there,

This is an approximate port of the [Cyan Light JetBrains](https://plugins.jetbrains.com/plugin/12102-cyan-light-theme) Light color scheme.

I hope others find it useful and would contribute if they find color accessibility issues.

Here are few screenshots

### Toml file preview
![image](https://github.com/helix-editor/helix/assets/302837/a52143b7-447a-4570-a148-676689db0b2c)

### Completion menu and diagnostics
![image](https://github.com/helix-editor/helix/assets/302837/3613a1a8-2678-4805-8095-c553864d6d85)

### Picker
![image](https://github.com/helix-editor/helix/assets/302837/b653b72d-4e55-46aa-a249-bdbc934b1e68)

### Multiple keys menu
![image](https://github.com/helix-editor/helix/assets/302837/35175ad1-61b5-4d23-85a8-71698c247cab)

### Multiple Cursors
https://github.com/helix-editor/helix/assets/302837/1d339b65-0fcf-4e0b-96a5-1de3497994e2


