### PR TITLE
Add  command to open a popup as a new buffer

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1121,7 +1121,7 @@ fn goto_next_paragraph(cx: &mut Context) {
     goto_para_impl(cx, movement::move_next_paragraph)
 }
 
-fn goto_file_start(cx: &mut Context) {
+pub fn goto_file_start(cx: &mut Context) {
     if cx.count.is_some() {
         goto_line(cx);
     } else {
@@ -3231,7 +3231,7 @@ fn normal_mode(cx: &mut Context) {
 }
 
 // Store a jump on the jumplist.
-fn push_jump(view: &mut View, doc: &Document) {
+pub fn push_jump(view: &mut View, doc: &Document) {
     let jump = (doc.id(), doc.selection(view.id).clone());
     view.jumps.push(jump);
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4065,13 +4065,13 @@ fn yank_main_selection_to_primary_clipboard(cx: &mut Context) {
 }
 
 #[derive(Copy, Clone)]
-enum Paste {
+pub enum Paste {
     Before,
     After,
     Cursor,
 }
 
-fn paste_impl(
+pub fn paste_impl(
     values: &[String],
     doc: &mut Document,
     view: &mut View,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1326,7 +1326,8 @@ pub fn hover(cx: &mut Context) {
                 // skip if contents empty
 
                 let strings_content = StringsContent {
-                    title: "hover hello".into(),
+                    // TODO: how to get the symbol name?
+                    title: "hover".into(),
                     body: contents.clone(),
                     language: "markdown".into(),
                 };

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -32,8 +32,8 @@ use crate::{
     compositor::{self, Compositor},
     job::Callback,
     ui::{
-        self, lsp::SignatureHelp, overlay::overlaid, DynamicPicker, FileLocation, Picker, Popup,
-        PromptEvent,
+        self, lsp::SignatureHelp, overlay::overlaid, popup::StringsContent, DynamicPicker,
+        FileLocation, Picker, Popup, PromptEvent,
     },
 };
 
@@ -1251,10 +1251,17 @@ pub fn signature_help_impl_with_future(
             contents.set_active_param_range(active_param_range());
 
             let old_popup = compositor.find_id::<Popup<SignatureHelp>>(SignatureHelp::ID);
-            let mut popup = Popup::new(SignatureHelp::ID, contents)
-                .position(old_popup.and_then(|p| p.get_position()))
-                .position_bias(Open::Above)
-                .ignore_escape_key(true);
+            // TODO: add the extra content here to allow opening
+            let strings_content = StringsContent {
+                title: "helloo".into(),
+                body: "helloo".into(),
+                language: "helloo".into(),
+            };
+            let mut popup =
+                Popup::new_with_contents_as_strings(SignatureHelp::ID, contents, strings_content)
+                    .position(old_popup.and_then(|p| p.get_position()))
+                    .position_bias(Open::Above)
+                    .ignore_escape_key(true);
 
             // Don't create a popup if it intersects the auto-complete menu.
             let size = compositor.size();
@@ -1318,8 +1325,15 @@ pub fn hover(cx: &mut Context) {
 
                 // skip if contents empty
 
+                let strings_content = StringsContent {
+                    title: "hover hello".into(),
+                    body: contents.clone(),
+                    language: "markdown".into(),
+                };
+
                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
-                let popup = Popup::new("hover", contents).auto_close(true);
+                let popup = Popup::new_with_contents_as_strings("hover", contents, strings_content)
+                    .auto_close(true);
                 compositor.replace_or_push("hover", popup);
             }
         },

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -264,7 +264,7 @@ impl<T: Component> Component for Popup<T> {
                 // put the content in the new buffer
                 let (view, doc) = current!(cx.editor);
                 paste_impl(
-                    &[stringified_body.into()],
+                    &[stringified_body],
                     doc,
                     view,
                     Paste::Before,
@@ -281,7 +281,7 @@ impl<T: Component> Component for Popup<T> {
                 // put a meaningful title
                 // TODO: get a meaningful buffer title
                 let stringified_buffername = Some(Path::new(&stringified_buffername));
-                doc.set_path(stringified_buffername.into());
+                doc.set_path(stringified_buffername);
 
                 // TODO: put a meaningful coloring scheme...
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -1,4 +1,5 @@
 use crate::{
+    commands::push_jump,
     commands::Open,
     compositor::{Callback, Component, Context, Event, EventResult},
     ctrl, key,
@@ -10,6 +11,7 @@ use tui::{
 
 use helix_core::Position;
 use helix_view::{
+    document::Mode,
     editor::Action,
     graphics::{Margin, Rect},
     Editor,
@@ -278,17 +280,23 @@ impl<T: Component> Component for Popup<T> {
                 )
                 .unwrap();
 
+                let text = doc.text().slice(..);
+                let selection = doc
+                    .selection(view.id)
+                    .clone()
+                    .transform(|range| range.put_cursor(text, 0, cx.editor.mode == Mode::Select));
+                push_jump(view, doc);
+                doc.set_selection(view.id, selection);
+
                 // put a meaningful title
                 // TODO: get a meaningful buffer title
                 let stringified_buffername = Some(Path::new(&stringified_buffername));
                 doc.set_path(stringified_buffername);
 
-                // TODO: put a meaningful coloring scheme...
-
                 // pretend that this buffer is up to date and has no changes: allow to just :bc when finished exporing, no need to :bc!, and no saving to disk happening after browsing around
                 doc.set_last_saved_revision(1);
                 // make readonly
-                // TODO: this does not work, why?
+                // TODO: this does not make really readonly from helix viewpoint, why?
                 doc.readonly = true;
 
                 // close the popup since we just opened it in a new buffer


### PR DESCRIPTION
closes #8748 

The idea is to make it possible to press ```ctrl-o``` to open the popup content in a new buffer. Once this work, I can easily add ```ctrl-h``` and ```ctrl-v``` to open in horizontal and vertical splits :) .

This is still an early WIP; what remains to be done:

- create the new buffer as read only to avoid the need to use ! to exit etc
- find how to grab the content of the popup to put it into the new buffer
- find how to grab a meaningful title for the popup to put it as the new buffer title
- find how to enable the correct coloring of the new buffer

I will look into this more in the days to come :) .