### PR TITLE
Add spaces around position percentage

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -327,7 +327,7 @@ fn render_total_line_numbers<'a>(context: &RenderContext) -> Spans<'a> {
 fn render_position_percentage<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
     let maxrows = context.doc.text().len_lines();
-    Span::raw(format!("{}%", (position.row + 1) * 100 / maxrows)).into()
+    Span::raw(format!(" {}% ", (position.row + 1) * 100 / maxrows)).into()
 }
 
 fn render_file_encoding<'a>(context: &RenderContext) -> Spans<'a> {


### PR DESCRIPTION
This adds a fix to #3168 by adding spaces around the percentage value. This makes it consistent with other status elements.