### PR TITLE
Add whole word selection commands

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -163,6 +163,16 @@ impl Range {
         self.from() <= pos && pos < self.to()
     }
 
+    /// Returns equal if anchor and head are the same, and disregards old_visual_position
+    pub fn eq(&self, other: Range) -> bool {
+        self.anchor == other.anchor && self.head == other.head
+            // When a single character is selected, the orientation is indistinguishable
+            // and should be disregarded
+            // TODO: this does not work for graphemes like \r\n
+            || (self.anchor == other.anchor + 1 && self.head + 1 == other.head)
+            || (self.anchor == other.anchor - 1 && self.head - 1 == other.head)
+    }
+
     /// Map a range through a set of changes. Returns a new range representing
     /// the same position after the changes are applied. Note that this
     /// function runs in O(N) (N is number of changes) and can therefore

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5218,7 +5218,7 @@ fn select_next_word(cx: &mut Context) {
     let current_selection = get_current_selection(cx);
     select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
     let new_selection = get_current_selection(cx);
-    if current_selection == new_selection {
+    if selection_eq(current_selection, new_selection) {
         move_next_word_end(cx);
         select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
     }
@@ -5228,7 +5228,7 @@ fn select_next_long_word(cx: &mut Context) {
     let current_selection = get_current_selection(cx);
     select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
     let new_selection = get_current_selection(cx);
-    if current_selection == new_selection {
+    if selection_eq(current_selection, new_selection) {
         move_next_long_word_end(cx);
         select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
     }
@@ -5239,7 +5239,7 @@ fn select_prev_word(cx: &mut Context) {
     select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
     flip_selections(cx);
     let new_selection = get_current_selection(cx);
-    if current_selection == new_selection {
+    if selection_eq(current_selection, new_selection) {
         move_prev_word_start(cx);
         select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
         flip_selections(cx);
@@ -5251,7 +5251,7 @@ fn select_prev_long_word(cx: &mut Context) {
     select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
     flip_selections(cx);
     let new_selection = get_current_selection(cx);
-    if current_selection == new_selection {
+    if selection_eq(current_selection, new_selection) {
         move_prev_long_word_start(cx);
         select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
         flip_selections(cx);
@@ -5261,6 +5261,13 @@ fn select_prev_long_word(cx: &mut Context) {
 fn get_current_selection(cx: &mut Context) -> Selection {
     let (view, doc) = current!(cx.editor);
     doc.selection(view.id).clone()
+}
+
+fn selection_eq(s1: Selection, s2: Selection) -> bool {
+    s1.ranges()
+        .iter()
+        .zip(s2.ranges().iter())
+        .all(|(&r1, &r2)| r1.eq(r2))
 }
 
 fn surround_add(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -460,6 +460,10 @@ impl MappableCommand {
         surround_delete, "Surround delete",
         select_textobject_around, "Select around object",
         select_textobject_inner, "Select inside object",
+        select_next_word, "Select next whole word",
+        select_next_long_word, "Select next whole long word",
+        select_prev_word, "Select previous whole word",
+        select_prev_long_word, "Select previous whole long word",
         goto_next_function, "Goto next function",
         goto_prev_function, "Goto previous function",
         goto_next_class, "Goto next type definition",
@@ -5114,71 +5118,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     cx.on_next_key(move |cx, event| {
         cx.editor.autoinfo = None;
         if let Some(ch) = event.char() {
-            let textobject = move |editor: &mut Editor| {
-                let (view, doc) = current!(editor);
-                let text = doc.text().slice(..);
-
-                let textobject_treesitter = |obj_name: &str, range: Range| -> Range {
-                    let (lang_config, syntax) = match doc.language_config().zip(doc.syntax()) {
-                        Some(t) => t,
-                        None => return range,
-                    };
-                    textobject::textobject_treesitter(
-                        text,
-                        range,
-                        objtype,
-                        obj_name,
-                        syntax.tree().root_node(),
-                        lang_config,
-                        count,
-                    )
-                };
-
-                if ch == 'g' && doc.diff_handle().is_none() {
-                    editor.set_status("Diff is not available in current buffer");
-                    return;
-                }
-
-                let textobject_change = |range: Range| -> Range {
-                    let diff_handle = doc.diff_handle().unwrap();
-                    let diff = diff_handle.load();
-                    let line = range.cursor_line(text);
-                    let hunk_idx = if let Some(hunk_idx) = diff.hunk_at(line as u32, false) {
-                        hunk_idx
-                    } else {
-                        return range;
-                    };
-                    let hunk = diff.nth_hunk(hunk_idx).after;
-
-                    let start = text.line_to_char(hunk.start as usize);
-                    let end = text.line_to_char(hunk.end as usize);
-                    Range::new(start, end).with_direction(range.direction())
-                };
-
-                let selection = doc.selection(view.id).clone().transform(|range| {
-                    match ch {
-                        'w' => textobject::textobject_word(text, range, objtype, count, false),
-                        'W' => textobject::textobject_word(text, range, objtype, count, true),
-                        't' => textobject_treesitter("class", range),
-                        'f' => textobject_treesitter("function", range),
-                        'a' => textobject_treesitter("parameter", range),
-                        'c' => textobject_treesitter("comment", range),
-                        'T' => textobject_treesitter("test", range),
-                        'p' => textobject::textobject_paragraph(text, range, objtype, count),
-                        'm' => textobject::textobject_pair_surround_closest(
-                            text, range, objtype, count,
-                        ),
-                        'g' => textobject_change(range),
-                        // TODO: cancel new ranges if inconsistent surround matches across lines
-                        ch if !ch.is_ascii_alphanumeric() => {
-                            textobject::textobject_pair_surround(text, range, objtype, ch, count)
-                        }
-                        _ => range,
-                    }
-                });
-                doc.set_selection(view.id, selection);
-            };
-            cx.editor.apply_motion(textobject);
+            select_textobject_for_char(cx, ch, objtype, count);
         }
     });
 
@@ -5201,6 +5141,126 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     ];
 
     cx.editor.autoinfo = Some(Info::new(title, &help_text));
+}
+
+fn select_textobject_for_char(
+    cx: &mut Context,
+    ch: char,
+    objtype: textobject::TextObject,
+    count: usize,
+) {
+    let textobject = move |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+        let text = doc.text().slice(..);
+
+        let textobject_treesitter = |obj_name: &str, range: Range| -> Range {
+            let (lang_config, syntax) = match doc.language_config().zip(doc.syntax()) {
+                Some(t) => t,
+                None => return range,
+            };
+            textobject::textobject_treesitter(
+                text,
+                range,
+                objtype,
+                obj_name,
+                syntax.tree().root_node(),
+                lang_config,
+                count,
+            )
+        };
+
+        if ch == 'g' && doc.diff_handle().is_none() {
+            editor.set_status("Diff is not available in current buffer");
+            return;
+        }
+
+        let textobject_change = |range: Range| -> Range {
+            let diff_handle = doc.diff_handle().unwrap();
+            let diff = diff_handle.load();
+            let line = range.cursor_line(text);
+            let hunk_idx = if let Some(hunk_idx) = diff.hunk_at(line as u32, false) {
+                hunk_idx
+            } else {
+                return range;
+            };
+            let hunk = diff.nth_hunk(hunk_idx).after;
+
+            let start = text.line_to_char(hunk.start as usize);
+            let end = text.line_to_char(hunk.end as usize);
+            Range::new(start, end).with_direction(range.direction())
+        };
+
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            match ch {
+                'w' => textobject::textobject_word(text, range, objtype, count, false),
+                'W' => textobject::textobject_word(text, range, objtype, count, true),
+                't' => textobject_treesitter("class", range),
+                'f' => textobject_treesitter("function", range),
+                'a' => textobject_treesitter("parameter", range),
+                'c' => textobject_treesitter("comment", range),
+                'T' => textobject_treesitter("test", range),
+                'p' => textobject::textobject_paragraph(text, range, objtype, count),
+                'm' => textobject::textobject_pair_surround_closest(text, range, objtype, count),
+                'g' => textobject_change(range),
+                // TODO: cancel new ranges if inconsistent surround matches across lines
+                ch if !ch.is_ascii_alphanumeric() => {
+                    textobject::textobject_pair_surround(text, range, objtype, ch, count)
+                }
+                _ => range,
+            }
+        });
+        doc.set_selection(view.id, selection);
+    };
+    cx.editor.apply_motion(textobject);
+}
+
+fn select_next_word(cx: &mut Context) {
+    let current_selection = get_current_selection(cx);
+    select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
+    let new_selection = get_current_selection(cx);
+    if current_selection == new_selection {
+        move_next_word_end(cx);
+        select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
+    }
+}
+
+fn select_next_long_word(cx: &mut Context) {
+    let current_selection = get_current_selection(cx);
+    select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
+    let new_selection = get_current_selection(cx);
+    if current_selection == new_selection {
+        move_next_long_word_end(cx);
+        select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
+    }
+}
+
+fn select_prev_word(cx: &mut Context) {
+    let current_selection = get_current_selection(cx);
+    select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
+    flip_selections(cx);
+    let new_selection = get_current_selection(cx);
+    if current_selection == new_selection {
+        move_prev_word_start(cx);
+        select_textobject_for_char(cx, 'w', textobject::TextObject::Inside, cx.count());
+        flip_selections(cx);
+    }
+}
+
+fn select_prev_long_word(cx: &mut Context) {
+    let current_selection = get_current_selection(cx);
+    select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
+    flip_selections(cx);
+    let new_selection = get_current_selection(cx);
+    if current_selection == new_selection {
+        move_prev_long_word_start(cx);
+        select_textobject_for_char(cx, 'W', textobject::TextObject::Inside, cx.count());
+        flip_selections(cx);
+    }
+}
+
+fn get_current_selection(cx: &mut Context) -> Selection {
+    let (view, doc) = current!(cx.editor);
+    doc.selection(view.id).clone()
 }
 
 fn surround_add(cx: &mut Context) {


### PR DESCRIPTION
This PR adds 4 new commands to navigate between words: "select_next_word", "select_next_long_word", "select_prev_word", "select_prev_long_word". 

The difference with the existing word-based navigation commands is that the existing commands select spaces and/or partial words. I found myself often pressing additional keystrokes to compensate for this, while I'm usually not interested in selecting partial words, and the additional selected space is too difficult for me to to reliably work with.

Here is a quick screen cap of how it work in practice

https://github.com/helix-editor/helix/assets/1030961/9fb2a43d-0f37-4b50-845d-86ff14e982e7

I've used these commands for 6 months using the following mapping in normal mode

```toml
"w" = "select_next_word"
"W" = "select_next_long_word"
"b" = "select_prev_word"
"B" = "select_prev_long_word"
"A-e" = "move_prev_word_start"
"A-E" = "move_prev_long_word_start"
```

and the accompanying extend mode commands

```toml

"w" = "extend_next_word_end"
"W" = "extend_next_long_word_end"
"b" = "extend_prev_word_start"
"B" = "extend_prev_long_word_start"
"A-e" = "extend_prev_word_start"
"A-E" = "extend_prev_long_word_start"
```
