### PR TITLE
swap yank command registers

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -59,8 +59,8 @@ Some registers have special behavior when read from and written to.
 | `#`                | Selection indices (first selection is `1`, second is `2`, etc.) | This register is not writable |
 | `.`                | Contents of the current selections | This register is not writable |
 | `%`                | Name of the current file | This register is not writable |
-| `*`                | Reads from the system clipboard | Joins and yanks to the system clipboard |
-| `+`                | Reads from the primary clipboard | Joins and yanks to the primary clipboard |
+| `+`                | Reads from the system clipboard | Joins and yanks to the system clipboard |
+| `*`                | Reads from the primary clipboard | Joins and yanks to the primary clipboard |
 
 When yanking multiple selections to the clipboard registers, the selections
 are joined with newlines. Pasting from these registers will paste multiple

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3897,12 +3897,12 @@ fn yank(cx: &mut Context) {
 }
 
 fn yank_to_clipboard(cx: &mut Context) {
-    yank_impl(cx.editor, '*');
+    yank_impl(cx.editor, '+');
     exit_select_mode(cx);
 }
 
 fn yank_to_primary_clipboard(cx: &mut Context) {
-    yank_impl(cx.editor, '+');
+    yank_impl(cx.editor, '*');
     exit_select_mode(cx);
 }
 
@@ -3959,13 +3959,13 @@ fn yank_joined(cx: &mut Context) {
 
 fn yank_joined_to_clipboard(cx: &mut Context) {
     let line_ending = doc!(cx.editor).line_ending;
-    yank_joined_impl(cx.editor, line_ending.as_str(), '*');
+    yank_joined_impl(cx.editor, line_ending.as_str(), '+');
     exit_select_mode(cx);
 }
 
 fn yank_joined_to_primary_clipboard(cx: &mut Context) {
     let line_ending = doc!(cx.editor).line_ending;
-    yank_joined_impl(cx.editor, line_ending.as_str(), '+');
+    yank_joined_impl(cx.editor, line_ending.as_str(), '*');
     exit_select_mode(cx);
 }
 
@@ -3982,12 +3982,12 @@ fn yank_primary_selection_impl(editor: &mut Editor, register: char) {
 }
 
 fn yank_main_selection_to_clipboard(cx: &mut Context) {
-    yank_primary_selection_impl(cx.editor, '*');
+    yank_primary_selection_impl(cx.editor, '+');
     exit_select_mode(cx);
 }
 
 fn yank_main_selection_to_primary_clipboard(cx: &mut Context) {
-    yank_primary_selection_impl(cx.editor, '+');
+    yank_primary_selection_impl(cx.editor, '*');
     exit_select_mode(cx);
 }
 
@@ -4088,19 +4088,19 @@ pub(crate) fn paste_bracketed_value(cx: &mut Context, contents: String) {
 }
 
 fn paste_clipboard_after(cx: &mut Context) {
-    paste(cx.editor, '*', Paste::After, cx.count());
-}
-
-fn paste_clipboard_before(cx: &mut Context) {
-    paste(cx.editor, '*', Paste::Before, cx.count());
-}
-
-fn paste_primary_clipboard_after(cx: &mut Context) {
     paste(cx.editor, '+', Paste::After, cx.count());
 }
 
-fn paste_primary_clipboard_before(cx: &mut Context) {
+fn paste_clipboard_before(cx: &mut Context) {
     paste(cx.editor, '+', Paste::Before, cx.count());
+}
+
+fn paste_primary_clipboard_after(cx: &mut Context) {
+    paste(cx.editor, '*', Paste::After, cx.count());
+}
+
+fn paste_primary_clipboard_before(cx: &mut Context) {
+    paste(cx.editor, '*', Paste::Before, cx.count());
 }
 
 fn replace_with_yanked(cx: &mut Context) {
@@ -4138,11 +4138,11 @@ fn replace_with_yanked_impl(editor: &mut Editor, register: char, count: usize) {
 }
 
 fn replace_selections_with_clipboard(cx: &mut Context) {
-    replace_with_yanked_impl(cx.editor, '*', cx.count());
+    replace_with_yanked_impl(cx.editor, '+', cx.count());
 }
 
 fn replace_selections_with_primary_clipboard(cx: &mut Context) {
-    replace_with_yanked_impl(cx.editor, '+', cx.count());
+    replace_with_yanked_impl(cx.editor, '*', cx.count());
 }
 
 fn paste(editor: &mut Editor, register: char, pos: Paste, count: usize) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -921,7 +921,7 @@ fn yank_main_selection_to_clipboard(
         return Ok(());
     }
 
-    yank_primary_selection_impl(cx.editor, '*');
+    yank_primary_selection_impl(cx.editor, '+');
     Ok(())
 }
 
@@ -956,7 +956,7 @@ fn yank_joined_to_clipboard(
     let doc = doc!(cx.editor);
     let default_sep = Cow::Borrowed(doc.line_ending.as_str());
     let separator = args.first().unwrap_or(&default_sep);
-    yank_joined_impl(cx.editor, separator, '*');
+    yank_joined_impl(cx.editor, separator, '+');
     Ok(())
 }
 
@@ -969,7 +969,7 @@ fn yank_main_selection_to_primary_clipboard(
         return Ok(());
     }
 
-    yank_primary_selection_impl(cx.editor, '+');
+    yank_primary_selection_impl(cx.editor, '*');
     Ok(())
 }
 
@@ -985,7 +985,7 @@ fn yank_joined_to_primary_clipboard(
     let doc = doc!(cx.editor);
     let default_sep = Cow::Borrowed(doc.line_ending.as_str());
     let separator = args.first().unwrap_or(&default_sep);
-    yank_joined_impl(cx.editor, separator, '+');
+    yank_joined_impl(cx.editor, separator, '*');
     Ok(())
 }
 
@@ -998,7 +998,7 @@ fn paste_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::After, 1);
+    paste(cx.editor, '+', Paste::After, 1);
     Ok(())
 }
 
@@ -1011,7 +1011,7 @@ fn paste_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::Before, 1);
+    paste(cx.editor, '+', Paste::Before, 1);
     Ok(())
 }
 
@@ -1024,7 +1024,7 @@ fn paste_primary_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::After, 1);
+    paste(cx.editor, '*', Paste::After, 1);
     Ok(())
 }
 
@@ -1037,7 +1037,7 @@ fn paste_primary_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::Before, 1);
+    paste(cx.editor, '*', Paste::Before, 1);
     Ok(())
 }
 
@@ -1050,7 +1050,7 @@ fn replace_selections_with_clipboard(
         return Ok(());
     }
 
-    replace_with_yanked_impl(cx.editor, '*', 1);
+    replace_with_yanked_impl(cx.editor, '+', 1);
     Ok(())
 }
 
@@ -1063,7 +1063,7 @@ fn replace_selections_with_primary_clipboard(
         return Ok(());
     }
 
-    replace_with_yanked_impl(cx.editor, '+', 1);
+    replace_with_yanked_impl(cx.editor, '*', 1);
     Ok(())
 }
 


### PR DESCRIPTION
#8703 swapped the `+` and `*` registers, but did not swap them in the corresponding yank commands.