### PR TITLE
Update tutor to show that helix does not have any recovery method yet

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -35,8 +35,10 @@
  CapsLock key is not pressed and hold the j key until you reach
  the first lesson.
 
-
-
+ PS:
+ Please note that helix does not have autosave enabled by default,
+ nor does helix have any method of recovering unsaved changes at
+ the moment. Please be aware of this and remember to write often.
 
 
 


### PR DESCRIPTION
Lost quite a bit of work, even though I went through the tutor. It would have been nice to be warned of this ahead of time. 

Up to you guys to determine if it is necessary, imo is that it would be nice to have some kind of warning somewhere.

