### PR TITLE
Added CWD option for editor.statusline

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -162,6 +162,7 @@ where
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
         helix_view::editor::StatusLineElement::Register => render_register,
+        helix_view::editor::StatusLineElement::WorkingDirectory => render_cwd,
     }
 }
 
@@ -513,4 +514,24 @@ where
     if let Some(reg) = context.editor.selected_register {
         write(context, format!(" reg={} ", reg), None)
     }
+}
+
+fn render_cwd<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let cwd = std::env::current_dir();
+    let title: String = match cwd {
+        // Errors converting resolve to String::Default
+        Ok(path) => path
+            .iter()
+            .last()
+            .unwrap_or_default()
+            .to_owned()
+            .into_string()
+            .unwrap_or_default(),
+        Err(_) => "".into(),
+    };
+
+    write(context, title, None);
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -524,6 +524,9 @@ pub enum StatusLineElement {
 
     /// Indicator for selected register
     Register,
+
+    /// Current Working Directory
+    WorkingDirectory,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs


### PR DESCRIPTION
Closes #8966 by adding support for CWD in editor.statusline.

Config example:

```
[editor.statusline]
left = ["mode"]
center=["working-directory", "file-name"]
right = ["diagnostics", "position-percentage"]
separator = "|"
```
<img width="207" alt="Screenshot 2024-01-09 at 13 50 39" src="https://github.com/helix-editor/helix/assets/75253485/370de3cc-35f6-4ea0-b6db-2dc0c20bf065">
