### PR TITLE
Use "rosewater" for the jump label color in catppuccin themes

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -89,7 +89,7 @@
 "ui.virtual.ruler" = { bg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
 "ui.virtual.inlay-hint" = { fg = "overlay0", bg = "base" }
-"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
+"ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }
 
 "ui.selection" = { bg = "surface1" }
 


### PR DESCRIPTION
Preview of `catppuccin_mocha` displaying `helix-term/src/main.rs`:

![image](https://github.com/helix-editor/helix/assets/535282/4a3b0a93-0efa-4bfb-bacc-e019e09ac81b)
