### PR TITLE
Basic completion item kind suport

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -56,6 +56,8 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |
 | `completion-trigger-len` | The min-length of word under cursor to trigger autocompletion | `2` |
 | `completion-replace` | Set to `true` to make completions always replace the entire word and not just the part before the cursor | `false` |
+| `completion-item-kinds` | Custom kind text for completion items | `{}` |
+| `completion-item-columns` | Which columns should be displayed on each completion menu row | `["name", "kind"]` |
 | `auto-info` | Whether to display info boxes | `true` |
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -36,8 +36,8 @@ impl RenderContext {
         let mut completion_item_kinds = HashMap::new();
         let mut insert_item_kind = |kind: lsp::CompletionItemKind| {
             let kind = CompletionItemKindWrapper(kind);
-            let name = kind.to_string();
-            let style = if &name == "unknown" {
+            let name = kind.name();
+            let style = if name == "unknown" {
                 editor.theme.get("ui.menu.kind")
             } else {
                 editor.theme.get(&format!("ui.menu.kind.{name}"))
@@ -47,7 +47,7 @@ impl RenderContext {
                 .completion_item_kinds
                 .get(&kind)
                 .cloned()
-                .unwrap_or(name);
+                .unwrap_or_else(|| name.to_string());
 
             completion_item_kinds.insert(kind, (text, style))
         };
@@ -129,7 +129,7 @@ impl menu::Item for CompletionItem {
                                 .get(&CompletionItemKindWrapper(kind))
                         })
                         .cloned()
-                        .unwrap_or_else(|| ("".into(), Style::default()));
+                        .unwrap_or_else(|| (String::new(), Style::default()));
                     menu::Cell::from(Span::styled(content, style))
                 }
             });

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -61,6 +61,10 @@ impl<T: Component> Popup<T> {
         self.position
     }
 
+    pub fn set_position(&mut self, position: Position) {
+        self.position = Some(position);
+    }
+
     /// Set the popup to prefer to render above or below the anchor position.
     ///
     /// This preference will be ignored if the viewport doesn't have enough space in the

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -238,8 +238,8 @@ impl From<lsp::CompletionItemKind> for CompletionItemKindWrapper {
     }
 }
 
-impl ToString for CompletionItemKindWrapper {
-    fn to_string(&self) -> String {
+impl CompletionItemKindWrapper {
+    pub fn name(&self) -> &str {
         match self.0 {
             CompletionItemKind::TEXT => "text",
             CompletionItemKind::METHOD => "method",
@@ -268,7 +268,6 @@ impl ToString for CompletionItemKindWrapper {
             CompletionItemKind::TYPE_PARAMETER => "type_parameter",
             _ => "invalid", // invalid, but should never get one.
         }
-        .into()
     }
 }
 
@@ -277,8 +276,8 @@ impl Serialize for CompletionItemKindWrapper {
     where
         S: Serializer,
     {
-        let name = self.to_string();
-        serializer.serialize_str(&name)
+        let name = self.name();
+        serializer.serialize_str(name)
     }
 }
 
@@ -297,34 +296,7 @@ impl<'de> Deserialize<'de> for CompletionItemKindWrapper {
 
 impl std::hash::Hash for CompletionItemKindWrapper {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write_i32(match self.0 {
-            CompletionItemKind::TEXT => 1,
-            CompletionItemKind::METHOD => 2,
-            CompletionItemKind::FUNCTION => 3,
-            CompletionItemKind::CONSTRUCTOR => 4,
-            CompletionItemKind::FIELD => 5,
-            CompletionItemKind::VARIABLE => 6,
-            CompletionItemKind::CLASS => 7,
-            CompletionItemKind::INTERFACE => 8,
-            CompletionItemKind::MODULE => 9,
-            CompletionItemKind::PROPERTY => 10,
-            CompletionItemKind::UNIT => 11,
-            CompletionItemKind::VALUE => 12,
-            CompletionItemKind::ENUM => 13,
-            CompletionItemKind::KEYWORD => 14,
-            CompletionItemKind::SNIPPET => 15,
-            CompletionItemKind::COLOR => 16,
-            CompletionItemKind::FILE => 17,
-            CompletionItemKind::REFERENCE => 18,
-            CompletionItemKind::FOLDER => 19,
-            CompletionItemKind::ENUM_MEMBER => 20,
-            CompletionItemKind::CONSTANT => 21,
-            CompletionItemKind::STRUCT => 22,
-            CompletionItemKind::EVENT => 23,
-            CompletionItemKind::OPERATOR => 24,
-            CompletionItemKind::TYPE_PARAMETER => 25,
-            _ => 0xFFFF, // invalid, but should never get one.
-        })
+        state.write(self.name().as_bytes())
     }
 }
 


### PR DESCRIPTION
This PR allows the completion menu's style to be more configurable, allowing configurations like this:

![image](https://github.com/helix-editor/helix/assets/104871514/d93eea04-012f-42f3-b280-1d7cb86ff439)

The concerned configuration options are:
- `editor.completion-item-columns`: A list of either `name` or `kind`, for the symbol name and a user-defined string for its kind respectively.
- `editor.completion-item-kinds`: A list of the user-defined strings for completion item kinds. When a kind name is not set, it will use the kind's snake_name form instead (the default before this PR)

```toml
completion-item-columns = ["kind", "name"]
[editor.completion-item-kinds]
text = ""
method = ""
function = ""
constructor = ""
field = ""
variable = ""
class = ""
interface = ""
module = ""
property = ""
unit = ""
value = ""
enum = ""
keyword = " "
snippet = ""
color = ""
file = ""
reference = ""
folder = ""
enum_member = ""
constant = ""
struct = ""
event = ""
operator = ""
type_parameter = ""
``` 

In addition to this, themes are also concerned. The `ui.menu.kind` scope is the default, and `ui.completion.kind.{name}` for each kind, where {name} is the snake_case name of the kind name.