### PR TITLE
Add support for `matlab-language-server`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -101,7 +101,7 @@
 | markdoc | ✓ |  |  | `markdoc-ls` |
 | markdown | ✓ |  |  | `marksman` |
 | markdown.inline | ✓ |  |  |  |
-| matlab | ✓ | ✓ | ✓ |  |
+| matlab | ✓ | ✓ | ✓ | `matlab-language-server` |
 | mermaid | ✓ |  |  |  |
 | meson | ✓ |  | ✓ |  |
 | mint |  |  |  | `mint` |

--- a/languages.toml
+++ b/languages.toml
@@ -137,6 +137,15 @@ inlayHints.discriminantHints.enable = "fieldless"
 inlayHints.lifetimeElisionHints.enable = "skip_trivial"
 inlayHints.typeHints.hideClosureInitialization = false
 
+[language-server.matlab-ls]
+command = "matlab-language-server"
+args = ["--stdio"]
+
+[language-server.matlab-ls.config.MATLAB]
+indexWorkspace = false
+installPath = ""
+matlabConnectionTiming = "onStart"
+telemetry = true
 
 [language-server.typescript-language-server]
 command = "typescript-language-server"
@@ -2469,6 +2478,7 @@ source = { git = "https://github.com/monaqa/tree-sitter-mermaid", rev = "d787c66
 name = "matlab"
 scope = "source.m"
 file-types = ["m"]
+language-servers = ["matlab-ls"]
 comment-token = "%"
 shebangs = ["octave-cli", "matlab"]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
This is currently **UNTESTED**, as I am currently away from my Linux tower, and I cannot find an easy way to install `matlab-language-server` on Windows. I can (and will) test this when I get back to my tower, but I'm opening the PR now in case others would like to test.

Closes #9276.