### PR TITLE
bash, make, css: highlight and indent queries improvement

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,7 +21,7 @@
 | cpon | ✓ |  | ✓ |  |
 | cpp | ✓ | ✓ | ✓ | `clangd` |
 | crystal | ✓ | ✓ |  | `crystalline` |
-| css | ✓ |  |  | `vscode-css-language-server` |
+| css | ✓ |  | ✓ | `vscode-css-language-server` |
 | cue | ✓ |  |  | `cuelsp` |
 | d | ✓ | ✓ | ✓ | `serve-d` |
 | dart | ✓ |  | ✓ | `dart` |
@@ -97,7 +97,7 @@
 | log | ✓ |  |  |  |
 | lpf | ✓ |  |  |  |
 | lua | ✓ | ✓ | ✓ | `lua-language-server` |
-| make | ✓ |  |  |  |
+| make | ✓ |  | ✓ |  |
 | markdoc | ✓ |  |  | `markdoc-ls` |
 | markdown | ✓ |  |  | `marksman` |
 | markdown.inline | ✓ |  |  |  |

--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -10,22 +10,36 @@
 (variable_name) @variable.other.member
 
 [
+  "if"
+  "then"
+  "else"
+  "elif"
+  "fi"
   "case"
+  "in"
+  "esac"
+] @keyword.control.conditional
+
+[
+  "for"
   "do"
   "done"
-  "elif"
-  "else"
-  "esac"
-  "export"
-  "fi"
-  "for"
-  "function"
-  "if"
-  "in"
-  "unset"
+  "select"
+  "until"
   "while"
-  "then"
+] @keyword.control.repeat
+
+[
+  "declare"
+  "typeset"
+  "export"
+  "readonly"
+  "local"
+  "unset"
+  "unsetenv"
 ] @keyword
+
+"function" @keyword.function
 
 (comment) @comment
 

--- a/runtime/queries/css/indents.scm
+++ b/runtime/queries/css/indents.scm
@@ -1,0 +1,7 @@
+[
+  (block)
+] @indent
+
+[
+ "}"
+] @outdent

--- a/runtime/queries/make/indents.scm
+++ b/runtime/queries/make/indents.scm
@@ -1,0 +1,8 @@
+[
+  (define_directive)
+  (rule)
+] @indent
+
+[
+  "endef"
+] @outdent


### PR DESCRIPTION
[highlights(bash): rework keywords section](https://github.com/helix-editor/helix/commit/579e55d7d45867d8e9a9738fa0c9d04abeab93e2) 

* Use more specified scope when possible for keywords like @keyword.repeat.
* Add more keywords like "local" or "unsetenv".

Limitation:
* Bash doesn't allow you to have a local variable outside of a function, so maybe we need to have better queries to not highlight the local in this case.
* If we name a function with a keyword (such as unset or local), it will use the highlight scope "keyword" instead of "function".

[indents(css, make): add basic queries](https://github.com/helix-editor/helix/commit/731dc49d1d694f03dfca180977ffc0b00d58ee7a) 

* Despite the fact that queries look simple, they improve indentation in some edge cases that helix couldn't handle correctly by default.


<details><summary>Dropped</summary>

[add ".h" extension to the C file-types](https://github.com/helix-editor/helix/commit/959dbfc2fb17233bfcaef8329142f1a499e09fd7) 

Previously, if you changed the tab-width for C but did not add ".h" to C file types, headers used Cpp's indentation (default is 2), which is undesirable.

</details>
