### PR TITLE
feat: Add ADL language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -1,6 +1,7 @@
 | Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Default LSP |
 | --- | --- | --- | --- | --- |
 | ada | ✓ | ✓ |  | `ada_language_server`, `ada_language_server` |
+| adl | ✓ | ✓ | ✓ |  |
 | agda | ✓ |  |  |  |
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -3477,4 +3477,4 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "adl"
-source = { git = "https://github.com/adl-lang/tree-sitter-adl", rev = "0399ed80b9fb88865a02259e7c11dc98de1d5ee5" }
+source = { git = "https://github.com/adl-lang/tree-sitter-adl", rev = "2787d04beadfbe154d3f2da6e98dc45a1b134bbf" }

--- a/languages.toml
+++ b/languages.toml
@@ -3460,3 +3460,21 @@ language-servers = ["earthlyls"]
 [[grammar]]
 name = "earthfile"
 source = { git = "https://github.com/glehmann/tree-sitter-earthfile", rev = "2a6ab191f5f962562e495a818aa4e7f45f8a556a" }
+
+[[language]]
+name = "adl"
+scope = "source.adl"
+injection-regex = "adl"
+file-types = ["adl"]
+roots = []
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+
+[language.auto-pairs]
+'"' = '"'
+'{' = '}'
+'<' = '>'
+
+[[grammar]]
+name = "adl"
+source = { git = "https://github.com/adl-lang/tree-sitter-adl", rev = "0399ed80b9fb88865a02259e7c11dc98de1d5ee5" }

--- a/runtime/queries/adl/highlights.scm
+++ b/runtime/queries/adl/highlights.scm
@@ -1,0 +1,39 @@
+; adl
+
+[
+"module"
+"struct"
+"union"
+"type"
+"newtype"
+"annotation"
+] @keyword
+
+(scoped_name) @variable
+(comment) @comment
+(doc_comment) @info
+(name) @type
+
+(ERROR) @error
+
+(fname) @property
+
+(type_expr (scoped_name) @type)
+
+(type_expr (scoped_name) @generic (type_param) @type.param)
+
+; json
+(key) @string.special.key
+
+(string) @string
+
+(number) @number
+
+[
+  (null)
+  (true)
+  (false)
+] @constant.builtin
+
+(escape_sequence) @escape
+

--- a/runtime/queries/adl/highlights.scm
+++ b/runtime/queries/adl/highlights.scm
@@ -14,20 +14,18 @@
 (doc_comment) @info
 (name) @type
 
-(ERROR) @error
-
 (fname) @property
 
 (type_expr (scoped_name) @type)
 
-(type_expr (scoped_name) @generic (type_param) @type.param)
+(type_expr (scoped_name) @generic (type_param) @type.parameter)
 
 ; json
 (key) @string.special.key
 
 (string) @string
 
-(number) @number
+(number) @constant.numeric
 
 [
   (null)
@@ -35,5 +33,5 @@
   (false)
 ] @constant.builtin
 
-(escape_sequence) @escape
+(escape_sequence) @constant.character.escape
 

--- a/runtime/queries/adl/highlights.scm
+++ b/runtime/queries/adl/highlights.scm
@@ -9,19 +9,19 @@
 "annotation"
 ] @keyword
 
-(scoped_name) @variable
+(adl (scoped_name)) @namespace
 (comment) @comment
-(doc_comment) @info
+(doc_comment) @comment.block.documentation
 (name) @type
 
-(fname) @property
+(fname) @variable.other.member
 
 (type_expr (scoped_name) @type)
 
-(type_expr (scoped_name) @generic (type_param) @type.parameter)
+(type_expr_params (param (scoped_name) @type.parameter))
 
 ; json
-(key) @string.special.key
+(key) @string.special
 
 (string) @string
 

--- a/runtime/queries/adl/indents.scm
+++ b/runtime/queries/adl/indents.scm
@@ -1,0 +1,12 @@
+[
+  (struct)
+  (union)
+  
+  (array)
+  (object)
+] @indent
+
+; [
+;  "}"
+;  "]"
+; ] @outdent

--- a/runtime/queries/adl/textobjects.scm
+++ b/runtime/queries/adl/textobjects.scm
@@ -1,0 +1,1 @@
+(struct (_) @function.inside) @funtion.around


### PR DESCRIPTION
Created a tree-sitter grammar for [ADL](https://github.com/adl-lang/adl) to get syntax highlighting (and other goodness) in Helix.