### PR TITLE
Add support for hyprland config

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -77,6 +77,7 @@
 | hosts | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server` |
 | hurl | ✓ |  | ✓ |  |
+| hyprlang | ✓ |  | ✓ |  |
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | ini | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3284,3 +3284,15 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "ld"
 source = { git = "https://github.com/mtoohey31/tree-sitter-ld", rev = "81978cde3844bfc199851e39c80a20ec6444d35e" }
+
+[[language]]
+name = "hyprlang"
+scope = "source.hyprlang"
+roots = ["hyprland.conf"]
+file-types = [ { glob = "hyprland.conf"} ]
+comment-token = "#"
+grammar = "hyprlang"
+
+[[grammar]]
+name = "hyprlang"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-hyprlang", rev = "27af9b74acf89fa6bed4fb8cb8631994fcb2e6f3"}

--- a/runtime/queries/hyprlang/highlights.scm
+++ b/runtime/queries/hyprlang/highlights.scm
@@ -1,0 +1,56 @@
+(comment) @comment @spell
+
+[
+  "source"
+  "exec"
+  "exec-once"
+] @keyword
+
+(keyword
+  (name) @keyword)
+
+(assignment
+  (name) @property)
+
+(section
+  (name) @module)
+
+(section
+  device: (device_name) @type)
+
+(variable) @variable
+
+"$" @punctuation.special
+
+(boolean) @boolean
+
+(mod) @constant
+
+[
+  "rgb"
+  "rgba"
+] @function.builtin
+
+[
+  (number)
+  (legacy_hex)
+  (angle)
+  (hex)
+] @number
+
+"deg" @type
+
+"," @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "="
+  "-"
+  "+"
+] @operator

--- a/runtime/queries/hyprlang/highlights.scm
+++ b/runtime/queries/hyprlang/highlights.scm
@@ -1,19 +1,19 @@
-(comment) @comment @spell
+(comment) @comment
 
 [
   "source"
   "exec"
   "exec-once"
-] @keyword
+] @function.builtin
 
 (keyword
   (name) @keyword)
 
 (assignment
-  (name) @property)
+  (name) @variable.other.member)
 
 (section
-  (name) @module)
+  (name) @namespace)
 
 (section
   device: (device_name) @type)
@@ -22,7 +22,9 @@
 
 "$" @punctuation.special
 
-(boolean) @boolean
+(boolean) @constant.builtin.boolean
+
+(string) @string
 
 (mod) @constant
 
@@ -36,7 +38,7 @@
   (legacy_hex)
   (angle)
   (hex)
-] @number
+] @constant.numeric
 
 "deg" @type
 

--- a/runtime/queries/hyprlang/indents.scm
+++ b/runtime/queries/hyprlang/indents.scm
@@ -1,0 +1,6 @@
+(section) @indent.begin
+
+(section
+  "}" @indent.end)
+
+"}" @indent.branch

--- a/runtime/queries/hyprlang/indents.scm
+++ b/runtime/queries/hyprlang/indents.scm
@@ -1,6 +1,6 @@
-(section) @indent.begin
+(section) @indent
 
 (section
-  "}" @indent.end)
+  "}" @outdent)
 
-"}" @indent.branch
+"}" @extend

--- a/runtime/queries/hyprlang/injections.scm
+++ b/runtime/queries/hyprlang/injections.scm
@@ -1,0 +1,3 @@
+(exec
+  (string) @injection.content
+  (#set! injection.language "bash"))


### PR DESCRIPTION
This adds support for the hyprland configuration language

![image](https://github.com/helix-editor/helix/assets/110528300/0107cba1-2957-4019-82e6-5dd2959f563b)
![image](https://github.com/helix-editor/helix/assets/110528300/afc29621-6984-42e9-84bc-b954c8814135)
![image](https://github.com/helix-editor/helix/assets/110528300/1c85e622-9388-43cd-b32e-1920b9b05535)
![image](https://github.com/helix-editor/helix/assets/110528300/87065d0d-50ed-4f16-a21d-762868ab90f3)

---

Old picture with unadjusted highlights

![image](https://github.com/helix-editor/helix/assets/110528300/ab2f3460-c958-47de-a841-6cf4c03b6ca8)
