### PR TITLE
Statusline indicator showing how many lines across all selections

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -121,6 +121,7 @@ The following statusline elements can be configured:
 | `workspace-diagnostics` | The number of warnings and/or errors on workspace |
 | `selections` | The number of active selections |
 | `primary-selection-length` | The number of characters currently in primary selection |
+| `selections-line-count` | Number of lines across all selections |
 | `position` | The cursor position |
 | `position-percentage` | The cursor position as a percentage of the total number of lines |
 | `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -534,6 +534,9 @@ pub enum StatusLineElement {
     /// The number of selections (cursors)
     Selections,
 
+    /// The number of lines across all selections
+    SelectionsLineCount,
+
     /// The number of characters currently in primary selection
     PrimarySelectionLength,
 


### PR DESCRIPTION
This indicator shows how many lines total are used by all selections in the current view.
* One or more selections on the same line only counts that line once
* A single cursor counts that line as well
* A selection that spans several lines will count all those lines as well.

Notes:
* The idea is, after making selections, if we run the `extend_to_line_bounds` command, how many lines do we get? That's the count I would like shown here.
* Maybe a zero width selection shouldn't be counted?
* Current implementation uses `HashSet`, maybe there's a better implementation that can use ranges only?