### PR TITLE
Respect lsp definition order for code actions

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -146,7 +146,7 @@ They have to be defined in the `[language-server]` table as described in the pre
 
 Different languages can use the same language server instance, e.g. `typescript-language-server` is used for javascript, jsx, tsx and typescript by default.
 
-The definition order of language servers affects the order in the results list of items in completion and action menu.
+The definition order of language servers affects the order in the results list of code action menu.
 
 In case multiple language servers are specified in the `language-servers` attribute of a `language`,
 it's often useful to only enable/disable certain language-server features for these language servers.

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -146,6 +146,8 @@ They have to be defined in the `[language-server]` table as described in the pre
 
 Different languages can use the same language server instance, e.g. `typescript-language-server` is used for javascript, jsx, tsx and typescript by default.
 
+The definition order of language servers affects the order in the results list of items in completion and action menu.
+
 In case multiple language servers are specified in the `language-servers` attribute of a `language`,
 it's often useful to only enable/disable certain language-server features for these language servers.
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1,4 +1,4 @@
-use futures_util::{stream::FuturesUnordered, FutureExt};
+use futures_util::{stream::FuturesOrdered, FutureExt};
 use helix_lsp::{
     block_on,
     lsp::{
@@ -339,7 +339,7 @@ pub fn symbol_picker(cx: &mut Context) {
 
     let mut seen_language_servers = HashSet::new();
 
-    let mut futures: FuturesUnordered<_> = doc
+    let mut futures: FuturesOrdered<_> = doc
         .language_servers_with_feature(LanguageServerFeature::DocumentSymbols)
         .filter(|ls| seen_language_servers.insert(ls.id()))
         .map(|language_server| {
@@ -414,7 +414,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     let get_symbols = move |pattern: String, editor: &mut Editor| {
         let doc = doc!(editor);
         let mut seen_language_servers = HashSet::new();
-        let mut futures: FuturesUnordered<_> = doc
+        let mut futures: FuturesOrdered<_> = doc
             .language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols)
             .filter(|ls| seen_language_servers.insert(ls.id()))
             .map(|language_server| {
@@ -580,7 +580,7 @@ pub fn code_action(cx: &mut Context) {
 
     let mut seen_language_servers = HashSet::new();
 
-    let mut futures: FuturesUnordered<_> = doc
+    let mut futures: FuturesOrdered<_> = doc
         .language_servers_with_feature(LanguageServerFeature::CodeAction)
         .filter(|ls| seen_language_servers.insert(ls.id()))
         // TODO this should probably already been filtered in something like "language_servers_with_feature"

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -199,7 +199,7 @@ fn request_completion(
     let mut futures: FuturesOrdered<_> = doc
         .language_servers_with_feature(LanguageServerFeature::Completion)
         .filter(|ls| seen_language_servers.insert(ls.id()))
-        .filter_map(|ls| {
+        .map(|ls| {
             let language_server_id = ls.id();
             let offset_encoding = ls.offset_encoding();
             let pos = pos_to_lsp_pos(text, cursor, offset_encoding);
@@ -227,8 +227,8 @@ fn request_completion(
                 }
             };
 
-            let completion_response = ls.completion(doc_id, pos, None, context)?;
-            Some(async move {
+            let completion_response = ls.completion(doc_id, pos, None, context).unwrap();
+            async move {
                 let json = completion_response.await?;
                 let response: Option<lsp::CompletionResponse> = serde_json::from_value(json)?;
                 let items = match response {
@@ -248,7 +248,7 @@ fn request_completion(
                 })
                 .collect();
                 anyhow::Ok(items)
-            })
+            }
         })
         .collect();
 

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
-use futures_util::stream::FuturesOrdered;
+use futures_util::stream::FuturesUnordered;
 use helix_core::chars::char_is_word;
 use helix_core::syntax::LanguageServerFeature;
 use helix_event::{
@@ -196,7 +196,7 @@ fn request_completion(
     let trigger_text = text.slice(..cursor);
 
     let mut seen_language_servers = HashSet::new();
-    let mut futures: FuturesOrdered<_> = doc
+    let mut futures: FuturesUnordered<_> = doc
         .language_servers_with_feature(LanguageServerFeature::Completion)
         .filter(|ls| seen_language_servers.insert(ls.id()))
         .map(|ls| {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -282,11 +282,6 @@ impl Completion {
                     let language_server = language_server!(item);
                     let offset_encoding = language_server.offset_encoding();
 
-                    let language_server = editor
-                        .language_servers
-                        .get_by_id(item.language_server_id)
-                        .unwrap();
-
                     // resolve item if not yet resolved
                     if !item.resolved {
                         if let Some(resolved) =


### PR DESCRIPTION
Hi!

It's small changes to render completions/actions from lsp by they definition order on languages.toml
