### PR TITLE
docs: Document what the `diff` gutter symbol does

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -340,7 +340,12 @@ Currently unused
 
 #### `[editor.gutters.diff]` Section
 
-Currently unused
+The `diff` gutter option displays colored bars indicating whether a `git` diff represents that a line was added, removed or changed.
+These colors are controlled by the theme attributes `diff.plus`, `diff.minus` and `diff.delta`.
+
+Other diff providers will eventually be supported by a future plugin system.
+
+There are currently no options for this section.
 
 #### `[editor.gutters.spacer]` Section
 


### PR DESCRIPTION
Before there was no document about what the `diff` gutter is displaying
or what the colors mean.

These docs clarify it's a `git` diff and makes it easier to
cross-reference the theme if you aren't sure what the colors mean or
want to change them.
