### PR TITLE
feat: make more commands exit select mode

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -984,6 +984,7 @@ fn align_selections(cx: &mut Context) {
 
     let transaction = Transaction::change(doc.text(), changes.into_iter());
     doc.apply(&transaction, view.id);
+    exit_select_mode(cx);
 }
 
 fn goto_window(cx: &mut Context, align: Align) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4085,22 +4085,27 @@ pub(crate) fn paste_bracketed_value(cx: &mut Context, contents: String) {
     };
     let (view, doc) = current!(cx.editor);
     paste_impl(&[contents], doc, view, paste, count, cx.editor.mode);
+    exit_select_mode(cx);
 }
 
 fn paste_clipboard_after(cx: &mut Context) {
     paste(cx.editor, '+', Paste::After, cx.count());
+    exit_select_mode(cx);
 }
 
 fn paste_clipboard_before(cx: &mut Context) {
     paste(cx.editor, '+', Paste::Before, cx.count());
+    exit_select_mode(cx);
 }
 
 fn paste_primary_clipboard_after(cx: &mut Context) {
     paste(cx.editor, '*', Paste::After, cx.count());
+    exit_select_mode(cx);
 }
 
 fn paste_primary_clipboard_before(cx: &mut Context) {
     paste(cx.editor, '*', Paste::Before, cx.count());
+    exit_select_mode(cx);
 }
 
 fn replace_with_yanked(cx: &mut Context) {
@@ -4160,6 +4165,7 @@ fn paste_after(cx: &mut Context) {
         Paste::After,
         cx.count(),
     );
+    exit_select_mode(cx);
 }
 
 fn paste_before(cx: &mut Context) {
@@ -4169,6 +4175,7 @@ fn paste_before(cx: &mut Context) {
         Paste::Before,
         cx.count(),
     );
+    exit_select_mode(cx);
 }
 
 fn get_lines(doc: &Document, view_id: ViewId) -> Vec<usize> {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1528,6 +1528,7 @@ where
     });
 
     doc.apply(&transaction, view.id);
+    exit_select_mode(cx);
 }
 
 fn switch_case(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5684,6 +5684,7 @@ fn increment_impl(cx: &mut Context, increment_direction: IncrementDirection) {
         let transaction = Transaction::change(doc.text(), changes.into_iter());
         let transaction = transaction.with_selection(new_selection);
         doc.apply(&transaction, view.id);
+        exit_select_mode(cx);
     }
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4144,10 +4144,12 @@ fn replace_with_yanked_impl(editor: &mut Editor, register: char, count: usize) {
 
 fn replace_selections_with_clipboard(cx: &mut Context) {
     replace_with_yanked_impl(cx.editor, '+', cx.count());
+    exit_select_mode(cx);
 }
 
 fn replace_selections_with_primary_clipboard(cx: &mut Context) {
     replace_with_yanked_impl(cx.editor, '*', cx.count());
+    exit_select_mode(cx);
 }
 
 fn paste(editor: &mut Editor, register: char, pos: Paste, count: usize) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4207,6 +4207,7 @@ fn indent(cx: &mut Context) {
         }),
     );
     doc.apply(&transaction, view.id);
+    exit_select_mode(cx);
 }
 
 fn unindent(cx: &mut Context) {
@@ -4246,6 +4247,7 @@ fn unindent(cx: &mut Context) {
     let transaction = Transaction::change(doc.text(), changes.into_iter());
 
     doc.apply(&transaction, view.id);
+    exit_select_mode(cx);
 }
 
 fn format_selections(cx: &mut Context) {


### PR DESCRIPTION
Fixes #8687 

The issue also mentioned that paste exits select mode but I don't think that is the case, only replace seems to. Should we also add exiting select mode to paste or any other commands?