### PR TITLE
Improve tree-sitter queries for Scala

### DIFF
--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -53,28 +53,13 @@
 (var_declaration
   name: (identifier) @variable)
 
-; method definition
+; function definitions/declarations
 
-(class_definition
-  body: (template_body
-    [
-      (function_definition
-        name: (identifier) @function.method)
-      (function_declaration
-        name: (identifier) @function.method)
-    ]))
-(trait_definition
-  body: (template_body
-    [
-      (function_definition
-        name: (identifier) @function.method)
-      (function_declaration
-        name: (identifier) @function.method)
-    ]))
-(object_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @function.method)))
+(function_declaration
+    name: (identifier) @function.method)
+
+(function_definition
+      name: (identifier) @function.method)
 
 ; imports/exports
 

--- a/runtime/queries/scala/textobjects.scm
+++ b/runtime/queries/scala/textobjects.scm
@@ -1,10 +1,13 @@
 ; Function queries
 
 (function_definition
-  body: (_) @function.inside) @function.around
+  body: (_) @function.inside) @function.around ; Does not include end marker
 
-; Does not match block lambdas or Scala 3 braceless lambdas
 (lambda_expression
+  (_) @function.inside) @function.around
+
+; Scala 3 braceless lambda
+(colon_argument
   (_) @function.inside) @function.around
 
 
@@ -30,6 +33,9 @@
 ; Parameter queries
 
 (parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(class_parameters
   ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (parameter_types


### PR DESCRIPTION
- Simplify function highlighting
- Highlight extension methods
- Textobject query (`mia`/`maa`) for class/trait constructor parameters/arguments
- Textobject query (`mif`/`maf`) for Scala 3 braceless lambdas