### PR TITLE
Add .glif to XML file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2320,7 +2320,8 @@ file-types = [
   "xpdl",
   "xul",
   "xoml",
-  "musicxml"
+  "musicxml",
+  "glif"
 ]
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
`.glif` files are standard files in the type design industry. From the Unified Font Object specification website:

> The Glyph Interchange Format (GLIF) is a simple and clear XML representation of a single glyph. GLIF files typically have a .glif extension.

https://unifiedfontobject.org/versions/ufo3/glyphs/glif/