### PR TITLE
update go highlight queries

### DIFF
--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -24,7 +24,6 @@
 
 ; Identifiers
 
-((identifier) @constant (match? @constant "^[A-Z][A-Z\\d_]+$"))
 (const_spec
   name: (identifier) @constant)
 
@@ -38,6 +37,7 @@
 (type_spec 
   name: (type_identifier) @constructor)
 (field_identifier) @variable.other.member
+(keyed_element (literal_element (identifier) @variable.other.member))
 (identifier) @variable
 (package_identifier) @namespace
 


### PR DESCRIPTION
I've removed the query for all caps vars, because naming variables in this way isn't a go convention, but can relocate it to the bottom of the file as suggested in the issue discussion if that's preferred. 

[Go Wiki](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps):
> See https://go.dev/doc/effective_go#mixed-caps. This applies even when it breaks conventions in other languages. For example an unexported constant is maxLength not MaxLength or MAX_LENGTH.

[Google Go Styleguide](https://google.github.io/styleguide/go/guide#mixedcaps):
> Go source code uses MixedCaps or mixedCaps (camel case) rather than underscores (snake case) when writing multi-word names.
>
> This applies even when it breaks conventions in other languages. For example, a constant is MaxLength (not MAX_LENGTH) if exported and maxLength (not max_length) if unexported.

fixes #8390 