### PR TITLE
Include interpolated SQL strings in Scala injection queries

### DIFF
--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -1,2 +1,16 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+
+; TODO for some reason multiline string (triple quotes) interpolation works only if it contains interpolated value
+; Matches these SQL interpolators:
+;  - Doobie: 'sql', 'fr'
+;  - Quill: 'sql', 'infix'
+;  - Slick: 'sql', 'sqlu'
+(interpolated_string_expression 
+  interpolator: 
+    ((identifier) @interpolator 
+     (#match? @interpolator "^(fr|infix|sql|sqlu)$"))
+  (interpolated_string) @injection.content
+  (#set! injection.language "sql"))
+

--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -1,4 +1,4 @@
-((comment) @injection.content
+([(comment) (block_comment)] @injection.content
  (#set! injection.language "comment"))
 
 

--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -10,7 +10,7 @@
 (interpolated_string_expression 
   interpolator: 
     ((identifier) @interpolator 
-     (#match? @interpolator "^(fr|infix|sql|sqlu)$"))
+     (#any-of? @interpolator "fr" "infix" "sql" "sqlu"))
   (interpolated_string) @injection.content
   (#set! injection.language "sql"))
 


### PR DESCRIPTION
Matches SQL strings from (at least) three popular Scala database libraries:
- [Doobie](https://tpolecat.github.io/doobie/docs/04-Selecting.html#reading-rows-into-collections)
- [Quill](https://zio.dev/zio-quill/extending-quill#raw-sql-queries)
- [Slick](https://scala-slick.org/doc/stable/sql.html)

Injection query matches this kind of syntax:
```scala
val query1 = sql"SELECT foo FROM bar WHERE baz IS NOT NULL"
```

For some reason the injection query does not reliably work for multiline strings:
<img width="511" alt="image" src="https://github.com/helix-editor/helix/assets/36770267/045f5fab-d5f4-4f23-8e25-fae2928a32e8">

I'm not sure whether this is a problem with tree-sitter-scala, tree-sitter-sql, Helix, or the injection query itself. Helix shows identical subtrees for `query1` and `query2`. To my understanding it should thus highlight them equally.

Nevertheless having some highlighting for inline SQL is an improvement to existing.