### PR TITLE
Key remappings for mouse configuration

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -26,6 +26,7 @@ use crate::{
     handlers,
     job::Jobs,
     keymap::Keymaps,
+    mousemap::Mousemaps,
     ui::{self, overlay::overlaid},
 };
 
@@ -152,7 +153,13 @@ impl Application {
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
             &config.keys
         }));
-        let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
+        let mouse = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
+            &config.mouse
+        }));
+        let editor_view = Box::new(ui::EditorView::new(
+            Keymaps::new(keys),
+            Mousemaps::new(mouse),
+        ));
         compositor.push(editor_view);
 
         if args.load_tutor {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1,5 +1,6 @@
 pub(crate) mod dap;
 pub(crate) mod lsp;
+pub(crate) mod mouse;
 pub(crate) mod typed;
 
 pub use dap::*;

--- a/helix-term/src/commands/mouse.rs
+++ b/helix-term/src/commands/mouse.rs
@@ -1,0 +1,283 @@
+use crate::ui::{
+    editor::{gutter_coords_and_view, pos_and_view},
+    EditorView,
+};
+use anyhow::anyhow;
+use helix_core::{movement::Direction, Range, Selection};
+use helix_view::{input::MouseEvent, Document, ViewId};
+
+use super::{
+    move_next_long_word_end, move_next_word_end, move_prev_long_word_start, move_prev_word_start,
+    paste_primary_clipboard_before, replace_selections_with_primary_clipboard,
+    yank_primary_selection_impl, Context,
+};
+
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Copy)]
+pub struct StaticMouseCommand {
+    name: &'static str,
+    pub(crate) fun: fn(&mut Context, &MouseEvent, &mut EditorView),
+    doc: &'static str,
+}
+
+impl std::str::FromStr for StaticMouseCommand {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        StaticMouseCommand::STATIC_MOUSE_COMMAND_LIST
+            .iter()
+            .find(|cmd| cmd.name() == s)
+            .cloned()
+            .ok_or_else(|| anyhow!("No command named '{}'", s))
+    }
+}
+
+macro_rules! static_mouse_commands {
+    ( $($name:ident, $doc:literal,)* ) => {
+        $(
+            #[allow(non_upper_case_globals)]
+            pub const $name: Self = Self {
+                name: stringify!($name),
+                fun: $name,
+                doc: $doc
+            };
+        )*
+
+        pub const STATIC_MOUSE_COMMAND_LIST: &'static [Self] = &[
+            $( Self::$name, )*
+        ];
+    }
+}
+
+impl StaticMouseCommand {
+    pub fn execute(&self, cx: &mut Context, event: &MouseEvent, editor_view: &mut EditorView) {
+        (self.fun)(cx, event, editor_view);
+    }
+
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn doc(&self) -> &str {
+        self.doc
+    }
+
+    #[rustfmt::skip]
+    static_mouse_commands!(
+        handle_main_button_mouse, "Handle the main button mouse iteraction (commonly left click)",
+        set_mouse_selection, "Set primary selection at mouse pointer",
+        select_word_mouse, "Select a word",
+        select_long_word_mouse, "Select a long word",
+        select_all_mouse, "Select whole document with mouse",
+        scroll_up_mouse, "Scroll view up with mouse line",
+        scroll_down_mouse, "Scroll view down with mouse line",
+        paste_primary_clipboard_before_mouse, "Paste primary clipboard before mouse",
+        yank_main_selection_to_primary_clipboard_mouse, "Yank Main selection to primary clipboard through mouse",
+        replace_selections_with_primary_clipboard_mouse, "Replace selection with primary clipboard through mouse",
+        add_breakpoint_mouse, "Add breakpoint with the mouse when clicking on the numbers on the left",
+        add_selection_mouse, "Add a selection at you mouse pointer",
+        go_to_definition_mouse, "Goto Definition with mouse",
+        code_action_mouse, "Perform code action with mouse",
+        dap_edit_condition_mouse, "Edit breakpoint condition on current line with mouse",
+        dap_edit_log_mouse, "Edit breakpoint log message on current line with mouse",
+    );
+}
+
+fn handle_selection_in_buffer(
+    cx: &mut Context,
+    evt: &MouseEvent,
+    ev: &mut EditorView,
+    callback: impl Fn(&mut Document, &ViewId, usize),
+) -> bool {
+    let editor = &mut cx.editor;
+
+    if let Some((pos, view_id)) = pos_and_view(editor, evt.row, evt.column, true) {
+        let prev_view_id = view!(editor).id;
+        let doc = doc_mut!(editor, &view!(editor, view_id).doc);
+
+        callback(doc, &view_id, pos);
+
+        if view_id != prev_view_id {
+            ev.clear_completion(editor);
+        }
+
+        editor.focus(view_id);
+        editor.ensure_cursor_in_view(view_id);
+
+        return true;
+    }
+    log::info!("false in return");
+    false
+}
+
+fn handle_main_button_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    if !handle_selection_in_buffer(
+        cx,
+        evt,
+        ev,
+        |doc: &mut Document, view_id: &ViewId, pos: usize| {
+            doc.set_selection(*view_id, Selection::point(pos));
+        },
+    ) {
+        add_breakpoint_mouse(cx, evt, ev);
+    }
+}
+
+fn set_mouse_selection(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    handle_selection_in_buffer(
+        cx,
+        evt,
+        ev,
+        |doc: &mut Document, view_id: &ViewId, pos: usize| {
+            doc.set_selection(*view_id, Selection::point(pos));
+        },
+    );
+}
+
+fn select_word_mouse(cx: &mut Context, _: &MouseEvent, _: &mut EditorView) {
+    move_prev_word_start(cx);
+    move_next_word_end(cx);
+}
+
+fn select_long_word_mouse(cx: &mut Context, _: &MouseEvent, _: &mut EditorView) {
+    move_prev_long_word_start(cx);
+    move_next_long_word_end(cx);
+}
+
+fn select_all_mouse(cx: &mut Context, _: &MouseEvent, _: &mut EditorView) {
+    super::select_all(cx)
+}
+
+fn scroll_mouse_impl(cx: &mut Context, evt: &MouseEvent, dir: Direction, _: &mut EditorView) {
+    let current_view = cx.editor.tree.focus;
+    match pos_and_view(cx.editor, evt.row, evt.column, false) {
+        Some((_, view_id)) => cx.editor.tree.focus = view_id,
+        None => return,
+    }
+    super::scroll(cx, cx.editor.config().scroll_lines.unsigned_abs(), dir);
+    cx.editor.tree.focus = current_view;
+    cx.editor.ensure_cursor_in_view(current_view);
+}
+
+fn scroll_up_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    scroll_mouse_impl(cx, evt, Direction::Backward, ev)
+}
+
+fn scroll_down_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    scroll_mouse_impl(cx, evt, Direction::Forward, ev)
+}
+
+fn paste_primary_clipboard_before_mouse(cx: &mut Context, evt: &MouseEvent, _: &mut EditorView) {
+    // if !config.middle_click_paste {
+    //     return;
+    // }
+    let editor = &mut cx.editor;
+    if let Some((pos, view_id)) = pos_and_view(editor, evt.row, evt.column, true) {
+        let doc = doc_mut!(editor, &view!(editor, view_id).doc);
+        doc.set_selection(view_id, Selection::point(pos));
+        cx.editor.focus(view_id);
+        paste_primary_clipboard_before(cx)
+    }
+}
+
+pub fn yank_main_selection_to_primary_clipboard_mouse(
+    cx: &mut Context,
+    _: &MouseEvent,
+    _: &mut EditorView,
+) {
+    let editor = &mut cx.editor;
+    let (view, doc) = current!(editor);
+    if doc
+        .selection(view.id)
+        .primary()
+        .slice(doc.text().slice(..))
+        .len_chars()
+        <= 1
+    {
+        return;
+    }
+
+    yank_primary_selection_impl(cx.editor, '*');
+}
+
+fn replace_selections_with_primary_clipboard_mouse(
+    cx: &mut Context,
+    _: &MouseEvent,
+    _: &mut EditorView,
+) {
+    // if !config.middle_click_paste {
+    //     return;
+    // }
+    replace_selections_with_primary_clipboard(cx)
+}
+
+fn add_breakpoint_mouse(cx: &mut Context, evt: &MouseEvent, _: &mut EditorView) {
+    log::info!("called breakpoint adder");
+    let editor = &mut cx.editor;
+    if let Some((coords, view_id)) = gutter_coords_and_view(editor, evt.row, evt.column) {
+        editor.focus(view_id);
+
+        let (view, doc) = current!(cx.editor);
+
+        let path = match doc.path() {
+            Some(path) => path.clone(),
+            None => return,
+        };
+
+        if let Some(char_idx) =
+            view.pos_at_visual_coords(doc, coords.row as u16, coords.col as u16, true)
+        {
+            let line = doc.text().char_to_line(char_idx);
+            super::dap_toggle_breakpoint_impl(cx, path, line);
+            return;
+        }
+    }
+}
+
+pub fn add_selection_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    handle_selection_in_buffer(
+        cx,
+        evt,
+        ev,
+        |doc: &mut Document, view_id: &ViewId, pos: usize| {
+            let selection = doc.selection(*view_id).clone();
+            doc.set_selection(*view_id, selection.push(Range::point(pos)));
+        },
+    );
+}
+
+pub fn go_to_definition_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    set_mouse_selection(cx, evt, ev);
+    super::goto_definition(cx)
+}
+
+pub fn code_action_mouse(cx: &mut Context, evt: &MouseEvent, ev: &mut EditorView) {
+    set_mouse_selection(cx, evt, ev);
+    super::code_action(cx)
+}
+
+fn dap_impl_mouse(cx: &mut Context, evt: &MouseEvent, callback: impl Fn(&mut Context)) {
+    let editor = &mut cx.editor;
+    if let Some((coords, view_id)) = gutter_coords_and_view(editor, evt.row, evt.column) {
+        editor.focus(view_id);
+
+        let (view, doc) = current!(editor);
+        if let Some(pos) =
+            view.pos_at_visual_coords(doc, coords.row as u16, coords.col as u16, true)
+        {
+            doc.set_selection(view_id, Selection::point(pos));
+            callback(cx);
+        }
+    }
+}
+
+fn dap_edit_condition_mouse(cx: &mut Context, evt: &MouseEvent, _: &mut EditorView) {
+    dap_impl_mouse(cx, evt, |cx| {
+        super::dap_edit_condition(cx);
+    })
+}
+
+fn dap_edit_log_mouse(cx: &mut Context, evt: &MouseEvent, _: &mut EditorView) {
+    dap_impl_mouse(cx, evt, |cx: &mut Context| {
+        super::dap_edit_log(cx);
+    })
+}

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod health;
 pub mod job;
 pub mod keymap;
