### PR TITLE
Update tokyonight themes

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -1,75 +1,96 @@
-# Author: Paul Graydon <p.y.graydon@gmail.com>
+# Author: Paul Graydon <untimely.creation97@proton.me>
 
-"comment" = { fg = "comment", modifiers = ["italic"] }
-"constant" = { fg = "orange" }
+attribute = { fg = "cyan" }
+comment = { fg = "comment", modifiers = ["italic"] }
+"comment.block.documentation" = { fg = "yellow" }
+constant = { fg = "orange" }
+"constant.builtin" = { fg = "aqua" }
+"constant.character" = { fg = "light-green" }
 "constant.character.escape" = { fg = "magenta" }
-"function" = { fg = "blue", modifiers = ["italic"] }
+constructor = { fg = "aqua" }
+function = { fg = "blue", modifiers = ["italic"] }
+"function.builtin" = { fg = "aqua" }
 "function.macro" = { fg = "cyan" }
-"keyword" = { fg = "cyan", modifiers = ["italic"] }
+"function.special" = { fg = "cyan" }
+keyword = { fg = "purple", modifiers = ["italic"] }
 "keyword.control" = { fg = "magenta" }
 "keyword.control.import" = { fg = "cyan" }
-"keyword.operator" = { fg = "turquoise" }
-"keyword.function" = { fg = "magenta", modifiers = ["italic"] }
-"operator" = { fg = "turquoise" }
-"punctuation" = { fg = "turquoise" }
-"string" = { fg = "light-green" }
-"string.regexp" = { fg = "light-blue" }
-"tag" = { fg = "red" }
-"type" = { fg = "teal" }
-"namespace" = { fg = "blue" }
-"variable" = { fg = "white" }
+"keyword.control.return" = { fg = "purple", modifiers = ["italic"] }
+"keyword.directive" = { fg = "cyan" }
+"keyword.function" = { fg = "magenta" }
+"keyword.operator" = { fg = "magenta" }
+label = { fg = "blue" }
+namespace = { fg = "cyan" }
+operator = { fg = "turquoise" }
+punctuation = { fg = "turquoise" }
+special = { fg = "aqua" }
+string = { fg = "light-green" }
+"string.regexp" = { fg = "light-cyan" }
+"string.special" = { fg = "aqua" }
+tag = { fg = "magenta" }
+type = { fg = "aqua" }
+"type.builtin" = { fg = "aqua" }
+"type.enum.variant" = { fg = "orange" }
+variable = { fg = "fg" }
 "variable.builtin" = { fg = "red" }
 "variable.other.member" = { fg = "green" }
 "variable.parameter" = { fg = "yellow", modifiers = ["italic"] }
 
