### PR TITLE
Fix rustc warnings about unused 'pub use's

### DIFF
--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -9,7 +9,6 @@ use crate::handlers::completion::CompletionHandler;
 use crate::handlers::signature_help::SignatureHelpHandler;
 
 pub use completion::trigger_auto_completion;
-pub use helix_view::handlers::lsp::SignatureHelpInvoked;
 pub use helix_view::handlers::Handlers;
 
 mod completion;

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -20,8 +20,6 @@ mod handlers;
 use ignore::DirEntry;
 use url::Url;
 
-pub use keymap::macros::*;
-
 #[cfg(windows)]
 fn true_color() -> bool {
     true


### PR DESCRIPTION
Newer rustc versions warn about these unused exports. On rustc 1.76.0 for example:

```
warning: unused import: `helix_view::handlers::lsp::SignatureHelpInvoked`
  --> helix-term/src/handlers.rs:12:9
   |
12 | pub use helix_view::handlers::lsp::SignatureHelpInvoked;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `keymap::macros::*`
  --> helix-term/src/lib.rs:23:9
   |
23 | pub use keymap::macros::*;
   |         ^^^^^^^^^^^^^^^^^

warning: `helix-term` (lib) generated 2 warnings (run `cargo fix --lib -p helix-term` to apply 2 suggestions)
```