### PR TITLE
Add handlebars language (for glimmer)

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -62,6 +62,7 @@
 | gotmpl | ✓ |  |  | `gopls` |
 | gowork | ✓ |  |  | `gopls` |
 | graphql | ✓ |  |  | `graphql-lsp` |
+| handlebars | ✓ |  |  | `ember-language-server` |
 | hare | ✓ |  |  |  |
 | haskell | ✓ | ✓ |  | `haskell-language-server-wrapper` |
 | haskell-persistent | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -24,6 +24,7 @@ dot-language-server = { command = "dot-language-server", args = ["--stdio"] }
 elixir-ls = { command = "elixir-ls", config = { elixirLS.dialyzerEnabled = false } }
 elm-language-server = { command = "elm-language-server" }
 elvish = { command = "elvish", args = ["-lsp"] }
+ember = { command = "ember-language-server", args=["--stdio"] }
 erlang-ls = { command = "erlang_ls" }
 forc = { command = "forc", args = ["lsp"] }
 forth-lsp = { command = "forth-lsp" }
@@ -2942,3 +2943,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "dbml"
 source = { git = "https://github.com/dynamotn/tree-sitter-dbml", rev = "2e2fa5640268c33c3d3f27f7e676f631a9c68fd9" }
+
+[[language]]
+name = "handlebars"
+injection-regex = "hbs"
+roots = ["package.json"]
+file-types = ["hbs"]
+grammar = "glimmer"
+language-servers = ["ember"]
+formatter = { command = "prettier", args = ['--parser', 'glimmer'] }
+scope = "source.glimmer"
+
+[[grammar]]
+name = "glimmer"
+source = { git = "https://github.com/alexlafroscia/tree-sitter-glimmer", rev = "f9746dc1d0707717fbba84cb5c22a71586af23e1" }

--- a/runtime/queries/handlebars/highlights.scm
+++ b/runtime/queries/handlebars/highlights.scm
@@ -1,0 +1,90 @@
+; https://github.com/alexlafroscia/tree-sitter-glimmer/blob/main/queries/highlights.scm
+
+; === Tag Names ===
+
+; Tags that start with a lower case letter are HTML tags
+; We'll also use this highlighting for named blocks (which start with `:`)
+((tag_name) @tag
+  (#match? @tag "^(:)?[a-z]"))
+; Tags that start with a capital letter are Glimmer components
+((tag_name) @constructor
+  (#match? @constructor "^[A-Z]"))
+
+(attribute_name) @property
+
+(string_literal) @string
+(number_literal) @number
+(boolean_literal) @boolean
+
+(concat_statement) @string
+
+; === Block Statements ===
+
+; Highlight the brackets
+(block_statement_start) @tag.delimiter
+(block_statement_end) @tag.delimiter
+
+; Highlight `if`/`each`/`let`
+(block_statement_start path: (identifier) @conditional)
+(block_statement_end path: (identifier) @conditional)
+((mustache_statement (identifier) @conditional)
+ (#match? @conditional "else"))
+
+; == Mustache Statements ===
+
+; Hightlight the whole statement, to color brackets and separators
+(mustache_statement) @tag.delimiter
+
+; An identifier in a mustache expression is a variable
+((mustache_statement [
+  (path_expression (identifier) @variable)
+  (identifier) @variable
+  ])
+  (#not-match? @variable "yield|outlet|this|else"))
+; As are arguments in a block statement
+(block_statement_start argument: [
+  (path_expression (identifier) @variable)
+  (identifier) @variable
+  ])
+; As is an identifier in a block param
+(block_params (identifier) @variable)
+; As are helper arguments
+((helper_invocation argument: [
+  (path_expression (identifier) @variable)
+  (identifier) @variable
+  ])
+  (#not-match? @variable "this"))
+; `this` should be highlighted as a built-in variable
+((identifier) @variable.builtin
+  (#match? @variable.builtin "this"))
+
+; If the identifier is just "yield" or "outlet", it's a keyword
+((mustache_statement (identifier) @keyword)
+  (#match? @keyword "yield|outlet"))
+
+; Helpers are functions
+((helper_invocation helper: [
+  (path_expression (identifier) @function)
+  (identifier) @function
+  ])
+  (#not-match? @function "if|yield"))
+((helper_invocation helper: (identifier) @conditional)
+  (#match? @conditional "if"))
+((helper_invocation helper: (identifier) @keyword)
+  (#match? @keyword "yield"))
+
+(hash_pair key: (identifier) @property)
+
+(comment_statement) @comment
+
+(attribute_node "=" @operator)
+
+(block_params "as" @keyword)
+(block_params "|" @operator)
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+] @tag.delimiter


### PR DESCRIPTION
# Add Handlebars Language (glimmer templates)

This adds support for glimmer `hbs` templates which are commonly used in `ember.js`. 

It uses the grammar and queries from https://github.com/alexlafroscia/tree-sitter-glimmer

## glimmer templates
![image](https://github.com/helix-editor/helix/assets/110528300/2d4b583c-4fce-445a-b173-406021364604)
![image](https://github.com/helix-editor/helix/assets/110528300/8da094a1-e201-4a18-9f04-206feeec6fd8)

## nonglimmer templates
![image](https://github.com/helix-editor/helix/assets/110528300/1fefbaa2-196c-48e5-9b9d-184ee9b5b3ef)