-"diff.plus" = { fg = "green" }
-"diff.delta" = { fg = "orange" }
-"diff.minus" = { fg = "red" }
+"markup.bold" = { modifiers = ["bold"] }
+"markup.heading" = { fg = "blue", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg-menu", fg = "fg" }
+"markup.heading.hover" = { bg = "fg-selected" }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.link" = { fg = "blue", underline = { style = "line" } }
+"markup.link.label" = { fg = "teal" }
+"markup.link.text" = { fg = "teal" }
+"markup.link.url" = { underline = { style = "line" } }
+"markup.list" = { fg = "orange", modifiers = ["bold"] }
+"markup.normal.completion" = { fg = "comment" }
+"markup.normal.hover" = { fg = "fg-dark" }
+"markup.raw" = { fg = "teal" }
+"markup.raw.inline" = { bg = "black", fg = "blue" }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 
-"ui.background" = { fg = "foreground", bg = "background" }
+"diff.delta" = { fg = "change" }
+"diff.delta.moved" = { fg = "blue" }
+"diff.minus" = { fg = "delete" }
+"diff.plus" = { fg = "add" }
+
+error = { fg = "error" }
+hint = { fg = "hint" }
+info = { fg = "info" }
+warning = { fg = "yellow" }
+"diagnostic.error" = { underline = { style = "curl" } }
+"diagnostic.warning" = { underline = { style = "curl" } }
+"diagnostic.info" = { underline = { style = "curl" } }
+"diagnostic.hint" = { underline = { style = "curl" } }
+
+"ui.background" = { bg = "bg", fg = "fg" }
 "ui.cursor" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { fg = "orange", modifiers = ["bold"] }
-"ui.cursor.primary" = { modifiers = ["reversed"] }
-"ui.cursorline.primary" = { bg = "background_menu" }
-"ui.help" = { fg = "foreground", bg = "background_menu" }
-"ui.linenr" = { fg = "foreground_gutter" }
-"ui.linenr.selected" = { fg = "foreground" }
-"ui.menu" = { fg = "foreground", bg = "background_menu" }
-"ui.menu.selected" = { bg = "background_highlight" }
-"ui.popup" = { fg = "foreground", bg = "background_menu" }
-"ui.selection" = { bg = "background_highlight" }
-"ui.selection.primary" = { bg = "background_highlight" }
-"ui.statusline" = { fg = "foreground", bg = "background_menu" }
-"ui.statusline.inactive" = { fg = "foreground_gutter", bg = "background_menu" }
-"ui.statusline.normal" = { fg = "black", bg = "blue" }
-"ui.statusline.insert" = { fg = "black", bg = "green" }
-"ui.statusline.select" = { fg = "black", bg = "magenta" }
-"ui.text" = { fg = "foreground" }
-"ui.text.focus" = { fg = "cyan" }
-"ui.virtual.ruler" = { bg = "foreground_gutter" }
-"ui.virtual.whitespace" = { fg = "foreground_gutter" }
-"ui.virtual.inlay-hint" = { fg = "comment" }
-"ui.window" = { fg = "black" }
-
-"error" = { fg = "red" }
-"warning" = { fg = "yellow" }
-"info" = { fg = "blue" }
-"hint" = { fg = "teal" }
-"diagnostic.error" = { underline = { style = "curl", color = "red" } }
-"diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
-"diagnostic.info" = { underline = { style = "curl", color = "blue" } }
-"diagnostic.hint" = { underline = { style = "curl", color = "teal" } }
-"special" = { fg = "orange" }
-
-"markup.heading" = { fg = "cyan", modifiers = ["bold"] }
-"markup.list" = { fg = "cyan" }
-"markup.bold" = { fg = "orange", modifiers = ["bold"] }
-"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "green" }
-"markup.link.text" = { fg = "light-gray" }
-"markup.quote" = { fg = "yellow", modifiers = ["italic"] }
-"markup.raw" = { fg = "cyan" }
+"ui.cursorline.primary" = { bg = "bg-menu" }
+"ui.help" = { bg = "bg-menu", fg = "fg" }
+"ui.linenr" = { fg = "fg-gutter" }
+"ui.linenr.selected" = { fg = "fg-linenr" }
+"ui.menu" = { bg = "bg-menu", fg = "fg" }
+"ui.menu.selected" = { bg = "fg-selected" }
+"ui.popup" = { bg = "bg-menu", fg = "border-highlight" }
+"ui.selection" = { bg = "bg-highlight" }
+"ui.selection.primary" = { bg = "bg-highlight" }
+"ui.statusline" = { bg = "bg-menu", fg = "fg-dark" }
+"ui.statusline.inactive" = { bg = "bg-menu", fg = "fg-gutter" }
+"ui.statusline.normal" = { bg = "blue", fg = "bg", modifiers = ["bold"] }
+"ui.statusline.insert" = { bg = "light-green", fg = "bg", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "magenta", fg = "bg", modifiers = ["bold"] }
+"ui.text" = { bg = "bg", fg = "fg" }
+"ui.text.focus" = { bg = "bg-visual" }
+"ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
+"ui.text.info" = { bg = "bg-menu", fg = "fg" }
+"ui.virtual.ruler" = { bg = "fg-gutter" }
+"ui.virtual.whitespace" = { fg = "fg-gutter" }
+"ui.virtual.inlay-hint" = {  bg = "bg-inlay", fg = "teal" }
+"ui.window" = { fg = "border", modifiers = ["bold"] }
 
 [palette]
 red = "#f7768e"
@@ -77,20 +98,34 @@ orange = "#ff9e64"
 yellow = "#e0af68"
 light-green = "#9ece6a"
 green = "#73daca"
+aqua = "#2ac3de"
+teal = "#1abc9c"
 turquoise = "#89ddff"
 light-cyan = "#b4f9f8"
-teal = "#2ac3de"
 cyan = "#7dcfff"
 blue = "#7aa2f7"
+purple = "#9d7cd8"
 magenta = "#bb9af7"
-white = "#c0caf5"
-light-gray = "#9aa5ce"
-parameters = "#cfc9c2"
 comment = "#565f89"
 black = "#414868"
-foreground = "#a9b1d6"
-foreground_highlight = "#c0caf5"
-foreground_gutter = "#363b54"
-background = "#1a1b26"
-background_highlight = "#30374b"
-background_menu = "#16161e"
+
+add = "#449dab"
+change = "#6183bb"
+delete = "#914c54"
+
+error = "#db4b4b"
+hint = "#1abc9c"
+info = "#0db9d7"
+
+fg = "#c0caf5"
+fg-dark = "#a9b1d6"
+fg-gutter = "#3b4261"
+fg-linenr = "#737aa2"
+fg-selected = "#343a55"
+border = "#15161e"
+border-highlight = "#27a1b9"
+bg = "#1a1b26"
+bg-inlay = "#1a2b32"
+bg-highlight = "#292e42"
+bg-menu = "#16161e"
+bg-visual = "#283457"

--- a/runtime/themes/tokyonight_day.toml
+++ b/runtime/themes/tokyonight_day.toml
@@ -1,0 +1,41 @@
+# Author: Paul Graydon <untimely.creation97@proton.me>
+
+inherits = "tokyonight"
+
+[palette]
+red = "#f52a65"
+orange = "#b15c00"
+yellow = "#8c6c3e"
+light-green = "#587539"
+green = "#387068"
+aqua = "#188092"
+teal = "#118c74"
+turquoise = "#006a83"
+light-cyan = "#2e5857"
+cyan = "#007197"
+blue = "#2e7de9"
+purple = "#7847bd"
+magenta = "#9854f1"
+comment = "#848cb5"
+black = "#a1a6c5"
+
+add = "#aecde6"
+change = "#d6d8e3"
+delete = "#dfccd4"
+
+error = "#c64343"
+hint = "#118c74"
+info = "#07879d"
+
+fg = "#3760bf"
+fg-dark = "#6172b0"
+fg-gutter = "#a8aecb"
+fg-linenr = "#68709a"
+fg-selected = "#b3b8d1"
+border = "#e9e9ed"
+border-highlight = "#2496ac"
+bg = "#e1e2e7"
+bg-inlay = "#acd7eb"
+bg-highlight = "#c4c8da"
+bg-menu = "#e9e9ec"
+bg-visual = "#b6bfe2"

--- a/runtime/themes/tokyonight_moon.toml
+++ b/runtime/themes/tokyonight_moon.toml
@@ -1,0 +1,41 @@
+# Author: Paul Graydon <untimely.creation97@proton.me>
+
+inherits = "tokyonight"
+
+[palette]
+red = "#ff757f"
+orange = "#ff966c"
+yellow = "#ffc777"
+light-green = "#c3e88d"
+green = "#4fd6be"
+aqua = "#65bcff"
+teal = "#4fd6be"
+turquoise = "#89ddff"
+light-cyan = "#b4f9f8"
+cyan = "#86e1fc"
+blue = "#82aaff"
+purple = "#fca7ea"
+magenta = "#c099ff"
+comment = "#636da6"
+black = "#444a73"
+
+add = "#b8db87"
+change = "#7ca1f2"
+delete = "#e26a75"
+
+error = "#c53b53"
+hint = "#4fd6be"
+info = "#0db9d7"
+
+fg = "#c8d3f5"
+fg-dark = "#828bb8"
+fg-gutter = "#3b4261"
+fg-linenr = "#737aa2"
+fg-selected = "#363c58"
+border = "#1b1d2b"
+border-highlight = "#589ed7"
+bg = "#222436"
+bg-inlay = "#273644"
+bg-highlight = "#2f334d"
+bg-menu = "#1e2030"
+bg-visual = "#2d3f76"

--- a/runtime/themes/tokyonight_storm.toml
+++ b/runtime/themes/tokyonight_storm.toml
@@ -1,8 +1,12 @@
-# Author: Paul Graydon <p.y.graydon@gmail.com>
+# Author: Paul Graydon <untimely.creation97@proton.me>
 
 inherits = "tokyonight"
 
 [palette]
-background = "#24283b"
-background_highlight = "#373d5a"
-background_menu = "#1f2335"
+border = "#1d202f"
+bg = "#24283b"
+bg-inlay = "#233745"
+bg-highlight = "#373d5a"
+bg-menu = "#1f2335"
+bg-visual = "#2e3c64"
+border-highlight = "#29a4bd"


### PR DESCRIPTION
Hey there!

After seeing some [auto-generated Helix themes](https://github.com/folke/tokyonight.nvim/tree/main/extras/helix) by folke in his `neovim` tokyonight repository, I decided to update Helix's themes accordingly.

I carefully went through everything and landed on a clean, best-of-both-worlds result which I think is a nice improvement from the previous versions. I've added the two missing themes, `tokyonight_moon` and `tokyonight_day`, and updated my email address.

Here are some screenshots below.

![20231215_164357](https://github.com/helix-editor/helix/assets/148399603/6c0afd65-b5ad-4208-a528-fbbe94d46ef6)
![20231215_164414](https://github.com/helix-editor/helix/assets/148399603/81d2e349-c37b-4c78-9b0a-b08747402b40)
![20231215_164426](https://github.com/helix-editor/helix/assets/148399603/d88c20bd-9d0a-44b0-9eb3-b93ddd66bb07)
![20231215_164441](https://github.com/helix-editor/helix/assets/148399603/1fe11d5c-53e7-49eb-b072-bfdede23a843)

If you see any mistake or improvement to make, feel free to contact me or make any changes!

Cheers!