### PR TITLE
theme: Make dark_plus.toml more accurate to VSCode

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -1,103 +1,87 @@
 # Author: Shafkath Shuhan <shafkathshuhannyc@gmail.com>
 
-"namespace" = { fg = "type" }
-"module" = { fg = "type" }
+# SYNTAX
+"attribute"                 = "fn_declaration"
+"comment"                   = "dark_green"
+"constant"                  = "constant"
+"constant.builtin"          = "blue2"
+"constant.character"        = "orange"
+"constant.character.escape" = "gold"
+"constant.numeric"          = "pale_green"
+"constructor"               = "type"
+"diff.delta"                = "blue4"
+"diff.minus"                = "orange_red"
+"diff.plus"                 = "dark_green2"
+"function"                  = "fn_declaration"
+"function.builtin"          = "fn_declaration"
+"function.macro"            = "blue2"
+"keyword"                   = "blue2"
+"keyword.control"           = "special"
+"keyword.directive"         = "special"
+"label"                     = "blue2"
+"module"                    = "type"
+"namespace"                 = "type"
+"operator"                  = "text"
+"punctuation"               = "text"
+"punctuation.delimiter"     = "text"
+"special"                   = "text"
+"string"                    = "orange"
+"string.regexp"             = "gold"
+"tag"                       = "blue2"
+"type"                      = "type"
+"type.builtin"              = "blue2"
+"type.enum.variant"         = "constant"
+"variable"                  = "variable"
+"variable.builtin"          = "blue2"
+"variable.other.member"     = "variable"
+"variable.parameter"        = "variable"
 
