### PR TITLE
Fix error message shown for goto references

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1066,11 +1066,13 @@ where
 
     cx.callback(
         future,
-        move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| match to_locations(
-            response,
-        ) {
-            items if items.is_empty() => editor.set_error("No definition found."),
-            items => goto_impl(editor, compositor, items, offset_encoding),
+        move |editor, compositor, response: Option<lsp::GotoDefinitionResponse>| {
+            let items = to_locations(response);
+            if items.is_empty() {
+                editor.set_error("No definition found.");
+            } else {
+                goto_impl(editor, compositor, items, offset_encoding);
+            }
         },
     );
 }
@@ -1128,11 +1130,13 @@ pub fn goto_reference(cx: &mut Context) {
 
     cx.callback(
         future,
-        move |editor, compositor, response: Option<Vec<lsp::Location>>| match response
-            .unwrap_or_default()
-        {
-            items if items.is_empty() => editor.set_error("No references found."),
-            items => goto_impl(editor, compositor, items, offset_encoding),
+        move |editor, compositor, response: Option<Vec<lsp::Location>>| {
+            let items = response.unwrap_or_default();
+            if items.is_empty() {
+                editor.set_error("No references found.");
+            } else {
+                goto_impl(editor, compositor, items, offset_encoding);
+            }
         },
     );
 }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1011,6 +1011,7 @@ pub fn apply_workspace_edit(
     Ok(())
 }
 
+/// Precondition: `locations` should be non-empty.
 fn goto_impl(
     editor: &mut Editor,
     compositor: &mut Compositor,
@@ -1023,10 +1024,7 @@ fn goto_impl(
         [location] => {
             jump_to_location(editor, location, offset_encoding, Action::Replace);
         }
-        // XXX: All call sites pass non empty containers. This pattern is redundant.
-        [] => {
-            editor.set_error("No results found.");
-        }
+        [] => unreachable!("`locations` should be non-empty for `goto_impl`"),
         _locations => {
             let picker = Picker::new(locations, cwdir, move |cx, location, action| {
                 jump_to_location(cx.editor, location, offset_encoding, action)


### PR DESCRIPTION
When a symbol with no references is <kbd>g</kbd><kbd>r</kbd>'d on, the message shown is `No definition found.` Make it `No references found.`

Achieves this by introducing empty container checks at call sites rendering one of the patterns redundant. Another possible solution is to pass the error message as another argument.