### PR TITLE
add picker config

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -522,12 +522,8 @@ impl<T: Item + 'static> Picker<T> {
         }
 
         let text_style = cx.editor.theme.get("ui.text");
-        let selected = cx.editor.theme.get(&picker_config.selected_style);
-        let highlight_style = cx
-            .editor
-            .theme
-            .get(&picker_config.highlight_style)
-            .add_modifier(Modifier::BOLD);
+        let selected = cx.editor.theme.get("ui.text.focus");
+        let highlight_style = cx.editor.theme.get("special").add_modifier(Modifier::BOLD);
 
         // -- Render the frame:
         // clear area

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -512,6 +512,7 @@ impl<T: Item + 'static> Picker<T> {
     }
 
     fn render_picker(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        let picker_config = &cx.editor.config.load().picker;
         let status = self.matcher.tick(10);
         let snapshot = self.matcher.snapshot();
         if status.changed {
@@ -521,8 +522,12 @@ impl<T: Item + 'static> Picker<T> {
         }
 
         let text_style = cx.editor.theme.get("ui.text");
-        let selected = cx.editor.theme.get("ui.text.focus");
-        let highlight_style = cx.editor.theme.get("special").add_modifier(Modifier::BOLD);
+        let selected = cx.editor.theme.get(&picker_config.selected_style);
+        let highlight_style = cx
+            .editor
+            .theme
+            .get(&picker_config.highlight_style)
+            .add_modifier(Modifier::BOLD);
 
         // -- Render the frame:
         // clear area
@@ -656,7 +661,7 @@ impl<T: Item + 'static> Picker<T> {
         let table = Table::new(options)
             .style(text_style)
             .highlight_style(selected)
-            .highlight_symbol(" > ")
+            .highlight_symbol(&picker_config.highlight_symbol)
             .column_spacing(1)
             .widths(&self.widths);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -165,6 +165,24 @@ impl Default for GutterLineNumbersConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    pub selected_style: String,
+    pub highlight_style: String,
+    pub highlight_symbol: String,
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        Self {
+            selected_style: "ui.text.focus".to_string(),
+            highlight_style: "special".to_string(),
+            highlight_symbol: " > ".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
     /// IgnoreOptions
     /// Enables ignoring hidden files.
@@ -291,6 +309,8 @@ pub struct Config {
     pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
+    /// Options that apply to all pickers
+    pub picker: PickerConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -846,6 +866,7 @@ impl Default for Config {
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,
             smart_tab: Some(SmartTabConfig::default()),
+            picker: PickerConfig::default(),
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -166,16 +166,13 @@ impl Default for GutterLineNumbersConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct PickerConfig {
-    pub selected_style: String,
-    pub highlight_style: String,
+    /// Symbol in front of selected picker item row
     pub highlight_symbol: String,
 }
 
 impl Default for PickerConfig {
     fn default() -> Self {
         Self {
-            selected_style: "ui.text.focus".to_string(),
-            highlight_style: "special".to_string(),
             highlight_symbol: " > ".to_string(),
         }
     }


### PR DESCRIPTION
This adds some general/global configurability for the picker. I've been running a fork and I was using different styles than the default. I figured others might like to as well.

Additionally I've noticed there are some PRs that maybe want to change how the picker works that might also like to put those options in the new `PickerConfig`. Namely #8155, #7124


<details>
  <summary>Old Example see <a href="#pullrequestreview-1683190609">comment</a></summary>
  
![helix-picker-config](https://github.com/helix-editor/helix/assets/1284289/81f34692-0c8c-45f3-83ad-03a921776912)
  
</details>


