### PR TITLE
feat: find closest pairs using tree-sitter

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -122,7 +122,7 @@ impl Range {
     }
 
     /// `Direction::Backward` when head < anchor.
-    /// `Direction::Backward` otherwise.
+    /// `Direction::Forward` otherwise.
     #[inline]
     #[must_use]
     pub fn direction(&self) -> Direction {

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -331,7 +331,7 @@ mod test {
             );
 
         assert_eq!(
-            get_surround_pos(doc.slice(..), &selection, Some('('), 1).unwrap(),
+            get_surround_pos(None, doc.slice(..), &selection, Some('('), 1).unwrap(),
             expectations
         );
     }
@@ -346,7 +346,7 @@ mod test {
             );
 
         assert_eq!(
-            get_surround_pos(doc.slice(..), &selection, Some('('), 1),
+            get_surround_pos(None, doc.slice(..), &selection, Some('('), 1),
             Err(Error::PairNotFound)
         );
     }
@@ -361,7 +361,7 @@ mod test {
             );
 
         assert_eq!(
-            get_surround_pos(doc.slice(..), &selection, Some('('), 1),
+            get_surround_pos(None, doc.slice(..), &selection, Some('('), 1),
             Err(Error::PairNotFound) // overlapping surround chars
         );
     }
@@ -376,7 +376,7 @@ mod test {
             );
 
         assert_eq!(
-            get_surround_pos(doc.slice(..), &selection, Some('['), 1),
+            get_surround_pos(None, doc.slice(..), &selection, Some('['), 1),
             Err(Error::CursorOverlap)
         );
     }
@@ -440,7 +440,7 @@ mod test {
             );
 
         assert_eq!(
-            find_nth_closest_pairs_pos(doc.slice(..), selection.primary(), 1),
+            find_nth_closest_pairs_pos(None, doc.slice(..), selection.primary(), 1),
             Err(Error::PairNotFound)
         )
     }

--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -1,17 +1,15 @@
 use std::fmt::Display;
 
-use crate::{movement::Direction, search, Range, Selection};
+use crate::{
+    graphemes::next_grapheme_boundary,
+    match_brackets::{
+        find_matching_bracket, find_matching_bracket_fuzzy, get_pair, is_close_bracket,
+        is_open_bracket,
+    },
+    movement::Direction,
+    search, Range, Selection, Syntax,
+};
 use ropey::RopeSlice;
-
-pub const PAIRS: &[(char, char)] = &[
-    ('(', ')'),
-    ('[', ']'),
-    ('{', '}'),
-    ('<', '>'),
-    ('«', '»'),
-    ('「', '」'),
-    ('（', '）'),
-];
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -34,32 +32,68 @@ impl Display for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-/// Given any char in [PAIRS], return the open and closing chars. If not found in
-/// [PAIRS] return (ch, ch).
+/// Finds the position of surround pairs of any [`crate::match_brackets::PAIRS`]
+/// using tree-sitter when possible.
 ///
-/// ```
-/// use helix_core::surround::get_pair;
+/// # Returns
 ///
