### PR TITLE
rust: add highlight scope for type parameters

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -155,6 +155,7 @@ We use a similar set of scopes as
 
 - `type` - Types
   - `builtin` - Primitive types provided by the language (`int`, `usize`)
+  - `parameter` - Generic type parameters (`T`)
   - `enum`
     - `variant`
 - `constructor`

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -13,6 +13,8 @@
   (type_identifier) @type.parameter)
 (constrained_type_parameter
   left: (type_identifier) @type.parameter)
+(optional_type_parameter
+  name: (type_identifier) @type.parameter)
 
 ; ---
 ; Primitives

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -9,6 +9,11 @@
 ; Types
 ; -------
 
+(type_parameters
+  (type_identifier) @type.parameter)
+(constrained_type_parameter
+  left: (type_identifier) @type.parameter)
+
 ; ---
 ; Primitives
 ; ---

--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -2,6 +2,12 @@
 
 [
   (function_item)
+  (struct_item)
+  (enum_item)
+  (union_item)
+  (type_item)
+  (trait_item)
+  (impl_item)
   (closure_expression)
   (block)
 ] @local.scope
@@ -11,8 +17,13 @@
 (parameter
   (identifier) @local.definition)
 
+(type_parameters
+  (type_identifier) @local.definition)
+(constrained_type_parameter
+  left: (type_identifier) @local.definition)
+
 (closure_parameters (identifier) @local.definition)
 
 ; References
 (identifier) @local.reference
-
+(type_identifier) @local.reference

--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -21,6 +21,8 @@
   (type_identifier) @local.definition)
 (constrained_type_parameter
   left: (type_identifier) @local.definition)
+(optional_type_parameter
+  name: (type_identifier) @local.definition)
 
 (closure_parameters (identifier) @local.definition)
 


### PR DESCRIPTION
Highly generic code can be challenging to read when type parameters are highlighted the same as other types. This is especially true when the type parameters are not single letters, e.g. `Fut` is somewhat common in Rust. 

So this PR adds a new highlighting scope for type parameters. I added it only for Rust as a proof-of-concept, but if accepted I'll update the queries for any other languages I'm familiar with (either in this PR or in a follow-up, whichever is preferred).

Here is a before and after with my in-progress port of the [Codely theme](https://plugins.jetbrains.com/plugin/12891-codely-theme).

![image](https://github.com/helix-editor/helix/assets/598175/b44ef603-6b76-4f4b-984b-6c4240178b5f)


![image](https://github.com/helix-editor/helix/assets/598175/5af10c4d-515f-4ef8-86e8-b278b7513b53)
