### PR TITLE
Add insert_space command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -366,6 +366,7 @@ impl MappableCommand {
         smart_tab, "Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.",
         insert_tab, "Insert tab char",
         insert_newline, "Insert newline char",
+        insert_space, "Insert whitespace",
         delete_char_backward, "Delete previous char",
         delete_char_forward, "Delete next char",
         delete_word_backward, "Delete previous word",
@@ -3706,6 +3707,16 @@ pub mod insert {
         transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
 
         let (view, doc) = current!(cx.editor);
+        doc.apply(&transaction, view.id);
+    }
+
+    pub fn insert_space(cx: &mut Context) {
+        let (view, doc) = current!(cx.editor);
+        let transaction = Transaction::insert(
+            doc.text(),
+            &doc.selection(view.id).clone().cursors(doc.text().slice(..)),
+            " ".into(),
+        );
         doc.apply(&transaction, view.id);
     }
 


### PR DESCRIPTION
Add command to insert whitespace.
Motivation: I would like to add a special binding in normal mode to Shift-Space shortcut.
However, in insert mode it is very easy to hit this combination by accident as Shift often remains depressed after a previous character was inserted.
Therefore, I would like to assign Shift-Space to insert space, just like Space does, but only in insert mode.