-"type" = { fg = "type" }
-"type.builtin" = { fg = "type" }
-"type.enum.variant" = { fg = "constant" }
-"constructor" = { fg = "type" }
-"variable.other.member" = { fg = "variable" }
-
-"keyword" = { fg = "blue2" }
-"keyword.directive" = { fg = "blue2" }
-"keyword.control" = { fg = "special" }
-"label" = { fg = "blue2" }
-"tag" = "blue2"
-
-"special" = { fg = "text" }
-"operator" = { fg = "text" }
-
-"punctuation" = { fg = "text" }
-"punctuation.delimiter" = { fg = "text" }
-
-"variable" = { fg = "variable" }
-"variable.parameter" = { fg = "variable" }
-"variable.builtin" = { fg = "blue2" }
-"constant" = { fg = "constant" }
-"constant.builtin" = { fg = "blue2" }
-
-"function" = { fg = "fn_declaration" }
-"function.builtin" = { fg = "fn_declaration" }
-"function.macro" = { fg = "blue2" }
-"attribute" = { fg = "fn_declaration" }
-
-"comment" = { fg = "dark_green" }
-
-"string" = { fg = "orange" }
-"constant.character" = { fg = "orange" }
-"string.regexp" = { fg = "gold" }
-"constant.numeric" = { fg = "pale_green" }
-"constant.character.escape" = { fg = "gold" }
-
-"markup.heading" = { fg = "blue2", modifiers = ["bold"] }
-"markup.list" = "blue3"
-"markup.bold" = { fg = "blue2", modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+# MARKUP
+"markup.heading"       = { fg = "blue2", modifiers = ["bold"] }
+"markup.list"          = "blue3"
+"markup.bold"          = { fg = "blue2", modifiers = ["bold"] }
+"markup.italic"        = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { modifiers = ["underlined"] }
-"markup.link.text" = "orange"
-"markup.quote" = "dark_green"
-"markup.raw" = "orange"
+"markup.link.url"      = { modifiers = ["underlined"] }
+"markup.link.text"     = "orange"
+"markup.quote"         = "dark_green"
+"markup.raw"           = "orange"
 
-"diff.plus" = { fg = "dark_green2" }
-"diff.delta" = { fg = "blue4" }
-"diff.minus" = { fg = "orange_red" }
-
-"ui.background" = { fg = "light_gray", bg = "dark_gray2" }
-
-"ui.window" = { bg = "widget" }
-"ui.popup" = { fg = "text", bg = "widget" }
-"ui.help" = { fg = "text", bg = "widget" }
-"ui.menu" = { fg = "text", bg = "widget" }
-"ui.menu.selected" = { bg = "dark_blue2" }
-
+# UI
+"ui.background"              = { fg = "light_gray", bg = "dark_gray2" }
+"ui.window"                  = { bg = "widget" }
+"ui.popup"                   = { fg = "text", bg = "widget" }
+"ui.help"                    = { fg = "text", bg = "widget" }
+"ui.menu"                    = { fg = "text", bg = "widget" }
+"ui.menu.selected"           = { bg = "dark_blue2" }
 # TODO: Alternate bg colour for `ui.cursor.match` and `ui.selection`.
-"ui.cursor" = { fg = "cursor", modifiers = ["reversed"] }
-"ui.cursor.primary" = { fg = "cursor", modifiers = ["reversed"] }
-"ui.cursor.match" = { bg = "#3a3d41", modifiers = ["underlined"] }
-
-"ui.selection" = { bg = "#3a3d41" }
-"ui.selection.primary" = { bg = "dark_blue" }
-
-"ui.linenr" = { fg = "dark_gray" }
-"ui.linenr.selected" = { fg = "light_gray2" }
-
-"ui.cursorline.primary" = { bg = "dark_gray3" }
-"ui.statusline" = { fg = "white", bg = "blue" }
-"ui.statusline.inactive" = { fg = "white", bg = "blue" }
-"ui.statusline.insert" = { fg = "white", bg = "yellow" }
-"ui.statusline.select" = { fg = "white", bg = "magenta" }
-
-"ui.bufferline" = { fg = "text", bg = "widget" }
-"ui.bufferline.active" = { fg = "white", bg = "blue" }
-"ui.bufferline.background" = { bg = "background" }
-
-"ui.text" = { fg = "text" }
-"ui.text.focus" = { fg = "white" }
-
-"ui.virtual.whitespace" = { fg = "dark_gray" }
-"ui.virtual.ruler" = { bg = "borders" }
-"ui.virtual.indent-guide" = { fg = "dark_gray4" }
-"ui.virtual.inlay-hint" = { fg = "dark_gray5"}
-
-"warning" = { fg = "gold2" }
-"error" = { fg = "red" }
-"info" = { fg = "light_blue" }
-"hint" = { fg = "light_gray3" }
-
+"ui.cursor"                  = { fg = "cursor", modifiers = ["reversed"] }
+"ui.cursor.primary"          = { fg = "cursor", modifiers = ["reversed"] }
+"ui.cursor.match"            = { bg = "#3a3d41", modifiers = ["underlined"] }
+"ui.selection"               = { bg = "#3a3d41" }
+"ui.selection.primary"       = { bg = "dark_blue" }
+"ui.linenr"                  = { fg = "dark_gray" }
+"ui.linenr.selected"         = { fg = "light_gray2" }
+"ui.cursorline.primary"      = { bg = "dark_gray3" }
+"ui.statusline"              = { fg = "white", bg = "blue" }
+"ui.statusline.inactive"     = { fg = "white", bg = "widget" }
+"ui.statusline.insert"       = { fg = "white", bg = "yellow" }
+"ui.statusline.select"       = { fg = "white", bg = "magenta" }
+"ui.bufferline"              = { fg = "text", bg = "widget" }
+"ui.bufferline.active"       = { fg = "white", bg = "blue" }
+"ui.bufferline.background"   = { bg = "background" }
+"ui.text"                    = { fg = "text" }
+"ui.text.focus"              = { fg = "white" }
+"ui.virtual.whitespace"      = { fg = "#3e3e3d" }
+"ui.virtual.ruler"           = { bg = "borders" }
+"ui.virtual.indent-guide"    = { fg = "dark_gray4" }
+"ui.virtual.inlay-hint"      = { fg = "dark_gray5"}
+"warning"                    = { fg = "gold2" }
+"error"                      = { fg = "red" }
+"info"                       = { fg = "light_blue" }
+"hint"                       = { fg = "light_gray3" }
 "diagnostic.error".underline = { color = "red", style = "curl" }
-"diagnostic".underline = { color = "gold", style = "curl" }
+"diagnostic".underline       = { color = "gold", style = "curl" }
 
 [palette]
 white = "#ffffff"

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -29,7 +29,7 @@
 "string.regexp"             = "gold"
 "tag"                       = "blue2"
 "type"                      = "type"
-"type.builtin"              = "blue2"
+"type.builtin"              = "type"
 "type.enum.variant"         = "constant"
 "variable"                  = "variable"
 "variable.builtin"          = "blue2"


### PR DESCRIPTION
The current implementation of the Dark+ has some inconsistencies with the original. I've made some modification, witch the most importants are:
1. Statusbar is now gray instead of blue, to make it more readable;
2. Whitespace are a more subtle color;
3. Indent Character is now distinguishable from the whitespaces.

## C

| Current | Updated | VSCode |
| --- | --- | --- |
| <img width="752" alt="Screenshot 2023-11-04 at 21 30 00" src="https://github.com/helix-editor/helix/assets/96259932/03f661a8-9ceb-4e94-baef-dee4c72fd317"> | <img width="752" alt="Screenshot 2023-11-04 at 21 28 33" src="https://github.com/helix-editor/helix/assets/96259932/d4b1507c-d018-4966-9b3f-7979a051ba9a"> | <img width="807" alt="Screenshot 2023-11-04 at 21 29 43" src="https://github.com/helix-editor/helix/assets/96259932/aae29564-1953-4d2b-a463-e71ab3194a7f"> |

## CPP

| Current | Updated | VSCode |
| --- | --- | --- |
| <img width="752" alt="Screenshot 2023-11-04 at 21 41 31" src="https://github.com/helix-editor/helix/assets/96259932/ac54b6ae-4af1-40ea-88ab-4f282da1c0c9"> | <img width="752" alt="Screenshot 2023-11-04 at 21 41 19" src="https://github.com/helix-editor/helix/assets/96259932/4eb0e04b-8bfe-4e90-be47-c556576f6960"> | <img width="886" alt="Screenshot 2023-11-04 at 21 41 14" src="https://github.com/helix-editor/helix/assets/96259932/82626989-93da-4b94-857e-f9d953888544"> |
