### PR TITLE
Set ui.virtual.ruler background for GitHub themes

### DIFF
--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -60,6 +60,7 @@ label = "scale.red.3"
 "ui.text.focus" = { fg = "fg.default" }
 "ui.text.inactive" = "fg.subtle"
 "ui.virtual" = { fg = "scale.gray.6" }
+"ui.virtual.ruler" = { bg = "canvas.subtle" }
 
 "ui.selection" = { bg = "scale.blue.8" }
 "ui.selection.primary" = { bg = "scale.blue.7" }

--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -60,6 +60,7 @@ label = "scale.red.5"
 "ui.text.focus" = { fg = "fg.default" }
 "ui.text.inactive" = "fg.subtle"
 "ui.virtual" = { fg = "scale.gray.2" }
+"ui.virtual.ruler" = { bg = "canvas.subtle" }
 
 "ui.selection" = { bg = "scale.blue.0" }
 "ui.selection.primary" = { bg = "scale.blue.1" }


### PR DESCRIPTION
Turning on a ruler does not show a visible ruler line for the GitHub themes. This change renders rulers using the `canvas.subtle` color. This matches the color used for the `cursorline` and creates a visible ruler that fits the theme.

<img width="1024" alt="Screenshot 2024-01-31 at 16 55 38" src="https://github.com/helix-editor/helix/assets/4931/5cb9c0ed-35eb-4aa9-b7fd-216088317498">
