### PR TITLE
Select subtree within injections in `:tree-sitter-subtree`

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2117,11 +2117,7 @@ fn tree_sitter_subtree(
         let text = doc.text();
         let from = text.char_to_byte(primary_selection.from());
         let to = text.char_to_byte(primary_selection.to());
-        if let Some(selected_node) = syntax
-            .tree()
-            .root_node()
-            .descendant_for_byte_range(from, to)
-        {
+        if let Some(selected_node) = syntax.descendant_for_byte_range(from, to) {
             let mut contents = String::from("```tsq\n");
             helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
             contents.push_str("\n```");


### PR DESCRIPTION
`:tree-sitter-subtree` could previously only print subtrees of nodes in the root injection layer. We can improve on that by finding the layer that contains the given byte range and printing the subtree within that layer. That gives more useful results when a selection is within an injection layer.

For example in a markdown file:

```markdown
One

<h1>
<div>
<p>Foo</p>
</div>

Two

<div>
<p>Bar</p>
</div>
</h1>

Three
```

Selecting the overall document will show the root layer's subtree while selecting a part within the injections like `<p>Foo</p>` will show that subtree within the HTML layer. This works even with combined injections, for example selecting around the `h1` tags.