### PR TITLE
fix: don't highlight colons (:) in comments

### DIFF
--- a/runtime/queries/comment/highlights.scm
+++ b/runtime/queries/comment/highlights.scm
@@ -1,5 +1,3 @@
-":" @punctuation.delimiter
-
 ; Hint level tags
 ((tag (name) @hint)
  (#match? @hint "^(HINT|MARK|PASSED|STUB|MOCK)$"))


### PR DESCRIPTION
Since https://github.com/helix-editor/helix/pull/9253 landed, `(` `)` and `:` are always highlighted in comments.

`(` `)` highlighting was resolved in https://github.com/helix-editor/helix/pull/9800, this PR removes `:` highlighting.

I imagine there are cases where we would like `:` to be highlighted, e.g. `TODO:`, but I have no idea what I'm doing, so in the meantime I think highlighting nothing is better than highlighting everything, especially when it comes to themes where it really stands out (in this case, noctis)

![image_2024-03-26_16-58-04](https://github.com/helix-editor/helix/assets/36513243/be4bfd9a-8ac4-49ec-898e-48229ab167f1)
![image](https://github.com/helix-editor/helix/assets/36513243/ef28377d-7b68-41da-b6ce-86243935f267)

