### PR TITLE
Update goto_line_start/end keybindings in normal mode

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -50,8 +50,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `F`                   | Find previous char                                 | `find_prev_char`            |
 | `G`                   | Go to line number `<n>`                            | `goto_line`                 |
 | `Alt-.`               | Repeat last motion (`f`, `t` or `m`)               | `repeat_last_motion`        |
-| `Home`                | Move to the start of the line                      | `goto_line_start`           |
-| `End`                 | Move to the end of the line                        | `goto_line_end`             |
+| `gh`, `Home`          | Move to the start of the line                      | `goto_line_start`           |
+| `gl`, `End`           | Move to the end of the line                        | `goto_line_end`             |
 | `Ctrl-b`, `PageUp`    | Move page up                                       | `page_up`                   |
 | `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                 |
 | `Ctrl-u`              | Move cursor and page half page up                  | `page_cursor_half_up`       |


### PR DESCRIPTION
Update to include gh and gl as alternative key bindings for goto_line_start and goto_line_end