### PR TITLE
Add blade support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -8,6 +8,7 @@
 | beancount | ✓ |  |  |  |
 | bibtex | ✓ |  |  | `texlab` |
 | bicep | ✓ |  |  | `bicep-langserver` |
+| blade | ✓ |  |  |  |
 | blueprint | ✓ |  |  | `blueprint-compiler` |
 | c | ✓ | ✓ | ✓ | `clangd` |
 | c-sharp | ✓ | ✓ |  | `OmniSharp` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -128,6 +128,7 @@
 | pem | ✓ |  |  |  |
 | perl | ✓ | ✓ | ✓ | `perlnavigator` |
 | php | ✓ | ✓ | ✓ | `intelephense` |
+| php-only | ✓ |  |  |  |
 | pkl | ✓ |  | ✓ |  |
 | po | ✓ | ✓ |  |  |
 | pod | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -943,6 +943,17 @@ name = "php-only"
 source = { git = "https://github.com/tree-sitter/tree-sitter-php", rev = "cf1f4a0f1c01c705c1d6cf992b104028d5df0b53", subpath = "php_only" }
 
 [[language]]
+name = "blade"
+scope = "source.blade.php"
+file-types = [{ glob = "*.blade.php" }, "blade"]
+injection-regex = "blade"
+roots = ["composer.json", "index.php"]
+
+[[grammar]]
+name = "blade"
+source = { git = "https://github.com/EmranMR/tree-sitter-blade", rev = "4c66efe1e05c639c555ee70092021b8223d2f440" }
+
+[[language]]
 name = "twig"
 scope = "source.twig"
 injection-regex = "twig"

--- a/languages.toml
+++ b/languages.toml
@@ -931,6 +931,18 @@ name = "php"
 source = { git = "https://github.com/tree-sitter/tree-sitter-php", rev = "f860e598194f4a71747f91789bf536b393ad4a56" }
 
 [[language]]
+name = "php-only"
+scope = "source.php-only"
+injection-regex = "php-only"
+file-types = []
+indent = { tab-width = 4, unit = "    " }
+roots = ["composer.json", "index.php"]
+
+[[grammar]]
+name = "php-only"
+source = { git = "https://github.com/tree-sitter/tree-sitter-php", rev = "cf1f4a0f1c01c705c1d6cf992b104028d5df0b53", subpath = "php_only" }
+
+[[language]]
 name = "twig"
 scope = "source.twig"
 injection-regex = "twig"

