### PR TITLE
Use a hook for resolving completion items

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1017,7 +1017,7 @@ impl Client {
     pub fn resolve_completion_item(
         &self,
         completion_item: lsp::CompletionItem,
-    ) -> Option<impl Future<Output = Result<Value>>> {
+    ) -> Option<impl Future<Output = Result<lsp::CompletionItem>>> {
         let capabilities = self.capabilities.get().unwrap();
 
         // Return early if the server does not support resolving completion items.
@@ -1029,7 +1029,8 @@ impl Client {
             _ => return None,
         }
 
-        Some(self.call::<lsp::request::ResolveCompletionItem>(completion_item))
+        let res = self.call::<lsp::request::ResolveCompletionItem>(completion_item);
+        Some(async move { Ok(serde_json::from_value(res.await?)?) })
     }
 
     pub fn resolve_code_action(

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1027,14 +1027,6 @@ impl EditorView {
     pub fn handle_idle_timeout(&mut self, cx: &mut commands::Context) -> EventResult {
         commands::compute_inlay_hints_for_all_views(cx.editor, cx.jobs);
 
-        if let Some(completion) = &mut self.completion {
-            return if completion.ensure_item_resolved(cx) {
-                EventResult::Consumed(None)
-            } else {
-                EventResult::Ignored(None)
-            };
-        }
-
         EventResult::Ignored(None)
     }
 }


### PR DESCRIPTION
Previously we used the IdleTimeout event to trigger LSP `completion/resolveItem` requests. We can now refactor this to use an event system hook instead and lower the timeout.

Connects #9629