### PR TITLE
Respect injections when using the syntax tree's root node

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -57,10 +57,10 @@ fn find_pair(
     pos_: usize,
     traverse_parents: bool,
 ) -> Option<usize> {
-    let tree = syntax.tree();
     let pos = doc.char_to_byte(pos_);
 
-    let mut node = tree.root_node().descendant_for_byte_range(pos, pos + 1)?;
+    let root = syntax.tree_for_byte_range(pos, pos + 1).root_node();
+    let mut node = root.descendant_for_byte_range(pos, pos + 1)?;
 
     loop {
         if node.is_named() {
@@ -118,9 +118,7 @@ fn find_pair(
         };
         node = parent;
     }
-    let node = tree
-        .root_node()
-        .named_descendant_for_byte_range(pos, pos + 1)?;
+    let node = root.named_descendant_for_byte_range(pos, pos + 1)?;
     if node.child_count() != 0 {
         return None;
     }

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -573,16 +573,11 @@ pub fn move_parent_node_end(
     dir: Direction,
     movement: Movement,
 ) -> Selection {
-    let tree = syntax.tree();
-
     selection.transform(|range| {
         let start_from = text.char_to_byte(range.from());
         let start_to = text.char_to_byte(range.to());
 
-        let mut node = match tree
-            .root_node()
-            .named_descendant_for_byte_range(start_from, start_to)
-        {
+        let mut node = match syntax.named_descendant_for_byte_range(start_from, start_to) {
             Some(node) => node,
             None => {
                 log::debug!(

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1338,7 +1338,7 @@ impl Syntax {
         result
     }
 
-    pub fn descendant_for_byte_range(&self, start: usize, end: usize) -> Option<Node<'_>> {
+    pub fn tree_for_byte_range(&self, start: usize, end: usize) -> &Tree {
         let mut container_id = self.root;
 
         for (layer_id, layer) in self.layers.iter() {
@@ -1349,8 +1349,11 @@ impl Syntax {
             }
         }
 
-        self.layers[container_id]
-            .tree()
+        self.layers[container_id].tree()
+    }
+
+    pub fn descendant_for_byte_range(&self, start: usize, end: usize) -> Option<Node<'_>> {
+        self.tree_for_byte_range(start, end)
             .root_node()
             .descendant_for_byte_range(start, end)
     }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1352,6 +1352,12 @@ impl Syntax {
         self.layers[container_id].tree()
     }
 
+    pub fn named_descendant_for_byte_range(&self, start: usize, end: usize) -> Option<Node<'_>> {
+        self.tree_for_byte_range(start, end)
+            .root_node()
+            .named_descendant_for_byte_range(start, end)
+    }
+
     pub fn descendant_for_byte_range(&self, start: usize, end: usize) -> Option<Node<'_>> {
         self.tree_for_byte_range(start, end)
             .root_node()

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1546,10 +1546,7 @@ fn tree_sitter_highlight_name(
         let text = doc.text().slice(..);
         let cursor = doc.selection(view.id).primary().cursor(text);
         let byte = text.char_to_byte(cursor);
-        let node = syntax
-            .tree()
-            .root_node()
-            .descendant_for_byte_range(byte, byte)?;
+        let node = syntax.descendant_for_byte_range(byte, byte)?;
         // Query the same range as the one used in syntax highlighting.
         let range = {
             // Calculate viewport byte ranges:


### PR DESCRIPTION
Previously we used the root syntax tree for bracket matching. We can use the new functionality in `Syntax` for finding the correct syntax tree for a given byte range though so we use the correct syntax tree within injections. This improves bracket matching behavior within HTML injections like script or style tags for example.

Fixes #9423