### PR TITLE
Add smooth jumping between Helix and Tmux panes.

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -291,6 +291,8 @@ pub struct Config {
     pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
+    /// Whether to jump between tmux panes when a view jump is triggered at the edge of the editor. Defaults to `false`.
+    pub jump_tmux_panes: bool
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -846,6 +848,7 @@ impl Default for Config {
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,
             smart_tab: Some(SmartTabConfig::default()),
+            jump_tmux_panes: false
         }
     }
 }
@@ -1630,10 +1633,15 @@ impl Editor {
         self.focus(self.tree.prev());
     }
 
-    pub fn focus_direction(&mut self, direction: tree::Direction) {
+    pub fn focus_direction(&mut self, direction: tree::Direction) -> anyhow::Result<(), ()> {
         let current_view = self.tree.focus;
+
         if let Some(id) = self.tree.find_split_in_direction(current_view, direction) {
-            self.focus(id)
+            self.focus(id);
+
+            Ok(())
+        } else {
+            Err(())
         }
     }
 


### PR DESCRIPTION
Hi,

I've recently switched over from Neovim, and I love Helix. However, one crucial thing I'm missing is smooth navigation between editor panes and Tmux panes.

I created a PoC adding this functionality to Helix. I based the implementation on [nvim-tmux-navigator](https://github.com/alexghergh/nvim-tmux-navigation/blob/543f090a45cef28156162883d2412fffecb6b750/lua/nvim-tmux-navigation/tmux_util.lua#L10).

It would probably be better to have it as a plugin, but the plugin system is not available yet, and I believe using TUI editors with Tmux is a very common case.

This PR adds an editor option `jump_tmux_panes: bool`. If enabled, commands `jump_view_(right|left|up|down)` will send the appropriate command to Tmux whenever there is no Helix pane to jump to, i.e. the focus is already at the edge of the editor.

Please let me know if this is something you'd be willing to add to Helix (in this or another form).