### PR TITLE
Replace threadpool with Rust's Standard Library for Parallel Execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,6 @@ dependencies = [
  "once_cell",
  "serde",
  "tempfile",
- "threadpool",
  "toml",
  "tree-sitter",
 ]
@@ -2268,15 +2267,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -29,7 +29,6 @@ log = "0.4"
 
 # cloning/compiling tree-sitter grammars
 cc = { version = "1" }
-threadpool = { version = "1.0" }
 tempfile = "3.10.1"
 dunce = "1.0.4"
 


### PR DESCRIPTION
## Description

In the existing `run_parallel`, the `threadpool` package was used to handle parallel tasks. However, this package was only used in this function, and it has been determined that the standard library of Rust can adequately address these needs. Therefore, modifications have been made to no longer use this library.

To replicate the functionality previously provided by threadpool, the following changes have been made:

1. For each `GrammarConfiguration` instance, `std::thread::spawn` is used to create a separate thread.
2. `std::sync::mpsc::channel` is used to collect the results of tasks executed in each thread.
3. The process waits until all threads have finished and then collects the results from each thread.