### PR TITLE
define bufferline colors for gruvbox

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -47,6 +47,9 @@
 "ui.statusline.insert" = { fg = "fg1", bg = "blue0" }
 "ui.statusline.select" = { fg = "fg1", bg = "orange0" }
 "ui.statusline.inactive" = { fg = "fg4", bg = "bg1" }
+"ui.bufferline" = { fg = "fg1", bg = "bg1" }
+"ui.bufferline.active" = { fg = "bg0", bg = "yellow0" }
+"ui.bufferline.background" = { bg = "bg2" }
 "ui.popup" = { bg = "bg1" }
 "ui.window" = { bg = "bg1" }
 "ui.help" = { bg = "bg1", fg = "fg1" }


### PR DESCRIPTION
Gruvbox theme doesn't take advantage of specific bufferline colors and just uses defaults

Colors were chosen for the following reasons:
- bufferline
  - fg - default text color
  - bg - slightly darker than statusline, enough contrast to see tabs
- bufferline.active
  - fg - contrast, hard and soft contrast will change this
  - bg - arbitrary, just looked right of the available colors in the palette
- bufferline.background
  - bg - match statusline