### PR TITLE
Don't run scheduled builds on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   check:
     name: Check (msrv)
     runs-on: ubuntu-latest
+    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
     env:
       RUST_BACKTRACE: 1
       HELIX_LOG_LEVEL: info
@@ -65,6 +67,7 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-latest
+    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -92,6 +95,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
From searching online, it doesn't seem like there is a way to do this by default, so I just added what was suggested in the issue :)

Closes #9591