### PR TITLE
Change R markdown language id to fix language server filetype detection

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1668,6 +1668,7 @@ source = { git = "https://github.com/r-lib/tree-sitter-r", rev = "cc04302e1bff76
 [[language]]
 name = "rmarkdown"
 scope = "source.rmd"
+language-id = "rmd"
 injection-regex = "(r|R)md"
 file-types = ["rmd", "Rmd"]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
This merge request renames the R markdown language from `rmarkdown` to `rmd`. When I added R and R markdown support back in #1998, I mistakenly chose the `rmarkdown` name because I didn't realize it was used for anything other than the display name in Helix's statusline. Switching the name to `rmd` is necessary to fix the R language server's filetype detection, which relies on the language name (see [this line of code](https://github.com/REditorSupport/languageserver/blob/7f7605b55a6cbe05e0033b40f21e87408c06e102/R/document.R#L18)).