### PR TITLE
CI: Publish stable book before master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,16 +26,16 @@ jobs:
           OUTDIR=$(basename ${{ github.ref }})
           echo "OUTDIR=$OUTDIR" >> $GITHUB_ENV
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/book
-          destination_dir: ./${{ env.OUTDIR }}
-
       - name: Deploy stable
         uses: peaceiris/actions-gh-pages@v3
         if: startswith(github.ref, 'refs/tags/')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book
+          destination_dir: ./${{ env.OUTDIR }}


### PR DESCRIPTION
Previously, the stable release would wipe the master files since master is a subdirectory of stable. We can publish stable first and then master so that both exist after pushing a new tag. This change swaps those two blocks.

See #8615