### PR TITLE
added languages-open command

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -173,6 +173,10 @@ pub fn lang_config_file() -> PathBuf {
     config_dir().join("languages.toml")
 }
 
+pub fn workspace_lang_file() -> PathBuf {
+    find_workspace().0.join(".helix").join("languages.toml")
+}
+
 pub fn default_log_file() -> PathBuf {
     cache_dir().join("helix.log")
 }

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -169,7 +169,7 @@ pub fn workspace_config_file() -> PathBuf {
     find_workspace().0.join(".helix").join("config.toml")
 }
 
-pub fn lang_config_file() -> PathBuf {
+pub fn languages_file() -> PathBuf {
     config_dir().join("languages.toml")
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2175,7 +2175,7 @@ fn open_languages(
         return Ok(());
     }
 
-    cx.editor.open(&helix_loader::lang_config_file(), Action::Replace)?;
+    cx.editor.open(&helix_loader::languages_file(), Action::Replace)?;
     Ok(())
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3041,7 +3041,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "languages-open",
-        aliases: &[],
+        aliases: &["langs-open"],
         doc: "Open the user languages.toml file.",
         fun: open_languages,
         signature: CommandSignature::none(),  
@@ -3055,7 +3055,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "languages-open-workspace",
-        aliases: &[],
+        aliases: &["langs-open-workspace"],
         doc: "Open the workspace languages.toml file",
         fun: open_workspace_langs,
         signature: CommandSignature::none(), 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2166,6 +2166,19 @@ fn open_config(
     Ok(())
 }
 
+fn open_languages(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor.open(&helix_loader::lang_config_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_workspace_config(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -3012,6 +3025,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Open the user config.toml file.",
         fun: open_config,
         signature: CommandSignature::none(),
+    },
+    TypableCommand {
+      name: "languages-open",
+        aliases: &[],
+        doc: "Open the user languages.toml file.",
+        fun: open_languages,
+        signature: CommandSignature::none(),  
     },
     TypableCommand {
         name: "config-open-workspace",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3027,7 +3027,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         signature: CommandSignature::none(),
     },
     TypableCommand {
-      name: "languages-open",
+        name: "languages-open",
         aliases: &[],
         doc: "Open the user languages.toml file.",
         fun: open_languages,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2193,7 +2193,7 @@ fn open_workspace_config(
     Ok(())
 }
 
-fn open_workspace_langs(
+fn open_workspace_languages(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
     event: PromptEvent
@@ -3057,7 +3057,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         name: "languages-open-workspace",
         aliases: &["langs-open-workspace"],
         doc: "Open the workspace languages.toml file",
-        fun: open_workspace_langs,
+        fun: open_workspace_languages,
         signature: CommandSignature::none(), 
     },
     TypableCommand {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2193,6 +2193,19 @@ fn open_workspace_config(
     Ok(())
 }
 
+fn open_workspace_langs(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor.open(&helix_loader::workspace_lang_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_log(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -3039,6 +3052,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Open the workspace config.toml file.",
         fun: open_workspace_config,
         signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "languages-open-workspace",
+        aliases: &[],
+        doc: "Open the workspace languages.toml file",
+        fun: open_workspace_langs,
+        signature: CommandSignature::none(), 
     },
     TypableCommand {
         name: "log-open",

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -50,7 +50,7 @@ pub fn general() -> std::io::Result<()> {
     let mut stdout = stdout.lock();
 
     let config_file = helix_loader::config_file();
-    let lang_file = helix_loader::lang_config_file();
+    let lang_file = helix_loader::languages_file();
     let log_file = helix_loader::log_file();
     let rt_dirs = helix_loader::runtime_dirs();
     let clipboard_provider = get_clipboard_provider();


### PR DESCRIPTION
added `languages-open` and `languages-open-workspace` commands to open the user and workspace languages.toml files respectively (both have aliases with `languages` -> `langs`)