### PR TITLE
Allow specifying a different style for diff indicator in vcs gutter

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -245,9 +245,12 @@ We use a similar set of scopes as
 
 - `diff` - version control changes
   - `plus` - additions
+    - `gutter` - gutter indicator
   - `minus` - deletions
+    - `gutter` - gutter indicator
   - `delta` - modifications
     - `moved` - renamed or moved files/changes
+    - `gutter` - gutter indicator
 
 #### Interface
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -94,9 +94,9 @@ pub fn diff<'doc>(
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
-    let added = theme.get("diff.plus");
-    let deleted = theme.get("diff.minus");
-    let modified = theme.get("diff.delta");
+    let added = theme.get("diff.plus.gutter");
+    let deleted = theme.get("diff.minus.gutter");
+    let modified = theme.get("diff.delta.gutter");
     if let Some(diff_handle) = doc.diff_handle() {
         let hunks = diff_handle.load();
         let mut hunk_i = 0;


### PR DESCRIPTION
Currently the `diff.plus/minus/delta` keys are used both for the gutter indicator and the syntax highlighting (for example in `.patch` files). This limits the abilities to theme the diffs nicely, as the background appear in the gutter line. For example, with existing `papercolor_light` theme this gives:

![image](https://github.com/helix-editor/helix/assets/329388/3716f9b5-0a84-4081-b718-f89efd06671b)

It is also hard to find a good color as the gutter indicator needs to be very colored as it has a very small surface, but it forces a very bright text.

This change allows using a different style for the gutter diff indicator, allowing things like:

![image](https://github.com/helix-editor/helix/assets/329388/4c60331f-4ad8-46eb-b216-7dfdd196e852)

with:

```toml
"diff.plus" = { fg = "fg-added", bg = "bg-added" }
"diff.plus.gutter" = "green-intense"
"diff.minus" = { fg = "fg-removed", bg = "bg-removed" }
"diff.minus.gutter" = "red-intense"
"diff.delta" = { fg = "fg-changed", bg = "bg-changed" }
"diff.delta.gutter" = "yellow-intense"
```

Making it a subkey allows maintaining compatibility with existing themes. Another option could be to add it to the `ui` key with a fallback on `diff`.