### PR TITLE
Add jump-label to Kanagawa theme + format

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -7,147 +7,147 @@
 # because of some theming differences, it's not an exact copy of the original.
 
 ## User interface
-"ui.selection"         = { bg = "waveBlue2" }
+"ui.selection" = { bg = "waveBlue2" }
 "ui.selection.primary" = { bg = "waveBlue1" }
-"ui.background"        = { fg = "fujiWhite", bg = "sumiInk1" }
+"ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
-"ui.linenr"          = { fg = "sumiInk4" }
+"ui.linenr" = { fg = "sumiInk4" }
 "ui.linenr.selected" = { fg = "roninYellow" }
 
-"ui.virtual"                      = "sumiInk4"
-"ui.virtual.ruler"                = { bg = "sumiInk2" }
-"ui.virtual.inlay-hint"           = "fujiGray"
+"ui.virtual" = "sumiInk4"
+"ui.virtual.ruler" = { bg = "sumiInk2" }
+"ui.virtual.inlay-hint" = "fujiGray"
 "ui.virtual.inlay-hint.parameter" = { fg = "carpYellow", modifiers = ["dim"] }
-"ui.virtual.inlay-hint.type"      = { fg = "waveAqua2", modifiers = ["dim"] }
-"ui.virtual.jump-label"           = { fg = "peachRed", modifiers = ["bold"] }
+"ui.virtual.inlay-hint.type" = { fg = "waveAqua2", modifiers = ["dim"] }
+"ui.virtual.jump-label" = { fg = "peachRed", modifiers = ["bold"] }
 
-"ui.statusline"          = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }
-"ui.statusline.normal"   = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
-"ui.statusline.insert"   = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
-"ui.statusline.select"   = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
+"ui.statusline.normal" = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
 
-"ui.bufferline"            = { fg = "fujiGray", bg = "sumiInk0" }
-"ui.bufferline.active"     = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.bufferline" = { fg = "fujiGray", bg = "sumiInk0" }
+"ui.bufferline.active" = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.bufferline.background" = { bg = "sumiInk0" }
 
-"ui.popup"      = { fg = "fujiWhite", bg = "sumiInk0" }
-"ui.window"     = { fg = "sumiInk0" }
-"ui.help"       = { fg = "fujiWhite", bg = "sumiInk0" }
-"ui.text"       = "fujiWhite"
+"ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.window" = { fg = "sumiInk0" }
+"ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.text" = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 
-"ui.cursor"         = { fg = "waveBlue1", bg = "waveAqua2" }
+"ui.cursor" = { fg = "waveBlue1", bg = "waveAqua2" }
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "fujiWhite" }
-"ui.cursor.match"   = { fg = "waveRed", modifiers = ["bold"] }
-"ui.highlight"      = { fg = "fujiWhite", bg = "waveBlue2" }
-"ui.menu"           = { fg = "fujiWhite", bg = "waveBlue1" }
-"ui.menu.selected"  = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
-"ui.menu.scroll"    = { fg = "oldWhite", bg = "waveBlue1" }
+"ui.cursor.match" = { fg = "waveRed", modifiers = ["bold"] }
+"ui.highlight" = { fg = "fujiWhite", bg = "waveBlue2" }
+"ui.menu" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "oldWhite", bg = "waveBlue1" }
 
-"ui.cursorline.primary"   = { bg = "sumiInk3" }
+"ui.cursorline.primary" = { bg = "sumiInk3" }
 "ui.cursorcolumn.primary" = { bg = "sumiInk3" }
 
