### PR TITLE
languages: add CEL, SpiceDB schema language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -14,6 +14,7 @@
 | cabal |  |  |  | `haskell-language-server-wrapper` |
 | cairo | ✓ | ✓ | ✓ | `cairo-language-server` |
 | capnp | ✓ |  | ✓ |  |
+| cel | ✓ |  |  |  |
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | comment | ✓ |  |  |  |
@@ -153,6 +154,7 @@
 | smithy | ✓ |  |  | `cs` |
 | sml | ✓ |  |  |  |
 | solidity | ✓ |  |  | `solc` |
+| spicedb | ✓ |  |  |  |
 | sql | ✓ |  |  |  |
 | sshclientconfig | ✓ |  |  |  |
 | starlark | ✓ | ✓ |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -504,6 +504,18 @@ name = "cel"
 source = { git = "https://github.com/bufbuild/tree-sitter-cel", rev = "9f2b65da14c216df53933748e489db0f11121464" }
 
 [[language]]
+name = "spicedb"
+scope = "source.zed"
+injection-regex = "spicedb"
+file-types = ["zed"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "spicedb"
+source = { git = "https://github.com/jzelinskie/tree-sitter-spicedb", rev = "04ea9c294b3e20f9e3433114fa138cc20dc92770" }
+
+[[language]]
 name = "go"
 scope = "source.go"
 injection-regex = "go"

--- a/languages.toml
+++ b/languages.toml
@@ -513,7 +513,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "spicedb"
-source = { git = "https://github.com/jzelinskie/tree-sitter-spicedb", rev = "04ea9c294b3e20f9e3433114fa138cc20dc92770" }
+source = { git = "https://github.com/jzelinskie/tree-sitter-spicedb", rev = "a4e4645651f86d6684c15dfa9931b7841dc52a66" }
 
 [[language]]
 name = "go"

--- a/languages.toml
+++ b/languages.toml
@@ -492,6 +492,18 @@ name = "c-sharp"
 source = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp", rev = "5b60f99545fea00a33bbfae5be956f684c4c69e2" }
 
 [[language]]
+name = "cel"
+scope = "source.cel"
+injection-regex = "cel"
+file-types = ["cel"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "cel"
+source = { git = "https://github.com/bufbuild/tree-sitter-cel", rev = "9f2b65da14c216df53933748e489db0f11121464" }
+
+[[language]]
 name = "go"
 scope = "source.go"
 injection-regex = "go"

--- a/runtime/queries/cel/highlights.scm
+++ b/runtime/queries/cel/highlights.scm
@@ -1,0 +1,65 @@
+; Operators
+
+[
+  "-"
+  "!"
+  "*"
+  "/"
+  "&&"
+  "%"
+  "+"
+  "<"
+  "<="
+  "=="
+  ">"
+  ">="
+  "||"
+] @operator
+
+; Keywords
+
+[
+"in"
+] @keyword
+
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(member_call_expression
+  function: (identifier) @function)
+
+; Identifiers
+
+(select_expression
+  operand: (identifier) @type)
+
+(select_expression
+  operand: (select_expression
+    member: (identifier) @type))
+
+(identifier) @property
+
+; Literals
+
+[
+  (double_quote_string_literal)
+  (single_quoted_string_literal)
+  (triple_double_quote_string_literal)
+  (triple_single_quoted_string_literal)
+] @string
+
+[
+  (int_literal)
+  (uint_literal)
+  (float_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (null)
+] @constant.builtin
+
+(comment) @comment

--- a/runtime/queries/cel/highlights.scm
+++ b/runtime/queries/cel/highlights.scm
@@ -39,7 +39,7 @@
   operand: (select_expression
     member: (identifier) @type))
 
-(identifier) @property
+(identifier) @variable.other.member
 
 ; Literals
 
@@ -53,13 +53,14 @@
 [
   (int_literal)
   (uint_literal)
-  (float_literal)
-] @number
+] @constant.numeric.integer
+(float_literal) @constant.numeric.float
 
 [
   (true)
   (false)
-  (null)
-] @constant.builtin
+] @constant.builtin.boolean
+
+(null) @constant.builtin
 
 (comment) @comment

--- a/runtime/queries/spicedb/highlights.scm
+++ b/runtime/queries/spicedb/highlights.scm
@@ -40,7 +40,7 @@
 (type_identifier) @type
 (cel_type_identifier) @type
 (cel_variable_identifier) @variable.parameter
-(field_identifier) @property
+(field_identifier) @variable.other.member
 [
   (func_identifier)
   (method_identifier)

--- a/runtime/queries/spicedb/highlights.scm
+++ b/runtime/queries/spicedb/highlights.scm
@@ -1,0 +1,47 @@
+; highlights.scm
+
+[
+  "definition"
+  "caveat"
+  "permission"
+  "relation"
+  "nil"
+] @keyword
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "|"
+  "+"
+  "-"
+  "&"
+  "#"
+  "->"
+  "="
+] @operator
+("with") @keyword.operator
+
+[
+  "nil"
+  "*"
+] @constant.builtin
+
+(comment) @comment
+(type_identifier) @type
+(cel_type_identifier) @type
+(cel_variable_identifier) @variable.parameter
+(field_identifier) @property
+[
+  (func_identifier)
+  (method_identifier)
+] @function.method

--- a/runtime/queries/spicedb/injections.scm
+++ b/runtime/queries/spicedb/injections.scm
@@ -1,0 +1,5 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+((caveat_expr) @injection.content
+ (#set! injection.language "cel"))

--- a/runtime/queries/spicedb/tags.scm
+++ b/runtime/queries/spicedb/tags.scm
@@ -1,0 +1,4 @@
+(object_definition
+  name: (type_identifier) @name) @definition.type
+
+(type_identifier) @name @reference.type


### PR DESCRIPTION
CEL (Common Expression Language) is a non-Turing-Complete language created at Google for embedding into programs. It's used in a variety of projects such as Kubernetes and SpiceDB.

SpiceDB is a popular, open source authorization system inspired by the system internal at Google, Zanzibar.

This PR adds language/grammar support for both of these projects.

I'm not sure the CEL highlighting is working -- I might need some help with writing custom queries for it. The SpiceDB grammar includes queries that target Helix.