### PR TITLE
Use terminfo to reset terminal cursor style

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -32,10 +32,21 @@ fn vte_version() -> Option<usize> {
 }
 
 /// Describes terminal capabilities like extended underline, truecolor, etc.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 struct Capabilities {
     /// Support for undercurled, underdashed, etc.
     has_extended_underlines: bool,
+    /// Support for resetting the cursor style back to normal.
+    reset_cursor_command: String,
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            has_extended_underlines: false,
+            reset_cursor_command: "\x1B[0 q".to_string(),
+        }
+    }
 }
 
 impl Capabilities {
@@ -54,6 +65,10 @@ impl Capabilities {
                     || t.extended_cap("Su").is_some()
                     || vte_version() >= Some(5102)
                     || matches!(term_program().as_deref(), Some("WezTerm")),
+                reset_cursor_command: t
+                    .utf8_string_cap(termini::StringCapability::CursorNormal)
+                    .unwrap_or("\x1B[0 q")
+                    .to_string(),
             },
         }
     }
@@ -154,7 +169,8 @@ where
 
     fn restore(&mut self, config: Config) -> io::Result<()> {
         // reset cursor shape
-        write!(self.buffer, "\x1B[0 q")?;
+        self.buffer
+            .write_all(self.capabilities.reset_cursor_command.as_bytes())?;
         if config.enable_mouse_capture {
             execute!(self.buffer, DisableMouseCapture)?;
         }


### PR DESCRIPTION
Uses the `cnorm` capability from `terminfo` if available to reset the terminal cursor style. I tested this with `xterm` and it seems to fix the issue with making the cursor blink like in #3741.

Closes #2684