### PR TITLE
Add tailwindcss language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -71,6 +71,7 @@ solc = { command = "solc", args = ["--lsp"] }
 sourcekit-lsp = { command = "sourcekit-lsp" }
 svlangserver = { command = "svlangserver", args = [] }
 swipl = { command = "swipl", args = [ "-g", "use_module(library(lsp_server))", "-g", "lsp_server:main", "-t", "halt", "--", "stdio" ] }
+tailwindcss-ls = { command = "tailwindcss-language-server", args = ["--stdio"] }
 taplo = { command = "taplo", args = ["lsp", "stdio"] }
 terraform-ls = { command = "terraform-ls", args = ["serve"] }
 texlab = { command = "texlab" }


### PR DESCRIPTION
EDIT I just saw https://github.com/helix-editor/helix/pull/7080 .. arrghhh! Please could people still have a look at the questions I bring up here and we can get the other one merged! Also, we have started merging more language server definitions since multiple language servers arrived on the scene...

The following appears to work fine with this pull request, which is simply `tailwindcss-ls = { command = "tailwindcss-language-server", args = ["--stdio"] }`:

```
sudo npm install -g @tailwindcss/language-server@insiders
```
```toml
[[language]]
name = "html"
language-servers = [ "vscode-html-language-server", "tailwindcss-ls" ]

[[language]]
name = "css"
language-servers = [ "vscode-css-language-server", "tailwindcss-ls" ]
```

`input.css`

(tailwind message)
![image](https://github.com/helix-editor/helix/assets/12832280/e759a09f-38b9-4bd9-9f78-d6e63958844a)
(vscode-css-language-server message)
![image](https://github.com/helix-editor/helix/assets/12832280/8c5552f4-bd7a-4b0d-9753-8124ba30e7e2)


`index.html`

(tailwind auto-completion)
![image](https://github.com/helix-editor/helix/assets/12832280/82d99069-df75-4db6-b11f-8f691c718209)


I followed [this thread,](https://github.com/helix-editor/helix/issues/2213), and it seems to be full of very outdated, complex, and redundant information. Passing language ID? Is any of that needed any more?

I have marked this as draft until someone confirms I have not missed something. The order you add the language server makes a difference, the first one gets the hover information when you press `space-k`, but the tailwind server seems 100% functional other than that feature, and you can get at the info in the auto complete anyway.