### PR TITLE
helix-term: allow to backspace out-of the command prompt

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -544,6 +544,10 @@ impl Component for Prompt {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }
             ctrl!('h') | key!(Backspace) | shift!(Backspace) => {
+                if self.line.is_empty() {
+                    (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
+                    return close_fn;
+                }
                 self.delete_char_backwards(cx.editor);
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }


### PR DESCRIPTION
This makes helix behave like vim and kakoune.