### PR TITLE
Update colors used for zed themes

### DIFF
--- a/runtime/themes/zed_onedark.toml
+++ b/runtime/themes/zed_onedark.toml
@@ -4,22 +4,20 @@
 "comment" = { fg = "light-gray", modifiers = ["italic"] }
 "constant" = { fg = "yellow" }
 "constant.numeric" = { fg = "orange" }
-"constant.builtin" = { fg = "orange" }
+"constant.builtin" = { fg = "yellow" }
 "constant.builtin.boolean" = { fg = "yellow" }
-"constant.character.escape" = { fg = "orange" }
+"constant.character.escape" = { fg = "yellow" }
 "constructor" = { fg = "blue" }
 "function" = { fg = "blue" }
 "function.builtin" = { fg = "blue" }
-"function.macro" = { fg = "purple" }
+"function.method" = { fg = "blue" }
+"function.macro" = { fg = "blue" }
 "keyword" = { fg = "purple" }
-"keyword.control" = { fg = "purple" }
-"keyword.control.import" = { fg = "purple" }
-"keyword.directive" = { fg = "purple" }
 "label" = { fg = "ui-text" }
 "namespace" = { fg = "ui-text" }
 "operator" = { fg = "ui-text" }
-"keyword.operator" = { fg = "purple" }
-"special" = { fg = "blue" }
+"puncuation" = { fg = "ui-text" }
+"special" = { fg = "ui-text" }
 "string" = { fg = "green" }
 "type" = { fg = "cyan" }
 "variable.builtin" = { fg = "orange" }
@@ -28,41 +26,43 @@
 
 "markup.heading" = { fg = "red" }
 "markup.raw.inline" = { fg = "green" }
-"markup.bold" = { fg = "orange", modifiers = ["bold"] }
+"markup.bold" = { fg = "yellow", modifiers = ["bold"] }
 "markup.italic" = { fg = "purple", modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.list" = { fg = "red" }
 "markup.quote" = { fg = "yellow" }
-"markup.link.url" = { fg = "cyan", modifiers = ["underlined"]}
+"markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }
 "markup.link.text" = { fg = "purple" }
 
 "diff.plus" = "green"
-"diff.delta" = "orange"
+"diff.delta" = "yellow"
 "diff.minus" = "red"
 
-"diagnostic.info".underline = { color = "blue", style = "curl" } 
-"diagnostic.hint".underline = { color = "green", style = "curl" } 
-"diagnostic.warning".underline = { color = "yellow", style = "curl" } 
-"diagnostic.error".underline = { color = "red", style = "curl" } 
+"diagnostic.info".underline = { color = "blue", style = "curl" }
+"diagnostic.hint".underline = { color = "green", style = "curl" }
+"diagnostic.warning".underline = { color = "yellow", style = "curl" }
+"diagnostic.error".underline = { color = "red", style = "curl" }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }
 "error" = { fg = "red", modifiers = ["bold"] }
 
 "ui.background" = { bg = "ui-text-reversed" }
+"ui.gutter" = { bg = "gray" }
 "ui.virtual" = { fg = "faint-gray" }
-"ui.virtual.indent-guide" = { fg = "faint-gray" }
+"ui.virtual.indent-guidje" = { fg = "faint-gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
 "ui.virtual.ruler" = { bg = "gray" }
-"ui.virtual.inlay-hint" = { fg = "light-gray" }
+"ui.virtual.inlay-hint" = { fg = "blue-gray", modifiers = ["bold"] }
 
 "ui.cursor" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }
-"ui.cursor.match" = { fg = "blue", modifiers = ["underlined"]}
+"ui.cursor.match" = { fg = "blue", modifiers = ["underlined"] }
+"ui.cursor.insert" = { fg = "dark-blue" }
 
 "ui.selection" = { bg = "faint-gray" }
-"ui.selection.primary" = { bg = "gray" }
-"ui.cursorline.primary" = { bg = "light-black" }
+"ui.selection.primary" = { bg = "#293b5bff" }
+"ui.cursorline.primary" = { bg = "black" }
 
 "ui.highlight" = { bg = "gray" }
 "ui.highlight.frameline" = { bg = "#97202a" }
@@ -70,14 +70,14 @@
 "ui.linenr" = { fg = "linenr" }
 "ui.linenr.selected" = { fg = "ui-text" }
 
