### PR TITLE
Add color modes to default theme #7060

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -49,6 +49,8 @@ label = "honey"
 "ui.linenr.selected" = { fg = "lilac" }
 "ui.statusline" = { fg = "lilac", bg = "revolver" }
 "ui.statusline.inactive" = { fg = "lavender", bg = "revolver" }
+"ui.statusline.normal" = { fg = "midnight", bg = "lilac" }
+"ui.statusline.insert" = { fg = "midnight", bg = "mint" }
 "ui.popup" = { bg = "revolver" }
 "ui.window" = { fg = "bossanova" }
 "ui.help" = { bg = "#7958DC", fg = "#171452" }


### PR DESCRIPTION
Default theme didn't had color modes which was annoying so I added them. I am open to color suggestions.
![Screenshot 2024-02-28 at 9 56 58 AM](https://github.com/helix-editor/helix/assets/2325157/9da1a634-aa61-49fc-9a43-8e74126d8e78)
![Screenshot 2024-02-28 at 9 57 07 AM](https://github.com/helix-editor/helix/assets/2325157/43bd9a87-f10b-44c1-a6be-bce71f7937ca)
