### PR TITLE
Update gleam grammar and queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1624,7 +1624,7 @@ auto-format = true
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "a59aadf3d7c11702cad244e7cd6b67b34ca9c16a" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "b2afa4fd6bb41a7bf912b034c653c90af7ae5122" }
 
 [[language]]
 name = "ron"

--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -21,6 +21,8 @@
 
 ; Functions
 (unqualified_import (identifier) @function)
+(unqualified_import "type" (type_identifier) @type)
+(unqualified_import (type_identifier) @constructor)
 (function
   name: (identifier) @function)
 (external_function
@@ -43,6 +45,13 @@
 (tuple_access
   index: (integer) @variable.other.member)
 
+; Attributes
+(attribute
+  "@" @attribute
+  name: (identifier) @attribute)
+
+(attribute_value (identifier) @constant)
+
 ; Type names
 (remote_type_identifier) @type
 (type_identifier) @type
@@ -60,10 +69,6 @@
 (identifier) @variable
 (discard) @comment.unused
 
-; Operators
-(binary_expression
-  operator: _ @operator)
-
 ; Keywords
 [
   (visibility_modifier) ; "pub"
@@ -72,6 +77,7 @@
   "assert"
   "case"
   "const"
+  ; DEPRECATED: 'external' was removed in v0.30.
   "external"
   "fn"
   "if"
@@ -79,10 +85,15 @@
   "let"
   "panic"
   "todo"
-  "try"
   "type"
   "use"
 ] @keyword
+
+; Operators
+(binary_expression
+  operator: _ @operator)
+(boolean_negation "!" @operator)
+(integer_negation "-" @operator)
 
 ; Punctuation
 [


### PR DESCRIPTION
Updates tree-sitter-gleam to 0.32.4.

I also updated the queries according to the ones [from tree-sitter-gleam itself](https://github.com/gleam-lang/tree-sitter-gleam/tree/v0.32.4/queries) and from a quick test everything seems to work fine.