### PR TITLE
Update keymap.md

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -58,6 +58,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`              |
 | `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`             |
 | `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`            |
+| `Shift-C`             | Add additional cursor under cursor                 |                             |
+| `,`                   | Collapse multiple cursors back into one            |                             |
 
 ### Changes
 


### PR DESCRIPTION
Added key-binds for add cursor `Shift-C` and collapse cursors into one `,` to Normal Mode section.

Had to search for this far too often in issues as a vim user used to visual block mode editing