### PR TITLE
Add HOCON language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -68,6 +68,7 @@
 | haskell-persistent | ✓ |  |  |  |
 | hcl | ✓ |  | ✓ | `terraform-ls` |
 | heex | ✓ | ✓ |  | `elixir-ls` |
+| hocon | ✓ |  | ✓ |  |
 | hosts | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server` |
 | hurl | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3006,3 +3006,15 @@ file-types = ["janet"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 grammar = "clojure"
+
+[[language]]
+name = "hocon"
+scope = "source.conf"
+file-types = ["conf"]
+comment-token = "#"
+auto-format = true
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "hocon"
+source = { git = "https://github.com/antosha417/tree-sitter-hocon", rev = "c390f10519ae69fdb03b3e5764f5592fb6924bcc" }

--- a/runtime/queries/hocon/highlights.scm
+++ b/runtime/queries/hocon/highlights.scm
@@ -28,6 +28,3 @@
 (path (_) @keyword)
 (unquoted_path "." @punctuation.delimiter)
 [ "," ] @punctuation.delimiter
-
-(ERROR) @error
-

--- a/runtime/queries/hocon/highlights.scm
+++ b/runtime/queries/hocon/highlights.scm
@@ -1,0 +1,33 @@
+(comment) @comment
+
+(null) @constant.builtin
+[(true) (false)] @constant.builtin.boolean
+(number) @constant.numeric
+(string) @string
+(multiline_string) @string
+(string (escape_sequence) @constant.character.escape)
+(unquoted_string) @string
+
+(value [":" "=" "+=" ] @operator)
+
+(substitution (_) @string)
+(substitution ["${" "${?" "}"] @punctuation.special)
+
+[ 
+  "url"
+  "file"
+  "classpath"
+  "required"
+] @function.builtin
+
+(include "include" @include)
+
+[ "(" ")" "[" "]" "{" "}" ]  @punctuation.bracket
+
+(unit) @keyword
+(path (_) @keyword)
+(unquoted_path "." @punctuation.delimiter)
+[ "," ] @punctuation.delimiter
+
+(ERROR) @error
+

--- a/runtime/queries/hocon/highlights.scm
+++ b/runtime/queries/hocon/highlights.scm
@@ -20,7 +20,7 @@
   "required"
 ] @function.builtin
 
-(include "include" @include)
+(include @keyword.control.import)
 
 [ "(" ")" "[" "]" "{" "}" ]  @punctuation.bracket
 

--- a/runtime/queries/hocon/highlights.scm
+++ b/runtime/queries/hocon/highlights.scm
@@ -20,7 +20,7 @@
   "required"
 ] @function.builtin
 
-(include @keyword.control.import)
+(include) @keyword.directive
 
 [ "(" ")" "[" "]" "{" "}" ]  @punctuation.bracket
 
@@ -28,3 +28,4 @@
 (path (_) @keyword)
 (unquoted_path "." @punctuation.delimiter)
 [ "," ] @punctuation.delimiter
+

--- a/runtime/queries/hocon/indents.scm
+++ b/runtime/queries/hocon/indents.scm
@@ -1,0 +1,10 @@
+[
+  (object)
+  (array)
+] @indent
+
+[
+  "]"
+  "}"
+] @outdent
+


### PR DESCRIPTION
Adds support for [HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) configuration language (highlights and indents).