### PR TITLE
PoC for printing config location

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -19,6 +19,7 @@ pub struct Args {
     pub files: Vec<(PathBuf, Position)>,
     pub open_cwd: bool,
     pub working_directory: Option<PathBuf>,
+    pub print_config_location: bool,
 }
 
 impl Args {
@@ -76,6 +77,7 @@ impl Args {
                         anyhow::bail!("--working-dir must specify an initial working directory")
                     }
                 },
+                "--print-config-location" => args.print_config_location = true,
                 arg if arg.starts_with("--") => {
                     anyhow::bail!("unexpected double dash argument: {}", arg)
                 }

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -143,6 +143,12 @@ FLAGS:
         }
     };
 
+    if args.print_config_location {
+        println!("Workspace config loaded: {}\nLocation:\n{}", config.local_location.1, config.local_location.0.to_str().unwrap());
+        println!("Global config loaded: {}\nLocation:\n{}", config.global_location.1, config.global_location.0.to_str().unwrap());
+        return Ok(0);
+    }
+
     let syn_loader_conf = helix_core::config::user_syntax_loader().unwrap_or_else(|err| {
         eprintln!("Bad language config: {}", err);
         eprintln!("Press <ENTER> to continue with default language config");


### PR DESCRIPTION
Hello,

Please don't worry too much about the code quality at the moment, I just wanted to get a feel for whether the functionality below would be considered useful.

I can find it a bit fiddly to find where Helix is loading config files from - especially on Windows. For example lots of software looks for config in `~`, `~/.config` which maps to `C:\Users\$USERNAME\` on modern Windows, Helix (or `etcetera`) puts things in `C:\Users\$USERNAME\AppData\Roaming\Helix` which might be more "technically correct" but doesn't help my config file woes.

It would help if I could quickly see where Helix was looking on a given system. Ideally through a CLI command so it could be semi-scripted. I've attempted to implement that below, where `hx --print-config-location` gives the output below.

```
$ cargo run -- --print-config-location
   Compiling helix-term v0.6.0 (helix\helix-term)
    Finished dev [unoptimized + debuginfo] target(s) in 12.54s
     Running `target\debug\hx.exe --print-config-location`
Workspace config loaded: false
Location:
C:\<snipped>\helix\.helix\config.toml
Global config loaded: false
Location:
C:\<snipped>\AppData\Roaming\helix\config.toml
```

If you do like the idea of this, I'm happy to polish it up and document it. I'd be interested in thoughts on:
1. Command name - is there something shorter than `--print-config-location` that makes it clear it's the path, not the content?
2. Thoughts on structure - should this logic be put into `helix-loader`?
3. Output format. Bear in mind someone is likely to want to do `cat "$(hx --print-config-location | tail -n 1)"` or similar, and especially on Windows that would likely be a path with spaces. This suggests to me the location would be on it's own on one line
4. Does `languages.toml` or anything else belong in the output as well?

Can anyone think of similar commands in other software? `git config --show-origin --list` is the only one that springs to mind. (As an aside in the future if Helix gets more complex I do wonder whether tagging the origin of each piece of config may be useful)