### PR TITLE
highlight(scala): highlight abstract methods in traits and classes

### DIFF
--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -57,13 +57,21 @@
 
 (class_definition
   body: (template_body
-    (function_definition
-      name: (identifier) @function.method)))
-(object_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @function.method)))
+    [
+      (function_definition
+        name: (identifier) @function.method)
+      (function_declaration
+        name: (identifier) @function.method)
+    ]))
 (trait_definition
+  body: (template_body
+    [
+      (function_definition
+        name: (identifier) @function.method)
+      (function_declaration
+        name: (identifier) @function.method)
+    ]))
+(object_definition
   body: (template_body
     (function_definition
       name: (identifier) @function.method)))


### PR DESCRIPTION
Updates Scala queries to highlight abstract methods in traits and abstract classes.

Currently they are highlighted differently:
<img width="157" alt="before" src="https://github.com/helix-editor/helix/assets/36770267/969a40bf-cae5-4e5c-afde-0d5d54fd9131">

Updated queries highlight them equally:
<img width="158" alt="after" src="https://github.com/helix-editor/helix/assets/36770267/cd606314-f8c6-4612-a376-b4c7ed0c423a">