-/// assert_eq!(get_pair('['), ('[', ']'));
-/// assert_eq!(get_pair('}'), ('{', '}'));
-/// assert_eq!(get_pair('"'), ('"', '"'));
-/// ```
-pub fn get_pair(ch: char) -> (char, char) {
-    PAIRS
-        .iter()
-        .find(|(open, close)| *open == ch || *close == ch)
-        .copied()
-        .unwrap_or((ch, ch))
+/// Tuple `(anchor, head)`, meaning it is not always ordered.
+pub fn find_nth_closest_pairs_pos(
+    syntax: Option<&Syntax>,
+    text: RopeSlice,
+    range: Range,
+    skip: usize,
+) -> Result<(usize, usize)> {
+    match syntax {
+        Some(syntax) => find_nth_closest_pairs_ts(syntax, text, range, skip),
+        None => find_nth_closest_pairs_plain(text, range, skip),
+    }
 }
 
-pub fn find_nth_closest_pairs_pos(
+fn find_nth_closest_pairs_ts(
+    syntax: &Syntax,
     text: RopeSlice,
     range: Range,
     mut skip: usize,
 ) -> Result<(usize, usize)> {
-    let is_open_pair = |ch| PAIRS.iter().any(|(open, _)| *open == ch);
-    let is_close_pair = |ch| PAIRS.iter().any(|(_, close)| *close == ch);
+    let mut opening = range.from();
+    // We want to expand the selection if we are already on the found pair,
+    // otherwise we would need to subtract "-1" from "range.to()".
+    let mut closing = range.to();
 
+    while skip > 0 {
+        closing = find_matching_bracket_fuzzy(syntax, text, closing).ok_or(Error::PairNotFound)?;
+        opening = find_matching_bracket(syntax, text, closing).ok_or(Error::PairNotFound)?;
+        // If we're already on a closing bracket "find_matching_bracket_fuzzy" will return
+        // the position of the opening bracket.
+        if closing < opening {
+            (opening, closing) = (closing, opening);
+        }
+
+        // In case found brackets are partially inside current selection.
+        if range.from() < opening || closing < range.to() - 1 {
+            closing = next_grapheme_boundary(text, closing);
+        } else {
+            skip -= 1;
+            if skip != 0 {
+                closing = next_grapheme_boundary(text, closing);
+            }
+        }
+    }
+
+    // Keep the original direction.
+    if let Direction::Forward = range.direction() {
+        Ok((opening, closing))
+    } else {
+        Ok((closing, opening))
+    }
+}
+
+fn find_nth_closest_pairs_plain(
+    text: RopeSlice,
+    range: Range,
+    mut skip: usize,
+) -> Result<(usize, usize)> {
     let mut stack = Vec::with_capacity(2);
     let pos = range.from();
     let mut close_pos = pos.saturating_sub(1);
@@ -67,7 +101,7 @@ pub fn find_nth_closest_pairs_pos(
     for ch in text.chars_at(pos) {
         close_pos += 1;
 
-        if is_open_pair(ch) {
+        if is_open_bracket(ch) {
             // Track open pairs encountered so that we can step over
             // the corresponding close pairs that will come up further
             // down the loop. We want to find a lone close pair whose
@@ -76,7 +110,7 @@ pub fn find_nth_closest_pairs_pos(
             continue;
         }
 
-        if !is_close_pair(ch) {
+        if !is_close_bracket(ch) {
             // We don't care if this character isn't a brace pair item,
             // so short circuit here.
             continue;
@@ -157,7 +191,11 @@ pub fn find_nth_pairs_pos(
         )
     };
 
-    Option::zip(open, close).ok_or(Error::PairNotFound)
+    // preserve original direction
+    match range.direction() {
+        Direction::Forward => Option::zip(open, close).ok_or(Error::PairNotFound),
+        Direction::Backward => Option::zip(close, open).ok_or(Error::PairNotFound),
+    }
 }
 
 fn find_nth_open_pair(
@@ -249,6 +287,7 @@ fn find_nth_close_pair(
 /// are automatically detected around each cursor (note that this may result
 /// in them selecting different surround characters for each selection).
 pub fn get_surround_pos(
+    syntax: Option<&Syntax>,
     text: RopeSlice,
     selection: &Selection,
     ch: Option<char>,
@@ -257,9 +296,13 @@ pub fn get_surround_pos(
     let mut change_pos = Vec::new();
 
     for &range in selection {
-        let (open_pos, close_pos) = match ch {
-            Some(ch) => find_nth_pairs_pos(text, ch, range, skip)?,
-            None => find_nth_closest_pairs_pos(text, range, skip)?,
+        let (open_pos, close_pos) = {
+            let range_raw = match ch {
+                Some(ch) => find_nth_pairs_pos(text, ch, range, skip)?,
+                None => find_nth_closest_pairs_pos(syntax, text, range, skip)?,
+            };
+            let range = Range::new(range_raw.0, range_raw.1);
+            (range.from(), range.to())
         };
         if change_pos.contains(&open_pos) || change_pos.contains(&close_pos) {
             return Err(Error::CursorOverlap);

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -7,9 +7,9 @@ use crate::chars::{categorize_char, char_is_whitespace, CharCategory};
 use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
 use crate::line_ending::rope_is_line_ending;
 use crate::movement::Direction;
-use crate::surround;
 use crate::syntax::LanguageConfiguration;
 use crate::Range;
+use crate::{surround, Syntax};
 
 fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, long: bool) -> usize {
     use CharCategory::{Eol, Whitespace};
@@ -199,25 +199,28 @@ pub fn textobject_paragraph(
 }
 
 pub fn textobject_pair_surround(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     ch: char,
     count: usize,
 ) -> Range {
-    textobject_pair_surround_impl(slice, range, textobject, Some(ch), count)
+    textobject_pair_surround_impl(syntax, slice, range, textobject, Some(ch), count)
 }
 
 pub fn textobject_pair_surround_closest(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
     count: usize,
 ) -> Range {
-    textobject_pair_surround_impl(slice, range, textobject, None, count)
+    textobject_pair_surround_impl(syntax, slice, range, textobject, None, count)
 }
 
 fn textobject_pair_surround_impl(
+    syntax: Option<&Syntax>,
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
@@ -226,8 +229,7 @@ fn textobject_pair_surround_impl(
 ) -> Range {
     let pair_pos = match ch {
         Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
-        // Automatically find the closest surround pairs
-        None => surround::find_nth_closest_pairs_pos(slice, range, count),
+        None => surround::find_nth_closest_pairs_pos(syntax, slice, range, count),
     };
     pair_pos
         .map(|(anchor, head)| match textobject {

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -576,7 +576,8 @@ mod test {
             let slice = doc.slice(..);
             for &case in scenario {
                 let (pos, objtype, expected_range, ch, count) = case;
-                let result = textobject_pair_surround(slice, Range::point(pos), objtype, ch, count);
+                let result =
+                    textobject_pair_surround(None, slice, Range::point(pos), objtype, ch, count);
                 assert_eq!(
                     result,
                     expected_range.into(),

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -664,3 +664,63 @@ async fn test_read_file() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn surround_delete() -> anyhow::Result<()> {
+    // Test `surround_delete` when head < anchor
+    test(("(#[|  ]#)", "mdm", "#[|  ]#")).await?;
+    test(("(#[|  ]#)", "md(", "#[|  ]#")).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn surround_replace_ts() -> anyhow::Result<()> {
+    const INPUT: &str = r#"\
+fn foo() {
+    if let Some(_) = None {
+        todo!("f#[|o]#o)");
+    }
+}
+"#;
+    test((
+        INPUT,
+        ":lang rust<ret>mrm'",
+        r#"\
+fn foo() {
+    if let Some(_) = None {
+        todo!('f#[|o]#o)');
+    }
+}
+"#,
+    ))
+    .await?;
+
+    test((
+        INPUT,
+        ":lang rust<ret>3mrm[",
+        r#"\
+fn foo() {
+    if let Some(_) = None [
+        todo!("f#[|o]#o)");
+    ]
+}
+"#,
+    ))
+    .await?;
+
+    test((
+        INPUT,
+        ":lang rust<ret>2mrm{",
+        r#"\
+fn foo() {
+    if let Some(_) = None {
+        todo!{"f#[|o]#o)"};
+    }
+}
+"#,
+    ))
+    .await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -107,6 +107,14 @@ async fn surround_by_character() -> anyhow::Result<()> {
     ))
     .await?;
 
+    // Selection direction is preserved
+    test((
+        "(so [many {go#[|od]#} text] here)",
+        "mi{",
+        "(so [many {#[|good]#} text] here)",
+    ))
+    .await?;
+
     Ok(())
 }
 
@@ -361,6 +369,41 @@ async fn surround_around_pair() -> anyhow::Result<()> {
         "mam",
         "#[(so (many (good) text) here\nso (many (good) text) here)|]#",
     ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn match_around_closest_ts() -> anyhow::Result<()> {
+    test_with_config(
+        AppBuilder::new().with_file("foo.rs", None),
+        (
+            r#"fn main() {todo!{"f#[|oo]#)"};}"#,
+            "mam",
+            r#"fn main() {todo!{#[|"foo)"]#};}"#,
+        ),
+    )
+    .await?;
+
+    test_with_config(
+        AppBuilder::new().with_file("foo.rs", None),
+        (
+            r##"fn main() { let _ = ("#[|1]#23", "#(|1)#23"); } "##,
+            "3mam",
+            r##"fn main() #[|{ let _ = ("123", "123"); }]# "##,
+        ),
+    )
+    .await?;
+
+    test_with_config(
+        AppBuilder::new().with_file("foo.rs", None),
+        (
+            r##" fn main() { let _ = ("12#[|3", "12]#3"); } "##,
+            "1mam",
+            r##" fn main() { let _ = #[|("123", "123")]#; } "##,
+        ),
+    )
     .await?;
 
     Ok(())


### PR DESCRIPTION
Closes #8325 
closes  #3615
closes #3432
closes #4475
closes #7012

Finding the closest surround pairs (`mim`, `mam`) was done without being aware of the syntax. This PR adds a tree-sitter implementation that may be faster (untested), but most important it's more correct.
If the syntax distinct strings than `mim` and `mam` will work inside strings (didn't work with plaintext impl), matching should also work inside injections.

<details>
<summary>OLD</summary>
`find_nth_closest_pairs_pos` produces unsorted tuple. The tuple must be sorted before passing it to the change Transaction. Otherwise, this statement will fail:
https://github.com/helix-editor/helix/blob/13d4463e4146473391e37b7f75e99b731aa55878/helix-core/src/transaction.rs#L582-L585

MRE: 
1. `hx`
2. repeat exact keys (two spaces after "("): `(  <esc>hvhmdm`. Make sure `auto-pairs` is turn on.
</details>