### PR TITLE
feat: Diff source autodetection and caching

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -79,6 +79,7 @@ use std::{
     future::Future,
     io::Read,
     num::NonZeroUsize,
+    sync::Arc,
 };
 
 use std::{
@@ -3481,7 +3482,7 @@ fn jumplist_picker(cx: &mut Context) {
 
 fn changed_file_picker(cx: &mut Context) {
     pub struct FileChangeData {
-        cwd: PathBuf,
+        cwd: Arc<Path>,
         style_untracked: Style,
         style_modified: Style,
         style_conflict: Style,
@@ -3489,7 +3490,7 @@ fn changed_file_picker(cx: &mut Context) {
         style_renamed: Style,
     }
 
-    let cwd = helix_stdx::env::current_working_dir();
+    let cwd: Arc<Path> = Arc::from(helix_stdx::env::current_working_dir().as_path());
     if !cwd.exists() {
         cx.editor
             .set_error("Current working directory does not exist");
@@ -3568,17 +3569,24 @@ fn changed_file_picker(cx: &mut Context) {
             helix_loader::workspace_trust::TrustQuery::Git,
         )
         .is_trusted();
-    cx.editor
-        .diff_providers
-        .clone()
-        .for_each_changed_file(cwd, trust_full, move |change| match change {
+    // Helix can be launched without arguments, in which case no diff provider will be loaded since
+    // there is no file to provide infos for.
+    //
+    // This ensures we have one to work with for cwd (and as a bonus it means any file opened
+    // from this picker will have its diff provider already in cache).
+    cx.editor.diff_providers.add(&cwd, trust_full);
+    cx.editor.diff_providers.clone().for_each_changed_file(
+        cwd.clone(),
+        move |change| match change {
             Ok(change) => injector.push(change).is_ok(),
             Err(err) => {
                 status::report_blocking(err);
                 true
             }
-        });
+        },
+    );
     cx.push_layer(Box::new(overlaid(picker)));
+    cx.editor.diff_providers.remove(&cwd);
 }
 
 pub fn command_palette(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1593,7 +1593,7 @@ fn reload(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyh
     let scrolloff = cx.editor.config().scrolloff;
     let trust_full = doc_trust_full(cx.editor);
     let (view, doc) = current!(cx.editor);
-    doc.reload(view, &cx.editor.diff_providers, trust_full)
+    doc.reload(view, &mut cx.editor.diff_providers, trust_full)
         .map(|_| {
             view.ensure_cursor_in_view(doc, scrolloff);
         })?;
@@ -1629,6 +1629,8 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
         })
         .collect();
 
+    cx.editor.diff_providers.reset();
+
     for (doc_id, view_ids) in docs_view_ids {
         let doc = doc_mut!(cx.editor, &doc_id);
 
@@ -1647,7 +1649,7 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
                 helix_loader::workspace_trust::TrustQuery::Git,
             )
             .is_trusted();
-        if let Err(error) = doc.reload(view, &cx.editor.diff_providers, trust_full) {
+        if let Err(error) = doc.reload(view, &mut cx.editor.diff_providers, trust_full) {
             cx.editor.set_error(format!("{}", error));
             continue;
         }

--- a/helix-vcs/Cargo.toml
+++ b/helix-vcs/Cargo.toml
@@ -17,10 +17,9 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync", "p
 parking_lot.workspace = true
 arc-swap.workspace = true
 
-gix = { version = "0.85.0", features = ["attributes", "status", "max-performance", "sha1"], default-features = false, optional = true }
+gix = { version = "0.85.0", features = ["attributes", "parallel", "status", "max-performance", "sha1"], default-features = false, optional = true }
 imara-diff =  "0.2.0"
 anyhow = "1"
-
 log = "0.4"
 
 [features]

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -22,22 +22,12 @@ use crate::FileChange;
 #[cfg(test)]
 mod test;
 
-#[inline]
-fn get_repo_dir(file: &Path) -> Result<&Path> {
-    file.parent().context("file has no parent directory")
-}
-
-pub fn get_diff_base(file: &Path, trust_full: bool) -> Result<Vec<u8>> {
+pub(super) fn get_diff_base(repo: &ThreadSafeRepository, file: &Path) -> Result<Vec<u8>> {
     debug_assert!(!file.exists() || file.is_file());
     debug_assert!(file.is_absolute());
     let file = gix::path::realpath(file).context("resolve symlinks")?;
 
-    // TODO cache repository lookup
-
-    let repo_dir = get_repo_dir(&file)?;
-    let repo = open_repo(repo_dir, trust_full)
-        .context("failed to open git repo")?
-        .to_thread_local();
+    let repo = repo.to_thread_local();
     let head = repo.head_commit()?;
     let file_oid = find_file_in_commit(&repo, &head, &file)?;
 
@@ -65,15 +55,8 @@ pub fn get_diff_base(file: &Path, trust_full: bool) -> Result<Vec<u8>> {
     }
 }
 
-pub fn get_current_head_name(file: &Path, trust_full: bool) -> Result<Arc<ArcSwap<Box<str>>>> {
-    debug_assert!(!file.exists() || file.is_file());
-    debug_assert!(file.is_absolute());
-    let file = gix::path::realpath(file).context("resolve symlinks")?;
-
-    let repo_dir = get_repo_dir(&file)?;
-    let repo = open_repo(repo_dir, trust_full)
-        .context("failed to open git repo")?
-        .to_thread_local();
+pub(super) fn get_current_head_name(repo: &ThreadSafeRepository) -> Result<Arc<ArcSwap<Box<str>>>> {
+    let repo = repo.to_thread_local();
     let head_ref = repo.head_ref()?;
     let head_commit = repo.head_commit()?;
 
@@ -85,15 +68,14 @@ pub fn get_current_head_name(file: &Path, trust_full: bool) -> Result<Arc<ArcSwa
     Ok(Arc::new(ArcSwap::from_pointee(name.into_boxed_str())))
 }
 
-pub fn for_each_changed_file(
-    cwd: &Path,
-    trust_full: bool,
+pub(super) fn for_each_changed_file(
+    repo: &ThreadSafeRepository,
     f: impl Fn(Result<FileChange>) -> bool,
 ) -> Result<()> {
-    status(&open_repo(cwd, trust_full)?.to_thread_local(), f)
+    status(&repo.to_thread_local(), f)
 }
 
-fn open_repo(path: &Path, trust_full: bool) -> Result<ThreadSafeRepository> {
+pub(super) fn open_repo(path: &Path, trust_full: bool) -> Result<ThreadSafeRepository> {
     // `trust_full` is the workspace-trust decision made by the caller, and it must be the
     // authority on the gix trust level. gix's own discovery (`discover_*`) ignores a
     // caller-supplied trust level: it always re-derives trust from `.git` ownership, so a malicious
@@ -109,6 +91,10 @@ fn open_repo(path: &Path, trust_full: bool) -> Result<ThreadSafeRepository> {
     } else {
         gix::sec::Trust::Reduced
     };
+
+    // Ensure the repo itself is an absolute real path, else we'll not match prefixes with
+    // symlink-resolved files in `get_diff_base()` above.
+    let path = gix::path::realpath(path)?;
 
     // On Windows various configuration options are bundled as part of the git installation. The
     // lookup is expensive; only do it there.
@@ -130,7 +116,7 @@ fn open_repo(path: &Path, trust_full: bool) -> Result<ThreadSafeRepository> {
         dot_git_only: true,
         ..Default::default()
     };
-    let (repo_path, _trust_from_ownership) = gix::discover::upwards_opts(path, discover_options)
+    let (repo_path, _trust_from_ownership) = gix::discover::upwards_opts(&path, discover_options)
         .context("failed to discover git repo")?;
     let (git_dir, _work_dir) = repo_path.into_repository_and_work_tree_directories();
 

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -54,7 +54,8 @@ fn missing_file() {
     let file = temp_git.path().join("file.txt");
     File::create(&file).unwrap().write_all(b"foo").unwrap();
 
-    assert!(git::get_diff_base(&file, true).is_err());
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
+    assert!(git::get_diff_base(&repo, &file).is_err());
 }
 
 #[test]
@@ -64,8 +65,10 @@ fn unmodified_file() {
     let contents = b"foo".as_slice();
     File::create(&file).unwrap().write_all(contents).unwrap();
     create_commit(temp_git.path(), true);
+
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
     assert_eq!(
-        git::get_diff_base(&file, true).unwrap(),
+        git::get_diff_base(&repo, &file).unwrap(),
         Vec::from(contents)
     );
 }
@@ -79,8 +82,9 @@ fn modified_file() {
     create_commit(temp_git.path(), true);
     File::create(&file).unwrap().write_all(b"bar").unwrap();
 
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
     assert_eq!(
-        git::get_diff_base(&file, true).unwrap(),
+        git::get_diff_base(&repo, &file).unwrap(),
         Vec::from(contents)
     );
 }
@@ -101,7 +105,9 @@ fn directory() {
 
     std::fs::remove_dir_all(&dir).unwrap();
     File::create(&dir).unwrap().write_all(b"bar").unwrap();
-    assert!(git::get_diff_base(&dir, true).is_err());
+
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
+    assert!(git::get_diff_base(&repo, &dir).is_err());
 }
 
 /// Test that `get_diff_base` resolves symlinks so that the same diff base is
@@ -128,8 +134,9 @@ fn symlink() {
     symlink("file.txt", &file_link).unwrap();
     create_commit(temp_git.path(), true);
 
-    assert_eq!(git::get_diff_base(&file_link, true).unwrap(), contents);
-    assert_eq!(git::get_diff_base(&file, true).unwrap(), contents);
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
+    assert_eq!(git::get_diff_base(&repo, &file_link).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&repo, &file).unwrap(), contents);
 }
 
 /// Test that `get_diff_base` returns content when the file is a symlink to
@@ -153,6 +160,7 @@ fn symlink_to_git_repo() {
     let file_link = temp_dir.path().join("file_link.txt");
     symlink(&file, &file_link).unwrap();
 
-    assert_eq!(git::get_diff_base(&file_link, true).unwrap(), contents);
-    assert_eq!(git::get_diff_base(&file, true).unwrap(), contents);
+    let repo = git::open_repo(temp_git.path(), true).unwrap();
+    assert_eq!(git::get_diff_base(&repo, &file_link).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&repo, &file).unwrap(), contents);
 }

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -2,12 +2,9 @@
 //! Currently `git` is the only supported provider for diffs, but this architecture allows
 //! for other providers to be added in the future.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::Result;
 use arc_swap::ArcSwap;
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 #[cfg(feature = "git")]
 mod git;
@@ -22,76 +19,218 @@ pub use status::FileChange;
 
 /// Contains all active diff providers. Diff providers are compiled in via features. Currently
 /// only `git` is supported.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct DiffProviderRegistry {
-    providers: Vec<DiffProvider>,
+    /// Repository root path mapped to their provider.
+    ///
+    /// When a root path cannot be found after having called `add_file`, it means there is no
+    /// provider to speak of.
+    providers: HashMap<Arc<Path>, DiffProvider>,
+    /// Count the number of files added for a specific provider path.
+    /// Providers themselves don't care about that, this is handled entirely in `Self::add_file`,
+    /// without knowledge from the `Self::add_file_<provider>` methods.
+    ///
+    /// Note: it *could* happen that a provider for a path is changed without the number of
+    /// associated files changing, e.g deleting a .git/ and initializing a .jj/ repo.
+    counters: HashMap<Arc<Path>, u32>,
 }
 
+/// Diff-related methods
 impl DiffProviderRegistry {
     /// Get the given file from the VCS. This provides the unedited document as a "base"
     /// for a diff to be created.
-    pub fn get_diff_base(&self, file: &Path, trust_full: bool) -> Option<Vec<u8>> {
-        self.providers
-            .iter()
-            .find_map(|provider| match provider.get_diff_base(file, trust_full) {
-                Ok(res) => Some(res),
-                Err(err) => {
-                    log::debug!("{err:#?}");
-                    log::debug!("failed to open diff base for {}", file.display());
-                    None
-                }
-            })
+    pub fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>> {
+        match self.provider_for(file)?.get_diff_base(file) {
+            Ok(diff_base) => Some(diff_base),
+            Err(err) => {
+                log::debug!("{err:#?}");
+                log::debug!("failed to open diff base for {}", file.display());
+                None
+            }
+        }
     }
 
     /// Get the current name of the current [HEAD](https://stackoverflow.com/questions/2304087/what-is-head-in-git).
-    pub fn get_current_head_name(
-        &self,
-        file: &Path,
-        trust_full: bool,
-    ) -> Option<Arc<ArcSwap<Box<str>>>> {
-        self.providers.iter().find_map(|provider| {
-            match provider.get_current_head_name(file, trust_full) {
-                Ok(res) => Some(res),
-                Err(err) => {
-                    log::debug!("{err:#?}");
-                    log::debug!("failed to obtain current head name for {}", file.display());
-                    None
-                }
+    pub fn get_current_head_name(&self, file: &Path) -> Option<Arc<ArcSwap<Box<str>>>> {
+        match self.provider_for(file)?.get_current_head_name() {
+            Ok(head_name) => Some(head_name),
+            Err(err) => {
+                log::debug!("{err:#?}");
+                log::debug!("failed to obtain current head name for {}", file.display());
+                None
             }
-        })
+        }
     }
 
     /// Fire-and-forget changed file iteration. Runs everything in a background task. Keeps
     /// iteration until `on_change` returns `false`.
     pub fn for_each_changed_file(
         self,
-        cwd: PathBuf,
-        trust_full: bool,
+        cwd: Arc<Path>,
         f: impl Fn(Result<FileChange>) -> bool + Send + 'static,
     ) {
         tokio::task::spawn_blocking(move || {
-            if self
-                .providers
-                .iter()
-                .find_map(|provider| provider.for_each_changed_file(&cwd, trust_full, &f).ok())
-                .is_none()
-            {
-                f(Err(anyhow!("no diff provider returns success")));
+            let Some(diff_provider) = self.provider_for(&cwd) else {
+                return;
+            };
+            if let Err(err) = diff_provider.for_each_changed_file(&f) {
+                f(Err(err));
             }
         });
     }
 }
 
-impl Default for DiffProviderRegistry {
-    fn default() -> Self {
-        // currently only git is supported
-        // TODO make this configurable when more providers are added
-        let providers = vec![
+/// Creation and update methods
+#[cfg_attr(not(feature = "git"), allow(unused))]
+impl DiffProviderRegistry {
+    /// Register a provider (if any is found) for the given path.
+    pub fn add(&mut self, path: &Path, trust_full: bool) {
+        let Some((repo_path, provider)) = get_possible_provider(path) else {
+            // Do nothing here: there is no path to use and so the actual methods to get infos
+            // like `get_diff_base` just won't do anything since they won't find a source to
+            // work with.
+            log::debug!("Found no potential diff provider for {}", path.display());
+            // Note: if a `.<vcs>/` dir is deleted, we may end up in a situation where we lose track
+            // of a now unused provider. This is acceptable because it doesn't happen that often in
+            // practice and people can just reload to force an update.
+            //
+            // If it becomes an issue in the future, we could fix it by recomputing the providers
+            // for each stored paths here.
+            return;
+        };
+
+        let result = match provider {
             #[cfg(feature = "git")]
-            DiffProvider::Git,
-            DiffProvider::None,
-        ];
-        DiffProviderRegistry { providers }
+            PossibleDiffProvider::Git => self.add_file_git(repo_path, trust_full),
+        };
+
+        match result {
+            Ok((key, prov)) => {
+                // Increase the count for this path.
+                let count = self.counters.entry(key).or_default();
+                let created = *count == 0;
+                *count += 1;
+
+                // Only log at info level when adding a new provider
+                if created {
+                    log::info!(
+                        "Added {prov:?} (repo: {}) from {}",
+                        repo_path.display(),
+                        path.display()
+                    )
+                } else {
+                    log::debug!(
+                        "Reused {prov:?} (repo: {}) for {}",
+                        repo_path.display(),
+                        path.display()
+                    );
+                }
+            }
+            Err(err) => log::debug!(
+                "Failed to open repo at {} for {}: {:?}",
+                repo_path.display(),
+                path.display(),
+                err
+            ),
+        }
+    }
+
+    /// Reload the provider for the given path.
+    pub fn reload(&mut self, path: &Path, trust_full: bool) {
+        self.remove(path);
+        self.add(path, trust_full);
+    }
+
+    /// Remove the given path from the provider cache. If it was the last one using it, this will
+    /// free up the provider.
+    pub fn remove(&mut self, path: &Path) {
+        let Some((repo_path, _)) = get_possible_provider(path) else {
+            return;
+        };
+
+        let Some(count) = self.counters.get_mut(repo_path) else {
+            return;
+        };
+
+        *count -= 1;
+        if *count == 0 {
+            // Cleanup the provider when the last user disappears
+            self.counters.remove(repo_path);
+            self.providers.remove(repo_path);
+
+            // While reallocating is costly, in most sessions of Helix there will be one main
+            // workspace and sometimes a jump to some temporary one (for example from a jump-to-def
+            // in an LSP) that will be closed after some time. We want to avoid keeping unused
+            // RAM for this.
+            self.providers.shrink_to_fit();
+            self.counters.shrink_to_fit();
+        }
+    }
+
+    /// Clears the saved providers completely.
+    pub fn reset(&mut self) {
+        // NOTE: we keep the allocated memory for reuse since this is mostly used through
+        // `reload_all`, in which case the underlying repository is most likely still there and the
+        // user just wants a clean slate for diffs and other features.
+        let Self {
+            providers,
+            counters,
+        } = self;
+        providers.clear();
+        counters.clear();
+    }
+}
+
+/// Private methods
+impl DiffProviderRegistry {
+    fn provider_for(&self, path: &Path) -> Option<&DiffProvider> {
+        let path = get_possible_provider(path)?.0;
+        self.providers.get(path)
+    }
+
+    // Remove a provider, notably used when its trust setting has changed from the original setup.
+    fn remove_provider(&mut self, repo_path: &Path) {
+        // Ensure we d'ont
+        let Self {
+            providers,
+            counters,
+        } = self;
+        providers.remove(repo_path);
+        counters.remove(repo_path);
+    }
+
+    /// Add the git repo to the known providers *if* it isn't already known.
+    #[cfg(feature = "git")]
+    fn add_file_git(
+        &mut self,
+        repo_path: &Path,
+        trust_full: bool,
+    ) -> Result<(Arc<Path>, PossibleDiffProvider)> {
+        // Don't build a git repo object if there is already one for that path.
+        if let Some((
+            key,
+            DiffProvider::Git {
+                trust_full: originally_trusted,
+                ..
+            },
+        )) = self.providers.get_key_value(repo_path)
+        {
+            if *originally_trusted == trust_full {
+                return Ok((Arc::clone(key), PossibleDiffProvider::Git));
+            } else {
+                self.remove_provider(repo_path);
+            }
+        }
+
+        match git::open_repo(repo_path, trust_full) {
+            Ok(repo) => {
+                let key = Arc::from(repo_path);
+                self.providers
+                    .insert(Arc::clone(&key), DiffProvider::Git { repo, trust_full });
+                Ok((key, PossibleDiffProvider::Git))
+            }
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -99,44 +238,70 @@ impl Default for DiffProviderRegistry {
 /// cloning [DiffProviderRegistry] as `Clone` cannot be used in trait objects.
 ///
 /// `Copy` is simply to ensure the `clone()` call is the simplest it can be.
-#[derive(Copy, Clone)]
-enum DiffProvider {
+#[derive(Clone)]
+pub enum DiffProvider {
     #[cfg(feature = "git")]
-    Git,
-    None,
+    Git {
+        repo: gix::ThreadSafeRepository,
+        trust_full: bool,
+    },
 }
 
+#[cfg_attr(not(feature = "git"), allow(unused))]
 impl DiffProvider {
-    fn get_diff_base(&self, file: &Path, trust_full: bool) -> Result<Vec<u8>> {
-        match self {
+    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>> {
+        // We need the */ref else we're matching on a reference and Rust considers all references
+        // inhabited. In our case
+        match *self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_diff_base(file, trust_full),
-            Self::None => bail!("No diff support compiled in"),
+            Self::Git { ref repo, .. } => git::get_diff_base(repo, file),
         }
     }
 
-    fn get_current_head_name(
-        &self,
-        file: &Path,
-        trust_full: bool,
-    ) -> Result<Arc<ArcSwap<Box<str>>>> {
-        match self {
+    fn get_current_head_name(&self) -> Result<Arc<ArcSwap<Box<str>>>> {
+        match *self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_current_head_name(file, trust_full),
-            Self::None => bail!("No diff support compiled in"),
+            Self::Git { ref repo, .. } => git::get_current_head_name(repo),
         }
     }
 
-    fn for_each_changed_file(
-        &self,
-        cwd: &Path,
-        trust_full: bool,
-        f: impl Fn(Result<FileChange>) -> bool,
-    ) -> Result<()> {
-        match self {
+    fn for_each_changed_file(&self, f: impl Fn(Result<FileChange>) -> bool) -> Result<()> {
+        match *self {
             #[cfg(feature = "git")]
-            Self::Git => git::for_each_changed_file(cwd, trust_full, f),
-            Self::None => bail!("No diff support compiled in"),
+            Self::Git { ref repo, .. } => git::for_each_changed_file(repo, f),
         }
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum PossibleDiffProvider {
+    /// Possibly a git repo rooted at the stored path (i.e. `<path>/.git` exists)
+    #[cfg(feature = "git")]
+    Git,
+}
+
+/// Does *possible* diff provider auto detection. Returns the 'root' of the workspace
+///
+/// We say possible because this function doesn't open the actual repository to check if that's
+/// actually the case.
+fn get_possible_provider(path: &Path) -> Option<(&Path, PossibleDiffProvider)> {
+    if cfg!(feature = "git") {
+        #[cfg_attr(not(feature = "git"), allow(unused))]
+        fn check_path(path: &Path) -> Option<(&Path, PossibleDiffProvider)> {
+            #[cfg(feature = "git")]
+            if path.join(".git").try_exists().ok()? {
+                return Some((path, PossibleDiffProvider::Git));
+            }
+
+            None
+        }
+
+        for parent in path.ancestors() {
+            if let Some(path_and_provider) = check_path(parent) {
+                return Some(path_and_provider);
+            }
+        }
+    }
+
+    None
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1282,7 +1282,7 @@ impl Document {
     pub fn reload(
         &mut self,
         view: &mut View,
-        provider_registry: &DiffProviderRegistry,
+        provider_registry: &mut DiffProviderRegistry,
         trust_full: bool,
     ) -> Result<(), Error> {
         let encoding = self.encoding;
@@ -1293,6 +1293,8 @@ impl Document {
                 false => bail!("can't find file to reload from {:?}", self.display_name()),
             },
         };
+
+        provider_registry.reload(&path, trust_full);
 
         // Once we have a valid path we check if its readonly status has changed
         self.detect_readonly();
@@ -1310,12 +1312,12 @@ impl Document {
         self.pickup_last_saved_time();
         self.detect_indent_and_line_ending();
 
-        match provider_registry.get_diff_base(&path, trust_full) {
+        match provider_registry.get_diff_base(&path) {
             Some(diff_base) => self.set_diff_base(diff_base),
             None => self.diff_handle = None,
         }
 
-        self.version_control_head = provider_registry.get_current_head_name(&path, trust_full);
+        self.version_control_head = provider_registry.get_current_head_name(&path);
 
         Ok(())
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2122,12 +2122,12 @@ impl Editor {
                 .workspace_trust
                 .query(doc.workspace_root(), TrustQuery::Git)
                 .is_trusted();
-            if let Some(diff_base) = self.diff_providers.get_diff_base(&path, trust_full) {
+            // When opening a *new* file, ensure its diff provider is loaded.
+            self.diff_providers.add(&path, trust_full);
+            if let Some(diff_base) = self.diff_providers.get_diff_base(&path) {
                 doc.set_diff_base(diff_base);
             }
-            doc.set_version_control_head(
-                self.diff_providers.get_current_head_name(&path, trust_full),
-            );
+            doc.set_version_control_head(self.diff_providers.get_current_head_name(&path));
 
             let id = self.new_document(doc);
             self.launch_language_servers(id);
@@ -2161,6 +2161,10 @@ impl Editor {
         };
         if !force && doc.is_modified() {
             return Err(CloseError::BufferModified(doc.display_name().into_owned()));
+        }
+
+        if let Some(path) = doc.path() {
+            self.diff_providers.remove(path);
         }
 
         // This will also disallow any follow-up writes


### PR DESCRIPTION
Following discussions in both https://github.com/helix-editor/helix/pull/9892 and https://github.com/helix-editor/helix/pull/8056, this PR adds diff source autodetection and caching.

Supported diff sources

- None
- Git (when the relevant feature is active)

Work left for another PR because it would clutter this one (it's possible not all of this will be implemented, those are ideas):

- Adding "File" Diff source
- Adding command to select diff source
- Adding config for diff source detection order
- Adding a statusline element to show the currently active diff source
- Adding support for JJ as an example of another vcs based diff source (see #12022)

I did not find any issue about diff source autodetection, if there is one I missed tell me or edit the PR desc to mark it as closing the issue if relevant :)