### PR TITLE
add json5 language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -76,6 +76,7 @@
 | jinja | ✓ |  |  |  |
 | jsdoc | ✓ |  |  |  |
 | json | ✓ |  | ✓ | `vscode-json-language-server` |
+| json5 | ✓ |  |  |  |
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ | `julia` |

--- a/languages.toml
+++ b/languages.toml
@@ -348,6 +348,22 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "73076754005a460947cafe8e03a8cf5fa4fa2938" }
 
+
+[[language]]
+name = "json5"
+scope = "source.json5"
+injection-regex = "json5"
+file-types = ["json5"]
+roots = []
+language-servers = []
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+# https://json5.org
+
+[[grammar]]
+name = "json5"
+source = { git = "https://github.com/Joakker/tree-sitter-json5", rev = "c23f7a9b1ee7d45f516496b1e0e4be067264fa0d" }
+
 [[language]]
 name = "c"
 scope = "source.c"

--- a/runtime/queries/json5/highlights.scm
+++ b/runtime/queries/json5/highlights.scm
@@ -1,0 +1,11 @@
+(string) @string
+
+(identifier) @constant
+
+(number) @constant.numeric
+
+(null) @constant.builtin
+
+[(true) (false)] @constant.builtin.boolean
+
+(comment) @comment


### PR DESCRIPTION
adds support for https://json5.org/

used for example by configuration files for [diffsitter](https://github.com/afnanenayet/diffsitter)