### PR TITLE
Check for rename support before showing LSP rename prompt

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1421,6 +1421,16 @@ pub fn rename_symbol(cx: &mut Context) {
 
     let (view, doc) = current_ref!(cx.editor);
 
+    if doc
+        .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
+        .next()
+        .is_none()
+    {
+        cx.editor
+            .set_error("No configured language server supports symbol renaming");
+        return;
+    }
+
     let language_server_with_prepare_rename_support = doc
         .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
         .find(|ls| {


### PR DESCRIPTION
Previously we always showed the prompt even if the current document didn't have a language server that could perform a rename. For example we showed a rename prompt even when using `<space>r` in a scratch buffer.

Instead we should check the document's language servers to see if any supports a rename and bail if there are none.

This was originally https://github.com/helix-editor/helix/issues/6249 (fixed in https://github.com/helix-editor/helix/pull/6257) but regressed in https://github.com/helix-editor/helix/pull/2507