### PR TITLE
Update rasmus.toml

### DIFF
--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -83,6 +83,8 @@
 "ui.text" = { fg = "fg" }
 "ui.text.focus" = { fg = "white" }
 
+"ui.virtual" = { fg = "gray03" }
+"ui.virtual.ruler" = { bg = "gray03" }
 "ui.virtual.indent-guide" = { fg = "gray04" }
 "ui.virtual.inlay-hint" = { fg = "gray05" }
 

--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -83,7 +83,6 @@
 "ui.text" = { fg = "fg" }
 "ui.text.focus" = { fg = "white" }
 
-"ui.virtual" = { fg = "gray03" }
 "ui.virtual.indent-guide" = { fg = "gray04" }
 "ui.virtual.inlay-hint" = { fg = "gray05" }
 


### PR DESCRIPTION
Remove "ui.virtual" setting as it selects seemingly random characters to highlight.

<img width="741" alt="image" src="https://github.com/helix-editor/helix/assets/33134197/dfd095c3-12b0-4fc2-9a8c-218dfcc60823">

To demonstrate what I'm talking about, I changed "gray03" (which is what "ui.virtual" is set to) to orange and everything else to gray. 

Also, [as per the docs](https://docs.helix-editor.com/themes.html), it seems as if this isn't a real field.

<img width="1105" alt="image" src="https://github.com/helix-editor/helix/assets/33134197/766b4659-5664-44bf-88dd-093072aaac7a">
It is fixed in the above picture.