### PR TITLE
Add tmux.conf glob as a bash file type

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -860,7 +860,7 @@ file-types = [
   "tcshrc",
   "bashrc_Apple_Terminal",
   "zshrc_Apple_Terminal",
-  "conf",
+  { glob = "tmux.conf" },
   { glob = ".bash_history" },
   { glob = ".bash_login" },
   { glob = ".bash_logout" },

--- a/languages.toml
+++ b/languages.toml
@@ -860,6 +860,7 @@ file-types = [
   "tcshrc",
   "bashrc_Apple_Terminal",
   "zshrc_Apple_Terminal",
+  "conf",
   { glob = ".bash_history" },
   { glob = ".bash_login" },
   { glob = ".bash_logout" },


### PR DESCRIPTION
Tmux and tmux.conf are used widely among Helix users. Having the tmux.conf file not have any syntax highlighting by default is (IMO) not ideal for an editor that otherwise "just works". Feel free to close without merge if you disagree, but I thought it's better I bring this up and give this change a chance to be merged.

## Before

![Screenshot 2024-02-17 at 21 10 13](https://github.com/helix-editor/helix/assets/9061239/62220c65-d0e1-4fb0-a4c4-079c7ebfb537)


## After

![Screenshot 2024-02-17 at 21 11 12](https://github.com/helix-editor/helix/assets/9061239/c1a47961-65d8-4c7c-828e-1af3951babf4)