--- a/runtime/queries/blade/folds.scm
+++ b/runtime/queries/blade/folds.scm
@@ -1,0 +1,8 @@
+((directive_start) @start
+    (directive_end) @end.after
+    (#set! role block))
+
+
+((bracket_start) @start
+    (bracket_end) @end
+    (#set! role block))

--- a/runtime/queries/blade/highlights.scm
+++ b/runtime/queries/blade/highlights.scm
@@ -1,0 +1,4 @@
+(directive) @tag
+(directive_start) @tag
+(directive_end) @tag
+(comment) @comment

--- a/runtime/queries/blade/injections.scm
+++ b/runtime/queries/blade/injections.scm
@@ -1,0 +1,9 @@
+((text) @injection.content
+    (#set! injection.combined)
+    (#set! injection.language php))
+
+((php_only) @injection.content
+    (#set! injection.language php-only))
+((parameter) @injection.content
+    (#set! injection.language php-only))
+

--- a/runtime/queries/php-only/highlights.scm
+++ b/runtime/queries/php-only/highlights.scm
@@ -1,0 +1,123 @@
+(php_tag) @tag
+"?>" @tag
+
+; Types
+
+(primitive_type) @type.builtin
+(cast_type) @type.builtin
+(named_type (name) @type) @type
+(named_type (qualified_name) @type) @type
+
+; Functions
+
+(array_creation_expression "array" @function.builtin)
+(list_literal "list" @function.builtin)
+
+(method_declaration
+  name: (name) @function.method)
+
+(function_call_expression
+  function: [(qualified_name (name)) (name)] @function)
+
+(scoped_call_expression
+  name: (name) @function)
+
+(member_call_expression
+  name: (name) @function.method)
+
+(function_definition
+  name: (name) @function)
+
+; Member
+
+(property_element
+  (variable_name) @variable.other.member)
+
+(member_access_expression
+  name: (variable_name (name)) @variable.other.member)
+(member_access_expression
+  name: (name) @variable.other.member)
+
+; Variables
+
+(relative_scope) @variable.builtin
+
+((name) @constant
+ (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
+((name) @constant.builtin
+ (#match? @constant.builtin "^__[A-Z][A-Z\d_]+__$"))
+
+((name) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((name) @variable.builtin
+ (#eq? @variable.builtin "this"))
+
+(variable_name) @variable
+
+; Basic tokens
+[
+  (string)
+  (string_value)
+  (encapsed_string)
+  (heredoc)
+  (heredoc_body)
+  (nowdoc_body)
+] @string
+(boolean) @constant.builtin.boolean
+(null) @constant.builtin
+(integer) @constant.builtin.integer
+(float) @constant.builtin.float
+(comment) @comment
+
+"$" @operator
+
+; Keywords
+
+"abstract" @keyword
+"as" @keyword
+"break" @keyword
+"case" @keyword
+"catch" @keyword
+"class" @keyword
+"const" @keyword
+"continue" @keyword
+"declare" @keyword
+"default" @keyword
+"do" @keyword
+"echo" @keyword
+"else" @keyword
+"elseif" @keyword
+"enddeclare" @keyword
+"endforeach" @keyword
+"endif" @keyword
+"endswitch" @keyword
+"endwhile" @keyword
+"extends" @keyword
+"final" @keyword
+"finally" @keyword
+"for" @keyword
+"foreach" @keyword
+"function" @keyword
+"global" @keyword
+"if" @keyword
+"implements" @keyword
+"include_once" @keyword
+"include" @keyword
+"insteadof" @keyword
+"interface" @keyword
+"namespace" @keyword
+"new" @keyword
+"private" @keyword
+"protected" @keyword
+"public" @keyword
+"require_once" @keyword
+"require" @keyword
+"return" @keyword
+"static" @keyword
+"switch" @keyword
+"throw" @keyword
+"trait" @keyword
+"try" @keyword
+"use" @keyword
+"while" @keyword

--- a/runtime/queries/php-only/injections.scm
+++ b/runtime/queries/php-only/injections.scm
@@ -1,0 +1,10 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+(heredoc
+  (heredoc_body) @injection.content
+  (heredoc_end) @injection.language)
+
+(nowdoc
+  (nowdoc_body) @injection.content
+  (heredoc_end) @injection.language)

--- a/runtime/queries/php-only/tags.scm
+++ b/runtime/queries/php-only/tags.scm
@@ -1,0 +1,40 @@
+(namespace_definition
+  name: (namespace_name) @name) @module
+
+(interface_declaration
+  name: (name) @name) @definition.interface
+
+(trait_declaration
+  name: (name) @name) @definition.interface
+
+(class_declaration
+  name: (name) @name) @definition.class
+
+(class_interface_clause [(name) (qualified_name)] @name) @impl
+
+(property_declaration
+  (property_element (variable_name (name) @name))) @definition.field
+
+(function_definition
+  name: (name) @name) @definition.function
+
+(method_declaration
+  name: (name) @name) @definition.function
+
+(object_creation_expression
+  [
+    (qualified_name (name) @name)
+    (variable_name (name) @name)
+  ]) @reference.class
+
+(function_call_expression
+  function: [
+    (qualified_name (name) @name)
+    (variable_name (name)) @name
+  ]) @reference.call
+
+(scoped_call_expression
+  name: (name) @name) @reference.call
+
+(member_call_expression
+  name: (name) @name) @reference.call


### PR DESCRIPTION
Fixes #8562

Add [`blade`](https://github.com/EmranMR/tree-sitter-blade) tree-sitter config.

It needs [`php_only`](https://github.com/tree-sitter/tree-sitter-php/tree/master/php_only), which is separate from the regular `php` grammar.

![image](https://github.com/helix-editor/helix/assets/31388299/cf78a307-d858-45fe-82b9-f381dbf2c1e1)
