### PR TITLE
Add Support for JSONC

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -87,6 +87,7 @@
 | jsdoc | ✓ |  |  |  |
 | json | ✓ |  | ✓ | `vscode-json-language-server` |
 | json5 | ✓ |  |  |  |
+| jsonc | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |
 | jsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ | `julia` |

--- a/languages.toml
+++ b/languages.toml
@@ -367,7 +367,6 @@ scope = "source.json"
 injection-regex = "json"
 file-types = [
   "json",
-  "jsonc",
   "arb",
   "ipynb",
   "geojson",
@@ -396,6 +395,15 @@ indent = { tab-width = 2, unit = "  " }
 name = "json"
 source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "73076754005a460947cafe8e03a8cf5fa4fa2938" }
 
+[[language]]
+name = "jsonc"
+scope = "source.json"
+injection-regex = "json"
+file-types = ["jsonc"]
+grammar = "json"
+language-servers = [ "vscode-json-language-server" ]
+auto-format = true
+indent = { tab-width = 2, unit = "  " }
 
 [[language]]
 name = "json5"

--- a/languages.toml
+++ b/languages.toml
@@ -398,7 +398,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "73076
 [[language]]
 name = "jsonc"
 scope = "source.json"
-injection-regex = "json"
+injection-regex = "jsonc"
 file-types = ["jsonc"]
 grammar = "json"
 language-servers = [ "vscode-json-language-server" ]

--- a/runtime/queries/jsonc/highlights.scm
+++ b/runtime/queries/jsonc/highlights.scm
@@ -1,22 +1,2 @@
-[
-  (true)
-  (false)
-] @constant.builtin.boolean
-(null) @constant.builtin
-(number) @constant.numeric
-(pair
-  key: (_) @keyword)
-
-(string) @string
-(escape_sequence) @constant.character.escape
-(ERROR) @error
-
-"," @punctuation.delimiter
-[
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
-
+; inherits: json
 (comment) @comment

--- a/runtime/queries/jsonc/highlights.scm
+++ b/runtime/queries/jsonc/highlights.scm
@@ -1,0 +1,22 @@
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+(null) @constant.builtin
+(number) @constant.numeric
+(pair
+  key: (_) @keyword)
+
+(string) @string
+(escape_sequence) @constant.character.escape
+(ERROR) @error
+
+"," @punctuation.delimiter
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(comment) @comment

--- a/runtime/queries/jsonc/indents.scm
+++ b/runtime/queries/jsonc/indents.scm
@@ -1,0 +1,9 @@
+[
+  (object)
+  (array)
+] @indent
+
+[
+  "]"
+  "}"
+] @outdent

--- a/runtime/queries/jsonc/indents.scm
+++ b/runtime/queries/jsonc/indents.scm
@@ -1,9 +1,1 @@
-[
-  (object)
-  (array)
-] @indent
-
-[
-  "]"
-  "}"
-] @outdent
+; inherits: json


### PR DESCRIPTION
`jsonc` is currently part of the `json` language definition.

This currently doesn't allow for comments to be added to the JSON. It is both linted as incorrect by the language server and not highlighted correctly.

![240317_14h34m34s_screenshot](https://github.com/helix-editor/helix/assets/17815769/f8463993-1f6b-4a49-8e77-1e83e4643e7c)


The language server configured by the JSON language can take either `json` or `jsonc` as valid language ids.

Here is what the same file opened as a `.jsonc` looks like in this PR:

![240317_14h48m44s_screenshot](https://github.com/helix-editor/helix/assets/17815769/180bf47a-4bf0-412c-a2c2-192d9cf8340d)
