### PR TITLE
Do not disable GNU extensions when building grammars

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -509,7 +509,7 @@ fn build_tree_sitter_library(
 
         if let Some(scanner_path) = scanner_path.as_ref() {
             if scanner_path.extension() == Some("c".as_ref()) {
-                command.arg("-xc").arg("-std=c11").arg(scanner_path);
+                command.arg("-xc").arg("-std=gnu11").arg(scanner_path);
             } else {
                 let mut cpp_command = Command::new(compiler.path());
                 cpp_command.current_dir(src_path);
@@ -526,7 +526,7 @@ fn build_tree_sitter_library(
                     .arg(header_path)
                     .arg("-o")
                     .arg(&object_file)
-                    .arg("-std=c++14")
+                    .arg("-std=gnu++14")
                     .arg("-c")
                     .arg(scanner_path);
                 let output = cpp_command
@@ -544,7 +544,7 @@ fn build_tree_sitter_library(
                 _path_guard = TempPath::from_path(object_file);
             }
         }
-        command.arg("-xc").arg("-std=c11").arg(parser_path);
+        command.arg("-xc").arg("-std=gnu11").arg(parser_path);
         if cfg!(all(
             unix,
             not(any(target_os = "macos", target_os = "illumos"))


### PR DESCRIPTION
Commit ca65d312e715413cd5675cafd599d74534900d3f ("always build grammars with c++14 and c11 (#6792)") turned on semi-strict standard mode for C and C++ by accident.  Some grammars use non-standard functions such as isascii (from <ctype.h>) and fail to build as a result, particularly with future compilers which do not support implicit function declarations.

(Ideally, the build environment would only raise the standard versions relative to the toolchain default, not lower them, but this change does not implement that.)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
