### PR TITLE
Make parse_macro work for "-" outside "<..>"

### DIFF
--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -549,7 +549,11 @@ pub fn parse_macro(keys_str: &str) -> anyhow::Result<Vec<KeyEvent>> {
         if c == ">" {
             keys_res = Err(anyhow!("Unmatched '>'"));
         } else if c != "<" {
-            keys.push(c);
+            if c != "-" {
+                keys.push(c);
+            } else {
+                keys.push("minus");
+            }
             i += end_i;
         } else {
             match s.find('>').context("'>' expected") {
@@ -805,6 +809,64 @@ mod test {
                 },
                 KeyEvent {
                     code: KeyCode::Char('r'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Enter,
+                    modifiers: KeyModifiers::NONE,
+                },
+            ])
+        );
+
+        assert_eq!(
+            parse_macro(":w aa-bb.txt<ret>").ok(),
+            Some(vec![
+                KeyEvent {
+                    code: KeyCode::Char(':'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('w'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char(' '),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('a'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('a'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('-'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('b'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('b'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('.'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('t'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('x'),
+                    modifiers: KeyModifiers::NONE,
+                },
+                KeyEvent {
+                    code: KeyCode::Char('t'),
                     modifiers: KeyModifiers::NONE,
                 },
                 KeyEvent {

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -549,11 +549,7 @@ pub fn parse_macro(keys_str: &str) -> anyhow::Result<Vec<KeyEvent>> {
         if c == ">" {
             keys_res = Err(anyhow!("Unmatched '>'"));
         } else if c != "<" {
-            if c != "-" {
-                keys.push(c);
-            } else {
-                keys.push("minus");
-            }
+            keys.push(if c == "-" { keys::MINUS } else { c });
             i += end_i;
         } else {
             match s.find('>').context("'>' expected") {


### PR DESCRIPTION
When running the integration tests, I ended up with temp file paths containing "-" in the name. This in turn triggered an issue where the key "" could not be resolved. This is one way of fixing this issue, another is to check for "-" in parse_macro() and replace it with "minus".