-"diagnostic.error"   = { underline = { color = "samuraiRed", style = "curl" } }
+"diagnostic.error" = { underline = { color = "samuraiRed", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
-"diagnostic.info"    = { underline = { color = "waveAqua1", style = "curl" } }
-"diagnostic.hint"    = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.info" = { underline = { color = "waveAqua1", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "dragonBlue", style = "curl" } }
 
-error   = "samuraiRed"
+error = "samuraiRed"
 warning = "roninYellow"
-info    = "waveAqua1"
-hint    = "dragonBlue"
+info = "waveAqua1"
+hint = "dragonBlue"
 
 ## Git gutter
-"diff.plus"  = "autumnGreen"
+"diff.plus" = "autumnGreen"
 "diff.minus" = "autumnRed"
 "diff.delta" = "autumnYellow"
 
 ## Syntax highlighting
-"attribute"                 = "waveRed"
-"type"                      = "waveAqua2"
-"constructor"               = "springBlue"
-"constant"                  = "surimiOrange"
-"constant.numeric"          = "sakuraPink"
+"attribute" = "waveRed"
+"type" = "waveAqua2"
+"constructor" = "springBlue"
+"constant" = "surimiOrange"
+"constant.numeric" = "sakuraPink"
 "constant.character.escape" = "springBlue"
-"string"                    = "springGreen"
-"string.regexp"             = "boatYellow2"
-"string.special.url"        = "springBlue"
-"string.special.symbol"     = "oniViolet"
-"comment"                   = "fujiGray"
-"variable"                  = "fujiWhite"
-"variable.builtin"          = "waveRed"
-"variable.parameter"        = "carpYellow"
-"variable.other.member"     = "carpYellow"
-"label"                     = "springBlue"
-"punctuation"               = "springViolet2"
-"keyword"                   = "oniViolet"
-"keyword.control.return"    = "peachRed"
+"string" = "springGreen"
+"string.regexp" = "boatYellow2"
+"string.special.url" = "springBlue"
+"string.special.symbol" = "oniViolet"
+"comment" = "fujiGray"
+"variable" = "fujiWhite"
+"variable.builtin" = "waveRed"
+"variable.parameter" = "carpYellow"
+"variable.other.member" = "carpYellow"
+"label" = "springBlue"
+"punctuation" = "springViolet2"
+"keyword" = "oniViolet"
+"keyword.control.return" = "peachRed"
 "keyword.control.exception" = "peachRed"
-"keyword.directive"         = "peachRed"
-"operator"                  = "boatYellow2"
-"function"                  = "crystalBlue"
-"function.builtin"          = "springBlue"
-"function.macro"            = "waveRed"
-"tag"                       = "waveAqua2"
-"namespace"                 = "surimiOrange"
-"special"                   = "peachRed"
+"keyword.directive" = "peachRed"
+"operator" = "boatYellow2"
+"function" = "crystalBlue"
+"function.builtin" = "springBlue"
+"function.macro" = "waveRed"
+"tag" = "waveAqua2"
+"namespace" = "surimiOrange"
+"special" = "peachRed"
 
 ## Markup modifiers
-"markup.heading.marker"  = "springViolet2"
-"markup.heading.1"       = { fg = "surimiOrange", modifiers = ["bold"] }
-"markup.heading.2"       = { fg = "carpYellow", modifiers = ["bold"] }
-"markup.heading.3"       = { fg = "waveAqua2", modifiers = ["bold"] }
-"markup.heading.4"       = { fg = "lightBlue", modifiers = ["bold"] }
-"markup.heading.5"       = { fg = "oniViolet", modifiers = ["bold"] }
-"markup.heading.6"       = { fg = "springViolet1", modifiers = ["bold"] }
-"markup.list.numbered"   = "sakuraPink"
+"markup.heading.marker" = "springViolet2"
+"markup.heading.1" = { fg = "surimiOrange", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "carpYellow", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "waveAqua2", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "lightBlue", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "oniViolet", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "springViolet1", modifiers = ["bold"] }
+"markup.list.numbered" = "sakuraPink"
 "markup.list.unnumbered" = "waveRed"
-"markup.bold"            = { modifiers = ["bold"] }
-"markup.italic"          = { modifiers = ["italic"] }
-"markup.strikethrough"   = { modifiers = ["crossed_out"] }
-"markup.link.text"       = "crystalBlue"
-"markup.link.url"        = { fg = "springBlue", underline.style = "line" }
-"markup.link.label"      = "surimiOrange"
-"markup.quote"           = "springViolet1"
-"markup.raw"             = "springGreen"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.text" = "crystalBlue"
+"markup.link.url" = { fg = "springBlue", underline.style = "line" }
+"markup.link.label" = "surimiOrange"
+"markup.quote" = "springViolet1"
+"markup.raw" = "springGreen"
 
 [palette]
-seaFoam       = "#C7CCD1" # custom lighter foreground
-fujiWhite     = "#DCD7BA" # default foreground
-oldWhite      = "#C8C093" # dark foreground, e.g. statuslines
-sumiInk0      = "#16161D" # dark background, e.g. statuslines, floating windows
-sumiInk1      = "#1F1F28" # default background
-sumiInk2      = "#2A2A37" # lighter background, e.g. colorcolumns, folds
-sumiInk3      = "#363646" # lighter background, e.g. cursorline
-sumiInk4      = "#54546D" # darker foreground, e.g. linenumbers, fold column
-waveBlue1     = "#223249" # popup background, visual selection background
-waveBlue2     = "#2D4F67" # popup selection background, search background
-winterGreen   = "#2B3328" # diff add background
-winterYellow  = "#49443C" # diff change background
-winterRed     = "#43242B" # diff deleted background
-winterBlue    = "#252535" # diff line background
-autumnGreen   = "#76946A" # git add
-autumnRed     = "#C34043" # git delete
-autumnYellow  = "#DCA561" # git change
-samuraiRed    = "#E82424" # diagnostic error
-roninYellow   = "#FF9E3B" # diagnostic warning
-waveAqua1     = "#6A9589" # diagnostic info
-dragonBlue    = "#658594" # diagnostic hint
-fujiGray      = "#727169" # comments
+seaFoam = "#C7CCD1"       # custom lighter foreground
+fujiWhite = "#DCD7BA"     # default foreground
+oldWhite = "#C8C093"      # dark foreground, e.g. statuslines
+sumiInk0 = "#16161D"      # dark background, e.g. statuslines, floating windows
+sumiInk1 = "#1F1F28"      # default background
+sumiInk2 = "#2A2A37"      # lighter background, e.g. colorcolumns, folds
+sumiInk3 = "#363646"      # lighter background, e.g. cursorline
+sumiInk4 = "#54546D"      # darker foreground, e.g. linenumbers, fold column
+waveBlue1 = "#223249"     # popup background, visual selection background
+waveBlue2 = "#2D4F67"     # popup selection background, search background
+winterGreen = "#2B3328"   # diff add background
+winterYellow = "#49443C"  # diff change background
+winterRed = "#43242B"     # diff deleted background
+winterBlue = "#252535"    # diff line background
+autumnGreen = "#76946A"   # git add
+autumnRed = "#C34043"     # git delete
+autumnYellow = "#DCA561"  # git change
+samuraiRed = "#E82424"    # diagnostic error
+roninYellow = "#FF9E3B"   # diagnostic warning
+waveAqua1 = "#6A9589"     # diagnostic info
+dragonBlue = "#658594"    # diagnostic hint
+fujiGray = "#727169"      # comments
 springViolet1 = "#938AA9" # light foreground
-oniViolet     = "#957FB8" # statements and keywords
-crystalBlue   = "#7E9CD8" # functions and titles
+oniViolet = "#957FB8"     # statements and keywords
+crystalBlue = "#7E9CD8"   # functions and titles
 springViolet2 = "#9CABCA" # brackets and punctuation
-springBlue    = "#7FB4CA" # specials and builtins
-lightBlue     = "#A3D4D5" # not used!
-waveAqua2     = "#7AA89F" # types
-springGreen   = "#98BB6C" # strings
-boatYellow1   = "#938056" # not used
-boatYellow2   = "#C0A36E" # operators, regex
-carpYellow    = "#E6C384" # identifiers
-sakuraPink    = "#D27E99" # numbers
-waveRed       = "#E46876" # standout specials 1, e.g. builtin variables
-peachRed      = "#FF5D62" # standout specials 2, e.g. exception handling, returns
-surimiOrange  = "#FFA066" # constants, imports, booleans
-katanaGray    = "#717C7C" # deprecated
+springBlue = "#7FB4CA"    # specials and builtins
+lightBlue = "#A3D4D5"     # not used!
+waveAqua2 = "#7AA89F"     # types
+springGreen = "#98BB6C"   # strings
+boatYellow1 = "#938056"   # not used
+boatYellow2 = "#C0A36E"   # operators, regex
+carpYellow = "#E6C384"    # identifiers
+sakuraPink = "#D27E99"    # numbers
+waveRed = "#E46876"       # standout specials 1, e.g. builtin variables
+peachRed = "#FF5D62"      # standout specials 2, e.g. exception handling, returns
+surimiOrange = "#FFA066"  # constants, imports, booleans
+katanaGray = "#717C7C"    # deprecated

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -7,109 +7,110 @@
 # because of some theming differences, it's not an exact copy of the original.
 
 ## User interface
-"ui.selection" = { bg = "waveBlue2" }
+"ui.selection"         = { bg = "waveBlue2" }
 "ui.selection.primary" = { bg = "waveBlue1" }
-"ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
+"ui.background"        = { fg = "fujiWhite", bg = "sumiInk1" }
 
-"ui.linenr" = { fg = "sumiInk4" }
+"ui.linenr"          = { fg = "sumiInk4" }
 "ui.linenr.selected" = { fg = "roninYellow" }
 
-"ui.virtual" = "sumiInk4"
-"ui.virtual.ruler" = { bg = "sumiInk2" }
-"ui.virtual.inlay-hint" = "fujiGray"
+"ui.virtual"                      = "sumiInk4"
+"ui.virtual.ruler"                = { bg = "sumiInk2" }
+"ui.virtual.inlay-hint"           = "fujiGray"
 "ui.virtual.inlay-hint.parameter" = { fg = "carpYellow", modifiers = ["dim"] }
-"ui.virtual.inlay-hint.type" = { fg = "waveAqua2", modifiers = ["dim"] }
+"ui.virtual.inlay-hint.type"      = { fg = "waveAqua2", modifiers = ["dim"] }
+"ui.virtual.jump-label"           = { fg = "peachRed", bg = "sumiInk0", modifiers = ["bold"] }
 
-"ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.statusline"          = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }
-"ui.statusline.normal" = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
-"ui.statusline.select" = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
+"ui.statusline.normal"   = { fg = "sumiInk0", bg = "crystalBlue", modifiers = ["bold"] }
+"ui.statusline.insert"   = { fg = "sumiInk0", bg = "autumnGreen", modifiers = ["bold"] }
+"ui.statusline.select"   = { fg = "sumiInk0", bg = "oniViolet", modifiers = ["bold"] }
 
-"ui.bufferline" = { fg = "fujiGray", bg = "sumiInk0" }
-"ui.bufferline.active" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.bufferline"            = { fg = "fujiGray", bg = "sumiInk0" }
+"ui.bufferline.active"     = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.bufferline.background" = { bg = "sumiInk0" }
 
-"ui.popup" = { fg = "fujiWhite", bg = "sumiInk0" }
-"ui.window" = { fg = "sumiInk0" }
-"ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
-"ui.text" = "fujiWhite"
+"ui.popup"      = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.window"     = { fg = "sumiInk0" }
+"ui.help"       = { fg = "fujiWhite", bg = "sumiInk0" }
+"ui.text"       = "fujiWhite"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue1", modifiers = ["bold"] }
 
-"ui.cursor" = { fg = "waveBlue1", bg = "waveAqua2"}
+"ui.cursor"         = { fg = "waveBlue1", bg = "waveAqua2" }
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "fujiWhite" }
-"ui.cursor.match" = { fg = "waveRed", modifiers = ["bold"] }
-"ui.highlight" = { fg = "fujiWhite", bg = "waveBlue2" }
-"ui.menu" = { fg = "fujiWhite", bg = "waveBlue1" }
-"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
-"ui.menu.scroll" = { fg = "oldWhite", bg = "waveBlue1" }
+"ui.cursor.match"   = { fg = "waveRed", modifiers = ["bold"] }
+"ui.highlight"      = { fg = "fujiWhite", bg = "waveBlue2" }
+"ui.menu"           = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu.selected"  = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+"ui.menu.scroll"    = { fg = "oldWhite", bg = "waveBlue1" }
 
