### PR TITLE
Fix typo in string representation of GotoReference

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -263,7 +263,7 @@ impl Display for LanguageServerFeature {
             GotoDeclaration => "goto-declaration",
             GotoDefinition => "goto-definition",
             GotoTypeDefinition => "goto-type-definition",
-            GotoReference => "goto-type-definition",
+            GotoReference => "goto-reference",
             GotoImplementation => "goto-implementation",
             SignatureHelp => "signature-help",
             Hover => "hover",


### PR DESCRIPTION
I noticed a small typo in the error message when no configured language server supports goto-reference. This pull request fixes it.