### PR TITLE
Default 'roots' field of language config

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -101,7 +101,8 @@ pub struct LanguageConfiguration {
     pub file_types: Vec<FileType>, // filename extension or ends_with? <Gemfile, rb, etc>
     #[serde(default)]
     pub shebangs: Vec<String>, // interpreter(s) associated with language
-    pub roots: Vec<String>,        // these indicate project roots <.git, Cargo.toml>
+    #[serde(default)]
+    pub roots: Vec<String>, // these indicate project roots <.git, Cargo.toml>
     pub comment_token: Option<String>,
     pub text_width: Option<usize>,
     pub soft_wrap: Option<SoftWrap>,

--- a/languages.toml
+++ b/languages.toml
@@ -249,7 +249,6 @@ name = "toml"
 scope = "source.toml"
 injection-regex = "toml"
 file-types = ["toml", "poetry.lock", "Cargo.lock"]
-roots = []
 comment-token = "#"
 language-servers = [ "taplo" ]
 indent = { tab-width = 2, unit = "  " }
@@ -263,7 +262,6 @@ name = "awk"
 scope = "source.awk"
 injection-regex = "awk"
 file-types = ["awk", "gawk", "nawk", "mawk"]
-roots = []
 comment-token = "#"
 language-servers = [ "awk-language-server" ]
 indent = { tab-width = 2, unit = "  " }
@@ -278,7 +276,6 @@ scope = "source.proto"
 injection-regex = "protobuf"
 file-types = ["proto"]
 language-servers = [ "bufls", "pbkit" ]
-roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 
@@ -307,7 +304,6 @@ scope = "source.fish"
 injection-regex = "fish"
 file-types = ["fish"]
 shebangs = ["fish"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 
@@ -321,7 +317,6 @@ scope = "source.mint"
 injection-regex = "mint"
 file-types = ["mint"]
 shebangs = []
-roots = []
 comment-token = "//"
 language-servers = [ "mint" ]
 indent = { tab-width = 2, unit = "  " }
@@ -351,7 +346,6 @@ file-types = [
   "composer.lock",
   ".watchmanconfig"
 ]
-roots = []
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
@@ -366,7 +360,6 @@ name = "json5"
 scope = "source.json5"
 injection-regex = "json5"
 file-types = ["json5"]
-roots = []
 language-servers = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
@@ -381,7 +374,6 @@ name = "c"
 scope = "source.c"
 injection-regex = "c"
 file-types = ["c"] # TODO: ["h"]
-roots = []
 comment-token = "//"
 language-servers = [ "clangd" ]
 indent = { tab-width = 2, unit = "  " }
@@ -418,7 +410,6 @@ name = "cpp"
 scope = "source.cpp"
 injection-regex = "cpp"
 file-types = ["cc", "hh", "c++", "cpp", "hpp", "h", "ipp", "tpp", "cxx", "hxx", "ixx", "txx", "ino", "C", "H", "cu", "cuh", "cppm", "h++", "ii", "inl", { suffix = ".hpp.in" }, { suffix = ".h.in" }]
-roots = []
 comment-token = "//"
 language-servers = [ "clangd" ]
 indent = { tab-width = 2, unit = "  " }
@@ -551,7 +542,6 @@ name = "gomod"
 scope = "source.gomod"
 injection-regex = "gomod"
 file-types = ["go.mod"]
-roots = []
 auto-format = true
 comment-token = "//"
 language-servers = [ "gopls" ]
@@ -566,7 +556,6 @@ name = "gotmpl"
 scope = "source.gotmpl"
 injection-regex = "gotmpl"
 file-types = ["gotmpl"]
-roots = []
 comment-token = "//"
 language-servers = [ "gopls" ]
 indent = { tab-width = 2, unit = " " }
@@ -580,7 +569,6 @@ name = "gowork"
 scope = "source.gowork"
 injection-regex = "gowork"
 file-types = ["go.work"]
-roots = []
 auto-format = true
 comment-token = "//"
 language-servers = [ "gopls" ]
@@ -597,7 +585,6 @@ injection-regex = "(js|javascript)"
 language-id = "javascript"
 file-types = ["js", "mjs", "cjs", "rules", "es6", "pac", "jakefile"]
 shebangs = ["node"]
-roots = []
 comment-token = "//"
 language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
@@ -624,7 +611,6 @@ scope = "source.jsx"
 injection-regex = "jsx"
 language-id = "javascriptreact"
 file-types = ["jsx"]
-roots = []
 comment-token = "//"
 language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
@@ -637,7 +623,6 @@ injection-regex = "(ts|typescript)"
 file-types = ["ts", "mts", "cts"]
 language-id = "typescript"
 shebangs = ["deno", "ts-node"]
-roots = []
 language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 
@@ -651,7 +636,6 @@ scope = "source.tsx"
 injection-regex = "(tsx)" # |typescript
 language-id = "typescriptreact"
 file-types = ["tsx"]
-roots = []
 language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 
@@ -664,7 +648,6 @@ name = "css"
 scope = "source.css"
 injection-regex = "css"
 file-types = ["css", "scss"]
-roots = []
 language-servers = [ "vscode-css-language-server" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
@@ -678,7 +661,6 @@ name = "scss"
 scope = "source.scss"
 injection-regex = "scss"
 file-types = ["scss"]
-roots = []
 language-servers = [ "vscode-css-language-server" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
@@ -692,7 +674,6 @@ name = "html"
 scope = "text.html.basic"
 injection-regex = "html"
 file-types = ["html", "htm", "shtml", "xhtml", "xht", "jsp", "asp", "aspx", "jshtm", "volt", "rhtml"]
-roots = []
 language-servers = [ "vscode-html-language-server" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
@@ -723,7 +704,6 @@ scope = "source.nickel"
 injection-regex = "nickel"
 file-types = ["ncl"]
 shebangs = []
-roots = []
 comment-token = "#"
 language-servers = [ "nls" ]
 indent = { tab-width = 2, unit = "  " }
@@ -744,7 +724,6 @@ scope = "source.nix"
 injection-regex = "nix"
 file-types = ["nix"]
 shebangs = []
-roots = []
 comment-token = "#"
 language-servers = [ "nil" ]
 indent = { tab-width = 2, unit = "  " }
@@ -794,7 +773,6 @@ file-types = [
   "Gymfile"
 ]
 shebangs = ["ruby"]
-roots = []
 comment-token = "#"
 language-servers = [ "solargraph" ]
 indent = { tab-width = 2, unit = "  " }
@@ -849,7 +827,6 @@ file-types = [
   "zshrc_Apple_Terminal"
 ]
 shebangs = ["sh", "bash", "dash", "zsh"]
-roots = []
 comment-token = "#"
 language-servers = [ "bash-language-server" ]
 indent = { tab-width = 2, unit = "  " }
@@ -877,7 +854,6 @@ name = "twig"
 scope = "source.twig"
 injection-regex = "twig"
 file-types = ["twig"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -889,7 +865,6 @@ name = "latex"
 scope = "source.tex"
 injection-regex = "tex"
 file-types = ["tex", "sty", "cls", "Rd", "bbx", "cbx"]
-roots = []
 comment-token = "%"
 language-servers = [ "texlab" ]
 indent = { tab-width = 4, unit = "\t" }
@@ -903,7 +878,6 @@ name = "bibtex"
 scope = "source.bib"
 injection-regex = "bib"
 file-types = ["bib"]
-roots = []
 comment-token = "%"
 language-servers = [ "texlab" ]
 indent = { tab-width = 4, unit = "\t" }
@@ -946,7 +920,6 @@ name = "lpf"
 comment-token = "#"
 scope = "source.lpf"
 file-types = ["lpf"]
-roots = []
 
 [[grammar]]
 name = "lpf"
@@ -985,7 +958,6 @@ name = "ledger"
 scope = "source.ledger"
 injection-regex = "ledger"
 file-types = ["ldg", "ledger", "journal"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 4, unit = "    " }
 
@@ -998,7 +970,6 @@ name = "beancount"
 scope = "source.beancount"
 injection-regex = "beancount"
 file-types = ["beancount", "bean"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 
@@ -1012,7 +983,6 @@ scope = "source.ocaml"
 injection-regex = "ocaml"
 file-types = ["ml"]
 shebangs = ["ocaml", "ocamlrun", "ocamlscript"]
-roots = []
 comment-token = "(**)"
 language-servers = [ "ocamllsp" ]
 indent = { tab-width = 2, unit = "  " }
@@ -1032,7 +1002,6 @@ name = "ocaml-interface"
 scope = "source.ocaml.interface"
 file-types = ["mli"]
 shebangs = []
-roots = []
 comment-token = "(**)"
 language-servers = [ "ocamllsp" ]
 indent = { tab-width = 2, unit = "  " }
@@ -1067,7 +1036,6 @@ name = "svelte"
 scope = "source.svelte"
 injection-regex = "svelte"
 file-types = ["svelte"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "svelteserver" ]
 
@@ -1092,7 +1060,6 @@ source = { git = "https://github.com/ikatyang/tree-sitter-vue", rev = "91fe27547
 name = "yaml"
 scope = "source.yaml"
 file-types = ["yml", "yaml"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "yaml-language-server", "ansible-language-server" ]
@@ -1120,7 +1087,6 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-haskell", rev = "d7
 name = "haskell-persistent"
 scope = "source.persistentmodels"
 file-types = ["persistentmodels"]
-roots = []
 comment-token = "--"
 indent = { tab-width = 2, unit = "  " }
 
@@ -1186,7 +1152,6 @@ source = { git = "https://github.com/maxxnino/tree-sitter-zig", rev = "0d08703e4
 [[language]]
 name = "prolog"
 scope = "source.prolog"
-roots = []
 file-types = ["pl", "prolog"]
 shebangs = ["swipl"]
 comment-token = "%"
@@ -1196,7 +1161,6 @@ language-servers = [ "swipl" ]
 name = "tsq"
 scope = "source.tsq"
 file-types = ["tsq"]
-roots = []
 comment-token = ";"
 injection-regex = "tsq"
 indent = { tab-width = 2, unit = "  " }
@@ -1209,7 +1173,6 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-tsq", rev = "48b5
 name = "cmake"
 scope = "source.cmake"
 file-types = ["cmake", "CMakeLists.txt"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "cmake-language-server" ]
@@ -1225,7 +1188,6 @@ scope = "source.make"
 file-types = ["Makefile", "makefile", "make", "mk", "mak", "GNUmakefile", "OCamlMakefile"]
 shebangs = ["make", "gmake"]
 injection-regex = "(make|makefile|Makefile|mk)"
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
 
@@ -1237,7 +1199,6 @@ source = { git = "https://github.com/alemuller/tree-sitter-make", rev = "a4b9187
 name = "glsl"
 scope = "source.glsl"
 file-types = ["glsl", "vert", "tesc", "tese", "geom", "frag", "comp" ]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 injection-regex = "glsl"
@@ -1251,7 +1212,6 @@ name = "perl"
 scope = "source.perl"
 file-types = ["pl", "pm", "t", "psgi", "raku", "rakumod", "rakutest", "rakudoc", "nqp", "p6", "pl6", "pm6"]
 shebangs = ["perl"]
-roots = []
 comment-token = "#"
 language-servers = [ "perlnavigator" ]
 indent = { tab-width = 2, unit = "  " }
@@ -1264,7 +1224,6 @@ source = { git = "https://github.com/tree-sitter-perl/tree-sitter-perl", rev = "
 name = "pod"
 scope = "source.pod"
 injection-regex = "pod"
-roots = []
 file-types = ["pod"]
 
 [[grammar]]
@@ -1274,7 +1233,6 @@ source = { git = "https://github.com/tree-sitter-perl/tree-sitter-pod", rev = "d
 [[language]]
 name = "racket"
 scope = "source.racket"
-roots = []
 file-types = ["rkt", "rktd", "rktl", "scrbl"]
 shebangs = ["racket"]
 comment-token = ";"
@@ -1285,7 +1243,6 @@ grammar = "scheme"
 [[language]]
 name = "common-lisp"
 scope = "source.lisp"
-roots = []
 file-types = ["lisp", "asd", "cl", "l", "lsp", "ny", "podsl", "sexp"]
 shebangs = ["lisp", "sbcl", "ccl", "clisp", "ecl"]
 comment-token = ";"
@@ -1302,7 +1259,6 @@ grammar = "scheme"
 [[language]]
 name = "comment"
 scope = "scope.comment"
-roots = []
 file-types = []
 injection-regex = "comment"
 
@@ -1314,7 +1270,6 @@ source = { git = "https://github.com/stsewd/tree-sitter-comment", rev = "5dd3c62
 name = "wgsl"
 scope = "source.wgsl"
 file-types = ["wgsl"]
-roots = []
 comment-token = "//"
 language-servers = [ "wgsl_analyzer" ]
 indent = { tab-width = 4, unit = "    " }
@@ -1326,7 +1281,6 @@ source = { git = "https://github.com/szebniok/tree-sitter-wgsl", rev = "272e89ef
 [[language]]
 name = "llvm"
 scope = "source.llvm"
-roots = []
 file-types = ["ll"]
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
@@ -1339,7 +1293,6 @@ source = { git = "https://github.com/benwilliamgraham/tree-sitter-llvm", rev = "
 [[language]]
 name = "llvm-mir"
 scope = "source.llvm_mir"
-roots = []
 file-types = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
@@ -1355,7 +1308,6 @@ name = "llvm-mir-yaml"
 #
 #     grammar = "yaml"
 scope = "source.yaml"
-roots = []
 file-types = ["mir"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
@@ -1363,7 +1315,6 @@ indent = { tab-width = 2, unit = "  " }
 [[language]]
 name = "tablegen"
 scope = "source.tablegen"
-roots = []
 file-types = ["td"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
@@ -1391,7 +1342,6 @@ name = "markdown.inline"
 scope = "source.markdown.inline"
 injection-regex = "markdown\\.inline"
 file-types = []
-roots = []
 grammar = "markdown_inline"
 
 [[grammar]]
@@ -1442,7 +1392,6 @@ source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = 
 [[language]]
 name = "git-commit"
 scope = "git.commitmsg"
-roots = []
 file-types = ["COMMIT_EDITMSG"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
@@ -1456,7 +1405,6 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-git-commit", rev 
 [[language]]
 name = "diff"
 scope = "source.diff"
-roots = []
 file-types = ["diff", "patch", "rej"]
 injection-regex = "diff"
 comment-token = "#"
@@ -1469,7 +1417,6 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-diff", rev = "fd7
 [[language]]
 name = "git-rebase"
 scope = "source.gitrebase"
-roots = []
 file-types = ["git-rebase-todo"]
 injection-regex = "git-rebase"
 comment-token = "#"
@@ -1484,7 +1431,6 @@ name = "regex"
 scope = "source.regex"
 injection-regex = "regex"
 file-types = ["regex", ".Rbuildignore"]
-roots = []
 
 [[grammar]]
 name = "regex"
@@ -1493,7 +1439,6 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-regex", rev = "e1cf
 [[language]]
 name = "git-config"
 scope = "source.gitconfig"
-roots = []
 file-types = [".gitmodules", ".gitconfig", { suffix = ".git/config" }, { suffix = ".config/git/config" }]
 injection-regex = "git-config"
 comment-token = "#"
@@ -1506,7 +1451,6 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-git-config", rev 
 [[language]]
 name = "git-attributes"
 scope = "source.gitattributes"
-roots = []
 file-types = [".gitattributes"]
 injection-regex = "git-attributes"
 comment-token = "#"
@@ -1519,7 +1463,6 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 [[language]]
 name = "git-ignore"
 scope = "source.gitignore"
-roots = []
 file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore", "CODEOWNERS"]
 injection-regex = "git-ignore"
 comment-token = "#"
@@ -1534,7 +1477,6 @@ name = "graphql"
 scope = "source.graphql"
 injection-regex = "graphql"
 file-types = ["gql", "graphql", "graphqls"]
-roots = []
 language-servers = [ "graphql-language-service" ]
 indent = { tab-width = 2, unit = "  " }
 
@@ -1562,7 +1504,6 @@ name = "iex"
 scope = "source.iex"
 injection-regex = "iex"
 file-types = ["iex"]
-roots = []
 
 [[grammar]]
 name = "iex"
@@ -1625,7 +1566,6 @@ scope = "source.hcl"
 injection-regex = "(hcl|tf|nomad)"
 language-id = "terraform"
 file-types = ["hcl", "tf", "nomad"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "terraform-ls" ]
@@ -1640,7 +1580,6 @@ name = "tfvars"
 scope = "source.tfvars"
 language-id = "terraform-vars"
 file-types = ["tfvars"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "terraform-ls" ]
@@ -1652,7 +1591,6 @@ name = "org"
 scope = "source.org"
 injection-regex = "org"
 file-types = ["org"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -1664,7 +1602,6 @@ name = "solidity"
 scope = "source.sol"
 injection-regex = "(sol|solidity)"
 file-types = ["sol"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 language-servers = [ "solc" ]
@@ -1693,7 +1630,6 @@ name = "ron"
 scope = "source.ron"
 injection-regex = "ron"
 file-types = ["ron"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 
@@ -1707,7 +1643,6 @@ scope = "source.robot"
 injection-regex = "robot"
 file-types = ["robot", "resource"]
 comment-token = "#"
-roots = []
 indent = { tab-width = 4, unit = " " }
 language-servers = [ "robotframework_ls" ]
 
@@ -1721,7 +1656,6 @@ scope = "source.r"
 injection-regex = "(r|R)"
 file-types = ["r", "R", ".Rprofile", "Rprofile.site", ".RHistory"]
 shebangs = ["r", "R"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "r" ]
@@ -1735,7 +1669,6 @@ name = "rmarkdown"
 scope = "source.rmd"
 injection-regex = "(r|R)md"
 file-types = ["rmd", "Rmd"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "markdown"
 language-servers = [ "r" ]
@@ -1759,7 +1692,6 @@ name = "erb"
 scope = "text.html.erb"
 injection-regex = "erb"
 file-types = ["erb"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "embedded-template"
 
@@ -1768,7 +1700,6 @@ name = "ejs"
 scope = "text.html.ejs"
 injection-regex = "ejs"
 file-types = ["ejs"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "embedded-template"
 
@@ -1805,7 +1736,6 @@ source = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "
 name = "sql"
 scope = "source.sql"
 file-types = ["sql", "dsql"]
-roots = []
 comment-token = "--"
 indent = { tab-width = 4, unit = "    " }
 injection-regex = "sql"
@@ -1851,7 +1781,6 @@ scope = "source.nu"
 injection-regex = "nu"
 file-types = ["nu"]
 shebangs = ["nu"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 
@@ -1864,7 +1793,6 @@ name = "vala"
 scope = "source.vala"
 injection-regex = "vala"
 file-types = ["vala", "vapi"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "vala-language-server" ]
@@ -1878,7 +1806,6 @@ name = "hare"
 scope = "source.hare"
 injection-regex = "hare"
 file-types = ["ha"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 8, unit = "\t" }
 
@@ -1891,7 +1818,6 @@ name = "devicetree"
 scope = "source.devicetree"
 injection-regex = "(dtsi?|devicetree|fdt)"
 file-types = ["dts", "dtsi"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "\t" }
 
@@ -1904,7 +1830,6 @@ name = "cairo"
 scope = "source.cairo"
 injection-regex = "cairo"
 file-types = ["cairo"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 # auto-format = true
@@ -1916,7 +1841,6 @@ name = "cpon"
 scope = "scope.cpon"
 injection-regex = "cpon"
 file-types = ["cpon", "cp"]
-roots = []
 auto-format = true
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
@@ -1944,7 +1868,6 @@ name = "meson"
 scope = "source.meson"
 injection-regex = "meson"
 file-types = ["meson.build", "meson_options.txt"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 
@@ -1956,7 +1879,6 @@ source = { git = "https://github.com/staysail/tree-sitter-meson", rev = "32a83e8
 name = "sshclientconfig"
 scope = "source.sshclientconfig"
 file-types = [{ suffix = ".ssh/config" }, { suffix = "/etc/ssh/ssh_config" }]
-roots = []
 comment-token = "#"
 
 [[grammar]]
@@ -1969,7 +1891,6 @@ scope = "source.scheme"
 injection-regex = "scheme"
 file-types = ["ss", "scm"]
 shebangs = ["scheme", "guile", "chicken"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 
@@ -1996,7 +1917,6 @@ source = {git = "https://github.com/v-analyzer/v-analyzer", subpath = "tree_sitt
 name = "verilog"
 scope = "source.verilog"
 file-types = ["v", "vh", "sv", "svh"]
-roots = []
 comment-token = "//"
 language-servers = [ "svlangserver" ]
 indent = { tab-width = 2, unit = "  " }
@@ -2011,7 +1931,6 @@ name = "edoc"
 scope = "source.edoc"
 file-types = ["edoc", "edoc.in"]
 injection-regex = "edoc"
-roots = []
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -2023,7 +1942,6 @@ name = "jsdoc"
 scope = "source.jsdoc"
 injection-regex = "jsdoc"
 file-types = ["jsdoc"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -2035,7 +1953,6 @@ name = "openscad"
 scope = "source.openscad"
 injection-regex = "openscad"
 file-types = ["scad"]
-roots = []
 comment-token = "//"
 language-servers = [ "openscad-lsp" ]
 indent = { tab-width = 2, unit = "\t" }
@@ -2077,7 +1994,6 @@ name = "starlark"
 scope = "source.starlark"
 injection-regex = "(starlark|bzl|bazel)"
 file-types = ["bzl", "bazel", "BUILD", "star"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 grammar = "python"
@@ -2086,7 +2002,6 @@ grammar = "python"
 name = "elvish"
 scope = "source.elvish"
 file-types = ["elv"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "elvish" ]
@@ -2102,7 +2017,6 @@ scope = "source.idr"
 injection-regex = "idr"
 file-types = ["idr"]
 shebangs = []
-roots = []
 comment-token = "--"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "idris2-lsp" ]
@@ -2126,7 +2040,6 @@ name = "ungrammar"
 scope = "source.ungrammar"
 injection-regex = "ungrammar"
 file-types = ["ungram", "ungrammar"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2139,7 +2052,6 @@ name = "dot"
 scope = "source.dot"
 injection-regex = "dot"
 file-types = ["dot"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 language-servers = [ "dot-language-server" ]
@@ -2169,7 +2081,6 @@ name = "slint"
 scope = "source.slint"
 injection-regex = "slint"
 file-types = ["slint"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 4, unit = "    " }
 language-servers = [ "slint-lsp" ]
@@ -2183,7 +2094,6 @@ name = "task"
 scope = "source.task"
 injection-regex = "task"
 file-types = ["task"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2196,7 +2106,6 @@ name = "xit"
 scope = "source.xit"
 injection-regex = "xit"
 file-types = ["xit"]
-roots = []
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -2221,7 +2130,6 @@ name = "pascal"
 scope = "source.pascal"
 injection-regex = "pascal"
 file-types = ["pas", "pp", "inc", "lpr", "lfm"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "pasls" ]
@@ -2236,7 +2144,6 @@ scope = "source.sml"
 injection-regex = "sml"
 file-types = ["sml"]
 comment-token = "(*"
-roots = []
 
 [[grammar]]
 name = "sml"
@@ -2260,7 +2167,6 @@ name = "astro"
 scope = "source.astro"
 injection-regex = "astro"
 file-types = ["astro"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -2272,7 +2178,6 @@ name = "bass"
 scope = "source.bass"
 injection-regex = "bass"
 file-types = ["bass"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "bass" ]
@@ -2286,7 +2191,6 @@ name = "wat"
 scope = "source.wat"
 comment-token = ";;"
 file-types = ["wat"]
-roots = []
 
 [[grammar]]
 name = "wat"
@@ -2297,7 +2201,6 @@ name = "wast"
 scope = "source.wast"
 comment-token = ";;"
 file-types = ["wast"]
-roots = []
 
 [[grammar]]
 name = "wast"
@@ -2307,7 +2210,6 @@ source = { git = "https://github.com/wasm-lsp/tree-sitter-wasm", rev = "2ca28a9f
 name = "d"
 scope = "source.d"
 file-types = [ "d", "dd" ]
-roots = []
 comment-token = "//"
 injection-regex = "d"
 indent = { tab-width = 4, unit = "    "}
@@ -2322,7 +2224,6 @@ source = { git = "https://github.com/gdamore/tree-sitter-d", rev="601c4a1e8310fb
 name = "vhs"
 scope = "source.vhs"
 file-types = ["tape"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 grammar = "vhs"
@@ -2335,7 +2236,6 @@ source = { git = "https://github.com/charmbracelet/tree-sitter-vhs", rev = "c6d8
 name = "kdl"
 scope = "source.kdl"
 file-types = ["kdl"]
-roots = []
 comment-token = "//"
 injection-regex = "kdl"
 
@@ -2404,7 +2304,6 @@ file-types = [
   "xoml"
 ]
 indent = { tab-width = 2, unit = "  " }
-roots = []
 
 [language.auto-pairs]
 '(' = ')'
@@ -2425,7 +2324,6 @@ scope = "source.dtd"
 injection-regex = "dtd"
 file-types = ["dtd", "ent"]
 indent = {tab-width = 2, unit = "  "}
-roots = []
 
 [language.auto-pairs]
 '(' = ')'
@@ -2443,7 +2341,6 @@ name = "wit"
 scope = "source.wit"
 injection-regex = "wit"
 file-types = ["wit"]
-roots = []
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2466,7 +2363,6 @@ file-types = [".env", ".env.local", ".env.development", ".env.production", ".env
 injection-regex = "env"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
-roots = []
 grammar = "bash"
 
 [[language]]
@@ -2499,7 +2395,6 @@ file-types = [
 injection-regex = "ini"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
-roots = []
 
 [[grammar]]
 name = "ini"
@@ -2509,7 +2404,6 @@ source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "4d247fb87
 name = "bicep"
 scope = "source.bicep"
 file-types = ["bicep"]
-roots = []
 auto-format = true
 comment-token = "//"
 indent = { tab-width = 2, unit = " "}
@@ -2523,7 +2417,6 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-bicep", rev = "d8
 name = "qml"
 scope = "source.qml"
 file-types = ["qml"]
-roots = []
 language-servers = [ "qmlls" ]
 indent = { tab-width = 4, unit = "    " }
 grammar = "qmljs"
@@ -2537,7 +2430,6 @@ name = "mermaid"
 scope = "source.mermaid"
 injection-regex = "mermaid"
 file-types = ["mermaid"]
-roots = []
 comment-token = "%%"
 indent = { tab-width = 4, unit = "    " }
 
@@ -2551,7 +2443,6 @@ scope = "source.m"
 file-types = ["m"]
 comment-token = "%"
 shebangs = ["octave-cli", "matlab"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -2576,7 +2467,6 @@ name = "dhall"
 scope = "source.dhall"
 injection-regex = "dhall"
 file-types = ["dhall"]
-roots = []
 comment-token = "--"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "dhall-lsp-server" ]
@@ -2591,7 +2481,6 @@ name = "sage"
 scope = "source.sage"
 file-types = ["sage"]
 injection-regex = "sage"
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 grammar = "python"
@@ -2602,7 +2491,6 @@ scope = "source.msbuild"
 injection-regex = "msbuild"
 file-types = ["proj", "vbproj", "csproj", "fsproj", "targets", "props"]
 indent = { tab-width = 2, unit = "  " }
-roots = []
 grammar = "xml"
 
 [language.auto-pairs]
@@ -2618,7 +2506,6 @@ name = "pem"
 scope = "source.pem"
 file-types = ["pem", "cert", "crt"]
 injection-regex = "pem"
-roots = []
 grammar = "pem"
 
 [[grammar]]
@@ -2629,7 +2516,6 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-pem", rev = "be67a433
 name = "passwd"
 scope = "source.passwd"
 file-types = ["passwd"]
-roots = []
 
 [[grammar]]
 name = "passwd"
@@ -2639,7 +2525,6 @@ source = { git = "https://github.com/ath3/tree-sitter-passwd", rev = "20239395ea
 name = "hosts"
 scope = "source.hosts"
 file-types = ["hosts"]
-roots = []
 comment-token = "#"
 
 [[grammar]]
@@ -2651,7 +2536,6 @@ name = "uxntal"
 scope = "source.tal"
 injection-regex = "tal"
 file-types = ["tal"]
-roots = []
 auto-format = false
 comment-token = "("
 
@@ -2664,7 +2548,6 @@ name = "yuck"
 scope = "source.yuck"
 injection-regex = "yuck"
 file-types = ["yuck"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2677,7 +2560,6 @@ name = "prql"
 scope = "source.prql"
 injection-regex = "prql"
 file-types = ["prql"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 
@@ -2689,7 +2571,6 @@ source = { git = "https://github.com/PRQL/tree-sitter-prql", rev = "09e158cd3650
 name = "po"
 scope = "source.po"
 file-types = ["po", "pot"]
-roots = []
 comment-token = "#"
 
 [[grammar]]
@@ -2701,7 +2582,6 @@ name = "nasm"
 scope = "source.nasm"
 file-types = ["asm", "S", "nasm"]
 injection-regex = "n?asm"
-roots = []
 comment-token = ";"
 indent = { tab-width = 8, unit = "        " }
 
@@ -2714,7 +2594,6 @@ name = "gas"
 scope = "source.gas"
 file-types = ["s"]
 injection-regex = "gas"
-roots = []
 comment-token = "#"
 indent = { tab-width = 8, unit = "        " }
 
@@ -2727,7 +2606,6 @@ name = "rst"
 scope = "source.rst"
 comment-token = ".."
 file-types = ["rst"]
-roots = []
 
 [[grammar]]
 name = "rst"
@@ -2738,7 +2616,6 @@ name = "capnp"
 scope = "source.capnp"
 injection-regex = "capnp"
 file-types = ["capnp"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2764,7 +2641,6 @@ source = { git = "https://github.com/indoorvivants/tree-sitter-smithy", rev = "c
 name = "vhdl"
 scope = "source.vhdl"
 file-types = ["vhd", "vhdl"]
-roots = []
 comment-token = "--"
 language-servers = [ "vhdl_ls" ]
 indent = { tab-width = 2, unit = "  " }
@@ -2776,7 +2652,6 @@ source = { git = "https://github.com/teburd/tree-sitter-vhdl", rev = "c57313adee
 
 [[language]]
 name = "rego"
-roots = []
 scope = "source.rego"
 injection-regex = "rego"
 file-types = ["rego"]
@@ -2795,7 +2670,6 @@ scope = "source.nim"
 injection-regex = "nim"
 file-types = ["nim", "nims", "nimble"]
 shebangs = []
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "nimlangserver" ]
@@ -2825,7 +2699,6 @@ name = "hurl"
 scope = "source.hurl"
 injection-regex = "hurl"
 file-types = ["hurl"]
-roots = []
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2836,7 +2709,6 @@ source = { git = "https://github.com/pfeiferj/tree-sitter-hurl", rev = "264c4206
 [[language]]
 name = "markdoc"
 scope = "text.markdoc"
-roots = []
 file-types = ["mdoc"]
 language-servers = [ "markdoc-ls" ]
 
@@ -2849,7 +2721,6 @@ name = "opencl"
 scope = "source.cl"
 injection-regex = "(cl|opencl)"
 file-types = ["cl"]
-roots = []
 comment-token = "//"
 language-servers = [ "clangd" ]
 
@@ -2862,7 +2733,6 @@ name = "just"
 scope = "source.just"
 file-types = ["justfile", "Justfile", ".justfile", ".Justfile"]
 injection-regex = "just"
-roots = []
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
 
@@ -2875,7 +2745,6 @@ name = "blueprint"
 scope = "source.blueprint"
 injection-regex = "blueprint"
 file-types = ["blp"]
-roots = []
 comment-token = "//"
 language-servers = [ "blueprint-compiler" ]
 indent = { tab-width = 4, unit = "    " }
@@ -2889,7 +2758,6 @@ name = "forth"
 scope = "source.forth"
 injection-regex = "forth"
 file-types = ["fs", "forth", "fth", "4th"]
-roots = []
 comment-token = "\\"
 language-servers = [ "forth-lsp" ]
 indent = { tab-width = 3, unit = "   " }
@@ -2918,7 +2786,6 @@ name = "t32"
 scope = "source.t32"
 injection-regex = "t32"
 file-types = ["cmm", "t32"]
-roots = []
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 
@@ -2931,7 +2798,6 @@ name = "webc"
 scope = "text.html.webc"
 injection-regex = "webc"
 file-types = ["webc"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "html"
 
@@ -2940,7 +2806,6 @@ name = "typst"
 scope = "source.typst"
 injection-regex = "typst"
 file-types = ["typst", "typ"]
-roots = []
 comment-token = "//"
 language-servers = ["typst-lsp"]
 indent = { tab-width = 2, unit = "  " }
@@ -2961,7 +2826,6 @@ name = "nunjucks"
 scope = "text.html.nunjucks"
 injection-regex = "nunjucks"
 file-types = ["njk"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "jinja2"
 
@@ -2970,7 +2834,6 @@ name = "jinja"
 scope = "text.html.jinja"
 injection-regex = "jinja"
 file-types = ["jinja", "jinja2", "j2"]
-roots = []
 indent = { tab-width = 2, unit = "  " }
 grammar = "jinja2"
 
@@ -2987,7 +2850,6 @@ name = "wren"
 scope = "source.wren"
 injection-regex = "wren"
 file-types = ["wren"]
-roots = []
 indent = { tab-width = 2, unit = "  "}
 
 [[language]]
@@ -2996,7 +2858,6 @@ scope = "source.unison"
 injection-regex = "unison"
 file-types = ["u"]
 shebangs = []
-roots = []
 auto-format = false
 comment-token = "--"
 indent = { tab-width = 4, unit = "    " }
@@ -3016,7 +2877,6 @@ source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "98c4e
 name = "todotxt"
 scope = "text.todotxt"
 file-types = [{ suffix = ".todo.txt" }, "todotxt"]
-roots = []
 formatter = { command = "sort" }
 auto-format = true
 
@@ -3028,7 +2888,6 @@ source = { git = "https://github.com/arnarg/tree-sitter-todotxt", rev = "0207f6a
 name = "strace"
 scope = "source.strace"
 file-types = ["strace"]
-roots = []
 
 [[grammar]]
 name = "strace"
@@ -3038,7 +2897,6 @@ source = { git = "https://github.com/sigmaSd/tree-sitter-strace", rev = "2b18fdf
 name = "gemini"
 scope = "source.gmi"
 file-types = ["gmi"]
-roots = []
 
 [[grammar]]
 name = "gemini"


### PR DESCRIPTION
Previously roots needed to be specified by every language and `[]` was used as an explicit default. Root files don't make sense for every language (for example TOML) so I think we should allow languages to not explicitly mention the key and have the `[]` default automatically.