### PR TITLE
Update Unison tree-sitter grammar for type changes and add indent queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -173,7 +173,7 @@
 | typescript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | typst | ✓ |  |  | `typst-lsp` |
 | ungrammar | ✓ |  |  |  |
-| unison | ✓ |  |  |  |
+| unison | ✓ |  | ✓ |  |
 | uxntal | ✓ |  |  |  |
 | v | ✓ | ✓ | ✓ | `v-analyzer` |
 | vala | ✓ |  |  | `vala-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2940,7 +2940,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "unison"
-source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "aaec316774c8b50d367ec7cf26523aac5ef0cfc5" }
+source = { git = "https://github.com/kylegoetz/tree-sitter-unison", rev = "1f505e2447fa876a87aee47ff3d70b9e141c744f" }
 
 [[language]]
 name = "todotxt"

--- a/runtime/queries/unison/highlights.scm
+++ b/runtime/queries/unison/highlights.scm
@@ -9,8 +9,6 @@
 ;; Keywords
 [
   (kw_forall)
-  (unique_kw)
-  (structural_kw)
   (type_kw)
   (kw_equals)
   (do)
@@ -51,7 +49,7 @@
 (blank_pattern) @variable.builtin
 
 ;; Types
-(record_field name: (wordy_id) @variable.other.member type: (wordy_id) @type)
+(record_field name: (wordy_id) @variable.other.member type: (_) @type)
 (type_constructor (type_name (wordy_id) @constructor))
 (ability_declaration type_name: (wordy_id) @type type_arg: (wordy_id) @variable.parameter)
 (effect (wordy_id) @special) ;; NOTE: an effect is just like a type, but in signature we special case it

--- a/runtime/queries/unison/indents.scm
+++ b/runtime/queries/unison/indents.scm
@@ -12,3 +12,4 @@
   (type_signature)
 ] @indent
 
+[(kw_then) (kw_else) (cases)] @indent.always @extend

--- a/runtime/queries/unison/indents.scm
+++ b/runtime/queries/unison/indents.scm
@@ -1,0 +1,14 @@
+[
+  (term_definition)
+  (type_declaration)
+  (pattern)
+  (tuple_or_parenthesized)
+  (literal_list)
+  (tuple_pattern)
+  (function_application)
+  (exp_if)
+  (constructor)
+  (delay_block)
+  (type_signature)
+] @indent
+


### PR DESCRIPTION
Unison's syntax changes and `unique` is now optional, updated grammar rev and tweaked the queries in this PR.