### PR TITLE
Make status line modes bold for theme onedark

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -73,9 +73,9 @@
 
 "ui.statusline" = { fg = "white", bg = "light-black" }
 "ui.statusline.inactive" = { fg = "light-gray", bg = "light-black" }
-"ui.statusline.normal" = { fg = "light-black", bg = "blue" }
-"ui.statusline.insert" = { fg = "light-black", bg = "green" }
-"ui.statusline.select" = { fg = "light-black", bg = "purple" }
+"ui.statusline.normal" = { fg = "light-black", bg = "blue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "light-black", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "light-black", bg = "purple", modifiers = ["bold"] }
 
 "ui.bufferline" = { fg = "light-gray", bg = "light-black" }
 "ui.bufferline.active" = { fg = "light-black", bg = "blue", underline = { color = "light-black", style = "line" } }

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -72,9 +72,9 @@
 
 "ui.statusline" = { fg = "white", bg = "light-black" }
 "ui.statusline.inactive" = { fg = "light-gray", bg = "light-black" }
-"ui.statusline.normal" = { fg = "light-black", bg = "purple", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "light-black", bg = "green", modifiers = ["bold"] }
-"ui.statusline.select" = { fg = "light-black", bg = "cyan", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "light-black", bg = "purple" }
+"ui.statusline.insert" = { fg = "light-black", bg = "green" }
+"ui.statusline.select" = { fg = "light-black", bg = "cyan" }
 
 "ui.bufferline" = { fg = "light-gray", bg = "light-black" }
 "ui.bufferline.active" = { fg = "light-black", bg = "blue", underline = { color = "light-black", style = "line" } }

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -72,9 +72,9 @@
 
 "ui.statusline" = { fg = "white", bg = "light-black" }
 "ui.statusline.inactive" = { fg = "light-gray", bg = "light-black" }
-"ui.statusline.normal" = { fg = "light-black", bg = "purple" }
-"ui.statusline.insert" = { fg = "light-black", bg = "green" }
-"ui.statusline.select" = { fg = "light-black", bg = "cyan" }
+"ui.statusline.normal" = { fg = "light-black", bg = "purple", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "light-black", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "light-black", bg = "cyan", modifiers = ["bold"] }
 
 "ui.bufferline" = { fg = "light-gray", bg = "light-black" }
 "ui.bufferline.active" = { fg = "light-black", bg = "blue", underline = { color = "light-black", style = "line" } }


### PR DESCRIPTION
This is just my opinion, but with the colored backgrounds, the mode is much easier to read when bold (like the catppuccin themes).

before:
![regular](https://github.com/helix-editor/helix/assets/16892444/f30b0904-2f44-464e-91cb-43858257452d)

after:
![bold](https://github.com/helix-editor/helix/assets/16892444/c4a64438-2af9-4d43-a318-ebdaff43928c)
