### PR TITLE
Add "zon" file type to zig language section

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1158,7 +1158,7 @@ source = { git = "https://github.com/postsolar/tree-sitter-purescript", rev = "5
 name = "zig"
 scope = "source.zig"
 injection-regex = "zig"
-file-types = ["zig"]
+file-types = ["zig", "zon"]
 roots = ["build.zig"]
 auto-format = true
 comment-token = "//"


### PR DESCRIPTION
`build.zig.zon` is what 0.11.0 uses for external dependencies.  The syntax is a subset of zig and can be highlighted and formatted like normal zig code.