### PR TITLE
fix(lsp): ensure we only highlight diagnostics for lsp with the feature enabled

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -365,7 +365,7 @@ impl EditorView {
         let mut warning_vec = Vec::new();
         let mut error_vec = Vec::new();
 
-        for diagnostic in doc.diagnostics() {
+        for diagnostic in doc.shown_diagnostics() {
             // Separate diagnostics into different Vecs by severity.
             let (vec, scope) = match diagnostic.severity {
                 Some(Severity::Info) => (&mut info_vec, info),


### PR DESCRIPTION
Should close https://github.com/helix-editor/helix/issues/8550

The PR ensures we only show diagnostic highlights for lsp that have the `diasgnostics` feature enabled!