### PR TITLE
add language fidl

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -44,6 +44,7 @@
 | erb | ✓ |  |  |  |
 | erlang | ✓ | ✓ |  | `erlang_ls` |
 | esdl | ✓ |  |  |  |
+| fidl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ |  |
 | forth | ✓ |  |  | `forth-lsp` |
 | fortran | ✓ |  | ✓ | `fortls` |

--- a/languages.toml
+++ b/languages.toml
@@ -3140,3 +3140,21 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "groovy"
 source = { git = "https://github.com/Decodetalkers/tree-sitter-groovy", rev = "7e023227f46fee428b16a0288eeb0f65ee2523ec" }
+
+[[language]]
+name = "fidl"
+scope = "source.fidl"
+injection-regex = "fidl"
+file-types = ["fidl"]
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+
+[language.auto-pairs]
+'"' = '"'
+'{' = '}'
+'(' = ')'
+'<' = '>'
+
+[[grammar]]
+name = "fidl"
+source = { git = "https://github.com/google/tree-sitter-fidl", rev = "bdbb635a7f5035e424f6173f2f11b9cd79703f8d" }

--- a/runtime/queries/fidl/folds.scm
+++ b/runtime/queries/fidl/folds.scm
@@ -1,0 +1,6 @@
+[
+  (layout_declaration)
+  (protocol_declaration)
+  (resource_declaration)
+  (service_declaration)
+] @fold

--- a/runtime/queries/fidl/highlights.scm
+++ b/runtime/queries/fidl/highlights.scm
@@ -1,0 +1,64 @@
+[
+  "ajar"
+  "alias"
+  "as"
+  "bits"
+  "closed"
+  "compose"
+  "const"
+  "enum"
+  "error"
+  "flexible"
+  "library"
+  "open"
+  ; "optional" we did not specify a node for optional yet
+  "overlay"
+  "protocol"
+  "reserved"
+  "resource"
+  "service"
+  "strict"
+  "struct"
+  "table"
+  "type"
+  "union"
+  "using"
+] @keyword
+
+(primitives_type) @type.builtin
+
+(builtin_complex_type) @type.builtin
+
+(const_declaration
+  (identifier) @constant)
+
+[
+  "="
+  "|"
+  "&"
+  "->"
+] @operator
+
+(attribute
+  "@" @attribute
+  (identifier) @attribute)
+
+(string_literal) @string
+
+(numeric_literal) @constant.numeric
+
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+(comment) @comment
+
+[
+  "("
+  ")"
+  "<"
+  ">"
+  "{"
+  "}"
+] @punctuation.bracket

--- a/runtime/queries/fidl/injections.scm
+++ b/runtime/queries/fidl/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Add language support for [FIDL](https://fuchsia.dev/fuchsia-src/reference/fidl/language/language) (Fuchsia Interface Definition Language), only treesitter support.