### PR TITLE
Add `.editorconfig` highlighting as INI

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2290,7 +2290,8 @@ file-types = [
   "container",
   "volume",
   "kube",
-  "network"
+  "network",
+  ".editorconfig"
 ]
 injection-regex = "ini"
 comment-token = "#"


### PR DESCRIPTION
As discussed in #8076 (https://github.com/helix-editor/helix/pull/8076#issuecomment-1722254250), this PR adds syntax highlighting for `.editorconfig` files as INI temporarily until Helix supports them directly.

While there is a difference between `.editorconfig` and INI syntax, it is very minor (see below) and most files are likely to highlight correctly, which should be a better compromise that not highlighting at all.

> EditorConfig files use an INI format that is compatible with the format used by Python ConfigParser Library, but [ and ] are allowed in the section names. The section names are filepath globs, similar to the format accepted by gitignore. Forward slashes (/) are used as path separators and semicolons (;) or octothorpes (#) are used for comments. Comments should go individual lines. EditorConfig files should be UTF-8 encoded, with either CRLF or LF line separators.

cc @the-mikedavis 