### PR TITLE
Mention license file for themes in README

### DIFF
--- a/runtime/themes/README.md
+++ b/runtime/themes/README.md
@@ -6,4 +6,12 @@ If you submit a theme, please include a comment at the top with your name and em
 # Author : Name <email@my.domain>
 ```
 
+If you are submitting a theme that is already published somewhere, then please
+add the corresponding license file for it under `licenses/` with the following
+name `theme_name.license` and add a comment at the top of the theme file:
+
+```toml
+# License: <License specification>
+```
+
 We have a preview page for themes on our [wiki](https://github.com/helix-editor/helix/wiki/Themes)!

--- a/runtime/themes/licenses/poimandres.LICENSE
+++ b/runtime/themes/licenses/poimandres.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 drcmda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/runtime/themes/licenses/starlight.LICENSE
+++ b/runtime/themes/licenses/starlight.LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
In the process of packaging helix for Fedora, I submitted a [PR](https://github.com/helix-editor/helix/commit/a069b928973aad99b85dffb9d5ade7dae4b58c43) to add missing license files for themes. This is **must** requirement for Fedora and probably other distributions. This PR adds a note and ask contributors to also submit license files with themes that require them. This is the case when the work is derived from another theme or color palette.

I also added the missing license files for the recently added themes.