### PR TITLE
re-detect language after file modifications

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -340,6 +340,8 @@ fn write_impl(
         insert_final_newline(doc, view);
     }
 
+    doc.detect_language(cx.editor.syn_loader.clone());
+
     let fmt = if config.auto_format {
         doc.auto_format().map(|fmt| {
             let callback = make_format_callback(
@@ -704,6 +706,8 @@ pub fn write_all_impl(
         if config.insert_final_newline {
             insert_final_newline(doc, view_mut!(cx.editor, target_view));
         }
+
+        doc.detect_language(cx.editor.syn_loader.clone());
 
         let fmt = if config.auto_format {
             doc.auto_format().map(|fmt| {
@@ -1320,6 +1324,7 @@ fn reload_all(
         view.sync_changes(doc);
 
         doc.reload(view, &cx.editor.diff_providers)?;
+        doc.detect_language(cx.editor.syn_loader.clone());
         if let Some(path) = doc.path() {
             cx.editor
                 .language_servers

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1273,6 +1273,7 @@ fn reload(
     doc.reload(view, &cx.editor.diff_providers).map(|_| {
         view.ensure_cursor_in_view(doc, scrolloff);
     })?;
+    doc.detect_language(cx.editor.syn_loader.clone());
     if let Some(path) = doc.path() {
         cx.editor
             .language_servers


### PR DESCRIPTION
While working on shell scripts without file extensions I noticed that the language is not detected after adding a shebang to the top of the file. I had to close the file using `buffer-close` and `open` it again for the changes to be detected.

I suggest that the language should be re-detected after the following commands:

- write
- write-all
- reload
- reload-all

Please let me know what you think and whether there are more commands that should have this behaviour.