### PR TITLE
Style Bold/Italic/Strikethrough markdown in docs

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -285,12 +285,12 @@ impl Markdown {
                                 HeadingLevel::H5 => heading_styles[4],
                                 HeadingLevel::H6 => heading_styles[5],
                             },
-                            _ => text_style.add_modifier(match tags.last() {
-                                Some(Tag::Emphasis) => Modifier::ITALIC,
-                                Some(Tag::Strong) => Modifier::BOLD,
-                                Some(Tag::Strikethrough) => Modifier::CROSSED_OUT,
-                                _ => Modifier::empty(),
-                            }),
+                            Some(Tag::Emphasis) => text_style.add_modifier(Modifier::ITALIC),
+                            Some(Tag::Strong) => text_style.add_modifier(Modifier::BOLD),
+                            Some(Tag::Strikethrough) => {
+                                text_style.add_modifier(Modifier::CROSSED_OUT)
+                            }
+                            _ => text_style,
                         };
                         spans.push(Span::styled(text, style));
                     }

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -14,6 +14,7 @@ use helix_core::{
 };
 use helix_view::{
     graphics::{Margin, Rect, Style},
+    theme::Modifier,
     Theme,
 };
 
@@ -275,17 +276,21 @@ impl Markdown {
                         );
                         lines.extend(tui_text.lines.into_iter());
                     } else {
-                        let style = if let Some(Tag::Heading(level, ..)) = tags.last() {
-                            match level {
+                        let style = match tags.last() {
+                            Some(Tag::Heading(level, ..)) => match level {
                                 HeadingLevel::H1 => heading_styles[0],
                                 HeadingLevel::H2 => heading_styles[1],
                                 HeadingLevel::H3 => heading_styles[2],
                                 HeadingLevel::H4 => heading_styles[3],
                                 HeadingLevel::H5 => heading_styles[4],
                                 HeadingLevel::H6 => heading_styles[5],
-                            }
-                        } else {
-                            text_style
+                            },
+                            _ => text_style.add_modifier(match tags.last() {
+                                Some(Tag::Emphasis) => Modifier::ITALIC,
+                                Some(Tag::Strong) => Modifier::BOLD,
+                                Some(Tag::Strikethrough) => Modifier::CROSSED_OUT,
+                                _ => Modifier::empty(),
+                            }),
                         };
                         spans.push(Span::styled(text, style));
                     }


### PR DESCRIPTION
Style doc comment markdown correctly with Bold / Strikethrough / Italics.
**Before:**
![image](https://github.com/helix-editor/helix/assets/58790821/32f75bda-8d3a-4163-afa5-8a90fe146177)

**After:**
![image](https://github.com/helix-editor/helix/assets/58790821/9a4300ec-1d05-4c44-88f3-d8de26d48b03)

Note the Italics of the word `do`