### PR TITLE
Add `.babelrc` highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -317,7 +317,7 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 scope = "source.json"
 injection-regex = "json"
-file-types = ["json", "jsonc", "arb", "ipynb", "geojson", "gltf", "flake.lock"]
+file-types = ["json", "jsonc", "arb", "ipynb", "geojson", "gltf", "flake.lock", ".babelrc"]
 roots = []
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true


### PR DESCRIPTION
In frontend projects using [Babel](https://babeljs.io), `.babelrc` is a config file variant that is allowed as an alias for `.babelrc.json`.

> For compatibility reasons, .babelrc is an alias for .babelrc.json.

This PR highlights those files as JSON.

Built locally and tested.