### PR TITLE
Fix precedence of svelte typescript injection

### DIFF
--- a/runtime/queries/svelte/injections.scm
+++ b/runtime/queries/svelte/injections.scm
@@ -19,13 +19,6 @@
    (quoted_attribute_value (attribute_value) @css))
  (#eq? @_attr "style"))
 
-((script_element
-  (raw_text) @injection.content)
-  (#set! injection.language "javascript"))
-
-((raw_text_expr) @injection.content
- (#set! injection.language "javascript"))
-
 (
   (script_element
     (start_tag
@@ -35,6 +28,13 @@
   (#match? @_lang "(ts|typescript)")
   (#set! injection.language "typescript")
 )
+
+((script_element
+  (raw_text) @injection.content)
+  (#set! injection.language "javascript"))
+
+((raw_text_expr) @injection.content
+ (#set! injection.language "javascript"))
 
 ((comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Reported here: https://github.com/helix-editor/helix/discussions/9623#discussioncomment-8643853

JavaScript was taking precedence because it was higher in the file