### PR TITLE
Add `code_action_picker` command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -316,6 +316,7 @@ impl MappableCommand {
         file_picker_in_current_buffer_directory, "Open file picker at current buffers's directory",
         file_picker_in_current_directory, "Open file picker at current working directory",
         code_action, "Perform code action",
+        code_action_picker, "Perform code action in a picker",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
         symbol_picker, "Open symbol picker",


### PR DESCRIPTION
Fixes #3502, adding a separate command `code_action_picker` which opens `code_action` but in a picker, allowing for searching.

## An Asciinema recording

Apologies for my slow computer loading lsp in this recording, but here is a demonstration of the functionality provided by this MR:

[Asciinema recording](https://asciinema.org/a/dZMKL7eS4dGgBNPwtJtaMpldV); lsp loads at 0:25