### PR TITLE
Update some grammars to a commit where the license file is included

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1142,7 +1142,7 @@ formatter = { command = "purs-tidy", args = ["format"] }
 
 [[grammar]]
 name = "purescript"
-source = { git = "https://github.com/postsolar/tree-sitter-purescript", rev = "593193b9bf0f46d5eee708a4e53044d2a9054897" }
+source = { git = "https://github.com/postsolar/tree-sitter-purescript", rev = "5ef5592674ea42de75fc2792972e4ea0b6e3da6c" }
 
 [[language]]
 name = "zig"

--- a/languages.toml
+++ b/languages.toml
@@ -95,7 +95,7 @@ command = "ansible-language-server"
 args = ["--stdio"]
 
 [language-server.lua-language-server]
-command = "lua-language-server" 
+command = "lua-language-server"
 
 [language-server.lua-language-server.config.Lua.hint]
 enable = true
@@ -1004,7 +1004,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "beancount"
-source = { git = "https://github.com/polarmutex/tree-sitter-beancount", rev = "4cbd1f09cd07c1f1fabf867c2cf354f9da53cc4c" }
+source = { git = "https://github.com/polarmutex/tree-sitter-beancount", rev = "f3741a3a68ade59ec894ed84a64673494d2ba8f3" }
 
 [[language]]
 name = "ocaml"
@@ -1307,7 +1307,7 @@ injection-regex = "comment"
 
 [[grammar]]
 name = "comment"
-source = { git = "https://github.com/stsewd/tree-sitter-comment", rev = "5dd3c62f1bbe378b220fe16b317b85247898639e" }
+source = { git = "https://github.com/stsewd/tree-sitter-comment", rev = "a37ca370310ac6f89b6e0ebf2b86b2219780494e" }
 
 [[language]]
 name = "wgsl"
@@ -1333,7 +1333,7 @@ injection-regex = "llvm"
 
 [[grammar]]
 name = "llvm"
-source = { git = "https://github.com/benwilliamgraham/tree-sitter-llvm", rev = "3b213925b9c4f42c1acfe2e10bfbb438d9c6834d" }
+source = { git = "https://github.com/benwilliamgraham/tree-sitter-llvm", rev = "e9948edc41e9e5869af99dddb2b5ff5cc5581af6" }
 
 [[language]]
 name = "llvm-mir"
@@ -2131,7 +2131,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ungrammar"
-source = { git = "https://github.com/Philipp-M/tree-sitter-ungrammar", rev = "0113de880a58ea14f2a75802e9b99fcc25003d9c" }
+source = { git = "https://github.com/Philipp-M/tree-sitter-ungrammar", rev = "a7e104629cff5a8b7367187610631e8f5eb7c6ea" }
 
 [[language]]
 name = "dot"
@@ -2264,7 +2264,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "astro"
-source = { git = "https://github.com/virchau13/tree-sitter-astro", rev = "5f5c3e73c45967df9aa42f861fad2d77cd4e0900" }
+source = { git = "https://github.com/virchau13/tree-sitter-astro", rev = "947e93089e60c66e681eba22283f4037841451e7" }
 
 [[language]]
 name = "bass"

--- a/languages.toml
+++ b/languages.toml
@@ -1258,7 +1258,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "perl"
-source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "9f3166800d40267fa68ed8273e96baf74f390517" }
+source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "e99bb5283805db4cb86c964722d709df21b0ac16" }
 
 [[language]]
 name = "pod"
@@ -1811,7 +1811,7 @@ injection-regex = "sql"
 
 [[grammar]]
 name = "sql"
-source = { git = "https://github.com/DerekStride/tree-sitter-sql", rev = "eeab7240a11098724e6f95bc57cc3ceaf5487d5f" }
+source = { git = "https://github.com/DerekStride/tree-sitter-sql", rev = "25be0b8f17e9189ad9e1b875869d025c5aec1286" }
 
 [[language]]
 name = "gdscript"
@@ -2656,7 +2656,7 @@ comment-token = "("
 
 [[grammar]]
 name = "uxntal"
-source = { git = "https://github.com/Jummit/tree-sitter-uxntal", rev = "9297e95ef74380b0ad84c4fd98f91e9f6e4319e6" }
+source = { git = "https://github.com/Jummit/tree-sitter-uxntal", rev = "d68406066648cd6db4c6a2f11ec305af02079884" }
 
 [[language]]
 name = "yuck"
@@ -2786,7 +2786,7 @@ grammar = "rego"
 
 [[grammar]]
 name = "rego"
