### PR TITLE
added custom opacity setting for forcing themes to use opaque backgrounds

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -65,6 +65,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
+| `bg-opacity` | Enables forcibly rendering the background as transparent. Can be `theme` or `transparent`. `theme` will use the transparency of the theme and `transparent` will force a transparent background. | `theme` | 
 
 ### `[editor.statusline]` Section
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1397,9 +1397,16 @@ impl Component for EditorView {
     }
 
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        // clear with background color
-        surface.set_style(area, cx.editor.theme.get("ui.background"));
         let config = cx.editor.config();
+
+        // clear with background color
+        let surface_theme = cx.editor.theme.get("ui.background");
+        let surface_theme = match config.bg_opacity {
+            helix_view::editor::Opacity::Transparent => surface_theme.bg(Color::Reset),
+            helix_view::editor::Opacity::Theme => surface_theme,
+        };
+
+        surface.set_style(area, surface_theme);
 
         // check if bufferline should be rendered
         use helix_view::editor::BufferLine;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -291,6 +291,21 @@ pub struct Config {
     pub insert_final_newline: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
+    /// Enables custom background opacity
+    pub bg_opacity: Opacity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum Opacity {
+    Transparent,
+    Theme,
+}
+
+impl Default for Opacity {
+    fn default() -> Self {
+        Self::Theme
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -846,6 +861,7 @@ impl Default for Config {
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,
             smart_tab: Some(SmartTabConfig::default()),
+            bg_opacity: Opacity::default(),
         }
     }
 }


### PR DESCRIPTION
This pull requests implements a way to configure Helix to force transparent backgrounds for any theme by setting the bg-transparent option to "transparent". I personally find this useful when there are themes which do not support transparency out of the box, so rather than make my own I can simply toggle this option so that every theme has  transparency.