### PR TITLE
Better bufferline

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -59,12 +59,26 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
-| `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
+
+### `[editor.bufferline]` Section
+
+Allows configuring the bufferline at the top of the editor.
+
+```toml
+[editor.bufferline]
+show = "always"
+style = "scroll"
+```
+
+| Key     | Description | Default |
+| ---     | ---         | ---     |
+| `show`  | Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
+| `style` | Can be `overflow`, `wrap` or `scroll`. | `overflow` |
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -23,7 +23,7 @@ use helix_core::{
 };
 use helix_view::{
     document::{Mode, SavePoint, SCRATCH_BUFFER_NAME},
-    editor::{CompleteAction, CursorShapeConfig},
+    editor::{BufferLine, BufferLineStyle, CompleteAction, CursorShapeConfig},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
@@ -56,6 +56,16 @@ pub enum InsertEvent {
     },
     TriggerCompletion,
     RequestCompletion,
+}
+
+#[derive(Debug, Clone)]
+pub struct BufferTab {
+    active: bool,
+    text: String,
+    width: u16,
+    x: i32,
+    y: i32,
+    style: Style,
 }
 
 impl Default for EditorView {
@@ -520,8 +530,25 @@ impl EditorView {
     }
 
     /// Render bufferline at the top
-    pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) -> u16 {
-        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
+    pub fn render_bufferline(
+        editor: &Editor,
+        viewport: Rect,
+        surface: &mut Surface,
+        config: BufferLine,
+    ) -> u16 {
+        // check if bufferline should be rendered
+        use helix_view::editor::BufferLineShow;
+        let use_bufferline = match config.show {
+            BufferLineShow::Always => true,
+            BufferLineShow::Multiple if editor.documents.len() > 1 => true,
+            _ => false,
+        };
+
+        if !use_bufferline {
+            return 0;
+        }
+
+        // Define styles
         let bufferline_active = editor
             .theme
             .try_get("ui.bufferline.active")
@@ -532,12 +559,14 @@ impl EditorView {
             .try_get("ui.bufferline")
             .unwrap_or_else(|| editor.theme.get("ui.statusline.inactive"));
 
-        let mut x = viewport.x;
-        let mut y = 0;
+        let mut x = viewport.x as i32;
+        let mut y = viewport.y as i32;
         let current_doc = view!(editor).doc;
 
-        let mut tabs = Vec::<(String, u16, u16, Style)>::new();
+        // Keep track of the tabs
+        let mut buffertabs = Vec::new();
 
+        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         for doc in editor.documents() {
             let fname = doc
                 .path()
@@ -547,25 +576,37 @@ impl EditorView {
                 .to_str()
                 .unwrap_or_default();
 
-            let style = if current_doc == doc.id() {
+            let active = current_doc == doc.id();
+
+            let style = if active {
                 bufferline_active
             } else {
                 bufferline_inactive
             };
 
             let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
-            let text_width = text.grapheme_indices(true).count() as u16;
+            let text_width = text.grapheme_indices(true).count();
 
-            if x + text_width > surface.area.width {
-                y += 1;
-                x = 0;
+            if config.style == BufferLineStyle::Wrap
+                && x.saturating_add(text_width as i32) >= viewport.right() as i32
+            {
+                y = y.saturating_add(1);
+                x = viewport.x as _;
             }
 
-            tabs.push((text, x, y, style));
-            x += text_width;
+            buffertabs.push(BufferTab {
+                active,
+                text,
+                width: text_width as _,
+                x,
+                y,
+                style,
+            });
+            x = x.saturating_add(text_width as _);
         }
 
-        let height = if x != 0 { y + 1 } else { y };
+        let height =
+            (if x != 0 { y.saturating_add(1) } else { y } as u16).saturating_sub(viewport.y);
 
         let viewport = viewport.with_height(height);
 
@@ -577,8 +618,77 @@ impl EditorView {
                 .unwrap_or_else(|| editor.theme.get("ui.statusline")),
         );
 
-        for (text, x, y, style) in tabs {
-            surface.set_string(x, y, text, style);
+        if config.style == BufferLineStyle::Scroll {
+            let viewport_center = (viewport.width as f64 / 2.).floor() as i32 + viewport.x as i32;
+
+            let maybe_active_buffertab = buffertabs.iter().find(|tab| tab.active);
+
+            if let Some(tab) = maybe_active_buffertab {
+                log::debug!("Activae buffer found");
+                let active_buffertab_center = (tab.width as f64 / 2.).floor() as i32 + tab.x;
+
+                let right_of_center = active_buffertab_center as i32 - viewport_center as i32;
+
+                log::debug!(
+                    "Viewport center {}, tab center {}, right of center {}",
+                    viewport_center,
+                    active_buffertab_center,
+                    right_of_center
+                );
+
+                if right_of_center > 0 {
+                    let rightmost = buffertabs.last().unwrap();
+                    let full_width = rightmost.x + rightmost.width as i32;
+
+                    let max_displacement = (full_width - viewport.width as i32).max(0);
+                    let displacement = right_of_center.min(max_displacement);
+                    log::debug!(
+                        "Full width {}, max displacement {}, displacement {}",
+                        full_width,
+                        max_displacement,
+                        displacement
+                    );
+
+                    for tab in buffertabs.iter_mut() {
+                        tab.x = tab.x.saturating_sub(displacement.abs());
+                    }
+                } // If on center, or left of center, nothing to do
+            } // If no active buffer, keep everything scrolled to leftmost
+        }
+
+        for tab in buffertabs.iter_mut() {
+            if tab.x < viewport.x as i32 {
+                if tab.x + tab.width as i32 > viewport.x as i32 {
+                    let new_width = tab.width as i32 + tab.x;
+
+                    tab.text = tab
+                        .text
+                        .graphemes(true)
+                        .into_iter()
+                        .skip((tab.width as i32 - new_width) as usize)
+                        .collect();
+
+                    tab.width -= new_width as u16;
+                    tab.x = viewport.x as _;
+                } else {
+                    // skip tabs completely of screen
+                    continue;
+                }
+            }
+            if tab.x > viewport.right() as i32 {
+                // Stop when off screen
+                break;
+            }
+
+            let _ = surface
+                .set_stringn(
+                    tab.x as _,
+                    tab.y as _,
+                    tab.text.clone(),
+                    (viewport.right() as usize).saturating_sub(tab.x as _),
+                    tab.style,
+                )
+                .0;
         }
 
         height
@@ -1413,20 +1523,11 @@ impl Component for EditorView {
         surface.set_style(area, cx.editor.theme.get("ui.background"));
         let config = cx.editor.config();
 
-        // check if bufferline should be rendered
-        use helix_view::editor::BufferLine;
-        let use_bufferline = match config.bufferline {
-            BufferLine::Always => true,
-            BufferLine::Multiple if cx.editor.documents.len() > 1 => true,
-            _ => false,
-        };
-
         // -1 for commandline and -1 for bufferline
         let mut editor_area = area.clip_bottom(1);
-        if use_bufferline {
-            let bufferline_height = Self::render_bufferline(cx.editor, area, surface);
-            editor_area = editor_area.clip_top(bufferline_height);
-        }
+        let buffer_line_height =
+            Self::render_bufferline(cx.editor, area, surface, config.bufferline.clone());
+        editor_area = editor_area.clip_top(buffer_line_height);
 
         // if the terminal size suddenly changed, we need to trigger a resize
         cx.editor.resize(editor_area);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -18,7 +18,7 @@ use helix_core::{
     movement::Direction,
     syntax::{self, HighlightEvent},
     text_annotations::TextAnnotations,
-    unicode::width::UnicodeWidthStr,
+    unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidthStr},
     visual_offset_from_block, Change, Position, Range, Selection, Transaction,
 };
 use helix_view::{
@@ -520,16 +520,8 @@ impl EditorView {
     }
 
     /// Render bufferline at the top
-    pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) {
+    pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) -> u16 {
         let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
-        surface.clear_with(
-            viewport,
-            editor
-                .theme
-                .try_get("ui.bufferline.background")
-                .unwrap_or_else(|| editor.theme.get("ui.statusline")),
-        );
-
         let bufferline_active = editor
             .theme
             .try_get("ui.bufferline.active")
@@ -541,7 +533,10 @@ impl EditorView {
             .unwrap_or_else(|| editor.theme.get("ui.statusline.inactive"));
 
         let mut x = viewport.x;
+        let mut y = 0;
         let current_doc = view!(editor).doc;
+
+        let mut tabs = Vec::<(String, u16, u16, Style)>::new();
 
         for doc in editor.documents() {
             let fname = doc
@@ -559,17 +554,34 @@ impl EditorView {
             };
 
             let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
-            let used_width = viewport.x.saturating_sub(x);
-            let rem_width = surface.area.width.saturating_sub(used_width);
+            let text_width = text.grapheme_indices(true).count() as u16;
 
-            x = surface
-                .set_stringn(x, viewport.y, text, rem_width as usize, style)
-                .0;
-
-            if x >= surface.area.right() {
-                break;
+            if x + text_width > surface.area.width {
+                y += 1;
+                x = 0;
             }
+
+            tabs.push((text, x, y, style));
+            x += text_width;
         }
+
+        let height = if x != 0 { y + 1 } else { y };
+
+        let viewport = viewport.with_height(height);
+
+        surface.clear_with(
+            viewport,
+            editor
+                .theme
+                .try_get("ui.bufferline.background")
+                .unwrap_or_else(|| editor.theme.get("ui.statusline")),
+        );
+
+        for (text, x, y, style) in tabs {
+            surface.set_string(x, y, text, style);
+        }
+
+        height
     }
 
     pub fn render_gutter<'d>(
@@ -1412,15 +1424,12 @@ impl Component for EditorView {
         // -1 for commandline and -1 for bufferline
         let mut editor_area = area.clip_bottom(1);
         if use_bufferline {
-            editor_area = editor_area.clip_top(1);
+            let bufferline_height = Self::render_bufferline(cx.editor, area, surface);
+            editor_area = editor_area.clip_top(bufferline_height);
         }
 
         // if the terminal size suddenly changed, we need to trigger a resize
         cx.editor.resize(editor_area);
-
-        if use_bufferline {
-            Self::render_bufferline(cx.editor, area.with_height(1), surface);
-        }
 
         for (view, is_focused) in cx.editor.tree.views() {
             let doc = cx.editor.document(view.doc).unwrap();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -576,11 +576,13 @@ impl Default for CursorShapeConfig {
     }
 }
 
-/// bufferline render modes
+/// bufferline configuration
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct BufferLine {
+    // Set when to show the bufferline
     pub show: BufferLineShow,
+    // Set how to handle overflowing
     pub style: BufferLineStyle,
 }
 
@@ -597,16 +599,16 @@ pub enum BufferLineShow {
     Multiple,
 }
 
-/// bufferline render
+/// bufferline render style
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BufferLineStyle {
-    /// Don't render bufferline
+    /// Overflow bufferline on the right
     #[default]
     Overflow,
-    /// Always render
+    /// Wrap when the bufferline overflows
     Wrap,
-    /// Only if multiple buffers are open
+    /// Scroll active buffer as centered in the bufferline as possible
     Scroll,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -578,8 +578,16 @@ impl Default for CursorShapeConfig {
 
 /// bufferline render modes
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct BufferLine {
+    pub show: BufferLineShow,
+    pub style: BufferLineStyle,
+}
+
+/// bufferline render modes
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum BufferLine {
+pub enum BufferLineShow {
     /// Don't render bufferline
     #[default]
     Never,
@@ -587,6 +595,19 @@ pub enum BufferLine {
     Always,
     /// Only if multiple buffers are open
     Multiple,
+}
+
+/// bufferline render
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BufferLineStyle {
+    /// Don't render bufferline
+    #[default]
+    Overflow,
+    /// Always render
+    Wrap,
+    /// Only if multiple buffers are open
+    Scroll,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR ads a way to change the behaviour of the bufferline on overflow.
This introduces a breaking change to the bufferline configuration, which now looks like

```toml
[editor.bufferline]
show = "always"
style = "scroll"
```

`editor.bufferline.show` accepts any of `always`, `multiple` or `never`, and `editor.bufferline.style` any of 

- `overflow`, original behaviour, let it overflow to the right and don't care.
- `wrap`, on overflow, expand downwards and wrap.
- `scroll`, on overflow, overflow and scroll the active buffer's tab as centred as possible, essentially scrolling the bufferline.

For now `overflow` is the default behaviour, but I'm unsure if this is a good default setting.
as alternative I'd propose `scroll` as this handles the bufferline similar to overflow, having a fixed height of one but adding the benefit of always showing what your active buffer is.