### PR TITLE
Fix panic when using join_selections_space

### DIFF
--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -526,3 +526,86 @@ async fn test_join_selections() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_join_selections_space() -> anyhow::Result<()> {
+    // join with empty lines panic
+    test((
+        platform_line(indoc! {"\
+            #[a
+
+            b
+
+            c
+
+            d
+
+            e|]#
+        "}),
+        "<A-J>",
+        platform_line(indoc! {"\
+            a#[ |]#b#( |)#c#( |)#d#( |)#e
+        "}),
+    ))
+    .await?;
+
+    // normal join
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+            def
+        "}),
+        "<A-J>",
+        platform_line(indoc! {"\
+            abc#[ |]#def
+        "}),
+    ))
+    .await?;
+
+    // join with empty line
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+
+            def
+        "}),
+        "<A-J>",
+        platform_line(indoc! {"\
+            #[a|]#bc
+            def
+        "}),
+    ))
+    .await?;
+
+    // join with additional space in non-empty line
+    test((
+        platform_line(indoc! {"\
+            #[a|]#bc
+
+                def
+        "}),
+        "<A-J><A-J>",
+        platform_line(indoc! {"\
+            abc#[ |]#def
+        "}),
+    ))
+    .await?;
+
+    // join with retained trailing spaces
+    test((
+        platform_line(indoc! {"\
+            #[aaa   
+
+            bb  
+
+            c |]#
+        "}),
+        "<A-J>",
+        platform_line(indoc! {"\
+            aaa   #[ |]#bb  #( |)#c 
+        "}),
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Joining lines with Alt-J does not properly select the inserted spaces when the selection contains blank lines. In the worst case it panics with an out of bounds index.

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Char index out of bounds: char index 11, Rope/RopeSlice char length 10'

Steps to reproduce:
* Create a new document 
   ```
    a
 
    b

    c

    d

    e
    ```
* % (Select all)
* Alt-J (join and select the spaces)