### PR TITLE
Support PureScript's new spago.yaml configs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1119,7 +1119,7 @@ name = "purescript"
 scope = "source.purescript"
 injection-regex = "purescript"
 file-types = ["purs"]
-roots = ["spago.dhall", "bower.json"]
+roots = ["spago.yaml", "spago.dhall", "bower.json"]
 comment-token = "--"
 language-servers = [ "purescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
[PureScript's rewritten package manager / build system, spago@next](https://discourse.purescript.org/t/announcing-spago-next-a-purescript-rewrite-registry-support-and-more/3737), has moved from `spago.dhall` to `spago.yaml` config files.

When [purescript-language-server](https://github.com/nwolverson/purescript-language-server) is launched in a directory that does not appear to be a PureScript (spago) project, it tries to ask the user to resolve this issue. [In Helix, this causes purescript-language-server to exit immediately](https://github.com/helix-editor/helix/pull/5492):

```
2024-01-16T22:47:18.699 helix_lsp::transport [ERROR] purescript-language-server err <- "ResponseError: Method not found: window/showMessageRequest\n"
```

This change adds support for new `spago.yaml` config files as PureScript project roots, which enables purescript-language-server to launch without issue for spago@next projects.
