### PR TITLE
adding asynchronous job tracking support for statusline

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -125,6 +125,7 @@ The following statusline elements can be configured:
 | `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |
 | `version-control` | The current branch name or detached commit hash of the opened workspace |
 | `register` | The current selected register |
+| `jobs` | The amount of asynchronous jobs currently scheduled |
 
 ### `[editor.lsp]` Section
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -8,6 +8,7 @@ use helix_view::{
     Document, Editor, View,
 };
 
+use crate::job::job_count;
 use crate::ui::ProgressSpinners;
 
 use helix_view::editor::StatusLineElement as StatusLineElementID;
@@ -162,6 +163,7 @@ where
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
         helix_view::editor::StatusLineElement::Register => render_register,
+        helix_view::editor::StatusLineElement::Jobs => render_jobs,
     }
 }
 
@@ -513,4 +515,11 @@ where
     if let Some(reg) = context.editor.selected_register {
         write(context, format!(" reg={} ", reg), None)
     }
+}
+
+fn render_jobs<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    write(context, format!("# {}", job_count()), None)
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -521,5 +521,8 @@ fn render_jobs<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    write(context, format!("# {}", job_count()), None)
+    let job_count = job_count();
+    if job_count > 0 {
+        write(context, format!("# {}", job_count), None)
+    }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -531,6 +531,9 @@ pub enum StatusLineElement {
 
     /// Indicator for selected register
     Register,
+
+    /// Current amount of jobs
+    Jobs,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs


### PR DESCRIPTION
Adding a statusline option for displaying the amount of asynchronous jobs which are scheduled. I find myself wanting this information because currently, when working on large workspaces, certain operations take a long time to process and therefore being able to see whether or not the job was successfully scheduled could help so that you're not spending time thinking about how many unfinished write commands you have ongoing, or if you correctly opened the workspace symbol picker because it takes so long to open. 