### PR TITLE
(feat) Vim-like EOL Inlay Hints

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1690,7 +1690,7 @@ fn compute_inlay_hints_for_view(
                         }
                         type_built_string.push_str(type_hint_suffix);
 
-                        InlineAnnotation::new(char_index, type_built_string)
+                        InlineAnnotation::new(0, type_built_string)
                     })
                     .collect()
             }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1654,11 +1654,17 @@ fn compute_inlay_hints_for_view(
                 });
             };
 
-            vimmise_inlays(&mut type_inlay_hints, " => ");
-            vimmise_inlays(&mut parameter_inlay_hints, " <= ");
-            vimmise_inlays(&mut other_inlay_hints, " == ");
-            padding_after_inlay_hints = vec![];
-            padding_before_inlay_hints = vec![];
+            {
+                let cfg = doc.config.load();
+                let vim_cfg = &cfg.lsp.vim_inlay_hints;
+                if vim_cfg.enable {
+                    vimmise_inlays(&mut type_inlay_hints, vim_cfg.type_inlay_prefix.as_str());
+                    vimmise_inlays(&mut parameter_inlay_hints, vim_cfg.parameter_inlay_prefix.as_str());
+                    vimmise_inlays(&mut other_inlay_hints, vim_cfg.other_inlay_prefix.as_str());
+                    padding_after_inlay_hints = vec![];
+                    padding_before_inlay_hints = vec![];
+                }
+            }
 
             doc.set_inlay_hints(
                 view_id,
@@ -1671,6 +1677,7 @@ fn compute_inlay_hints_for_view(
                     padding_after_inlay_hints: padding_after_inlay_hints.into(),
                 },
             );
+
             doc.inlay_hints_oudated = false;
         },
     );

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -367,6 +367,25 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct VimInlayConfig {
+    pub enable: bool,
+    pub type_inlay_prefix: String,
+    pub parameter_inlay_prefix: String,
+    pub other_inlay_prefix: String,
+}
+impl Default for VimInlayConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            type_inlay_prefix: String::from(" => "),
+            parameter_inlay_prefix: String::from(" <= "),
+            other_inlay_prefix: String::from(" == "),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
     /// Enables LSP
     pub enable: bool,
@@ -378,6 +397,8 @@ pub struct LspConfig {
     pub display_signature_help_docs: bool,
     /// Display inlay hints
     pub display_inlay_hints: bool,
+    /// Vim-style inlay hints
+    pub vim_inlay_hints: VimInlayConfig,
     /// Whether to enable snippet support
     pub snippets: bool,
     /// Whether to include declaration in the goto reference query
@@ -392,6 +413,7 @@ impl Default for LspConfig {
             auto_signature_help: true,
             display_signature_help_docs: true,
             display_inlay_hints: false,
+            vim_inlay_hints: VimInlayConfig::default(),
             snippets: true,
             goto_reference_include_declaration: true,
         }


### PR DESCRIPTION
Adds an option that makes inlay hints appear on the end of the line, as well as some configuration option for the prefix before the hints.

https://github.com/helix-editor/helix/assets/101683475/f0d97568-6ae3-44b7-847d-9b407ae838a2

Need to figure out a way to get rid of all the `: `s, which is why this PR is a draft.