### PR TITLE
Add ability to specify interval for line numbering

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -223,6 +223,8 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
+    /// Line number interval.
+    pub line_number_interval: usize,
     /// Highlight the lines cursors are currently on. Defaults to false.
     pub cursorline: bool,
     /// Highlight the columns cursors are currently on. Defaults to false.
@@ -811,6 +813,7 @@ impl Default for Config {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },
             line_number: LineNumber::Absolute,
+            line_number_interval: 1,
             cursorline: false,
             cursorcolumn: false,
             gutters: GutterConfig::default(),

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -163,6 +163,7 @@ pub fn line_numbers<'doc>(
         .char_to_line(doc.selection(view.id).primary().cursor(text));
 
     let line_number = editor.config().line_number;
+    let interval = editor.config().line_number_interval;
     let mode = editor.mode;
 
     Box::new(
@@ -190,7 +191,7 @@ pub fn line_numbers<'doc>(
                     linenr
                 };
 
-                if first_visual_line {
+                if first_visual_line && (display_num % interval == 0 || current_line == line) {
                     write!(out, "{:>1$}", display_num, width).unwrap();
                 } else {
                     write!(out, "{:>1$}", " ", width).unwrap();


### PR DESCRIPTION
The default value doesn't change anything. If the value of `line-number-interval` is changed then only every n-th line is printed (except for the current line which is always printed).

A similar setting was implemented for VSCode: https://github.com/microsoft/vscode/pull/37120

This is how it looks with a value of 5:

![latest](https://github.com/helix-editor/helix/assets/1718963/ebccce52-379c-4162-a4ca-1687d11315be)
