### PR TITLE
statusline - add document position indicator

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -162,6 +162,7 @@ where
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
         helix_view::editor::StatusLineElement::Register => render_register,
+        helix_view::editor::StatusLineElement::DocPos => render_doc_pos,
     }
 }
 
@@ -197,6 +198,22 @@ where
             None
         },
     );
+}
+
+fn render_doc_pos<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    // Simple representation of how many documents are opened and which
+    // position the current opened one is
+    let docs_len: usize = context.editor.documents.len();
+    let doc_id: helix_view::DocumentId = context.doc.id();
+    let doc_pos: usize = match context.editor.documents.keys().position(|&key| key == doc_id) {
+        Some(p) => p + 1,
+        None => 0,
+    };
+
+    write(context, format!("[{}/{}] ", doc_pos, docs_len), None);
 }
 
 // TODO think about handling multiple language servers

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -437,6 +437,7 @@ impl Default for StatusLineConfig {
                 E::Register,
                 E::Position,
                 E::FileEncoding,
+                E::DocPos,
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
@@ -524,6 +525,9 @@ pub enum StatusLineElement {
 
     /// Indicator for selected register
     Register,
+
+    // Indicator for selected Document
+    DocPos,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs


### PR DESCRIPTION
highly miscellaneous feature that allows the user to keep track of how many documents (or buffers) are opened and which position the current opened one is occupying at the moment.