### PR TITLE
feat: Use custom character to draw editor rulers

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,36 +37,37 @@ Its settings will be merged with the configuration directory `config.toml` and t
 
 ### `[editor]` Section
 
-| Key | Description | Default |
-|--|--|---------|
-| `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
-| `mouse` | Enable mouse mode | `true` |
-| `middle-click-paste` | Middle click paste support | `true` |
-| `scroll-lines` | Number of lines to scroll per scroll wheel step | `3` |
-| `shell` | Shell to use when running external commands | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]` |
-| `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `absolute` |
-| `cursorline` | Highlight all lines with a cursor | `false` |
-| `cursorcolumn` | Highlight all columns with a cursor | `false` |
-| `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
-| `auto-completion` | Enable automatic pop up of auto-completion | `true` |
-| `auto-format` | Enable automatic formatting on save | `true` |
-| `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
-| `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant | `250` |
-| `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |
-| `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
-| `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
-| `auto-info` | Whether to display info boxes | `true` |
-| `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
-| `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
-| `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
-| `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
-| `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
-| `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
-| `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
-| `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
-| `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
-| `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |
-| `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`
+| Key                         | Description                                                                                                                                                                                                                                                                                                                                                                                 | Default                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `scrolloff`                 | Number of lines of padding around the edge of the screen when scrolling                                                                                                                                                                                                                                                                                                                     | `5`                                                           |
+| `mouse`                     | Enable mouse mode                                                                                                                                                                                                                                                                                                                                                                           | `true`                                                        |
+| `middle-click-paste`        | Middle click paste support                                                                                                                                                                                                                                                                                                                                                                  | `true`                                                        |
+| `scroll-lines`              | Number of lines to scroll per scroll wheel step                                                                                                                                                                                                                                                                                                                                             | `3`                                                           |
+| `shell`                     | Shell to use when running external commands                                                                                                                                                                                                                                                                                                                                                 | Unix: `["sh", "-c"]`<br/>Windows: `["cmd", "/C"]`             |
+| `line-number`               | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers                                                                                                                                                                              | `absolute`                                                    |
+| `cursorline`                | Highlight all lines with a cursor                                                                                                                                                                                                                                                                                                                                                           | `false`                                                       |
+| `cursorcolumn`              | Highlight all columns with a cursor                                                                                                                                                                                                                                                                                                                                                         | `false`                                                       |
+| `gutters`                   | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty                                                                                                                                                                 | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
+| `auto-completion`           | Enable automatic pop up of auto-completion                                                                                                                                                                                                                                                                                                                                                  | `true`                                                        |
+| `auto-format`               | Enable automatic formatting on save                                                                                                                                                                                                                                                                                                                                                         | `true`                                                        |
+| `auto-save`                 | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal                                                                                                                                                                                                                 | `false`                                                       |
+| `idle-timeout`              | Time in milliseconds since last keypress before idle timers trigger. Used for autocompletion, set to 0 for instant                                                                                                                                                                                                                                                                          | `250`                                                         |
+| `preview-completion-insert` | Whether to apply completion item instantly when selected                                                                                                                                                                                                                                                                                                                                    | `true`                                                        |
+| `completion-trigger-len`    | The min-length of word under cursor to trigger autocompletion                                                                                                                                                                                                                                                                                                                               | `2`                                                           |
+| `completion-replace`        | Set to `true` to make completions always replace the entire word and not just the part before the cursor                                                                                                                                                                                                                                                                                    | `false`                                                       |
+| `auto-info`                 | Whether to display info boxes                                                                                                                                                                                                                                                                                                                                                               | `true`                                                        |
+| `true-color`                | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative                                                                                                                                                                                                                                                                                | `false`                                                       |
+| `undercurl`                 | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative                                                                                                                                                                                                                                                                                | `false`                                                       |
+| `rulers`                    | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file                                                                                                                                                                                                                                                           | `[]`                                                          |
+| `ruler-char`                | If specified, this character is used when rendering the rulers in the editor.                                                                                                                                                                                                                                                                                                               | `none`                                                        |
+| `bufferline`                | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use)                                                                                                                                                                                                                                      | `never`                                                       |
+| `color-modes`               | Whether to color the mode indicator with different colors depending on the mode itself                                                                                                                                                                                                                                                                                                      | `false`                                                       |
+| `text-width`                | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set                                                                                                                                                                                                                                                                              | `80`                                                          |
+| `workspace-lsp-roots`       | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`                                                                                                                                                                                                                                                                        | `[]`                                                          |
+| `default-line-ending`       | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`).                                                                                                                                                                                                          | `native`                                                      |
+| `insert-final-newline`      | Whether to automatically insert a trailing line-ending on write if missing                                                                                                                                                                                                                                                                                                                  | `true`                                                        |
+| `popup-border`              | Draw border around `popup`, `menu`, `all`, or `none`                                                                                                                                                                                                                                                                                                                                        | `none`                                                        |
+| `indent-heuristic`          | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`                                                      |
 
 ### `[editor.statusline]` Section
 
