### PR TITLE
Info on how to skip grammar build when building from source

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -207,7 +207,7 @@ RUSTFLAGS="-C target-feature=-crt-static"
    This command will create the `hx` executable and construct the tree-sitter
    grammars in the local `runtime` folder.
 
-> ❗💡 In case you do not want to build grammars, set an environment variable `HELIX_DISABLE_AUTO_GRAMMAR_BUILD` = 1
+> 💡 If you do not want to fetch or build grammars, set an environment variable `HELIX_DISABLE_AUTO_GRAMMAR_BUILD`
 
 > 💡 Tree-sitter grammars can be fetched and compiled if not pre-packaged. Fetch
 > grammars with `hx --grammar fetch` and compile them with

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -207,6 +207,8 @@ RUSTFLAGS="-C target-feature=-crt-static"
    This command will create the `hx` executable and construct the tree-sitter
    grammars in the local `runtime` folder.
 
+> ❗💡 In case you do not want to build grammars, set an environment variable `HELIX_DISABLE_AUTO_GRAMMAR_BUILD` = 1
+
 > 💡 Tree-sitter grammars can be fetched and compiled if not pre-packaged. Fetch
 > grammars with `hx --grammar fetch` and compile them with
 > `hx --grammar build`. This will install them in


### PR DESCRIPTION
## Situation:
Currently, the documentation doesn't indicate users can compile Helix without building grammars

## Proposal:
Add instructions on how to compile without compiling grammars to the install doc