### PR TITLE
Add +N CLI argument to jump to first file's line number

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -18,6 +18,7 @@ pub struct Args {
     pub config_file: Option<PathBuf>,
     pub files: Vec<(PathBuf, Position)>,
     pub working_directory: Option<PathBuf>,
+    pub line_number: usize,
 }
 
 impl Args {
@@ -88,6 +89,16 @@ impl Args {
                         }
                     }
                 }
+                arg if arg.starts_with('+') => {
+                    let arg = arg.get(1..).unwrap();
+                    args.line_number = match arg.parse() {
+                        Ok(n) => n,
+                        _ => anyhow::bail!("bad line number after +"),
+                    };
+                    if args.line_number > 0 {
+                        args.line_number -= 1;
+                    }
+                }
                 arg => args.files.push(parse_file(arg)),
             }
         }
@@ -95,6 +106,10 @@ impl Args {
         // push the remaining args, if any to the files
         for arg in argv {
             args.files.push(parse_file(&arg));
+        }
+
+        if let Some(file) = args.files.first_mut() {
+            file.1.row = args.line_number;
         }
 
         Ok(args)

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -106,7 +106,9 @@ impl Args {
         }
 
         if let Some(file) = args.files.first_mut() {
-            file.1.row = line_number;
+            if line_number != 0 {
+                file.1.row = line_number;
+            }
         }
 
         Ok(args)

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -67,7 +67,7 @@ FLAGS:
     --vsplit                       Splits all given files vertically into different windows
     --hsplit                       Splits all given files horizontally into different windows
     -w, --working-dir <path>       Specify an initial working directory
-    +N                             Goto line number N
+    +N                             Open the first given file at line number N
 ",
         env!("CARGO_PKG_NAME"),
         VERSION_AND_GIT_HASH,

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -67,6 +67,7 @@ FLAGS:
     --vsplit                       Splits all given files vertically into different windows
     --hsplit                       Splits all given files horizontally into different windows
     -w, --working-dir <path>       Specify an initial working directory
+    +N                             Goto line number N
 ",
         env!("CARGO_PKG_NAME"),
         VERSION_AND_GIT_HASH,


### PR DESCRIPTION
Since the PR #5603 has not been updated, I went ahead and fixed the minor feedback from that PR and created a new one. I also fixed an issue making the first file never working with `<file>:<line>` as it was overridden.

Fixes https://github.com/helix-editor/helix/issues/5437