@@ -88,57 +89,57 @@ mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
 ```
+
 The `[editor.statusline]` key takes the following sub-keys:
 
-| Key           | Description | Default |
-| ---           | ---         | ---     |
-| `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
-| `center`      | A list of elements aligned to the middle of the statusline | `[]` |
-| `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding"]` |
-| `separator`   | The character used to separate elements in the statusline | `"│"` |
-| `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
-| `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |
-| `mode.select` | The text shown in the `mode` element for select mode | `"SEL"` |
+| Key           | Description                                                | Default                                                                                  |
+| ------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `left`        | A list of elements aligned to the left of the statusline   | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
+| `center`      | A list of elements aligned to the middle of the statusline | `[]`                                                                                     |
+| `right`       | A list of elements aligned to the right of the statusline  | `["diagnostics", "selections", "register", "position", "file-encoding"]`                 |
+| `separator`   | The character used to separate elements in the statusline  | `"│"`                                                                                    |
+| `mode.normal` | The text shown in the `mode` element for normal mode       | `"NOR"`                                                                                  |
+| `mode.insert` | The text shown in the `mode` element for insert mode       | `"INS"`                                                                                  |
+| `mode.select` | The text shown in the `mode` element for select mode       | `"SEL"`                                                                                  |
 
 The following statusline elements can be configured:
 
-| Key    | Description |
-| ------ | ----------- |
-| `mode` | The current editor mode (`mode.normal`/`mode.insert`/`mode.select`) |
-| `spinner` | A progress spinner indicating LSP activity |
-| `file-name` | The path/name of the opened file |
-| `file-base-name` | The basename of the opened file |
+| Key                           | Description                                                                                         |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- |
+| `mode`                        | The current editor mode (`mode.normal`/`mode.insert`/`mode.select`)                                 |
+| `spinner`                     | A progress spinner indicating LSP activity                                                          |
+| `file-name`                   | The path/name of the opened file                                                                    |
+| `file-base-name`              | The basename of the opened file                                                                     |
 | `file-modification-indicator` | The indicator to show whether the file is modified (a `[+]` appears when there are unsaved changes) |
