### PR TITLE
Fix C++ highlight not working

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -47,7 +47,7 @@
 ; Constants
 
 (this) @variable.builtin
-(nullptr) @constant.builtin
+("nullptr") @constant.builtin
 
 ; Keywords
 


### PR DESCRIPTION
Everything works on my laptop, but, for some reason, on my PC there is treesitter error because of `nullptr` is not in `""`