### PR TITLE
highlights: add type.parameter scope to several more languages 

### DIFF
--- a/runtime/queries/_typescript/highlights.scm
+++ b/runtime/queries/_typescript/highlights.scm
@@ -107,6 +107,8 @@
 ; Types
 ; -----
 
+(type_parameter
+  name: (type_identifier) @type.parameter)
 (type_identifier) @type
 (predefined_type) @type.builtin
 

--- a/runtime/queries/_typescript/locals.scm
+++ b/runtime/queries/_typescript/locals.scm
@@ -1,5 +1,17 @@
+; Scopes
+;-------
+
+[
+  (type_alias_declaration)
+  (class_declaration)
+  (interface_declaration)
+] @local.scope
+
 ; Definitions
 ;------------
+
+(type_parameter
+  name: (type_identifier) @local.definition)
 
 ; Javascript and Typescript Treesitter grammars deviate when defining the
 ; tree structure for parameters, so we need to address them in each specific
@@ -14,3 +26,8 @@
 ; (i?: t = 1) // Invalid but still posible to hihglight.
 (optional_parameter
   (identifier) @local.definition)
+
+; References
+;-----------
+
+(type_identifier) @local.reference

--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -11,6 +11,18 @@
   function: (selector_expression
     field: (field_identifier) @function.method))
 
+
+; Types
+
+(type_parameter_list
+  (parameter_declaration
+    name: (identifier) @type.parameter))
+
+((type_identifier) @type.builtin
+  (match? @type.builtin "^(any|bool|byte|comparable|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
+
+(type_identifier) @type
+
 ; Function definitions
 
 (function_declaration
@@ -30,10 +42,6 @@
 (parameter_declaration (identifier) @variable.parameter)
 (variadic_parameter_declaration (identifier) @variable.parameter)
 
-((type_identifier) @type.builtin
-  (match? @type.builtin "^(any|bool|byte|comparable|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
-
-(type_identifier) @type
 (type_spec 
   name: (type_identifier) @constructor)
 (field_identifier) @variable.other.member

--- a/runtime/queries/go/locals.scm
+++ b/runtime/queries/go/locals.scm
@@ -1,8 +1,16 @@
 ; Scopes
 
-(block) @local.scope
+[
+  (function_declaration)
+  (type_declaration)
+  (block)
+] @local.scope
 
 ; Definitions
+
+(type_parameter_list
+  (parameter_declaration
+    name: (identifier) @local.definition))
 
 (parameter_declaration (identifier) @local.definition)
 (variadic_parameter_declaration (identifier) @local.definition)
@@ -27,4 +35,4 @@
 
 (identifier) @local.reference
 (field_identifier) @local.reference
-
+(type_identifier) @local.reference

--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -124,7 +124,7 @@
 ;; Types
 
 (type) @type
-(type_variable) @type
+(type_variable) @type.parameter
 
 (constructor) @constructor
 

--- a/runtime/queries/kotlin/highlights.scm
+++ b/runtime/queries/kotlin/highlights.scm
@@ -244,7 +244,10 @@
 	. (identifier)) @namespace
 
 ((type_identifier) @type.builtin
-	(#match? @function.builtin "^(Byte|Short|Int|Long|UByte|UShort|UInt|ULong|Float|Double|Boolean|Char|String|Array|ByteArray|ShortArray|IntArray|LongArray|UByteArray|UShortArray|UIntArray|ULongArray|FloatArray|DoubleArray|BooleanArray|CharArray|Map|Set|List|EmptyMap|EmptySet|EmptyList|MutableMap|MutableSet|MutableList)$"))
+	(#match? @type.builtin "^(Byte|Short|Int|Long|UByte|UShort|UInt|ULong|Float|Double|Boolean|Char|String|Array|ByteArray|ShortArray|IntArray|LongArray|UByteArray|UShortArray|UIntArray|ULongArray|FloatArray|DoubleArray|BooleanArray|CharArray|Map|Set|List|EmptyMap|EmptySet|EmptyList|MutableMap|MutableSet|MutableList)$"))
+
+(type_parameter
+  (type_identifier) @type.parameter)
 
 (type_identifier) @type
 

--- a/runtime/queries/kotlin/locals.scm
+++ b/runtime/queries/kotlin/locals.scm
@@ -1,0 +1,15 @@
+; Scopes
+
+[
+  (class_declaration)
+  (function_declaration)
+] @local.scope
+
+; Definitions
+
+(type_parameter
+  (type_identifier) @local.definition)
+
+; References
+
+(type_identifier) @local.reference

--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -8,6 +8,8 @@
 
 [(class_name) (class_type_name) (type_constructor)] @type
 
+(type_variable) @type.parameter
+
 [(constructor_name) (tag)] @constructor
 
 ; Functions


### PR DESCRIPTION
This is a follow-up to https://github.com/helix-editor/helix/pull/8660 where I introduced the `@type.parameter` highlight scope to improve readability of generic code.

I've added the scope to several more languages:

* TypeScript
* Go
* Haskell
* OCaml
  * The above two don't need queries `locals.scm` since type variables are distinguished syntactically
* Kotlin
  * There was a typo causing all types to be highlighted as builtins, so I fixed that as well