### PR TITLE
Fix comment key bind behaviour in OCaml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1083,7 +1083,6 @@ injection-regex = "ocaml"
 file-types = ["ml"]
 shebangs = ["ocaml", "ocamlrun", "ocamlscript"]
 block-comment-tokens = { start = "(*", end = "*)" }
-comment-token = "(**)"
 language-servers = [ "ocamllsp" ]
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
Fixes #9893.

There are only block comments in OCaml. Removed the `comment-token`.

https://github.com/helix-editor/helix/assets/64728420/a8ccdcbf-abf9-4b43-a270-6c6ca4e9d2dd