### PR TITLE
Add indent queries for scheme

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -16,7 +16,7 @@
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | comment | ✓ |  |  |  |
-| common-lisp | ✓ |  |  | `cl-lsp` |
+| common-lisp | ✓ |  | ✓ | `cl-lsp` |
 | cpon | ✓ |  | ✓ |  |
 | cpp | ✓ | ✓ | ✓ | `clangd` |
 | crystal | ✓ | ✓ |  | `crystalline` |
@@ -128,7 +128,7 @@
 | python | ✓ | ✓ | ✓ | `pylsp` |
 | qml | ✓ |  | ✓ | `qmlls` |
 | r | ✓ |  |  | `R` |
-| racket | ✓ |  |  | `racket` |
+| racket | ✓ |  | ✓ | `racket` |
 | regex | ✓ |  |  |  |
 | rego | ✓ |  |  | `regols` |
 | rescript | ✓ | ✓ |  | `rescript-language-server` |
@@ -140,7 +140,7 @@
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |
 | sage | ✓ | ✓ |  |  |
 | scala | ✓ |  | ✓ | `metals` |
-| scheme | ✓ |  |  |  |
+| scheme | ✓ |  | ✓ |  |
 | scss | ✓ |  |  | `vscode-css-language-server` |
 | slint | ✓ |  | ✓ | `slint-lsp` |
 | smithy | ✓ |  |  | `cs` |

--- a/languages.toml
+++ b/languages.toml
@@ -1278,6 +1278,7 @@ roots = []
 file-types = ["rkt", "rktd", "rktl", "scrbl"]
 shebangs = ["racket"]
 comment-token = ";"
+indent = { tab-width = 2, unit = "  " }
 language-servers = [ "racket" ]
 grammar = "scheme"
 

--- a/runtime/queries/common-lisp/indents.scm
+++ b/runtime/queries/common-lisp/indents.scm
@@ -1,0 +1,1 @@
+; inherits: scheme

--- a/runtime/queries/racket/indents.scm
+++ b/runtime/queries/racket/indents.scm
@@ -1,0 +1,1 @@
+; inherits: scheme

--- a/runtime/queries/scheme/indents.scm
+++ b/runtime/queries/scheme/indents.scm
@@ -1,0 +1,43 @@
+; This roughly follows the description at: https://github.com/ds26gte/scmindent#how-subforms-are-indented
+
+; Exclude literals in the first patterns, since different rules apply for them.
+; Similarly, exclude certain keywords (detected by a regular expression).
+; If a list has 2 elements on the first line, it is aligned to the second element.
+(list . (_) @first . (_) @anchor
+  (#same-line? @first @anchor)
+  (#set! "scope" "tail")
+  (#not-kind-eq? @first "boolean") (#not-kind-eq? @first "character") (#not-kind-eq? @first "string") (#not-kind-eq? @first "number")
+  (#not-match? @first "def.*|let.*|set!")) @align
+; If the first element in a list is also a list and on a line by itself, the outer list is aligned to it
+(list . (list) @anchor .
+  (#set! "scope" "tail")
+  (#not-kind-eq? @first "boolean") (#not-kind-eq? @first "character") (#not-kind-eq? @first "string") (#not-kind-eq? @first "number")) @align
+(list . (list) @anchor . (_) @second
+  (#not-same-line? @anchor @second)
+  (#set! "scope" "tail")
+  (#not-kind-eq? @first "boolean") (#not-kind-eq? @first "character") (#not-kind-eq? @first "string") (#not-kind-eq? @first "number")
+  (#not-match? @first "def.*|let.*|set!")) @align
+; If the first element in a list is not a list and on a line by itself, the outer list is aligned to
+; it plus 1 additional space. This cannot currently be modelled exactly by our indent queries,
+; but the following is equivalent, assuming that:
+; - the indent width is 2 (the default for scheme)
+; - There is no space between the opening parenthesis of the list and the first element
+(list . (_) @first .
+  (#not-kind-eq? @first "boolean") (#not-kind-eq? @first "character") (#not-kind-eq? @first "string") (#not-kind-eq? @first "number")
+  (#not-match? @first "def.*|let.*|set!")) @indent
+(list . (_) @first . (_) @second
+  (#not-same-line? @first @second)
+  (#not-kind-eq? @first "boolean") (#not-kind-eq? @first "character") (#not-kind-eq? @first "string") (#not-kind-eq? @first "number")
+  (#not-match? @first "def.*|let.*|set!")) @indent
+
+; If the first element in a list is a literal, align the list to it
+(list . [(boolean) (character) (string) (number)] @anchor
+  (#set! "scope" "tail")) @align
+
+; If the first element is among a set of predefined keywords, align the list to this element
+; plus 1 space (using the same workaround as above for now). This is a simplification since actually
+; the second line of the list should be indented by 2 spaces more in some cases. Supporting this would
+; be possible but require significantly more patterns.
+(list . (symbol) @first
+  (#match? @first "def.*|let.*|set!")) @indent
+


### PR DESCRIPTION
Add indent queries for scheme following [this guide](https://github.com/ds26gte/scmindent#how-subforms-are-indented). The only thing which isn't fully implemented is the section about Lisp keywords: The queries handle them in a very simple way that sometimes underestimates the indent and the regex that matches keywords is definitely not complete. Still, it should be good enough to provide a good editing experience. Since I don't have any experience with Scheme/Lisp, it wouldn't hurt if someone more knowledgeable double-checked this though.

Since Lisp & Racket use the same grammar, I also just inherited the queries from scheme for them. For Racket, I added a default indent width, since there is a workaround in the queries that requires this (this workaround is a short-term solution but a better solution requires extending the indentation system).