### PR TITLE
Add osm and osc extensions to xml language filetypes

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2371,6 +2371,8 @@ file-types = [
   "menu",
   "mxml",
   "nuspec",
+  "osc",
+  "osm",
   "pt",
   "publishsettings",
   "pubxml",


### PR DESCRIPTION
This PR adds two [OpenStreetMap](https://www.openstreetmap.org/about)-related filetypes to the XML `file-types` list in `languages.toml`:
- `.osm` is the uncompressed [XML-based format](https://wiki.openstreetmap.org/wiki/OSM_XML) for OSM data
- `.osc` is an XML-based file format for describing [changes](https://wiki.openstreetmap.org/wiki/OsmChange) (diffs) to `.osm` files

Mostly these file types are generated by OSM ecosystem tools, but it's occasionally useful to edit them by hand (especially when developing said tools) and it's nice to have syntax highlighting on those occasions.