### PR TITLE
Make nix flake respect unused grammars

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -28,7 +28,8 @@
     owner = builtins.elemAt match 0;
     repo = builtins.elemAt match 1;
   };
-  grammarsToUse = builtins.filter (grammar: !(builtins.elem grammar.name (languagesConfig.use-grammars.except or []))) languagesConfig.grammar;
+  useGrammar = grammar: !(builtins.elem grammar.name (languagesConfig.use-grammars.except or []));
+  grammarsToUse = builtins.filter useGrammar languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
   buildGrammar = grammar: let
     gh = toGitHubFetcher grammar.source.git;

--- a/grammars.nix
+++ b/grammars.nix
@@ -28,7 +28,7 @@
     owner = builtins.elemAt match 0;
     repo = builtins.elemAt match 1;
   };
-  grammarsToUse = builtins.filter (grammar: !(builtins.elem grammar.name languagesConfig.use-grammars.except)) languagesConfig.grammar;
+  grammarsToUse = builtins.filter (grammar: !(builtins.elem grammar.name (languagesConfig.use-grammars.except or []))) languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
   buildGrammar = grammar: let
     gh = toGitHubFetcher grammar.source.git;

--- a/grammars.nix
+++ b/grammars.nix
@@ -28,7 +28,15 @@
     owner = builtins.elemAt match 0;
     repo = builtins.elemAt match 1;
   };
-  useGrammar = grammar: !(builtins.elem grammar.name (languagesConfig.use-grammars.except or []));
+  # If `use-grammars.only` is set, use only those grammars.
+  # If `use-grammars.except` is set, use all other grammars.
+  # Otherwise use all grammars.
+  useGrammar = grammar:
+    if languagesConfig?use-grammars.only then
+      builtins.elem grammar.name languagesConfig.use-grammars.only
+    else if languagesConfig?use-grammars.except then
+      !(builtins.elem grammar.name languagesConfig.use-grammars.except)
+    else true;
   grammarsToUse = builtins.filter useGrammar languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
   buildGrammar = grammar: let

--- a/grammars.nix
+++ b/grammars.nix
@@ -28,7 +28,8 @@
     owner = builtins.elemAt match 0;
     repo = builtins.elemAt match 1;
   };
-  gitGrammars = builtins.filter isGitGrammar languagesConfig.grammar;
+  grammarsToUse = builtins.filter (grammar: !(builtins.elem grammar.name languagesConfig.use-grammars.except)) languagesConfig.grammar;
+  gitGrammars = builtins.filter isGitGrammar grammarsToUse;
   buildGrammar = grammar: let
     gh = toGitHubFetcher grammar.source.git;
     sourceGit = builtins.fetchTree {


### PR DESCRIPTION
https://github.com/helix-editor/helix/commit/17dd102e5cccbb2a9a0f0224af63e52f3dab846b marked some grammars as "do not use", but the nix flake doesn't respect this setting. This is my attempt to rectify this situation.