### PR TITLE
Bothersome softwrapping of only a newline character

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -293,7 +293,7 @@ impl<'t> DocumentFormatter<'t> {
 
         loop {
             // softwrap word if necessary
-            if word_width + self.visual_pos.col >= self.text_fmt.viewport_width as usize {
+            if word_width + self.visual_pos.col > self.text_fmt.viewport_width as usize {
                 // wrapping this word would move too much text to the next line
                 // split the word at the line end instead
                 if word_width > self.text_fmt.max_wrap as usize {


### PR DESCRIPTION
When a line perfectly fills the viewport width and softwrap is enabled, the newline character will be softwrapped, leading to an extra blank line below.

<img width="639" alt="Screenshot 2023-10-27 at 17 47 29" src="https://github.com/helix-editor/helix/assets/79615262/2767c3ee-de95-4b30-b93c-158ca47a834f">

This behavior can be mitigated by simply changing the inequality that checks for softwraps to a strict inequality, which this PR does. However, this change has the side effect that when the cursor is on the newline, it will be off-screen. To be clear, these are both problems exclusively experienced when a line has the exact number of characters to fill the width of the viewport. These two behaviors are both rather bothersome, so I am not sure which is preferable, so it's up to the maintainers whether to accept this PR or not.