### PR TITLE
Fix panic in surround_replace/delete nested multi-cursor

### DIFF
--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -577,6 +577,23 @@ async fn test_surround_replace() -> anyhow::Result<()> {
     ))
     .await?;
 
+    test((
+        platform_line(indoc! {"\
+            {{
+
+            #(}|)#
+            #[}|]#
+            "}),
+        "mrm)",
+        platform_line(indoc! {"\
+            ((
+
+            #()|)#
+            #[)|]#
+            "}),
+    ))
+    .await?;
+
     Ok(())
 }
 
@@ -601,6 +618,18 @@ async fn test_surround_delete() -> anyhow::Result<()> {
         platform_line(indoc! {"\
             #[a|]#
             "}),
+    ))
+    .await?;
+
+    test((
+        platform_line(indoc! {"\
+            {{
+
+            #(}|)#
+            #[}|]#
+            "}),
+        "mdm",
+        platform_line("\n\n#(\n|)##[\n|]#"),
     ))
     .await?;
 


### PR DESCRIPTION
Test Document
-------------
```
{{

}
}

```

Steps To Reproduce
------------------
1. 2j  # move_visual_line_down
1. C   # copy_selection_on_next_line
1. mdm # surround_delete

Debug
-----
`assertion failed: last <= from', transaction.rs:597:13`

Release
-------
`called `Result::unwrap()` on an `Err` value: Char range out of bounds: char range 18446744073709551614..18446744073709551615, Rope/RopeSlice char length 7', ropey-1.6.1/src/rope.rs:546:37`

Description
-----------

Processing the surrounding pairs in order violates the assertion the ranges are ordered. To handle nested surrounds all positions have to be sorted. Also surround_replace has to track the proper replacement character for each position.