### PR TITLE
Fix selected text background in toykonight

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -76,15 +76,15 @@ hint = { fg = "hint" }
 "ui.menu" = { bg = "bg-menu", fg = "fg" }
 "ui.menu.selected" = { bg = "fg-selected" }
 "ui.popup" = { bg = "bg-menu", fg = "border-highlight" }
-"ui.selection" = { bg = "bg-highlight" }
-"ui.selection.primary" = { bg = "bg-highlight" }
+"ui.selection" = { bg = "bg-selection" }
+"ui.selection.primary" = { bg = "bg-selection" }
 "ui.statusline" = { bg = "bg-menu", fg = "fg-dark" }
 "ui.statusline.inactive" = { bg = "bg-menu", fg = "fg-gutter" }
 "ui.statusline.normal" = { bg = "blue", fg = "bg", modifiers = ["bold"] }
 "ui.statusline.insert" = { bg = "light-green", fg = "bg", modifiers = ["bold"] }
 "ui.statusline.select" = { bg = "magenta", fg = "bg", modifiers = ["bold"] }
 "ui.text" = { bg = "bg", fg = "fg" }
-"ui.text.focus" = { bg = "bg-visual" }
+"ui.text.focus" = { bg = "bg-focus" }
 "ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
 "ui.text.info" = { bg = "bg-menu", fg = "fg" }
 "ui.virtual.ruler" = { bg = "fg-gutter" }
@@ -126,6 +126,6 @@ border = "#15161e"
 border-highlight = "#27a1b9"
 bg = "#1a1b26"
 bg-inlay = "#1a2b32"
-bg-highlight = "#292e42"
+bg-selection = "#283457"
 bg-menu = "#16161e"
-bg-visual = "#283457"
+bg-focus = "#292e42"


### PR DESCRIPTION
Before the fix, the color that the original (Neovim) tokyonight uses for Neovim's visual mode was used in Helix for highlighting the selected item in the picker. But for the highlighting of selected _text_ in Helix (corresponding to Neovim's visual mode), a much darker background was used. This made it very hard to pick out selected text, in particular in suboptimal lighting conditions.

I swapped the two colors, so that text selection now looks like in Neovim, while selected items in the picker are highlighted a bit less strongly. (But still easy to see because the whole line is highlighted.)