### PR TITLE
grammars.nix: allow the user to apply overlays

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -5,6 +5,7 @@
   runCommand,
   yj,
   includeGrammarIf ? _: true,
+  grammarOverlays ? [],
   ...
 }: let
   # HACK: nix < 2.6 has a bug in the toml parser, so we convert to JSON
@@ -48,22 +49,22 @@
       then sourceGitHub
       else sourceGit;
   in
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation {
       # see https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix
 
       pname = "helix-tree-sitter-${grammar.name}";
       version = grammar.source.rev;
 
-      src =
-        if builtins.hasAttr "subpath" grammar.source
-        then "${source}/${grammar.source.subpath}"
-        else source;
+      src = source;
+      sourceRoot = if builtins.hasAttr "subpath" grammar.source then
+        "source/${grammar.source.subpath}"
+      else
+        "source";
 
-      dontUnpack = true;
       dontConfigure = true;
 
       FLAGS = [
-        "-I${src}/src"
+        "-Isrc"
         "-g"
         "-O3"
         "-fPIC"
@@ -76,13 +77,13 @@
       buildPhase = ''
         runHook preBuild
 
-        if [[ -e "$src/src/scanner.cc" ]]; then
-          $CXX -c "$src/src/scanner.cc" -o scanner.o $FLAGS
-        elif [[ -e "$src/src/scanner.c" ]]; then
-          $CC -c "$src/src/scanner.c" -o scanner.o $FLAGS
+        if [[ -e src/scanner.cc ]]; then
+          $CXX -c src/scanner.cc -o scanner.o $FLAGS
+        elif [[ -e src/scanner.c ]]; then
+          $CC -c src/scanner.c -o scanner.o $FLAGS
         fi
 
-        $CC -c "$src/src/parser.c" -o parser.o $FLAGS
+        $CC -c src/parser.c -o parser.o $FLAGS
         $CXX -shared -o $NAME.so *.o
 
         ls -al
@@ -105,15 +106,17 @@
       '';
     };
   grammarsToBuild = builtins.filter includeGrammarIf gitGrammars;
-  builtGrammars =
-    builtins.map (grammar: {
-      inherit (grammar) name;
-      artifact = buildGrammar grammar;
-    })
-    grammarsToBuild;
-  grammarLinks =
-    builtins.map (grammar: "ln -s ${grammar.artifact}/${grammar.name}.so $out/${grammar.name}.so")
-    builtGrammars;
+  builtGrammars = builtins.map (grammar: {
+    inherit (grammar) name;
+    value = buildGrammar grammar;
+  }) grammarsToBuild;
+  extensibleGrammars =
+    lib.makeExtensible (self: builtins.listToAttrs builtGrammars);
+  overlayedGrammars = lib.pipe extensibleGrammars
+    (builtins.map (overlay: grammar: grammar.extend overlay) grammarOverlays);
+  grammarLinks = lib.mapAttrsToList
+    (name: artifact: "ln -s ${artifact}/${name}.so $out/${name}.so")
+    (lib.filterAttrs (n: v: lib.isDerivation v) overlayedGrammars);
 in
   runCommand "consolidated-helix-grammars" {} ''
     mkdir -p $out


### PR DESCRIPTION
You can now apply overlays to the grammar derivations via `grammarOverlays`. Also, the `src` in the derivation is now properly unpacked to the build directory, allowing the user to mutate the source files if they want to.

Example usage:

```nix
helix.override {
  grammarOverlays = [
    (final: prev: {
      markdown_inline = prev.markdown_inline.overrideAttrs {
        EXTENSION_TAGS = 1;
        EXTENSION_WIKI_LINK = 1;
        nativeBuildInputs = with pkgs; [ tree-sitter nodejs ];
        preBuild = ''
          rm src/parser.c
          tree-sitter generate
        '';
      };
    })
  ];
}
```

This builds the `markdown_inline` parser with optional extensions enabled.