### PR TITLE
Fix minor typo: anntoation -> annotation

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -130,7 +130,7 @@ pub struct DocumentFormatter<'t> {
     /// Line breaks to be reserved for virtual text
     /// at the next line break
     virtual_lines: usize,
-    inline_anntoation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
+    inline_annotation_graphemes: Option<(Graphemes<'t>, Option<Highlight>)>,
 
     // softwrap specific
     /// The indentation of the current line
@@ -176,7 +176,7 @@ impl<'t> DocumentFormatter<'t> {
                 word_buf: Vec::with_capacity(64),
                 word_i: 0,
                 line_pos: block_line_idx,
-                inline_anntoation_graphemes: None,
+                inline_annotation_graphemes: None,
             },
             block_char_idx,
         )
@@ -185,7 +185,7 @@ impl<'t> DocumentFormatter<'t> {
     fn next_inline_annotation_grapheme(&mut self) -> Option<(&'t str, Option<Highlight>)> {
         loop {
             if let Some(&mut (ref mut annotation, highlight)) =
-                self.inline_anntoation_graphemes.as_mut()
+                self.inline_annotation_graphemes.as_mut()
             {
                 if let Some(grapheme) = annotation.next() {
                     return Some((grapheme, highlight));
@@ -195,7 +195,7 @@ impl<'t> DocumentFormatter<'t> {
             if let Some((annotation, highlight)) =
                 self.annotations.next_inline_annotation_at(self.char_pos)
             {
-                self.inline_anntoation_graphemes = Some((
+                self.inline_annotation_graphemes = Some((
                     UnicodeSegmentation::graphemes(&*annotation.text, true),
                     highlight,
                 ))


### PR DESCRIPTION
Just a minor typo fix I found reading the source :) . Fixed using the LSP ("space" + "r" to replace symbol in the whole project).