### PR TITLE
Initialize diagnostics when opening a document

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1795,7 +1795,6 @@ impl HighlightConfiguration {
                 let mut best_index = None;
                 let mut best_match_len = 0;
                 for (i, recognized_name) in recognized_names.iter().enumerate() {
-                    let recognized_name = recognized_name;
                     let mut len = 0;
                     let mut matches = true;
                     for (i, part) in recognized_name.split('.').enumerate() {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -797,18 +797,21 @@ impl Application {
                         });
 
                         if let Some(doc) = doc {
+                            let diagnostic_of_language_server_and_not_in_unchanged_sources =
+                                |diagnostic: &lsp::Diagnostic, ls_id| {
+                                    ls_id == server_id
+                                        && diagnostic.source.as_ref().map_or(true, |source| {
+                                            !unchanged_diag_sources.contains(source)
+                                        })
+                                };
+                            let diagnostics = Editor::doc_diagnostics_with_filter(
+                                &self.editor.language_servers,
+                                &self.editor.diagnostics,
+                                doc,
+                                diagnostic_of_language_server_and_not_in_unchanged_sources,
+                            );
                             doc.replace_diagnostics(
-                                Editor::doc_diagnostics_with_filter(
-                                    &self.editor.language_servers,
-                                    &self.editor.diagnostics,
-                                    doc,
-                                    |diagnostic, ls_id| {
-                                        ls_id == server_id
-                                            && diagnostic.source.as_ref().map_or(true, |source| {
-                                                !unchanged_diag_sources.contains(source)
-                                            })
-                                    },
-                                ),
+                                diagnostics,
                                 &unchanged_diag_sources,
                                 Some(server_id),
                             );

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -386,6 +386,12 @@ impl Application {
         self.editor.syn_loader = self.syn_loader.clone();
         for document in self.editor.documents.values_mut() {
             document.detect_language(self.syn_loader.clone());
+            let diagnostics = Editor::doc_diagnostics(
+                &self.editor.language_servers,
+                &self.editor.diagnostics,
+                document,
+            );
+            document.replace_diagnostics(diagnostics, &[], None);
         }
 
         Ok(())
@@ -561,6 +567,14 @@ impl Application {
             let id = doc.id();
             doc.detect_language(loader);
             self.editor.refresh_language_servers(id);
+            // and again a borrow checker workaround...
+            let doc = doc_mut!(self.editor, &doc_save_event.doc_id);
+            let diagnostics = Editor::doc_diagnostics(
+                &self.editor.language_servers,
+                &self.editor.diagnostics,
+                doc,
+            );
+            doc.replace_diagnostics(diagnostics, &[], None);
         }
 
         // TODO: fix being overwritten by lsp

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2008,6 +2008,10 @@ fn language(
 
     let id = doc.id();
     cx.editor.refresh_language_servers(id);
+    let doc = doc_mut!(cx.editor);
+    let diagnostics =
+        Editor::doc_diagnostics(&cx.editor.language_servers, &cx.editor.diagnostics, doc);
+    doc.replace_diagnostics(diagnostics, &[], None);
     Ok(())
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1502,7 +1502,7 @@ fn lsp_stop(
 
         for doc in cx.editor.documents_mut() {
             if let Some(client) = doc.remove_language_server_by_name(ls_name) {
-                doc.clear_diagnostics(client.id());
+                doc.clear_diagnostics(Some(client.id()));
             }
         }
     }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -386,7 +386,7 @@ impl EditorView {
         let mut warning_vec = Vec::new();
         let mut error_vec = Vec::new();
 
-        for diagnostic in doc.shown_diagnostics() {
+        for diagnostic in doc.diagnostics() {
             // Separate diagnostics into different Vecs by severity.
             let (vec, scope) = match diagnostic.severity {
                 Some(Severity::Info) => (&mut info_vec, info),
@@ -684,7 +684,7 @@ impl EditorView {
             .primary()
             .cursor(doc.text().slice(..));
 
-        let diagnostics = doc.shown_diagnostics().filter(|diagnostic| {
+        let diagnostics = doc.diagnostics().iter().filter(|diagnostic| {
             diagnostic.range.start <= cursor && diagnostic.range.end >= cursor
         });
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -480,8 +480,7 @@ impl<T: Item + 'static> Picker<T> {
                                 .find::<Overlay<DynamicPicker<T>>>()
                                 .map(|overlay| &mut overlay.content.file_picker),
                         };
-                        let Some(picker) = picker
-                        else {
+                        let Some(picker) = picker else {
                             log::info!("picker closed before syntax highlighting finished");
                             return;
                         };
@@ -489,7 +488,15 @@ impl<T: Item + 'static> Picker<T> {
                         let doc = match current_file {
                             PathOrId::Id(doc_id) => doc_mut!(editor, &doc_id),
                             PathOrId::Path(path) => match picker.preview_cache.get_mut(&path) {
-                                Some(CachedPreview::Document(ref mut doc)) => doc,
+                                Some(CachedPreview::Document(ref mut doc)) => {
+                                    let diagnostics = Editor::doc_diagnostics(
+                                        &editor.language_servers,
+                                        &editor.diagnostics,
+                                        doc,
+                                    );
+                                    doc.replace_diagnostics(diagnostics, &[], None);
+                                    doc
+                                }
                                 _ => return,
                             },
                         };

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -227,7 +227,8 @@ where
 {
     let (warnings, errors) = context
         .doc
-        .shown_diagnostics()
+        .diagnostics()
+        .iter()
         .fold((0, 0), |mut counts, diag| {
             use helix_core::diagnostic::Severity;
             match diag.severity {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1077,14 +1077,6 @@ impl Document {
         };
     }
 
-    /// Set the programming language for the file if you know the name (scope) but don't have the
-    /// [`syntax::LanguageConfiguration`] for it.
-    pub fn set_language2(&mut self, scope: &str, config_loader: Arc<syntax::Loader>) {
-        let language_config = config_loader.language_config_for_scope(scope);
-
-        self.set_language(language_config, Some(config_loader));
-    }
-
     /// Set the programming language for the file if you know the language but don't have the
     /// [`syntax::LanguageConfiguration`] for it.
     pub fn set_language_by_language_id(

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -4,10 +4,12 @@ use arc_swap::ArcSwap;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
 use helix_core::auto_pairs::AutoPairs;
+use helix_core::chars::char_is_word;
 use helix_core::doc_formatter::TextFormat;
 use helix_core::encoding::Encoding;
 use helix_core::syntax::{Highlight, LanguageServerFeature};
 use helix_core::text_annotations::{InlineAnnotation, TextAnnotations};
+use helix_lsp::util::lsp_pos_to_pos;
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
 
 use ::parking_lot::Mutex;
@@ -1709,29 +1711,107 @@ impl Document {
         )
     }
 
+    pub fn lsp_diagnostic_to_diagnostic(
+        text: &Rope,
+        language_config: Option<&LanguageConfiguration>,
+        diagnostic: &helix_lsp::lsp::Diagnostic,
+        language_server_id: usize,
+        offset_encoding: helix_lsp::OffsetEncoding,
+    ) -> Option<Diagnostic> {
+        use helix_core::diagnostic::{Range, Severity::*};
+
+        // TODO: convert inside server
+        let start =
+            if let Some(start) = lsp_pos_to_pos(text, diagnostic.range.start, offset_encoding) {
+                start
+            } else {
+                log::warn!("lsp position out of bounds - {:?}", diagnostic);
+                return None;
+            };
+
+        let end = if let Some(end) = lsp_pos_to_pos(text, diagnostic.range.end, offset_encoding) {
+            end
+        } else {
+            log::warn!("lsp position out of bounds - {:?}", diagnostic);
+            return None;
+        };
+
+        let severity = diagnostic.severity.map(|severity| match severity {
+            lsp::DiagnosticSeverity::ERROR => Error,
+            lsp::DiagnosticSeverity::WARNING => Warning,
+            lsp::DiagnosticSeverity::INFORMATION => Info,
+            lsp::DiagnosticSeverity::HINT => Hint,
+            severity => unreachable!("unrecognized diagnostic severity: {:?}", severity),
+        });
+
+        if let Some(lang_conf) = language_config {
+            if let Some(severity) = severity {
+                if severity < lang_conf.diagnostic_severity {
+                    return None;
+                }
+            }
+        };
+        use helix_core::diagnostic::{DiagnosticTag, NumberOrString};
+
+        let code = match diagnostic.code.clone() {
+            Some(x) => match x {
+                lsp::NumberOrString::Number(x) => Some(NumberOrString::Number(x)),
+                lsp::NumberOrString::String(x) => Some(NumberOrString::String(x)),
+            },
+            None => None,
+        };
+
+        let tags = if let Some(tags) = &diagnostic.tags {
+            let new_tags = tags
+                .iter()
+                .filter_map(|tag| match *tag {
+                    lsp::DiagnosticTag::DEPRECATED => Some(DiagnosticTag::Deprecated),
+                    lsp::DiagnosticTag::UNNECESSARY => Some(DiagnosticTag::Unnecessary),
+                    _ => None,
+                })
+                .collect();
+
+            new_tags
+        } else {
+            Vec::new()
+        };
+
+        let ends_at_word =
+            start != end && end != 0 && text.get_char(end - 1).map_or(false, char_is_word);
+        let starts_at_word = start != end && text.get_char(start).map_or(false, char_is_word);
+
+        Some(Diagnostic {
+            range: Range { start, end },
+            ends_at_word,
+            starts_at_word,
+            zero_width: start == end,
+            line: diagnostic.range.start.line as usize,
+            message: diagnostic.message.clone(),
+            severity,
+            code,
+            tags,
+            source: diagnostic.source.clone(),
+            data: diagnostic.data.clone(),
+            language_server_id,
+        })
+    }
+
     #[inline]
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
-    }
-
-    pub fn shown_diagnostics(&self) -> impl Iterator<Item = &Diagnostic> + DoubleEndedIterator {
-        self.diagnostics.iter().filter(|d| {
-            self.language_servers_with_feature(LanguageServerFeature::Diagnostics)
-                .any(|ls| ls.id() == d.language_server_id)
-        })
     }
 
     pub fn replace_diagnostics(
         &mut self,
         diagnostics: impl IntoIterator<Item = Diagnostic>,
         unchanged_sources: &[String],
-        language_server_id: usize,
+        language_server_id: Option<usize>,
     ) {
         if unchanged_sources.is_empty() {
             self.clear_diagnostics(language_server_id);
         } else {
             self.diagnostics.retain(|d| {
-                if d.language_server_id != language_server_id {
+                if language_server_id.map_or(false, |id| id != d.language_server_id) {
                     return true;
                 }
 
@@ -1752,9 +1832,13 @@ impl Document {
         });
     }
 
-    pub fn clear_diagnostics(&mut self, language_server_id: usize) {
-        self.diagnostics
-            .retain(|d| d.language_server_id != language_server_id);
+    /// clears diagnostics for a given language server id if set, otherwise all diagnostics are cleared
+    pub fn clear_diagnostics(&mut self, language_server_id: Option<usize>) {
+        if let Some(id) = language_server_id {
+            self.diagnostics.retain(|d| d.language_server_id != id);
+        } else {
+            self.diagnostics.clear();
+        }
     }
 
     /// Get the document's auto pairs. If the document has a recognized


### PR DESCRIPTION
I've noticed, that diagnostics that are sent from the language server aren't propagated when opening a document (via `helix_view::Document::open`). So that the language server needs to send a `PublishDiagnostics` again to populate the document with diagnostics. This can take some time (noticed with rust-analyzer), when opening a file via the workspace diagnostic picker (if it is sent at all). 

This PR should ensure that diagnostics that are already in the editor instance are propagated when opening a document.
This has the additional advantage, that diagnostics can be rendered directly in the workspace diagnostic picker, when the file/buffer isn't open yet. 

