### PR TITLE
Add bufferline config for onedark & onedarker themes

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -77,6 +77,10 @@
 "ui.statusline.insert" = { fg = "light-black", bg = "green" }
 "ui.statusline.select" = { fg = "light-black", bg = "purple" }
 
+"ui.bufferline" = { fg = "light-gray", bg = "light-black" }
+"ui.bufferline.active" = { fg = "light-black", bg = "blue", underline = { color = "light-black", style = "line" } }
+"ui.bufferline.background" = { bg = "light-black" }
+
 "ui.text" = { fg = "white" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -75,6 +75,11 @@
 "ui.statusline.normal" = { fg = "light-black", bg = "purple" }
 "ui.statusline.insert" = { fg = "light-black", bg = "green" }
 "ui.statusline.select" = { fg = "light-black", bg = "cyan" }
+
+"ui.bufferline" = { fg = "light-gray", bg = "light-black" }
+"ui.bufferline.active" = { fg = "light-black", bg = "blue", underline = { color = "light-black", style = "line" } }
+"ui.bufferline.background" = { bg = "light-black" }
+
 "ui.text" = { fg = "white" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 


### PR DESCRIPTION
Highlight the active buffer more clearly in onedark and onedarker themes.

Before:
<img width="348" alt="before" src="https://github.com/helix-editor/helix/assets/36770267/056419cb-8d1a-40da-a545-e22d83c915f7">

After:
<img width="347" alt="after" src="https://github.com/helix-editor/helix/assets/36770267/64fd4c48-f214-442e-a3dd-5d2d32a6ed37">

