### PR TITLE
Add rclone.conf as a glob to make it behave as an ini file

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2616,6 +2616,7 @@ file-types = [
   "kube",
   "network",
   { glob = ".editorconfig" },
+  { glob = "rclone.conf" },
   "properties",
   "cfg",
   "directory"


### PR DESCRIPTION
`rclone.conf` is actually an ini file, it is stated in the docs:

https://rclone.org/docs/#config-config-file
> The file format is basic [INI](https://en.wikipedia.org/wiki/INI_file#Format): Sections of text, led by a [section] header and followed by key=value entries on separate lines.

Following the discussion https://github.com/helix-editor/helix/pull/9653 relating to `.conf` files I have added it here as a glob so as the config file gets the correct highlighting and treesitter editing features.