### PR TITLE
Add argument to textobject in gdscript

### DIFF
--- a/runtime/queries/gdscript/textobjects.scm
+++ b/runtime/queries/gdscript/textobjects.scm
@@ -13,5 +13,7 @@
     (typed_default_parameter)  
   ] @parameter.inside @parameter.around)
 
+(arguments (_expression) @parameter.inside @parameter.around)
+
 (comment) @comment.inside
 (comment)+ @comment.around


### PR DESCRIPTION
Currently `maa` only selects parameters in a function definition.
Allow it to also select arguments inside a function call.
