### PR TITLE
update which crate to 5.0.0

### DIFF
--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "net", "sync"] }
-which = "4.4"
+which = "5.0.0"
 
 [dev-dependencies]
 fern = "0.6"

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -21,7 +21,7 @@ etcetera = "0.8"
 tree-sitter.workspace = true
 once_cell = "1.18"
 log = "0.4"
-which = "4.4"
+which = "5.0.0"
 
 # TODO: these two should be on !wasm32 only
 

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -27,5 +27,5 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.34", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "sync"] }
 tokio-stream = "0.1.14"
-which = "4.4"
+which = "5.0.0"
 parking_lot = "0.12.1"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -34,7 +34,7 @@ helix-loader = { version = "0.6", path = "../helix-loader" }
 anyhow = "1"
 once_cell = "1.18"
 
-which = "4.4"
+which = "5.0.0"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 toml = "0.7"
 log = "~0.4"
 
-which = "4.4"
+which = "5.0.0"
 parking_lot = "0.12.1"
 
 


### PR DESCRIPTION
Looking at which crate changelog for version 5.0.0

## 5.0.0

- Remove several unused error messages
- Windows executables can now be found even if they don't have a '.exe' extension.
- Add new error message, `Error::CannotGetCurrentDirAndPathListEmpty`

It seems that no breaking changes have been implemented