### PR TITLE
Update Scala tree-sitter grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1393,7 +1393,7 @@ language-servers = [ "metals" ]
 
 [[grammar]]
 name = "scala"
-source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "23d21310fe4ab4b3273e7a6810e781224a3e7fe1" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "7891815f42dca9ed6aeb464c2edc39d479ab965c" }
 
 [[language]]
 name = "dockerfile"

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -263,7 +263,7 @@
 
 "return" @keyword.control.return
 
-(comment) @comment
+[(comment) (block_comment)] @comment
 
 ;; `case` is a conditional keyword in case_block
 

--- a/runtime/queries/scala/textobjects.scm
+++ b/runtime/queries/scala/textobjects.scm
@@ -51,8 +51,8 @@
 
 ; Comment queries
 
-(comment) @comment.inside
-(comment) @comment.around ; Does not match consecutive block comments
+[(comment) (block_comment)] @comment.inside
+[(comment) (block_comment)] @comment.around ; Does not match consecutive block comments
 
 
 ; Test queries


### PR DESCRIPTION
Updates Scala grammar to the [latest commit in master](https://github.com/tree-sitter/tree-sitter-scala/tree/7891815f42dca9ed6aeb464c2edc39d479ab965c).

I verified quickly that everything seems still working.

Fixes multiple things, at least:
- Scala 3 [braceless](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html) try-catch highlighting in one-liner catch clause
- Enables text object queries for block lambdas and Scala 3 [fewer braces](https://docs.scala-lang.org/sips/fewer-braces.html) lambdas
- Highlights scala-cli [using directives](https://scala-cli.virtuslab.org/docs/reference/directives/)