### PR TITLE
runtime/themes: adding "ttox" theme

### DIFF
--- a/runtime/themes/ttox.toml
+++ b/runtime/themes/ttox.toml
@@ -1,6 +1,9 @@
 # Author : Tomas Ruud <git@me.2ms.no>
 
 "ui.selection" = { fg = "white", bg = "gray" }
+"ui.cursor" = { fg = "black", bg = "light-gray" }
+"ui.cursor.primary" = { fg = "black", bg = "light-gray" }
+"ui.cursor.match" = { modifiers = ["underlined"] }
 "ui.background.separator" = "gray"
 "ui.linenr" = "gray"
 "ui.linenr.selected" = { fg = "white", bg = "gray" }

--- a/runtime/themes/ttox.toml
+++ b/runtime/themes/ttox.toml
@@ -1,0 +1,28 @@
+# Author : Tomas Ruud <git@me.2ms.no>
+
+"ui.selection" = { fg = "white", bg = "gray" }
+"ui.background.separator" = "gray"
+"ui.linenr" = "gray"
+"ui.linenr.selected" = { fg = "white", bg = "gray" }
+"ui.statusline" = { bg = "black", fg = "white" }
+"ui.menu" = { fg = "white", bg = "black" }
+"ui.menu.selected" = { bg = "light-gray", fg = "black" }
+"ui.popup" = { fg = "white", bg = "black" }
+"ui.help" = { fg = "white", bg = "black" }
+"ui.virtual.ruler" = { underline = { style = "line"} }
+
+"string" = { bg = "light-green", fg = "black" }
+"constant" = { bg = "light-cyan", fg = "black" }
+"comment" = { bg = "light-magenta", fg = "black" }
+
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "gray"
+
+"warning" = { fg = "black", bg = "light-yellow" }
+"error" = { fg = "black", bg = "light-red" }
+"hint" = { fg = "black", bg = "light-blue" }
+
+"diagnostic.warning" = { fg = "black", bg = "light-yellow" }
+"diagnostic.error" = { fg = "black", bg = "light-red" }
+"diagnostic.hint" = { fg = "black", bg = "light-blue" }


### PR DESCRIPTION
I've made a small theme that should play well with most terminals, including Terminal.app on macOS. This theme has no explicit `ui.background` which means that if you were to use something like Terminal.app, it automatically handles dark and light mode for you.

Here are a couple of screenshots

![light mode](https://raw.githubusercontent.com/tomasruud/ttox/main/screenshot-day.png)
![dark mode](https://raw.githubusercontent.com/tomasruud/ttox/main/screenshot-night.png)