### PR TITLE
Add main.odin to Odin roots

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2011,7 +2011,7 @@ name = "odin"
 auto-format = true
 scope = "source.odin"
 file-types = ["odin"]
-roots = ["ols.json"]
+roots = ["ols.json", "main.odin"]
 language-servers = [ "ols" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }


### PR DESCRIPTION
`ols` recently gained the ability to use a global `ols.json` config instead of/in addition to local `ols.json` configs. However, a global config cannot properly work on its own in Helix, as Helix is unable to create the workspace it needs without a local config.

But, most Odin projects will have a `main.odin` file at the route of their sources, so also detecting this as a root could be a workaround for most Odin projects that don't want/need a local config.