### PR TITLE
Use groovy support when editing Gradle files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3130,7 +3130,7 @@ source = { git = "https://github.com/apple/tree-sitter-pkl", rev = "c03f04a313b7
 name = "groovy"
 language-id = "groovy"
 scope = "source.groovy"
-file-types = ["groovy", "jenkinsfile", { glob = "Jenkinsfile" },  { glob = "Jenkinsfile.*" }]
+file-types = ["gradle", "groovy", "jenkinsfile", { glob = "Jenkinsfile" },  { glob = "Jenkinsfile.*" }]
 shebangs = ["groovy"]
 comment-token = "//"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
The Gradle build tool provides two DSLs for configuring builds. On is
based on Groovy and Gradle build files written in Gradle Groovy DSL use
*.gradle file ending.

This change adds `gradle` to the supported file types of the groovy
language configuration.
