### PR TITLE
Bump tree-sitter-erlang, add `*.app.src` file-type

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1598,7 +1598,7 @@ source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "
 name = "erlang"
 scope = "source.erlang"
 injection-regex = "erl(ang)?"
-file-types = ["erl", "hrl", "app", { glob = "rebar.config" }, { glob = "rebar.lock" }]
+file-types = ["erl", "hrl", "app", { glob = "rebar.config" }, { glob = "rebar.lock" }, { glob = "*.app.src" }]
 roots = ["rebar.config"]
 shebangs = ["escript"]
 comment-token = "%%"
@@ -1615,7 +1615,7 @@ language-servers = [ "erlang-ls" ]
 
 [[grammar]]
 name = "erlang"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "ce0ed253d72c199ab93caba7542b6f62075339c4" }
+source = { git = "https://github.com/the-mikedavis/tree-sitter-erlang", rev = "731e50555a51f0d8635992b0e60dc98cc47a58d7" }
 
 [[language]]
 name = "kotlin"

--- a/runtime/queries/erlang/highlights.scm
+++ b/runtime/queries/erlang/highlights.scm
@@ -145,8 +145,9 @@
 ((atom) @constant.builtin.boolean
  (#match? @constant.builtin.boolean "^(true|false)$"))
 (atom) @string.special.symbol
-(string) @string
+[(string) (sigil)] @string
 (character) @constant.character
+(escape_sequence) @constant.character.escape
 
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float


### PR DESCRIPTION
This update fixes parsing for some newer accepted EEPs:

* <https://www.erlang.org/eeps/eep-0058> map comprehensions
* <https://www.erlang.org/eeps/eep-0064> triple quoted strings
* <https://www.erlang.org/eeps/eep-0066> sigils

Also now that glob file-types are supported I've added `*.app.src` which are files that build tools like rebar or make will generate into `.app` files.