### PR TITLE
Use range positions to determine insert_newline motion

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3650,8 +3650,7 @@ pub mod insert {
 
                 (pos, pos, local_offs)
             };
-
-            let new_range = if doc.restore_cursor {
+            let new_range = if range.head > range.anchor {
                 // when appending, extend the range by local_offs
                 Range::new(
                     range.anchor + global_offs,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3650,7 +3650,8 @@ pub mod insert {
 
                 (pos, pos, local_offs)
             };
-            let new_range = if range.head > range.anchor {
+
+            let new_range = if range.cursor(text) > range.anchor {
                 // when appending, extend the range by local_offs
                 Range::new(
                     range.anchor + global_offs,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1904,10 +1904,12 @@ impl Editor {
         if doc.restore_cursor {
             let text = doc.text().slice(..);
             let selection = doc.selection(view.id).clone().transform(|range| {
-                Range::new(
-                    range.from(),
-                    graphemes::prev_grapheme_boundary(text, range.to()),
-                )
+                let mut head = range.to();
+                if range.head > range.anchor {
+                    head = graphemes::prev_grapheme_boundary(text, head);
+                }
+
+                Range::new(range.from(), head)
             });
 
             doc.set_selection(view.id, selection);


### PR DESCRIPTION
Fixes #9443

Uses the relative postion of the anchor and the head of a selection to determine whether to shift the selection or to extend it.