### PR TITLE
Use Maskhjarnas tree-sitter-purescript

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -120,7 +120,7 @@
 | prolog |  |  |  | `swipl` |
 | protobuf | ✓ |  | ✓ | `bufls`, `pb` |
 | prql | ✓ |  |  |  |
-| purescript | ✓ |  |  | `purescript-language-server` |
+| purescript | ✓ | ✓ |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | `pylsp` |
 | qml | ✓ |  | ✓ | `qmlls` |
 | r | ✓ |  |  | `R` |

--- a/languages.toml
+++ b/languages.toml
@@ -1003,7 +1003,10 @@ language-servers = [ "purescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 auto-format = true
 formatter = { command = "purs-tidy", args = ["format"] }
-grammar = "haskell"
+
+[[grammar]]
+name = "purescript"
+source = { git = "https://github.com/maskhjarna/tree-sitter-purescript", rev = "a9af5ded2ccb3bd83b99724762cfde600fcf867c" }
 
 [[language]]
 name = "zig"

--- a/languages.toml
+++ b/languages.toml
@@ -1006,7 +1006,7 @@ formatter = { command = "purs-tidy", args = ["format"] }
 
 [[grammar]]
 name = "purescript"
-source = { git = "https://github.com/maskhjarna/tree-sitter-purescript", rev = "a9af5ded2ccb3bd83b99724762cfde600fcf867c" }
+source = { git = "https://github.com/maskhjarna/tree-sitter-purescript", rev = "5f5a030826849b7be17596d372967f60051b42bd" }
 
 [[language]]
 name = "zig"

--- a/runtime/queries/purescript/highlights.scm
+++ b/runtime/queries/purescript/highlights.scm
@@ -1,1 +1,121 @@
-; inherits: haskell
+; ----------------------------------------------------------------------------
+; Literals and comments
+
+ (integer) @constant.numeric.integer
+ (exp_negation) @constant.numeric.integer
+ (exp_literal (float)) @constant.numeric.float
+ (char) @constant.character
+ (string) @string
+
+ (con_unit) @constant.builtin ; unit, as in ()
+
+ (comment) @comment
+
+
+; ----------------------------------------------------------------------------
+; Punctuation
+
+ [
+   "("
+   ")"
+   "{"
+   "}"
+   "["
+   "]"
+ ] @punctuation.bracket
+
+ [
+ (comma)
+ ";"
+ ] @punctuation.delimiter
+
+
+; ----------------------------------------------------------------------------
+; Keywords, operators, includes
+
+ (pragma) @constant.macro
+
+ [
+   "if"
+   "then"
+   "else"
+   "case"
+   "of"
+ ] @keyword.control.conditional
+
+ [
+   "import"
+   "module"
+ ] @keyword.control.import
+
+ [
+   (operator)
+   (constructor_operator)
+   (type_operator)
+   (tycon_arrow)
+   (qualified_module)  ; grabs the `.` (dot), ex: import System.IO
+   (all_names)
+   (wildcard)
+   "="
+   "|"
+   "::"
+   "=>"
+   "->"
+   "<-"
+   "\\"
+   "`"
+   "@"
+ ] @operator
+
+ (qualified_module (module) @constructor)
+ (module) @namespace
+ (qualified_type (module) @namespace)
+ (qualified_variable (module) @namespace)
+ (import (module) @namespace)
+
+ [
+   (where)
+   "let"
+   "in"
+   "class"
+   "instance"
+   "derive"
+   "foreign"
+   "data"
+   "newtype"
+   "type"
+   "as"
+   "do"
+   "ado"
+   "forall"
+   "∀"
+   "infix"
+   "infixl"
+   "infixr"
+ ] @keyword
+
+
+; ----------------------------------------------------------------------------
+; Functions and variables
+
+ (signature name: (variable) @type)
+ (function name: (variable) @function)
+
+ ; true or false
+((variable) @constant.builtin.boolean
+ (#match? @constant.builtin.boolean "^(true|false)$"))
+
+ (variable) @variable
+
+ (exp_infix (variable) @operator)  ; consider infix functions as operators
+
+ ("@" @namespace)  ; "as" pattern operator, e.g. x@Constructor
+
+
+; ----------------------------------------------------------------------------
+; Types
+
+ (type) @type
+
+ (constructor) @constructor
+

--- a/runtime/queries/purescript/highlights.scm
+++ b/runtime/queries/purescript/highlights.scm
@@ -33,8 +33,6 @@
 ; ----------------------------------------------------------------------------
 ; Keywords, operators, includes
 
- (pragma) @constant.macro
-
  [
    "if"
    "then"
@@ -55,7 +53,6 @@
    (tycon_arrow)
    (qualified_module)  ; grabs the `.` (dot), ex: import System.IO
    (all_names)
-   (wildcard)
    "="
    "|"
    "::"

--- a/runtime/queries/purescript/injections.scm
+++ b/runtime/queries/purescript/injections.scm
@@ -1,1 +1,2 @@
-; inherits: haskell
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/purescript/locals.scm
+++ b/runtime/queries/purescript/locals.scm
@@ -1,1 +1,4 @@
-; inherits: haskell
+(signature name: (variable)) @local.definition
+(function name: (variable)) @local.definition
+(pat_name (variable)) @local.definition
+(exp_name (variable)) @local.reference

--- a/runtime/queries/purescript/textobjects.scm
+++ b/runtime/queries/purescript/textobjects.scm
@@ -1,13 +1,13 @@
 (comment) @comment.inside
 
 [
-  (decl_adt)
-  (decl_type)
+  (data)
+  (type)
   (newtype)
 ] @class.around
 
 ((signature)? (function rhs:(_) @function.inside)) @function.around 
 (exp_lambda) @function.around
 
-(adt (type_variable) @parameter.inside)
+(data (type_variable) @parameter.inside)
 (patterns (_) @parameter.inside)

--- a/runtime/queries/purescript/textobjects.scm
+++ b/runtime/queries/purescript/textobjects.scm
@@ -1,0 +1,13 @@
+(comment) @comment.inside
+
+[
+  (decl_adt)
+  (decl_type)
+  (newtype)
+] @class.around
+
+((signature)? (function rhs:(_) @function.inside)) @function.around 
+(exp_lambda) @function.around
+
+(adt (type_variable) @parameter.inside)
+(patterns (_) @parameter.inside)


### PR DESCRIPTION
Currently PureScript piggybacks on the haskell tree-sitter, which is less than optimal. I use @Maskhjarna's tree-sitter-purescript, which currently is the most feature complete implementation. I use this daily in my work, and while it has a couple bugs, it's far better than the haskell tree-sitter.