### PR TITLE
Update idle-timeout in docs

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -51,7 +51,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
-| `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant | `400` |
+| `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant | `250` |
 | `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |


### PR DESCRIPTION
I was reading the 23.10 changelog and saw that idle-timeout has been changed to 250ms https://github.com/helix-editor/helix/commit/060e73a