### PR TITLE
feat(queries): regex injection for golang

### DIFF
--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -1,2 +1,14 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+
+(call_expression
+  (selector_expression) @_function
+  (#any-of? @_function "regexp.Match" "regexp.MatchReader" "regexp.MatchString" "regexp.Compile" "regexp.CompilePOSIX" "regexp.MustCompile" "regexp.MustCompilePOSIX")
+  (argument_list
+    .
+    [
+      (raw_string_literal)
+      (interpreted_string_literal)
+    ] @injection.content
+    (#set! injection.language "regex")))


### PR DESCRIPTION
Ported from nvim.[^1]

[^1]: https://github.com/nvim-treesitter/nvim-treesitter/blob/f2119df35cdcdb0c6c9bf791a04000d4d131cef7/queries/go/injections.scm