### PR TITLE
Fix cursor dissapearing when over indent lines in Darcula themes

### DIFF
--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -15,7 +15,7 @@
 "ui.statusline.select" = { bg = "orange", fg = "grey01" }
 "ui.help" = { fg = "grey04", bg = "grey01" }
 "ui.cursor" = { fg = "grey04", modifiers = ["reversed"] }
-"ui.cursor.primary" = { fg = "grey05", modifiers = ["reversed"] }
+"ui.cursor.primary" = { fg = "grey02", bg = "grey05" }
 "ui.cursor.match" = { fg = "white", modifiers = ["underlined"] }
 "ui.cursorline.primary" = { bg = "grey02" }
 "ui.cursorline.secondary" = { bg = "grey02" }


### PR DESCRIPTION
Before:
![before](https://github.com/helix-editor/helix/assets/24444379/041203f0-00bb-45ac-9b4d-8b5afb59ef17)

After:
![after](https://github.com/helix-editor/helix/assets/24444379/a49bf63e-8a89-43ed-a425-354c2afc0cb6)

The cursor is in the exact same position in both screenshots.