### PR TITLE
Do not stop reloading docs on error

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1318,7 +1318,11 @@ fn reload_all(
         // Ensure that the view is synced with the document's history.
         view.sync_changes(doc);
 
-        doc.reload(view, &cx.editor.diff_providers)?;
+        if let Err(error) = doc.reload(view, &cx.editor.diff_providers) {
+            cx.editor.set_error(format!("{}", error));
+            continue;
+        }
+
         if let Some(path) = doc.path() {
             cx.editor
                 .language_servers

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -993,11 +993,13 @@ impl Document {
         provider_registry: &DiffProviderRegistry,
     ) -> Result<(), Error> {
         let encoding = self.encoding;
-        let path = self
-            .path()
-            .filter(|path| path.exists())
-            .ok_or_else(|| anyhow!("can't find file to reload from {:?}", self.display_name()))?
-            .to_owned();
+        let path = match self.path() {
+            None => return Ok(()),
+            Some(path) => match path.exists() {
+                true => path.to_owned(),
+                false => bail!("can't find file to reload from {:?}", self.display_name()),
+            },
+        };
 
         // Once we have a valid path we check if its readonly status has changed
         self.detect_readonly();


### PR DESCRIPTION
In the `reload-all` command, we should not stop reloading the documents if one error is found. Instead, we should report the error and continue trying to reload the current open documents. This is useful in cases where a backing file does not exist temporarily (e.g. when editing a git patch in the outstanding chain that doesn't have a file just yet).

This change also remove the error messages in the cases where the backing is `None`, like in new docs or `tutor`.