### PR TITLE
feat: add using as typescript keyword

### DIFF
--- a/runtime/queries/_typescript/highlights.scm
+++ b/runtime/queries/_typescript/highlights.scm
@@ -89,6 +89,7 @@
   "namespace"
   "override"
   "satisfies"
+  "using"
 ] @keyword
 
 [


### PR DESCRIPTION
https://www.totaltypescript.com/typescript-5-2-new-keyword-using

deno recently add support for this https://github.com/denoland/deno/commit/6dc8682b9acabea56fd69a25c28b6a8f95c2ce26 (you can test with deno upgrade --canary)

I didn't test how the colors looks like