### PR TITLE
add command history picker

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -278,6 +278,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`         |
 | `b`     | Open buffer picker                                                      | `buffer_picker`                            |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
+| `:`     | Open command history picker                                             | `command_history_picker`                   |
 | `g`     | Debug (experimental)                                                    | N/A                                        |
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
 | `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                            |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -310,6 +310,7 @@ impl MappableCommand {
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
+        command_history_picker, "Open command history picker",
         symbol_picker, "Open symbol picker",
         select_references_to_symbol_under_cursor, "Select symbol references",
         workspace_symbol_picker, "Open workspace symbol picker",
@@ -2747,6 +2748,46 @@ fn buffer_picker(cx: &mut Context) {
             .cursor_line(doc.text().slice(..));
         Some((meta.id.into(), Some((line, line))))
     });
+    cx.push_layer(Box::new(overlaid(picker)));
+}
+
+fn command_history_picker(cx: &mut Context) {
+    let command_history = cx.editor.registers.read(':', cx.editor);
+
+    let items = command_history
+        .into_iter()
+        .flat_map(|reg| reg)
+        .map(|entry| Command {
+            args: entry.to_string(),
+        })
+        .collect();
+
+    struct Command {
+        args: String,
+    }
+
+    impl ui::menu::Item for Command {
+        type Data = ();
+
+        fn format(&self, _data: &Self::Data) -> Row {
+            Row::new([format!(":{}", self.args)])
+        }
+    }
+
+    let picker = Picker::new(items, (), |cx, option, _action| {
+        let args = option.args.clone();
+
+        cx.jobs.callback(async move {
+            let callback = |editor: &mut Editor, compositor: &mut Compositor| {
+                let prompt = command_mode_prompt().with_line(args, editor);
+
+                compositor.push(Box::new(prompt));
+            };
+
+            Ok(Callback::EditorCompositor(Box::new(callback)))
+        })
+    });
+
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3023,6 +3023,14 @@ pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableComma
 
 #[allow(clippy::unnecessary_unwrap)]
 pub(super) fn command_mode(cx: &mut Context) {
+    let mut prompt = command_mode_prompt();
+
+    // Calculate initial completion
+    prompt.recalculate_completion(cx.editor);
+    cx.push_layer(Box::new(prompt));
+}
+
+pub(super) fn command_mode_prompt() -> Prompt {
     let mut prompt = Prompt::new(
         ":".into(),
         Some(':'),
@@ -3113,9 +3121,7 @@ pub(super) fn command_mode(cx: &mut Context) {
         None
     });
 
-    // Calculate initial completion
-    prompt.recalculate_completion(cx.editor);
-    cx.push_layer(Box::new(prompt));
+    prompt
 }
 
 fn argument_number_of(shellwords: &Shellwords) -> usize {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -218,6 +218,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "F" => file_picker_in_current_directory,
             "b" => buffer_picker,
             "j" => jumplist_picker,
+            ":" => command_history_picker,
             "s" => symbol_picker,
             "S" => workspace_symbol_picker,
             "d" => diagnostics_picker,


### PR DESCRIPTION
Adds a simple command history picker:

![image](https://github.com/helix-editor/helix/assets/1636604/b278f038-959c-48df-af5e-8b19bc28235f)

cf. https://github.com/helix-editor/helix/discussions/7617