### PR TITLE
Support LSP diagnostic tags

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -333,5 +333,7 @@ These scopes are used for theming the editor interface:
 | `diagnostic.info`                 | Diagnostics info (editing area)                                                                |
 | `diagnostic.warning`              | Diagnostics warning (editing area)                                                             |
 | `diagnostic.error`                | Diagnostics error (editing area)                                                               |
+| `diagnostic.unnecessary`          | Diagnostics with unnecessary tag (editing area)                                                |
+| `diagnostic.deprecated`           | Diagnostics with deprecated tag (editing area)                                                 |
 
 [editor-section]: ./configuration.md#editor-section

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -631,6 +631,12 @@ impl Client {
                     }),
                     publish_diagnostics: Some(lsp::PublishDiagnosticsClientCapabilities {
                         version_support: Some(true),
+                        tag_support: Some(lsp::TagSupport {
+                            value_set: vec![
+                                lsp::DiagnosticTag::UNNECESSARY,
+                                lsp::DiagnosticTag::DEPRECATED,
+                            ],
+                        }),
                         ..Default::default()
                     }),
                     inlay_hint: Some(lsp::InlayHintClientCapabilities {

--- a/theme.toml
+++ b/theme.toml
@@ -80,6 +80,8 @@ label = "honey"
 "diagnostic.info" = { underline = { color = "delta", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "lightning", style = "curl" } }
 "diagnostic.error" = { underline = { color = "apricot", style = "curl" } }
+"diagnostic.unnecessary" = { underline = { color = "silver", style = "curl" }, modifiers = ["dim"] }
+"diagnostic.deprecated" = { underline = { color = "silver", style = "curl" }, modifiers = ["crossed_out"] }
 
 warning = "lightning"
 error = "apricot"


### PR DESCRIPTION
These are defined as [`DiagnosticTag`] in the spec. Tags are an optional part of a diagnostic that can give some extra metadata. Currently the spec only contains `Unnecessary` and `Deprecated` and it gives some hints on how to theme those keys. We can introduce some new theme keys for these tags and fall back to the diagnostic's severity highlight.

[`DiagnosticTag`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticTag