### PR TITLE
Fix precedence of ui.virtual.whitespace

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -307,7 +307,7 @@ pub fn render_text<'t>(
 pub struct TextRenderer<'a> {
     pub surface: &'a mut Surface,
     pub text_style: Style,
-    pub whitespace_style: Style,
+    pub whitespace_style: Style, // TODO: this prop can be removed
     pub indent_guide_char: String,
     pub indent_guide_style: Style,
     pub newline: String,
@@ -395,7 +395,7 @@ impl<'a> TextRenderer<'a> {
     pub fn draw_grapheme(
         &mut self,
         grapheme: Grapheme,
-        mut style: Style,
+        style: Style,
         is_virtual: bool,
         last_indent_level: &mut usize,
         is_in_indent_area: &mut bool,
@@ -403,12 +403,6 @@ impl<'a> TextRenderer<'a> {
     ) {
         let cut_off_start = self.col_offset.saturating_sub(position.col);
         let is_whitespace = grapheme.is_whitespace();
-
-        // TODO is it correct to apply the whitespace style to all unicode white spaces?
-        if is_whitespace {
-            style = style.patch(self.whitespace_style);
-        }
-
         let width = grapheme.width();
         let space = if is_virtual { " " } else { &self.space };
         let nbsp = if is_virtual { " " } else { &self.nbsp };

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -307,7 +307,6 @@ pub fn render_text<'t>(
 pub struct TextRenderer<'a> {
     pub surface: &'a mut Surface,
     pub text_style: Style,
-    pub whitespace_style: Style, // TODO: this prop can be removed
     pub indent_guide_char: String,
     pub indent_guide_style: Style,
     pub newline: String,
@@ -374,7 +373,6 @@ impl<'a> TextRenderer<'a> {
             space,
             tab,
             virtual_tab,
-            whitespace_style: theme.get("ui.virtual.whitespace"),
             indent_width,
             starting_indent: col_offset / indent_width as usize
                 + (col_offset % indent_width as usize != 0) as usize

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -136,6 +136,10 @@ impl EditorView {
             highlights = Box::new(syntax::merge(highlights, overlay_highlights));
         }
 
+        let whitespace_highlights =
+            Self::doc_whitespace_highlights(doc, view.offset.anchor, inner.height, theme);
+        highlights = Box::new(syntax::merge(highlights, whitespace_highlights));
+
         for diagnostic in Self::doc_diagnostics_highlights(doc, theme) {
             // Most of the `diagnostic` Vecs are empty most of the time. Skipping
             // a merge for any empty Vec saves a significant amount of work.
@@ -144,10 +148,6 @@ impl EditorView {
             }
             highlights = Box::new(syntax::merge(highlights, diagnostic));
         }
-
-        let whitespace_highlights =
-            Self::doc_whitespace_highlights(doc, view.offset.anchor, inner.height, theme);
-        highlights = Box::new(syntax::merge(highlights, whitespace_highlights));
 
         let highlights: Box<dyn Iterator<Item = HighlightEvent>> = if is_focused {
             let highlights = syntax::merge(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -448,9 +448,9 @@ impl EditorView {
                 }
             }
         }
-        cur_span.map(|span| {
+        if let Some(span) = cur_span {
             spans.push((whitespace_scope, span));
-        });
+        }
 
         spans
     }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -748,6 +748,13 @@ impl<T: Item + 'static> Picker<T> {
                 }
                 highlights = Box::new(helix_core::syntax::merge(highlights, spans));
             }
+            let whitespace_highlights = EditorView::doc_whitespace_highlights(
+                doc,
+                offset.anchor,
+                area.height,
+                &cx.editor.theme,
+            );
+            highlights = Box::new(helix_core::syntax::merge(highlights, whitespace_highlights));
             let mut decorations: Vec<Box<dyn LineDecoration>> = Vec::new();
 
             if let Some((start, end)) = range {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -742,12 +742,6 @@ impl<T: Item + 'static> Picker<T> {
                 area.height,
                 &cx.editor.theme,
             );
-            for spans in EditorView::doc_diagnostics_highlights(doc, &cx.editor.theme) {
-                if spans.is_empty() {
-                    continue;
-                }
-                highlights = Box::new(helix_core::syntax::merge(highlights, spans));
-            }
             let whitespace_highlights = EditorView::doc_whitespace_highlights(
                 doc,
                 offset.anchor,
@@ -755,6 +749,12 @@ impl<T: Item + 'static> Picker<T> {
                 &cx.editor.theme,
             );
             highlights = Box::new(helix_core::syntax::merge(highlights, whitespace_highlights));
+            for spans in EditorView::doc_diagnostics_highlights(doc, &cx.editor.theme) {
+                if spans.is_empty() {
+                    continue;
+                }
+                highlights = Box::new(helix_core::syntax::merge(highlights, spans));
+            }
             let mut decorations: Vec<Box<dyn LineDecoration>> = Vec::new();
 
             if let Some((start, end)) = range {


### PR DESCRIPTION
This fixes the first half of https://github.com/helix-editor/helix/issues/5675, namely the whitespace case.
The idea is to move the whitespace highlighting logic to the same place as the other highlighting logic, such that it's precedence can be precisely controlled.