-"ui.cursorline.primary" = { bg = "sumiInk3"}
+"ui.cursorline.primary"   = { bg = "sumiInk3" }
 "ui.cursorcolumn.primary" = { bg = "sumiInk3" }
 
-"diagnostic.error" = { underline = { color = "samuraiRed", style = "curl" } }
+"diagnostic.error"   = { underline = { color = "samuraiRed", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
-"diagnostic.info" = { underline = { color = "waveAqua1", style = "curl" } }
-"diagnostic.hint" = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.info"    = { underline = { color = "waveAqua1", style = "curl" } }
+"diagnostic.hint"    = { underline = { color = "dragonBlue", style = "curl" } }
 
-error = "samuraiRed"
+error   = "samuraiRed"
 warning = "roninYellow"
-info = "waveAqua1"
-hint = "dragonBlue"
+info    = "waveAqua1"
+hint    = "dragonBlue"
 
 ## Git gutter
-"diff.plus" = "autumnGreen"
+"diff.plus"  = "autumnGreen"
 "diff.minus" = "autumnRed"
 "diff.delta" = "autumnYellow"
 
 ## Syntax highlighting
-"attribute" = "waveRed"
-"type" = "waveAqua2"
-"constructor" = "springBlue"
-"constant" = "surimiOrange"
-"constant.numeric" = "sakuraPink"
+"attribute"                 = "waveRed"
+"type"                      = "waveAqua2"
+"constructor"               = "springBlue"
+"constant"                  = "surimiOrange"
+"constant.numeric"          = "sakuraPink"
 "constant.character.escape" = "springBlue"
-"string" = "springGreen"
-"string.regexp" = "boatYellow2"
-"string.special.url" = "springBlue"
-"string.special.symbol" = "oniViolet"
-"comment" = "fujiGray"
-"variable" = "fujiWhite"
-"variable.builtin" = "waveRed"
-"variable.parameter" = "carpYellow"
-"variable.other.member" = "carpYellow"
-"label" = "springBlue"
-"punctuation" = "springViolet2"
-"keyword" = "oniViolet"
-"keyword.control.return" = "peachRed"
+"string"                    = "springGreen"
+"string.regexp"             = "boatYellow2"
+"string.special.url"        = "springBlue"
+"string.special.symbol"     = "oniViolet"
+"comment"                   = "fujiGray"
+"variable"                  = "fujiWhite"
+"variable.builtin"          = "waveRed"
+"variable.parameter"        = "carpYellow"
+"variable.other.member"     = "carpYellow"
+"label"                     = "springBlue"
+"punctuation"               = "springViolet2"
+"keyword"                   = "oniViolet"
+"keyword.control.return"    = "peachRed"
 "keyword.control.exception" = "peachRed"
-"keyword.directive" = "peachRed"
-"operator" = "boatYellow2"
-"function" = "crystalBlue"
-"function.builtin" = "springBlue"
-"function.macro" = "waveRed"
-"tag" = "waveAqua2"
-"namespace" = "surimiOrange"
-"special" = "peachRed"
+"keyword.directive"         = "peachRed"
+"operator"                  = "boatYellow2"
+"function"                  = "crystalBlue"
+"function.builtin"          = "springBlue"
+"function.macro"            = "waveRed"
+"tag"                       = "waveAqua2"
+"namespace"                 = "surimiOrange"
+"special"                   = "peachRed"
 
 ## Markup modifiers
-"markup.heading.marker" = "springViolet2"
-"markup.heading.1" = { fg = "surimiOrange", modifiers = ["bold"] }
-"markup.heading.2" = { fg = "carpYellow", modifiers = ["bold"] }
-"markup.heading.3" = { fg = "waveAqua2", modifiers = ["bold"] }
-"markup.heading.4" = { fg = "lightBlue", modifiers = ["bold"] }
-"markup.heading.5" = { fg = "oniViolet", modifiers = ["bold"] }
-"markup.heading.6" = { fg = "springViolet1", modifiers = ["bold"] }
-"markup.list.numbered" = "sakuraPink"
+"markup.heading.marker"  = "springViolet2"
+"markup.heading.1"       = { fg = "surimiOrange", modifiers = ["bold"] }
+"markup.heading.2"       = { fg = "carpYellow", modifiers = ["bold"] }
+"markup.heading.3"       = { fg = "waveAqua2", modifiers = ["bold"] }
+"markup.heading.4"       = { fg = "lightBlue", modifiers = ["bold"] }
+"markup.heading.5"       = { fg = "oniViolet", modifiers = ["bold"] }
+"markup.heading.6"       = { fg = "springViolet1", modifiers = ["bold"] }
+"markup.list.numbered"   = "sakuraPink"
 "markup.list.unnumbered" = "waveRed"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.text" = "crystalBlue"
-"markup.link.url" = { fg = "springBlue", underline.style = "line" }
-"markup.link.label" = "surimiOrange"
-"markup.quote" = "springViolet1"
-"markup.raw" = "springGreen"
+"markup.bold"            = { modifiers = ["bold"] }
+"markup.italic"          = { modifiers = ["italic"] }
+"markup.strikethrough"   = { modifiers = ["crossed_out"] }
+"markup.link.text"       = "crystalBlue"
+"markup.link.url"        = { fg = "springBlue", underline.style = "line" }
+"markup.link.label"      = "surimiOrange"
+"markup.quote"           = "springViolet1"
+"markup.raw"             = "springGreen"
 
 [palette]
 seaFoam       = "#C7CCD1" # custom lighter foreground

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -19,7 +19,7 @@
 "ui.virtual.inlay-hint"           = "fujiGray"
 "ui.virtual.inlay-hint.parameter" = { fg = "carpYellow", modifiers = ["dim"] }
 "ui.virtual.inlay-hint.type"      = { fg = "waveAqua2", modifiers = ["dim"] }
-"ui.virtual.jump-label"           = { fg = "peachRed", bg = "sumiInk0", modifiers = ["bold"] }
+"ui.virtual.jump-label"           = { fg = "peachRed", modifiers = ["bold"] }
 
 "ui.statusline"          = { fg = "oldWhite", bg = "sumiInk0" }
 "ui.statusline.inactive" = { fg = "fujiGray", bg = "sumiInk0" }


### PR DESCRIPTION
I added the `ui.virtual.jump-label` to the Kanagawa theme and made some formatting.
Please let me know if I overstepped while formatting the file.

I got the colors from the [official Kanagawa repository](https://github.com/rebelot/kanagawa.nvim/blob/bfa818c7bf6259152f1d89cf9fbfba3554c93695/extras/kanagawa-theme.el#L394)