### PR TITLE
update tempfile dev-dependency to 3.9

### DIFF
--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -55,4 +55,4 @@ parking_lot = "0.12"
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }
 indoc = "2.0.4"
-tempfile = "3.7.0"
+tempfile = "3.9"


### PR DESCRIPTION
We use `3.9` already in our dependency tree