### PR TITLE
`Picker`s "v2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "cov-mark"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffa3d3e0138386cd4361f63537765cac7ee40698028844635a54495a92f67f3"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "nucleo"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5331f4bcce475cf28cb29c95366c3091af4b0aa7703f1a6bc858f29718fdf3"
+checksum = "6350a138d8860658523a7593cbf6813999d17a099371d14f70c5c905b37593e9"
 dependencies = [
  "nucleo-matcher",
  "parking_lot",
@@ -1796,11 +1790,10 @@ dependencies = [
 
 [[package]]
 name = "nucleo-matcher"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b702b402fe286162d1f00b552a046ce74365d2ac473a2607ff36ba650f9bd57"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
 dependencies = [
- "cov-mark",
  "memchr",
  "unicode-segmentation",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "nucleo"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6350a138d8860658523a7593cbf6813999d17a099371d14f70c5c905b37593e9"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
 dependencies = [
  "nucleo-matcher",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "termini",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "unicode-general-category",
  "unicode-segmentation",
  "unicode-width",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ package.helix-term.opt-level = 2
 
 [workspace.dependencies]
 tree-sitter = { version = "0.22" }
-nucleo = "0.4.1"
+nucleo = "0.5.0"
 slotmap = "1.0.7"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ package.helix-term.opt-level = 2
 
 [workspace.dependencies]
 tree-sitter = { version = "0.22" }
-nucleo = "0.2.0"
+nucleo = "0.4.1"
 slotmap = "1.0.7"
 thiserror = "1.0"
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -298,6 +298,7 @@ These scopes are used for theming the editor interface:
 | `ui.popup`                        | Documentation popups (e.g. Space + k)                                                          |
 | `ui.popup.info`                   | Prompt for multiple key options                                                                |
 | `ui.picker.header`                | Column names in pickers with multiple columns                                                  |
+| `ui.picker.header.active`         | The column name in pickers with multiple columns where the cursor is entering into.            |
 | `ui.window`                       | Borderlines separating splits                                                                  |
 | `ui.help`                         | Description box for commands                                                                   |
 | `ui.text`                         | Default text style, command prompts, popup text, etc.                                          |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -297,6 +297,7 @@ These scopes are used for theming the editor interface:
 | `ui.bufferline.background`        | Style for bufferline background                                                                |
 | `ui.popup`                        | Documentation popups (e.g. Space + k)                                                          |
 | `ui.popup.info`                   | Prompt for multiple key options                                                                |
+| `ui.picker.header`                | Column names in pickers with multiple columns                                                  |
 | `ui.window`                       | Borderlines separating splits                                                                  |
 | `ui.help`                         | Description box for commands                                                                   |
 | `ui.text`                         | Default text style, command prompts, popup text, etc.                                          |

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = "2.6"
 ahash = "0.8.11"
 hashbrown = { version = "0.14.5", features = ["raw"] }
 dunce = "1.0"
+url = "2.5.0"
 
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-core/src/fuzzy.rs
+++ b/helix-core/src/fuzzy.rs
@@ -1,6 +1,6 @@
 use std::ops::DerefMut;
 
-use nucleo::pattern::{Atom, AtomKind, CaseMatching};
+use nucleo::pattern::{Atom, AtomKind, CaseMatching, Normalization};
 use nucleo::Config;
 use parking_lot::Mutex;
 
@@ -38,6 +38,12 @@ pub fn fuzzy_match<T: AsRef<str>>(
     if path {
         matcher.config.set_match_paths();
     }
-    let pattern = Atom::new(pattern, CaseMatching::Smart, AtomKind::Fuzzy, false);
+    let pattern = Atom::new(
+        pattern,
+        CaseMatching::Smart,
+        Normalization::Smart,
+        AtomKind::Fuzzy,
+        false,
+    );
     pattern.match_list(items, &mut matcher)
 }

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod test;
 pub mod text_annotations;
 pub mod textobject;
 mod transaction;
+pub mod uri;
 pub mod wrap;
 
 pub mod unicode {
@@ -66,3 +67,5 @@ pub use diagnostic::Diagnostic;
 
 pub use line_ending::{LineEnding, NATIVE_LINE_ENDING};
 pub use transaction::{Assoc, Change, ChangeSet, Deletion, Operation, Transaction};
+
+pub use uri::Uri;

--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -1,0 +1,122 @@
+use std::path::{Path, PathBuf};
+
+/// A generic pointer to a file location.
+///
+/// Currently this type only supports paths to local files.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Uri {
+    File(PathBuf),
+}
+
+impl Uri {
+    // This clippy allow mirrors url::Url::from_file_path
+    #[allow(clippy::result_unit_err)]
+    pub fn to_url(&self) -> Result<url::Url, ()> {
+        match self {
+            Uri::File(path) => url::Url::from_file_path(path),
+        }
+    }
+
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::File(path) => Some(path),
+        }
+    }
+
+    pub fn as_path_buf(self) -> Option<PathBuf> {
+        match self {
+            Self::File(path) => Some(path),
+        }
+    }
+}
+
+impl From<PathBuf> for Uri {
+    fn from(path: PathBuf) -> Self {
+        Self::File(path)
+    }
+}
+
+impl TryFrom<Uri> for PathBuf {
+    type Error = ();
+
+    fn try_from(uri: Uri) -> Result<Self, Self::Error> {
+        match uri {
+            Uri::File(path) => Ok(path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UrlConversionError {
+    source: url::Url,
+    kind: UrlConversionErrorKind,
+}
+
+#[derive(Debug)]
+pub enum UrlConversionErrorKind {
+    UnsupportedScheme,
+    UnableToConvert,
+}
+
+impl std::fmt::Display for UrlConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            UrlConversionErrorKind::UnsupportedScheme => {
+                write!(f, "unsupported scheme in URL: {}", self.source.scheme())
+            }
+            UrlConversionErrorKind::UnableToConvert => {
+                write!(f, "unable to convert URL to file path: {}", self.source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for UrlConversionError {}
+
+fn convert_url_to_uri(url: &url::Url) -> Result<Uri, UrlConversionErrorKind> {
+    if url.scheme() == "file" {
+        url.to_file_path()
+            .map(|path| Uri::File(helix_stdx::path::normalize(path)))
+            .map_err(|_| UrlConversionErrorKind::UnableToConvert)
+    } else {
+        Err(UrlConversionErrorKind::UnsupportedScheme)
+    }
+}
+
+impl TryFrom<url::Url> for Uri {
+    type Error = UrlConversionError;
+
+    fn try_from(url: url::Url) -> Result<Self, Self::Error> {
+        convert_url_to_uri(&url).map_err(|kind| Self::Error { source: url, kind })
+    }
+}
+
+impl TryFrom<&url::Url> for Uri {
+    type Error = UrlConversionError;
+
+    fn try_from(url: &url::Url) -> Result<Self, Self::Error> {
+        convert_url_to_uri(url).map_err(|kind| Self::Error {
+            source: url.clone(),
+            kind,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use url::Url;
+
+    #[test]
+    fn unknown_scheme() {
+        let url = Url::parse("csharp:/metadata/foo/bar/Baz.cs").unwrap();
+        assert!(matches!(
+            Uri::try_from(url),
+            Err(UrlConversionError {
+                kind: UrlConversionErrorKind::UnsupportedScheme,
+                ..
+            })
+        ));
+    }
+}

--- a/helix-event/src/lib.rs
+++ b/helix-event/src/lib.rs
@@ -34,7 +34,9 @@
 use anyhow::Result;
 pub use cancel::{cancelable_future, cancelation, CancelRx, CancelTx};
 pub use debounce::{send_blocking, AsyncHook};
-pub use redraw::{lock_frame, redraw_requested, request_redraw, start_frame, RenderLockGuard};
+pub use redraw::{
+    lock_frame, redraw_requested, request_redraw, start_frame, RenderLockGuard, RequestRedrawOnDrop,
+};
 pub use registry::Event;
 
 mod cancel;

--- a/helix-event/src/redraw.rs
+++ b/helix-event/src/redraw.rs
@@ -51,3 +51,12 @@ pub fn start_frame() {
 pub fn lock_frame() -> RenderLockGuard {
     RENDER_LOCK.read()
 }
+
+/// A zero sized type that requests a redraw via [request_redraw] when the type [Drop]s.
+pub struct RequestRedrawOnDrop;
+
+impl Drop for RequestRedrawOnDrop {
+    fn drop(&mut self) {
+        request_redraw();
+    }
+}

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -56,6 +56,7 @@ ignore = "0.4"
 pulldown-cmark = { version = "0.11", default-features = false }
 # file type detection
 content_inspector = "0.2.4"
+thiserror = "1.0"
 
 # opening URLs
 open = "5.2.0"

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2404,7 +2404,7 @@ fn global_search(cx: &mut Context) {
     let picker = Picker::new(
         columns,
         1, // contents
-        vec![],
+        [],
         config,
         move |cx, FileResult { path, line_num, .. }, action| {
             let doc = match cx.editor.open(path, action) {
@@ -2991,16 +2991,12 @@ fn jumplist_picker(cx: &mut Context) {
     let picker = Picker::new(
         columns,
         1, // path
-        cx.editor
-            .tree
-            .views()
-            .flat_map(|(view, _)| {
-                view.jumps
-                    .iter()
-                    .rev()
-                    .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
-            })
-            .collect(),
+        cx.editor.tree.views().flat_map(|(view, _)| {
+            view.jumps
+                .iter()
+                .rev()
+                .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
+        }),
         (),
         |cx, meta, action| {
             cx.editor.switch(meta.id, action);
@@ -3077,7 +3073,7 @@ fn changed_file_picker(cx: &mut Context) {
     let picker = Picker::new(
         columns,
         1, // path
-        Vec::new(),
+        [],
         FileChangeData {
             cwd: cwd.clone(),
             style_untracked: added,
@@ -3124,14 +3120,15 @@ pub fn command_palette(cx: &mut Context) {
                 [&cx.editor.mode]
                 .reverse_map();
 
-            let mut commands: Vec<MappableCommand> = MappableCommand::STATIC_COMMAND_LIST.into();
-            commands.extend(typed::TYPABLE_COMMAND_LIST.iter().map(|cmd| {
-                MappableCommand::Typable {
-                    name: cmd.name.to_owned(),
-                    doc: cmd.doc.to_owned(),
-                    args: Vec::new(),
-                }
-            }));
+            let commands = MappableCommand::STATIC_COMMAND_LIST.iter().cloned().chain(
+                typed::TYPABLE_COMMAND_LIST
+                    .iter()
+                    .map(|cmd| MappableCommand::Typable {
+                        name: cmd.name.to_owned(),
+                        args: Vec::new(),
+                        doc: cmd.doc.to_owned(),
+                    }),
+            );
 
             let columns = vec![
                 ui::PickerColumn::new("name", |item, _| match item {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2265,7 +2265,7 @@ fn global_search(cx: &mut Context) {
         file_picker_config: config.file_picker.clone(),
     };
 
-    let columns = vec![
+    let columns = [
         PickerColumn::new("path", |item: &FileResult, _| {
             let path = helix_stdx::path::get_relative_path(&item.path);
             format!("{}:{}", path.to_string_lossy(), item.line_num + 1).into()
@@ -2886,7 +2886,7 @@ fn buffer_picker(cx: &mut Context) {
     // mru
     items.sort_unstable_by_key(|item| std::cmp::Reverse(item.focused_at));
 
-    let columns = vec![
+    let columns = [
         PickerColumn::new("id", |meta: &BufferMeta, _| meta.id.to_string().into()),
         PickerColumn::new("flags", |meta: &BufferMeta, _| {
             let mut flags = String::new();
@@ -2960,7 +2960,7 @@ fn jumplist_picker(cx: &mut Context) {
         }
     };
 
-    let columns = vec![
+    let columns = [
         ui::PickerColumn::new("id", |item: &JumpMeta, _| item.id.to_string().into()),
         ui::PickerColumn::new("path", |item: &JumpMeta, _| {
             let path = item
@@ -3039,7 +3039,7 @@ fn changed_file_picker(cx: &mut Context) {
     let deleted = cx.editor.theme.get("diff.minus");
     let renamed = cx.editor.theme.get("diff.delta.moved");
 
-    let columns = vec![
+    let columns = [
         PickerColumn::new("change", |change: &FileChange, data: &FileChangeData| {
             match change {
                 FileChange::Untracked { .. } => Span::styled("+ untracked", data.style_untracked),
@@ -3130,7 +3130,7 @@ pub fn command_palette(cx: &mut Context) {
                     }),
             );
 
-            let columns = vec![
+            let columns = [
                 ui::PickerColumn::new("name", |item, _| match item {
                     MappableCommand::Typable { name, .. } => format!(":{name}").into(),
                     MappableCommand::Static { name, .. } => (*name).into(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3,6 +3,7 @@ pub(crate) mod lsp;
 pub(crate) mod typed;
 
 pub use dap::*;
+use futures_util::FutureExt;
 use helix_event::status;
 use helix_stdx::{
     path::expand_tilde,
@@ -2255,222 +2256,204 @@ fn global_search(cx: &mut Context) {
         }
     }
 
+    struct GlobalSearchConfig {
+        smart_case: bool,
+        file_picker_config: helix_view::editor::FilePickerConfig,
+    }
+
     let config = cx.editor.config();
-    let smart_case = config.search.smart_case;
-    let file_picker_config = config.file_picker.clone();
+    let config = GlobalSearchConfig {
+        smart_case: config.search.smart_case,
+        file_picker_config: config.file_picker.clone(),
+    };
 
-    let reg = cx.register.unwrap_or('/');
-    let completions = search_completions(cx, Some(reg));
-    ui::raw_regex_prompt(
-        cx,
-        "global-search:".into(),
-        Some(reg),
-        move |_editor: &Editor, input: &str| {
-            completions
-                .iter()
-                .filter(|comp| comp.starts_with(input))
-                .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone())))
-                .collect()
-        },
-        move |cx, _, input, event| {
-            if event != PromptEvent::Validate {
-                return;
+    let columns = vec![
+        PickerColumn::new("path", |item: &FileResult, _| {
+            let path = helix_stdx::path::get_relative_path(&item.path);
+            format!("{}:{}", path.to_string_lossy(), item.line_num + 1).into()
+        }),
+        PickerColumn::new("contents", |item: &FileResult, _| {
+            item.line_content.as_str().into()
+        })
+        .without_filtering(),
+    ];
+
+    let get_files = |query: &str,
+                     editor: &mut Editor,
+                     config: std::sync::Arc<GlobalSearchConfig>,
+                     injector: &ui::picker::Injector<_, _>| {
+        if query.is_empty() {
+            return async { Ok(()) }.boxed();
+        }
+
+        let search_root = helix_stdx::env::current_working_dir();
+        if !search_root.exists() {
+            return async { Err(anyhow::anyhow!("Current working directory does not exist")) }
+                .boxed();
+        }
+
+        let documents: Vec<_> = editor
+            .documents()
+            .map(|doc| (doc.path().cloned(), doc.text().to_owned()))
+            .collect();
+
+        let matcher = match RegexMatcherBuilder::new()
+            .case_smart(config.smart_case)
+            .build(query)
+        {
+            Ok(matcher) => {
+                // Clear any "Failed to compile regex" errors out of the statusline.
+                editor.clear_status();
+                matcher
             }
-            cx.editor.registers.last_search_register = reg;
+            Err(err) => {
+                log::info!("Failed to compile search pattern in global search: {}", err);
+                return async { Err(anyhow::anyhow!("Failed to compile regex")) }.boxed();
+            }
+        };
 
-            let current_path = doc_mut!(cx.editor).path().cloned();
-            let documents: Vec<_> = cx
-                .editor
-                .documents()
-                .map(|doc| (doc.path().cloned(), doc.text().to_owned()))
-                .collect();
+        let dedup_symlinks = config.file_picker_config.deduplicate_links;
+        let absolute_root = search_root
+            .canonicalize()
+            .unwrap_or_else(|_| search_root.clone());
 
-            if let Ok(matcher) = RegexMatcherBuilder::new()
-                .case_smart(smart_case)
-                .build(input)
-            {
-                let search_root = helix_stdx::env::current_working_dir();
-                if !search_root.exists() {
+        let injector = injector.clone();
+        async move {
+            let searcher = SearcherBuilder::new()
+                .binary_detection(BinaryDetection::quit(b'\x00'))
+                .build();
+            WalkBuilder::new(search_root)
+                .hidden(config.file_picker_config.hidden)
+                .parents(config.file_picker_config.parents)
+                .ignore(config.file_picker_config.ignore)
+                .follow_links(config.file_picker_config.follow_symlinks)
+                .git_ignore(config.file_picker_config.git_ignore)
+                .git_global(config.file_picker_config.git_global)
+                .git_exclude(config.file_picker_config.git_exclude)
+                .max_depth(config.file_picker_config.max_depth)
+                .filter_entry(move |entry| {
+                    filter_picker_entry(entry, &absolute_root, dedup_symlinks)
+                })
+                .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
+                .add_custom_ignore_filename(".helix/ignore")
+                .build_parallel()
+                .run(|| {
+                    let mut searcher = searcher.clone();
+                    let matcher = matcher.clone();
+                    let injector = injector.clone();
+                    let documents = &documents;
+                    Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
+                        let entry = match entry {
+                            Ok(entry) => entry,
+                            Err(_) => return WalkState::Continue,
+                        };
+
+                        match entry.file_type() {
+                            Some(entry) if entry.is_file() => {}
+                            // skip everything else
+                            _ => return WalkState::Continue,
+                        };
+
+                        let mut stop = false;
+                        let sink = sinks::UTF8(|line_num, line_content| {
+                            stop = injector
+                                .push(FileResult::new(
+                                    entry.path(),
+                                    line_num as usize - 1,
+                                    line_content.to_string(),
+                                ))
+                                .is_err();
+
+                            Ok(!stop)
+                        });
+                        let doc = documents.iter().find(|&(doc_path, _)| {
+                            doc_path
+                                .as_ref()
+                                .map_or(false, |doc_path| doc_path == entry.path())
+                        });
+
+                        let result = if let Some((_, doc)) = doc {
+                            // there is already a buffer for this file
+                            // search the buffer instead of the file because it's faster
+                            // and captures new edits without requiring a save
+                            if searcher.multi_line_with_matcher(&matcher) {
+                                // in this case a continous buffer is required
+                                // convert the rope to a string
+                                let text = doc.to_string();
+                                searcher.search_slice(&matcher, text.as_bytes(), sink)
+                            } else {
+                                searcher.search_reader(
+                                    &matcher,
+                                    RopeReader::new(doc.slice(..)),
+                                    sink,
+                                )
+                            }
+                        } else {
+                            searcher.search_path(&matcher, entry.path(), sink)
+                        };
+
+                        if let Err(err) = result {
+                            log::error!("Global search error: {}, {}", entry.path().display(), err);
+                        }
+                        if stop {
+                            WalkState::Quit
+                        } else {
+                            WalkState::Continue
+                        }
+                    })
+                });
+            Ok(())
+        }
+        .boxed()
+    };
+
+    let mut picker = Picker::new(
+        columns,
+        1, // contents
+        vec![],
+        config,
+        move |cx, FileResult { path, line_num, .. }, action| {
+            let doc = match cx.editor.open(path, action) {
+                Ok(id) => doc_mut!(cx.editor, &id),
+                Err(e) => {
                     cx.editor
-                        .set_error("Current working directory does not exist");
+                        .set_error(format!("Failed to open file '{}': {}", path.display(), e));
                     return;
                 }
+            };
 
-                let columns = vec![
-                    PickerColumn::new(
-                        "path",
-                        |item: &FileResult, current_path: &Option<PathBuf>| {
-                            let relative_path = helix_stdx::path::get_relative_path(&item.path)
-                                .to_string_lossy()
-                                .into_owned();
-                            if current_path
-                                .as_ref()
-                                .map(|p| p == &item.path)
-                                .unwrap_or(false)
-                            {
-                                format!("{} (*)", relative_path).into()
-                            } else {
-                                relative_path.into()
-                            }
-                        },
-                    ),
-                    PickerColumn::new("contents", |item: &FileResult, _| {
-                        item.line_content.as_str().into()
-                    }),
-                ];
-                let (picker, injector) = Picker::stream(columns, current_path);
-
-                let dedup_symlinks = file_picker_config.deduplicate_links;
-                let absolute_root = search_root
-                    .canonicalize()
-                    .unwrap_or_else(|_| search_root.clone());
-                let injector_ = injector.clone();
-
-                std::thread::spawn(move || {
-                    let searcher = SearcherBuilder::new()
-                        .binary_detection(BinaryDetection::quit(b'\x00'))
-                        .build();
-
-                    let mut walk_builder = WalkBuilder::new(search_root);
-
-                    walk_builder
-                        .hidden(file_picker_config.hidden)
-                        .parents(file_picker_config.parents)
-                        .ignore(file_picker_config.ignore)
-                        .follow_links(file_picker_config.follow_symlinks)
-                        .git_ignore(file_picker_config.git_ignore)
-                        .git_global(file_picker_config.git_global)
-                        .git_exclude(file_picker_config.git_exclude)
-                        .max_depth(file_picker_config.max_depth)
-                        .filter_entry(move |entry| {
-                            filter_picker_entry(entry, &absolute_root, dedup_symlinks)
-                        })
-                        .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
-                        .add_custom_ignore_filename(".helix/ignore")
-                        .build_parallel()
-                        .run(|| {
-                            let mut searcher = searcher.clone();
-                            let matcher = matcher.clone();
-                            let injector = injector_.clone();
-                            let documents = &documents;
-                            Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
-                                let entry = match entry {
-                                    Ok(entry) => entry,
-                                    Err(_) => return WalkState::Continue,
-                                };
-
-                                match entry.file_type() {
-                                    Some(entry) if entry.is_file() => {}
-                                    // skip everything else
-                                    _ => return WalkState::Continue,
-                                };
-
-                                let mut stop = false;
-                                let sink = sinks::UTF8(|line_num, line_content| {
-                                    stop = injector
-                                        .push(FileResult::new(
-                                            entry.path(),
-                                            line_num as usize - 1,
-                                            line_content.to_string(),
-                                        ))
-                                        .is_err();
-
-                                    Ok(!stop)
-                                });
-                                let doc = documents.iter().find(|&(doc_path, _)| {
-                                    doc_path
-                                        .as_ref()
-                                        .map_or(false, |doc_path| doc_path == entry.path())
-                                });
-
-                                let result = if let Some((_, doc)) = doc {
-                                    // there is already a buffer for this file
-                                    // search the buffer instead of the file because it's faster
-                                    // and captures new edits without requiring a save
-                                    if searcher.multi_line_with_matcher(&matcher) {
-                                        // in this case a continous buffer is required
-                                        // convert the rope to a string
-                                        let text = doc.to_string();
-                                        searcher.search_slice(&matcher, text.as_bytes(), sink)
-                                    } else {
-                                        searcher.search_reader(
-                                            &matcher,
-                                            RopeReader::new(doc.slice(..)),
-                                            sink,
-                                        )
-                                    }
-                                } else {
-                                    searcher.search_path(&matcher, entry.path(), sink)
-                                };
-
-                                if let Err(err) = result {
-                                    log::error!(
-                                        "Global search error: {}, {}",
-                                        entry.path().display(),
-                                        err
-                                    );
-                                }
-                                if stop {
-                                    WalkState::Quit
-                                } else {
-                                    WalkState::Continue
-                                }
-                            })
-                        });
-                });
-
-                cx.jobs.callback(async move {
-                    let call = move |_: &mut Editor, compositor: &mut Compositor| {
-                        let picker = Picker::with_stream(
-                            picker,
-                            0,
-                            injector,
-                            move |cx, FileResult { path, line_num, .. }, action| {
-                                let doc = match cx.editor.open(path, action) {
-                                    Ok(id) => doc_mut!(cx.editor, &id),
-                                    Err(e) => {
-                                        cx.editor.set_error(format!(
-                                            "Failed to open file '{}': {}",
-                                            path.display(),
-                                            e
-                                        ));
-                                        return;
-                                    }
-                                };
-
-                                let line_num = *line_num;
-                                let view = view_mut!(cx.editor);
-                                let text = doc.text();
-                                if line_num >= text.len_lines() {
-                                    cx.editor.set_error(
+            let line_num = *line_num;
+            let view = view_mut!(cx.editor);
+            let text = doc.text();
+            if line_num >= text.len_lines() {
+                cx.editor.set_error(
                     "The line you jumped to does not exist anymore because the file has changed.",
                 );
-                                    return;
-                                }
-                                let start = text.line_to_char(line_num);
-                                let end = text.line_to_char((line_num + 1).min(text.len_lines()));
+                return;
+            }
+            let start = text.line_to_char(line_num);
+            let end = text.line_to_char((line_num + 1).min(text.len_lines()));
 
-                                doc.set_selection(view.id, Selection::single(start, end));
-                                if action.align_view(view, doc.id()) {
-                                    align_view(doc, view, Align::Center);
-                                }
-                            },
-                        )
-                        .with_preview(
-                            |_editor, FileResult { path, line_num, .. }| {
-                                Some((path.clone().into(), Some((*line_num, *line_num))))
-                            },
-                        );
-                        compositor.push(Box::new(overlaid(picker)))
-                    };
-                    Ok(Callback::EditorCompositor(Box::new(call)))
-                })
-            } else {
-                // Otherwise do nothing
-                // log::warn!("Global Search Invalid Pattern")
+            doc.set_selection(view.id, Selection::single(start, end));
+            if action.align_view(view, doc.id()) {
+                align_view(doc, view, Align::Center);
             }
         },
-    );
+    )
+    .with_preview(|_editor, FileResult { path, line_num, .. }| {
+        Some((path.clone().into(), Some((*line_num, *line_num))))
+    })
+    .with_dynamic_query(get_files, Some(275));
+
+    if let Some((reg, line)) = cx
+        .register
+        .and_then(|reg| Some((reg, cx.editor.registers.first(reg, cx.editor)?)))
+    {
+        picker = picker.with_line(line.into_owned(), cx.editor);
+        cx.editor.registers.last_search_register = reg;
+    }
+
+    cx.push_layer(Box::new(overlaid(picker)));
 }
 
 enum Extend {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2435,7 +2435,7 @@ fn global_search(cx: &mut Context) {
         },
     )
     .with_preview(|_editor, FileResult { path, line_num, .. }| {
-        Some((path.clone().into(), Some((*line_num, *line_num))))
+        Some((path.as_path().into(), Some((*line_num, *line_num))))
     })
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
@@ -3098,7 +3098,7 @@ fn changed_file_picker(cx: &mut Context) {
             }
         },
     )
-    .with_preview(|_editor, meta| Some((meta.path().to_path_buf().into(), None)));
+    .with_preview(|_editor, meta| Some((meta.path().into(), None)));
     let injector = picker.injector();
 
     cx.editor

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2317,7 +2317,9 @@ fn global_search(cx: &mut Context) {
                     return;
                 }
 
-                let (picker, injector) = Picker::stream(current_path);
+                // TODO
+                let columns = vec![];
+                let (picker, injector) = Picker::stream(columns, current_path);
 
                 let dedup_symlinks = file_picker_config.deduplicate_links;
                 let absolute_root = search_root
@@ -2420,6 +2422,7 @@ fn global_search(cx: &mut Context) {
                     let call = move |_: &mut Editor, compositor: &mut Compositor| {
                         let picker = Picker::with_stream(
                             picker,
+                            0,
                             injector,
                             move |cx, FileResult { path, line_num }, action| {
                                 let doc = match cx.editor.open(path, action) {
@@ -2937,7 +2940,8 @@ fn buffer_picker(cx: &mut Context) {
     // mru
     items.sort_unstable_by_key(|item| std::cmp::Reverse(item.focused_at));
 
-    let picker = Picker::new(items, (), |cx, meta, action| {
+    let columns = vec![];
+    let picker = Picker::new(columns, 0, items, (), |cx, meta, action| {
         cx.editor.switch(meta.id, action);
     })
     .with_preview(|editor, meta| {
@@ -3014,7 +3018,10 @@ fn jumplist_picker(cx: &mut Context) {
         }
     };
 
+    let columns = vec![];
     let picker = Picker::new(
+        columns,
+        0,
         cx.editor
             .tree
             .views()
@@ -3180,7 +3187,8 @@ pub fn command_palette(cx: &mut Context) {
                 }
             }));
 
-            let picker = Picker::new(commands, keymap, move |cx, command, _action| {
+            let columns = vec![];
+            let picker = Picker::new(columns, 0, commands, keymap, move |cx, command, _action| {
                 let mut ctx = Context {
                     register,
                     count,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2243,15 +2243,13 @@ fn global_search(cx: &mut Context) {
         path: PathBuf,
         /// 0 indexed lines
         line_num: usize,
-        line_content: String,
     }
 
     impl FileResult {
-        fn new(path: &Path, line_num: usize, line_content: String) -> Self {
+        fn new(path: &Path, line_num: usize) -> Self {
             Self {
                 path: path.to_path_buf(),
                 line_num,
-                line_content,
             }
         }
     }
@@ -2272,10 +2270,7 @@ fn global_search(cx: &mut Context) {
             let path = helix_stdx::path::get_relative_path(&item.path);
             format!("{}:{}", path.to_string_lossy(), item.line_num + 1).into()
         }),
-        PickerColumn::new("contents", |item: &FileResult, _| {
-            item.line_content.as_str().into()
-        })
-        .without_filtering(),
+        PickerColumn::hidden("contents"),
     ];
 
     let get_files = |query: &str,
@@ -2355,13 +2350,9 @@ fn global_search(cx: &mut Context) {
                         };
 
                         let mut stop = false;
-                        let sink = sinks::UTF8(|line_num, line_content| {
+                        let sink = sinks::UTF8(|line_num, _line_content| {
                             stop = injector
-                                .push(FileResult::new(
-                                    entry.path(),
-                                    line_num as usize - 1,
-                                    line_content.to_string(),
-                                ))
+                                .push(FileResult::new(entry.path(), line_num as usize - 1))
                                 .is_err();
 
                             Ok(!stop)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2407,7 +2407,10 @@ fn global_search(cx: &mut Context) {
         .boxed()
     };
 
-    let mut picker = Picker::new(
+    let reg = cx.register.unwrap_or('/');
+    cx.editor.registers.last_search_register = reg;
+
+    let picker = Picker::new(
         columns,
         1, // contents
         vec![],
@@ -2443,15 +2446,8 @@ fn global_search(cx: &mut Context) {
     .with_preview(|_editor, FileResult { path, line_num, .. }| {
         Some((path.clone().into(), Some((*line_num, *line_num))))
     })
+    .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
-
-    if let Some((reg, line)) = cx
-        .register
-        .and_then(|reg| Some((reg, cx.editor.registers.first(reg, cx.editor)?)))
-    {
-        picker = picker.with_line(line.into_owned(), cx.editor);
-        cx.editor.registers.last_search_register = reg;
-    }
 
     cx.push_layer(Box::new(overlaid(picker)));
 }

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -61,7 +61,7 @@ fn thread_picker(
             .with_preview(move |editor, thread| {
                 let frames = editor.debugger.as_ref()?.stack_frames.get(&thread.id)?;
                 let frame = frames.first()?;
-                let path = frame.source.as_ref()?.path.clone()?;
+                let path = frame.source.as_ref()?.path.as_ref()?.as_path();
                 let pos = Some((
                     frame.line.saturating_sub(1),
                     frame.end_line.unwrap_or(frame.line).saturating_sub(1),
@@ -747,10 +747,10 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
         frame
             .source
             .as_ref()
-            .and_then(|source| source.path.clone())
+            .and_then(|source| source.path.as_ref())
             .map(|path| {
                 (
-                    path.into(),
+                    path.as_path().into(),
                     Some((
                         frame.line.saturating_sub(1),
                         frame.end_line.unwrap_or(frame.line).saturating_sub(1),

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -73,9 +73,14 @@ fn thread_picker(
             let debugger = debugger!(editor);
 
             let thread_states = debugger.thread_states.clone();
-            let picker = Picker::new(threads, thread_states, move |cx, thread, _action| {
-                callback_fn(cx.editor, thread)
-            })
+            let columns = vec![];
+            let picker = Picker::new(
+                columns,
+                0,
+                threads,
+                thread_states,
+                move |cx, thread, _action| callback_fn(cx.editor, thread),
+            )
             .with_preview(move |editor, thread| {
                 let frames = editor.debugger.as_ref()?.stack_frames.get(&thread.id)?;
                 let frame = frames.first()?;
@@ -268,7 +273,11 @@ pub fn dap_launch(cx: &mut Context) {
 
     let templates = config.templates.clone();
 
+    let columns = vec![];
+
     cx.push_layer(Box::new(overlaid(Picker::new(
+        columns,
+        0,
         templates,
         (),
         |cx, template, _action| {
@@ -736,7 +745,8 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
 
     let frames = debugger.stack_frames[&thread_id].clone();
 
-    let picker = Picker::new(frames, (), move |cx, frame, _action| {
+    let columns = vec![];
+    let picker = Picker::new(columns, 0, frames, (), move |cx, frame, _action| {
         let debugger = debugger!(cx.editor);
         // TODO: this should be simpler to find
         let pos = debugger.stack_frames[&thread_id]

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -41,7 +41,7 @@ fn thread_picker(
             let debugger = debugger!(editor);
 
             let thread_states = debugger.thread_states.clone();
-            let columns = vec![
+            let columns = [
                 ui::PickerColumn::new("name", |item: &Thread, _| item.name.as_str().into()),
                 ui::PickerColumn::new("state", |item: &Thread, thread_states: &ThreadStates| {
                     thread_states
@@ -250,7 +250,7 @@ pub fn dap_launch(cx: &mut Context) {
 
     let templates = config.templates.clone();
 
-    let columns = vec![ui::PickerColumn::new(
+    let columns = [ui::PickerColumn::new(
         "template",
         |item: &DebugTemplate, _| item.name.as_str().into(),
     )];
@@ -725,7 +725,7 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
 
     let frames = debugger.stack_frames[&thread_id].clone();
 
-    let columns = vec![ui::PickerColumn::new("frame", |item: &StackFrame, _| {
+    let columns = [ui::PickerColumn::new("frame", |item: &StackFrame, _| {
         item.name.as_str().into() // TODO: include thread_states in the label
     })];
     let picker = Picker::new(columns, 0, frames, (), move |cx, frame, _action| {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -371,7 +371,7 @@ pub fn symbol_picker(cx: &mut Context) {
             symbols.append(&mut lsp_items);
         }
         let call = move |_editor: &mut Editor, compositor: &mut Compositor| {
-            let columns = vec![
+            let columns = [
                 ui::PickerColumn::new("kind", |item: &SymbolInformationItem, _| {
                     display_symbol_kind(item.symbol.kind).into()
                 }),
@@ -478,7 +478,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
         }
         .boxed()
     };
-    let columns = vec![
+    let columns = [
         ui::PickerColumn::new("kind", |item: &SymbolInformationItem, _| {
             display_symbol_kind(item.symbol.kind).into()
         }),
@@ -855,7 +855,7 @@ fn goto_impl(
         }
         [] => unreachable!("`locations` should be non-empty for `goto_impl`"),
         _locations => {
-            let columns = vec![ui::PickerColumn::new(
+            let columns = [ui::PickerColumn::new(
                 "location",
                 |item: &lsp::Location, cwdir: &std::path::PathBuf| {
                     // The preallocation here will overallocate a few characters since it will account for the

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -501,7 +501,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     let picker = Picker::new(
         columns,
         1, // name column
-        vec![],
+        [],
         (),
         move |cx, item, action| {
             jump_to_location(

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1404,7 +1404,12 @@ fn lsp_workspace_command(
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
                 move |_editor: &mut Editor, compositor: &mut Compositor| {
-                    let columns = vec![];
+                    let columns = vec![ui::PickerColumn::new(
+                        "title",
+                        |(_ls_id, command): &(_, helix_lsp::lsp::Command), _| {
+                            command.title.as_str().into()
+                        },
+                    )];
                     let picker = ui::Picker::new(
                         columns,
                         0,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1404,7 +1404,7 @@ fn lsp_workspace_command(
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
                 move |_editor: &mut Editor, compositor: &mut Compositor| {
-                    let columns = vec![ui::PickerColumn::new(
+                    let columns = [ui::PickerColumn::new(
                         "title",
                         |(_ls_id, command): &(_, helix_lsp::lsp::Command), _| {
                             command.title.as_str().into()

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::Reverse, path::PathBuf};
+use std::{borrow::Cow, cmp::Reverse};
 
 use crate::{
     compositor::{Callback, Component, Compositor, Context, Event, EventResult},
@@ -28,18 +28,6 @@ pub trait Item: Sync + Send + 'static {
     fn filter_text(&self, data: &Self::Data) -> Cow<str> {
         let label: String = self.format(data).cell_text().collect();
         label.into()
-    }
-}
-
-impl Item for PathBuf {
-    /// Root prefix to strip.
-    type Data = PathBuf;
-
-    fn format(&self, root_path: &Self::Data) -> Row {
-        self.strip_prefix(root_path)
-            .unwrap_or(self)
-            .to_string_lossy()
-            .into()
     }
 }
 

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -5,7 +5,7 @@ use crate::{
     ctrl, key, shift,
 };
 use helix_core::fuzzy::MATCHER;
-use nucleo::pattern::{Atom, AtomKind, CaseMatching};
+use nucleo::pattern::{Atom, AtomKind, CaseMatching, Normalization};
 use nucleo::{Config, Utf32Str};
 use tui::{buffer::Buffer as Surface, widgets::Table};
 
@@ -80,7 +80,13 @@ impl<T: Item> Menu<T> {
     pub fn score(&mut self, pattern: &str, incremental: bool) {
         let mut matcher = MATCHER.lock();
         matcher.config = Config::DEFAULT;
-        let pattern = Atom::new(pattern, CaseMatching::Ignore, AtomKind::Fuzzy, false);
+        let pattern = Atom::new(
+            pattern,
+            CaseMatching::Ignore,
+            Normalization::Smart,
+            AtomKind::Fuzzy,
+            false,
+        );
         let mut buf = Vec::new();
         if incremental {
             self.matches.retain_mut(|(index, score)| {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -244,7 +244,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
             }
         },
     )
-    .with_preview(|_editor, path| Some((path.clone().into(), None)));
+    .with_preview(|_editor, path| Some((path.as_path().into(), None)));
     let injector = picker.injector();
     let timeout = std::time::Instant::now() + std::time::Duration::from_millis(30);
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -219,7 +219,15 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
-    let columns = vec![];
+    let columns = vec![PickerColumn::new(
+        "path",
+        |item: &PathBuf, root: &PathBuf| {
+            item.strip_prefix(root)
+                .unwrap_or(item)
+                .to_string_lossy()
+                .into()
+        },
+    )];
     let picker = Picker::new(
         columns,
         0,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -228,22 +228,16 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
                 .into()
         },
     )];
-    let picker = Picker::new(
-        columns,
-        0,
-        Vec::new(),
-        root,
-        move |cx, path: &PathBuf, action| {
-            if let Err(e) = cx.editor.open(path, action) {
-                let err = if let Some(err) = e.source() {
-                    format!("{}", err)
-                } else {
-                    format!("unable to open \"{}\"", path.display())
-                };
-                cx.editor.set_error(err);
-            }
-        },
-    )
+    let picker = Picker::new(columns, 0, [], root, move |cx, path: &PathBuf, action| {
+        if let Err(e) = cx.editor.open(path, action) {
+            let err = if let Some(err) = e.source() {
+                format!("{}", err)
+            } else {
+                format!("unable to open \"{}\"", path.display())
+            };
+            cx.editor.set_error(err);
+        }
+    })
     .with_preview(|_editor, path| Some((path.as_path().into(), None)));
     let injector = picker.injector();
     let timeout = std::time::Instant::now() + std::time::Duration::from_millis(30);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -219,7 +219,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
     });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
-    let columns = vec![PickerColumn::new(
+    let columns = [PickerColumn::new(
         "path",
         |item: &PathBuf, root: &PathBuf| {
             item.strip_prefix(root)

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -21,7 +21,7 @@ pub use editor::EditorView;
 use helix_stdx::rope;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{DynamicPicker, FileLocation, Picker};
+pub use picker::{Column as PickerColumn, DynamicPicker, FileLocation, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};
@@ -170,7 +170,9 @@ pub fn raw_regex_prompt(
     cx.push_layer(Box::new(prompt));
 }
 
-pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker<PathBuf> {
+type FilePicker = Picker<PathBuf, PathBuf>;
+
+pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePicker {
     use ignore::{types::TypesBuilder, WalkBuilder};
     use std::time::Instant;
 
@@ -217,16 +219,23 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
     });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
-    let picker = Picker::new(Vec::new(), root, move |cx, path: &PathBuf, action| {
-        if let Err(e) = cx.editor.open(path, action) {
-            let err = if let Some(err) = e.source() {
-                format!("{}", err)
-            } else {
-                format!("unable to open \"{}\"", path.display())
-            };
-            cx.editor.set_error(err);
-        }
-    })
+    let columns = vec![];
+    let picker = Picker::new(
+        columns,
+        0,
+        Vec::new(),
+        root,
+        move |cx, path: &PathBuf, action| {
+            if let Err(e) = cx.editor.open(path, action) {
+                let err = if let Some(err) = e.source() {
+                    format!("{}", err)
+                } else {
+                    format!("unable to open \"{}\"", path.display())
+                };
+                cx.editor.set_error(err);
+            }
+        },
+    )
     .with_preview(|_editor, path| Some((path.clone().into(), None)));
     let injector = picker.injector();
     let timeout = std::time::Instant::now() + std::time::Duration::from_millis(30);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -21,7 +21,7 @@ pub use editor::EditorView;
 use helix_stdx::rope;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{Column as PickerColumn, DynamicPicker, FileLocation, Picker};
+pub use picker::{Column as PickerColumn, FileLocation, Picker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use spinner::{ProgressSpinners, Spinner};

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -298,7 +298,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     pub fn new(
         columns: Vec<Column<T, D>>,
         primary_column: usize,
-        options: Vec<T>,
+        options: impl IntoIterator<Item = T>,
         editor_data: D,
         callback_fn: impl Fn(&mut Context, &T, Action) + 'static,
     ) -> Self {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -18,6 +18,7 @@ use futures_util::future::BoxFuture;
 use helix_event::AsyncHook;
 use nucleo::pattern::CaseMatching;
 use nucleo::{Config, Nucleo, Utf32String};
+use thiserror::Error;
 use tokio::sync::mpsc::Sender;
 use tui::{
     buffer::Buffer as Surface,
@@ -170,6 +171,8 @@ impl<I, D> Clone for Injector<I, D> {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("picker has been shut down")]
 pub struct InjectorShutdown;
 
 impl<T, D> Injector<T, D> {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -787,13 +787,21 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
         // -- Header
         if self.columns.len() > 1 {
+            let active_column = self.query.active_column(self.prompt.position());
             let header_style = cx.editor.theme.get("ui.picker.header");
 
             table = table.header(Row::new(self.columns.iter().map(|column| {
                 if column.hidden {
                     Cell::default()
                 } else {
-                    Cell::from(Span::styled(Cow::from(&*column.name), header_style))
+                    let style = if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name))
+                    {
+                        cx.editor.theme.get("ui.picker.header.active")
+                    } else {
+                        header_style
+                    };
+
+                    Cell::from(Span::styled(Cow::from(&*column.name), style))
                 }
             })));
         }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use futures_util::future::BoxFuture;
 use helix_event::AsyncHook;
-use nucleo::pattern::CaseMatching;
+use nucleo::pattern::{CaseMatching, Normalization};
 use nucleo::{Config, Nucleo, Utf32String};
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
@@ -506,9 +506,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 continue;
             }
             let is_append = pattern.starts_with(old_pattern);
-            self.matcher
-                .pattern
-                .reparse(i, pattern, CaseMatching::Smart, is_append);
+            self.matcher.pattern.reparse(
+                i,
+                pattern,
+                CaseMatching::Smart,
+                Normalization::Smart,
+                is_append,
+            );
         }
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1,4 +1,5 @@
 mod handlers;
+mod query;
 
 use crate::{
     alt,
@@ -9,6 +10,7 @@ use crate::{
     ui::{
         self,
         document::{render_document, LineDecoration, LinePos, TextRenderer},
+        picker::query::PickerQuery,
         EditorView,
     },
 };
@@ -226,7 +228,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
 
     cursor: u32,
     prompt: Prompt,
-    previous_pattern: String,
+    query: PickerQuery,
 
     /// Whether to show the preview panel (default true)
     show_preview: bool,
@@ -331,6 +333,8 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             .map(|column| Constraint::Length(column.name.chars().count() as u16))
             .collect();
 
+        let query = PickerQuery::new(columns.iter().map(|col| &col.name).cloned(), default_column);
+
         Self {
             columns,
             primary_column: default_column,
@@ -339,7 +343,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             shutdown,
             cursor: 0,
             prompt,
-            previous_pattern: String::new(),
+            query,
             truncate_start: true,
             show_preview: true,
             callback_fn: Box::new(callback_fn),
@@ -441,6 +445,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             .map(|item| item.data)
     }
 
+    fn primary_query(&self) -> Arc<str> {
+        self.query
+            .get(&self.columns[self.primary_column].name)
+            .cloned()
+            .unwrap_or_else(|| "".into())
+    }
+
     fn header_height(&self) -> u16 {
         if self.columns.len() > 1 {
             1
@@ -461,16 +472,36 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     fn handle_prompt_change(&mut self) {
-        let pattern = self.prompt.line();
         // TODO: better track how the pattern has changed
-        if pattern != &self.previous_pattern {
-            self.matcher.pattern.reparse(
-                0,
-                pattern,
-                CaseMatching::Smart,
-                pattern.starts_with(&self.previous_pattern),
-            );
-            self.previous_pattern = pattern.clone();
+        let line = self.prompt.line();
+        let old_query = self.query.parse(line);
+        if self.query == old_query {
+            return;
+        }
+        // Have nucleo reparse each changed column.
+        for (i, column) in self
+            .columns
+            .iter()
+            .filter(|column| column.filter)
+            .enumerate()
+        {
+            let pattern = self
+                .query
+                .get(&column.name)
+                .map(|f| &**f)
+                .unwrap_or_default();
+            let old_pattern = old_query
+                .get(&column.name)
+                .map(|f| &**f)
+                .unwrap_or_default();
+            // Fastlane: most columns will remain unchanged after each edit.
+            if pattern == old_pattern {
+                continue;
+            }
+            let is_append = pattern.starts_with(old_pattern);
+            self.matcher
+                .pattern
+                .reparse(i, pattern, CaseMatching::Smart, is_append);
         }
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -153,6 +153,12 @@ pub struct Injector<T, D> {
     editor_data: Arc<D>,
     version: usize,
     picker_version: Arc<AtomicUsize>,
+    /// A marker that requests a redraw when the injector drops.
+    /// This marker causes the "running" indicator to disappear when a background job
+    /// providing items is finished and drops. This could be wrapped in an [Arc] to ensure
+    /// that the redraw is only requested when all Injectors drop for a Picker (which removes
+    /// the "running" indicator) but the redraw handle is debounced so this is unnecessary.
+    _redraw: helix_event::RequestRedrawOnDrop,
 }
 
 impl<I, D> Clone for Injector<I, D> {
@@ -163,6 +169,7 @@ impl<I, D> Clone for Injector<I, D> {
             editor_data: self.editor_data.clone(),
             version: self.version,
             picker_version: self.picker_version.clone(),
+            _redraw: helix_event::RequestRedrawOnDrop,
         }
     }
 }
@@ -284,6 +291,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             editor_data: Arc::new(editor_data),
             version: 0,
             picker_version: Arc::new(AtomicUsize::new(0)),
+            _redraw: helix_event::RequestRedrawOnDrop,
         };
         (matcher, streamer)
     }
@@ -386,6 +394,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             editor_data: self.editor_data.clone(),
             version: self.version.load(atomic::Ordering::Relaxed),
             picker_version: self.version.clone(),
+            _redraw: helix_event::RequestRedrawOnDrop,
         }
     }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -15,7 +15,7 @@ use crate::{
 use futures_util::future::BoxFuture;
 use helix_event::AsyncHook;
 use nucleo::pattern::{CaseMatching, Normalization};
-use nucleo::{Config, Nucleo, Utf32String};
+use nucleo::{Config, Nucleo};
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
 use tui::{
@@ -135,14 +135,9 @@ fn inject_nucleo_item<T, D>(
     item: T,
     editor_data: &D,
 ) {
-    let column_texts: Vec<Utf32String> = columns
-        .iter()
-        .filter(|column| column.filter)
-        .map(|column| column.format_text(&item, editor_data).into())
-        .collect();
-    injector.push(item, |dst| {
-        for (i, text) in column_texts.into_iter().enumerate() {
-            dst[i] = text;
+    injector.push(item, |item, dst| {
+        for (column, text) in columns.iter().filter(|column| column.filter).zip(dst) {
+            *text = column.format_text(item, editor_data).into()
         }
     });
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -512,6 +512,8 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         if self.query == old_query {
             return;
         }
+        // If the query has meaningfully changed, reset the cursor to the top of the results.
+        self.cursor = 0;
         // Have nucleo reparse each changed column.
         for (i, column) in self
             .columns

--- a/helix-term/src/ui/picker/handlers.rs
+++ b/helix-term/src/ui/picker/handlers.rs
@@ -174,11 +174,8 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> AsyncHook for DynamicQu
                 if let Err(err) = get_options.await {
                     log::info!("Dynamic request failed: {err}");
                 }
-                // The picker's shows its running indicator when there are any active
-                // injectors. When we're done injecting new options, drop the injector
-                // and request a redraw to remove the running indicator.
-                drop(injector);
-                helix_event::request_redraw();
+                // NOTE: the Drop implementation of Injector will request a redraw when the
+                // injector falls out of scope here, clearing the "running" indicator.
             });
         })
     }

--- a/helix-term/src/ui/picker/handlers.rs
+++ b/helix-term/src/ui/picker/handlers.rs
@@ -1,0 +1,117 @@
+use std::{path::Path, sync::Arc, time::Duration};
+
+use helix_event::AsyncHook;
+use tokio::time::Instant;
+
+use crate::{
+    job,
+    ui::{menu::Item, overlay::Overlay},
+};
+
+use super::{CachedPreview, DynamicPicker, Picker};
+
+pub(super) struct PreviewHighlightHandler<T: Item> {
+    trigger: Option<Arc<Path>>,
+    phantom_data: std::marker::PhantomData<T>,
+}
+
+impl<T: Item> Default for PreviewHighlightHandler<T> {
+    fn default() -> Self {
+        Self {
+            trigger: None,
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+impl<T: Item> AsyncHook for PreviewHighlightHandler<T> {
+    type Event = Arc<Path>;
+
+    fn handle_event(
+        &mut self,
+        path: Self::Event,
+        timeout: Option<tokio::time::Instant>,
+    ) -> Option<tokio::time::Instant> {
+        if self
+            .trigger
+            .as_ref()
+            .is_some_and(|trigger| trigger == &path)
+        {
+            // If the path hasn't changed, don't reset the debounce
+            timeout
+        } else {
+            self.trigger = Some(path);
+            Some(Instant::now() + Duration::from_millis(150))
+        }
+    }
+
+    fn finish_debounce(&mut self) {
+        let Some(path) = self.trigger.take() else {
+            return;
+        };
+
+        job::dispatch_blocking(move |editor, compositor| {
+            let picker = match compositor.find::<Overlay<Picker<T>>>() {
+                Some(Overlay { content, .. }) => content,
+                None => match compositor.find::<Overlay<DynamicPicker<T>>>() {
+                    Some(Overlay { content, .. }) => &mut content.file_picker,
+                    None => return,
+                },
+            };
+
+            let Some(CachedPreview::Document(ref mut doc)) = picker.preview_cache.get_mut(&path)
+            else {
+                return;
+            };
+
+            if doc.language_config().is_some() {
+                return;
+            }
+
+            let Some(language_config) = doc.detect_language_config(&editor.syn_loader.load())
+            else {
+                return;
+            };
+            doc.language = Some(language_config.clone());
+            let text = doc.text().clone();
+            let loader = editor.syn_loader.clone();
+
+            tokio::task::spawn_blocking(move || {
+                let Some(syntax) = language_config
+                    .highlight_config(&loader.load().scopes())
+                    .and_then(|highlight_config| {
+                        helix_core::Syntax::new(text.slice(..), highlight_config, loader)
+                    })
+                else {
+                    log::info!("highlighting picker item failed");
+                    return;
+                };
+
+                job::dispatch_blocking(move |editor, compositor| {
+                    let picker = match compositor.find::<Overlay<Picker<T>>>() {
+                        Some(Overlay { content, .. }) => Some(content),
+                        None => compositor
+                            .find::<Overlay<DynamicPicker<T>>>()
+                            .map(|overlay| &mut overlay.content.file_picker),
+                    };
+                    let Some(picker) = picker else {
+                        log::info!("picker closed before syntax highlighting finished");
+                        return;
+                    };
+                    let Some(CachedPreview::Document(ref mut doc)) =
+                        picker.preview_cache.get_mut(&path)
+                    else {
+                        return;
+                    };
+                    let diagnostics = helix_view::Editor::doc_diagnostics(
+                        &editor.language_servers,
+                        &editor.diagnostics,
+                        doc,
+                    );
+                    doc.replace_diagnostics(diagnostics, &[], None);
+                    doc.syntax = Some(syntax);
+                });
+            });
+        });
+    }
+}

--- a/helix-term/src/ui/picker/query.rs
+++ b/helix-term/src/ui/picker/query.rs
@@ -1,0 +1,282 @@
+use std::{collections::HashMap, mem, sync::Arc};
+
+#[derive(Debug)]
+pub(super) struct PickerQuery {
+    /// The column names of the picker.
+    column_names: Box<[Arc<str>]>,
+    /// The index of the primary column in `column_names`.
+    /// The primary column is selected by default unless another
+    /// field is specified explicitly with `%fieldname`.
+    primary_column: usize,
+    /// The mapping between column names and input in the query
+    /// for those columns.
+    inner: HashMap<Arc<str>, Arc<str>>,
+}
+
+impl PartialEq<HashMap<Arc<str>, Arc<str>>> for PickerQuery {
+    fn eq(&self, other: &HashMap<Arc<str>, Arc<str>>) -> bool {
+        self.inner.eq(other)
+    }
+}
+
+impl PickerQuery {
+    pub(super) fn new<I: Iterator<Item = Arc<str>>>(
+        column_names: I,
+        primary_column: usize,
+    ) -> Self {
+        let column_names: Box<[_]> = column_names.collect();
+        let inner = HashMap::with_capacity(column_names.len());
+        Self {
+            column_names,
+            primary_column,
+            inner,
+        }
+    }
+
+    pub(super) fn get(&self, column: &str) -> Option<&Arc<str>> {
+        self.inner.get(column)
+    }
+
+    pub(super) fn parse(&mut self, input: &str) -> HashMap<Arc<str>, Arc<str>> {
+        let mut fields: HashMap<Arc<str>, String> = HashMap::new();
+        let primary_field = &self.column_names[self.primary_column];
+        let mut escaped = false;
+        let mut in_field = false;
+        let mut field = None;
+        let mut text = String::new();
+
+        macro_rules! finish_field {
+            () => {
+                let key = field.take().unwrap_or(primary_field);
+
+                if let Some(pattern) = fields.get_mut(key) {
+                    pattern.push(' ');
+                    pattern.push_str(text.trim());
+                } else {
+                    fields.insert(key.clone(), text.trim().to_string());
+                }
+                text.clear();
+            };
+        }
+
+        for ch in input.chars() {
+            match ch {
+                // Backslash escaping
+                _ if escaped => {
+                    // '%' is the only character that is special cased.
+                    // You can escape it to prevent parsing the text that
+                    // follows it as a field name.
+                    if ch != '%' {
+                        text.push('\\');
+                    }
+                    text.push(ch);
+                    escaped = false;
+                }
+                '\\' => escaped = !escaped,
+                '%' => {
+                    if !text.is_empty() {
+                        finish_field!();
+                    }
+                    in_field = true;
+                }
+                ' ' if in_field => {
+                    // Go over all columns and their indices, find all that starts with field key,
+                    // select a column that fits key the most.
+                    field = self
+                        .column_names
+                        .iter()
+                        .filter(|col| col.starts_with(&text))
+                        // select "fittest" column
+                        .min_by_key(|col| col.len());
+                    text.clear();
+                    in_field = false;
+                }
+                _ => text.push(ch),
+            }
+        }
+
+        if !in_field && !text.is_empty() {
+            finish_field!();
+        }
+
+        let new_inner: HashMap<_, _> = fields
+            .into_iter()
+            .map(|(field, query)| (field, query.as_str().into()))
+            .collect();
+
+        mem::replace(&mut self.inner, new_inner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use helix_core::hashmap;
+
+    use super::*;
+
+    #[test]
+    fn parse_query_test() {
+        let mut query = PickerQuery::new(
+            [
+                "primary".into(),
+                "field1".into(),
+                "field2".into(),
+                "another".into(),
+                "anode".into(),
+            ]
+            .into_iter(),
+            0,
+        );
+
+        // Basic field splitting
+        query.parse("hello world");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello world".into(),
+            )
+        );
+        query.parse("hello %field1 world %field2 !");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "field1".into() => "world".into(),
+                "field2".into() => "!".into(),
+            )
+        );
+        query.parse("%field1 abc %field2 def xyz");
+        assert_eq!(
+            query,
+            hashmap!(
+                "field1".into() => "abc".into(),
+                "field2".into() => "def xyz".into(),
+            )
+        );
+
+        // Trailing space is trimmed
+        query.parse("hello ");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+            )
+        );
+
+        // Unknown fields are trimmed.
+        query.parse("hello %foo");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+            )
+        );
+
+        // Multiple words in a field
+        query.parse("hello %field1 a b c");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "field1".into() => "a b c".into(),
+            )
+        );
+
+        // Escaping
+        query.parse(r#"hello\ world"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => r#"hello\ world"#.into(),
+            )
+        );
+        query.parse(r#"hello \%field1 world"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello %field1 world".into(),
+            )
+        );
+        query.parse(r#"%field1 hello\ world"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "field1".into() => r#"hello\ world"#.into(),
+            )
+        );
+        query.parse(r#"hello %field1 a\"b"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "field1".into() => r#"a\"b"#.into(),
+            )
+        );
+        query.parse(r#"%field1 hello\ world"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "field1".into() => r#"hello\ world"#.into(),
+            )
+        );
+        query.parse(r#"\bfoo\b"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => r#"\bfoo\b"#.into(),
+            )
+        );
+        query.parse(r#"\\n"#);
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => r#"\\n"#.into(),
+            )
+        );
+
+        // Only the prefix of a field is required.
+        query.parse("hello %anot abc");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "another".into() => "abc".into(),
+            )
+        );
+        // The shortest matching the prefix is selected.
+        query.parse("hello %ano abc");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "anode".into() => "abc".into()
+            )
+        );
+        // Multiple uses of a column are concatenated with space separators.
+        query.parse("hello %field1 xyz %fie abc");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "field1".into() => "xyz abc".into()
+            )
+        );
+        query.parse("hello %fie abc");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello".into(),
+                "field1".into() => "abc".into()
+            )
+        );
+        // The primary column can be explicitly qualified.
+        query.parse("hello %fie abc %prim world");
+        assert_eq!(
+            query,
+            hashmap!(
+                "primary".into() => "hello world".into(),
+                "field1".into() => "abc".into()
+            )
+        );
+    }
+}

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -92,6 +92,12 @@ impl Prompt {
         }
     }
 
+    /// Gets the byte index in the input representing the current cursor location.
+    #[inline]
+    pub(crate) fn position(&self) -> usize {
+        self.cursor
+    }
+
     pub fn with_line(mut self, line: String, editor: &Editor) -> Self {
         self.set_line(line, editor);
         self

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -93,11 +93,15 @@ impl Prompt {
     }
 
     pub fn with_line(mut self, line: String, editor: &Editor) -> Self {
+        self.set_line(line, editor);
+        self
+    }
+
+    pub fn set_line(&mut self, line: String, editor: &Editor) {
         let cursor = line.len();
         self.line = line;
         self.cursor = cursor;
         self.recalculate_completion(editor);
-        self
     }
 
     pub fn with_language(

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1741,6 +1741,10 @@ impl Document {
         Url::from_file_path(self.path()?).ok()
     }
 
+    pub fn uri(&self) -> Option<helix_core::Uri> {
+        Some(self.path()?.clone().into())
+    }
+
     #[inline]
     pub fn text(&self) -> &Rope {
         &self.text

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -44,7 +44,7 @@ pub use helix_core::diagnostic::Severity;
 use helix_core::{
     auto_pairs::AutoPairs,
     syntax::{self, AutoPairConfig, IndentationHeuristic, LanguageServerFeature, SoftWrap},
-    Change, LineEnding, Position, Range, Selection, NATIVE_LINE_ENDING,
+    Change, LineEnding, Position, Range, Selection, Uri, NATIVE_LINE_ENDING,
 };
 use helix_dap as dap;
 use helix_lsp::lsp;
@@ -1022,7 +1022,7 @@ pub struct Editor {
     pub macro_recording: Option<(char, Vec<KeyEvent>)>,
     pub macro_replaying: Vec<char>,
     pub language_servers: helix_lsp::Registry,
-    pub diagnostics: BTreeMap<PathBuf, Vec<(lsp::Diagnostic, LanguageServerId)>>,
+    pub diagnostics: BTreeMap<Uri, Vec<(lsp::Diagnostic, LanguageServerId)>>,
     pub diff_providers: DiffProviderRegistry,
 
     pub debugger: Option<dap::Client>,
@@ -1929,7 +1929,7 @@ impl Editor {
     /// Returns all supported diagnostics for the document
     pub fn doc_diagnostics<'a>(
         language_servers: &'a helix_lsp::Registry,
-        diagnostics: &'a BTreeMap<PathBuf, Vec<(lsp::Diagnostic, LanguageServerId)>>,
+        diagnostics: &'a BTreeMap<Uri, Vec<(lsp::Diagnostic, LanguageServerId)>>,
         document: &Document,
     ) -> impl Iterator<Item = helix_core::Diagnostic> + 'a {
         Editor::doc_diagnostics_with_filter(language_servers, diagnostics, document, |_, _| true)
@@ -1939,15 +1939,15 @@ impl Editor {
     /// filtered by `filter` which is invocated with the raw `lsp::Diagnostic` and the language server id it came from
     pub fn doc_diagnostics_with_filter<'a>(
         language_servers: &'a helix_lsp::Registry,
-        diagnostics: &'a BTreeMap<PathBuf, Vec<(lsp::Diagnostic, LanguageServerId)>>,
+        diagnostics: &'a BTreeMap<Uri, Vec<(lsp::Diagnostic, LanguageServerId)>>,
         document: &Document,
         filter: impl Fn(&lsp::Diagnostic, LanguageServerId) -> bool + 'a,
     ) -> impl Iterator<Item = helix_core::Diagnostic> + 'a {
         let text = document.text().clone();
         let language_config = document.language.clone();
         document
-            .path()
-            .and_then(|path| diagnostics.get(path))
+            .uri()
+            .and_then(|uri| diagnostics.get(&uri))
             .map(|diags| {
                 diags.iter().filter_map(move |(diagnostic, lsp_id)| {
                     let ls = language_servers.get_by_id(*lsp_id)?;


### PR DESCRIPTION
I was hoping to make these picker changes as separate PRs but they layer in a way that makes reviewing them independently awkward: one commit changes a block and the next changes it again, so I think it's easier to review altogether. This PR is a kind of "version 2" for the `Picker` component that resolves a bunch of things we've wanted to change about `Picker`s:

* Lay out items in a table format so that we can filter on columns independently (previously https://github.com/helix-editor/helix/pull/7265)
* Control whether certain columns are used for Nucleo-based filtering or not (useful for `DynamicPicker`s, see #5714)
* Replace the ad-hoc `IdleTimeout` approach for syntax highlighting the preview with an event-system hook (https://github.com/helix-editor/helix/issues/9629)
* Use `DynamicPicker` for `global_search` (https://github.com/helix-editor/helix/issues/196)
* Use an event-system hook for `DynamicPicker` rather than `IdleTimeout`. As a consequence, we can merge the `DynamicPicker` type into `Picker`, a refactor that joyously removes [this unfortunate block](https://github.com/helix-editor/helix/blob/76e512f9445b2a26655248b46cf13413f9a6bbba/helix-term/src/ui/picker.rs#L480-L485).

Shout out to @pascalkuthe's excellent work with the event system (#8021) and Nucleo (#7814) that make this change possible.

The table format and filtering by columns (originally posted [in #7265](https://github.com/helix-editor/helix/pull/7265)):

![table-picker demo](https://github.com/helix-editor/helix/assets/21230295/30a1bcb4-e5c1-430f-9a97-997704354f5c)

Dynamic global search running against a very large directory (originally posted [in #196](https://github.com/helix-editor/helix/issues/196#issuecomment-1712931640)):

![global search demo](https://github.com/helix-editor/helix/assets/21230295/11449e8f-4ea0-46dd-91cb-aede44b948e5)

Related to #9629
Closes #196
Closes #5714
Closes #5446
Closes #3543
Closes #4956
Closes #2109
