### PR TITLE
Improve textobjects for parameter/argument for Dart

### DIFF
--- a/runtime/queries/dart/textobjects.scm
+++ b/runtime/queries/dart/textobjects.scm
@@ -56,9 +56,34 @@
 
 (documentation_comment)+ @comment.around
 
-(formal_parameter) @parameter.inside
+(formal_parameter_list
+  (
+    (formal_parameter) @parameter.inside . ","? @parameter.around
+  ) @parameter.around
+)
 
-(formal_parameter_list) @parameter.around
+(optional_formal_parameters
+  (
+    (formal_parameter) @parameter.inside . ","? @parameter.around
+  ) @parameter.around
+)
+
+(arguments
+  (
+    [
+      (argument) @parameter.inside
+      (named_argument (label) . (_)* @parameter.inside)
+    ]
+    . ","? @parameter.around
+  ) @parameter.around
+)
+
+(type_arguments
+  (
+    ((_) . ("." . (_) @parameter.inside @parameter.around)?) @parameter.inside
+    . ","? @parameter.around
+  ) @parameter.around
+)
 
 (expression_statement
   ((identifier) @_name (#any-of? @_name "test" "testWidgets"))


### PR DESCRIPTION
Change queries for `@parameter` for Dart to match a single parameter (instead of all of them), and add queries to match arguments and type parameters