### PR TITLE
Add JSON highlighting for `flake.lock` files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -317,7 +317,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 scope = "source.json"
 injection-regex = "json"
-file-types = ["json", "jsonc", "arb", "ipynb", "geojson", "gltf"]
+file-types = ["json", "jsonc", "arb", "ipynb", "geojson", "gltf", "flake.lock"]
 roots = []
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true


### PR DESCRIPTION
Configures `flake.lock` Nix files to use JSON highlighting.

Built locally and verified that this works.

Closes #8281