### PR TITLE
Update some grammars to a commit where the license file is included

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1246,7 +1246,7 @@ file-types = ["pod"]
 
 [[grammar]]
 name = "pod"
-source = { git = "https://github.com/tree-sitter-perl/tree-sitter-pod", rev = "d466b84009a63986834498073ec05d58d727d55f" }
+source = { git = "https://github.com/tree-sitter-perl/tree-sitter-pod", rev = "39da859947b94abdee43e431368e1ae975c0a424" }
 
 [[language]]
 name = "racket"
@@ -2256,7 +2256,7 @@ grammar = "vhs"
 
 [[grammar]]
 name = "vhs"
-source = { git = "https://github.com/charmbracelet/tree-sitter-vhs", rev = "c6d81f34c011c29ee86dd73b45a8ecc9f2e2bdaf" }
+source = { git = "https://github.com/charmbracelet/tree-sitter-vhs", rev = "9534865e614c95eb9418e5e73f061c32fa4d9540" }
 
 [[language]]
 name = "kdl"
@@ -2663,7 +2663,7 @@ language-servers = [ "cs" ]
 
 [[grammar]]
 name = "smithy"
-source = { git = "https://github.com/indoorvivants/tree-sitter-smithy", rev = "cf8c7eb9faf7c7049839585eac19c94af231e6a0" }
+source = { git = "https://github.com/indoorvivants/tree-sitter-smithy", rev = "8327eb84d55639ffbe08c9dc82da7fff72a1ad07" }
 
 [[language]]
 name = "vhdl"
@@ -2914,7 +2914,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "unison"
-source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "98c4e8bc5c9f5989814a720457cf36963cf4043d" }
+source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "aaec316774c8b50d367ec7cf26523aac5ef0cfc5" }
 
 [[language]]
 name = "todotxt"

