### PR TITLE
feat(languages): add support for `*.Dockerfile` `file-types` naming convention

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1493,7 +1493,20 @@ name = "dockerfile"
 scope = "source.dockerfile"
 injection-regex = "docker|dockerfile"
 roots = ["Dockerfile", "Containerfile"]
-file-types = [{ glob = "Dockerfile*" }, { glob = "dockerfile*" }, { glob = "Containerfile*" }, { glob = "containerfile*" }]
+file-types = [
+  "Dockerfile",
+  { glob = "Dockerfile" },
+  { glob = "Dockerfile.*" },
+  "dockerfile",
+  { glob = "dockerfile" },
+  { glob = "dockerfile.*" },
+  "Containerfile",
+  { glob = "Containerfile" },
+  { glob = "Containerfile.*" },
+  "containerfile",
+  { glob = "containerfile" },
+  { glob = "containerfile.*" },
+]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "docker-langserver" ]


### PR DESCRIPTION
Current `file-types` only supports up to a `Dockerfile.frontend` naming scheme.

With these changes `frontend.Dockerfile` now gives proper highlights and lsp actions.