### PR TITLE
Show hover results for multiple LSPs

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1013,7 +1013,7 @@ pub fn hover(cx: &mut Context) {
 
             // attach lsp name if more than one is available
             if lsp_count > 1 {
-                contents = format!("# {}:\n\n{}", lsp_name, contents);
+                contents = format!("# [**LSP**] {}:\n\n{}", lsp_name, contents);
             }
 
             contents

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -338,6 +338,10 @@ impl Markdown {
 
         Text::from(lines)
     }
+
+    pub fn contents_mut(&mut self) -> &mut String {
+        &mut self.contents
+    }
 }
 
 impl Component for Markdown {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -338,10 +338,6 @@ impl Markdown {
 
         Text::from(lines)
     }
-
-    pub fn contents_mut(&mut self) -> &mut String {
-        &mut self.contents
-    }
 }
 
 impl Component for Markdown {


### PR DESCRIPTION
This PR attempts to address #8985.

Currently, only the first configured LSP is used for handling hover feature. This PR supports multiple configured LSPs and merged the results by appending in the popup markdown.

# Result:

## with single LSP configured

- effectively same behaviour as before this PR.
<img width="687" alt="single-lsp" src="https://github.com/helix-editor/helix/assets/10257858/6a4d540b-6f2d-45d4-a224-be3a33584587">

## with multiple LSP configured

- results are joined in LSP response order, with LSP name prefixed to identify which LSP the result came from.
<img width="708" alt="multiple-lsp" src="https://github.com/helix-editor/helix/assets/10257858/0b569d17-5ab4-4582-a40e-38e9b5518db8">

Testing:

1. modify `languages.toml` to add multiple LSPs
```toml
# rust
[[language]]
name = "rust"
# multiple lsp
language-servers = [ "rust-analyzer", "rust-analyzer-dup"]

# secondary rust-analyzer
[language-server.rust-analyzer-dup]
command = "rust-analyzer"
```
1. open a codebase, and trigger LSP hover commands

## Discussion

### Ordering of results

- Since the LSP hover requests are dispatched in async callback style, the ordering of results is not guaranteed. So the ordering in popup markdown will follow to the LSP response order. 
- The LSP name prefix would help identify which LSP the response is coming from.

