### PR TITLE
update languages.toml: tree-sitter-lua grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1101,7 +1101,7 @@ language-servers = [ "lua-language-server" ]
 
 [[grammar]]
 name = "lua"
-source = { git = "https://github.com/MunifTanjim/tree-sitter-lua", rev = "887dfd4e83c469300c279314ff1619b1d0b85b91" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-lua", rev = "88e446476a1e97a8724dff7a23e2d709855077f2" }
 
 [[language]]
 name = "svelte"

--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -128,9 +128,9 @@
 
 ;; Tables
 
-(field name: (identifier) @field)
+(field name: (identifier) @variable.other.member)
 
-(dot_index_expression field: (identifier) @field)
+(dot_index_expression field: (identifier) @variable.other.member)
 
 (table_constructor
 [
@@ -198,7 +198,7 @@
 ;; Nodes
 (comment) @comment
 (string) @string
-(escape_sequence) @string.escape
+(escape_sequence) @constant.character.escape
 (number) @constant.numeric.integer
 (label_statement) @label
 ; A bit of a tricky one, this will only match field names

--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -1,9 +1,5 @@
 ;;; Highlighting for lua
 
-;;; Builtins
-((identifier) @variable.builtin
- (#eq? @variable.builtin "self"))
-
 ;; Keywords
 
 (if_statement
@@ -130,16 +126,65 @@
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
-;; Parameters
-(parameters
-  (identifier) @variable.parameter)
+;; Tables
 
-; ;; Functions
-(function_declaration name: (identifier) @function)
-(function_call name: (identifier) @function.call)
+(field name: (identifier) @field)
 
-(function_declaration name: (dot_index_expression field: (identifier) @function))
-(function_call name: (dot_index_expression field: (identifier) @function.call))
+(dot_index_expression field: (identifier) @field)
+
+(table_constructor
+[
+  "{"
+  "}"
+] @constructor)
+
+;; Functions
+
+(parameters (identifier) @variable.parameter)
+
+(function_call
+  (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ;; built-in functions in Lua 5.1
+    "assert" "collectgarbage" "dofile" "error" "getfenv" "getmetatable" "ipairs"
+    "load" "loadfile" "loadstring" "module" "next" "pairs" "pcall" "print"
+    "rawequal" "rawget" "rawset" "require" "select" "setfenv" "setmetatable"
+    "tonumber" "tostring" "type" "unpack" "xpcall"))
+
+(function_declaration
+  name: [
+    (identifier) @function
+    (dot_index_expression
+      field: (identifier) @function)
+  ])
+
+(function_declaration
+  name: (method_index_expression
+    method: (identifier) @function.method))
+
+(assignment_statement
+  (variable_list .
+    name: [
+      (identifier) @function
+      (dot_index_expression
+        field: (identifier) @function)
+    ])
+  (expression_list .
+    value: (function_definition)))
+
+(table_constructor
+  (field
+    name: (identifier) @function
+    value: (function_definition)))
+
+(function_call
+  name: [
+    (identifier) @function.call
+    (dot_index_expression
+      field: (identifier) @function.call)
+    (method_index_expression
+      method: (identifier) @function.method.call)
+  ])
 
 ; TODO: incorrectly highlights variable N in `N, nop = 42, function() end`
 (assignment_statement
@@ -153,6 +198,7 @@
 ;; Nodes
 (comment) @comment
 (string) @string
+(escape_sequence) @string.escape
 (number) @constant.numeric.integer
 (label_statement) @label
 ; A bit of a tricky one, this will only match field names
@@ -162,7 +208,16 @@
 ;; Property
 (dot_index_expression field: (identifier) @variable.other.member)
 
-;; Variable
+;; Variables
+((identifier) @variable.builtin
+ (#eq? @variable.builtin "self"))
+
+(variable_list
+  (attribute
+    "<" @punctuation.bracket
+    (identifier) @attribute
+    ">" @punctuation.bracket))
+
 (identifier) @variable
 
 ;; Error


### PR DESCRIPTION
repo has moved, use new URL and the rev of the latest release (v0.0.19)

There is a more recent release of the tree-sitter-lua grammar (and new repo url, which appears to be the same repo, just moved):
https://github.com/tree-sitter-grammars/tree-sitter-lua/commit/88e446476a1e97a8724dff7a23e2d709855077f2

I'm a first-time contributor, opening this PR per request from @archseer on #9726. 

I tested locally by adding a `.config/helix/languages.toml` file with the following content (the `source =` line is the same content as this PR):
```toml
use-grammars = { only = [ "lua" ] }

[[grammar]]
name = "lua"
source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-lua", rev = "88e446476a1e97a8724dff7a23e2d709855077f2" }
```

Then updated the grammar:
```zsh
% hx --grammar fetch
Fetching 1 grammars
1 updated grammars
	lua now on 88e446476a1e97a8724dff7a23e2d709855077f2
% hx --grammar build
Building 1 grammars
1 grammars built now
	["lua"]
```

Then confirmed that the new grammar is being used. It is, yea! 

fixes: #9726