### PR TITLE
Add Avro schema file support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -346,7 +346,8 @@ file-types = [
   "jsonld",
   ".vuerc",
   "composer.lock",
-  ".watchmanconfig"
+  ".watchmanconfig",
+  "avsc"
 ]
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true


### PR DESCRIPTION
Add Apache Avro schema file extension to the list of JSON file types.

[(See here.)](https://avro.apache.org/docs/1.11.1/#schemas)