-source = { git = "https://github.com/FallenAngel97/tree-sitter-rego", rev = "b2667c975f07b33be3ceb83bea5cfbad88095866" }
+source = { git = "https://github.com/FallenAngel97/tree-sitter-rego", rev = "9ac75e71b2d791e0aadeef68098319d86a2a14cf" }
 
 [[language]]
 name = "nim"
@@ -2895,7 +2895,7 @@ indent = { tab-width = 3, unit = "   " }
 
 [[grammar]]
 name = "forth"
-source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "304ed77beb113e37af38b20ff14e3c37bf350d10" }
+source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "90189238385cf636b9ee99ce548b9e5b5e569d48" }
 
 [[language]]
 name = "fsharp"

--- a/runtime/queries/purescript/highlights.scm
+++ b/runtime/queries/purescript/highlights.scm
@@ -1,4 +1,20 @@
 ; ----------------------------------------------------------------------------
+; Record fields would need to come before literal strings in order to be captured correctly
+
+ (record_accessor
+    field: [ (variable)
+             (string)
+             (triple_quote_string)
+           ] @variable.other.member)
+
+ (exp_record_access
+    field: [ (variable)
+             (string)
+             (triple_quote_string)
+           ] @variable.other.member)
+
+
+; ----------------------------------------------------------------------------
 ; Literals and comments
 
  (integer) @constant.numeric.integer
@@ -117,8 +133,7 @@
 
  (row_field (field_name) @variable.other.member)
  (record_field (field_name) @variable.other.member)
- (record_accessor (variable) @variable.other.member)
- (exp_record_access (variable) @variable.other.member)
+ (record_field (field_pun) @variable.other.member)
 
  (signature name: (variable) @type)
  (function name: (variable) @function)
@@ -126,8 +141,8 @@
  (derive_declaration (instance_name) @function)
 
  ; true or false
-((variable) @constant.builtin.boolean
- (#match? @constant.builtin.boolean "^(true|false)$"))
+ ((variable) @constant.builtin.boolean
+  (#match? @constant.builtin.boolean "^(true|false)$"))
 
  ; The former one works for `tree-sitter highlight` but not in Helix/Kakoune.
  ; The latter two work in Helix (but not Kakoune) and are a good compromise between not highlighting anything at all

--- a/runtime/queries/sql/highlights.scm
+++ b/runtime/queries/sql/highlights.scm
@@ -131,6 +131,7 @@
   (keyword_partition)
   (keyword_group)
   (keyword_with)
+  (keyword_without)
   (keyword_as)
   (keyword_having)
   (keyword_limit)
@@ -227,6 +228,7 @@
   (keyword_input)
   (keyword_name)
   (keyword_oid)
+  (keyword_oids)
   (keyword_options)
   (keyword_plpgsql)
   (keyword_precision)
@@ -264,6 +266,44 @@
   (keyword_user)
   (keyword_valid)
   (keyword_action)
+  (keyword_definer)
+  (keyword_invoker)
+  (keyword_security)
+  (keyword_extension)
+  (keyword_version)
+  (keyword_out)
+  (keyword_inout)
+  (keyword_variadic)
+  (keyword_session)
+  (keyword_isolation)
+  (keyword_level)
+  (keyword_serializable)
+  (keyword_repeatable)
+  (keyword_read)
+  (keyword_write)
+  (keyword_committed)
+  (keyword_uncommitted)
+  (keyword_deferrable)
+  (keyword_names)
+  (keyword_zone)
+  (keyword_immediate)
+  (keyword_deferred)
+  (keyword_constraints)
+  (keyword_snapshot)
+  (keyword_characteristics)
+  (keyword_off)
+  (keyword_follows)
+  (keyword_precedes)
+  (keyword_each)
+  (keyword_instead)
+  (keyword_of)
+  (keyword_initially)
+  (keyword_old)
+  (keyword_new)
+  (keyword_referencing)
+  (keyword_statement)
+  (keyword_execute)
+  (keyword_procedure)
 ] @keyword
 
 [
@@ -373,10 +413,8 @@
   ">="
   ">"
   "<>"
-  "->"
-  "->>"
-  "#>"
-  "#>>"
+  (op_other)
+  (op_unary_other)
 ] @operator
 
 [


### PR DESCRIPTION
This PR is kind of tricky because I am unsure how you guys handle language / grammar updates.

Problem I am trying to solve here: We need to include license files for all grammars. Some grammars that are used in `languages.toml` use an old commit where the license file is not included. I updated the grammars to a commit that includes the license file. 