### PR TITLE
Handle failure when enabling bracketed paste

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -131,12 +131,22 @@ where
 {
     fn claim(&mut self, config: Config) -> io::Result<()> {
         terminal::enable_raw_mode()?;
-        execute!(
+        match execute!(
             self.buffer,
             terminal::EnterAlternateScreen,
             EnableBracketedPaste,
             EnableFocusChange
-        )?;
+        ) {
+            Ok(_) => {}
+            Err(e) => match e.kind() {
+                io::ErrorKind::Unsupported => {
+                    log::error!("Bracketed paste is not supported on this terminal.")
+                }
+                _ => {
+                    return Err(e);
+                }
+            },
+        };
         execute!(self.buffer, terminal::Clear(terminal::ClearType::All))?;
         if config.enable_mouse_capture {
             execute!(self.buffer, EnableMouseCapture)?;

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -206,12 +206,8 @@ where
         // disable without calling enable previously
         let _ = execute!(stdout, DisableMouseCapture);
         let _ = execute!(stdout, PopKeyboardEnhancementFlags);
-        execute!(
-            stdout,
-            DisableBracketedPaste,
-            DisableFocusChange,
-            terminal::LeaveAlternateScreen
-        )?;
+        let _ = execute!(stdout, DisableBracketedPaste);
+        execute!(stdout, DisableFocusChange, terminal::LeaveAlternateScreen)?;
         terminal::disable_raw_mode()
     }
 

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -186,9 +186,11 @@ where
         if self.supports_keyboard_enhancement_protocol() {
             execute!(self.buffer, PopKeyboardEnhancementFlags)?;
         }
+        if self.supports_bracketed_paste {
+            execute!(self.buffer, DisableBracketedPaste,)?;
+        }
         execute!(
             self.buffer,
-            DisableBracketedPaste,
             DisableFocusChange,
             terminal::LeaveAlternateScreen
         )?;


### PR DESCRIPTION
match statement instead of crash for https://github.com/helix-editor/helix/issues/9336