### PR TITLE
Ignore more version control systems

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -48,10 +48,13 @@ fn true_color() -> bool {
 
 /// Function used for filtering dir entries in the various file pickers.
 fn filter_picker_entry(entry: &DirEntry, root: &Path, dedup_symlinks: bool) -> bool {
-    // We always want to ignore the .git directory, otherwise if
+    // We always want to ignore popular VCS directories, otherwise if
     // `ignore` is turned off, we end up with a lot of noise
     // in our picker.
-    if entry.file_name() == ".git" {
+    if matches!(
+        entry.file_name().to_str(),
+        Some(".git" | ".pijul" | ".jj" | ".hg")
+    ) {
         return false;
     }
 


### PR DESCRIPTION
Ignore `.pijul`, `.hg` and `.jj` as well as `.git`. This makes hx so much more usable with VCSes other than git!