--- a/runtime/queries/pod/highlights.scm
+++ b/runtime/queries/pod/highlights.scm
@@ -7,7 +7,7 @@
 (command_paragraph
   (command) @keyword
   (#match? @keyword "^=head")
-  (content) @text.title)
+  (content) @markup.title)
 
 (command_paragraph
   (command) @keyword
@@ -17,7 +17,7 @@
 (command_paragraph
   (command) @keyword
   (#match? @keyword "^=item")
-  (content) @text)
+  (content) @markup)
 
 (command_paragraph
   (command) @keyword
@@ -29,7 +29,7 @@
   (#not-match? @keyword "^=(head|over|item|encoding)")
   (content) @string)
 
-(verbatim_paragraph (content) @text.literal)
+(verbatim_paragraph (content) @markup.raw)
 
 (interior_sequence
   (sequence_letter) @character
@@ -39,32 +39,32 @@
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "B")
-  (content) @text.strong)
+  (content) @markup.strong)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "C")
-  (content) @text.literal)
+  (content) @markup.literal)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "F")
-  (content) @text.underline @string.special)
+  (content) @markup.underline @string.special)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "I")
-  (content) @text.emphasis)
+  (content) @markup.emphasis)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "L")
-  (content) @text.uri)
+  (content) @markup.uri)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "X")
-  (content) @text.reference)
+  (content) @markup.reference)
 
 (interior_sequence
   (sequence_letter) @character

--- a/runtime/queries/pod/highlights.scm
+++ b/runtime/queries/pod/highlights.scm
@@ -6,8 +6,33 @@
 
 (command_paragraph
   (command) @keyword
-  (#match? @keyword "^=head")
-  (content) @markup.title)
+  (#eq? @keyword "=head1")
+  (content) @markup.heading.1)
+
+(command_paragraph
+  (command) @keyword
+  (#eq? @keyword "=head2")
+  (content) @markup.heading.2)
+
+(command_paragraph
+  (command) @keyword
+  (#eq? @keyword "=head3")
+  (content) @markup.heading.3)
+
+(command_paragraph
+  (command) @keyword
+  (#eq? @keyword "=head4")
+  (content) @markup.heading.4)
+
+(command_paragraph
+  (command) @keyword
+  (#eq? @keyword "=head5")
+  (content) @markup.heading.5)
+
+(command_paragraph
+  (command) @keyword
+  (#eq? @keyword "=head6")
+  (content) @markup.heading.6)
 
 (command_paragraph
   (command) @keyword
@@ -69,4 +94,4 @@
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "E")
-  (content) @string.escape)
+  (content) @string.special.escape)

--- a/runtime/queries/pod/highlights.scm
+++ b/runtime/queries/pod/highlights.scm
@@ -1,61 +1,72 @@
-[(pod_directive)
- (head_directive)
- (over_directive)
- (item_directive)
- (back_directive)
- (encoding_directive)
- (cut_directive)] @tag
+; A highlight file for nvim-treesitter to use
 
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head1")
-  (content) @markup.heading.1)
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head2")
-  (content) @markup.heading.2)
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head3")
-  (content) @markup.heading.3)
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head4")
-  (content) @markup.heading.4)
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head5")
-  (content) @markup.heading.5)
-(head_paragraph
-  (head_directive) @directive
-  (#eq? @directive "=head6")
-  (content) @markup.heading.6)
+[(pod_command)
+ (command)
+ (cut_command)] @keyword
 
-(over_paragraph (content) @constant.numeric.integer)
-(item_paragraph (content) @markup.list)
-(encoding_paragraph (content) @string)
+(command_paragraph
+  (command) @keyword
+  (#match? @keyword "^=head")
+  (content) @text.title)
 
-(verbatim_paragraph (content) @markup.raw)
+(command_paragraph
+  (command) @keyword
+  (#match? @keyword "^=over")
+  (content) @number)
 
-(interior_sequence) @tag
+(command_paragraph
+  (command) @keyword
+  (#match? @keyword "^=item")
+  (content) @text)
+
+(command_paragraph
+  (command) @keyword
+  (#match? @keyword "^=encoding")
+  (content) @string.special)
+
+(command_paragraph
+  (command) @keyword
+  (#not-match? @keyword "^=(head|over|item|encoding)")
+  (content) @string)
+
+(verbatim_paragraph (content) @text.literal)
 
 (interior_sequence
-  (sequence_letter) @letter
-  (#eq? @letter "B")
-  (content) @markup.bold)
+  (sequence_letter) @character
+  ["<" ">"] @punctuation.delimiter
+)
+
 (interior_sequence
-  (sequence_letter) @letter
-  (#eq? @letter "C")
-  (content) @markup.raw)
+  (sequence_letter) @character
+  (#eq? @character "B")
+  (content) @text.strong)
+
 (interior_sequence
-  (sequence_letter) @letter
-  (#eq? @letter "F")
-  (content) @markup.italic)
+  (sequence_letter) @character
+  (#eq? @character "C")
+  (content) @text.literal)
+
 (interior_sequence
-  (sequence_letter) @letter
-  (#eq? @letter "I")
-  (content) @markup.italic)
+  (sequence_letter) @character
+  (#eq? @character "F")
+  (content) @text.underline @string.special)
+
 (interior_sequence
-  (sequence_letter) @letter
-  (#eq? @letter "L")
-  (content) @markup.link.url)
+  (sequence_letter) @character
+  (#eq? @character "I")
+  (content) @text.emphasis)
+
+(interior_sequence
+  (sequence_letter) @character
+  (#eq? @character "L")
+  (content) @text.uri)
+
+(interior_sequence
+  (sequence_letter) @character
+  (#eq? @character "X")
+  (content) @text.reference)
+
+(interior_sequence
+  (sequence_letter) @character
+  (#eq? @character "E")
+  (content) @string.escape)

--- a/runtime/queries/pod/highlights.scm
+++ b/runtime/queries/pod/highlights.scm
@@ -12,7 +12,7 @@
 (command_paragraph
   (command) @keyword
   (#match? @keyword "^=over")
-  (content) @number)
+  (content) @constant.numeric)
 
 (command_paragraph
   (command) @keyword
@@ -32,14 +32,14 @@
 (verbatim_paragraph (content) @markup.raw)
 
 (interior_sequence
-  (sequence_letter) @character
+  (sequence_letter) @constant.character
   ["<" ">"] @punctuation.delimiter
 )
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "B")
-  (content) @markup.strong)
+  (content) @markup.bold)
 
 (interior_sequence
   (sequence_letter) @character
@@ -54,12 +54,12 @@
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "I")
-  (content) @markup.emphasis)
+  (content) @markup.bold)
 
 (interior_sequence
   (sequence_letter) @character
   (#eq? @character "L")
-  (content) @markup.uri)
+  (content) @markup.link.url)
 
 (interior_sequence
   (sequence_letter) @character

--- a/runtime/queries/unison/highlights.scm
+++ b/runtime/queries/unison/highlights.scm
@@ -63,7 +63,7 @@
 ;; Terms
 (type_signature term_name: (path)? @variable term_name: (wordy_id) @variable)
 (type_signature (wordy_id) @type)
-(type_signature (delayed (wordy_id)) @type)
+(type_signature (term_type(delayed(wordy_id))) @type)
 
 (term_definition param: (wordy_id) @variable.parameter)
 

--- a/runtime/queries/vhs/highlights.scm
+++ b/runtime/queries/vhs/highlights.scm
@@ -37,9 +37,9 @@
 
 [ "@" ] @operator
 (control) @function.macro
-(float) @float
-(integer) @number
-(comment) @comment @spell
-[(path) (string) (json)] @string
-(time) @symbol
-(boolean) @boolean
+(float) @constant.numeric.float
+(integer) @constant.numeric.integer
+(comment) @comment
+[(path) (string) (json)] @string.special.path
+(time) @string.special.symbol
+(boolean) @constant.builtin.boolean

--- a/runtime/queries/vhs/highlights.scm
+++ b/runtime/queries/vhs/highlights.scm
@@ -1,4 +1,4 @@
-[ 
+[
   "Output"
   "Backspace"
   "Down"
@@ -15,22 +15,31 @@
   "Hide"
   "Show" ] @keyword
 
-[ "FontFamily"
+[ "Shell"
+  "FontFamily"
   "FontSize"
   "Framerate"
+  "PlaybackSpeed"
   "Height"
   "LetterSpacing"
   "TypingSpeed"
   "LineHeight"
   "Padding"
   "Theme"
-  "Width" ] @type
+  "LoopOffset"
+  "Width"
+  "BorderRadius"
+  "Margin"
+  "MarginFill"
+  "WindowBar"
+  "WindowBarSize"
+  "CursorBlink" ] @type
 
 [ "@" ] @operator
 (control) @function.macro
-(float) @constant.numeric.float
-(integer) @constant.numeric.integer
-(comment) @comment
-(path) @string.special.path
-[(string) (json)] @string
-(time) @string.special.symbol
+(float) @float
+(integer) @number
+(comment) @comment @spell
+[(path) (string) (json)] @string
+(time) @symbol
+(boolean) @boolean


### PR DESCRIPTION
This is the second part of https://github.com/helix-editor/helix/pull/8691.
This PR should include all remaining grammars, that don't have license files. Except `tree-sitter-eex` because upstream seems to be dead.

I am unsure if the changes to the `scm` files are 100% OK. I'd appreciate it if someone could double check them.