### PR TITLE
Bump tree-sitter to 0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,8 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
-source = "git+https://github.com/helix-editor/tree-sitter?rev=660481dbf71413eba5a928b0b0ab8da50c1109e0#660481dbf71413eba5a928b0b0ab8da50c1109e0"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb9c9f15eae91dcd00ee0d86a281d16e6263786991b662b34fa9632c21a046b"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
 [workspace.dependencies]
-tree-sitter = { version = "0.20", git = "https://github.com/helix-editor/tree-sitter", rev = "660481dbf71413eba5a928b0b0ab8da50c1109e0" }
+tree-sitter = { version = "0.22" }
 nucleo = "0.2.0"
 
 [workspace.package]

--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -2,7 +2,7 @@
 
 (call_expression
   function: (identifier) @function.builtin
-  (match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+  (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
 
 (call_expression
   function: (identifier) @function)
@@ -19,7 +19,7 @@
     name: (identifier) @type.parameter))
 
 ((type_identifier) @type.builtin
-  (match? @type.builtin "^(any|bool|byte|comparable|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
+  (#match? @type.builtin "^(any|bool|byte|comparable|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
 
 (type_identifier) @type
 

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -231,7 +231,7 @@
 ] @keyword
 
 ; TODO: fix this
-((identifier) @keyword (match? @keyword "global|local"))
+((identifier) @keyword (#match? @keyword "global|local"))
 
 ; ---------
 ; Operators
@@ -277,12 +277,12 @@
 ; SCREAMING_SNAKE_CASE
 (
   (identifier) @constant
-  (match? @constant "^[A-Z][A-Z0-9_]*$"))
+  (#match? @constant "^[A-Z][A-Z0-9_]*$"))
 
 ; remaining identifiers that start with capital letters should be types (PascalCase)
 (
   (identifier) @type
-  (match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ; Field expressions are either module content or struct fields.
 ; Module types and constants should already be captured, so this

--- a/runtime/queries/pkl/highlights.scm
+++ b/runtime/queries/pkl/highlights.scm
@@ -172,7 +172,7 @@
 (clazz (identifier) @type)
 (typeAlias (identifier) @type)
 ((identifier) @type
- (match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 (typeArgumentList
   "<" @punctuation.bracket

--- a/runtime/queries/pkl/injections.scm
+++ b/runtime/queries/pkl/injections.scm
@@ -18,7 +18,7 @@
 (
   ((methodCallExpr (identifier) @methodName (argumentList (slStringLiteral) @injection.content))
     (#set! injection.language "regex"))
-  (eq? @methodName "Regex"))
+  (#eq? @methodName "Regex"))
  
 ((lineComment) @injection.content
  (#set! injection.language "comment"))

--- a/runtime/queries/scss/highlights.scm
+++ b/runtime/queries/scss/highlights.scm
@@ -44,9 +44,9 @@
 "@while" @keyword.control.repeat
 
 ((property_name) @variable
- (match? @variable "^--"))
+ (#match? @variable "^--"))
 ((plain_value) @variable
- (match? @variable "^--"))
+ (#match? @variable "^--"))
 
 (tag_name) @tag
 (universal_selector) @tag

--- a/xtask/src/querycheck.rs
+++ b/xtask/src/querycheck.rs
@@ -21,7 +21,7 @@ pub fn query_check() -> Result<(), DynError> {
             let query_text = read_query(language_name, query_file);
             if let Ok(lang) = language {
                 if !query_text.is_empty() {
-                    if let Err(reason) = Query::new(lang, &query_text) {
+                    if let Err(reason) = Query::new(&lang, &query_text) {
                         return Err(format!(
                             "Failed to parse {} queries for {}: {}",
                             query_file, language_name, reason


### PR DESCRIPTION
There were breaking changes to the `Language` type necessary because of loading WASM-based parsers: https://github.com/tree-sitter/tree-sitter/pull/2840. `Hash` is now implemented for `Language` though which simplifies our `Hash for LanguageLayer` impl