### PR TITLE
Allow numbers as second input event

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -303,12 +303,13 @@ impl Keymaps {
         self.sticky.as_ref()
     }
 
-    pub fn key_exists(&self, mode: Mode, key: KeyEvent) -> bool {
+    pub fn contains_key(&self, mode: Mode, key: KeyEvent) -> bool {
         let keymaps = &*self.map();
         let keymap = &keymaps[&mode];
-        let mut ks = self.pending().to_vec();
-        ks.push(key);
-        keymap.search(&ks).is_some()
+        keymap
+            .search(self.pending())
+            .and_then(KeyTrie::node)
+            .is_some_and(|node| node.contains_key(&key))
     }
 
     /// Lookup `key` in the keymap to try and find a command to execute. Escape

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -303,6 +303,14 @@ impl Keymaps {
         self.sticky.as_ref()
     }
 
+    pub fn key_exists(&self, mode: Mode, key: KeyEvent) -> bool {
+        let keymaps = &*self.map();
+        let keymap = &keymaps[&mode];
+        let mut ks = self.pending().to_vec();
+        ks.push(key);
+        keymap.search(&ks).is_some()
+    }
+
     /// Lookup `key` in the keymap to try and find a command to execute. Escape
     /// key cancels pending keystrokes. If there are no pending keystrokes but a
     /// sticky node is in use, it will be cleared.

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -887,7 +887,12 @@ impl EditorView {
         match (event, cxt.editor.count) {
             // count handling
             (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _)
-                if self.keymaps.pending().is_empty() =>
+                if self.keymaps.pending().is_empty()
+                    || self.keymaps.pending().last()
+                        == Some(&KeyEvent {
+                            code: KeyCode::Char('g'),
+                            modifiers: KeyModifiers::NONE,
+                        }) =>
             {
                 let i = i.to_digit(10).unwrap() as usize;
                 cxt.editor.count =

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -887,7 +887,7 @@ impl EditorView {
         match (event, cxt.editor.count) {
             // count handling
             (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _)
-                if !self.keymaps.key_exists(mode, event) =>
+                if !self.keymaps.contains_key(mode, event) =>
             {
                 let i = i.to_digit(10).unwrap() as usize;
                 cxt.editor.count =

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -887,12 +887,7 @@ impl EditorView {
         match (event, cxt.editor.count) {
             // count handling
             (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _)
-                if self.keymaps.pending().is_empty()
-                    || self.keymaps.pending().last()
-                        == Some(&KeyEvent {
-                            code: KeyCode::Char('g'),
-                            modifiers: KeyModifiers::NONE,
-                        }) =>
+                if !self.keymaps.key_exists(mode, event) =>
             {
                 let i = i.to_digit(10).unwrap() as usize;
                 cxt.editor.count =

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -886,7 +886,9 @@ impl EditorView {
     fn command_mode(&mut self, mode: Mode, cxt: &mut commands::Context, event: KeyEvent) {
         match (event, cxt.editor.count) {
             // count handling
-            (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _) => {
+            (key!(i @ '0'), Some(_)) | (key!(i @ '1'..='9'), _)
+                if self.keymaps.pending().is_empty() =>
+            {
                 let i = i.to_digit(10).unwrap() as usize;
                 cxt.editor.count =
                     std::num::NonZeroUsize::new(cxt.editor.count.map_or(i, |c| c.get() * 10 + i));


### PR DESCRIPTION
This will allow using numbers as second key event. Closes #8113 