### PR TITLE
book: Describe usage of `.ignore` and helix-specific ignore files in `[editor.file-picker]` section

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -177,6 +177,21 @@ All git related options are only enabled in a git repository.
 |`git-exclude` | Enables reading `.git/info/exclude` files | `true`
 |`max-depth` | Set with an integer value for maximum depth to recurse | Defaults to `None`.
 
+Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
+
+Additionally, you can use Helix-specific ignore files by creating a local `.helix/ignore` file in the current workspace or a global `ignore` file located in your Helix config directory:
+- Linux and Mac: `~/.config/helix/ignore`
+- Windows: `%AppData%\helix\ignore`
+
+Example:
+
+```ini
+# unignore in file picker and global search
+!.github/
+!.gitignore
+!.gitattributes
+```
+
 ### `[editor.auto-pairs]` Section
 
 Enables automatic insertion of pairs to parentheses, brackets, etc. Can be a


### PR DESCRIPTION
Hello, first-timer here 👋

Just wanted to add this since the documentation didn't mention much about .ignore files and did state nothing about helix-specific ignore files. But now, the `[editor.file-picker]` section has a nice addition to it:

![image](https://github.com/helix-editor/helix/assets/68142933/9a029ed4-3858-4de1-b176-1fc9639098a0)

This PR is relevant to #8099 and #7423.