### PR TITLE
Add textobject queries for vala

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -166,7 +166,7 @@
 | unison | ✓ |  |  |  |
 | uxntal | ✓ |  |  |  |
 | v | ✓ | ✓ | ✓ | `v-analyzer` |
-| vala | ✓ |  |  | `vala-language-server` |
+| vala | ✓ | ✓ |  | `vala-language-server` |
 | verilog | ✓ | ✓ |  | `svlangserver` |
 | vhdl | ✓ |  |  | `vhdl_ls` |
 | vhs | ✓ |  |  |  |

--- a/runtime/queries/vala/textobjects.scm
+++ b/runtime/queries/vala/textobjects.scm
@@ -1,0 +1,27 @@
+(method_declaration
+  (block) @function.inside) @function.around
+
+(creation_method_declaration
+  (block) @function.inside) @function.around
+
+(method_declaration
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+[
+  (class_declaration)
+  (struct_declaration)
+  (interface_declaration)
+] @class.around
+
+(type_arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(creation_method_declaration
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(method_call_expression
+  ((argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around


### PR DESCRIPTION
This adds textobjects queries for vala, with support for functions, classes, comments, and parameters. Class support is partial - I couldn't find a way to support `@class.inside` with the vala grammar.