### PR TITLE
Remove unwrap on line option, preventing DAP crash

### DIFF
--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -226,10 +226,15 @@ impl Editor {
                                     breakpoints.iter().position(|b| b.id == breakpoint.id)
                                 {
                                     breakpoints[i].verified = breakpoint.verified;
-                                    breakpoints[i].message = breakpoint.message.clone();
-                                    breakpoints[i].line =
-                                        breakpoint.line.map_or(0, |line| line.saturating_sub(1));
-                                    breakpoints[i].column = breakpoint.column;
+                                    breakpoints[i].message = breakpoint
+                                        .message
+                                        .clone()
+                                        .or_else(|| breakpoints[i].message.take());
+                                    breakpoints[i].line = breakpoint
+                                        .line
+                                        .map_or(breakpoints[i].line, |line| line.saturating_sub(1));
+                                    breakpoints[i].column =
+                                        breakpoint.column.or(breakpoints[i].column);
                                 }
                             }
                         }

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -228,7 +228,7 @@ impl Editor {
                                     breakpoints[i].verified = breakpoint.verified;
                                     breakpoints[i].message = breakpoint.message.clone();
                                     breakpoints[i].line =
-                                        breakpoint.line.unwrap().saturating_sub(1); // TODO: no unwrap
+                                        breakpoint.line.map_or(0, |line| line.saturating_sub(1));
                                     breakpoints[i].column = breakpoint.column;
                                 }
                             }


### PR DESCRIPTION
Fix #4683.
xdebug.php-debug-1.34.0 does not provide a line value for this event, this change fixes the issue for me

```
helix_dap::transport [INFO] <- DAP event Breakpoint(Breakpoint { reason: "changed", breakpoint: Breakpoint { id: Some(6), verified: false, message: None, source: None, line: None, column: None, end_line: None, end_column: None, instruction_reference: None, offset: None } })
```

