### PR TITLE
update history of a newly focused view

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1302,8 +1302,6 @@ impl Component for EditorView {
                 cx.editor.status_msg = None;
 
                 let mode = cx.editor.mode();
-                let (view, _) = current!(cx.editor);
-                let focus = view.id;
 
                 if let Some(on_next_key) = self.on_next_key.take() {
                     // if there's a command waiting input, do that first
@@ -1385,20 +1383,16 @@ impl Component for EditorView {
                     return EventResult::Ignored(None);
                 }
 
-                // if the focused view still exists and wasn't closed
-                if cx.editor.tree.contains(focus) {
-                    let config = cx.editor.config();
-                    let mode = cx.editor.mode();
-                    let view = view_mut!(cx.editor, focus);
-                    let doc = doc_mut!(cx.editor, &view.doc);
+                let config = cx.editor.config();
+                let mode = cx.editor.mode();
+                let (view, doc) = current!(cx.editor);
 
-                    view.ensure_cursor_in_view(doc, config.scrolloff);
+                view.ensure_cursor_in_view(doc, config.scrolloff);
 
-                    // Store a history state if not in insert mode. This also takes care of
-                    // committing changes when leaving insert mode.
-                    if mode != Mode::Insert {
-                        doc.append_changes_to_history(view);
-                    }
+                // Store a history state if not in insert mode. This also takes care of
+                // committing changes when leaving insert mode.
+                if mode != Mode::Insert {
+                    doc.append_changes_to_history(view);
                 }
 
                 EventResult::Consumed(callback)


### PR DESCRIPTION
closes #9181

This change effectively reverts #3508 and #3633.
When a view is changed we must make history commits (and ensure that
the cursor is in view) for the newly focused view. Not the old view.
We already create a history commit on view change so the old view should not need them (the current solution was inadequate for that case anyway since it didn't handle multiple view changes).

These changes were originally introduced to fix mode switch hooks.
However, the mode switch hooks have been moved elsewhere so that concern
no longer applies. In particular, because modes are now editor-wide
and not per view and also because view switches now always reset the
editor back to normal mode.

I tested all the reproduction cases from back in the day and unsurprisingly all of them do not cause any panic with this change.