-| `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
-| `file-line-ending` | The file line endings (CRLF or LF) |
-| `read-only-indicator` | An indicator that shows `[readonly]` when a file cannot be written |
-| `total-line-numbers` | The total line numbers of the opened file |
-| `file-type` | The type of the opened file |
-| `diagnostics` | The number of warnings and/or errors |
-| `workspace-diagnostics` | The number of warnings and/or errors on workspace |
-| `selections` | The number of active selections |
-| `primary-selection-length` | The number of characters currently in primary selection |
-| `position` | The cursor position |
-| `position-percentage` | The cursor position as a percentage of the total number of lines |
-| `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |
-| `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |
-| `version-control` | The current branch name or detached commit hash of the opened workspace |
-| `register` | The current selected register |
+| `file-encoding`               | The encoding of the opened file if it differs from UTF-8                                            |
+| `file-line-ending`            | The file line endings (CRLF or LF)                                                                  |
+| `read-only-indicator`         | An indicator that shows `[readonly]` when a file cannot be written                                  |
+| `total-line-numbers`          | The total line numbers of the opened file                                                           |
+| `file-type`                   | The type of the opened file                                                                         |
+| `diagnostics`                 | The number of warnings and/or errors                                                                |
+| `workspace-diagnostics`       | The number of warnings and/or errors on workspace                                                   |
+| `selections`                  | The number of active selections                                                                     |
+| `primary-selection-length`    | The number of characters currently in primary selection                                             |
+| `position`                    | The cursor position                                                                                 |
+| `position-percentage`         | The cursor position as a percentage of the total number of lines                                    |
+| `separator`                   | The string defined in `editor.statusline.separator` (defaults to `"│"`)                             |
+| `spacer`                      | Inserts a space between elements (multiple/contiguous spacers may be specified)                     |
+| `version-control`             | The current branch name or detached commit hash of the opened workspace                             |
+| `register`                    | The current selected register                                                                       |
 
 ### `[editor.lsp]` Section
 
-| Key                   | Description                                                 | Default |
-| ---                   | -----------                                                 | ------- |
-| `enable`              | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.| `true` |
-| `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
-| `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
-| `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |
-| `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
-| `snippets`      | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |
-| `goto-reference-include-declaration` | Include declaration in the goto references popup. | `true`  |
+| Key                                  | Description                                                                                                           | Default |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------- |
+| `enable`                             | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.   | `true`  |
+| `display-messages`                   | Display LSP progress messages below statusline[^1]                                                                    | `false` |
+| `auto-signature-help`                | Enable automatic popup of signature help (parameter hints)                                                            | `true`  |
+| `display-inlay-hints`                | Display inlay hints[^2]                                                                                               | `false` |
+| `display-signature-help-docs`        | Display docs under signature help popup                                                                               | `true`  |
+| `snippets`                           | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |
+| `goto-reference-include-declaration` | Include declaration in the goto references popup.                                                                     | `true`  |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
-
 [^2]: You may also have to activate them in the LSP config for them to appear, not just in Helix. Inlay hints in Helix are still being improved on and may be a little bit laggy/janky under some circumstances. Please report any bugs you see so we can fix them!
 
 ### `[editor.cursor-shape]` Section
@@ -150,7 +151,7 @@ Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
 > change shape.
 
 | Key      | Description                                | Default |
-| ---      | -----------                                | ------- |
+| -------- | ------------------------------------------ | ------- |
 | `normal` | Cursor shape in [normal mode][normal mode] | `block` |
 | `insert` | Cursor shape in [insert mode][insert mode] | `block` |
 | `select` | Cursor shape in [select mode][select mode] | `block` |
@@ -166,21 +167,22 @@ not visible in the Helix file picker and global search.
 
 All git related options are only enabled in a git repository.
 
-| Key | Description | Default |
-|--|--|---------|
-|`hidden` | Enables ignoring hidden files | `true`
-|`follow-symlinks` | Follow symlinks instead of ignoring them | `true`
-|`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | `true`
-|`parents` | Enables reading ignore files from parent directories | `true`
-|`ignore` | Enables reading `.ignore` files | `true`
-|`git-ignore` | Enables reading `.gitignore` files | `true`
-|`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
-|`git-exclude` | Enables reading `.git/info/exclude` files | `true`
-|`max-depth` | Set with an integer value for maximum depth to recurse | Defaults to `None`.
+| Key                 | Description                                                                                              | Default             |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | ------------------- |
+| `hidden`            | Enables ignoring hidden files                                                                            | `true`              |
+| `follow-symlinks`   | Follow symlinks instead of ignoring them                                                                 | `true`              |
+| `deduplicate-links` | Ignore symlinks that point at files already shown in the picker                                          | `true`              |
+| `parents`           | Enables reading ignore files from parent directories                                                     | `true`              |
+| `ignore`            | Enables reading `.ignore` files                                                                          | `true`              |
+| `git-ignore`        | Enables reading `.gitignore` files                                                                       | `true`              |
+| `git-global`        | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`              |
+| `git-exclude`       | Enables reading `.git/info/exclude` files                                                                | `true`              |
+| `max-depth`         | Set with an integer value for maximum depth to recurse                                                   | Defaults to `None`. |
 
 Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
 
 Additionally, you can use Helix-specific ignore files by creating a local `.helix/ignore` file in the current workspace or a global `ignore` file located in your Helix config directory:
+
 - Linux and Mac: `~/.config/helix/ignore`
 - Windows: `%AppData%\helix\ignore`
 
@@ -241,19 +243,19 @@ name = "rust"
 
 Search specific options.
 
