### PR TITLE
Join empty lines with only one space in `join_selections`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4412,7 +4412,8 @@ fn join_selections_impl(cx: &mut Context, select_space: bool) {
             // need to skip from start, not end
             let change = {
                 let separator = {
-                    let line_contains_only_space = LineEnding::from_char(text.char(end)).is_some();
+                    let line_end_index = line_end_char_index(&slice, line + 1);
+                    let line_contains_only_space = end == line_end_index;
                     if line_contains_only_space {
                         None
                     } else {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4413,7 +4413,7 @@ fn join_selections_impl(cx: &mut Context, select_space: bool) {
             // need to skip from start, not end
             let change = {
                 let separator = {
-                    let line_contains_only_space = text.char(end) == '\n';
+                    let line_contains_only_space = LineEnding::from_char(text.char(end)).is_some();
                     if line_contains_only_space {
                         None
                     } else {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4396,13 +4396,12 @@ fn join_selections_impl(cx: &mut Context, select_space: bool) {
     let mut changes = Vec::new();
 
     for selection in doc.selection(view.id) {
-        let lines = {
-            let (start, mut end) = selection.line_range(slice);
-            if start == end {
-                end = (end + 1).min(text.len_lines() - 1);
-            }
-            start..end
-        };
+        let (start, mut end) = selection.line_range(slice);
+        if start == end {
+            end = (end + 1).min(text.len_lines() - 1);
+        }
+        let lines = start..end;
+
         changes.reserve(lines.len());
 
         for line in lines {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4409,21 +4409,13 @@ fn join_selections_impl(cx: &mut Context, select_space: bool) {
             let mut end = text.line_to_char(line + 1);
             end = skip_while(slice, end, |ch| matches!(ch, ' ' | '\t')).unwrap_or(end);
 
-            // need to skip from start, not end
-            let change = {
-                let separator = {
-                    let line_end_index = line_end_char_index(&slice, line + 1);
-                    let line_contains_only_space = end == line_end_index;
-                    if line_contains_only_space {
-                        None
-                    } else {
-                        Some(Tendril::from(" "))
-                    }
-                };
-
-                (start, end, separator)
+            let separator = if end == line_end_char_index(&slice, line + 1) {
+                // the joining line contains only space-characters => don't include a whitespace when joining
+                None
+            } else {
+                Some(Tendril::from(" "))
             };
-            changes.push(change);
+            changes.push((start, end, separator));
         }
     }
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -480,3 +480,49 @@ fn bar() {#(\n|)#\
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_join_selections() -> anyhow::Result<()> {
+    // normal join
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+            def
+        "}),
+        "J",
+        platform_line(indoc! {"\
+            #[a|]#bc def
+        "}),
+    ))
+    .await?;
+
+    // join with empty line
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+
+            def
+        "}),
+        "JJ",
+        platform_line(indoc! {"\
+            #[a|]#bc def
+        "}),
+    ))
+    .await?;
+
+    // join with additional space in non-empty line
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+
+                def
+        "}),
+        "JJ",
+        platform_line(indoc! {"\
+            #[a|]#bc def
+        "}),
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
fixes the issue that lines with only spaces are getting joined as well

fixes https://github.com/helix-editor/helix/issues/8977