### PR TITLE
Fixed look of inlay hints in sonokai theme

### DIFF
--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -72,6 +72,7 @@
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.virtual.whitespace" = { fg = "grey_dim" }
 "ui.virtual.ruler" = { bg = "grey_dim" }
+"ui.virtual.inlay-hint" = { fg = "grey_dim" }
 
 info = { fg = 'green', bg = 'bg2' }
 hint = { fg = 'blue', bg = 'bg2', modifiers = ['bold'] }


### PR DESCRIPTION
Added `"ui.virtual.whitespace" = { fg = "grey_dim" }` line