### PR TITLE
Refactor statusline elements to build `Spans`

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -4,7 +4,6 @@ use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
     graphics::Rect,
-    theme::Style,
     Document, Editor, View,
 };
 
@@ -58,25 +57,17 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
 
     surface.set_style(viewport.with_height(1), base_style);
 
-    let write_left = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.left, text, &base_style, style)
-    };
-    let write_center = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.center, text, &base_style, style)
-    };
-    let write_right = |context: &mut RenderContext, text, style| {
-        append(&mut context.parts.right, text, &base_style, style)
-    };
-
     // Left side of the status line.
 
     let config = context.editor.config();
 
     let element_ids = &config.statusline.left;
-    element_ids
+    context.parts.left = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_left));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     surface.set_spans(
         viewport.x,
@@ -88,10 +79,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Right side of the status line.
 
     let element_ids = &config.statusline.right;
-    element_ids
+    context.parts.right = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_right));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     surface.set_spans(
         viewport.x
@@ -106,10 +99,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     // Center of the status line.
 
     let element_ids = &config.statusline.center;
-    element_ids
+    context.parts.center = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
-        .for_each(|render| render(context, write_center));
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
 
     // Width of the empty space between the left and center area and between the center and right area.
     let spacing = 1u16;
@@ -126,17 +121,9 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
     );
 }
 
-fn append(buffer: &mut Spans, text: String, base_style: &Style, style: Option<Style>) {
-    buffer.0.push(Span::styled(
-        text,
-        style.map_or(*base_style, |s| (*base_style).patch(s)),
-    ));
-}
-
-fn get_render_function<F>(element_id: StatusLineElementID) -> impl Fn(&mut RenderContext, F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn get_render_function<'a>(
+    element_id: StatusLineElementID,
+) -> impl Fn(&RenderContext) -> Spans<'a> {
     match element_id {
         helix_view::editor::StatusLineElement::Mode => render_mode,
         helix_view::editor::StatusLineElement::Spinner => render_lsp_spinner,
@@ -166,48 +153,40 @@ where
     }
 }
 
-fn render_mode<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_mode<'a>(context: &RenderContext) -> Spans<'a> {
     let visible = context.focused;
     let config = context.editor.config();
     let modenames = &config.statusline.mode;
-    write(
-        context,
-        format!(
-            " {} ",
-            if visible {
-                match context.editor.mode() {
-                    Mode::Insert => &modenames.insert,
-                    Mode::Select => &modenames.select,
-                    Mode::Normal => &modenames.normal,
-                }
-            } else {
-                // If not focused, explicitly leave an empty space instead of returning None.
-                "   "
-            }
-        ),
-        if visible && config.color_modes {
+    let modename = if visible {
+        match context.editor.mode() {
+            Mode::Insert => modenames.insert.clone(),
+            Mode::Select => modenames.select.clone(),
+            Mode::Normal => modenames.normal.clone(),
+        }
+    } else {
+        // If not focused, explicitly leave an empty space.
+        " ".into()
+    };
+    let modename = format!(" {} ", modename);
+    if config.color_modes {
+        Span::styled(
+            modename,
             match context.editor.mode() {
-                Mode::Insert => Some(context.editor.theme.get("ui.statusline.insert")),
-                Mode::Select => Some(context.editor.theme.get("ui.statusline.select")),
-                Mode::Normal => Some(context.editor.theme.get("ui.statusline.normal")),
-            }
-        } else {
-            None
-        },
-    );
+                Mode::Insert => context.editor.theme.get("ui.statusline.insert"),
+                Mode::Select => context.editor.theme.get("ui.statusline.select"),
+                Mode::Normal => context.editor.theme.get("ui.statusline.normal"),
+            },
+        )
+        .into()
+    } else {
+        Span::raw(modename).into()
+    }
 }
 
 // TODO think about handling multiple language servers
