### PR TITLE
fix(themes-catppuccin): make inlay hints more legible

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -88,7 +88,7 @@
 "ui.virtual" = "overlay0"
 "ui.virtual.ruler" = { bg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
-"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
+"ui.virtual.inlay-hint" = { fg = "overlay0", bg = "base" }
 
 "ui.selection" = { bg = "surface1" }
 


### PR DESCRIPTION
See https://github.com/catppuccin/helix/commit/4bf31e995ead4e5f6e8cd4a08ea0497f1d35695b