### PR TITLE
ci: add labeler action to automate labeling of common cases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,31 @@
+A-core:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-core/** ]
+
+A-debug-adapter:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-dap/** ]
+
+A-helix-term:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-term/** ]
+
+A-keymap:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-term/src/keymap/**, helix-term/src/keymap.rs ]
+
+A-language-server:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-lsp/** ]
+
+A-theme:
+  - changed-files:
+    - any-glob-to-any-file: [ runtime/themes/** ]
+
+A-tree-sitter:
+  - changed-files:
+    - any-glob-to-any-file: [ runtime/queries/** ]
+
+A-vcs:
+  - changed-files:
+    - any-glob-to-any-file: [ helix-vcs/** ]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "labeler: PR"
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This is purely for convenience to avoid needing to label common file
changes. The labeling is only done when opening and not when updating
the PR as empirically it's more annoying to keep removing an unwanted
label each time a PR is updated, rather than adding a wanted label once.
