### PR TITLE
fix: typo in multiple files

### DIFF
--- a/runtime/queries/_typescript/highlights.scm
+++ b/runtime/queries/_typescript/highlights.scm
@@ -39,11 +39,11 @@
     (identifier) @variable.parameter))
 
 ; (p?: t)
-; (p?: t = 1) // Invalid but still posible to hihglight.
+; (p?: t = 1) // Invalid but still possible to highlight.
 (optional_parameter 
   (identifier) @variable.parameter)
 
-; (...p?: t) // Invalid but still posible to hihglight.
+; (...p?: t) // Invalid but still possible to highlight.
 (optional_parameter
   (rest_pattern
     (identifier) @variable.parameter))
@@ -59,7 +59,7 @@
     (pair_pattern
       value: (identifier) @variable.parameter)))
 
-; ([ p ]?: t[]) // Invalid but still posible to hihglight.
+; ([ p ]?: t[]) // Invalid but still possible to highlight.
 (optional_parameter
   (array_pattern
     (identifier) @variable.parameter))

--- a/runtime/queries/yuck/highlights.scm
+++ b/runtime/queries/yuck/highlights.scm
@@ -101,7 +101,7 @@
 (list
   (symbol) @tag)
 
-; Other stuff that has not been catched by the previous queries yet
+; Other stuff that has not been caught by the previous queries yet
 
 (ident) @variable
 (index) @variable


### PR DESCRIPTION
This PR fix the typos seen in multiple files

```pseudo
continous > continuous
indecies > indicies
posible > possible
thhis > this
reeplace > replace
witth > with
```