### PR TITLE
Fix outdated diagnostics detection

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -726,7 +726,7 @@ impl Application {
                         let offset_encoding = language_server.offset_encoding();
                         let doc = self.editor.document_by_path_mut(&path).filter(|doc| {
                             if let Some(version) = params.version {
-                                if version != doc.version() {
+                                if doc.version() > version {
                                     log::info!("Version ({version}) is out of date for {path:?} (expected ({}), dropping PublishDiagnostic notification", doc.version());
                                     return false;
                                 }


### PR DESCRIPTION
context: https://github.com/helix-editor/helix/discussions/8754

copying from discussion:

Question: it seems like (maybe only sometimes) diagnostics are not updating after fixing an issue in my Elixir projects. I'm seeing the following logs:

```
2023-11-08T09:41:48.358 helix_lsp::transport [INFO] elixir-ls <- {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"diagnostics":[],"uri":"file:///Users/dvic/Development/pluto/lib/sentry_filter.ex","version":5}}
2023-11-08T09:41:48.358 helix_term::application [ERROR] received malformed notification from Language Server: Unhandled
2023-11-08T09:41:48.358 helix_term::application [INFO] Version (5) is out of date for "/Users/dvic/Development/pluto/lib/sentry_filter.ex" (expected (4), dropping PublishDiagnostic notification
```

This PR fixes the issues, but I'm not 100% sure it's the right fix?