### PR TITLE
feat: add hard/soft contrast for gruvbox light mode

### DIFF
--- a/runtime/themes/gruvbox_light_hard.toml
+++ b/runtime/themes/gruvbox_light_hard.toml
@@ -1,0 +1,7 @@
+# Author : Twinkle <saintwinkle@gmail.com>
+# The theme uses the gruvbox light palette with hard contrast: github.com/morhetz/gruvbox
+
+inherits = "gruvbox_light"
+
+[palette]
+bg0 = "#f9f5d7" # main background

--- a/runtime/themes/gruvbox_light_soft.toml
+++ b/runtime/themes/gruvbox_light_soft.toml
@@ -1,0 +1,7 @@
+# Author : Twinkle <saintwinkle@gmail.com>
+# The theme uses the gruvbox light palette with soft contrast: github.com/morhetz/gruvbox
+
+inherits = "gruvbox_light"
+
+[palette]
+bg0 = "#f2e5bc" # main background


### PR DESCRIPTION
This PR adds the hard & soft contrast variants of gruvbox light theme.

ref: #7139
doc: https://github.com/morhetz/gruvbox