### PR TITLE
Enable backtraces by default if RUST_BACKTRACE is not set

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -34,6 +34,11 @@ fn setup_logging(verbosity: u64) -> Result<()> {
 }
 
 fn main() -> Result<()> {
+    // Print backtraces by default
+    if std::env::var_os("RUST_BACKTRACE").is_none() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+
     let exit_code = main_impl()?;
     std::process::exit(exit_code);
 }


### PR DESCRIPTION
This was inspired because I occasionally run across a pretty rare error that unfortunately isn't very useful on its own:

```
thread 'main' panicked at 'Positions [(9997, After), (9998, Before)] are out of range for changeset len 8910!', helix-core/src/transaction.rs:461:9
```

Having backtraces enabled by default should make it easier to get more information about a bug that cannot be easily reproduced, without requiring users to configure the `RUST_BACKTRACE` environment variable themselves.