### PR TITLE
Set the working directory before loading the config

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -33,9 +33,9 @@ pub fn current_working_dir() -> PathBuf {
     path
 }
 
-pub fn set_current_working_dir(path: PathBuf) -> std::io::Result<()> {
+pub fn set_current_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
     let path = dunce::canonicalize(path)?;
-    std::env::set_current_dir(path.clone())?;
+    std::env::set_current_dir(&path)?;
     let mut cwd = CWD.write().unwrap();
     *cwd = Some(path);
     Ok(())
@@ -280,7 +280,7 @@ mod merge_toml_tests {
         let cwd = current_working_dir();
         assert_ne!(cwd, new_path);
 
-        set_current_working_dir(new_path.clone()).expect("Couldn't set new path");
+        set_current_working_dir(&new_path).expect("Couldn't set new path");
 
         let cwd = current_working_dir();
         assert_eq!(cwd, new_path);

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -156,9 +156,6 @@ impl Application {
         let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
         compositor.push(editor_view);
 
-        if let Some(path) = args.working_directory {
-            helix_loader::set_current_working_dir(path)?
-        }
         if args.load_tutor {
             let path = helix_loader::runtime_file(Path::new("tutor"));
             editor.open(&path, Action::VerticalSplit)?;
@@ -167,7 +164,7 @@ impl Application {
         } else if !args.files.is_empty() {
             let first = &args.files[0].0; // we know it's not empty
             if first.is_dir() {
-                helix_loader::set_current_working_dir(first.clone())?;
+                // NOTE: The working directory is already set to args.files[0] in main()
                 editor.new_file(Action::VerticalSplit);
                 let picker = ui::file_picker(".".into(), &config.load().editor);
                 compositor.push(Box::new(overlaid(picker)));

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -115,6 +115,14 @@ FLAGS:
 
     setup_logging(args.verbosity).context("failed to initialize logging")?;
 
+    // NOTE: Set the working directory early so the correct configuration is loaded. Be aware that
+    // Application::new() depends on this logic so it must be updated if this changes.
+    if let Some((path, true)) = args.files.first().map(|(path, _)| (path, path.is_dir())) {
+        helix_loader::set_current_working_dir(path)?;
+    } else if let Some(path) = &args.working_directory {
+        helix_loader::set_current_working_dir(path)?;
+    }
+
     let config = match Config::load_default() {
         Ok(config) => config,
         Err(ConfigLoadError::Error(err)) if err.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
When you start the editor with a directory as the first argument, or specify `-w, --working-dir <path>` it loads `.helix/config.toml` as if you didn't specify it.

This fixes issue #8469