### PR TITLE
feat: add variable segment movements and textobject

### DIFF
--- a/helix-core/src/chars.rs
+++ b/helix-core/src/chars.rs
@@ -11,6 +11,15 @@ pub enum CharCategory {
     Unknown,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum WordCharCategory {
+    Underscore,
+    Numeric,
+    UpperCase,
+    LowerCase,
+    Unknown,
+}
+
 #[inline]
 pub fn categorize_char(ch: char) -> CharCategory {
     if char_is_line_ending(ch) {
@@ -23,6 +32,22 @@ pub fn categorize_char(ch: char) -> CharCategory {
         CharCategory::Punctuation
     } else {
         CharCategory::Unknown
+    }
+}
+
+#[inline]
+pub fn categorize_word_char(ch: char) -> WordCharCategory {
+    if ch == '_' {
+        WordCharCategory::Underscore
+    } else if ch.is_numeric() {
+        WordCharCategory::Numeric
+    } else if ch.is_uppercase() {
+        WordCharCategory::UpperCase
+    } else if ch.is_alphabetic() {
+        // Treat any alphabetic char which is not UpperCase as LowerCase
+        WordCharCategory::LowerCase
+    } else {
+        WordCharCategory::Unknown
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -257,6 +257,8 @@ impl MappableCommand {
         move_prev_long_word_start, "Move to start of previous long word",
         move_next_long_word_end, "Move to end of next long word",
         move_prev_long_word_end, "Move to end of previous long word",
+        move_prev_partial_word_start, "Move to start of previous partial word",
+        move_next_partial_word_end, "Move to end of next partial word",
         move_parent_node_end, "Move to end of the parent node",
         move_parent_node_start, "Move to beginning of the parent node",
         extend_next_word_start, "Extend to start of next word",
@@ -269,6 +271,8 @@ impl MappableCommand {
         extend_prev_long_word_end, "Extend to end of prev long word",
         extend_parent_node_end, "Extend to end of the parent node",
         extend_parent_node_start, "Extend to beginning of the parent node",
+        extend_prev_partial_word_start, "Extend to start of previous partial word",
+        extend_next_partial_word_end, "Extend to end of next partial word",
         find_till_char, "Move till next occurrence of char",
         find_next_char, "Move to next occurrence of char",
         extend_till_char, "Extend till next occurrence of char",
@@ -1110,6 +1114,14 @@ fn move_next_long_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_long_word_end)
 }
 
+fn move_prev_partial_word_start(cx: &mut Context) {
+    move_word_impl(cx, movement::move_prev_partial_word_start)
+}
+
+fn move_next_partial_word_end(cx: &mut Context) {
+    move_word_impl(cx, movement::move_next_partial_word_end)
+}
+
 fn goto_para_impl<F>(cx: &mut Context, move_fn: F)
 where
     F: Fn(RopeSlice, Range, usize, Movement) -> Range + 'static,
@@ -1321,6 +1333,14 @@ fn extend_prev_long_word_end(cx: &mut Context) {
 
 fn extend_next_long_word_end(cx: &mut Context) {
     extend_word_impl(cx, movement::move_next_long_word_end)
+}
+
+fn extend_prev_partial_word_start(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_prev_partial_word_start)
+}
+
+fn extend_next_partial_word_end(cx: &mut Context) {
+    extend_word_impl(cx, movement::move_next_partial_word_end)
 }
 
 /// Separate branch to find_char designed only for `<ret>` char.
@@ -5330,6 +5350,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                     match ch {
                         'w' => textobject::textobject_word(text, range, objtype, count, false),
                         'W' => textobject::textobject_word(text, range, objtype, count, true),
+                        'v' => textobject::textobject_partial_word(text, range, objtype),
                         't' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),
@@ -5362,6 +5383,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     let help_text = [
         ("w", "Word"),
         ("W", "WORD"),
+        ("v", "Partial word"),
         ("p", "Paragraph"),
         ("t", "Type definition (tree-sitter)"),
         ("f", "Function (tree-sitter)"),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5350,7 +5350,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                     match ch {
                         'w' => textobject::textobject_word(text, range, objtype, count, false),
                         'W' => textobject::textobject_word(text, range, objtype, count, true),
-                        'v' => textobject::textobject_partial_word(text, range, objtype),
+                        'e' => textobject::textobject_partial_word(text, range, objtype),
                         't' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -34,9 +34,6 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "B" => move_prev_long_word_start,
         "E" => move_next_long_word_end,
 
-        "H" => move_prev_partial_word_start,
-        "L" => move_next_partial_word_end,
-
         "v" => select_mode,
         "G" => goto_line,
         "g" => { "Goto"
@@ -347,8 +344,6 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "W" => extend_next_long_word_start,
         "B" => extend_prev_long_word_start,
         "E" => extend_next_long_word_end,
-        "H" => extend_prev_partial_word_start,
-        "L" => extend_next_partial_word_end,
 
         "A-e" => extend_parent_node_end,
         "A-b" => extend_parent_node_start,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -34,6 +34,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "B" => move_prev_long_word_start,
         "E" => move_next_long_word_end,
 
+        "H" => move_prev_partial_word_start,
+        "L" => move_next_partial_word_end,
+
         "v" => select_mode,
         "G" => goto_line,
         "g" => { "Goto"
@@ -344,6 +347,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "W" => extend_next_long_word_start,
         "B" => extend_prev_long_word_start,
         "E" => extend_next_long_word_end,
+        "H" => extend_prev_partial_word_start,
+        "L" => extend_next_partial_word_end,
 
         "A-e" => extend_parent_node_end,
         "A-b" => extend_parent_node_start,


### PR DESCRIPTION
Hi,

I only discovered helix a few days ago, but I've already (more or less) switched over from nvim - so thanks for an awesome editor! 🙂 

However, one plugin I really like in nvim is [vim-textobj-variable-segment](https://github.com/Julian/vim-textobj-variable-segment) which makes it a lot easier to navigate variables in title/camel/snake-case and edit parts of it.

In this draft PR I have made a simple implementation of it in helix, i.e. added
- `move/extend_prev_partial_word_start` (keybind `H`)
  - Ex `let |VarInTitleCase` => `let |Var|InTitleCase` => `let Var|In|TitleCase`
- `move/extend_next_partial_word_end` (keybind `L`)
  - Ex `let var_in_snake_case| ` => `let var_in_snake|_case|`  => `let var_in|_snake|_case` 
- textobject `partial word` (keybind `v` in match inside/outside mode)
  - Ex `let var_in_sn|ake_case ` => mav => `let var_in|_snake|_case `
  - Ex `let var_in_sn|ake_case ` => miv => `let var_in_|snake|_case `
 
(I named everything `partial_word` in the code, because that's what I thought the vim plugin was called until I looked it up...)

Do you think these commands belong to the helix core? If that's the case then I'll add unit tests to the PR. 

I'll also gladly rename `partial_word` to something better if you can think of something, and you probably also want to reserve the keys `H` and `L` for something else.. (I think the movements could be added without default keybindings). 