### PR TITLE
Add text object queries for dart

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -24,7 +24,7 @@
 | css | ✓ |  | ✓ | `vscode-css-language-server` |
 | cue | ✓ |  |  | `cuelsp` |
 | d | ✓ | ✓ | ✓ | `serve-d` |
-| dart | ✓ |  | ✓ | `dart` |
+| dart | ✓ | ✓ | ✓ | `dart` |
 | dbml | ✓ |  |  |  |
 | devicetree | ✓ |  |  |  |
 | dhall | ✓ | ✓ |  | `dhall-lsp-server` |

--- a/runtime/queries/dart/textobjects.scm
+++ b/runtime/queries/dart/textobjects.scm
@@ -61,7 +61,7 @@
 (formal_parameter_list) @parameter.around
 
 (expression_statement
-  ((identifier) @_name1 (#any-of? @_name1 "test" "testWidgets"))
+  ((identifier) @_name (#any-of? @_name "test" "testWidgets"))
   .
   (selector (argument_part (arguments . (_) . (argument) @test.inside)))
 ) @test.around

--- a/runtime/queries/dart/textobjects.scm
+++ b/runtime/queries/dart/textobjects.scm
@@ -61,10 +61,7 @@
 (formal_parameter_list) @parameter.around
 
 (expression_statement
-  [
-    ((identifier) @_name1 (#eq? @_name1 "test"))
-    ((identifier) @_name2 (#eq? @_name2 "testWidgets"))
-  ]
+  ((identifier) @_name1 (#any-of? @_name1 "test" "testWidgets"))
   .
   (selector (argument_part (arguments . (_) . (argument) @test.inside)))
 ) @test.around

--- a/runtime/queries/dart/textobjects.scm
+++ b/runtime/queries/dart/textobjects.scm
@@ -1,0 +1,71 @@
+(class_definition
+  body: (_) @class.inside) @class.around
+
+(mixin_declaration
+  (class_body) @class.inside) @class.around
+
+(extension_declaration
+  (extension_body) @class.inside) @class.around
+
+(enum_declaration
+  body: (_) @class.inside) @class.around
+
+(type_alias) @class.around
+
+(_
+  (
+    [
+      (getter_signature)
+      (setter_signature)
+      (function_signature)
+      (method_signature)
+      (constructor_signature)
+    ]
+    .
+    (function_body) @function.inside @function.around
+  )  @function.around
+)
+
+(declaration
+  [
+    (constant_constructor_signature)
+    (constructor_signature)
+    (factory_constructor_signature)
+    (redirecting_factory_constructor_signature)
+    (getter_signature)
+    (setter_signature)
+    (operator_signature)
+    (function_signature)
+  ]
+) @function.around
+
+(lambda_expression
+    body: (_) @function.inside
+) @function.around
+
+(function_expression
+    body: (_) @function.inside
+) @function.around
+
+[
+  (comment)
+  (documentation_comment)
+] @comment.inside
+
+(comment)+ @comment.around
+
+(documentation_comment)+ @comment.around
+
+(formal_parameter) @parameter.inside
+
+(formal_parameter_list) @parameter.around
+
+(expression_statement
+  [
+    ((identifier) @_name1 (#eq? @_name1 "test"))
+    ((identifier) @_name2 (#eq? @_name2 "testWidgets"))
+  ]
+  .
+  (selector (argument_part (arguments . (_) . (argument) @test.inside)))
+) @test.around
+


### PR DESCRIPTION
I added queries for text objects for dart.

To do it, I looked at what was done in queries for rust. And I looked with `:tree-sitter-scopes` and `:tree-sitter-subtree` in my dart code. I works quite well for me (and should work well for others too, unless there is parts of the grammar not covered in my dart code)

For the "test" object, I used an alternation with `#eq?` predicates, because I could not make it work with one `#any-of?` predicate (it matched any name). I don't know if I missed something and it could work, or if I missed something in my understanding and that it cannot work