### PR TITLE
add initial support for bitbake language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -9,6 +9,7 @@
 | beancount | ✓ |  |  |  |
 | bibtex | ✓ |  |  | `texlab` |
 | bicep | ✓ |  |  | `bicep-langserver` |
+| bitbake | ✓ |  |  | `bitbake-language-server` |
 | blade | ✓ |  |  |  |
 | blueprint | ✓ |  |  | `blueprint-compiler` |
 | c | ✓ | ✓ | ✓ | `clangd` |

--- a/languages.toml
+++ b/languages.toml
@@ -12,6 +12,7 @@ awk-language-server = { command = "awk-language-server" }
 bash-language-server = { command = "bash-language-server", args = ["start"] }
 bass = { command = "bass", args = ["--lsp"] }
 bicep-langserver = { command = "bicep-langserver" }
+bitbake-language-server = { command = "bitbake-language-server" }
 bufls = { command = "bufls", args = ["serve"] }
 cairo-language-server = { command = "cairo-language-server", args = [] }
 cl-lsp = { command = "cl-lsp", args = [ "stdio" ] }
@@ -3208,6 +3209,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "dbml"
 source = { git = "https://github.com/dynamotn/tree-sitter-dbml", rev = "2e2fa5640268c33c3d3f27f7e676f631a9c68fd9" }
+
+[[language]]
+name = "bitbake"
+language-servers = [ "bitbake-language-server" ]
+scope = "source.bitbake"
+file-types = ["bb", "bbappend", "bbclass", {glob = "conf/*.conf" }, {glob = "conf/*/*.{inc,conf}" }, { glob = "recipe-*/*/*.inc" }]
+comment-token = "#"
+
+[[grammar]]
+name = "bitbake"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-bitbake", rev = "10bacac929ff36a1e8f4056503fe4f8717b21b94" }
 
 [[language]]
 name = "log"

--- a/runtime/queries/bitbake/highlights.scm
+++ b/runtime/queries/bitbake/highlights.scm
@@ -1,0 +1,82 @@
+
+; variables
+(variable_assignment (identifier) @variable.other.member)
+(variable_assignment (concatenation (identifier) @variable.other.member))
+(unset_statement (identifier) @variable.other.member)
+(export_statement (identifier) @variable.other.member)
+(variable_expansion (identifier) @variable.other.member)
+(python_function_definition (parameters (python_identifier) @variable.other.member))
+
+(variable_assignment (override) @keyword.storage.modifier)
+(overrides_statement (identifier) @keyword.storage.modifier)
+(flag) @keyword.storage.modifier
+
+[
+  "="
+  "?="
+  "??="
+  ":="
+  "=+"
+  "+="
+  ".="
+  "=."
+
+] @operator
+
+(variable_expansion [ "${" "}" ] @punctuation.special)
+[ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
+
+[
+  "noexec"
+  "INHERIT"
+  "OVERRIDES"
+  "$BB_ENV_PASSTHROUGH"
+  "$BB_ENV_PASSTHROUGH_ADDITIONS"
+] @variable.builtin
+
+; functions
+
+(python_function_definition (python_identifier) @function)
+(anonymous_python_function (identifier) @function)
+(function_definition (identifier) @function)
+(export_functions_statement (identifier) @function)
+(addtask_statement (identifier) @function)
+(deltask_statement (identifier) @function)
+(addhandler_statement (identifier) @function)
+(function_definition (override) @keyword.storage.modifier)
+
+[
+  "addtask"
+  "deltask"
+  "addhandler"
+  "unset"
+  "EXPORT_FUNCTIONS"
+  "python"
+  "def"
+] @keyword.function
+
+[
+  "append"
+  "prepend"
+  "remove"
+
+  "before"
+  "after"
+] @keyword.operator
+
+; imports
+
+[
+  "inherit"
+  "include"
+  "require"
+  "export"
+  "import"
+] @keyword.control.import
+
+(inherit_path) @namespace
+(include_path) @namespace
+
+
+(string) @string
+(comment) @comment

--- a/runtime/queries/bitbake/injections.scm
+++ b/runtime/queries/bitbake/injections.scm
@@ -1,0 +1,18 @@
+((python_function_definition) @injection.content
+  (#set! injection.language "python")
+  (#set! injection.include-children))
+
+((anonymous_python_function (block) @injection.content)
+  (#set! injection.language "python")
+  (#set! injection.include-children))
+
+((inline_python) @injection.content
+  (#set! injection.language "python")
+  (#set! injection.include-children))
+
+((function_definition) @injection.content
+  (#set! injection.language "bash")
+  (#set! injection.include-children))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
- integrate bitbake treesitter from https://github.com/tree-sitter-grammars/tree-sitter-bitbake
- highlights.scm and injections.scm are now nearly written from scratch and small, taking advantage of injections as bitbake is mostly based on bash and python languages. tested OK with treesitter examples https://github.com/tree-sitter-grammars/tree-sitter-bitbake/tree/master/examples
- bitbake-language-server integration tested with https://github.com/Freed-Wu/bitbake-language-server.git