### PR TITLE
Fix issue with opening a relative directory with `hx <dir>` introduced in #8498

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -162,8 +162,7 @@ impl Application {
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None);
         } else if !args.files.is_empty() {
-            let first = &args.files[0].0; // we know it's not empty
-            if first.is_dir() {
+            if args.open_cwd {
                 // NOTE: The working directory is already set to args.files[0] in main()
                 editor.new_file(Action::VerticalSplit);
                 let picker = ui::file_picker(".".into(), &config.load().editor);

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
     pub files: Vec<(PathBuf, Position)>,
+    pub open_cwd: bool,
     pub working_directory: Option<PathBuf>,
 }
 

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -320,6 +320,14 @@ impl AppBuilder {
     }
 
     pub fn build(self) -> anyhow::Result<Application> {
+        if let Some(path) = &self.args.working_directory {
+            bail!("Changing the working directory to {path:?} is not yet supported for integration tests");
+        }
+
+        if let Some((path, _)) = self.args.files.first().filter(|p| p.0.is_dir()) {
+            bail!("Having the directory {path:?} in args.files[0] is not yet supported for integration tests");
+        }
+
         let mut app = Application::new(self.args, self.config, self.syn_conf)?;
 
         if let Some((text, selection)) = self.input {


### PR DESCRIPTION
When opening the editor using `hx <dir>` where `<dir>` is relative it would either open the wrong directory in the picker, or a new file.

This was introduced by #8498 

My solution is to replace the first argument by "." when it is a directory and override `args.working_directory`. This should effectively leave the original logic in place while still solve the config issue.