-"ui.statusline" = { fg = "white", bg = "light-black" }
-"ui.statusline.inactive" = { fg = "light-gray", bg = "light-black" }
-"ui.statusline.normal" = { fg = "light-black", bg = "blue" }
-"ui.statusline.insert" = { fg = "light-black", bg = "green" }
-"ui.statusline.select" = { fg = "light-black", bg = "purple" }
+"ui.statusline" = { fg = "white", bg = "gray" }
+"ui.statusline.inactive" = { fg = "light-gray", bg = "black" }
+"ui.statusline.normal" = { fg = "black", bg = "blue" }
+"ui.statusline.insert" = { fg = "black", bg = "green" }
+"ui.statusline.select" = { fg = "black", bg = "purple" }
 
 "ui.text" = { fg = "ui-text" }
-"ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
+"ui.text.focus" = { fg = "white", bg = "black", modifiers = ["bold"] }
 
 "ui.help" = { fg = "white", bg = "gray" }
 "ui.popup" = { bg = "gray" }
@@ -89,22 +89,21 @@
 "ui.debug" = { fg = "red" }
 
 [palette]
-
-yellow = "#dac18c"
-blue = "#7ca8dd"
-red = "#bd7476"
-purple = "#9d74b9"
-green = "#a0b783"
-orange = "#b4926e" 
-cyan = "#7eb2be"
-light-black = "#2e323a"
-gray = "#363f4c"
-light-gray = "#5c606b"
+yellow = "#dfc184ff"
+orange = "#bf956aff"
+blue = "#73ade9ff"
+blue-gray = "#5a6f89ff"
+red = "#d07277ff"
+purple = "#b477cfff"
+green = "#a1c181ff"
+cyan = "#6eb4bfff"
+gray = "#2f343ebf"
+light-gray = "#5d636fff"
 faint-gray = "#3B4048"
-linenr = "#4B5263"
+linenr = "#5d636fff"
 
-white = "#a8adb7"
-black = "#292c33"
+white = "#c8ccd4ff"
+black = "#282c33ff"
 # black and white are used for a lot of the UI text
-ui-text = "#a8adb7" #white
-ui-text-reversed = "#292c33" #black
+ui-text = "#c8ccd4ff"          #white
+ui-text-reversed = "#282c33ff" #black

--- a/runtime/themes/zed_onelight.toml
+++ b/runtime/themes/zed_onelight.toml
@@ -16,8 +16,12 @@ inherits = "zed_onedark"
 
 "ui.cursor" = { fg = "dark-blue", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "dark-blue", modifiers = ["reversed"] }
+"ui.cursor.insert" = { fg = "dark-blue" }
 
+"ui.selection.primary" = { bg = "blue-gray" }
 "ui.cursorline.primary" = { bg = "faint-gray" }
+
+"ui.virtual.inlay-hint" = { fg = "violet", modifiers = ["bold"] }
 
 "ui.statusline" = { fg = "black", bg = "gray" }
 "ui.statusline.inactive" = { fg = "white", bg = "light-black" }
@@ -33,23 +37,26 @@ inherits = "zed_onedark"
 
 [palette]
 
-yellow = "#dac18c"
-blue = "#5185b5"
-red = "#bd7476"
-dark-blue = "#607bdb"
-orange = "#ca7667"
-purple = "#a160ac"
-green = "#739d60"
-gold = "#a8763c"
-cyan = "#4b80b2"
+yellow = "#dabb7e"
+red = "#d36151ff"
+orange = "#d3604fff"
+blue = "#5b79e3ff"
+dark-blue = "#4a62db"
+purple = "#a449abff"
+violet = "#9294beff"
+green = "#649f57ff"
+gold = "#ad6e25ff"
+cyan = "#3882b7ff"
 light-black = "#2e323a"
-gray = "#dcdcdd"
+# gray = "#dcdcdd"
+gray = "#eaeaed"
 dark-gray = "#ebebec"
-light-gray = "#a6a6aa"
+light-gray = "#a2a3a7ff"
+blue-gray = "#d9dcea"
 faint-gray = "#efefef"
-linenr = "#4B5263"
+linenr = "#b0b1b3"
 
-black = "#404248"
-white = "#fafafa"
-ui-text = "#404248"
-ui-text-reversed = "#fafafa"
+black = "#383a41ff"
+white = "#fafafaff"
+ui-text = "#383a41ff"
+ui-text-reversed = "#fafafaff"


### PR DESCRIPTION
Official colors used are now [publicly available](https://github.com/zed-industries/zed/blob/main/assets/themes/one/one.json)
Modified the theme to more accurately reflect the actual colors being used.