### PR TITLE
Add yaml LSP for docker compose

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -31,7 +31,7 @@
 | devicetree | ✓ |  |  |  |
 | dhall | ✓ | ✓ |  | `dhall-lsp-server` |
 | diff | ✓ |  |  |  |
-| docker-compose | ✓ |  | ✓ | `docker-compose-langserver` |
+| docker-compose | ✓ |  | ✓ | `docker-compose-langserver`, `yaml-language-server` |
 | dockerfile | ✓ |  |  | `docker-langserver` |
 | dot | ✓ |  |  | `dot-language-server` |
 | dtd | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1550,7 +1550,7 @@ source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = 
 name = "docker-compose"
 scope = "source.yaml.docker-compose"
 roots = ["docker-compose.yaml", "docker-compose.yml"]
-language-servers = [ "docker-compose-langserver" ]
+language-servers = [ "docker-compose-langserver", "yaml-language-server" ]
 file-types = [{ glob = "docker-compose.yaml" }, { glob = "docker-compose.yml" }]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Since docker compose LSP does not support for example `documentSymbol` requests, add yaml-language-server as a second LSP to provide missing capabilities.