### PR TITLE
update which crate to 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,27 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,11 +1307,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1643,12 +1622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,17 +1768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -2454,14 +2416,15 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "which"
-version = "4.4.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad25fe5717e59ada8ea33511bbbf7420b11031730a24c65e82428766c307006"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
 dependencies = [
- "dirs",
  "either",
+ "home",
  "once_cell",
  "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "net", "sync"] }
-which = "4.4"
+which = "5.0.0"
 
 [dev-dependencies]
 fern = "0.6"

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -21,7 +21,7 @@ etcetera = "0.8"
 tree-sitter.workspace = true
 once_cell = "1.18"
 log = "0.4"
-which = "4.4"
+which = "5.0.0"
 
 # TODO: these two should be on !wasm32 only
 

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -27,5 +27,5 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.34", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "sync"] }
 tokio-stream = "0.1.14"
-which = "4.4"
+which = "5.0.0"
 parking_lot = "0.12.1"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -34,7 +34,7 @@ helix-loader = { version = "0.6", path = "../helix-loader" }
 anyhow = "1"
 once_cell = "1.18"
 
-which = "4.4"
+which = "5.0.0"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 toml = "0.7"
 log = "~0.4"
 
-which = "4.4"
+which = "5.0.0"
 parking_lot = "0.12.1"
 
 


### PR DESCRIPTION


Looking at which crate changelog for version 5.0.0
5.0.0

    Remove several unused error messages
    Windows executables can now be found even if they don't have a '.exe' extension.
    Add new error message, Error::CannotGetCurrentDirAndPathListEmpty

It seems that no breaking changes have been implemented

UPDATE: added cargo lock to PR due to a CI error in previous upload