### PR TITLE
Updated Swift grammar, adding 'any' and 'await' keywords.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1730,7 +1730,7 @@ language-servers = [ "sourcekit-lsp" ]
 
 [[grammar]]
 name = "swift"
-source = { git = "https://github.com/alex-pinkus/tree-sitter-swift", rev = "77c6312c8438f4dbaa0350cec92b3d6dd3d74a66" }
+source = { git = "https://github.com/alex-pinkus/tree-sitter-swift", rev = "b1b66955d420d5cf5ff268ae552f0d6e43ff66e1" }
 
 [[language]]
 name = "erb"

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -1,10 +1,10 @@
-; Upstream: https://github.com/alex-pinkus/tree-sitter-swift/blob/8d2fd80e3322df51e3f70952e60d57f5d4077eb8/queries/highlights.scm
+; Upstream: https://github.com/alex-pinkus/tree-sitter-swift/blob/1c586339fb00014b23d6933f2cc32b588a226f3b/queries/highlights.scm
 
 (line_string_literal
   ["\\(" ")"] @punctuation.special)
 
 ["." ";" ":" "," ] @punctuation.delimiter
-["(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 ; Identifiers
 (attribute) @variable
@@ -26,6 +26,7 @@
 (function_declaration "init" @constructor)
 (throws) @keyword
 "async" @keyword
+"await" @keyword
 (where_keyword) @keyword
 (parameter external_name: (simple_identifier) @variable.parameter)
 (parameter name: (simple_identifier) @variable.parameter)
@@ -48,6 +49,7 @@
   "convenience"
   "required"
   "some"
+  "any"
 ] @keyword
 
 [


### PR DESCRIPTION
This updates `runtime/queries/swift/highlights.scm`, adding `any` and `await` as keywords. It also removes a todo that was already done, and updates the upstream-comment on Line 1 with newest commit ID for `tree-sitter-swift (main)`.

The `languages.toml` file was also updated, setting Swift's `source.rev` to the newest commit ID for `tree-sitter-swift (with-generated-files)`.

There are a handful of other issues with Swift syntax-highlighting, but they're all upstream, so I'll summarize them here, and open issues with tree-sitter/tree-sitter-swift:

- `defer` should be a keyword
- `inout` is highlighted, but `borrowing` and `consuming` are not
- `Self` and `self` should be highlighted the same way (`Self` is also a builtin variable)
- the new if- and switch-expressions are not parsed correctly
- in Xcode, `try` is highlighted as a keyword, and `?` and `!` as suffix operators (when in suffix position), but tree-sitter tokenizes `try?` and `try!` as single (operator) tokens

P.S. Thanks again to @the-mikedavis and @Dispersia. I really appreciate your help.