### PR TITLE
fix: ahash breaking nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = "1.19"
 arc-swap = "1"
 regex = "1"
 bitflags = "2.4"
-ahash = "0.8.6"
+ahash = "0.8.7"
 hashbrown = { version = "0.14.3", features = ["raw"] }
 dunce = "1.0"
 

--- a/helix-event/Cargo.toml
+++ b/helix-event/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ahash = "0.8.3"
+ahash = "0.8.7"
 hashbrown = "0.14.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync", "parking_lot", "macros"] }
 # the event registry is essentially read only but must be an rwlock so we can


### PR DESCRIPTION
When building helix in nightly, I get the following error:
```
error[E0635]: unknown feature `stdsimd`
  --> /home/mc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.6/src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^
```

The issue appears to have been fixed in `0.8.7`, cf https://github.com/tkaitchuck/aHash/issues/200.