### PR TITLE
Global .ignore file

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -86,6 +86,7 @@ mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
 ```
+
 The `[editor.statusline]` key takes the following sub-keys:
 
 | Key           | Description | Default |
@@ -171,6 +172,7 @@ All git related options are only enabled in a git repository.
 |`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | true
 |`parents` | Enables reading ignore files from parent directories | true
 |`ignore` | Enables reading `.ignore` files | true
+|`global-ignore` | Enables reading a global `.ignore` file from the same directory as the config.toml configuration | true
 |`git-ignore` | Enables reading `.gitignore` files | true
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludefile` option | true
 |`git-exclude` | Enables reading `.git/info/exclude` files | true
@@ -337,7 +339,7 @@ Options for soft wrapping lines that exceed the view width:
 | `enable`             | Whether soft wrapping is enabled.                            | `false` |
 | `max-wrap`           | Maximum free space left at the end of the line.              | `20`    |
 | `max-indent-retain`  | Maximum indentation to carry over when soft wrapping a line. | `40`    |
-| `wrap-indicator`     | Text inserted before soft wrapped lines, highlighted with `ui.virtual.wrap` | `↪ `    |
+| `wrap-indicator`     | Text inserted before soft wrapped lines, highlighted with `ui.virtual.wrap` | `↪`    |
 | `wrap-at-text-width` | Soft wrap at `text-width` instead of using the full viewport size. | `false` |
 
 Example:

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -171,7 +171,6 @@ All git related options are only enabled in a git repository.
 |`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | true
 |`parents` | Enables reading ignore files from parent directories | true
 |`ignore` | Enables reading `.ignore` files | true
-|`global-ignore` | Enables reading a global `.ignore` file from the same directory as the config.toml configuration | true
 |`git-ignore` | Enables reading `.gitignore` files | true
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludefile` option | true
 |`git-exclude` | Enables reading `.git/info/exclude` files | true

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -86,7 +86,6 @@ mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
 ```
-
 The `[editor.statusline]` key takes the following sub-keys:
 
 | Key           | Description | Default |
@@ -339,7 +338,7 @@ Options for soft wrapping lines that exceed the view width:
 | `enable`             | Whether soft wrapping is enabled.                            | `false` |
 | `max-wrap`           | Maximum free space left at the end of the line.              | `20`    |
 | `max-indent-retain`  | Maximum indentation to carry over when soft wrapping a line. | `40`    |
-| `wrap-indicator`     | Text inserted before soft wrapped lines, highlighted with `ui.virtual.wrap` | `↪`    |
+| `wrap-indicator`     | Text inserted before soft wrapped lines, highlighted with `ui.virtual.wrap` | `↪ `    |
 | `wrap-at-text-width` | Soft wrap at `text-width` instead of using the full viewport size. | `false` |
 
 Example:

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -357,3 +357,8 @@ wrap-indicator = ""  # set wrap-indicator to "" to hide it
 |------------|-------------|---------|
 | `enable` | If set to true, then when the cursor is in a position with non-whitespace to its left, instead of inserting a tab, it will run `move_parent_node_end`. If there is only whitespace to the left, then it inserts a tab as normal. With the default bindings, to explicitly insert a tab character, press Shift-tab. | `true` |
 | `supersede-menu` | Normally, when a menu is on screen, such as when auto complete is triggered, the tab key is bound to cycling through the items. This means when menus are on screen, one cannot use the tab key to trigger the `smart-tab` command. If this option is set to true, the `smart-tab` command always takes precedence, which means one cannot use the tab key to cycle through menu items. One of the other bindings must be used instead, such as arrow keys or `C-n`/`C-p`. | `false` |
+
+
+## Global .ignore file
+
+You can add a global .ignore file to the config directory. This will have the lowest priority when resolving ignore files (.ignore and .gitignore).

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -177,6 +177,15 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks));
 
+    // Add global .ignore
+    if config.file_picker.global_ignore {
+        if let Some(ignore_error) =
+            walk_builder.add_ignore(helix_loader::config_dir().join(".ignore"))
+        {
+            log::error!("Failed to add the global ignore file: {}", ignore_error);
+        }
+    }
+
     // We want to exclude files that the editor can't handle yet
     let mut type_builder = TypesBuilder::new();
     type_builder

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -177,11 +177,10 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks));
 
-    // Add global .ignore
-    if config.file_picker.global_ignore {
-        if let Some(ignore_error) =
-            walk_builder.add_ignore(helix_loader::config_dir().join(".ignore"))
-        {
+    // Add global .ignore when available
+    let global_ignore_path = helix_loader::config_dir().join(".ignore");
+    if global_ignore_path.exists() {
+        if let Some(ignore_error) = walk_builder.add_ignore(global_ignore_path) {
             log::error!("Failed to add the global ignore file: {}", ignore_error);
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -180,6 +180,8 @@ pub struct FilePickerConfig {
     /// Enables reading `.ignore` files.
     /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to true.
     pub ignore: bool,
+    /// Enables reading a global `.ignore` file. Defaults to true.
+    pub global_ignore: bool,
     /// Enables reading `.gitignore` files.
     /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to true.
     pub git_ignore: bool,
@@ -202,6 +204,7 @@ impl Default for FilePickerConfig {
             deduplicate_links: true,
             parents: true,
             ignore: true,
+            global_ignore: true,
             git_ignore: true,
             git_global: true,
             git_exclude: true,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -180,8 +180,6 @@ pub struct FilePickerConfig {
     /// Enables reading `.ignore` files.
     /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to true.
     pub ignore: bool,
-    /// Enables reading a global `.ignore` file. Defaults to true.
-    pub global_ignore: bool,
     /// Enables reading `.gitignore` files.
     /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to true.
     pub git_ignore: bool,
@@ -204,7 +202,6 @@ impl Default for FilePickerConfig {
             deduplicate_links: true,
             parents: true,
             ignore: true,
-            global_ignore: true,
             git_ignore: true,
             git_global: true,
             git_exclude: true,


### PR DESCRIPTION
I was missing an option to use a global .ignore file to globally ignore (some) binary files. Some of those (e.g. images) might be checked into VCS, so the global git ignore is not helpful in that case.  
I considered just checking whether the file exists and adding it but then switched to adding it to the config instead. The option could also be a path to the global .ignore.

A command to create such a default global .ignore could be added, but a follow-up PR would probably make more sense for that.