### PR TITLE
Fix version of Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,18 +121,18 @@
       rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       craneLibMSRV = (crane.mkLib pkgs).overrideToolchain rustToolchain;
       craneLibStable = (crane.mkLib pkgs).overrideToolchain pkgs.pkgsBuildHost.rust-bin.stable.latest.default;
-      commonArgs =
-        {
-          inherit stdenv;
-          src = filteredSource;
-          # disable fetching and building of tree-sitter grammars in the helix-term build.rs
-          HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-          buildInputs = [stdenv.cc.cc.lib];
-          # disable tests
-          doCheck = false;
-          meta.mainProgram = "hx";
-        }
-        // craneLibMSRV.crateNameFromCargoToml {cargoToml = ./helix-term/Cargo.toml;};
+      commonArgs = {
+        inherit stdenv;
+        inherit (craneLibMSRV.crateNameFromCargoToml {cargoToml = ./helix-term/Cargo.toml;}) pname;
+        inherit (craneLibMSRV.crateNameFromCargoToml {cargoToml = ./Cargo.toml;}) version;
+        src = filteredSource;
+        # disable fetching and building of tree-sitter grammars in the helix-term build.rs
+        HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+        buildInputs = [stdenv.cc.cc.lib];
+        # disable tests
+        doCheck = false;
+        meta.mainProgram = "hx";
+      };
       cargoArtifacts = craneLibMSRV.buildDepsOnly commonArgs;
     in {
       packages = {


### PR DESCRIPTION
The version of the Nix package is using a placeholder (probably since bf7c4e1).

This PR fixes this issue by taking the package's version from the workspace `Cargo.toml`.