### PR TITLE
Add textobject queries for protobuf grammar.

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -127,7 +127,7 @@
 | ponylang | ✓ | ✓ | ✓ |  |
 | prisma | ✓ |  |  | `prisma-language-server` |
 | prolog |  |  |  | `swipl` |
-| protobuf | ✓ |  | ✓ | `bufls`, `pb` |
+| protobuf | ✓ | ✓ | ✓ | `bufls`, `pb` |
 | prql | ✓ |  |  |  |
 | purescript | ✓ | ✓ |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | `pylsp` |

--- a/runtime/queries/protobuf/textobjects.scm
+++ b/runtime/queries/protobuf/textobjects.scm
@@ -1,0 +1,9 @@
+(message (messageBody) @class.inside) @class.around
+(enum (enumBody) @class.inside) @class.around
+(service (serviceBody) @class.inside) @class.around
+
+(rpc (enumMessageType) @parameter.inside) @function.inside
+(rpc (enumMessageType) @parameter.around) @function.around
+
+(comment) @comment.inside
+(comment)+ @comment.around


### PR DESCRIPTION
Given `message Foo {string s = 1;}`
- `mat` selects `message Foo {string s = 1}`
- `mit` selects `{string s = 1;}`

Given `service SearchService { rpc Search(Req) returns (Resp); }`
- `mit` or `mat` selects `Req` or `Resp`
- `mif` or `maf` selects `rpc Search(Req) returns (Resp);`
- `mit` selects `{ rpc Search(Req) returns (Resp); }`
- `mat` selects `service SearchService { rpc Search(Req) returns (Resp); }`
