### PR TITLE
Mark GTK builder ui files as XML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2469,7 +2469,8 @@ file-types = [
   "xul",
   "xoml",
   "musicxml",
-  "glif"
+  "glif",
+  "ui"
 ]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
GTK builder files are XML and typically suffixed `.ui`: https://docs.gtk.org/gtk4/class.Builder.html