### PR TITLE
Add musicxml to xml extensions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2303,7 +2303,8 @@ file-types = [
   "xliff",
   "xpdl",
   "xul",
-  "xoml"
+  "xoml",
+  "musicxml"
 ]
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
MusicXML is an open standard for digital sheet music

[https://www.w3.org/2021/06/musicxml40/](https://www.w3.org/2021/06/musicxml40/)
[https://en.wikipedia.org/wiki/MusicXML](https://en.wikipedia.org/wiki/MusicXML)

PS:
Note that `mxl` is the extension for compressed MusicXml files and should not be treated as `XML`