### PR TITLE
rust-toolchain.toml: bump MSRV to 1.70.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@1.70
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@1.70
         with:
           components: rustfmt, clippy
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@1.70
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -212,10 +212,7 @@ impl<'de> Deserialize<'de> for FileType {
             {
                 match map.next_entry::<String, String>()? {
                     Some((key, suffix)) if key == "suffix" => Ok(FileType::Suffix({
-                        // FIXME: use `suffix.replace('/', std::path::MAIN_SEPARATOR_STR)`
-                        //        if MSRV is updated to 1.68
-                        let mut separator = [0; 1];
-                        suffix.replace('/', std::path::MAIN_SEPARATOR.encode_utf8(&mut separator))
+                        suffix.replace('/', std::path::MAIN_SEPARATOR_STR)
                     })),
                     Some((key, _value)) => Err(serde::de::Error::custom(format!(
                         "unknown key in `file-types` list: {}",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 include = ["src/**/*", "README.md"]
 default-run = "hx"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [features]
 default = ["git"]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1318,7 +1318,7 @@ fn extend_next_long_word_end(cx: &mut Context) {
     extend_word_impl(cx, movement::move_next_long_word_end)
 }
 
-/// Separate branch to find_char designed only for <ret> char.
+/// Separate branch to find_char designed only for `<ret>` char.
 //
 // This is necessary because the one document can have different line endings inside. And we
 // cannot predict what character to find when <ret> is pressed. On the current line it can be `lf`

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5606,12 +5606,18 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
         };
 
         // These `usize`s cannot underflow because selection ranges cannot overlap.
-        // Once the MSRV is 1.66.0 (mixed_integer_ops is stabilized), we can use checked
-        // arithmetic to assert this.
-        let anchor = (to as isize + offset - deleted_len as isize) as usize;
+        let anchor = to
+            .checked_add_signed(offset)
+            .expect("Selection ranges cannot overlap")
+            .checked_sub(deleted_len)
+            .expect("Selection ranges cannot overlap");
         let new_range = Range::new(anchor, anchor + output_len).with_direction(range.direction());
         ranges.push(new_range);
-        offset = offset + output_len as isize - deleted_len as isize;
+        offset = offset
+            .checked_add_unsigned(output_len)
+            .expect("Selection ranges cannot overlap")
+            .checked_sub_unsigned(deleted_len)
+            .expect("Selection ranges cannot overlap");
 
         changes.push((from, to, Some(output)));
     }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -49,7 +49,7 @@ use std::{
 /// If there is no configured language server that supports the feature, this displays a status message.
 /// Using this macro in a context where the editor automatically queries the LSP
 /// (instead of when the user explicitly does so via a keybind like `gd`)
-/// will spam the "No configured language server supports <feature>" status message confusingly.
+/// will spam the "No configured language server supports \<feature>" status message confusingly.
 #[macro_export]
 macro_rules! language_server_with_feature {
     ($editor:expr, $doc:expr, $feature:expr) => {{

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -213,7 +213,7 @@ impl Buffer {
             && y < self.area.bottom()
     }
 
-    /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates.
+    /// Returns the index in the `Vec<Cell>` for the given global (x, y) coordinates.
     ///
     /// Global coordinates are offset by the Buffer's area offset (`x`/`y`).
     ///
@@ -242,7 +242,7 @@ impl Buffer {
         ((y - self.area.y) as usize) * (self.area.width as usize) + ((x - self.area.x) as usize)
     }
 
-    /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates,
+    /// Returns the index in the `Vec<Cell>` for the given global (x, y) coordinates,
     /// or `None` if the coordinates are outside the buffer's area.
     fn index_of_opt(&self, x: u16, y: u16) -> Option<usize> {
         if self.in_bounds(x, y) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -727,7 +727,7 @@ pub struct WhitespaceCharacters {
 impl Default for WhitespaceCharacters {
     fn default() -> Self {
         Self {
-            space: '·',    // U+00B7
+            space: '·',   // U+00B7
             nbsp: '⍽',    // U+237D
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -755,12 +755,13 @@ impl Default for IndentGuidesConfig {
 }
 
 /// Line ending configuration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LineEndingConfig {
     /// The platform's native line ending.
     ///
     /// `crlf` on Windows, otherwise `lf`.
+    #[default]
     Native,
     /// Line feed.
     LF,
@@ -775,12 +776,6 @@ pub enum LineEndingConfig {
     /// Next line.
     #[cfg(feature = "unicode-lines")]
     Nel,
-}
-
-impl Default for LineEndingConfig {
-    fn default() -> Self {
-        LineEndingConfig::Native
-    }
 }
 
 impl From<LineEndingConfig> for LineEnding {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -9,8 +9,7 @@ use crate::{
 };
 
 fn count_digits(n: usize) -> usize {
-    // TODO: use checked_log10 when MSRV reaches 1.67
-    std::iter::successors(Some(n), |&n| (n >= 10).then_some(n / 10)).count()
+    (usize::checked_ilog10(n).unwrap_or(0) + 1) as usize
 }
 
 pub type GutterFn<'doc> = Box<dyn FnMut(usize, bool, bool, &mut String) -> Option<Style> + 'doc>;

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -369,9 +369,7 @@ impl Editor {
                     {
                         Ok(process) => process,
                         Err(err) => {
-                            // TODO replace the pretty print {:?} with a regular format {}
-                            // when the MSRV is raised to 1.60.0
-                            self.set_error(format!("Error starting external terminal: {:?}", err));
+                            self.set_error(format!("Error starting external terminal: {}", err));
                             return true;
                         }
                     };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.70.0"
 components = ["rustfmt", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.70.0"
-components = ["rustfmt", "rust-src"]
+components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
With Firefox 120 released on 21 November 2023, the MSRV is now 1.70.0.

---

According to https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html (and after attempting to download Firefox myself), Firefox 120 has been released. Since helix follows Firefox's MSRV (https://github.com/helix-editor/helix/blob/47b6c4bc78d449e3586f28d26507bfc8fb8608e2/docs/CONTRIBUTING.md#minimum-stable-rust-version-msrv-policy), I bumped the MSRV to 1.70.0 in line with Firefox!

(The main thing I'm looking forward to is the sparse crates registry support added in 1.68.0.)