### PR TITLE
Completely fix bash autocomplete handling of filenames with spaces

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -8,14 +8,14 @@ _hx() {
 
 	case "$3" in
 	-g | --grammar)
-		COMPREPLY="$(compgen -W "fetch build" -- $2)"
+		COMPREPLY="$(compgen -W 'fetch build' -- $2)"
 		;;
 	--health)
 		local languages=$(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g')
-		COMPREPLY="$(compgen -W "$languages" -- $2)"
+		COMPREPLY="$(compgen -W """$languages""" -- $2)"
 		;;
 	*)
-		COMPREPLY="$(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- $2)"
+		COMPREPLY="$(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")"
 		;;
 	esac
 


### PR DESCRIPTION
I made an PR earlier (#9702) to fix issue #9701, but it seems that I forgot to wrap a `$2` in quotes and escape the quotes in some of the lines above. With this mistake, most of the behavior when filenames include spaces still works properly, but some problems still occur when multiple file paths are similar and contain spaces.

## Broken behavior 
 - Assume the current directory contains the file "foo bar.txt" and "foo biz.txt"
 - `hx foo\ ba` + `Tab` autocompletes to `hx foo\ b`
 - `hx foo\ biz` + `Tab` autocompletes to `hx foo\ b`
## New behavior
 - `hx foo\ ba` + `Tab` autocompletes to `hx foo\ bar.txt`
 - `hx foo\ biz` + `Tab` autocompletes to `hx foo\ biz.txt`
# Testing
 - This change can be tested by replacing the contents of `/usr/share/bash-completion/completions/hx` with the new contents of `contrib/completion/hx.bash`.