### PR TITLE
improve handling of different URI schemes over LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,8 @@ dependencies = [
  "etcetera",
  "ropey",
  "tempfile",
+ "thiserror",
+ "url",
  "which",
 ]
 

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -68,6 +68,27 @@ pub mod util {
     use helix_core::{chars, RopeSlice, SmallVec};
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
 
+    #[derive(Debug, Error)]
+    pub enum FilePathError {
+        #[error("unsupported scheme in URI")]
+        UnsupportedScheme,
+        #[error("unable to convert URI to file path")]
+        UnableToConvert,
+    }
+
+    /// Converts a [`Url`] into a [`PathBuf`].
+    ///
+    /// Unlike [`Url::to_file_path`], this method respects the uri's scheme
+    /// and returns `Ok(None)` if the scheme was not "file".
+    pub fn uri_to_file_path(uri: &Url) -> ::core::result::Result<PathBuf, FilePathError> {
+        if uri.scheme() == "file" {
+            uri.to_file_path()
+                .map_err(|_| FilePathError::UnableToConvert)
+        } else {
+            Err(FilePathError::UnsupportedScheme)
+        }
+    }
+
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
     ///
     /// Panics when [`pos_to_lsp_pos`] would for an invalid range on the diagnostic.

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -68,27 +68,6 @@ pub mod util {
     use helix_core::{chars, RopeSlice, SmallVec};
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
 
-    #[derive(Debug, Error)]
-    pub enum FilePathError {
-        #[error("unsupported scheme in URI")]
-        UnsupportedScheme,
-        #[error("unable to convert URI to file path")]
-        UnableToConvert,
-    }
-
-    /// Converts a [`Url`] into a [`PathBuf`].
-    ///
-    /// Unlike [`Url::to_file_path`], this method respects the uri's scheme
-    /// and returns `Ok(None)` if the scheme was not "file".
-    pub fn uri_to_file_path(uri: &Url) -> ::core::result::Result<PathBuf, FilePathError> {
-        if uri.scheme() == "file" {
-            uri.to_file_path()
-                .map_err(|_| FilePathError::UnableToConvert)
-        } else {
-            Err(FilePathError::UnsupportedScheme)
-        }
-    }
-
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
     ///
     /// Panics when [`pos_to_lsp_pos`] would for an invalid range on the diagnostic.

--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -15,6 +15,8 @@ homepage.workspace = true
 dunce = "1.0"
 etcetera = "0.8"
 ropey = { version = "1.6.1", default-features = false }
+thiserror = "1.0.57"
+url = "2.5.0"
 which = "6.0"
 
 [dev-dependencies]

--- a/helix-stdx/src/lib.rs
+++ b/helix-stdx/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod env;
 pub mod path;
 pub mod rope;
+pub mod uri;

--- a/helix-stdx/src/uri.rs
+++ b/helix-stdx/src/uri.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Error)]
+pub enum FilePathError<'a> {
+    #[error("unsupported scheme in URI: {0}")]
+    UnsupportedScheme(&'a Url),
+    #[error("unable to convert URI to file path: {0}")]
+    UnableToConvert(&'a Url),
+}
+
+/// Converts a [`Url`] into a [`PathBuf`].
+///
+/// Unlike [`Url::to_file_path`], this method respects the uri's scheme
+/// and returns `Ok(None)` if the scheme was not "file".
+pub fn uri_to_file_path(uri: &Url) -> Result<PathBuf, FilePathError> {
+    if uri.scheme() == "file" {
+        uri.to_file_path()
+            .map_err(|_| FilePathError::UnableToConvert(uri))
+    } else {
+        Err(FilePathError::UnsupportedScheme(uri))
+    }
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -3,10 +3,10 @@ use futures_util::Stream;
 use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Selection};
 use helix_lsp::{
     lsp::{self, notification::Notification},
-    util::{lsp_range_to_range, uri_to_file_path},
+    util::lsp_range_to_range,
     LspProgressMap,
 };
-use helix_stdx::path::get_relative_path;
+use helix_stdx::{path::get_relative_path, uri::uri_to_file_path};
 use helix_view::{
     align_view,
     document::DocumentSavedEventResult,
@@ -726,7 +726,7 @@ impl Application {
                         let path = match uri_to_file_path(&params.uri) {
                             Ok(path) => path,
                             Err(err) => {
-                                log::error!("{err}: {}", params.uri);
+                                log::error!("{err}");
                                 return;
                             }
                         };
@@ -1130,7 +1130,7 @@ impl Application {
         let path = match uri_to_file_path(&uri) {
             Ok(path) => path,
             Err(err) => {
-                log::error!("{err}: {uri}");
+                log::error!("{err}");
                 return lsp::ShowDocumentResult { success: false };
             }
         };

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -3,7 +3,7 @@ use futures_util::Stream;
 use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Selection};
 use helix_lsp::{
     lsp::{self, notification::Notification},
-    util::lsp_range_to_range,
+    util::{lsp_range_to_range, uri_to_file_path},
     LspProgressMap,
 };
 use helix_stdx::path::get_relative_path;
@@ -723,10 +723,10 @@ impl Application {
                         }
                     }
                     Notification::PublishDiagnostics(mut params) => {
-                        let path = match params.uri.to_file_path() {
+                        let path = match uri_to_file_path(&params.uri) {
                             Ok(path) => path,
-                            Err(_) => {
-                                log::error!("Unsupported file URI: {}", params.uri);
+                            Err(err) => {
+                                log::error!("{err}: {}", params.uri);
                                 return;
                             }
                         };
@@ -1127,10 +1127,10 @@ impl Application {
             ..
         } = params;
 
-        let path = match uri.to_file_path() {
+        let path = match uri_to_file_path(&uri) {
             Ok(path) => path,
             Err(err) => {
-                log::error!("unsupported file URI: {}: {:?}", uri, err);
+                log::error!("{err}: {uri}");
                 return lsp::ShowDocumentResult { success: false };
             }
         };

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -75,7 +75,7 @@ impl ToString for ApplyEditErrorKind {
 
 impl Editor {
     fn uri_to_file_path(&mut self, uri: &helix_lsp::Url) -> Result<PathBuf, ApplyEditErrorKind> {
-        match uri_to_file_path(&uri) {
+        match uri_to_file_path(uri) {
             Ok(path) => Ok(path),
             Err(err) => {
                 let err = format!("{err}: {uri}");


### PR DESCRIPTION
## Objective

[`url::Url::to_file_path`](https://docs.rs/url/latest/url/struct.Url.html#method.to_file_path) does not check which scheme the URI adheres to, meaning currently when a language server sends us a URI containing an unrecognized scheme, we blindly treat it as if it were a file path, leading to strange results.

This was causing issues for me using [csharp-ls](https://github.com/razzmatazz/csharp-language-server) since when it resolves definitions over assembly boundaries, it will return a `csharp:/metadata/foo/bar/Baz.cs` URI, which a willing client can use to get readonly, decompiled definition info. In the current version, helix opens a blank buffer at `/metadata/foo/bar/Baz.cs`.

## Solution

This PR introduces a `uri_to_file_path` method which performs the expected behaviour, first checking the scheme, and changes all relevant uses of `Url::to_file_path` to go via the new method instead and error without panicking when an unexpected scheme is found.

## Details

It appears the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri) says nothing about which schemes are valid, so I don't think csharp-ls is at fault here (though I wouldn't expect us to support the "csharp" scheme without plugins).

> [!NOTE]
> Strangely, while csharp-ls uses its own scheme, omnisharp's URIs are of the form `file:///$metadata$/foo/bar/Baz.cs`. It seems they adhere strongly to VSCode's lsp model which lets an extension act as middleware to intercept that URI to use other behaviour. Ergo, this PR does not fix the issue for omnisharp.