### PR TITLE
fix: replace kdl tree-sitter to fix highlighting

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -81,7 +81,7 @@
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ | `julia` |
 | just | ✓ | ✓ | ✓ |  |
-| kdl | ✓ |  |  |  |
+| kdl | ✓ | ✓ | ✓ |  |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
 | latex | ✓ | ✓ |  | `texlab` |
 | lean | ✓ |  |  | `lean` |

--- a/languages.toml
+++ b/languages.toml
@@ -2334,7 +2334,7 @@ injection-regex = "kdl"
 
 [[grammar]]
 name = "kdl"
-source = { git = "https://github.com/Unoqwy/tree-sitter-kdl", rev = "e1cd292c6d15df6610484e1d4b5c987ecad52373" }
+source = { git = "https://github.com/amaanq/tree-sitter-kdl", rev = "3ca569b9f9af43593c24f9e7a21f02f43a13bb88" }
 
 [[language]]
 name = "xml"

--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -1,12 +1,10 @@
-(comment) @comment
 (single_line_comment) @comment
+(multi_line_comment) @comment
 
 (node
-    name: (identifier) @function)
+    (identifier) @function)
 (prop (identifier) @attribute)
 (type) @type
-
-(bare_identifier) @variable.other.member
 
 (keyword) @keyword
 

--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -2,9 +2,11 @@
 (multi_line_comment) @comment
 
 (node
-    (identifier) @function)
+    (identifier) @variable)
+
 (prop (identifier) @attribute)
-(type) @type
+
+(type (_) @type) @punctuation.bracket
 
 (keyword) @keyword
 

--- a/runtime/queries/kdl/indents.scm
+++ b/runtime/queries/kdl/indents.scm
@@ -1,7 +1,3 @@
-[
-  (node_children)
-] @indent
+(node_children) @indent
 
-[
-  "}"
-] @outdent
+ "}" @outdent

--- a/runtime/queries/kdl/indents.scm
+++ b/runtime/queries/kdl/indents.scm
@@ -1,0 +1,7 @@
+[
+  (node_children)
+] @indent
+
+[
+  "}"
+] @outdent

--- a/runtime/queries/kdl/textobjects.scm
+++ b/runtime/queries/kdl/textobjects.scm
@@ -1,0 +1,27 @@
+(type (_) @test.inside) @test.around
+
+(node
+	children: (node_children)? @class.inside) @class.around
+
+(node
+	children: (node_children)? @function.inside) @function.around
+
+(node (identifier) @function.movement)
+
+[
+	(single_line_comment)
+	(multi_line_comment)
+] @comment.inside
+
+[
+	(single_line_comment)+
+	(multi_line_comment)+
+] @comment.around
+
+[
+	(prop)
+	(value)
+] @parameter.inside
+
+(value (type) ? (_) @parameter.inside @parameter.movement . ) @parameter.around
+


### PR DESCRIPTION
The tree-sitter for the kdl language currently being used contains bugs.

Consider the following kdl config:
```kdl
bigFlatItems "multiline \" \" \"\nstring\n" null
c "multiline string\nwith special characters:\n\t \n \" \"\n"
```

With the current tree-sitter implementation, escaped double quotes `\"` are being detected as characters ending a string. As such, they are improperly highlighted.

I propose to change the used implementation to https://github.com/amaanq/tree-sitter-kdl. It seems to be more up to date, more activate and highlights the previous example correctly.

![grafik](https://github.com/helix-editor/helix/assets/26804763/2a317e34-ce18-441b-ac64-54b9f16fd67e)
