### PR TITLE
Fix export instructions in installation doc

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -216,12 +216,12 @@ RUSTFLAGS="-C target-feature=-crt-static"
 
 #### Linux and macOS
 
-The **runtime** directory is one below the Helix source, so either set a
+The **runtime** directory is one below the Helix source, so either export a
 `HELIX_RUNTIME` environment variable to point to that directory and add it to
 your `~/.bashrc` or equivalent:
 
 ```sh
-HELIX_RUNTIME=~/src/helix/runtime
+export HELIX_RUNTIME=~/src/helix/runtime
 ```
 
 Or, create a symbolic link:


### PR DESCRIPTION
I have tried to install helix from source, including following the instructions at: https://docs.helix-editor.com/install.html#configuring-helixs-runtime-files . I am on Ubuntu 22.04, and I tried to install the latest master branch.

I hit 2 issues:

- 1: if I understand well, in bash, in order to export an env variable, the ```export``` keyword is needed; otherwise, the variable is not exported to child processes, and helix does not seem to receive the env variable (inspecting the ```hx --health``` output without the ```export``` keyword, I cannot see the added path from ```HELIX_RUNTIME``` listed).

- 2: it seems that helix is not able to expand ```~```. I.e., if I use in my ```.bashrc```: ```export HELIX_RUNTIME="~/src/helix/runtime"```, I then get a not recognized path:

```sh
kzm@kzm-bpq:~$ hx --health | head -8
Config file: /home/kzm/.config/helix/config.toml
Language file: default
Log file: /home/kzm/.cache/helix/helix.log
Runtime directories: /home/kzm/.config/helix/runtime;~/src/helix/runtime;/home/kzm/.cargo/bin/runtime
Runtime directory does not exist: ~/src/helix/runtime
Runtime directory is empty: /home/kzm/.cargo/bin/runtime
Clipboard provider: wl-paste+wl-copy
System clipboard provider: wl-paste+wl-copy
```

while if I use in my ```.bashrc```: ```export HELIX_RUNTIME="${HOME}"/src/helix/runtime```, then the path is well recognized:

```
kzm@kzm-bpq:~$ hx --health | head -8
Config file: /home/kzm/.config/helix/config.toml
Language file: default
Log file: /home/kzm/.cache/helix/helix.log
Runtime directories: /home/kzm/.config/helix/runtime;/home/kzm/src/helix/runtime;/home/kzm/.cargo/bin/runtime
Runtime directory is empty: /home/kzm/.cargo/bin/runtime
Clipboard provider: wl-paste+wl-copy
System clipboard provider: wl-paste+wl-copy
```

This PR updates these 2 points.

