### PR TITLE
Exit a language server if it sends a message with invalid json

### DIFF
--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -302,7 +302,7 @@ impl Transport {
                 }
                 Err(err) => {
                     error!("{} err: <- {err:?}", transport.name);
-                    break;
+                    continue;
                 }
             }
         }

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -309,7 +309,10 @@ impl Transport {
                     break;
                 }
                 Err(err) => {
-                    error!("Unexpected error when processing message from {}. Closing language server. err: <- {err:?}", &transport.name);
+                    error!(
+                        "Closing {} after unexpected error: {err:?}",
+                        &transport.name
+                    );
                     close_language_server(&transport, &client_tx).await;
                     break;
                 }

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -253,8 +253,6 @@ impl Transport {
         mut server_stdout: BufReader<ChildStdout>,
         client_tx: UnboundedSender<(usize, jsonrpc::Call)>,
     ) {
-        let mut recv_buffer = String::new();
-
         async fn close_language_server(
             transport: &Arc<Transport>,
             client_tx: &UnboundedSender<(usize, crate::Call)>,
@@ -287,6 +285,8 @@ impl Transport {
                 }
             }
         }
+
+        let mut recv_buffer = String::new();
 
         loop {
             match Self::recv_server_message(&mut server_stdout, &mut recv_buffer, &transport.name)

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -287,7 +287,6 @@ impl Transport {
         }
 
         let mut recv_buffer = String::new();
-
         loop {
             match Self::recv_server_message(&mut server_stdout, &mut recv_buffer, &transport.name)
                 .await

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -253,7 +253,7 @@ impl Transport {
         mut server_stdout: BufReader<ChildStdout>,
         client_tx: UnboundedSender<(usize, jsonrpc::Call)>,
     ) {
-        async fn close_language_server(
+        async fn exit_language_server(
             transport: &Arc<Transport>,
             client_tx: &UnboundedSender<(usize, crate::Call)>,
         ) {
@@ -305,15 +305,15 @@ impl Transport {
                     };
                 }
                 Err(Error::StreamClosed) => {
-                    close_language_server(&transport, &client_tx).await;
+                    exit_language_server(&transport, &client_tx).await;
                     break;
                 }
                 Err(err) => {
                     error!(
-                        "Closing {} after unexpected error: {err:?}",
+                        "Exiting {} after unexpected error: {err:?}",
                         &transport.name
                     );
-                    close_language_server(&transport, &client_tx).await;
+                    exit_language_server(&transport, &client_tx).await;
                     break;
                 }
             }

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -271,38 +271,13 @@ impl Transport {
                     };
                 }
                 Err(Error::StreamClosed) => {
-                    // Close any outstanding requests.
-                    for (id, tx) in transport.pending_requests.lock().await.drain() {
-                        match tx.send(Err(Error::StreamClosed)).await {
-                            Ok(_) => (),
-                            Err(_) => {
-                                error!("Could not close request on a closed channel (id={:?})", id)
-                            }
-                        }
-                    }
-
-                    // Hack: inject a terminated notification so we trigger code that needs to happen after exit
-                    use lsp_types::notification::Notification as _;
-                    let notification =
-                        ServerMessage::Call(jsonrpc::Call::Notification(jsonrpc::Notification {
-                            jsonrpc: None,
-                            method: lsp_types::notification::Exit::METHOD.to_string(),
-                            params: jsonrpc::Params::None,
-                        }));
-                    match transport
-                        .process_server_message(&client_tx, notification, &transport.name)
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(err) => {
-                            error!("err: <- {:?}", err);
-                        }
-                    }
+                    close_language_server(&transport, &client_tx).await;
                     break;
                 }
                 Err(err) => {
-                    error!("{} err: <- {err:?}", transport.name);
-                    continue;
+                    error!("Unexpected error when processing message from {}. Closing language server. err: <- {err:?}", &transport.name);
+                    close_language_server(&transport, &client_tx).await;
+                    break;
                 }
             }
         }
@@ -421,6 +396,38 @@ impl Transport {
                     }
                 }
             }
+        }
+    }
+}
+
+async fn close_language_server(
+    transport: &Arc<Transport>,
+    client_tx: &UnboundedSender<(usize, crate::Call)>,
+) {
+    // Close any outstanding requests.
+    for (id, tx) in transport.pending_requests.lock().await.drain() {
+        match tx.send(Err(Error::StreamClosed)).await {
+            Ok(_) => (),
+            Err(_) => {
+                error!("Could not close request on a closed channel (id={:?})", id)
+            }
+        }
+    }
+
+    // Hack: inject a terminated notification so we trigger code that needs to happen after exit
+    use lsp_types::notification::Notification as _;
+    let notification = ServerMessage::Call(jsonrpc::Call::Notification(jsonrpc::Notification {
+        jsonrpc: None,
+        method: lsp_types::notification::Exit::METHOD.to_string(),
+        params: jsonrpc::Params::None,
+    }));
+    match transport
+        .process_server_message(client_tx, notification, &transport.name)
+        .await
+    {
+        Ok(_) => {}
+        Err(err) => {
+            error!("err: <- {:?}", err);
         }
     }
 }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -677,7 +677,7 @@ impl Application {
                     Ok(notification) => notification,
                     Err(err) => {
                         log::info!(
-                            "received malformed notification from Language Server: {}",
+                            "Ignoring unknown notification from Language Server: {}",
                             err
                         );
                         return;

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -676,7 +676,7 @@ impl Application {
                 let notification = match Notification::parse(&method, params) {
                     Ok(notification) => notification,
                     Err(err) => {
-                        log::error!(
+                        log::info!(
                             "received malformed notification from Language Server: {}",
                             err
                         );

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -33,7 +33,7 @@ use crate::{
     ui::{self, overlay::overlaid},
 };
 
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 #[cfg(not(feature = "integration"))]
 use std::io::stdout;
 use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
@@ -675,8 +675,12 @@ impl Application {
             Call::Notification(helix_lsp::jsonrpc::Notification { method, params, .. }) => {
                 let notification = match Notification::parse(&method, params) {
                     Ok(notification) => notification,
+                    Err(helix_lsp::Error::Unhandled) => {
+                        info!("Ignoring Unhandled notification from Language Server");
+                        return;
+                    }
                     Err(err) => {
-                        log::info!(
+                        error!(
                             "Ignoring unknown notification from Language Server: {}",
                             err
                         );


### PR DESCRIPTION
I've been struggling to get c# + omnisharp working reliably with helix. Omnisharp [occasionally sends messages with malformed json](https://github.com/OmniSharp/omnisharp-roslyn/issues/2594), which causes the helix LSP event listener thread to die. After this happens, the LSP functionality within helix no longer works, even though omnisharp is still up and running. If I try to close helix at this point, it hangs for a bit and writes an lsp shutdown timeout log. If I run `:lsp-restart`, a second instance of omnisharp is started, leaving the first one running in the background.

This PR updates the recv function in helix-lsp::transport to request that an LSP is exited after it sends a message that cannot be parsed. This causes the `Language server exited` message to be displayed in the status bar within the editor. Surprisingly, the omnisharp process is still running at this point. Despite that, exiting helix is quick and running `:lsp-restart` restarts the process as expected.

Additionally, I updated some logging that caused confusion as I was troubleshooting.