### PR TITLE
Fix panic due to partial jumplist sync in jump_view_*

### DIFF
--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -190,3 +190,10 @@ async fn test_changes_in_splits_apply_to_all_views() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_changes_in_splits_jumplist_sync() -> anyhow::Result<()> {
+    test(("#[test|]#", "<C-w>sgf<C-w>wd<C-w>w<C-o><C-w>q", "#[|]#")).await?;
+
+    Ok(())
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1737,8 +1737,9 @@ impl Editor {
             self.ensure_cursor_in_view(view_id);
 
             // Update jumplist selections with new document changes.
-            for (view, _focused) in self.tree.views_mut() {
-                let doc = doc_mut!(self, &view.doc);
+            let view = view_mut!(self, view_id);
+            for doc_id in view.jumps.iter().map(|e| e.0).collect::<Vec<_>>().iter() {
+                let doc = doc_mut!(self, doc_id);
                 view.sync_changes(doc);
             }
         }


### PR DESCRIPTION
Test Document
-------------
```
test
```

Steps to Reproduce
------------------
1. %        # select_all
1. Ctrl-w s # hsplit
1. gf       # goto_file
1. Ctrl-w w # rotate_view
1. d        # delete_selection
1. Ctrl-w w # rotate_view
1. Ctrl-o   # jump_backward

Debug
-----
`thread 'main' panicked at 'assertion failed:
char_idx <= slice.len_chars()', helix-core/src/graphemes.rs:168:5`

Release
-------
`thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Char index out of bounds: char index 4, Rope/RopeSlice char length 0', ropey-1.6.1/src/slice.rs:360:41`

Description
-----------
The jumplist selections are not completely synced when moving between views. Currently, only the active document in every view is checked. The fix syncs all documents in the destination view's jumplist only.