### PR TITLE
direnv: Watch the rust-toolchain file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 watch_file shell.nix
 watch_file flake.lock
+watch_file rust-toolchain.toml
 
 # try to use flakes, if it fails use normal nix (ie. shell.nix)
 use flake || use nix


### PR DESCRIPTION
This allows direnv to switch the Nix dev shell when switching across branches running different Rust verions.

Switching between master and older branches won't automatically change cargo/Rust versions after #8877 unless direnv is watching the rust-toolchain file.