### PR TITLE
highlighting: Gate multiple captures behind `#is-not? local` predicates

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2306,6 +2306,7 @@ impl<'a> Iterator for HighlightIter<'a> {
             // highlighting patterns that are disabled for local variables.
             if definition_highlight.is_some() || reference_highlight.is_some() {
                 while layer.config.non_local_variable_patterns[match_.pattern_index] {
+                    match_.remove();
                     if let Some((next_match, next_capture_index)) = captures.peek() {
                         let next_capture = next_match.captures[*next_capture_index];
                         if next_capture.node == capture.node {


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/tree-sitter-gleam/issues/81

This is a part of https://github.com/tree-sitter/tree-sitter/pull/1602 - I forgot to make this change to Helix after making it to tree-sitter-cli. If you have a pattern that has multiple captures and uses the `#is-not? local` predicate:

```scm
; runtime/queries/gleam/highlights.scm
((field_access
  record: (identifier) @namespace
  field: (label) @function)
 (#is-not? local))
```

the entire pattern should not apply if the `@namespace` (i.e. the first) capture is not defined locally. To do that we need to remove the match so that the captures iterator doesn't return the remaining captures from the match in the future.