### PR TITLE
Revert allowing backspace to close empty prompts

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -544,10 +544,6 @@ impl Component for Prompt {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }
             ctrl!('h') | key!(Backspace) | shift!(Backspace) => {
-                if self.line.is_empty() {
-                    (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
-                    return close_fn;
-                }
                 self.delete_char_backwards(cx.editor);
                 (self.callback_fn)(cx, &self.line, PromptEvent::Update);
             }


### PR DESCRIPTION
This reverts commit 0dc67ff8852ce99d40ad4464062ebe212b0b03a1 / #9828.

See the post-merge discussion in #9828. The old behavior was less surprising and we have other ways to abort from a prompt, so let's revert the behavior change.