### PR TITLE
lang(git-ignore): add `helix/ignore` to git-ignore file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1484,7 +1484,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 [[language]]
 name = "git-ignore"
 scope = "source.gitignore"
-file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore", "CODEOWNERS"]
+file-types = [".gitignore", ".gitignore_global", ".ignore", ".prettierignore", ".eslintignore", ".npmignore", "CODEOWNERS", { suffix = ".config/helix/ignore" }, { suffix = ".helix/ignore" }]
 injection-regex = "git-ignore"
 comment-token = "#"
 grammar = "gitignore"


### PR DESCRIPTION
`.config/helix/ignore` and `.helix/ignore` support was added in https://github.com/helix-editor/helix/pull/8099
