### PR TITLE
Highlight types and enum members in the rust prelude

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -49,43 +49,51 @@
   (identifier) @label)
 
 ; ---
-; Standard library
+; Prelude
 ; ---
 
-((identifier) @constant.builtin
+((identifier) @type.enum.variant.builtin
  (#any-of? @constant.builtin "Some" "None" "Ok" "Err"))
 
-((identifier) @type.builtin
- (#any-of?
-    @type.builtin
-    "Result"
-    "Option"
-    "Vec"
-    "Box"
-    "Clone"
-    "Iterator"
-    "IntoIterator"
-    "DoubleEndedIterator"
-    "ExactSizeIterator"
-    "String"
-    "ToString"
-    "TryFrom"
-    "TryInto"))
+
 
 ((type_identifier) @type.builtin
  (#any-of?
     @type.builtin
-    "Result"
-    "Option"
-    "Vec"
-    "Box"
-    "Clone"
-    "Iterator"
-    "IntoIterator"
+    "Send"
+    "Sized"
+    "Sync"
+    "Unpin"
+    "Drop"
+    "Fn"
+    "FnMut"
+    "FnOnce"
+    "AsMut"
+    "AsRef"
+    "From"
+    "Into"
     "DoubleEndedIterator"
     "ExactSizeIterator"
+    "Extend"
+    "IntoIterator"
+    "Iterator"
+    "Option"
+    "Result"
+    "Clone"
+    "Copy"
+    "Debug"
+    "Default"
+    "Eq"
+    "Hash"
+    "Ord"
+    "PartialEq"
+    "PartialOrd"
+    "ToOwned"
+    "Box"
     "String"
     "ToString"
+    "Vec"
+    "FromIterator"
     "TryFrom"
     "TryInto"))
 

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -53,7 +53,7 @@
 ; ---
 
 ((identifier) @type.enum.variant.builtin
- (#any-of? @constant.builtin "Some" "None" "Ok" "Err"))
+ (#any-of? @type.enum.variant.builtin "Some" "None" "Ok" "Err"))
 
 
 

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -49,6 +49,47 @@
   (identifier) @label)
 
 ; ---
+; Standard library
+; ---
+
+((identifier) @constant.builtin
+ (#any-of? @constant.builtin "Some" "None" "Ok" "Err"))
+
+((identifier) @type.builtin
+ (#any-of?
+    @type.builtin
+    "Result"
+    "Option"
+    "Vec"
+    "Box"
+    "Clone"
+    "Iterator"
+    "IntoIterator"
+    "DoubleEndedIterator"
+    "ExactSizeIterator"
+    "String"
+    "ToString"
+    "TryFrom"
+    "TryInto"))
+
+((type_identifier) @type.builtin
+ (#any-of?
+    @type.builtin
+    "Result"
+    "Option"
+    "Vec"
+    "Box"
+    "Clone"
+    "Iterator"
+    "IntoIterator"
+    "DoubleEndedIterator"
+    "ExactSizeIterator"
+    "String"
+    "ToString"
+    "TryFrom"
+    "TryInto"))
+
+; ---
 ; Punctuation
 ; ---
 


### PR DESCRIPTION
A relatively simple change, but I like having the things in the prelude highlighted as builtin types