### PR TITLE
Update MSRV to reduce install times

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 default-run = "hx"
-rust-version = "1.65"
+rust-version = "1.68.2"
 
 [features]
 default = ["git"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.68.0"
 components = ["rustfmt", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.68.2"
 components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
As I didn't have the prior rust toolchain version installed, the install from source of helix was very very long, in large part as I needed to do a full crates.io registry update. 


[In 1.68.0](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol) sparse registry protocol was introduced, and this _radically_ reduces the build time (order of a few minuets for me) including the registry update. Here I propose the MSRV is bumped to at least this release, inclusive of patches to 1.68.2 .