### PR TITLE
Add optional runtime fallback directory

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -224,7 +224,7 @@ Or, create a symbolic link:
 ln -Ts $PWD/runtime ~/.config/helix/runtime
 ```
 
-If the above command fails to create a symbolic link because the file exists either move `~/.config/helix/runtime` to a new location or delete it, then run the symlink command above again. 
+If the above command fails to create a symbolic link because the file exists either move `~/.config/helix/runtime` to a new location or delete it, then run the symlink command above again.
 
 #### Windows
 
@@ -257,11 +257,31 @@ following order:
 1. `runtime/` sibling directory to `$CARGO_MANIFEST_DIR` directory (this is intended for
   developing and testing helix only).
 2. `runtime/` subdirectory of OS-dependent helix user config directory.
-3. `$HELIX_RUNTIME`.
-4. `runtime/` subdirectory of path to Helix executable.
+3. `$HELIX_RUNTIME`
+4. Distribution-specific fallback directory (set at compile time—not run time—
+   with the `HELIX_DEFAULT_RUNTIME` environment variable)
+5. `runtime/` subdirectory of path to Helix executable.
 
 This order also sets the priority for selecting which file will be used if multiple runtime
 directories have files with the same name.
+
+#### Note to packagers
+
+If you are making a package of Helix for end users, to provide a good out of
+the box experience, you should set the `HELIX_DEFAULT_RUNTIME` environment
+variable at build time (before invoking `cargo build`) to a directory which
+will store the final runtime files after installation. For example, say you want
+to package the runtime into `/usr/lib/helix/runtime`. The rough steps a build
+script could follow are:
+
+1. `export HELIX_DEFAULT_RUNTIME=/usr/lib/helix/runtime`
+1. `cargo build --profile opt --locked --path helix-term`
+1. `cp -r runtime $BUILD_DIR/usr/lib/helix/`
+1. `cp target/opt/hx $BUILD_DIR/usr/bin/hx`
+
+This way the resulting `hx` binary will always look for its runtime directory in
+`/usr/lib/helix/runtime` if the user has no custom runtime in `~/.config/helix`
+or `HELIX_RUNTIME`.
 
 ### Validating the installation
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -60,7 +60,8 @@ pub fn initialize_log_file(specified_file: Option<PathBuf>) {
 /// 1. sibling directory to `CARGO_MANIFEST_DIR` (if environment variable is set)
 /// 2. subdirectory of user config directory (always included)
 /// 3. `HELIX_RUNTIME` (if environment variable is set)
-/// 4. subdirectory of path to helix executable (always included)
+/// 4. `HELIX_DEFAULT_RUNTIME` (if environment variable is set *at build time*)
+/// 5. subdirectory of path to helix executable (always included)
 ///
 /// Postcondition: returns at least two paths (they might not exist).
 fn prioritize_runtime_dirs() -> Vec<PathBuf> {
@@ -78,6 +79,14 @@ fn prioritize_runtime_dirs() -> Vec<PathBuf> {
     rt_dirs.push(conf_rt_dir);
 
     if let Ok(dir) = std::env::var("HELIX_RUNTIME") {
+        rt_dirs.push(dir.into());
+    }
+
+    // If this variable is set during build time, it will always be included
+    // in the lookup list. This allows downstream packagers to set a fallback
+    // directory to a location that is conventional on their distro so that they
+    // need not resort to a wrapper script or a global environment variable.
+    if let Some(dir) = std::option_env!("HELIX_DEFAULT_RUNTIME") {
         rt_dirs.push(dir.into());
     }
 


### PR DESCRIPTION
Currently, Helix looks for its runtime directory in the user's home directory, in the `HELIX_RUNTIME` directory if set, and finally the binary's directory. This makes it somewhat difficult for downstream packagers to figure out how to package the Helix runtime that we generate so that Helix can find it out of the box with no other user intervention.

Additionally, since each OS and distro will have its own conventional place they put application files, we can't simply choose a directory we think is common.

This has led to a few packages resorting to making `hx` a wrapper script that sets `HELIX_RUNTIME` and then invokes the real binary, which is not ideal.

This change adds the ability to hardcode one additional directory into the runtime search path by setting the `HELIX_DEFAULT_RUNTIME` environment variable at build time. If set, then Helix will look in this directory for the runtime after `~/.config/helix` and `HELIX_RUNTIME`. This way, each packager can choose which directory they'd like the final helix binary to look for the runtime they will include in their package without having to resort to a wrapper script or setting a global environment variable.