### PR TITLE
fix crashes in match bracket code

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -141,7 +141,7 @@ fn find_pair(
 #[must_use]
 pub fn find_matching_bracket_plaintext(doc: RopeSlice, cursor_pos: usize) -> Option<usize> {
     // Don't do anything when the cursor is not on top of a bracket.
-    let bracket = doc.char(cursor_pos);
+    let bracket = doc.get_char(cursor_pos)?;
     if !is_valid_bracket(bracket) {
         return None;
     }
@@ -264,6 +264,12 @@ fn as_char(doc: RopeSlice, node: &Node) -> Option<(usize, char)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn find_matching_bracket_empty_file() {
+        let actual = find_matching_bracket_plaintext("".into(), 0);
+        assert_eq!(actual, None);
+    }
 
     #[test]
     fn test_find_matching_bracket_current_line_plaintext() {

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -60,7 +60,7 @@ fn find_pair(
     let tree = syntax.tree();
     let pos = doc.char_to_byte(pos_);
 
-    let mut node = tree.root_node().descendant_for_byte_range(pos, pos)?;
+    let mut node = tree.root_node().descendant_for_byte_range(pos, pos + 1)?;
 
     loop {
         if node.is_named() {
@@ -118,7 +118,9 @@ fn find_pair(
         };
         node = parent;
     }
-    let node = tree.root_node().named_descendant_for_byte_range(pos, pos)?;
+    let node = tree
+        .root_node()
+        .named_descendant_for_byte_range(pos, pos + 1)?;
     if node.child_count() != 0 {
         return None;
     }


### PR DESCRIPTION
fixes #9327

This crash was caused by two (if you count upstream 3) separate bugs:
* the TS match bracket code would try to perform plaintext matching on empty nodes if there were any at the cursor
* the plaintext bracket matching code crashes when used at the eof character (always for empty files)

Fixing the first bug alone is not enough to fix the crash since TS produces only an error node at (0, 0) and apparently if there is no node within the requested subrange TS returns the original range (I consider this a bug in TS but maybe its intentional?).  for now I simply request a range with at least a byte length of 1 (TS doesn't care about codepoint alignment) to avoid empty nodes messing with plaintext bracket matching. The TS bug doesn't matter too much since the rest of the code now handles empty ranges correctly. 

It was neccessary to fix the second bug anyway since that can lead to crashes when pressing `mm` at the eof char. 
