### PR TITLE
Consistent statusline padding

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -75,20 +75,6 @@ pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans
         .flat_map(|render| render(context).0)
         .collect::<Vec<Span>>();
 
-    let element_ids = &config.statusline.left;
-    let mut left = element_ids
-        .iter()
-        .map(|element_id| get_render_function(*element_id))
-        .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>();
-
-    let element_ids = &config.statusline.center;
-    let mut center = element_ids
-        .iter()
-        .map(|element_id| get_render_function(*element_id))
-        .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>();
-
     let element_ids = &config.statusline.right;
     let mut right = element_ids
         .iter()
@@ -187,15 +173,18 @@ fn render_mode<'a>(context: &RenderContext) -> Spans<'a> {
     }
 }
 
-// TODO think about handling multiple language servers
 fn render_lsp_spinner<'a>(context: &RenderContext) -> Spans<'a> {
     let frame = context
         .doc
         .language_servers()
-        .next()
-        .and_then(|srv| context.spinners.get(srv.id()))
-        .and_then(|spinner| spinner.frame());
-    if let Some(frame) = frame {
+        .map(|srv| {
+            context
+                .spinners
+                .get(srv.id())
+                .and_then(|spinner| spinner.frame())
+        })
+        .find(|frame| frame.is_some());
+    if let Some(Some(frame)) = frame {
         Span::raw(format!(" {} ", frame)).into()
     } else {
         Spans::default()

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -61,7 +61,6 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
 pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans<'a> {
     let config = context.editor.config();
 
-<<<<<<< HEAD
     let element_ids = &config.statusline.left;
     let mut left = element_ids
         .iter()
@@ -75,35 +74,20 @@ pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans
         .map(|element_id| get_render_function(*element_id))
         .flat_map(|render| render(context).0)
         .collect::<Vec<Span>>();
-=======
-    let element_ids = &config.statusline.right;
-    context.parts.right = element_ids
+
+    let element_ids = &config.statusline.left;
+    let mut left = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
         .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>()
-        .into();
-
-    surface.set_spans(
-        viewport.x
-            + viewport
-                .width
-                .saturating_sub(context.parts.right.width() as u16),
-        viewport.y,
-        &context.parts.right,
-        context.parts.right.width() as u16,
-    );
-
-    // Center of the status line.
+        .collect::<Vec<Span>>();
 
     let element_ids = &config.statusline.center;
-    context.parts.center = element_ids
+    let mut center = element_ids
         .iter()
         .map(|element_id| get_render_function(*element_id))
         .flat_map(|render| render(context).0)
-        .collect::<Vec<Span>>()
-        .into();
->>>>>>> 368a1c01 (Refactor statusline elements to return Spans)
+        .collect::<Vec<Span>>();
 
     let element_ids = &config.statusline.right;
     let mut right = element_ids
@@ -396,7 +380,6 @@ fn render_file_name<'a>(context: &RenderContext) -> Spans<'a> {
     Span::raw(title).into()
 }
 
-<<<<<<< HEAD
 fn render_file_absolute_path<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let path = context.doc.path();
@@ -410,8 +393,6 @@ fn render_file_absolute_path<'a>(context: &RenderContext) -> Spans<'a> {
     Span::raw(title).into()
 }
 
-=======
->>>>>>> 368a1c01 (Refactor statusline elements to return Spans)
 fn render_file_modification_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = (if context.doc.is_modified() {
         "[+]"

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -61,6 +61,7 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
 pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans<'a> {
     let config = context.editor.config();
 
+<<<<<<< HEAD
     let element_ids = &config.statusline.left;
     let mut left = element_ids
         .iter()
@@ -74,6 +75,35 @@ pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans
         .map(|element_id| get_render_function(*element_id))
         .flat_map(|render| render(context).0)
         .collect::<Vec<Span>>();
+=======
+    let element_ids = &config.statusline.right;
+    context.parts.right = element_ids
+        .iter()
+        .map(|element_id| get_render_function(*element_id))
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
+
+    surface.set_spans(
+        viewport.x
+            + viewport
+                .width
+                .saturating_sub(context.parts.right.width() as u16),
+        viewport.y,
+        &context.parts.right,
+        context.parts.right.width() as u16,
+    );
+
+    // Center of the status line.
+
+    let element_ids = &config.statusline.center;
+    context.parts.center = element_ids
+        .iter()
+        .map(|element_id| get_render_function(*element_id))
+        .flat_map(|render| render(context).0)
+        .collect::<Vec<Span>>()
+        .into();
+>>>>>>> 368a1c01 (Refactor statusline elements to return Spans)
 
     let element_ids = &config.statusline.right;
     let mut right = element_ids
@@ -366,6 +396,7 @@ fn render_file_name<'a>(context: &RenderContext) -> Spans<'a> {
     Span::raw(title).into()
 }
 
+<<<<<<< HEAD
 fn render_file_absolute_path<'a>(context: &RenderContext) -> Spans<'a> {
     let title = {
         let path = context.doc.path();
@@ -379,6 +410,8 @@ fn render_file_absolute_path<'a>(context: &RenderContext) -> Spans<'a> {
     Span::raw(title).into()
 }
 
+=======
+>>>>>>> 368a1c01 (Refactor statusline elements to return Spans)
 fn render_file_modification_indicator<'a>(context: &RenderContext) -> Spans<'a> {
     let title = (if context.doc.is_modified() {
         "[+]"

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -435,10 +435,10 @@ impl Default for StatusLineConfig {
         Self {
             left: vec![
                 E::Mode,
-                E::Spinner,
                 E::FileName,
                 E::ReadOnlyIndicator,
                 E::FileModificationIndicator,
+                E::Spinner,
             ],
             center: vec![],
             right: vec![


### PR DESCRIPTION
Closes #8061.

Statusline elements were inconsistent in their use of spacing: some had margins, some didn't, some reserved space for when they were not in use while others did not.

This PR adjusts each element to act consistently, without involving the statusline renderer:
 - Every statusline element hides when not in use.
 - Every statusline element has a single space margin.

This creates a 2 space gap between every element, avoiding confusion with spaces between words, and a 1 space padding from the statusline edges.

Since elements handle their own padding, special cases like `color-modes`, `spacer` and `separator` work correctly.