### PR TITLE
Revert "build(deps): bump ahash from 0.8.6 to 0.8.7"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.19"
 arc-swap = "1"
 regex = "1"
 bitflags = "2.4"
-ahash = "0.8.7"
+ahash = "0.8.6"
 hashbrown = { version = "0.14.3", features = ["raw"] }
 dunce = "1.0"
 


### PR DESCRIPTION
Reverts helix-editor/helix#9281

Ahash 0.8.7 regressed its MSRV to 1.72 for aarch64 builds. We don't really loose much from reverting (changes are mostly relevant to rustc bootstrap) so lets fix the build for those platforms. We don't have an aarch64 CI yet hence it wasn't caught.

ref https://github.com/tkaitchuck/aHash/issues/195