### PR TITLE
Update grammars for Nushell to rev 358c4f50

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1832,7 +1832,7 @@ language-servers = [ "nu-lsp" ]
 
 [[grammar]]
 name = "nu"
-source = { git = "https://github.com/nushell/tree-sitter-nu", rev = "98c11c491e3405c75affa1cf004097692da3dda2" }
+source = { git = "https://github.com/nushell/tree-sitter-nu", rev = "358c4f509eb97f0148bbd25ad36acc729819b9c1" }
 
 [[language]]
 name = "vala"

--- a/runtime/queries/nu/highlights.scm
+++ b/runtime/queries/nu/highlights.scm
@@ -2,7 +2,6 @@
 ;;; keywords
 [
     "def"
-    "def-env"
     "alias"
     "export-env"
     "export"
@@ -73,7 +72,6 @@
         "tb" "tB" "Tb" "TB"
         "pb" "pB" "Pb" "PB"
         "eb" "eB" "Eb" "EB"
-        "zb" "zB" "Zb" "ZB"
 
         "kib" "kiB" "kIB" "kIb" "Kib" "KIb" "KIB"
         "mib" "miB" "mIB" "mIb" "Mib" "MIb" "MIB"
@@ -81,7 +79,6 @@
         "tib" "tiB" "tIB" "tIb" "Tib" "TIb" "TIB"
         "pib" "piB" "pIB" "pIb" "Pib" "PIb" "PIB"
         "eib" "eiB" "eIB" "eIb" "Eib" "EIb" "EIB"
-        "zib" "ziB" "zIB" "zIb" "Zib" "ZIb" "ZIB"
     ] @variable.parameter
 )
 (val_binary


### PR DESCRIPTION
[https://github.com/nushell/tree-sitter-nu](tree-sitter-nu) has seen many updates since the version currently specified in `languages.toml` and the language itself has changed to the extent that my modern configs (for 0.89.0) don't really parse well anymore, particularly with commands like `def` now taking flags like `--wrapped` and `--env`.

This commit specifies the latest version, and also updates the queries.