### PR TITLE
LSP: Fix codeAction/resolve server capability check

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -971,12 +971,12 @@ impl Client {
     ) -> Option<impl Future<Output = Result<Value>>> {
         let capabilities = self.capabilities.get().unwrap();
 
-        // Return early if the server does not support resolving code action.
-        match capabilities.completion_provider {
-            Some(lsp::CompletionOptions {
+        // Return early if the server does not support resolving code actions.
+        match capabilities.code_action_provider {
+            Some(lsp::CodeActionProviderCapability::Options(lsp::CodeActionOptions {
                 resolve_provider: Some(true),
                 ..
-            }) => (),
+            })) => (),
             _ => return None,
         }
 


### PR DESCRIPTION
Previously we accidentally checked the server's _completion_ resolve capability rather than the code action resolve capability. It looks like this was an oversight introduced in #7677.

Fixes https://github.com/helix-editor/helix/issues/8413
Fixes https://github.com/astral-sh/ruff-lsp/issues/249