### PR TITLE
Theme cyan light diff colors

### DIFF
--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -10,7 +10,7 @@
 "constant" = "darker_blue"
 "constant.builtin.boolean" = "blue"
 "constant.character" = "blue"
-"constant.character.escape" = "blue"
+"constant.character.escape" = "dark_red"
 "constant.numeric" = "blue"
 
 "string" = "green"

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -10,7 +10,7 @@
 "constant" = "darker_blue"
 "constant.builtin.boolean" = "blue"
 "constant.character" = "blue"
-"constant.character.escape" = "dark_red"
+"constant.character.escape" = "blue"
 "constant.numeric" = "blue"
 
 "string" = "green"
@@ -57,9 +57,12 @@
 "markup.raw.inline" = "green"
 "markup.raw.block" = "green"
 
-"diff.plus" = "diff_green"
-"diff.minus" = "diff_red"
-"diff.delta" = "diff_blue"
+"diff.plus" = "green"
+"diff.plus.gutter" = "gutter_green"
+"diff.minus" = "red"
+"diff.minus.gutter" = "gutter_red"
+"diff.delta" = "blue"
+"diff.delta.gutter" = "gutter_blue"
 
 # ui specific
 "ui.background" = { bg = "shade00" }
@@ -121,7 +124,7 @@ foreground = "#25293c"
 
 comment_gray = "#808080"
 
-diff_blue = "#C3D6E8"
+gutter_blue = "#C3D6E8"
 faint_blue = "#E8Eef1"
 lighter_blue = "#d0eaff"
 light_blue = "#99ccff"
@@ -134,7 +137,7 @@ darker_blue = "#000080"
 purple = "#660E7A"
 light_purple = "#ED9CFF"
 
-diff_green = "#C9DEC1"
+gutter_green = "#C9DEC1"
 green = "#00733B"
 light_green = "#5DCE87"
 green_blue = "#458383"
@@ -146,6 +149,6 @@ dark_yellow = "#7A7A43"
 light_orange = "#f9c881"
 orange = "#F49810"
 
-diff_red = "#EBBCBC"
+gutter_red = "#EBBCBC"
 red = "#d90016"
 dark_red = "#7F0000"


### PR DESCRIPTION
Use the highlight names that are used to separate between gutter colors from diff lang colors in the highlight names and thus have better colors for diff lang

![image](https://github.com/helix-editor/helix/assets/302837/b82c4126-d825-4c66-a1c0-ccf86c02f69c)

👇🏼 

![image](https://github.com/helix-editor/helix/assets/302837/c7bc20b6-60ed-43de-91c7-ed48be1cd909)
