### PR TITLE
Fix missing HTML tag colorization in onedark theme

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -1,5 +1,6 @@
 # Author : Gokul Soumya <gokulps15@gmail.com>
 
+"tag" = { fg = "red" }
 "attribute" = { fg = "yellow" }
 "comment" = { fg = "light-gray", modifiers = ["italic"] }
 "constant" = { fg = "cyan" }


### PR DESCRIPTION
HTML Tags were not colorized if using the "onedark" theme. I just set them to the color "red" like its also done in VSCode using the onedark theme.