### PR TITLE
feat(languages): add formatter for just, fish

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -311,6 +311,8 @@ file-types = ["fish"]
 shebangs = ["fish"]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
+auto-format = true
+formatter = { command = "fish_indent" }
 
 [[grammar]]
 name = "fish"

--- a/languages.toml
+++ b/languages.toml
@@ -2790,6 +2790,8 @@ file-types = ["justfile", "Justfile", ".justfile", ".Justfile"]
 injection-regex = "just"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+formatter = { command = "just", args = ["--dump"] }
 
 [[grammar]]
 name = "just"


### PR DESCRIPTION
Per the [documentation](https://just.systems/man/en/chapter_57.html?highlight=format#formatting-and-dumping-justfiles) `just --dump` can be used to output a formatted representation of the justfile in the current working directory to stdout.