+pub mod mousemap;
 pub mod ui;
 
 use std::path::Path;

--- a/helix-term/src/mousemap.rs
+++ b/helix-term/src/mousemap.rs
@@ -1,0 +1,210 @@
+pub mod default;
+pub mod macros;
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use arc_swap::{
+    access::{DynAccess, DynGuard},
+    ArcSwap,
+};
+use chrono::{DateTime, Local};
+use helix_view::{
+    document::Mode,
+    input::{MouseEvent, MouseEventKind, MouseModifiers},
+};
+use serde::Deserialize;
+
+use crate::commands::mouse::StaticMouseCommand;
+
+pub type MouseTrieMapper = HashMap<MouseEvent, MouseTrie>;
+
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone)]
+pub enum MouseTrie {
+    MappableCommand(StaticMouseCommand),
+    Sequence(Vec<StaticMouseCommand>),
+}
+
+struct MouseTrieVisitor;
+
+impl<'de> Deserialize<'de> for MouseTrie {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        log::info!("going into Visitor");
+        deserializer.deserialize_any(MouseTrieVisitor)
+    }
+}
+
+impl<'de> serde::de::Visitor<'de> for MouseTrieVisitor {
+    type Value = MouseTrie;
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            formatter,
+            "an internal command or list of internal commands"
+        )
+    }
+
+    fn visit_str<E>(self, command: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        log::info!("gone into seq");
+        command
+            .parse::<StaticMouseCommand>()
+            .map(MouseTrie::MappableCommand)
+            .map_err(E::custom)
+    }
+
+    fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+    where
+        S: serde::de::SeqAccess<'de>,
+    {
+        log::info!("gone into seq");
+        let mut commands = Vec::new();
+        while let Some(command) = seq.next_element::<String>()? {
+            commands.push(
+                command
+                    .parse::<StaticMouseCommand>()
+                    .map_err(serde::de::Error::custom)?,
+            )
+        }
+        Ok(MouseTrie::Sequence(commands))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MousemapResult {
+    /// Needs more keys to execute a command. Contains valid keys for next keystroke.
+    Matched(StaticMouseCommand),
+    /// Matched a sequence of commands to execute.
+    MatchedSequence(Vec<StaticMouseCommand>),
+    /// Key was not found in the root keymap
+    NotFound,
+}
+
+pub struct Mousemaps {
+    pub map: Box<dyn DynAccess<HashMap<Mode, HashMap<MouseEvent, MouseTrie>>>>,
+    /// Stores pending keys waiting for the next key. This is relative to a
+    /// sticky node if one is in use.
+    last_event: Option<MouseEvent>,
+    last_time_mouse_pressed: DateTime<Local>,
+}
+
+impl Mousemaps {
+    pub fn new(map: Box<dyn DynAccess<HashMap<Mode, HashMap<MouseEvent, MouseTrie>>>>) -> Self {
+        Self {
+            map,
+            last_event: None,
+            last_time_mouse_pressed: Local::now(),
+        }
+    }
+
+    pub fn map(&self) -> DynGuard<HashMap<Mode, HashMap<MouseEvent, MouseTrie>>> {
+        self.map.load()
+    }
+
+    /// Returns list of keys waiting to be disambiguated in current mode.
+    pub fn last_event(&self) -> Option<&MouseEvent> {
+        self.last_event.as_ref()
+    }
+
+    fn get_from_event(
+        &self,
+        values: &HashMap<MouseEvent, MouseTrie>,
+        key: &MouseEvent,
+    ) -> MousemapResult {
+        match values.get(key) {
+            Some(v) => match v {
+                MouseTrie::MappableCommand(m) => MousemapResult::Matched(m.to_owned()),
+                MouseTrie::Sequence(m) => MousemapResult::MatchedSequence(m.to_owned()),
+            },
+            None => MousemapResult::NotFound,
+        }
+    }
+
+    pub fn get(&mut self, mode: Mode, key: &MouseEvent, mouse_idle: &Duration) -> MousemapResult {
+        let mousemaps = &*self.map();
+
+        if let Some(values) = mousemaps.get(&mode) {
+            match key.kind {
+                MouseEventKind::Down(_) => {
+                    let current_date = Local::now();
+                    let diff = current_date - self.last_time_mouse_pressed;
+                    self.last_time_mouse_pressed = current_date;
+                    let mut replace_key = true;
+                    if diff.num_milliseconds() as u128 > mouse_idle.as_millis() {
+                        self.last_event = None;
+                    } else if let Some(last_mouse_event) = self.last_event.as_mut() {
+                        // same modifiers (not mouse_mofifiers) and buttons (columns are excepted)
+                        if last_mouse_event.light_eq(&key) {
+                            last_mouse_event.mouse_modifiers =
+                                match last_mouse_event.mouse_modifiers {
+                                    MouseModifiers::MultipleClick(v) => {
+                                        MouseModifiers::MultipleClick(v + 1)
+                                    }
+                                };
+                            replace_key = false;
+                        }
+                    }
+
+                    if replace_key {
+                        self.last_event = Some(key.clone_without_coords());
+                    }
+                    let res = self.get_from_event(values, self.last_event.as_ref().unwrap());
+                    return res;
+                }
+                MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
+                    self.last_event = None;
+                    let res = self.get_from_event(values, &key.clone_without_coords());
+                    return res;
+                }
+                _ => (),
+            }
+        }
+        return MousemapResult::NotFound;
+    }
+}
+
+impl Default for Mousemaps {
+    fn default() -> Self {
+        Self::new(Box::new(ArcSwap::new(Arc::new(default::default()))))
+    }
+}
+
+pub fn merge_mouse_keys(
+    dst: &mut HashMap<Mode, MouseTrieMapper>,
+    delta: &HashMap<Mode, MouseTrieMapper>,
+) {
+    for (mode, mapper) in delta.iter() {
+        if let Some(dst_mapper) = dst.get_mut(mode) {
+            for (event, trie) in mapper.iter() {
+                dst_mapper.insert(*event, trie.to_owned());
+            }
+        } else {
+            dst.insert(*mode, mapper.to_owned());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mousemap;
+    use helix_core::hashmap;
+
+    use super::Mousemaps;
+
+    #[test]
+    #[should_panic]
+    fn duplicate_mouse_keys_should_panic() {
+        mousemap!({
+            "1-left" => code_action_mouse,
+            "1-left" => add_selection_mouse,
+        });
+    }
+
+    #[test]
+    fn check_duplicate_keys_in_default_mousemap() {
+        Mousemaps::default();
+    }
+}

--- a/helix-term/src/mousemap/default.rs
+++ b/helix-term/src/mousemap/default.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+use helix_core::hashmap;
+use helix_view::{document::Mode, input::MouseEvent};
+
+use crate::mousemap;
+
+use super::MouseTrie;
+
+pub fn default() -> HashMap<Mode, HashMap<MouseEvent, MouseTrie>> {
+    let normal = mousemap!({
+        "1-left" => handle_main_button_mouse,
+        "2-left" => select_word_mouse,
+        "3-left" => select_long_word_mouse,
+        "A-1-left" => add_selection_mouse,
+        "1-right" => yank_main_selection_to_primary_clipboard_mouse,
+        "A-1-middle" => replace_selections_with_primary_clipboard_mouse,
+        "1-middle" => paste_primary_clipboard_before_mouse,
+        "scroll_up" => scroll_up_mouse,
+        "scroll_down" => scroll_down_mouse,
+
+    });
+    let insert = normal.clone();
+    let select = normal.clone();
+    hashmap!(
+        Mode::Normal => normal,
+        Mode::Insert => insert,
+        Mode::Select => select,
+    )
+}

--- a/helix-term/src/mousemap/macros.rs
+++ b/helix-term/src/mousemap/macros.rs
@@ -1,0 +1,29 @@
+#[macro_export]
+macro_rules! mousemap {
+    (@trie $cmd:ident) => {
+        $crate::mousemap::MouseTrie::MappableCommand($crate::commands::mouse::StaticMouseCommand::$cmd)
+    };
+
+    (@trie [$($cmd:ident),* $(,)?]) => {
+        $crate::mousemap::MouseTrie::Sequence(vec![$($crate::commands::mouse::StaticMouseCommand::$cmd),*])
+    };
+
+    (
+        {  $($key:literal => $value:tt,)+ }
+    ) => {
+        // modified from the hashmap! macro
+        {
+            let _cap = hashmap!(@count $($key),*);
+            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            $(
+                let _key = $key.parse::<::helix_view::input::MouseEvent>().unwrap();
+                let _duplicate = _map.insert(
+                    _key,
+                    mousemap!(@trie $value)
+                );
+                assert!(_duplicate.is_none(), "Duplicate key found: {:?}", _duplicate.unwrap());
+            )+
+            _map
+        }
+    };
+}

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -4,6 +4,7 @@ use crate::{
     events::{OnModeSwitch, PostCommand},
     key,
     keymap::{KeymapResult, Keymaps},
+    mousemap::{MousemapResult, Mousemaps},
     ui::{
         document::{render_document, LinePos, TextRenderer, TranslatedPosition},
         Completion, ProgressSpinners,
@@ -15,11 +16,10 @@ use helix_core::{
     graphemes::{
         ensure_grapheme_boundary_next_byte, next_grapheme_boundary, prev_grapheme_boundary,
     },
-    movement::Direction,
     syntax::{self, HighlightEvent},
     text_annotations::TextAnnotations,
     unicode::width::UnicodeWidthStr,
-    visual_offset_from_block, Change, Position, Range, Selection, Transaction,
+    visual_offset_from_block, Change, Position, Transaction,
 };
 use helix_view::{
     document::{Mode, SavePoint, SCRATCH_BUFFER_NAME},
@@ -27,7 +27,7 @@ use helix_view::{
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
-    Document, Editor, Theme, View,
+    Document, Editor, Theme, View, ViewId,
 };
 use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc};
 
@@ -38,6 +38,8 @@ use super::{completion::CompletionItem, statusline};
 
 pub struct EditorView {
     pub keymaps: Keymaps,
+    mousemaps: Mousemaps,
+    is_dragging: bool,
     on_next_key: Option<OnKeyCallback>,
     pseudo_pending: Vec<KeyEvent>,
     pub(crate) last_insert: (commands::MappableCommand, Vec<InsertEvent>),
@@ -60,14 +62,16 @@ pub enum InsertEvent {
 
 impl Default for EditorView {
     fn default() -> Self {
-        Self::new(Keymaps::default())
+        Self::new(Keymaps::default(), Mousemaps::default())
     }
 }
 
 impl EditorView {
-    pub fn new(keymaps: Keymaps) -> Self {
+    pub fn new(keymaps: Keymaps, mousemaps: Mousemaps) -> Self {
         Self {
             keymaps,
+            mousemaps,
+            is_dragging: false,
             on_next_key: None,
             pseudo_pending: Vec::new(),
             last_insert: (commands::MappableCommand::normal_mode, Vec::new()),
@@ -1043,11 +1047,31 @@ impl EditorView {
         event: &MouseEvent,
         cxt: &mut commands::Context,
     ) -> EventResult {
-        if event.kind != MouseEventKind::Moved {
-            cxt.editor.reset_idle_timer();
+        if event.kind == MouseEventKind::Moved {
+            self.is_dragging = false;
+            return EventResult::Ignored(None);
         }
+        cxt.editor.reset_idle_timer();
 
         let config = cxt.editor.config();
+
+        match self
+            .mousemaps
+            .get(cxt.editor.mode, event, &config.idle_timeout)
+        {
+            MousemapResult::Matched(cmd) => {
+                cmd.execute(cxt, event, self);
+                self.is_dragging = false;
+                return EventResult::Consumed(None);
+            }
+            MousemapResult::MatchedSequence(cmds) => {
+                self.is_dragging = false;
+                cmds.iter().for_each(|cmd| cmd.execute(cxt, event, self));
+                return EventResult::Consumed(None);
+            }
+            MousemapResult::NotFound => (),
+        };
+
         let MouseEvent {
             kind,
             row,
@@ -1056,73 +1080,10 @@ impl EditorView {
             ..
         } = *event;
 
-        let pos_and_view = |editor: &Editor, row, column, ignore_virtual_text| {
-            editor.tree.views().find_map(|(view, _focus)| {
-                view.pos_at_screen_coords(
-                    &editor.documents[&view.doc],
-                    row,
-                    column,
-                    ignore_virtual_text,
-                )
-                .map(|pos| (pos, view.id))
-            })
-        };
-
-        let gutter_coords_and_view = |editor: &Editor, row, column| {
-            editor.tree.views().find_map(|(view, _focus)| {
-                view.gutter_coords_at_screen_coords(row, column)
-                    .map(|coords| (coords, view.id))
-            })
-        };
-
         match kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                let editor = &mut cxt.editor;
-
-                if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
-                    let prev_view_id = view!(editor).id;
-                    let doc = doc_mut!(editor, &view!(editor, view_id).doc);
-
-                    if modifiers == KeyModifiers::ALT {
-                        let selection = doc.selection(view_id).clone();
-                        doc.set_selection(view_id, selection.push(Range::point(pos)));
-                    } else {
-                        doc.set_selection(view_id, Selection::point(pos));
-                    }
-
-                    if view_id != prev_view_id {
-                        self.clear_completion(editor);
-                    }
-
-                    editor.focus(view_id);
-                    editor.ensure_cursor_in_view(view_id);
-
-                    return EventResult::Consumed(None);
-                }
-
-                if let Some((coords, view_id)) = gutter_coords_and_view(editor, row, column) {
-                    editor.focus(view_id);
-
-                    let (view, doc) = current!(cxt.editor);
-
-                    let path = match doc.path() {
-                        Some(path) => path.clone(),
-                        None => return EventResult::Ignored(None),
-                    };
-
-                    if let Some(char_idx) =
-                        view.pos_at_visual_coords(doc, coords.row as u16, coords.col as u16, true)
-                    {
-                        let line = doc.text().char_to_line(char_idx);
-                        commands::dap_toggle_breakpoint_impl(cxt, path, line);
-                        return EventResult::Consumed(None);
-                    }
-                }
-
-                EventResult::Ignored(None)
-            }
-
+            // this type of event is not and should not be handled by the mousemaps
             MouseEventKind::Drag(MouseButton::Left) => {
+                self.is_dragging = true;
                 let (view, doc) = current!(cxt.editor);
 
                 let pos = match view.pos_at_screen_coords(doc, row, column, true) {
@@ -1139,99 +1100,24 @@ impl EditorView {
                 EventResult::Consumed(None)
             }
 
-            MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-                let current_view = cxt.editor.tree.focus;
-
-                let direction = match event.kind {
-                    MouseEventKind::ScrollUp => Direction::Backward,
-                    MouseEventKind::ScrollDown => Direction::Forward,
-                    _ => unreachable!(),
-                };
-
-                match pos_and_view(cxt.editor, row, column, false) {
-                    Some((_, view_id)) => cxt.editor.tree.focus = view_id,
-                    None => return EventResult::Ignored(None),
-                }
-
-                let offset = config.scroll_lines.unsigned_abs();
-                commands::scroll(cxt, offset, direction);
-
-                cxt.editor.tree.focus = current_view;
-                cxt.editor.ensure_cursor_in_view(current_view);
-
-                EventResult::Consumed(None)
-            }
-
             MouseEventKind::Up(MouseButton::Left) => {
-                if !config.middle_click_paste {
-                    return EventResult::Ignored(None);
-                }
-
-                let (view, doc) = current!(cxt.editor);
-
-                if doc
-                    .selection(view.id)
-                    .primary()
-                    .slice(doc.text().slice(..))
-                    .len_chars()
-                    <= 1
+                // must be dragging, and ALT avoids copying the selected text
+                if !config.middle_click_paste
+                    || !self.is_dragging
+                    || modifiers.contains(KeyModifiers::ALT)
                 {
                     return EventResult::Ignored(None);
                 }
 
-                commands::MappableCommand::yank_main_selection_to_primary_clipboard.execute(cxt);
+                commands::mouse::yank_main_selection_to_primary_clipboard_mouse(cxt, event, self);
 
                 EventResult::Consumed(None)
             }
 
-            MouseEventKind::Up(MouseButton::Right) => {
-                if let Some((coords, view_id)) = gutter_coords_and_view(cxt.editor, row, column) {
-                    cxt.editor.focus(view_id);
-
-                    let (view, doc) = current!(cxt.editor);
-                    if let Some(pos) =
-                        view.pos_at_visual_coords(doc, coords.row as u16, coords.col as u16, true)
-                    {
-                        doc.set_selection(view_id, Selection::point(pos));
-                        if modifiers == KeyModifiers::ALT {
-                            commands::MappableCommand::dap_edit_log.execute(cxt);
-                        } else {
-                            commands::MappableCommand::dap_edit_condition.execute(cxt);
-                        }
-
-                        return EventResult::Consumed(None);
-                    }
-                }
-
+            _ => {
+                self.is_dragging = false;
                 EventResult::Ignored(None)
             }
-
-            MouseEventKind::Up(MouseButton::Middle) => {
-                let editor = &mut cxt.editor;
-                if !config.middle_click_paste {
-                    return EventResult::Ignored(None);
-                }
-
-                if modifiers == KeyModifiers::ALT {
-                    commands::MappableCommand::replace_selections_with_primary_clipboard
-                        .execute(cxt);
-
-                    return EventResult::Consumed(None);
-                }
-
-                if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
-                    let doc = doc_mut!(editor, &view!(editor, view_id).doc);
-                    doc.set_selection(view_id, Selection::point(pos));
-                    cxt.editor.focus(view_id);
-                    commands::MappableCommand::paste_primary_clipboard_before.execute(cxt);
-
-                    return EventResult::Consumed(None);
-                }
-
-                EventResult::Ignored(None)
-            }
-
-            _ => EventResult::Ignored(None),
         }
     }
 }
@@ -1375,7 +1261,14 @@ impl Component for EditorView {
                 EventResult::Consumed(callback)
             }
 
-            Event::Mouse(event) => self.handle_mouse_event(event, &mut cx),
+            Event::Mouse(event) => {
+                let res = self.handle_mouse_event(event, &mut cx);
+                // set cursor in view if cursor was moved by mouse
+                let config = cx.editor.config();
+                let (view, doc) = current!(cx.editor);
+                view.ensure_cursor_in_view(doc, config.scrolloff);
+                res
+            }
             Event::IdleTimeout => self.handle_idle_timeout(&mut cx),
             Event::FocusGained => {
                 self.terminal_focused = true;
@@ -1519,4 +1412,31 @@ fn canonicalize_key(key: &mut KeyEvent) {
     {
         key.modifiers.remove(KeyModifiers::SHIFT)
     }
+}
+pub fn pos_and_view(
+    editor: &Editor,
+    row: u16,
+    column: u16,
+    ignore_virtual_text: bool,
+) -> Option<(usize, ViewId)> {
+    editor.tree.views().find_map(|(view, _focus)| {
+        view.pos_at_screen_coords(
+            &editor.documents[&view.doc],
+            row,
+            column,
+            ignore_virtual_text,
+        )
+        .map(|pos| (pos, view.id))
+    })
+}
+
+pub fn gutter_coords_and_view(
+    editor: &Editor,
+    row: u16,
+    column: u16,
+) -> Option<(Position, ViewId)> {
+    editor.tree.views().find_map(|(view, _focus)| {
+        view.gutter_coords_at_screen_coords(row, column)
+            .map(|coords| (coords, view.id))
+    })
 }

--- a/helix-view/src/keyboard.rs
+++ b/helix-view/src/keyboard.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use bitflags::bitflags;
 
 bitflags! {
@@ -8,6 +10,29 @@ bitflags! {
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
         const NONE = 0b0000_0000;
+    }
+}
+
+impl fmt::Display for KeyModifiers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "{}{}{}",
+            if self.contains(KeyModifiers::SHIFT) {
+                "S-"
+            } else {
+                ""
+            },
+            if self.contains(KeyModifiers::ALT) {
+                "A-"
+            } else {
+                ""
+            },
+            if self.contains(KeyModifiers::CONTROL) {
+                "C-"
+            } else {
+                ""
+            },
+        ))
     }
 }
 


### PR DESCRIPTION
Feature: from the configuration file, it is now possible to map mouse buttons on some helix functionality.

Code:
Added new simple structures for Mousemaps,
and cloned only few key maps functions into mouse functions, do not hesitate if more are required.