### PR TITLE
Fix the parameter highlighting in the signature help overlay

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1235,9 +1235,13 @@ pub fn signature_help_impl_with_future(
                     .unwrap_or(0) as usize;
                 let param = signature.parameters.as_ref()?.get(param_idx)?;
                 match &param.label {
-                    lsp::ParameterLabel::Simple(string) => {
-                        let start = signature.label.find(string.as_str())?;
-                        Some((start, start + string.len()))
+                    lsp::ParameterLabel::Simple(param_label) => {
+                        // rfind will be more reliable than find:
+                        // Consider 'def modify_foo(foo)'. Find will hightlight
+                        // the function name (wrong). rfind will highlight the param.
+                        let start = signature.label.rfind(param_label.as_str())?;
+
+                        Some((start, start + param_label.len()))
                     }
                     lsp::ParameterLabel::LabelOffsets([start, end]) => {
                         // LS sends offsets based on utf-16 based string representation


### PR DESCRIPTION
Bug occured when:
* LSP sends simple ParameterLabel (just the name of the parameter instead of its location)
* the highlight is for a parameter which is a substring of the function name

Explanation: The heuristic for determining the byte offset of the parameter just does a `find` on the signature string. However, when the parameter name is a substring of the function name, then this hightlights this part of the function name instead of the parameter.

This PR changes the find to an rfind. The bug will still come up if the parameter is a substring a following parameter. However, it at least takes the function name out of the equation as this would be mathed at the very end.

An alternative approach might be to make a regex match of some sort to make sure that the highlighted region is a complete word/identifier.

![hx_bug_wrong_param_highlight](https://github.com/helix-editor/helix/assets/140162083/0ecb5ee1-4988-428c-8531-d3be9dea78b7)
