### PR TITLE
fix: close #9771 fix comments with `(` and `)`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1095,7 +1095,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ocaml"
-source = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", rev = "23d419ba45789c5a47d31448061557716b02750a", subpath = "ocaml" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", rev = "9965d208337d88bbf1a38ad0b0fe49e5f5ec9677", subpath = "ocaml" }
 
 [[language]]
 name = "ocaml-interface"
@@ -1115,7 +1115,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ocaml-interface"
-source = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", rev = "23d419ba45789c5a47d31448061557716b02750a", subpath = "interface" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", rev = "9965d208337d88bbf1a38ad0b0fe49e5f5ec9677", subpath = "interface" }
 
 [[language]]
 name = "lua"

--- a/runtime/queries/comment/highlights.scm
+++ b/runtime/queries/comment/highlights.scm
@@ -1,8 +1,3 @@
-[
- "("
- ")"
-] @punctuation.bracket
-
 ":" @punctuation.delimiter
 
 ; Hint level tags

--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -1,14 +1,17 @@
 ; Modules
 ;--------
 
-[(module_name) (module_type_name)] @namespace
+[(module_name) (module_type_name)] @module
 
 ; Types
 ;------
 
-[(class_name) (class_type_name) (type_constructor)] @type
+(
+  (type_constructor) @type.builtin
+  (#match? @type.builtin "^(int|char|bytes|string|float|bool|unit|exn|array|list|option|int32|int64|nativeint|format6|lazy_t)$")
+)
 
-(type_variable) @type.parameter
+[(class_name) (class_type_name) (type_constructor)] @type
 
 [(constructor_name) (tag)] @constructor
 
@@ -29,84 +32,104 @@
 
 (method_name) @function.method
 
-; Variables
-;----------
-
-(value_pattern) @variable.parameter
-
 ; Application
 ;------------
 
+(
+  (value_name) @function.builtin
+  (#match? @function.builtin "^(raise(_notrace)?|failwith|invalid_arg)$")
+)
+
 (infix_expression
   left: (value_path (value_name) @function)
-  (infix_operator) @operator
+  operator: (concat_operator) @operator
   (#eq? @operator "@@"))
 
 (infix_expression
-  (infix_operator) @operator
+  operator: (rel_operator) @operator
   right: (value_path (value_name) @function)
   (#eq? @operator "|>"))
 
 (application_expression
   function: (value_path (value_name) @function))
 
+; Variables
+;----------
+
+[(value_name) (type_variable)] @variable
+
+(value_pattern) @variable.parameter
+
 ; Properties
 ;-----------
 
-[(label_name) (field_name) (instance_variable_name)] @variable.other.member
+[(label_name) (field_name) (instance_variable_name)] @property
 
 ; Constants
 ;----------
 
-[(boolean) (unit)] @constant
+(boolean) @constant
 
-[(number) (signed_number)] @constant.numeric.integer
+[(number) (signed_number)] @number
 
-(character) @constant.character
-
-(string) @string
+[(string) (character)] @string
 
 (quoted_string "{" @string "}" @string) @string
 
-(escape_sequence) @constant.character.escape
+(escape_sequence) @escape
+
+(conversion_specification) @string.special
+
+; Operators
+;----------
+
+(match_expression (match_operator) @keyword)
+
+(value_definition [(let_operator) (let_and_operator)] @keyword)
 
 [
-  (conversion_specification)
-  (pretty_printing_indication)
-] @punctuation.special
+  (prefix_operator)
+  (sign_operator)
+  (pow_operator)
+  (mult_operator)
+  (add_operator)
+  (concat_operator)
+  (rel_operator)
+  (and_operator)
+  (or_operator)
+  (assign_operator)
+  (hash_operator)
+  (indexing_operator)
+  (let_operator)
+  (let_and_operator)
+  (match_operator)
+] @operator
+
+["*" "#" "::" "<-"] @operator
 
 ; Keywords
 ;---------
 
 [
-  "and" "as" "assert" "begin" "class" "constraint"
-  "end" "external" "in"
-  "inherit" "initializer" "lazy" "let" "match" "method" "module"
-  "mutable" "new" "nonrec" "object" "of" "private" "rec" "sig" "struct"
-  "type" "val" "virtual" "when" "with"
+  "and" "as" "assert" "begin" "class" "constraint" "do" "done" "downto" "else"
+  "end" "exception" "external" "for" "fun" "function" "functor" "if" "in"
+  "include" "inherit" "initializer" "lazy" "let" "match" "method" "module"
+  "mutable" "new" "nonrec" "object" "of" "open" "private" "rec" "sig" "struct"
+  "then" "to" "try" "type" "val" "virtual" "when" "while" "with"
 ] @keyword
 
-["fun" "function" "functor"] @keyword.function
+; Punctuation
+;------------
 
-["if" "then" "else"] @keyword.control.conditional
+(attribute ["[@" "]"] @punctuation.special)
+(item_attribute ["[@@" "]"] @punctuation.special)
+(floating_attribute ["[@@@" "]"] @punctuation.special)
+(extension ["[%" "]"] @punctuation.special)
+(item_extension ["[%%" "]"] @punctuation.special)
+(quoted_extension ["{%" "}"] @punctuation.special)
+(quoted_item_extension ["{%%" "}"] @punctuation.special)
 
-["exception" "try"] @keyword.control.exception
-
-["include" "open"] @keyword.control.import
-
-["for" "to" "downto" "while" "do" "done"] @keyword.control.repeat
-
-; Macros
-;-------
-
-(attribute ["[@" "]"] @attribute)
-(item_attribute ["[@@" "]"] @attribute)
-(floating_attribute ["[@@@" "]"] @attribute)
-(extension ["[%" "]"] @function.macro)
-(item_extension ["[%%" "]"] @function.macro)
-(quoted_extension ["{%" "}"] @function.macro)
-(quoted_item_extension ["{%%" "}"] @function.macro)
-"%" @function.macro
+"%" @punctuation.special
 
 ["(" ")" "[" "]" "{" "}" "[|" "|]" "[<" "[>"] @punctuation.bracket
 
@@ -117,46 +140,12 @@
   "->" ";;" ":>" "+=" ":=" ".."
 ] @punctuation.delimiter
 
-; Operators
-;----------
-
-[
-  (prefix_operator)
-  (sign_operator)
-  (infix_operator)
-  (hash_operator)
-  (indexing_operator)
-  (let_operator)
-  (and_operator)
-  (match_operator)
-] @operator
-
-(match_expression (match_operator) @keyword)
-
-(value_definition [(let_operator) (and_operator)] @keyword)
-
-;; TODO: this is an error now
-;(prefix_operator "!" @operator)
-
-(infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
-
-(signed_number ["+" "-"] @operator)
-
-["*" "#" "::" "<-"] @operator
-
 ; Attributes
 ;-----------
 
-(attribute_id) @variable.other.member
+(attribute_id) @tag
 
 ; Comments
 ;---------
 
 [(comment) (line_number_directive) (directive) (shebang)] @comment
-
-(ERROR) @error
-
-; Blanket highlights
-; ------------------
-
-[(value_name) (type_variable)] @variable

--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -1,7 +1,7 @@
 ; Modules
 ;--------
 
-[(module_name) (module_type_name)] @module
+[(module_name) (module_type_name)] @namespace
 
 ; Types
 ;------

--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -63,20 +63,20 @@
 ; Properties
 ;-----------
 
-[(label_name) (field_name) (instance_variable_name)] @property
+[(label_name) (field_name) (instance_variable_name)] @variable.other.member
 
 ; Constants
 ;----------
 
-(boolean) @constant
+(boolean) @constant.builtin.boolean
 
-[(number) (signed_number)] @number
+[(number) (signed_number)] @constant.numeric
 
 [(string) (character)] @string
 
 (quoted_string "{" @string "}" @string) @string
 
-(escape_sequence) @escape
+(escape_sequence) @constant.character.escape
 
 (conversion_specification) @string.special
 


### PR DESCRIPTION
Jumped forward three years for the OCaml tree-sitter :)

Fixes #9771 for all languages.
