### PR TITLE
Add one line scroll up and down commands.

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -56,6 +56,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                 |
 | `Ctrl-u`              | Move cursor and page half page up                  | `page_cursor_half_up`       |
 | `Ctrl-d`              | Move cursor and page half page down                | `page_cursor_half_down`     |
+| `Ctrl-y`              | Scroll one line up                                 | `scroll_line_up`            |
+| `Ctrl-e`              | Scroll one line down                               | `scroll_line_down`          |
 | `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`              |
 | `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`             |
 | `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`            |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -282,6 +282,8 @@ impl MappableCommand {
         page_cursor_down, "Move page and cursor down",
         page_cursor_half_up, "Move page and cursor half up",
         page_cursor_half_down, "Move page and cursor half down",
+        scroll_line_up, "Scroll one line up",
+        scroll_line_down, "Scroll one line down",
         select_all, "Select whole document",
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
@@ -1762,6 +1764,14 @@ fn page_cursor_half_down(cx: &mut Context) {
     let view = view!(cx.editor);
     let offset = view.inner_height() / 2;
     scroll(cx, offset, Direction::Forward, true);
+}
+
+fn scroll_line_up(cx: &mut Context) {
+    scroll(cx, cx.count(), Direction::Backward, false);
+}
+
+fn scroll_line_down(cx: &mut Context) {
+    scroll(cx, cx.count(), Direction::Forward, false);
 }
 
 #[allow(deprecated)]

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -180,6 +180,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "C-f" | "pagedown" => page_down,
         "C-u" => page_cursor_half_up,
         "C-d" => page_cursor_half_down,
+        "C-y" => scroll_line_up,
+        "C-e" => scroll_line_down,
 
         "C-w" => { "Window"
             "C-w" | "w" => rotate_view,


### PR DESCRIPTION
This feature is by default implemented in vim and mapped to C-y and C-e by default. This patch mimics the same in helix.