### PR TITLE
Import obsd patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
   "xtask",
 ]
 
+resolver = "2"
+
 default-members = [
   "helix-term"
 ]

--- a/helix-loader/build.rs
+++ b/helix-loader/build.rs
@@ -5,6 +5,9 @@ use std::process::Command;
 const VERSION: &str = include_str!("../VERSION");
 
 fn main() {
+    #[cfg(target_os = "openbsd")]
+    let git_hash: Option<&String> = None;
+    #[cfg(not(target_os = "openbsd"))]
     let git_hash = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -92,6 +92,13 @@ fn ensure_git_is_available() -> Result<()> {
     }
 }
 
+#[cfg(target_os = "openbsd")]
+pub fn fetch_grammars() -> Result<()> {
+    println!("Command to fetch grammars disabled");
+    Ok(())
+}
+
+#[cfg(not(target_os = "openbsd"))]
 pub fn fetch_grammars() -> Result<()> {
     ensure_git_is_available()?;
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -92,11 +92,14 @@ fn prioritize_runtime_dirs() -> Vec<PathBuf> {
 
     // fallback to location of the executable being run
     // canonicalize the path in case the executable is symlinked
+    #[cfg(not(target_os = "openbsd"))]
     let exe_rt_dir = std::env::current_exe()
         .ok()
         .and_then(|path| std::fs::canonicalize(path).ok())
         .and_then(|path| path.parent().map(|path| path.to_path_buf().join(RT_DIR)))
         .unwrap();
+    #[cfg(target_os = "openbsd")]
+    let exe_rt_dir = std::path::PathBuf::from("%%DATADIR%%").join(RT_DIR);
     rt_dirs.push(exe_rt_dir);
     rt_dirs
 }


### PR DESCRIPTION
not sure why not given before but here are some openbsd patches. there is one more but not sure if needed. dont know why fetch disabled. maybe takes too long or ulimit hit? may need to contact author about it or questions.

ref: https://github.com/openbsd/ports/tree/master/editors/helix/patches

feel free to edit