### PR TITLE
Add modus operandi themes

### DIFF
--- a/runtime/themes/modus_operandi.toml
+++ b/runtime/themes/modus_operandi.toml
@@ -1,0 +1,194 @@
+# Author: Alexis Mousset <contact@amousset.me>
+# Adapted from https://protesilaos.com/emacs/modus-themes, by Protesilaos Stavrou
+# Version 4.3.0
+#
+
+# Syntax highlighting
+# -------------------
+"type" = "cyan-cooler"
+"constructor" = "cyan-cooler"
+
+"constant" = "blue-cooler"
+"constant.character.escape" = "magenta"
+
+"string" = "blue-warmer"
+"string.regexp" = "magenta-faint"
+"string.special" = "blue-faint" # used for colors in CSS
+
+"comment" = "fg-dim"
+
+"variable.parameter" = "cyan"
+"variable.builtin" = "magenta-cooler"
+"label" = "fg-dim" # used for language in markdown code blocks
+"keyword" = "magenta-cooler"
+"keyword.directive" = "red-cooler"
+"function" = "magenta"
+"function.macro" = "magenta-warmer"
+
+punctuation = "fg-dim"
+"tag" = "magenta"
+"attribute" = "cyan-cooler"
+"namespace" = "blue-cooler"
+"special" = "red-cooler"
+
+"markup.heading.marker" = "fg-dim"
+"markup.heading.1" = { fg = "fg-main", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "yellow-faint", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "fg-alt", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "magenta", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "green-faint", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "red-faint", modifiers = ["bold"] }
+"markup.list" = "fg-dim"
+"markup.list.checked" = { fg = "yellow-warmer" }
+"markup.list.unchecked" = { fg = "yellow-warmer" }
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "cyan" }
+"markup.link.text" = { fg = "blue-warmer", modifiers = ["underlined"] }
+"markup.raw.block" = { bg = "bg-dim" }
+"markup.raw.inline" = { fg = "green-cooler" }
+
+"diff.plus" = { fg = "fg-added", bg = "bg-added" }
+"diff.plus.gutter" = "green-intense"
+"diff.minus" = { fg = "fg-removed", bg = "bg-removed" }
+"diff.minus.gutter" = "red-intense"
+"diff.delta" = { fg = "fg-changed", bg = "bg-changed" }
+"diff.delta.gutter" = "yellow-intense"
+
+# User Interface
+# --------------
+
+"ui.background" = { bg = "bg-main" }
+
+"ui.linenr" = { fg = "fg-dim", bg = "bg-dim" }
+"ui.linenr.selected" = { fg = "fg-main", bg = "bg-active" }
+
+"ui.statusline" = { fg = "fg-mode-line-active", bg = "bg-mode-line-active" }
+"ui.statusline.inactive" = { fg = "fg-mode-line-inactive", bg = "bg-mode-line-inactive" }
+"ui.statusline.normal" = { fg = "blue-warmer" }
+"ui.statusline.insert" = { fg = "green-warmer" }
+"ui.statusline.select" = { fg = "magenta-warmer" }
+
+"ui.popup" = { fg = "fg-main", bg = "bg-dim" }
+"ui.window" = { fg = "fg-dim" }
+"ui.help" = { fg = "fg-main", bg = "bg-dim" }
+"ui.gutter" = { bg = "bg-dim" }
+"ui.text" = "fg-main"
+"ui.text.focus" = { fg = "fg-main", bg = "bg-completion", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "fg-dim" }
+"ui.virtual" = "bg-active"
+"ui.virtual.ruler" = { bg = "bg-dim" }
+"ui.virtual.inlay-hint" = { fg = "fg-dim", modifiers = ["italic"] }
+
+"ui.selection" = { fg = "fg-main", bg = "bg-inactive" }
+"ui.selection.primary" = { fg = "fg-main", bg = "bg-active" }
+
+"ui.cursor" = { fg = "bg-main", bg = "fg-main" }
+"ui.cursor.primary" = { fg = "bg-main", bg = "fg-dim" }
+"ui.cursor.match" = { bg = "bg-paren-match" }
+"ui.cursorline.primary" = { bg = "bg-hl-line" }
+
+"ui.highlight" = { bg = "bg-hl-line" }
+
+"ui.menu" = { fg = "fg-main", bg = "bg-dim" }
+"ui.menu.selected" = { fg = "fg-main", bg = "bg-completion", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "fg-dim", bg = "bg-cyan-intense" }
+
+"diagnostic.error" = { underline = { color = "red-intense", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow-intense", style = "curl" } }
+"diagnostic.info" = { underline = { color = "cyan-intense", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue-intense", style = "curl" } }
+
+error = "red"
+warning = "yellow-warmer"
+info = "cyan-cooler"
+hint = "blue-cooler"
+
+[palette]
+# Basic values
+bg-main = "#ffffff"
+bg-dim = "#f2f2f2"
+fg-main = "#000000"
+fg-dim = "#595959"
+fg-alt = "#193668"
+bg-active = "#c4c4c4"
+bg-inactive = "#e0e0e0"
+
+# Common accent foregrounds
+red = "#a60000"
+red-warmer = "#972500"
+red-cooler = "#a0132f"
+red-faint = "#7f0000"
+red-intense = "#d00000"
+green = "#006800"
+green-warmer = "#316500"
+green-cooler = "#00663f"
+green-faint = "#2a5045"
+green-intense = "#008900"
+yellow = "#6f5500"
+yellow-warmer = "#884900"
+yellow-cooler = "#7a4f2f"
+yellow-faint = "#624416"
+yellow-intense = "#808000"
+blue = "#0031a9"
+blue-warmer = "#354fcf"
+blue-cooler = "#0000b0"
+blue-faint = "#003497"
+blue-intense = "#0000ff"
+magenta = "#721045"
+magenta-warmer = "#8f0075"
+magenta-cooler = "#531ab6"
+magenta-faint = "#7c318f"
+magenta-intense = "#dd22dd"
+cyan = "#005e8b"
+cyan-warmer = "#3f578f"
+cyan-cooler = "#005f5f"
+cyan-faint = "#005077"
+cyan-intense = "#008899"
+
+# Common accent backgrounds
+bg-red-intense = "#ff8f88"
+bg-green-intense = "#8adf80"
+bg-yellow-intense = "#f3d000"
+bg-blue-intense = "#bfc9ff"
+bg-magenta-intense = "#dfa0f0"
+bg-cyan-intense = "#a4d5f9"
+
+bg-red-subtle = "#ffcfbf"
+bg-green-subtle = "#b3fabf"
+bg-yellow-subtle = "#fff576"
+bg-blue-subtle = "#ccdfff"
+bg-magenta-subtle = "#ffddff"
+bg-cyan-subtle = "#bfefff"
+
+bg-red-nuanced = "#fff1f0"
+bg-green-nuanced = "#ecf7ed"
+bg-yellow-nuanced = "#fff3da"
+bg-blue-nuanced = "#f3f3ff"
+bg-magenta-nuanced = "#fdf0ff"
+bg-cyan-nuanced = "#ebf6fa"
+
+# Special purpose
+bg-completion = "#c0deff"
+bg-hl-line = "#dae5ec"
+
+bg-mode-line-active = "#c8c8c8"
+fg-mode-line-active = "#000000"
+bg-mode-line-inactive = "#e6e6e6"
+fg-mode-line-inactive = "#585858"
+
+modeline-err = "#7f0000"
+modeline-warning = "#5f0070"
+modeline-info = "#002580"
+
+# Diffs
+bg-added = "#c1f2d1"
+fg-added = "#005000"
+bg-changed = "#ffdfa9"
+fg-changed = "#553d00"
+bg-removed = "#ffd8d5"
+fg-removed = "#8f1313"
+
+# Paren match
+bg-paren-match = "#5fcfff"

--- a/runtime/themes/modus_operandi_deuteranopia.toml
+++ b/runtime/themes/modus_operandi_deuteranopia.toml
@@ -1,0 +1,46 @@
+# Author: Alexis Mousset <contact@amousset.me>
+# modus_operandi.toml variant
+#
+# This variant is optimized for users with red-green color deficiency (deuteranopia)
+
+inherits = "modus_operandi"
+
+"constant.character.escape" = "magenta"
+"comment" = "yellow-cooler"
+"function" = "magenta"
+"tag" = "magenta"
+
+"ui.cursor" = { fg = "bg-main", bg = "blue-intense" }
+"ui.cursor.primary.normal" = { fg = "bg-main", bg = "blue-intense" }
+
+"diagnostic.error" = { underline = { color = "yellow-intense", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "magenta-faint", style = "curl" } }
+"diagnostic.info" = { underline = { color = "cyan", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "curl" } }
+
+error = "yellow-intense"
+warning = "magenta-faint"
+info = "cyan"
+hint = "blue"
+
+[palette]
+
+yellow = "#695500"
+yellow-warmer = "#973300"
+yellow-cooler = "#77492f"
+
+bg-mode-line-active = "#d0d6ff"
+fg-mode-line-active = "#0f0f0f"
+border-mode-line-active = "#4f4f74"
+
+modeline-err = "#603a00"
+modeline-warning = "#454500"
+modeline-info = "#023d92"
+
+# Diffs
+bg-added = "#d5d7ff"
+fg-added = "#303099"
+bg-changed = "#eecfdf"
+fg-changed = "#6f1343"
+bg-removed = "#f4f099"
+fg-removed = "#553d00"

--- a/runtime/themes/modus_operandi_tinted.toml
+++ b/runtime/themes/modus_operandi_tinted.toml
@@ -1,0 +1,45 @@
+# Author: Alexis Mousset <contact@amousset.me>
+# modus_operandi.toml variant
+
+inherits = "modus_operandi"
+
+"comment" = "red-faint"
+
+"ui.cursor.primary" = { fg = "bg-main", bg = "red" }
+
+[palette]
+# Basic values
+bg-main = "#fbf7f0"
+bg-dim = "#efe9dd"
+bg-active = "#c9b9b0"
+bg-inactive = "#dfd5cf"
+border = "#9f9690"
+
+# Common accent backgrounds
+bg-red-nuanced = "#ffe8f0"
+bg-green-nuanced = "#e0f5e0"
+bg-yellow-nuanced = "#f9ead0"
+bg-blue-nuanced = "#ebebff"
+bg-magenta-nuanced = "#f6e7ff"
+bg-cyan-nuanced = "#e1f3fc"
+
+# Special purpose
+bg-completion = "#f0c1cf"
+bg-hl-line = "#f1d5d0"
+bg-region = "#c2bcb5"
+
+bg-mode-line-active = "#cab9b2"
+border-mode-line-active = "#545454"
+bg-mode-line-inactive = "#dfd9cf"
+border-mode-line-inactive = "#a59a94"
+
+bg-tab-bar = "#e0d4ce"
+bg-tab-current = "#fbf7f0"
+bg-tab-other = "#c8b8b2"
+
+# Diffs
+bg-added = "#c3ebc1"
+bg-removed = "#f4d0cf"
+
+# Paren match
+bg-paren-match = "#7fdfcf"

--- a/runtime/themes/modus_operandi_tritanopia.toml
+++ b/runtime/themes/modus_operandi_tritanopia.toml
@@ -1,0 +1,73 @@
+# Author: Alexis Mousset <contact@amousset.me>
+# modus_operandi.toml variant
+#
+# This variant is optimized for users with blue-yellow color deficiency (tritanopia)
+
+inherits = "modus_operandi"
+
+"type" = "blue-warmer"
+"constructor" = "blue-warmer"
+"constant" = "green-cooler"
+"constant.character.escape" = "red-cooler"
+"string" = "cyan"
+"comment" = "red-faint"
+"variable.parameter" = "cyan-cooler"
+"keyword" = "red-cooler"
+"keyword.directive" = "red-warmer"
+"function" = "cyan-warmer"
+"function.macro" = "magenta"
+"tag" = "red-cooler"
+
+"markup.heading.2" = { fg = "red-faint", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "cyan-faint", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "magenta-faint", modifiers = ["bold"] }
+"markup.link.url" = { fg = "cyan-cooler" }
+"markup.link.text" = { fg = "cyan", modifiers = ["underlined"] }
+
+"ui.cursor" = { fg = "bg-main", bg = "red-intense" }
+"ui.cursor.primary.normal" = { fg = "bg-main", bg = "red-intense" }
+
+"diagnostic.error" = { underline = { color = "red-warmer", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "magenta", style = "curl" } }
+"diagnostic.info" = { underline = { color = "cyan", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "curl" } }
+
+error = "red-warmer"
+warning = "magenta"
+info = "cyan"
+hint = "blue"
+
+[palette]
+
+# Common accent foregrounds
+red-warmer = "#b21100"
+red-faint = "#702000"
+yellow = "#695500"
+yellow-warmer = "#973300"
+yellow-cooler = "#77492f"
+magenta-intense = "#cd22bd"
+cyan-faint = "#004f5f"
+
+# Special purpose
+bg-completion = "#afdfef"
+bg-hover = "#ffafbc"
+bg-hover-secondary = "#9fdfff"
+bg-hl-line = "#dfeaec"
+
+bg-char-0 = "#ff908f"
+bg-char-1 = "#bfbfff"
+bg-char-2 = "#5fcfdf"
+
+bg-mode-line-active = "#afe0f2"
+fg-mode-line-active = "#0f0f0f"
+border-mode-line-active = "#2f4f44"
+
+modeline-err = "#8f0000"
+modeline-warning = "#6f306f"
+modeline-info = "#00445f"
+
+# Diffs
+bg-added = "#b5e7ff"
+fg-added = "#005079"
+bg-changed = "#eecfdf"
+fg-changed = "#6f1343"


### PR DESCRIPTION
This PR adds themes based on the light variants of the carefully designed [modus](https://protesilaos.com/emacs/modus-themes) themes (built-in with Emacs). This is not a port of the original theme, as Emacs themes are much more than a color scheme, but a set of Helix themes inspired by the defaults of the modus operandi (light) theme, and reusing their color palette. They follow the same goals, i.e. legibility and accessibility (following the highest WCAG AAA standard), even over esthetics when necessary. 

The themes are:
* `modus_operandi`: the base theme
* `modus_operandi_tritanopia`: a variant of the base theme for blue-yellow color deficiency
* `modus_operandi_deuteranopia`: a variant of the base theme for red-green color deficiency
* `modus_operandi_tinted`: a variant with a toned-downed background

**modus operandi**
![Screenshot from 2023-11-06 02-29-41](https://github.com/helix-editor/helix/assets/329388/5967d983-1c41-4516-b704-62ba98d5e1ac)

**modus operandi tinted**
![Screenshot from 2023-11-06 02-24-30](https://github.com/helix-editor/helix/assets/329388/0537f618-7ca3-4ef7-a685-eb8b6c2e2d44)
![Screenshot from 2023-11-06 02-23-48](https://github.com/helix-editor/helix/assets/329388/3e49971e-9c65-466b-9058-b040917cc889)
![Screenshot from 2023-11-06 02-23-12-1](https://github.com/helix-editor/helix/assets/329388/71c7abb5-126b-4d5c-95a2-6e828582e3cc)

Licensing note: Even if the theme for Emacs is licensed under GPLv3+, the color palette itself is [placed under CC0](https://protesilaos.com/emacs/modus-themes-colors).
