### PR TITLE
Add an installation method field to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -56,6 +56,16 @@ body:
     validations:
       required: true
   - type: input
+    id: installation-method
+    attributes:
+      label: Installation Method
+      description: >
+        How you installed Helix - from a package manager like Homebrew or the
+        AUR, built from source, downloaded a binary from the releases page, etc.
+      placeholder: "source / brew / nixpkgs / flake / releases page"
+    validations:
+      required: true
+  - type: input
     id: helix-version
     attributes:
       label: Helix Version


### PR DESCRIPTION
We can guess the installation method from the version tag and platform in some cases but it would be useful to have this be explicit for the sake of debugging packager-specific problems.