### PR TITLE
Remove sourcehut tree-sitter grammars from default build

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1,6 +1,8 @@
 # Language support configuration.
 # See the languages documentation: https://docs.helix-editor.com/master/languages.html
 
+use-grammars = { except = [ "hare", "wren", "gemini" ] }
+
 [language-server]
 
 als = { command = "als" }


### PR DESCRIPTION
Sourcehut has outages occasionally that cause the CI and from-source builds to fail. It also doesn't setup redirects when a user renames themselves, so if a user that publishes a tree-sitter grammar we use changes their sourcehut name then it breaks the build and any prior builds using that grammar.

For now let's remove them from the default build. It's a bandaid over a larger reliability and trust problem with the grammar repositories but it should fix the build for now.