### PR TITLE
Fix panic in select_textobject_around

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -167,6 +167,10 @@ fn find_nth_open_pair(
     mut pos: usize,
     n: usize,
 ) -> Option<usize> {
+    if pos >= text.len_chars() {
+        return None;
+    }
+
     let mut chars = text.chars_at(pos + 1);
 
     // Adjusts pos for the first iteration, and handles the case of the
@@ -380,6 +384,21 @@ mod test {
         assert_eq!(
             find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 1),
             Err(Error::CursorOnAmbiguousPair)
+        )
+    }
+
+    #[test]
+    fn test_find_nth_closest_pairs_pos_index_range_panic() {
+        #[rustfmt::skip]
+        let (doc, selection, _) =
+            rope_with_selections_and_expectations(
+                "(a)c)",
+                "^^^^^"
+            );
+
+        assert_eq!(
+            find_nth_closest_pairs_pos(doc.slice(..), selection.primary(), 1),
+            Err(Error::PairNotFound)
         )
     }
 


### PR DESCRIPTION
Test Document
-------------
```
a)b
```

Steps to Reproduce
------------------
1. %   # select_all
1. ms( # surround_add
1. mam # select_textobject_around

Debug and Release
-----------------
`thread 'main' panicked at 'Attempt to index past end of RopeSlice: char index 7, RopeSlice char length 6', ropey-1.6.1/src/slice.rs:796:13`

Description
-----------
An index was selected beyond the end of the slice with chars_at. The fix adds a guard check to `find_nth_open_pair`, like in the other find_nth* functions.