### PR TITLE
Respect undercurl config even with no terminfo

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -52,10 +52,14 @@ impl Default for Capabilities {
 impl Capabilities {
     /// Detect capabilities from the terminfo database located based
     /// on the $TERM environment variable. If detection fails, returns
-    /// a default value where no capability is supported.
+    /// a default value where no capability is supported, or just undercurl
+    /// if config.undercurl is set.
     pub fn from_env_or_default(config: &EditorConfig) -> Self {
         match termini::TermInfo::from_env() {
-            Err(_) => Capabilities::default(),
+            Err(_) => Capabilities {
+                has_extended_underlines: config.undercurl,
+                ..Capabilities::default()
+            },
             Ok(t) => Capabilities {
                 // Smulx, VTE: https://unix.stackexchange.com/a/696253/246284
                 // Su (used by kitty): https://sw.kovidgoyal.net/kitty/underlines


### PR DESCRIPTION
I have just found out that my recent Windows Terminal version supported rendering undercurl (see
https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-20-release ). However, looking at the source, terminfo is required for helix to emit the undercurl control code, which isn't available on Windows AFAIK.

This commit make helix respects the `editor.undercurl` option when there is no terminfo.

Tested on Windows Terminal Preview 1.20. Works without WSL.

![image](https://github.com/helix-editor/helix/assets/40488299/a0250312-8434-4160-870c-cf51953d4a79)

Fixes #7065?

