### PR TITLE
feat(themes): add `jump-label` for gruvbox themes

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -65,6 +65,7 @@
 "ui.virtual.ruler" = { bg = "bg1" }
 "ui.virtual.inlay-hint" = { fg = "gray1" }
 "ui.virtual.wrap" = { fg = "bg2" }
+"ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
 
 "diagnostic.warning" = { underline = { color = "orange1", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }


### PR DESCRIPTION
`gruvbox`:
![image](https://github.com/helix-editor/helix/assets/12489689/827f8f9e-761e-4675-8dea-e5f0b913385e)

`gruvbox-dark-hard`:
![image](https://github.com/helix-editor/helix/assets/12489689/e31b0dae-adfc-4fe5-a8df-6d6775ade376)

`gruvbox-dark-soft`
![image](https://github.com/helix-editor/helix/assets/12489689/29cdd115-9367-4f26-a3f2-e3b749d9a900)

`gruvbox-light`:
![image](https://github.com/helix-editor/helix/assets/12489689/28c07cdc-e976-4f37-8662-f868e177babf)

`gruvbox-light-hard`:
![image](https://github.com/helix-editor/helix/assets/12489689/3e6fa963-d756-42bb-aafb-01e0355677ab)

`gruvbox-light-soft`:
![image](https://github.com/helix-editor/helix/assets/12489689/53008943-4e06-4c76-8976-cf1526b2a10d)