-fn render_lsp_spinner<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_lsp_spinner<'a>(context: &RenderContext) -> Spans<'a> {
     let language_server = context.doc.language_servers().next();
-    write(
-        context,
+    Span::raw(
         language_server
             .and_then(|srv| {
                 context
@@ -218,14 +197,11 @@ where
             // Even if there's no spinner; reserve its space to avoid elements frequently shifting.
             .unwrap_or(" ")
             .to_string(),
-        None,
-    );
+    )
+    .into()
 }
 
-fn render_diagnostics<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_diagnostics<'a>(context: &RenderContext) -> Spans<'a> {
     let (warnings, errors) = context
         .doc
         .diagnostics()
@@ -240,29 +216,28 @@ where
             counts
         });
 
+    let mut output = Spans::default();
+
     if warnings > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
+            context.editor.theme.get("warning"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", warnings)));
     }
 
     if errors > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+            context.editor.theme.get("error"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", errors)));
     }
+
+    output
 }
 
-fn render_workspace_diagnostics<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_workspace_diagnostics<'a>(context: &RenderContext) -> Spans<'a> {
     let (warnings, errors) =
         context
             .editor
@@ -278,51 +253,49 @@ where
                 counts
             });
 
+    let mut output = Spans::default();
+
     if warnings > 0 || errors > 0 {
-        write(context, " W ".into(), None);
+        output.0.push(Span::raw(" W "));
     }
 
     if warnings > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
+            context.editor.theme.get("warning"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", warnings)));
     }
 
     if errors > 0 {
-        write(
-            context,
+        output.0.push(Span::styled(
             "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+            context.editor.theme.get("error"),
+        ));
+        output.0.push(Span::raw(format!(" {} ", errors)));
     }
+
+    output
 }
 
-fn render_selections<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_selections<'a>(context: &RenderContext) -> Spans<'a> {
     let count = context.doc.selection(context.view.id).len();
-    write(
-        context,
-        format!(" {} sel{} ", count, if count == 1 { "" } else { "s" }),
-        None,
-    );
+    Span::raw(format!(
+        " {} sel{} ",
+        count,
+        if count == 1 { "" } else { "s" }
+    ))
+    .into()
 }
 
-fn render_primary_selection_length<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_primary_selection_length<'a>(context: &RenderContext) -> Spans<'a> {
     let tot_sel = context.doc.selection(context.view.id).primary().len();
-    write(
-        context,
-        format!(" {} char{} ", tot_sel, if tot_sel == 1 { "" } else { "s" }),
-        None,
-    );
+    Span::raw(format!(
+        " {} char{} ",
+        tot_sel,
+        if tot_sel == 1 { "" } else { "s" }
+    ))
+    .into()
 }
 
 fn get_position(context: &RenderContext) -> Position {
@@ -336,55 +309,33 @@ fn get_position(context: &RenderContext) -> Position {
     )
 }
 
-fn render_position<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_position<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
-    write(
-        context,
-        format!(" {}:{} ", position.row + 1, position.col + 1),
-        None,
-    );
+    Span::raw(format!(" {}:{} ", position.row + 1, position.col + 1)).into()
 }
 
-fn render_total_line_numbers<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_total_line_numbers<'a>(context: &RenderContext) -> Spans<'a> {
     let total_line_numbers = context.doc.text().len_lines();
-
-    write(context, format!(" {} ", total_line_numbers), None);
+    Span::raw(format!(" {} ", total_line_numbers)).into()
 }
 
-fn render_position_percentage<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_position_percentage<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
     let maxrows = context.doc.text().len_lines();
-    write(
-        context,
-        format!("{}%", (position.row + 1) * 100 / maxrows),
-        None,
-    );
+    Span::raw(format!("{}%", (position.row + 1) * 100 / maxrows)).into()
 }
 
-fn render_file_encoding<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_encoding<'a>(context: &RenderContext) -> Spans<'a> {
     let enc = context.doc.encoding();
 
     if enc != encoding::UTF_8 {
-        write(context, format!(" {} ", enc.name()), None);
+        Span::raw(format!(" {} ", enc.name())).into()
+    } else {
+        Spans::default()
     }
 }
 
