### PR TITLE
Convert LSP URLs into custom URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "unicode-general-category",
  "unicode-segmentation",
  "unicode-width",
+ "url",
 ]
 
 [[package]]

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -35,6 +35,7 @@ bitflags = "2.4"
 ahash = "0.8.6"
 hashbrown = { version = "0.14.3", features = ["raw"] }
 dunce = "1.0"
+url = "2.5.0"
 
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod test;
 pub mod text_annotations;
 pub mod textobject;
 mod transaction;
+pub mod uri;
 pub mod wrap;
 
 pub mod unicode {
@@ -69,3 +70,5 @@ pub use diagnostic::Diagnostic;
 
 pub use line_ending::{LineEnding, NATIVE_LINE_ENDING};
 pub use transaction::{Assoc, Change, ChangeSet, Deletion, Operation, Transaction};
+
+pub use uri::Uri;

--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -1,0 +1,122 @@
+use std::path::{Path, PathBuf};
+
+/// A generic pointer to a file location.
+///
+/// Currently this type only supports paths to local files.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Uri {
+    File(PathBuf),
+}
+
+impl Uri {
+    // This clippy allow mirrors url::Url::from_file_path
+    #[allow(clippy::result_unit_err)]
+    pub fn to_url(&self) -> Result<url::Url, ()> {
+        match self {
+            Uri::File(path) => url::Url::from_file_path(path),
+        }
+    }
+
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::File(path) => Some(path),
+        }
+    }
+
+    pub fn as_path_buf(self) -> Option<PathBuf> {
+        match self {
+            Self::File(path) => Some(path),
+        }
+    }
+}
+
+impl From<PathBuf> for Uri {
+    fn from(path: PathBuf) -> Self {
+        Self::File(path)
+    }
+}
+
+impl TryFrom<Uri> for PathBuf {
+    type Error = ();
+
+    fn try_from(uri: Uri) -> Result<Self, Self::Error> {
+        match uri {
+            Uri::File(path) => Ok(path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UrlConversionError {
+    source: url::Url,
+    kind: UrlConversionErrorKind,
+}
+
+#[derive(Debug)]
+pub enum UrlConversionErrorKind {
+    UnsupportedScheme,
+    UnableToConvert,
+}
+
+impl std::fmt::Display for UrlConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            UrlConversionErrorKind::UnsupportedScheme => {
+                write!(f, "unsupported scheme in URL: {}", self.source.scheme())
+            }
+            UrlConversionErrorKind::UnableToConvert => {
+                write!(f, "unable to convert URL to file path: {}", self.source)
+            }
+        }
+    }
+}
+
+impl std::error::Error for UrlConversionError {}
+
+fn convert_url_to_uri(url: &url::Url) -> Result<Uri, UrlConversionErrorKind> {
+    if url.scheme() == "file" {
+        url.to_file_path()
+            .map(|path| Uri::File(helix_stdx::path::normalize(path)))
+            .map_err(|_| UrlConversionErrorKind::UnableToConvert)
+    } else {
+        Err(UrlConversionErrorKind::UnsupportedScheme)
+    }
+}
+
+impl TryFrom<url::Url> for Uri {
+    type Error = UrlConversionError;
+
+    fn try_from(url: url::Url) -> Result<Self, Self::Error> {
+        convert_url_to_uri(&url).map_err(|kind| Self::Error { source: url, kind })
+    }
+}
+
+impl TryFrom<&url::Url> for Uri {
+    type Error = UrlConversionError;
+
+    fn try_from(url: &url::Url) -> Result<Self, Self::Error> {
+        convert_url_to_uri(url).map_err(|kind| Self::Error {
+            source: url.clone(),
+            kind,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use url::Url;
+
+    #[test]
+    fn unknown_scheme() {
+        let url = Url::parse("csharp:/metadata/foo/bar/Baz.cs").unwrap();
+        assert!(matches!(
+            Uri::try_from(url),
+            Err(UrlConversionError {
+                kind: UrlConversionErrorKind::UnsupportedScheme,
+                ..
+            })
+        ));
+    }
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -723,10 +723,10 @@ impl Application {
                         }
                     }
                     Notification::PublishDiagnostics(mut params) => {
-                        let path = match params.uri.to_file_path() {
-                            Ok(path) => path,
-                            Err(_) => {
-                                log::error!("Unsupported file URI: {}", params.uri);
+                        let uri = match helix_core::Uri::try_from(params.uri) {
+                            Ok(uri) => uri,
+                            Err(err) => {
+                                log::error!("{err}");
                                 return;
                             }
                         };
@@ -737,11 +737,11 @@ impl Application {
                         }
                         // have to inline the function because of borrow checking...
                         let doc = self.editor.documents.values_mut()
-                            .find(|doc| doc.path().map(|p| p == &path).unwrap_or(false))
+                            .find(|doc| doc.uri().is_some_and(|u| u == uri))
                             .filter(|doc| {
                                 if let Some(version) = params.version {
                                     if version != doc.version() {
-                                        log::info!("Version ({version}) is out of date for {path:?} (expected ({}), dropping PublishDiagnostic notification", doc.version());
+                                        log::info!("Version ({version}) is out of date for {uri:?} (expected ({}), dropping PublishDiagnostic notification", doc.version());
                                         return false;
                                     }
                                 }
@@ -753,9 +753,7 @@ impl Application {
                             let lang_conf = doc.language.clone();
 
                             if let Some(lang_conf) = &lang_conf {
-                                if let Some(old_diagnostics) =
-                                    self.editor.diagnostics.get(&params.uri)
-                                {
+                                if let Some(old_diagnostics) = self.editor.diagnostics.get(&uri) {
                                     if !lang_conf.persistent_diagnostic_sources.is_empty() {
                                         // Sort diagnostics first by severity and then by line numbers.
                                         // Note: The `lsp::DiagnosticSeverity` enum is already defined in decreasing order
@@ -788,7 +786,7 @@ impl Application {
                         // Insert the original lsp::Diagnostics here because we may have no open document
                         // for diagnosic message and so we can't calculate the exact position.
                         // When using them later in the diagnostics picker, we calculate them on-demand.
-                        let diagnostics = match self.editor.diagnostics.entry(params.uri) {
+                        let diagnostics = match self.editor.diagnostics.entry(uri) {
                             Entry::Occupied(o) => {
                                 let current_diagnostics = o.into_mut();
                                 // there may entries of other language servers, which is why we can't overwrite the whole entry
@@ -1127,20 +1125,22 @@ impl Application {
             ..
         } = params;
 
-        let path = match uri.to_file_path() {
-            Ok(path) => path,
+        let uri = match helix_core::Uri::try_from(uri) {
+            Ok(uri) => uri,
             Err(err) => {
-                log::error!("unsupported file URI: {}: {:?}", uri, err);
+                log::error!("{err}");
                 return lsp::ShowDocumentResult { success: false };
             }
         };
+        // If `Uri` gets another variant other than `Path` this may not be valid.
+        let path = uri.as_path().expect("URIs are valid paths");
 
         let action = match take_focus {
             Some(true) => helix_view::editor::Action::Replace,
             _ => helix_view::editor::Action::VerticalSplit,
         };
 
-        let doc_id = match self.editor.open(&path, action) {
+        let doc_id = match self.editor.open(path, action) {
             Ok(id) => id,
             Err(err) => {
                 log::error!("failed to open path: {:?}: {:?}", uri, err);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1670,6 +1670,10 @@ impl Document {
         Url::from_file_path(self.path()?).ok()
     }
 
+    pub fn uri(&self) -> Option<helix_core::Uri> {
+        Some(self.path()?.clone().into())
+    }
+
     #[inline]
     pub fn text(&self) -> &Rope {
         &self.text

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -1,6 +1,7 @@
 use crate::editor::Action;
 use crate::Editor;
 use crate::{DocumentId, ViewId};
+use helix_core::Uri;
 use helix_lsp::util::generate_transaction_from_edits;
 use helix_lsp::{lsp, OffsetEncoding};
 
@@ -54,10 +55,22 @@ pub struct ApplyEditError {
 pub enum ApplyEditErrorKind {
     DocumentChanged,
     FileNotFound,
-    UnknownURISchema,
+    InvalidUrl(helix_core::uri::UrlConversionError),
     IoError(std::io::Error),
     // TODO: check edits before applying and propagate failure
     // InvalidEdit,
+}
+
+impl From<std::io::Error> for ApplyEditErrorKind {
+    fn from(err: std::io::Error) -> Self {
+        ApplyEditErrorKind::IoError(err)
+    }
+}
+
+impl From<helix_core::uri::UrlConversionError> for ApplyEditErrorKind {
+    fn from(err: helix_core::uri::UrlConversionError) -> Self {
+        ApplyEditErrorKind::InvalidUrl(err)
+    }
 }
 
 impl ToString for ApplyEditErrorKind {
@@ -65,7 +78,7 @@ impl ToString for ApplyEditErrorKind {
         match self {
             ApplyEditErrorKind::DocumentChanged => "document has changed".to_string(),
             ApplyEditErrorKind::FileNotFound => "file not found".to_string(),
-            ApplyEditErrorKind::UnknownURISchema => "URI schema not supported".to_string(),
+            ApplyEditErrorKind::InvalidUrl(err) => err.to_string(),
             ApplyEditErrorKind::IoError(err) => err.to_string(),
         }
     }
@@ -74,25 +87,28 @@ impl ToString for ApplyEditErrorKind {
 impl Editor {
     fn apply_text_edits(
         &mut self,
-        uri: &helix_lsp::Url,
+        url: &helix_lsp::Url,
         version: Option<i32>,
         text_edits: Vec<lsp::TextEdit>,
         offset_encoding: OffsetEncoding,
     ) -> Result<(), ApplyEditErrorKind> {
-        let path = match uri.to_file_path() {
-            Ok(path) => path,
-            Err(_) => {
-                let err = format!("unable to convert URI to filepath: {}", uri);
-                log::error!("{}", err);
-                self.set_error(err);
-                return Err(ApplyEditErrorKind::UnknownURISchema);
+        let uri = match Uri::try_from(url) {
+            Ok(uri) => uri,
+            Err(err) => {
+                log::error!("{err}");
+                return Err(err.into());
             }
         };
+        let path = uri.as_path().expect("URIs are valid paths");
 
-        let doc_id = match self.open(&path, Action::Load) {
+        let doc_id = match self.open(path, Action::Load) {
             Ok(doc_id) => doc_id,
             Err(err) => {
-                let err = format!("failed to open document: {}: {}", uri, err);
+                let err = format!(
+                    "failed to open document: {}: {}",
+                    path.to_string_lossy(),
+                    err
+                );
                 log::error!("{}", err);
                 self.set_error(err);
                 return Err(ApplyEditErrorKind::FileNotFound);
@@ -102,7 +118,7 @@ impl Editor {
         let doc = doc_mut!(self, &doc_id);
         if let Some(version) = version {
             if version != doc.version() {
-                let err = format!("outdated workspace edit for {path:?}");
+                let err = format!("outdated workspace edit for {:?}", path);
                 log::error!("{err}, expected {} but got {version}", doc.version());
                 self.set_error(err);
                 return Err(ApplyEditErrorKind::DocumentChanged);
@@ -158,9 +174,9 @@ impl Editor {
                     for (i, operation) in operations.iter().enumerate() {
                         match operation {
                             lsp::DocumentChangeOperation::Op(op) => {
-                                self.apply_document_resource_op(op).map_err(|io| {
+                                self.apply_document_resource_op(op).map_err(|err| {
                                     ApplyEditError {
-                                        kind: ApplyEditErrorKind::IoError(io),
+                                        kind: err,
                                         failed_change_idx: i,
                                     }
                                 })?;
@@ -214,12 +230,18 @@ impl Editor {
         Ok(())
     }
 
-    fn apply_document_resource_op(&mut self, op: &lsp::ResourceOp) -> std::io::Result<()> {
+    fn apply_document_resource_op(
+        &mut self,
+        op: &lsp::ResourceOp,
+    ) -> Result<(), ApplyEditErrorKind> {
         use lsp::ResourceOp;
         use std::fs;
+        // NOTE: If `Uri` gets another variant other than `Path` the below `expect`s
+        // may no longer be valid.
         match op {
             ResourceOp::Create(op) => {
-                let path = op.uri.to_file_path().unwrap();
+                let uri = Uri::try_from(&op.uri)?;
+                let path = uri.as_path_buf().expect("URIs are valid paths");
                 let ignore_if_exists = op.options.as_ref().map_or(false, |options| {
                     !options.overwrite.unwrap_or(false) && options.ignore_if_exists.unwrap_or(false)
                 });
@@ -236,7 +258,8 @@ impl Editor {
                 }
             }
             ResourceOp::Delete(op) => {
-                let path = op.uri.to_file_path().unwrap();
+                let uri = Uri::try_from(&op.uri)?;
+                let path = uri.as_path_buf().expect("URIs are valid paths");
                 if path.is_dir() {
                     let recursive = op
                         .options
@@ -251,17 +274,19 @@ impl Editor {
                     }
                     self.language_servers.file_event_handler.file_changed(path);
                 } else if path.is_file() {
-                    fs::remove_file(&path)?;
+                    fs::remove_file(path)?;
                 }
             }
             ResourceOp::Rename(op) => {
-                let from = op.old_uri.to_file_path().unwrap();
-                let to = op.new_uri.to_file_path().unwrap();
+                let from_uri = Uri::try_from(&op.old_uri)?;
+                let from = from_uri.as_path().expect("URIs are valid paths");
+                let to_uri = Uri::try_from(&op.new_uri)?;
+                let to = to_uri.as_path().expect("URIs are valid paths");
                 let ignore_if_exists = op.options.as_ref().map_or(false, |options| {
                     !options.overwrite.unwrap_or(false) && options.ignore_if_exists.unwrap_or(false)
                 });
                 if !ignore_if_exists || !to.exists() {
-                    self.move_path(&from, &to)?;
+                    self.move_path(from, to)?;
                 }
             }
         }


### PR DESCRIPTION
This introduces a custom URI type for core meant to be extended later if we support other schemes. For now it's just a wrapper over a `PathBuf`. We use this new `Uri` type to firewall `lsp::Url` so that:

* we normalize URLs consistently (for example URL-encoded characters like `+` or Windows drive letters)
* we handle language servers sending valid URLs that we can't understand (for example C#'s LS sending `csharp:/metadata/foo/bar/Baz.cs` URLs)

Closes #2109
Closes #3267
Closes https://github.com/helix-editor/helix/pull/7367