### PR TITLE
build(nix): Fix Nix grammars build due to breaking changes in fetchTree

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -21,13 +21,6 @@
     builtins.hasAttr "source" grammar
     && builtins.hasAttr "git" grammar.source
     && builtins.hasAttr "rev" grammar.source;
-  isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
-  toGitHubFetcher = url: let
-    match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" url;
-  in {
-    owner = builtins.elemAt match 0;
-    repo = builtins.elemAt match 1;
-  };
   # If `use-grammars.only` is set, use only those grammars.
   # If `use-grammars.except` is set, use all other grammars.
   # Otherwise use all grammars.
@@ -40,24 +33,13 @@
   grammarsToUse = builtins.filter useGrammar languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
   buildGrammar = grammar: let
-    gh = toGitHubFetcher grammar.source.git;
-    sourceGit = builtins.fetchTree {
+    source = builtins.fetchTree {
       type = "git";
       url = grammar.source.git;
       rev = grammar.source.rev;
       ref = grammar.source.ref or "HEAD";
       shallow = true;
     };
-    sourceGitHub = builtins.fetchTree {
-      type = "github";
-      owner = gh.owner;
-      repo = gh.repo;
-      inherit (grammar.source) rev;
-    };
-    source =
-      if isGitHubGrammar grammar
-      then sourceGitHub
-      else sourceGit;
   in
     stdenv.mkDerivation {
       # see https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix


### PR DESCRIPTION
Due to https://github.com/NixOS/nix/commit/09d76e512a468ad65bedaeda56871de7043849b0
Fixes issue #9866

This is the easiest fix for now. We maybe should consider prefetching the GitHub repos and calculate the NAR hashes but this would be an extra step that cannot be integrated into the pure build evaluation.