### PR TITLE
add linker script language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -94,6 +94,7 @@
 | kdl | ✓ | ✓ | ✓ |  |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
 | latex | ✓ | ✓ |  | `texlab` |
+| ld | ✓ |  | ✓ |  |
 | lean | ✓ |  |  | `lean` |
 | ledger | ✓ |  |  |  |
 | llvm | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3273,3 +3273,15 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "powershell"
 source = { git = "https://github.com/airbus-cert/tree-sitter-powershell", rev = "c9316be0faca5d5b9fd3b57350de650755f42dc0" }
+
+[[language]]
+name = "ld"
+scope = "source.ld"
+injection-regex = "ld"
+file-types = ["ld"]
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "ld"
+source = { git = "https://github.com/mtoohey31/tree-sitter-ld", rev = "81978cde3844bfc199851e39c80a20ec6444d35e" }

--- a/runtime/queries/ld/highlights.scm
+++ b/runtime/queries/ld/highlights.scm
@@ -1,0 +1,173 @@
+; Identifiers
+
+(section
+  .
+  (NAME) @namespace)
+
+(NAME) @variable
+
+; Operators
+
+[
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "<<="
+  ">>="
+  "&="
+  "|="
+  "^="
+  "*"
+  "/"
+  "%"
+  "+"
+  "-"
+  "<<"
+  ">>"
+  "=="
+  "!="
+  "<="
+  ">="
+  "<"
+  ">"
+  "&"
+  "^"
+  "|"
+  "&&"
+  "||"
+  "?"
+] @operator
+
+; Keywords
+
+[
+  "ABSOLUTE"
+  "ADDR"
+  "ALIGNOF"
+  "ASSERT"
+  "BYTE"
+  "CONSTANT"
+  "DATA_SEGMENT_ALIGN"
+  "DATA_SEGMENT_END"
+  "DATA_SEGMENT_RELRO_END"
+  "DEFINED"
+  "LOADADDR"
+  "LOG2CEIL"
+  "LONG"
+  "MAX"
+  "MIN"
+  "NEXT"
+  "QUAD"
+  "SHORT"
+  "SIZEOF"
+  "SQUAD"
+  "FILL"
+  "SEGMENT_START"
+] @function.builtin
+
+[
+  "CONSTRUCTORS"
+  "CREATE_OBJECT_SYMBOLS"
+  "LINKER_VERSION"
+  "SIZEOF_HEADERS"
+] @constant.builtin
+
+[
+  "AFTER"
+  "ALIGN"
+  "ALIGN_WITH_INPUT"
+  "ASCIZ"
+  "AS_NEEDED"
+  "AT"
+  "BEFORE"
+  "BIND"
+  "BLOCK"
+  "COPY"
+  "DSECT"
+  "ENTRY"
+  "EXCLUDE_FILE"
+  "EXTERN"
+  "extern"
+  "FLOAT"
+  "FORCE_COMMON_ALLOCATION"
+  "FORCE_GROUP_ALLOCATION"
+  "global"
+  "GROUP"
+  "HIDDEN"
+  "HLL"
+  "INCLUDE"
+  "INFO"
+  "INHIBIT_COMMON_ALLOCATION"
+  "INPUT"
+  "INPUT_SECTION_FLAGS"
+  "KEEP"
+  "l"
+  "LD_FEATURE"
+  "len"
+  "LENGTH"
+  "local"
+  "MAP"
+  "MEMORY"
+  "NOCROSSREFS"
+  "NOCROSSREFS_TO"
+  "NOFLOAT"
+  "NOLOAD"
+  "o"
+  "ONLY_IF_RO"
+  "ONLY_IF_RW"
+  "org"
+  "ORIGIN"
+  "OUTPUT"
+  "OUTPUT_ARCH"
+  "OUTPUT_FORMAT"
+  "OVERLAY"
+  "PHDRS"
+  "PROVIDE"
+  "PROVIDE_HIDDEN"
+  "READONLY"
+  "REGION_ALIAS"
+  "REVERSE"
+  "SEARCH_DIR"
+  "SECTIONS"
+  "SORT"
+  "SORT_BY_ALIGNMENT"
+  "SORT_BY_INIT_PRIORITY"
+  "SORT_BY_NAME"
+  "SORT_NONE"
+  "SPECIAL"
+  "STARTUP"
+  "SUBALIGN"
+  "SYSLIB"
+  "TARGET"
+  "TYPE"
+  "VERSION"
+] @keyword
+
+; Delimiters
+
+[
+  ","
+  ";"
+  "&"
+  ":"
+  ">"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Literals
+
+(INT) @constant.numeric.integer
+
+; Comment
+
+(comment) @comment

--- a/runtime/queries/ld/indents.scm
+++ b/runtime/queries/ld/indents.scm
@@ -1,0 +1,12 @@
+[
+  (sections)
+  (memory)
+  (section)
+  (phdrs)
+  (overlay_section)
+  (version)
+  (vers_node)
+  (vers_defns)
+] @indent
+
+"}" @outdent @extend.prevent-once

--- a/runtime/queries/ld/injections.scm
+++ b/runtime/queries/ld/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This pull request adds support for linker scripts. The grammar is based on the `ld/ldgram.y` file in the binutils-gdb repository located at `git://sourceware.org/git/binutils-gdb.git`. The grammar succesfully parses all `.ld` files in that repository's `ld/testsuite` directory, except two.

Here's a screenshot with the gruvbox theme:

![2024-03-07T23:30:08,085046628-05:00](https://github.com/helix-editor/helix/assets/36740602/4e839ae9-4b99-4130-b13d-d39cc433b35b)