### PR TITLE
Fix crash on LSP text edits with invalid ranges

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -539,6 +539,16 @@ pub mod util {
                 } else {
                     return (0, 0, None);
                 };
+
+                if start > end {
+                    log::error!(
+                        "Invalid LSP text edit start {:?} > end {:?}, discarding",
+                        start,
+                        end
+                    );
+                    return (0, 0, None);
+                }
+
                 (start, end, replacement)
             }),
         )


### PR DESCRIPTION
This PR attempts to fix #9624.

While testing helix-gpt out, helix crashed many times for me. I decided to take a shot at fixing this issue myself, with a simple check inside the Transaction change edit's closure. When the range is invalid, I simply discarded the edit and logged it.

As noted in the issue, this is mainly a problem inside helix-gpt itself, but a crash is undesirable.