### PR TITLE
Add new theme keys for LSP diagnostic tags for dark_plus

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -98,6 +98,8 @@
 
 "diagnostic.error".underline = { color = "red", style = "curl" }
 "diagnostic".underline = { color = "gold", style = "curl" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 white = "#ffffff"


### PR DESCRIPTION
Now https://github.com/helix-editor/helix/pull/9780 is merged I have added the new theme keys.

Deprecated used to look like:

![Screenshot from 2024-03-20 19-22-40](https://github.com/helix-editor/helix/assets/12832280/b8a15f0a-8ed0-4f9f-bb03-505b1e963ed7)

Now it looks like:

![Screenshot from 2024-03-20 19-35-28](https://github.com/helix-editor/helix/assets/12832280/337b47e4-68a8-428a-b8f4-8476d1267e25)

I can't find any code to show `unnecessary`, but the `dim` modifier works in general in the theme and does exactly as expected, it just dims the text slightly.

@kirawi Looks good to you?