### PR TITLE
Add command to move files with LSP support

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -85,4 +85,4 @@
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
-| `:rename`, `:rnm` | Rename the currently selected buffer |
+| `:move` | Move the current buffer and its corresponding file to a different path |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -85,4 +85,4 @@
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
-| `:rename` | Rename the currently selected buffer |
+| `:rename`, `:rnm` | Rename the currently selected buffer |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -85,3 +85,4 @@
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
+| `:rename` | Rename the currently selected buffer |

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -709,7 +709,7 @@ impl Client {
         &self,
         params: &Vec<lsp::FileRename>,
     ) -> impl Future<Output = Result<Option<lsp::WorkspaceEdit>>> {
-        let files = params.clone();
+        let files = params.to_owned();
         let request = self.call::<lsp::request::WillRenameFiles>(lsp::RenameFilesParams { files });
 
         async move {
@@ -719,11 +719,8 @@ impl Client {
         }
     }
 
-    pub fn did_rename_files(
-        &self,
-        params: &Vec<lsp::FileRename>,
-    ) -> impl Future<Output = Result<()>> {
-        let files = params.clone();
+    pub fn did_rename_files(&self, params: &[lsp::FileRename]) -> impl Future<Output = Result<()>> {
+        let files = params.to_owned();
         self.notify::<lsp::notification::DidRenameFiles>(lsp::RenameFilesParams { files })
     }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2432,8 +2432,8 @@ fn rename_buffer(
         return Err(anyhow!("This file already exists"));
     }
 
-    if std::fs::rename(&path, &path_new).is_err() {
-        return Err(anyhow!("Could not rename file"));
+    if let Err(e) = std::fs::rename(&path, &path_new) {
+        return Err(anyhow!("Could not rename file, error: {}", e));
     }
     let (_, doc) = current!(cx.editor);
     doc.set_path(Some(path_new.as_path()))
@@ -2441,20 +2441,21 @@ fn rename_buffer(
 
     let mut lsp_success = false;
     if let Some(lsp_client) = doc.language_server() {
-        let old_uri = Url::from_file_path(&path)
-            .map_err(|_| anyhow!("Language server request failed, could not get current path uri"))?
-            .to_string();
-        let new_uri = Url::from_file_path(&path_new)
-            .map_err(|_| anyhow!("Language server request failed, could not get new path uri"))?
-            .to_string();
-        let mut files = vec![lsp::FileRename { old_uri, new_uri }];
-        let result = helix_lsp::block_on(lsp_client.will_rename_files(&files))?;
-        _ = helix_lsp::block_on(lsp_client.did_rename_files(&files)).is_ok();
-        if let Some(edit) = result {
-            apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit);
-            lsp_success = true;
+        if let Ok(old_uri_str) = Url::from_file_path(&path) {
+            let old_uri = old_uri_str.to_string();
+            if let Ok(new_uri_str) = Url::from_file_path(&path_new) {
+                let new_uri = new_uri_str.to_string();
+                let files = vec![lsp::FileRename { old_uri, new_uri }];
+                let result = helix_lsp::block_on(lsp_client.will_rename_files(&files))?;
+                if let Some(edit) = result {
+                    apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit);
+                    lsp_success = true;
+                }
+            } else {
+                log::error!(":rename command could not get new path uri")
+            }
         } else {
-            files.clear();
+            log::error!(":rename command could not get current path uri")
         }
     }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2426,8 +2426,6 @@ fn rename_buffer(
     let path = doc
         .relative_path()
         .ok_or_else(|| anyhow!("Scratch buffers can not be renamed, use :write"))?
-        .canonicalize()
-        .map_err(|_| anyhow!("Could not get absolute path of the document"))?;
     let mut path_new = path.clone();
     path_new.set_file_name(OsStr::new(new_name.as_ref()));
     if path_new.exists() {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2424,7 +2424,7 @@ fn rename_buffer(
 
     let (_, doc) = current!(cx.editor);
     let path = doc
-        .relative_path()
+        .path()
         .ok_or_else(|| anyhow!("Scratch buffers can not be renamed, use :write"))?
     let mut path_new = path.clone();
     path_new.set_file_name(OsStr::new(new_name.as_ref()));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2429,17 +2429,16 @@ fn rename_buffer(
     let mut path_new = path.clone();
     path_new.set_file_name(OsStr::new(new_name.as_ref()));
     if path_new.exists() {
-        return Err(anyhow!("This file already exists"));
+        bail!("This file already exists");
     }
 
     if let Err(e) = std::fs::rename(&path, &path_new) {
-        return Err(anyhow!("Could not rename file, error: {}", e));
+        bail!("Could not rename file, error: {}", e);
     }
     let (_, doc) = current!(cx.editor);
     doc.set_path(Some(path_new.as_path()))
         .map_err(|_| anyhow!("File renamed, but could not set path of the document"))?;
 
-    let mut lsp_success = false;
     if let Some(lsp_client) = doc.language_server() {
         if let Ok(old_uri_str) = Url::from_file_path(&path) {
             let old_uri = old_uri_str.to_string();
@@ -2449,7 +2448,8 @@ fn rename_buffer(
                 let result = helix_lsp::block_on(lsp_client.will_rename_files(&files))?;
                 if let Some(edit) = result {
                     apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit);
-                    lsp_success = true;
+                } else {
+                    bail!("File renaming succeded, but language server did not respond to change")
                 }
             } else {
                 log::error!(":rename command could not get new path uri")
@@ -2458,13 +2458,8 @@ fn rename_buffer(
             log::error!(":rename command could not get current path uri")
         }
     }
-
-    match lsp_success {
-        true => Ok(()),
-        false => Err(anyhow!(
-            "File renaming succeeded, but language server did not respond to change"
-        )),
-    }
+    cx.editor.set_status(format!("Renamed file to {}", new_name));
+    Ok(())
 }
 
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,15 +1,13 @@
 use std::fmt::Write;
-use std::fmt::Write;
 use std::ops::Deref;
-use std::{ffi::OsStr, ops::Deref};
 
 use crate::job::Job;
 
 use super::*;
 
 use helix_core::fuzzy::fuzzy_match;
-use helix_core::{encoding, line_ending, shellwords::Shellwords};
-use helix_lsp::{lsp, Url};
+use helix_core::{encoding, line_ending, path::get_canonicalized_path, shellwords::Shellwords};
+use helix_lsp::{OffsetEncoding, Url};
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::editor::{Action, CloseError, ConfigEvent};
 use serde_json::Value;
@@ -2421,22 +2419,61 @@ fn move_buffer(
     }
 
     ensure!(args.len() == 1, format!(":move takes one argument"));
+    let doc = doc!(cx.editor);
 
-    let new_path =
-        helix_core::path::get_normalized_path(&PathBuf::from(args.first().unwrap().as_ref()));
-    let (_, doc) = current!(cx.editor);
-
+    let new_path = get_canonicalized_path(&PathBuf::from(args.first().unwrap().to_string()));
     let old_path = doc
         .path()
         .ok_or_else(|| anyhow!("Scratch buffer cannot be moved. Use :write instead"))?
         .clone();
+    let old_path_as_url = doc.url().unwrap();
+    let new_path_as_url = Url::from_file_path(&new_path).unwrap();
+
+    let edits: Vec<(
+        helix_lsp::Result<helix_lsp::lsp::WorkspaceEdit>,
+        OffsetEncoding,
+        String,
+    )> = doc
+        .language_servers()
+        .map(|lsp| {
+            (
+                lsp.prepare_file_rename(&old_path_as_url, &new_path_as_url),
+                lsp.offset_encoding(),
+                lsp.name().to_owned(),
+            )
+        })
+        .filter(|(f, _, _)| f.is_some())
+        .map(|(f, encoding, name)| (helix_lsp::block_on(f.unwrap()), encoding, name))
+        .collect();
+
+    for (lsp_reply, encoding, name) in edits {
+        match lsp_reply {
+            Ok(edit) => {
+                if let Err(e) = apply_workspace_edit(cx.editor, encoding, &edit) {
+                    log::error!(
+                        ":move command failed to apply edits from lsp {}: {:?}",
+                        name,
+                        e
+                    );
+                };
+            }
+            Err(e) => {
+                log::error!("LSP {} failed to treat willRename request: {:?}", name, e);
+            }
+        };
+    }
+
+    let doc = doc_mut!(cx.editor);
 
     doc.set_path(Some(new_path.as_path()));
-
-    if let Err(e) = std::fs::rename(&old_path, doc.path().unwrap()) {
+    if let Err(e) = std::fs::rename(&old_path, &new_path) {
         doc.set_path(Some(old_path.as_path()));
         bail!("Could not move file: {}", e);
     };
+
+    doc.language_servers().for_each(|lsp| {
+        lsp.did_file_rename(&old_path_as_url, &new_path_as_url);
+    });
 
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2445,7 +2445,6 @@ fn rename_buffer(
             if let Ok(new_uri_str) = Url::from_file_path(&path_new) {
                 let new_uri = new_uri_str.to_string();
                 let files = vec![lsp::FileRename { old_uri, new_uri }];
-                log::debug!("{:?}", files);
                 match helix_lsp::block_on(lsp_client.will_rename_files(&files)) {
                     Ok(edit) => {
                         apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit)

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3069,10 +3069,10 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "rename",
-        aliases: &[],
+        aliases: &["rnm"],
         doc: "Rename the currently selected buffer",
         fun: rename_buffer,
-        completer: None
+        signature: CommandSignature::none(),
     },
 ];
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2453,7 +2453,7 @@ fn rename_buffer(
                             log::error!(":rename command failed to apply edits")
                         }
                     }
-                    Err(err) => log::error!("Language server error: {}", err),
+                    Err(err) => log::error!("willRename request failed: {err}"),
                 }
             } else {
                 log::error!(":rename command could not get new path uri")

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,4 +1,6 @@
 use std::fmt::Write;
+use std::fmt::Write;
+use std::ops::Deref;
 use std::{ffi::OsStr, ops::Deref};
 
 use crate::job::Job;
@@ -2447,7 +2449,11 @@ fn rename_buffer(
                 let files = vec![lsp::FileRename { old_uri, new_uri }];
                 match helix_lsp::block_on(lsp_client.will_rename_files(&files)) {
                     Ok(edit) => {
-                        apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit)
+                        if apply_workspace_edit(cx.editor, helix_lsp::OffsetEncoding::Utf8, &edit)
+                            .is_err()
+                        {
+                            log::error!(":rename command failed to apply edits")
+                        }
                     }
                     Err(err) => log::error!("Language server error: {}", err),
                 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2475,6 +2475,11 @@ fn move_buffer(
         lsp.did_file_rename(&old_path_as_url, &new_path_as_url);
     });
 
+    cx.editor
+        .language_servers
+        .file_event_handler
+        .file_changed(new_path);
+
     Ok(())
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2433,7 +2433,7 @@ fn rename_buffer(
     }
 
     if let Err(e) = std::fs::rename(&path, &path_new) {
-        bail!("Could not rename file, error: {}", e);
+        bail!("Could not rename file: {e}");
     }
     let (_, doc) = current!(cx.editor);
     doc.set_path(Some(path_new.as_path()))

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2429,7 +2429,7 @@ fn rename_buffer(
     let mut path_new = path.clone();
     path_new.set_file_name(OsStr::new(new_name.as_ref()));
     if path_new.exists() {
-        bail!("This file already exists");
+        bail!("Destination already exists");
     }
 
     if let Err(e) = std::fs::rename(&path, &path_new) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2425,7 +2425,7 @@ fn rename_buffer(
     let (_, doc) = current!(cx.editor);
     let path = doc
         .relative_path()
-        .ok_or_else(|| anyhow!("Buffer not saved, use :write"))?
+        .ok_or_else(|| anyhow!("Scratch buffers can not be renamed, use :write"))?
         .canonicalize()
         .map_err(|_| anyhow!("Could not get absolute path of the document"))?;
     let mut path_new = path.clone();

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2428,6 +2428,9 @@ fn rename_buffer(
         .map_err(|_| anyhow!("Could not get absolute path of the document"))?;
     let mut path_new = path.clone();
     path_new.set_file_name(OsStr::new(new_name.as_ref()));
+    if path_new.exists() {
+        return Err(anyhow!("This file already exists"));
+    }
 
     if std::fs::rename(&path, &path_new).is_err() {
         return Err(anyhow!("Could not rename file"));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2417,7 +2417,7 @@ fn rename_buffer(
     if event != PromptEvent::Validate {
         return Ok(());
     }
-    ensure!(args.len() == 1, ":rename_buffer takes one argument");
+    ensure!(args.len() == 1, ":rename takes one argument");
     let new_name = args.first().unwrap();
 
     let (_, doc) = current!(cx.editor);


### PR DESCRIPTION
close #4393

Allows to rename the active buffer by moving it to another path.

```
:move my_new_file.rs
```

Heavily based on all the work done in https://github.com/helix-editor/helix/pull/5531 by @ontley and apply the suggestions

The PR seems dead and I would really like to see that feature come into helix :)

