### PR TITLE
Change Fedora installation to the new official Helix package

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -65,10 +65,7 @@ sudo apt install helix
 
 ### Fedora/RHEL
 
-Enable the `COPR` repository for Helix:
-
 ```sh
-sudo dnf copr enable varlad/helix
 sudo dnf install helix
 ```
 


### PR DESCRIPTION
Remove COPR install in favour of official Helix package


===

Helix has now been approved for official inclusion into the Fedora project, so this PR updates the documentation to enable users to install the official version rather than the community provided COPR version.

Please do not merge this just yet, as it will still be a week or so until the package is live, at which point I will update this from a draft to allow merging.

Thanks.
