### PR TITLE
feat: add support for gjs and gts

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -62,6 +62,7 @@
 | git-config | ✓ |  |  |  |
 | git-ignore | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
+| gjs | ✓ | ✓ | ✓ | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | gleam | ✓ | ✓ |  | `gleam` |
 | glimmer | ✓ |  |  | `ember-language-server` |
 | glsl | ✓ | ✓ | ✓ |  |
@@ -73,6 +74,7 @@
 | gowork | ✓ |  |  | `gopls` |
 | graphql | ✓ | ✓ |  | `graphql-lsp` |
 | groovy | ✓ |  |  |  |
+| gts | ✓ | ✓ | ✓ | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | hare | ✓ |  |  |  |
 | haskell | ✓ | ✓ |  | `haskell-language-server-wrapper` |
 | haskell-persistent | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -197,6 +197,28 @@ inlayHints.functionLikeReturnTypes.enabled = true
 inlayHints.enumMemberValues.enabled = true
 inlayHints.parameterNames.enabled = "all"
 
+[language-server.vscode-eslint-language-server]
+command = "vscode-eslint-language-server"
+args = ["--stdio"]
+
+[language-server.vscode-eslint-language-server.config]
+validate = "on"
+experimental = { useFlatConfig = false }
+rulesCustomizations = []
+run = "onType"
+problems = { shortenToSingleLine = false }
+nodePath = ""
+
+[language-server.vscode-eslint-language-server.config.codeAction.disableRuleComment]
+enable = true
+location = "separateLine"
+
+[language-server.vscode-eslint-language-server.config.codeAction.showDocumentation]
+enable = true
+
+[language-server.vscode-eslint-language-server.config.workingDirectory]
+mode = "location"
+
 [[language]]
 name = "rust"
 scope = "source.rust"
@@ -3579,3 +3601,51 @@ language-servers = ["pest-language-server"]
 [[grammar]]
 name = "pest"
 source = { git = "https://github.com/pest-parser/tree-sitter-pest", rev = "a8a98a824452b1ec4da7f508386a187a2f234b85" }
+
+[[language]]
+name = "gjs"
+scope = "source.gjs"
+file-types = ["gjs"]
+roots = ["package.json", "ember-cli-build.js"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+language-servers = [
+    { except-features = [
+        "format", "diagnostics",
+    ], name = "typescript-language-server" },
+    "vscode-eslint-language-server",
+    "ember-language-server",
+]
+indent = { tab-width = 2, unit = "  " }
+grammar = "javascript"
+
+[language.auto-pairs]
+'<' = '>'
+"'" = "'"
+"{" = "}"
+"(" = ")"
+'"' = '"'
+
+[[language]]
+name = "gts"
+scope = "source.gts"
+file-types = ["gts"]
+roots = ["package.json", "ember-cli-build.js"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+language-servers = [
+    { except-features = [
+        "format", "diagnostics",
+    ], name = "typescript-language-server" },
+    "vscode-eslint-language-server",
+    "ember-language-server",
+]
+indent = { tab-width = 2, unit = "  " }
+grammar = "typescript"
+
+[language.auto-pairs]
+'<' = '>'
+"'" = "'"
+"{" = "}"
+"(" = ")"
+'"' = '"'

--- a/runtime/queries/_gjs/highlights.scm
+++ b/runtime/queries/_gjs/highlights.scm
@@ -1,0 +1,5 @@
+[
+  (glimmer_opening_tag)
+  (glimmer_closing_tag)
+] @constant.builtin
+

--- a/runtime/queries/_gjs/injections.scm
+++ b/runtime/queries/_gjs/injections.scm
@@ -1,0 +1,20 @@
+; PARSE GLIMMER TEMPLATES
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; e.g.: <template><SomeComponent @arg={{double @value}} /></template>
+((glimmer_template) @injection.content
+ (#set! injection.language "hbs"))
+
+; Parse Ember/Glimmer/Handlebars/HTMLBars/etc. template literals
+; e.g.: await render(hbs`<SomeComponent />`)
+(call_expression
+  function: ((identifier) @_name
+             (#eq? @_name "hbs"))
+  arguments: ((template_string) @glimmer
+              (#offset! @glimmer 0 1 0 -1)))

--- a/runtime/queries/gjs/highlights.scm
+++ b/runtime/queries/gjs/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gjs/indents.scm
+++ b/runtime/queries/gjs/indents.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gjs/injections.scm
+++ b/runtime/queries/gjs/injections.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gjs/locals.scm
+++ b/runtime/queries/gjs/locals.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gjs/tags.scm
+++ b/runtime/queries/gjs/tags.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gjs/textobjects.scm
+++ b/runtime/queries/gjs/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_javascript,ecma

--- a/runtime/queries/gts/highlights.scm
+++ b/runtime/queries/gts/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma

--- a/runtime/queries/gts/indents.scm
+++ b/runtime/queries/gts/indents.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma

--- a/runtime/queries/gts/injections.scm
+++ b/runtime/queries/gts/injections.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma

--- a/runtime/queries/gts/locals.scm
+++ b/runtime/queries/gts/locals.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma

--- a/runtime/queries/gts/tags.scm
+++ b/runtime/queries/gts/tags.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma

--- a/runtime/queries/gts/textobjects.scm
+++ b/runtime/queries/gts/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: _gjs,_typescript,ecma


### PR DESCRIPTION
Add support for glimmer-js and glimmer-ts
=

## gjs
![image](https://github.com/helix-editor/helix/assets/110528300/26a478b6-2041-47dd-9cf9-c050ffafaaef)
![image](https://github.com/helix-editor/helix/assets/110528300/51d6b1d0-914a-4e58-8808-2571b225cf04)
![image](https://github.com/helix-editor/helix/assets/110528300/fb66565c-79a3-40d6-91b9-fc81e32679be)


## gts
(error due to using linguist sample and missing imports)
![image](https://github.com/helix-editor/helix/assets/110528300/1290d721-0c3b-42b7-9e8b-787786d0d208)
![image](https://github.com/helix-editor/helix/assets/110528300/f1afa6d1-4058-4620-bb9c-6d3867aeb3b0)
![image](https://github.com/helix-editor/helix/assets/110528300/beba60d9-3026-4aba-bc29-bf13915e48df)
