### PR TITLE
Update `just` grammar and queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2935,7 +2935,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/IndianBoy42/tree-sitter-just", rev = "8af0aab79854aaf25b620a52c39485849922f766" }
+source = { git = "https://github.com/IndianBoy42/tree-sitter-just", rev = "80d612d198b8d6207416225c9fcea0fe86ffb96e" }
 
 [[language]]
 name = "gn"

--- a/runtime/queries/just/folds.scm
+++ b/runtime/queries/just/folds.scm
@@ -1,4 +1,10 @@
-(body) @fold
-(recipe) @fold
-(interpolation) @fold
-(item (_) @fold)
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/folds.scm>
+
+; Define collapse points
+
+([
+  (recipe)
+  (string)
+  (external_command)
+] @fold
+  (#trim! @fold))

--- a/runtime/queries/just/highlights.scm
+++ b/runtime/queries/just/highlights.scm
@@ -1,33 +1,149 @@
-(assignment (NAME) @variable)
-(alias (NAME) @variable)
-(value (NAME) @variable)
-(parameter (NAME) @variable)
-(setting (NAME) @keyword)
-(setting "shell" @keyword)
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/highlights.scm>
 
-(call (NAME) @function)
-(dependency (NAME) @function)
-(depcall (NAME) @function)
-(recipeheader (NAME) @function)
+; This file specifies how matched syntax patterns should be highlighted
 
-(depcall (expression) @variable.parameter)
-(parameter) @variable.parameter
-(variadic_parameters) @variable.parameter
+[
+  "export"
+  "import"
+] @keyword.control.import
 
-["if" "else"] @keyword.control.conditional
+"mod" @keyword.directive
 
-(string) @string
+[
+  "alias"
+  "set"
+  "shell"
+] @keyword
 
-(boolean ["true" "false"]) @constant.builtin.boolean
+[
+  "if"
+  "else"
+] @keyword.control.conditional
 
-(comment) @comment
+; Variables
 
-; (interpolation) @string
+(value
+  (identifier) @variable)
 
-(shebang interpreter:(TEXT) @keyword ) @comment
+(alias
+  left: (identifier) @variable)
 
-["export" "alias" "set"] @keyword
+(assignment
+  left: (identifier) @variable)
 
-["@" "==" "!=" "+" ":="] @operator
+; Functions
 
-[ "(" ")" "[" "]" "{{" "}}" "{" "}"] @punctuation.bracket
+(recipe_header
+  name: (identifier) @function)
+
+(dependency
+  name: (identifier) @function)
+
+(dependency_expression
+  name: (identifier) @function)
+
+(function_call
+  name: (identifier) @function)
+
+; Parameters
+
+(parameter
+  name: (identifier) @variable.parameter)
+
+; Namespaces
+
+(module
+  name: (identifier) @namespace)
+
+; Operators
+
+[
+  ":="
+  "?"
+  "=="
+  "!="
+  "=~"
+  "@"
+  "="
+  "$"
+  "*"
+  "+"
+  "&&"
+  "@-"
+  "-@"
+  "-"
+  "/"
+  ":"
+] @operator
+
+; Punctuation
+
+"," @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  "("
+  ")"
+  "{{"
+  "}}"
+] @punctuation.bracket
+
+[ "`" "```" ] @punctuation.special
+
+; Literals
+
+(boolean) @constant.builtin.boolean
+
+[
+  (string)
+  (external_command)
+] @string
+
+(escape_sequence) @constant.character.escape
+
+; Comments
+
+(comment) @comment.line
+
+(shebang) @keyword.directive
+
+; highlight known settings (filtering does not always work)
+(setting
+  left: (identifier) @keyword
+  (#any-of? @keyword
+    "allow-duplicate-recipes"
+    "dotenv-filename"
+    "dotenv-load"
+    "dotenv-path"
+    "export"
+    "fallback"
+    "ignore-comments"
+    "positional-arguments"
+    "shell"
+    "tempdi"
+    "windows-powershell"
+    "windows-shell"))
+
+; highlight known attributes (filtering does not always work)
+(attribute
+  (identifier) @attribute
+  (#any-of? @attribute
+    "private"
+    "allow-duplicate-recipes"
+    "dotenv-filename"
+    "dotenv-load"
+    "dotenv-path"
+    "export"
+    "fallback"
+    "ignore-comments"
+    "positional-arguments"
+    "shell"
+    "tempdi"
+    "windows-powershell"
+    "windows-shell"))
+
+; Numbers are part of the syntax tree, even if disallowed
+(numeric_error) @error

--- a/runtime/queries/just/indents.scm
+++ b/runtime/queries/just/indents.scm
@@ -1,3 +1,11 @@
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/indents.scm>
+;
+; This query specifies how to auto-indent logical blocks.
+;
+; Better documentation with diagrams is in https://docs.helix-editor.com/guides/indent.html
+
 [
-	(recipe_body)
-] @indent
+  (recipe)
+  (string)
+  (external_command)
+] @indent @extend

