### PR TITLE
Add instructions for building a specific version of helix

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -195,6 +195,15 @@ RUSTFLAGS="-C target-feature=-crt-static"
    cd helix
    ```
 
+   By default, git will checkout the master branch, which is the latest
+   development version of helix. To get a specific release, you can
+   checkout the code for that release after running the above commands
+   by running:
+
+   ```sh
+   git checkout tags/23.10
+   ```
+
 2. Compile from source:
 
    ```sh


### PR DESCRIPTION
This PR adds a small note in the book in the section on installing from source reminding users to checkout a version specific tag if they want to build a particular version from source.

I have tripped over this a few times and accidentally installed the master version.