### PR TITLE
Use is_ascii_graphic for checking auto completion words

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -61,8 +61,8 @@ pub enum OffsetEncoding {
 pub mod util {
     use super::*;
     use helix_core::line_ending::{line_end_byte_index, line_end_char_index};
-    use helix_core::{chars, RopeSlice, SmallVec};
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
+    use helix_core::{RopeSlice, SmallVec};
 
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
     ///
@@ -272,14 +272,14 @@ pub mod util {
             - text
                 .chars_at(cursor)
                 .reversed()
-                .take_while(|ch| chars::char_is_word(*ch))
+                .take_while(char::is_ascii_graphic)
                 .count();
         let mut end = cursor;
         if replace_mode {
             end += text
                 .chars_at(cursor)
                 .skip(1)
-                .take_while(|ch| chars::char_is_word(*ch))
+                .take_while(char::is_ascii_graphic)
                 .count();
         }
         (start, end)


### PR DESCRIPTION
Before, auto completion would reset if one types a character that is not `[a-zA-Z_]` which is really annoying especially when working with html,css and tailwindcss-language-server.
Example:
```css
a {
}
```
Put cursor between braces and type `background-color`. When you type in the hyphen, completion results would reset and it will only show completion for `color`. This pr fixes this behavior.