### PR TITLE
Kakoune-like selection history

### DIFF
--- a/helix-core/src/history.rs
+++ b/helix-core/src/history.rs
@@ -429,21 +429,19 @@ struct SelectionRevision {
     selection: Selection,
 }
 
-impl Default for SelectionHistory {
-    fn default() -> Self {
+impl SelectionHistory {
+    pub fn new(selection: Selection, revision: usize) -> Self {
         Self {
             revisions: vec![SelectionRevision {
-                revision: 0,
+                revision,
                 parent: 0,
                 last_child: None,
-                selection: Selection::point(0),
+                selection,
             }],
             current: 0,
         }
     }
-}
 
-impl SelectionHistory {
     pub fn commit_revision(&mut self, selection: Selection, revision: usize) {
         let new_current = self.revisions.len();
         self.revisions[self.current].last_child = NonZeroUsize::new(new_current);
@@ -466,6 +464,7 @@ impl SelectionHistory {
         }
         let revision = &self.revisions[self.current];
         let selection = revision.selection.clone();
+        self.current = revision.parent;
 
         if let Some(tx) = history.between(revision.revision, history.current_revision()) {
             Some(Transaction::default().with_selection(selection.map(tx.changes())))

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -613,12 +613,12 @@ impl Selection {
         self.normalize()
     }
 
-    // Ensures the selection adheres to the following invariants:
-    // 1. All ranges are grapheme aligned.
-    // 2. All ranges are at least 1 character wide, unless at the
-    //    very end of the document.
-    // 3. Ranges are non-overlapping.
-    // 4. Ranges are sorted by their position in the text.
+    /// Ensures the selection adheres to the following invariants:
+    /// 1. All ranges are grapheme aligned.
+    /// 2. All ranges are at least 1 character wide, unless at the
+    ///    very end of the document.
+    /// 3. Ranges are non-overlapping.
+    /// 4. Ranges are sorted by their position in the text.
     pub fn ensure_invariants(self, text: RopeSlice) -> Self {
         self.transform(|r| r.min_width_1(text).grapheme_aligned(text))
             .normalize()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -380,6 +380,8 @@ impl MappableCommand {
         kill_to_line_end, "Delete till end of line",
         undo, "Undo change",
         redo, "Redo change",
+        soft_undo, "Undo selection change",
+        soft_redo, "Redo selection change",
         earlier, "Move backward in history",
         later, "Move forward in history",
         commit_undo_checkpoint, "Commit changes to new checkpoint",
@@ -3934,9 +3936,24 @@ fn redo(cx: &mut Context) {
 fn soft_undo(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
+    for _ in 0..count {
+        if !doc.soft_undo(view) {
+            cx.editor.set_status("Already at oldest selection");
+            break;
+        }
+    }
 }
 
-fn soft_redo(cx: &mut Context) {}
+fn soft_redo(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    for _ in 0..count {
+        if !doc.soft_redo(view) {
+            cx.editor.set_status("Already at newest selection");
+            break;
+        }
+    }
+}
 
 fn earlier(cx: &mut Context) {
     let count = cx.count();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3931,6 +3931,13 @@ fn redo(cx: &mut Context) {
     }
 }
 
+fn soft_undo(cx: &mut Context) {
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+}
+
+fn soft_redo(cx: &mut Context) {}
+
 fn earlier(cx: &mut Context) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
@@ -4185,9 +4192,13 @@ fn replace_with_yanked(cx: &mut Context) {
 }
 
 fn replace_with_yanked_impl(editor: &mut Editor, register: char, count: usize) {
-    let Some(values) = editor.registers
+    let Some(values) = editor
+        .registers
         .read(register, editor)
-        .filter(|values| values.len() > 0) else { return };
+        .filter(|values| values.len() > 0)
+    else {
+        return;
+    };
     let values: Vec<_> = values.map(|value| value.to_string()).collect();
 
     let (view, doc) = current!(editor);
@@ -4224,7 +4235,9 @@ fn replace_selections_with_primary_clipboard(cx: &mut Context) {
 }
 
 fn paste(editor: &mut Editor, register: char, pos: Paste, count: usize) {
-    let Some(values) = editor.registers.read(register, editor) else { return };
+    let Some(values) = editor.registers.read(register, editor) else {
+        return;
+    };
     let values: Vec<_> = values.map(|value| value.to_string()).collect();
 
     let (view, doc) = current!(editor);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -6,6 +6,7 @@ use futures_util::FutureExt;
 use helix_core::auto_pairs::AutoPairs;
 use helix_core::doc_formatter::TextFormat;
 use helix_core::encoding::Encoding;
+use helix_core::history::SelectionHistory;
 use helix_core::syntax::{Highlight, LanguageServerFeature};
 use helix_core::text_annotations::{InlineAnnotation, TextAnnotations};
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
@@ -165,6 +166,7 @@ pub struct Document {
     // it back as it separated from the edits. We could split out the parts manually but that will
     // be more troublesome.
     pub history: Cell<History>,
+    pub selection_history: HashMap<ViewId, SelectionHistory>,
     pub config: Arc<dyn DynAccess<Config>>,
 
     savepoints: Vec<Weak<SavePoint>>,
@@ -666,6 +668,7 @@ impl Document {
             diagnostics: Vec::new(),
             version: 0,
             history: Cell::new(History::default()),
+            selection_history: HashMap::default(),
             savepoints: Vec::new(),
             last_saved_time: SystemTime::now(),
             last_saved_revision: 0,
@@ -1342,6 +1345,11 @@ impl Document {
     /// Redo the last modification to the [`Document`]. Returns whether the redo was successful.
     pub fn redo(&mut self, view: &mut View) -> bool {
         self.undo_redo_impl(view, false)
+    }
+
+    pub fn soft_undo_redo_impl(&mut self, view: &mut View, undo: bool) {
+        let history = self.history.get_mut();
+        let selection_history = self.selection_history.get(&view.id);
     }
 
     /// Creates a reference counted snapshot (called savpepoint) of the document.


### PR DESCRIPTION
Resolves #1596 by implementing a separate selection history. Each selection revision tracks the associated edit revision and selections are automatically mapped to different document revisions.

Waiting to see what should be done about transaction selections to finish this PR.