### PR TITLE
Dynamic command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -86,3 +86,4 @@
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
 | `:move` | Move the current buffer and its corresponding file to a different path |
+| `:dynamic` | Run a potentially dynamically generated command |


### PR DESCRIPTION
This pull request is meant to pair with: https://github.com/helix-editor/helix/pull/6979

It adds the `dynamic` command which is basically a placeholder command. When paired with shell expansion in the above pull request it allows for commands like the following:
```
:dynamic %sh{if [ -f Cargo.toml ]; then echo vsplit Cargo.toml; fi}
```
The above command uses a simple bash if else to check if Cargo.toml exists, before issuing the `vsplit` command with `Cargo.toml` as its argument. If `Cargo.toml` does not exist it does nothing. 

I personally use this command in concert with Wezterm to integrate tools like ripgrep for live fuzzy searching and ranger for an awesome file picking experience right from helix. Specifically, I dynamically generate `vsplit`, `hsplit`, and `open` commands depending on keystrokes that I issue, but with this dynamic command and the shell expansion in https://github.com/helix-editor/helix/pull/6979 anything becomes possible!

This is my first pull request so I apologize if I am missing some necessary tests or anything. Please let me know what you all think. Thank you!