### PR TITLE
Bump tree-sitter to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.10"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=ab09ae20d640711174b8da8a654f6b3dec93da1a#ab09ae20d640711174b8da8a654f6b3dec93da1a"
+source = "git+https://github.com/helix-editor/tree-sitter?rev=660481dbf71413eba5a928b0b0ab8da50c1109e0#660481dbf71413eba5a928b0b0ab8da50c1109e0"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
 [workspace.dependencies]
-tree-sitter = { version = "0.20", git = "https://github.com/tree-sitter/tree-sitter", rev = "ab09ae20d640711174b8da8a654f6b3dec93da1a" }
+tree-sitter = { version = "0.20", git = "https://github.com/helix-editor/tree-sitter", rev = "660481dbf71413eba5a928b0b0ab8da50c1109e0" }
 nucleo = "0.2.0"
 
 [workspace.package]

--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -315,6 +315,10 @@ The first argument (a capture) must/must not be equal to the second argument
 The first argument (a capture) must/must not match the regex given in the
 second argument (a string).
 
+- `#any-of?`/`#not-any-of?`:
+The first argument (a capture) must/must not be one of the other arguments
+(strings).
+
 Additionally, we support some custom predicates for indent queries:
 
 - `#not-kind-eq?`:

--- a/book/src/guides/injection.md
+++ b/book/src/guides/injection.md
@@ -54,4 +54,7 @@ The first argument (a capture) must be equal to the second argument
 The first argument (a capture) must match the regex given in the
 second argument (a string).
 
+- `#any-of?` (standard):
+The first argument (a capture) must be one of the other arguments (strings).
+
 [upstream-docs]: http://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -551,7 +551,7 @@ fn query_indents<'a>(
         // The row/column position of the optional anchor in this query
         let mut anchor: Option<tree_sitter::Node> = None;
         for capture in m.captures {
-            let capture_name = query.capture_names()[capture.index as usize].as_str();
+            let capture_name = query.capture_names()[capture.index as usize];
             let capture_type = match capture_name {
                 "indent" => IndentCaptureType::Indent,
                 "indent.always" => IndentCaptureType::IndentAlways,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1727,7 +1727,7 @@ impl HighlightConfiguration {
         let mut local_scope_capture_index = None;
         for (i, name) in query.capture_names().iter().enumerate() {
             let i = Some(i as u32);
-            match name.as_str() {
+            match *name {
                 "local.definition" => local_def_capture_index = i,
                 "local.definition-value" => local_def_value_capture_index = i,
                 "local.reference" => local_ref_capture_index = i,
@@ -1738,7 +1738,7 @@ impl HighlightConfiguration {
 
         for (i, name) in injections_query.capture_names().iter().enumerate() {
             let i = Some(i as u32);
-            match name.as_str() {
+            match *name {
                 "injection.content" => injection_content_capture_index = i,
                 "injection.language" => injection_language_capture_index = i,
                 "injection.filename" => injection_filename_capture_index = i,
@@ -1768,7 +1768,7 @@ impl HighlightConfiguration {
     }
 
     /// Get a slice containing all of the highlight names used in the configuration.
-    pub fn names(&self) -> &[String] {
+    pub fn names(&self) -> &[&str] {
         self.query.capture_names()
     }
 

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -41,7 +41,7 @@
 (capture) @label
 
 ((predicate_name) @function
- (#match? @function "^#(eq\\?|match\\?|is\\?|is-not\\?|not-same-line\\?|not-kind-eq\\?|set!|select-adjacent!|strip!)$"))
+ (#any-of? @function "#eq?" "#match?" "#any-of?" "#not-any-of?" "#is?" "#is-not?" "#not-same-line?" "#not-kind-eq?" "#set!" "#select-adjacent!" "#strip!"))
 (predicate_name) @error
 
 (escape_sequence) @constant.character.escape


### PR DESCRIPTION
* query capture names now return `&str`s rather than `String`s
* the `#any-of?` predicate is now supported

I've also switched to our fork after fast-forwarding it to the latest master. The plan will be to publish a release to Cargo of our tree-sitter fork (with no changes to the library) right before the next Helix release.