### PR TITLE
fix: Fix `this document is excluded` for toml lsp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -262,6 +262,7 @@ name = "toml"
 scope = "source.toml"
 injection-regex = "toml"
 file-types = ["toml", { glob = "poetry.lock" }, { glob = "Cargo.lock" }]
+roots = ["."]
 comment-token = "#"
 language-servers = [ "taplo" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
When opening a `toml` file outside of git project, `taplo` lsp only returns `this document is excluded` because it cannot find the root folder.

Detail: https://github.com/tamasfe/taplo/issues/580