### PR TITLE
fix lsp config reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ name = "helix-lsp"
 version = "23.10.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "futures-executor",
  "futures-util",
  "globset",

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -1,10 +1,11 @@
+use arc_swap::ArcSwap;
 use helix_core::{
     indent::{indent_level_for_line, treesitter_indent_for_pos, IndentStyle},
     syntax::{Configuration, Loader},
     Syntax,
 };
 use ropey::Rope;
-use std::{ops::Range, path::PathBuf, process::Command};
+use std::{ops::Range, path::PathBuf, process::Command, sync::Arc};
 
 #[test]
 fn test_treesitter_indent_rust() {
@@ -197,7 +198,12 @@ fn test_treesitter_indent(
     let indent_style = IndentStyle::from_str(&language_config.indent.as_ref().unwrap().unit);
     let highlight_config = language_config.highlight_config(&[]).unwrap();
     let text = doc.slice(..);
-    let syntax = Syntax::new(text, highlight_config, std::sync::Arc::new(loader)).unwrap();
+    let syntax = Syntax::new(
+        text,
+        highlight_config,
+        Arc::new(ArcSwap::from_pointee(loader)),
+    )
+    .unwrap();
     let indent_query = language_config.indent_query().unwrap();
 
     for i in 0..doc.len_lines() {

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -30,3 +30,4 @@ thiserror = "1.0"
 tokio = { version = "1.36", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "sync"] }
 tokio-stream = "0.1.14"
 parking_lot = "0.12.1"
+arc-swap = "1"

--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use helix_core::syntax;
 use helix_view::graphics::{Margin, Rect, Style};
 use tui::buffer::Buffer;
@@ -18,13 +19,17 @@ pub struct SignatureHelp {
     active_param_range: Option<(usize, usize)>,
 
     language: String,
-    config_loader: Arc<syntax::Loader>,
+    config_loader: Arc<ArcSwap<syntax::Loader>>,
 }
 
 impl SignatureHelp {
     pub const ID: &'static str = "signature-help";
 
-    pub fn new(signature: String, language: String, config_loader: Arc<syntax::Loader>) -> Self {
+    pub fn new(
+        signature: String,
+        language: String,
+        config_loader: Arc<ArcSwap<syntax::Loader>>,
+    ) -> Self {
         Self {
             signature,
             signature_doc: None,

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -1,4 +1,5 @@
 use crate::compositor::{Component, Context};
+use arc_swap::ArcSwap;
 use tui::{
     buffer::Buffer as Surface,
     text::{Span, Spans, Text},
@@ -31,7 +32,7 @@ pub fn highlighted_code_block<'a>(
     text: &str,
     language: &str,
     theme: Option<&Theme>,
-    config_loader: Arc<syntax::Loader>,
+    config_loader: Arc<ArcSwap<syntax::Loader>>,
     additional_highlight_spans: Option<Vec<(usize, std::ops::Range<usize>)>>,
 ) -> Text<'a> {
     let mut spans = Vec::new();
@@ -48,6 +49,7 @@ pub fn highlighted_code_block<'a>(
 
     let ropeslice = RopeSlice::from(text);
     let syntax = config_loader
+        .load()
         .language_configuration_for_injection_string(&InjectionLanguageMarker::Name(
             language.into(),
         ))
@@ -121,7 +123,7 @@ pub fn highlighted_code_block<'a>(
 pub struct Markdown {
     contents: String,
 
-    config_loader: Arc<syntax::Loader>,
+    config_loader: Arc<ArcSwap<syntax::Loader>>,
 }
 
 // TODO: pre-render and self reference via Pin
@@ -140,7 +142,7 @@ impl Markdown {
     ];
     const INDENT: &'static str = "  ";
 
-    pub fn new(contents: String, config_loader: Arc<syntax::Loader>) -> Self {
+    pub fn new(contents: String, config_loader: Arc<ArcSwap<syntax::Loader>>) -> Self {
         Self {
             contents,
             config_loader,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -336,8 +336,8 @@ pub mod completers {
     pub fn language(editor: &Editor, input: &str) -> Vec<Completion> {
         let text: String = "text".into();
 
-        let language_ids = editor
-            .syn_loader
+        let loader = editor.syn_loader.load();
+        let language_ids = loader
             .language_configs()
             .map(|config| &config.language_id)
             .chain(std::iter::once(&text));

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,5 +1,6 @@
 use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
+use arc_swap::ArcSwap;
 use helix_core::syntax;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
@@ -34,7 +35,7 @@ pub struct Prompt {
     callback_fn: CallbackFn,
     pub doc_fn: DocFn,
     next_char_handler: Option<PromptCharHandler>,
-    language: Option<(&'static str, Arc<syntax::Loader>)>,
+    language: Option<(&'static str, Arc<ArcSwap<syntax::Loader>>)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -98,7 +99,11 @@ impl Prompt {
         self
     }
 
-    pub fn with_language(mut self, language: &'static str, loader: Arc<syntax::Loader>) -> Self {
+    pub fn with_language(
+        mut self,
+        language: &'static str,
+        loader: Arc<ArcSwap<syntax::Loader>>,
+    ) -> Self {
         self.language = Some((language, loader));
         self
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -681,7 +681,7 @@ impl Document {
     pub fn open(
         path: &Path,
         encoding: Option<&'static Encoding>,
-        config_loader: Option<Arc<syntax::Loader>>,
+        config_loader: Option<Arc<ArcSwap<syntax::Loader>>>,
         config: Arc<dyn DynAccess<Config>>,
     ) -> Result<Self, Error> {
         // Open the file if it exists, otherwise assume it is a new file (and thus empty).
@@ -922,10 +922,11 @@ impl Document {
     }
 
     /// Detect the programming language based on the file type.
-    pub fn detect_language(&mut self, config_loader: Arc<syntax::Loader>) {
+    pub fn detect_language(&mut self, config_loader: Arc<ArcSwap<syntax::Loader>>) {
+        let loader = config_loader.load();
         self.set_language(
-            self.detect_language_config(&config_loader),
-            Some(config_loader),
+            self.detect_language_config(&loader),
+            Some(Arc::clone(&config_loader)),
         );
     }
 
@@ -1059,10 +1060,12 @@ impl Document {
     pub fn set_language(
         &mut self,
         language_config: Option<Arc<helix_core::syntax::LanguageConfiguration>>,
-        loader: Option<Arc<helix_core::syntax::Loader>>,
+        loader: Option<Arc<ArcSwap<helix_core::syntax::Loader>>>,
     ) {
         if let (Some(language_config), Some(loader)) = (language_config, loader) {
-            if let Some(highlight_config) = language_config.highlight_config(&loader.scopes()) {
+            if let Some(highlight_config) =
+                language_config.highlight_config(&(*loader).load().scopes())
+            {
                 self.syntax = Syntax::new(self.text.slice(..), highlight_config, loader);
             }
 
@@ -1078,9 +1081,10 @@ impl Document {
     pub fn set_language_by_language_id(
         &mut self,
         language_id: &str,
-        config_loader: Arc<syntax::Loader>,
+        config_loader: Arc<ArcSwap<syntax::Loader>>,
     ) -> anyhow::Result<()> {
-        let language_config = config_loader
+        let language_config = (*config_loader)
+            .load()
             .language_config_for_language_id(language_id)
             .ok_or_else(|| anyhow!("invalid language id: {}", language_id))?;
         self.set_language(Some(language_config), Some(config_loader));


### PR DESCRIPTION
This PR attempts to fix #9398 

`syn_loader` was replaced rather than interior value being replace, 
old value was still being referenced and not updated after `:config-refresh`. 

By using `ArcSwap` similarly to `config`, each `.load()` call will return the most updated value.

## Testing Steps

1. Open the helix repo in Helix and open a document.
1. Add a custom language config for `rust-analyzer` in `languages.toml`.
    ```
      [language-server.rust-analyzer.config]
      cargo.features = "all" 
      rust-analyzer.check.command = "clippy"
    + rust-analyzer.inlayHints.typeHints.enable= false
    + rust-analyzer.inlayHints.parameterHints.enable= false
    + rust-analyzer.inlayHints.chainingHints.enable= false
    ```
1. `:config-reload` and `:lsp-restart`
1. page-up/down to trigger re-rendering
1. inlay hints should now be disabled, lsp config is reloaded

PS. This is my first PR, please let me know if there is anything I missed/ overlooked. 