-fn render_file_line_ending<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_line_ending<'a>(context: &RenderContext) -> Spans<'a> {
     use helix_core::LineEnding::*;
     let line_ending = match context.doc.line_ending {
         Crlf => "CRLF",
@@ -403,22 +354,16 @@ where
         PS => "PS", // U+2029 -- ParagraphSeparator
     };
 
-    write(context, format!(" {} ", line_ending), None);
+    Span::raw(format!(" {} ", line_ending)).into()
 }
 
-fn render_file_type<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_type<'a>(context: &RenderContext) -> Spans<'a> {
     let file_type = context.doc.language_name().unwrap_or(DEFAULT_LANGUAGE_NAME);
 
-    write(context, format!(" {} ", file_type), None);
+    Span::raw(format!(" {} ", file_type)).into()
 }
 
-fn render_file_name<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_name<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let rel_path = context.doc.relative_path();
         let path = rel_path
@@ -428,13 +373,10 @@ where
         format!(" {} ", path)
     };
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_file_absolute_path<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_absolute_path<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let path = context.doc.path();
         let path = path
@@ -444,13 +386,10 @@ where
         format!(" {} ", path)
     };
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_file_modification_indicator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_modification_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = (if context.doc.is_modified() {
         "[+]"
     } else {
@@ -458,26 +397,20 @@ where
     })
     .to_string();
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_read_only_indicator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_read_only_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = if context.doc.readonly {
         " [readonly] "
     } else {
         ""
     }
     .to_string();
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_file_base_name<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_file_base_name<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let rel_path = context.doc.relative_path();
         let path = rel_path
@@ -487,47 +420,37 @@ where
         format!(" {} ", path)
     };
 
-    write(context, title, None);
+    Span::raw(title).into()
 }
 
-fn render_separator<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_separator<'a>(context: &RenderContext) -> Spans<'a> {
     let sep = &context.editor.config().statusline.separator;
 
-    write(
-        context,
+    Span::styled(
         sep.to_string(),
-        Some(context.editor.theme.get("ui.statusline.separator")),
-    );
+        context.editor.theme.get("ui.statusline.separator"),
+    )
+    .into()
 }
 
-fn render_spacer<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
-    write(context, String::from(" "), None);
+fn render_spacer<'a>(_context: &RenderContext) -> Spans<'a> {
+    Span::raw(" ").into()
 }
 
-fn render_version_control<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_version_control<'a>(context: &RenderContext) -> Spans<'a> {
     let head = context
         .doc
         .version_control_head()
         .unwrap_or_default()
         .to_string();
 
-    write(context, head, None);
+    Span::raw(head).into()
 }
 
-fn render_register<F>(context: &mut RenderContext, write: F)
-where
-    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
-{
+fn render_register<'a>(context: &RenderContext) -> Spans<'a> {
     if let Some(reg) = context.editor.selected_register {
-        write(context, format!(" reg={} ", reg), None)
+        Span::raw(format!(" reg={} ", reg)).into()
+    } else {
+        Spans::default()
     }
 }


### PR DESCRIPTION
The current statusline implementation uses ad-hoc write callbacks to render statusline elements. This make statusline elements hard to work with, because we get no useful information about their output.

This PR refactors these elements to work more like widgets: each `render_*` function returns a `Spans`, which can be combined into a complete statusline. This has remained the responsibility of the `render` function.

This PR also separates the `render` function into two parts: `render_statusline` combines the aforementioned elements into one large `Spans` with given size constraints, while `render` blits it to a given `Surface` as it has done so previously. 

The rationale behind this is to allow post-processing the widget outputs and to make decisions based on them. 
For example, in the future we can now check if the statusline is empty and autohide it. Or revisit #7310 and automatically space the elements.

*This is merely a refactor; the current apparent behavior of each statusline element should be identical to previous versions.*