### PR TITLE
Add more accurate to official theme type highlighting to Darcula themes

### DIFF
--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -35,7 +35,11 @@
 "constant.numeric" = "lightblue"
 "constant.character.escape" = "white"
 "attribute" = "yellow"
-"type" = "orange"
+"type" = "white"
+"type.builtin" = "orange"
+"type.parameter" = { fg = "white", modifiers = ["bold"] }
+"type.enum" = "darkred"
+"type.enum.variant" = "orange"
 "string"  = "darkgreen"
 "function" = "yellow"
 "function.macro" = "green"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -38,7 +38,7 @@
 "type" = "white"
 "type.builtin" = "orange"
 "type.parameter" = { fg = "white", modifiers = ["bold"] }
-"type.enum" = "darkred"
+"type.enum" = "white"
 "type.enum.variant" = "orange"
 "string"  = "darkgreen"
 "function" = "yellow"


### PR DESCRIPTION
Includes new type parameter settings as implemented by https://github.com/helix-editor/helix/pull/8660.