### PR TITLE
Update the url of documentation

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1,5 +1,5 @@
 # Language support configuration.
-# See the languages documentation: https://docs.helix-editor.com/master/languages.html
+# See the languages documentation: https://docs.helix-editor.com/languages.html
 
 [language-server]
 


### PR DESCRIPTION
Replaces `https://docs.helix-editor.com/master/languages.html` which is 404