### PR TITLE
Properly handle spaces in filenames in bash autocomplete

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -5,19 +5,20 @@ _hx() {
 	# $1 command name
 	# $2 word being completed
 	# $3 word preceding
-	COMPREPLY=()
 
 	case "$3" in
 	-g | --grammar)
-		COMPREPLY=($(compgen -W "fetch build" -- $2))
+		COMPREPLY="$(compgen -W "fetch build" -- $2)"
 		;;
 	--health)
 		local languages=$(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g')
-		COMPREPLY=($(compgen -W "$languages" -- $2))
+		COMPREPLY="$(compgen -W "$languages" -- $2)"
 		;;
 	*)
-		COMPREPLY=($(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- $2))
+		COMPREPLY="$(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- $2)"
 		;;
 	esac
-} && complete -o filenames -F _hx hx
 
+	local IFS=$'\n'
+	COMPREPLY=($COMPREPLY)
+} && complete -o filenames -F _hx hx


### PR DESCRIPTION
Attempt to fix issue #9701.