### PR TITLE
added local search functionality (like global search only in the current document)

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -295,6 +295,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `Y`     | Yank main selection to clipboard                                        | `yank_main_selection_to_clipboard`         |
 | `R`     | Replace selections by clipboard contents                                | `replace_selections_with_clipboard`        |
 | `/`     | Global search in workspace folder                                       | `global_search`                            |
+| '&'     | Local search in buffer contents                                         | `local_search`                             |
 | `?`     | Open command palette                                                    | `command_palette`                          |
 
 > 💡 Global search displays results in a fuzzy picker, use `Space + '` to bring it back up after opening a file.

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -273,6 +273,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "P" => paste_clipboard_before,
             "R" => replace_selections_with_clipboard,
             "/" => global_search,
+            "&" => local_search,
             "k" => hover,
             "r" => rename_symbol,
             "h" => select_references_to_symbol_under_cursor,


### PR DESCRIPTION
This code adds the equivalent of global-search but only within a single buffer. It's useful because using the global-search functionality as a ctrl + f equivalent for a single document is a bit tedious and something like this will make the processes of finding instances of something within a single document a lot easier.