### PR TITLE
Add textobjects for Java native funcs and constructors

### DIFF
--- a/runtime/queries/java/textobjects.scm
+++ b/runtime/queries/java/textobjects.scm
@@ -1,4 +1,7 @@
 (method_declaration
+  body: (_)? @function.inside) @function.around
+
+(constructor_declaration
   body: (_) @function.inside) @function.around
 
 (interface_declaration


### PR DESCRIPTION
This allows native functions definitions and constructors to be accessible as part of goto_{next,prev}_func.

Change-Id: Ia1234004e8b38e1c5871331a38fcf4f267da935e