### PR TITLE
Revert "build(deps): bump cc from 1.0.83 to 1.0.84 (#8809)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.84"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The dependency `cc` version `1.0.84` was yanked. Here is the [explanation](https://github.com/rust-lang/cc-rs/releases/tag/1.0.84) on the release page.

This PR simply reverts back to the previous version of the dependency. It will also fix issue #8820 .