### PR TITLE
languages: update rescript grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1523,7 +1523,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "rescript"
-source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "65609807c628477f3b94052e7ef895885ac51c3c" }
+source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "467dcf99f68c47823d7b378779a6b282d7ef9782" }
 
 [[language]]
 name = "erlang"


### PR DESCRIPTION
The currently pinned revision of the rescript grammar is failing to build with clang. https://github.com/jaredramirez/tree-sitter-rescript/pull/2 has been merged, and addresses it in the referenced repo. This PR updates the pinned revision in `languages.toml` to reflect the fix.

This should also eventually allow the patch in nixpkgs (https://github.com/NixOS/nixpkgs/pull/268191) to be cleaned up.
