### PR TITLE
Add .envrc.local and .envrc.private to env file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2362,7 +2362,7 @@ source = { git = "https://github.com/hh9527/tree-sitter-wit", rev = "c917790ab9a
 [[language]]
 name = "env"
 scope = "source.env"
-file-types = [".env", ".env.local", ".env.development", ".env.production", ".env.dist", ".envrc"]
+file-types = [".env", ".env.local", ".env.development", ".env.production", ".env.dist", ".envrc", ".envrc.local", ".envrc.private"]
 injection-regex = "env"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
These files are commonly used in .envrc with the source_env or source_env_if_exists functions. The direnv stdlib shows an example with .envrc.private and my use of sourcegraph showed .envrc, .envrc.local, and .envrc.private as the most popular basenames for these files. It would be nice to have the common files highlighted without having to extend the config locally.