### PR TITLE
Highlight Rust doc comments with markdown

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2687,10 +2687,10 @@ mod test {
             )
         };
 
-        test("quantified_nodes", 1..36);
+        test("quantified_nodes", 1..37);
         // NOTE: Enable after implementing proper node group capturing
-        // test("quantified_nodes_grouped", 1..36);
-        // test("multiple_nodes_grouped", 1..36);
+        // test("quantified_nodes_grouped", 1..37);
+        // test("multiple_nodes_grouped", 1..37);
     }
 
     #[test]
@@ -2861,7 +2861,7 @@ mod test {
 
     #[test]
     fn test_pretty_print() {
-        let source = r#"/// Hello"#;
+        let source = r#"// Hello"#;
         assert_pretty_print("rust", source, "(line_comment)", 0, source.len());
 
         // A large tree should be indented with fields:

--- a/languages.toml
+++ b/languages.toml
@@ -234,7 +234,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "0431a2c60828731f27491ee9fdefe25e250ce9c9" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "35f4a5b8a29c161402e89dba83dcdc9876ba1dac" }
 
 [[language]]
 name = "sway"

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -51,7 +51,7 @@
 (lifetime
   "'" @label
   (identifier) @label)
-(loop_label
+(label
   "'" @label
   (identifier) @label)
 

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -1,5 +1,9 @@
-([(line_comment) (block_comment)] @injection.content
+([(line_comment !doc) (block_comment !doc)] @injection.content
  (#set! injection.language "comment"))
+
+((doc_comment) @injection.content
+ (#set! injection.language "markdown")
+ (#set! injection.combined))
 
 ((macro_invocation
    macro:


### PR DESCRIPTION
tree-sitter-rust recently added nodes for doc comments and we can inject in markdown. This is waiting on a few fixes/refactors in https://github.com/tree-sitter/tree-sitter-rust/pull/212

Closes https://github.com/helix-editor/helix/issues/3391