--- a/runtime/queries/just/injections.scm
+++ b/runtime/queries/just/injections.scm
@@ -1,16 +1,84 @@
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/injections.scm>
+;
+; Specify nested languages that live within a `justfile`
+
+; ================ Always applicable ================
+
 ((comment) @injection.content
- (#set! injection.language "comment"))
+  (#set! injection.language "comment"))
 
-(shebang_recipe 
-    (shebang 
-        interpreter:(TEXT) @injection.language)
-    (shebang_body) @injection.content
-) 
+; Highlight the RHS of `=~` as regex
+((regex_literal
+  (_) @injection.content)
+  (#set! injection.language "regex"))
 
-(source_file 
-    (item (setting lang:(NAME) @injection.language))
-    (item (recipe (body (recipe_body) @injection.content)))
-) 
+; ================ Global defaults ================
 
-; ((interpolation (expression) @injection.content)
-;  (#set! injection.language "just"))
+; Default everything to be bash
+(recipe_body
+  !shebang
+  (#set! injection.language "bash")
+  (#set! injection.include-children)) @injection.content
+
+(external_command
+  (command_body) @injection.content
+  (#set! injection.language "bash"))
+
+; ================ Global language specified ================
+; Global language is set with something like one of the following:
+;
+;    set shell := ["bash", "-c", ...]
+;    set shell := ["pwsh.exe"]
+;
+; We can extract the first item of the array, but we can't extract the language
+; name from the string with something like regex. So instead we special case
+; two things: powershell, which is likely to come with a `.exe` attachment that
+; we need to strip, and everything else which hopefully has no extension. We
+; separate this with a `#match?`.
+;
+; Unfortunately, there also isn't a way to allow arbitrary nesting or
+; alternatively set "global" capture variables. So we can set this for item-
+; level external commands, but not for e.g. external commands within an
+; expression without getting _really_ annoying. Should at least look fine since
+; they default to bash. Limitations...
+; See https://github.com/tree-sitter/tree-sitter/issues/880 for more on that.
+
+(source_file
+  (setting "shell" ":=" "[" (string) @_langstr
+    (#match? @_langstr ".*(powershell|pwsh|cmd).*")
+    (#set! injection.language "powershell"))
+  [
+    (recipe
+      (recipe_body
+        !shebang
+        (#set! injection.include-children)) @injection.content)
+
+    (assignment
+      (expression
+        (value
+          (external_command
+            (command_body) @injection.content))))
+  ])
+
+(source_file
+  (setting "shell" ":=" "[" (string) @injection.language
+    (#not-match? @injection.language ".*(powershell|pwsh|cmd).*"))
+  [
+    (recipe
+      (recipe_body
+        !shebang
+        (#set! injection.include-children)) @injection.content)
+
+    (assignment
+      (expression
+        (value
+          (external_command
+            (command_body) @injection.content))))
+  ])
+
+; ================ Recipe language specified - Helix only ================
+
+; Set highlighting for recipes that specify a language using builtin shebang matching
+(recipe_body
+  (shebang) @injection.shebang
+  (#set! injection.include-children)) @injection.content

--- a/runtime/queries/just/locals.scm
+++ b/runtime/queries/just/locals.scm
@@ -1,10 +1,42 @@
-(assignment (NAME) @local.definition)
-(alias left:(NAME) @local.definition)
-(alias right:(NAME) @local.reference)
-(value (NAME) @local.reference)
-(parameter (NAME) @local.definition)
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/locals.scm>
+;
+; This file tells us about the scope of variables so e.g. local
+; variables override global functions with the same name
 
-(call (NAME) @local.reference)
-(dependency (NAME) @local.reference)
-(depcall (NAME) @local.reference)
-(recipeheader (NAME) @local.definition)
+; Scope
+
+(recipe) @local.scope
+
+; Definitions
+
+(alias
+  left: (identifier) @local.definition)
+
+(assignment
+  left: (identifier) @local.definition)
+
+(module
+  name: (identifier) @local.definition)
+
+(parameter
+  name: (identifier) @local.definition)
+
+(recipe_header
+  name: (identifier) @local.definition)
+
+; References
+
+(alias
+  right: (identifier) @local.reference)
+
+(function_call
+  name: (identifier) @local.reference)
+
+(dependency
+  name: (identifier) @local.reference)
+
+(dependency_expression
+  name: (identifier) @local.reference)
+
+(value
+  (identifier) @local.reference)

--- a/runtime/queries/just/textobjects.scm
+++ b/runtime/queries/just/textobjects.scm
@@ -1,48 +1,18 @@
-(body) @function.inside
-(recipe) @function.around
-(expression 
-    if:(expression) @function.inside 
-) 
-(expression 
-    else:(expression) @function.inside
-) 
-(interpolation (expression) @function.inside) @function.around
-(settinglist (stringlist) @function.inside) @function.around
+; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/textobjects.scm>
+;
+; Specify how to navigate around logical blocks in code
 
-(call (NAME) @class.inside) @class.around
-(dependency (NAME) @class.inside) @class.around
-(depcall (NAME) @class.inside)
+(recipe
+  (recipe_body) @function.inside) @function.around
 
-(dependency) @parameter.around
-(depcall) @parameter.inside
-(depcall (expression) @parameter.inside) 
+(parameters
+  ((_) @parameter.inside . ","? @parameter.around)) @parameter.around
 
-(stringlist 
-    (string) @parameter.inside
-    . ","? @_end
-    ; Commented out since we don't support `#make-range!` at the moment
-    ; (#make-range! "parameter.around" @parameter.inside @_end)
-)
-(parameters 
-    [(parameter) 
-    (variadic_parameters)] @parameter.inside
-    . " "? @_end
-    ; Commented out since we don't support `#make-range!` at the moment
-    ; (#make-range! "parameter.around" @parameter.inside @_end)
-)
+(dependency_expression
+  (_) @parameter.inside) @parameter.around
 
-(expression 
-    (condition) @function.inside
-) @function.around
-(expression 
-    if:(expression) @function.inside 
-)
-(expression 
-    else:(expression) @function.inside
-)
-
-(item [(alias) (assignment) (export) (setting)]) @class.around
-(recipeheader) @class.around
-(line) @class.around
+(function_call
+  arguments: (sequence
+    (expression) @parameter.inside) @parameter.around) @function.around
 
 (comment) @comment.around


### PR DESCRIPTION
Bump the git revision and use the queries from <https://github.com/IndianBoy42/tree-sitter-just/tree/80d612d198b8d6207416225c9fcea0fe86ffb96e/queries-flavored/helix> to update Helix's sources.

Tree-sitter-just has queries for Helix in-tree, I will make any changes from this review upstream.

Originally added at https://github.com/helix-editor/helix/pull/6453 (cc @VuiMuich)

Fixes: #8226