-| Key | Description | Default |
-|--|--|---------|
-| `smart-case` | Enable smart case regex searching (case-insensitive unless pattern contains upper case characters) | `true` |
-| `wrap-around`| Whether the search should wrap after depleting the matches | `true` |
+| Key           | Description                                                                                        | Default |
+| ------------- | -------------------------------------------------------------------------------------------------- | ------- |
+| `smart-case`  | Enable smart case regex searching (case-insensitive unless pattern contains upper case characters) | `true`  |
+| `wrap-around` | Whether the search should wrap after depleting the matches                                         | `true`  |
 
 ### `[editor.whitespace]` Section
 
 Options for rendering whitespace with visible characters. Use `:set whitespace.render all` to temporarily enable visible whitespace.
 
-| Key | Description | Default |
-|-----|-------------|---------|
-| `render` | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `nbsp`, `tab`, and `newline` | `"none"` |
-| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad` | See example below |
+| Key          | Description                                                                                                                     | Default           |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `render`     | Whether to render whitespace. May either be `"all"` or `"none"`, or a table with sub-keys `space`, `nbsp`, `tab`, and `newline` | `"none"`          |
+| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `newline` or `tabpad`       | See example below |
 
 Example
 
@@ -279,7 +281,7 @@ tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 Options for rendering vertical indent guides.
 
 | Key           | Description                                             | Default |
-| ---           | ---                                                     | ---     |
+| ------------- | ------------------------------------------------------- | ------- |
 | `render`      | Whether to render indent guides                         | `false` |
 | `character`   | Literal character to use for rendering the indent guide | `│`     |
 | `skip-levels` | Number of indent levels to skip                         | `0`     |
@@ -308,7 +310,7 @@ be used. This section contains top level settings, as well as settings for
 specific gutter components as subsections.
 
 | Key      | Description                    | Default                                                       |
-| ---      | ---                            | ---                                                           |
+| -------- | ------------------------------ | ------------------------------------------------------------- |
 | `layout` | A vector of gutters to display | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 
 Example:
@@ -323,7 +325,7 @@ layout = ["diff", "diagnostics", "line-numbers", "spacer"]
 Options for the line number gutter
 
 | Key         | Description                             | Default |
-| ---         | ---                                     | ---     |
+| ----------- | --------------------------------------- | ------- |
 | `min-width` | The minimum number of characters to use | `3`     |
 
 Example:
@@ -349,13 +351,13 @@ Currently unused
 
 Options for soft wrapping lines that exceed the view width:
 
-| Key                  | Description                                                  | Default |
-| ---                  | ---                                                          | ---     |
-| `enable`             | Whether soft wrapping is enabled.                            | `false` |
-| `max-wrap`           | Maximum free space left at the end of the line.              | `20`    |
-| `max-indent-retain`  | Maximum indentation to carry over when soft wrapping a line. | `40`    |
+| Key                  | Description                                                                 | Default |
+| -------------------- | --------------------------------------------------------------------------- | ------- |
+| `enable`             | Whether soft wrapping is enabled.                                           | `false` |
+| `max-wrap`           | Maximum free space left at the end of the line.                             | `20`    |
+| `max-indent-retain`  | Maximum indentation to carry over when soft wrapping a line.                | `40`    |
 | `wrap-indicator`     | Text inserted before soft wrapped lines, highlighted with `ui.virtual.wrap` | `↪ `    |
-| `wrap-at-text-width` | Soft wrap at `text-width` instead of using the full viewport size. | `false` |
+| `wrap-at-text-width` | Soft wrap at `text-width` instead of using the full viewport size.          | `false` |
 
 Example:
 
@@ -369,8 +371,7 @@ wrap-indicator = ""  # set wrap-indicator to "" to hide it
 
 ### `[editor.smart-tab]` Section
 
-
-| Key        | Description | Default |
-|------------|-------------|---------|
-| `enable` | If set to true, then when the cursor is in a position with non-whitespace to its left, instead of inserting a tab, it will run `move_parent_node_end`. If there is only whitespace to the left, then it inserts a tab as normal. With the default bindings, to explicitly insert a tab character, press Shift-tab. | `true` |
+| Key              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Default |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `enable`         | If set to true, then when the cursor is in a position with non-whitespace to its left, instead of inserting a tab, it will run `move_parent_node_end`. If there is only whitespace to the left, then it inserts a tab as normal. With the default bindings, to explicitly insert a tab character, press Shift-tab.                                                                                                                                                         | `true`  |
 | `supersede-menu` | Normally, when a menu is on screen, such as when auto complete is triggered, the tab key is bound to cycling through the items. This means when menus are on screen, one cannot use the tab key to trigger the `smart-tab` command. If this option is set to true, the `smart-tab` command always takes precedence, which means one cannot use the tab key to cycle through menu items. One of the other bindings must be used instead, such as arrow keys or `C-n`/`C-p`. | `false` |

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -149,9 +149,7 @@ pub struct LanguageConfiguration {
     /// global setting.
     #[serde(default, skip_serializing, deserialize_with = "deserialize_auto_pairs")]
     pub auto_pairs: Option<AutoPairs>,
-
-    // pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
-    pub rulers: Option<Vec<RulerConfig>>, // if set, override editor's rulers
+    pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
 
     /// Hardcoded LSP root directories relative to the workspace root, like `examples` or `tools/fuzz`.
     /// Falling back to the current working directory if none are configured.
@@ -2519,11 +2517,21 @@ fn pretty_print_tree_impl<W: fmt::Write>(
     Ok(())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum RulerConfig {
-    Normal(u16),
-    WithCharacter { with_char: char, pos: u16 },
-}
+// #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// #[serde(untagged)]
+// pub enum RulerConfig {
+//     Normal(u16),
+//     WithCharacter { with_char: char, pos: u16 },
+// }
+
+// impl RulerConfig {
+//     pub fn get_pos(&self) -> u16 {
+//         match self {
+//             Self::Normal(p) => *p,
+//             Self::WithCharacter { pos, .. } => *pos,
+//         }
+//     }
+// }
 
 #[cfg(test)]
 mod test {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -150,7 +150,8 @@ pub struct LanguageConfiguration {
     #[serde(default, skip_serializing, deserialize_with = "deserialize_auto_pairs")]
     pub auto_pairs: Option<AutoPairs>,
 
-    pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+    // pub rulers: Option<Vec<u16>>, // if set, override editor's rulers
+    pub rulers: Option<Vec<RulerConfig>>, // if set, override editor's rulers
 
     /// Hardcoded LSP root directories relative to the workspace root, like `examples` or `tools/fuzz`.
     /// Falling back to the current working directory if none are configured.
@@ -2516,6 +2517,12 @@ fn pretty_print_tree_impl<W: fmt::Write>(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RulerConfig {
+    Normal(u16),
+    WithCharacter { with_char: char, pos: u16 },
 }
 
 #[cfg(test)]

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -15,6 +15,7 @@ use helix_vcs::DiffProviderRegistry;
 
 use futures_util::stream::select_all::SelectAll;
 use futures_util::{future, StreamExt};
+use helix_core::syntax::RulerConfig;
 use helix_lsp::Call;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -272,7 +273,8 @@ pub struct Config {
     pub lsp: LspConfig,
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
-    pub rulers: Vec<u16>,
+    // pub rulers: Vec<u16>,
+    pub rulers: Vec<RulerConfig>,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -15,7 +15,6 @@ use helix_vcs::DiffProviderRegistry;
 
 use futures_util::stream::select_all::SelectAll;
 use futures_util::{future, StreamExt};
-use helix_core::syntax::RulerConfig;
 use helix_lsp::Call;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -273,8 +272,12 @@ pub struct Config {
     pub lsp: LspConfig,
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
-    // pub rulers: Vec<u16>,
-    pub rulers: Vec<RulerConfig>,
+    pub rulers: Vec<u16>,
+
+    /// If set, use this character to draw the editor's rulers.
+    #[serde(rename = "ruler-char")]
+    pub ruler_char: Option<char>,
+
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
@@ -842,6 +845,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
+            ruler_char: None,
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),


### PR DESCRIPTION
This pull request adds functionality requested in #5190.

The user may specify a character that is used when rendering rulers, instead of colouring a line in the editor. The default behaviour is retained - if the user does not specify the ruler character config, the original behaviour is used. This functionality will be useful for users that want to, for example, use a box-drawing character to draw the ruler.

Please feel free to make suggestions and comments on my pull request, as it is my first time contributing to Helix. Additionally, I would like to thank the Helix project for making an awesome piece of software that has helped with my daily tasks.

## Example config:
```
[editor]
ruler = [70]
ruler-char = '│'
```

## Screenshot:
<img width="577" alt="Screen Shot 2024-01-06 at 12 12 08 pm" src="https://github.com/helix-editor/helix/assets/19375541/ceaf388a-401e-4a4d-b1d1-26a0ce7a1c21">





