### PR TITLE
Update tree-sitter-julia

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -969,7 +969,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "julia"
-source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "8fb38abff74652c4faddbf04d2d5bbbc6b4bae25" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-julia", rev = "e84f10db8eeb8b9807786bfc658808edaa1b4fa2" }
 
 [[language]]
 name = "java"

--- a/runtime/queries/julia/folds.scm
+++ b/runtime/queries/julia/folds.scm
@@ -1,11 +1,14 @@
 [
- (module_definition)
- (struct_definition)
- (macro_definition)
- (function_definition)
- (compound_expression) ; begin blocks
- (let_statement)
- (if_statement)
- (for_statement)
- (while_statement)
+  (module_definition)
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+  (if_statement)
+  (try_statement)
+  (for_statement)
+  (while_statement)
+  (let_statement)
+  (quote_statement)
+  (do_clause)
+  (compound_statement) ; begin block
 ] @fold

--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -1,39 +1,48 @@
-; ----------
-; Primitives
-; ----------
+; ------------
+; Variables identifiers
+; ------------
 
-[
-  (line_comment)
-  (block_comment)
-] @comment
+(identifier) @variable
 
+; Remaining identifiers that start with capital letters should be types (PascalCase)
 (
-  ((identifier) @constant.builtin)
-  (#match? @constant.builtin "^(nothing|missing|undef)$"))
+  (identifier) @type
+  (match? @type "^[A-Z]"))
 
-[
-  (true)
-  (false)
-] @constant.builtin.boolean
-
-(integer_literal) @constant.numeric.integer
-(float_literal) @constant.numeric.float
-
+; SCREAMING_SNAKE_CASE
 (
-  ((identifier) @constant.numeric.float)
-  (#match? @constant.numeric.float "^((Inf|NaN)(16|32|64)?)$"))
+  (identifier) @constant
+  (match? @constant "^[A-Z][A-Z0-9_]*$"))
 
-(character_literal) @constant.character
-(escape_sequence) @constant.character.escape
+(const_statement
+  (assignment
+    . (identifier) @constant))
 
-(string_literal) @string
-
-(prefixed_string_literal
-  prefix: (identifier) @function.macro) @string
+; Field expressions are either module content or struct fields.
+; Module types and constants should already be captured, so this
+; assumes the remaining identifiers to be struct fields.
+(field_expression
+  (_)
+  (identifier) @variable.other.member)
 
 (quote_expression
-  (identifier) @string.special.symbol) 
-  
+  ":" @string.special.symbol
+  [
+    (identifier)
+    (operator)
+  ] @string.special.symbol)
+
+; ------
+; Macros
+; ------
+
+(macro_definition
+  name: (identifier) @function.macro)
+
+(macro_identifier
+  "@" @function.macro
+  (identifier) @function.macro)
+
 ; -------------------
 ; Modules and Imports
 ; -------------------
@@ -49,49 +58,6 @@
 
 (scoped_identifier
   (identifier) @namespace)
-
-; -----
-; Types
-; -----
-
-(abstract_definition
-  name: (identifier) @type)
-  
-(primitive_definition
-  name: (identifier) @type)
-
-(struct_definition
-  name: (identifier) @type)
-
-(struct_definition
-  . (_)
-    (identifier) @variable.other.member)
-
-(struct_definition
-  . (_)
-  (typed_expression
-    . (identifier) @variable.other.member))
-    
-(type_parameter_list
-  (identifier) @type)
-
-(constrained_type_parameter
-  (identifier) @type)
-  
-(subtype_clause
-  (identifier) @type)
-
-(typed_expression
-  (identifier) @type . )
-
-(parameterized_identifier
-  (identifier) @type)
-  
-(type_argument_list
-  (identifier) @type)
-
-(where_clause
-  (identifier) @type)
 
 ; -------------------
 ; Function definition
@@ -119,22 +85,6 @@
   ; prevent constructors (PascalCase) to be highlighted as functions
   (#match? @function "^[^A-Z]"))
 
-(parameter_list
-  (identifier) @variable.parameter)
-
-(typed_parameter
-  (identifier) @variable.parameter
-  (identifier)? @type)
-
-(optional_parameter
-  . (identifier) @variable.parameter)
-
-(slurp_parameter
-  (identifier) @variable.parameter)
-
-(function_expression
-  . (identifier) @variable.parameter)
-
 ; ---------------
 ; Functions calls
 ; ---------------
@@ -146,92 +96,293 @@
   (#match? @function "^[^A-Z]"))
 
 (
-  (broadcast_call_expression
-    (identifier) @function)
-  (#match? @function "^[^A-Z]"))
-
-(
   (call_expression
     (field_expression (identifier) @function .))
   (#match? @function "^[^A-Z]"))
 
 (
   (broadcast_call_expression
+    (identifier) @function)
+  (#match? @function "^[^A-Z]"))
+
+(
+  (broadcast_call_expression
     (field_expression (identifier) @function .))
   (#match? @function "^[^A-Z]"))
 
-; ------
-; Macros
-; ------
 
-(macro_definition
-  name: (identifier) @function.macro)
+; -------------------
+; Functions builtins
+; -------------------
 
-(macro_identifier
-  "@" @function.macro
-  (identifier) @function.macro)
+((identifier) @function.builtin
+  (#any-of? @function.builtin
+    "_abstracttype" "_apply_iterate" "_apply_pure" "_call_in_world" "_call_in_world_total"
+    "_call_latest" "_equiv_typedef" "_expr" "_primitivetype" "_setsuper!" "_structtype" "_typebody!"
+    "_typevar" "applicable" "apply_type" "arrayref" "arrayset" "arraysize" "const_arrayref"
+    "donotdelete" "fieldtype" "get_binding_type" "getfield" "ifelse" "invoke" "isa" "isdefined"
+    "modifyfield!" "nfields" "replacefield!" "set_binding_type!" "setfield!" "sizeof" "svec"
+    "swapfield!" "throw" "tuple" "typeassert" "typeof"))
+
+; -----------
+; Parameters
+; -----------
+
+(parameter_list
+  (identifier) @variable.parameter)
+
+(optional_parameter
+  . (identifier) @variable.parameter)
+
+(slurp_parameter
+  (identifier) @variable.parameter)
+
+(typed_parameter
+  parameter: (identifier)? @variable.parameter
+  type: (_) @type)
+
+(function_expression
+  . (identifier) @variable.parameter) ; Single parameter arrow functions
+
+; -----
+; Types
+; -----
+
+; Definitions
+(abstract_definition
+  name: (identifier) @type.definition) @keyword
+
+(primitive_definition
+  name: (identifier) @type.definition) @keyword
+
+(struct_definition
+  name: (identifier) @type)
+
+(struct_definition
+  . (_)
+    (identifier) @variable.other.member)
+
+(struct_definition
+  . (_)
+  (typed_expression
+    . (identifier) @variable.other.member))
+
+(type_clause
+  [
+    (identifier) @type
+    (field_expression
+      (identifier) @type .)
+  ])
+
+; Annotations
+(parametrized_type_expression
+  (_) @type
+  (curly_expression
+    (_) @type))
+
+(type_parameter_list
+  (identifier) @type)
+
+(typed_expression
+  (identifier) @type . )
+
+(function_definition
+  return_type: (identifier) @type)
+
+(short_function_definition
+  return_type: (identifier) @type)
+
+(where_clause
+  (identifier) @type)
+
+(where_clause
+  (curly_expression
+    (_) @type))
+
+; ---------
+; Builtins
+; ---------
+
+; This list was generated with:
+;
+;  istype(x) = typeof(x) === DataType || typeof(x) === UnionAll
+;  get_types(m) = filter(x -> istype(Base.eval(m, x)), names(m))
+;  type_names = sort(union(get_types(Core), get_types(Base)))
+;
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    "AbstractArray" "AbstractChannel" "AbstractChar" "AbstractDict" "AbstractDisplay"
+    "AbstractFloat" "AbstractIrrational" "AbstractLock" "AbstractMatch" "AbstractMatrix"
+    "AbstractPattern" "AbstractRange" "AbstractSet" "AbstractSlices" "AbstractString"
+    "AbstractUnitRange" "AbstractVecOrMat" "AbstractVector" "Any" "ArgumentError" "Array"
+    "AssertionError" "Atomic" "BigFloat" "BigInt" "BitArray" "BitMatrix" "BitSet" "BitVector" "Bool"
+    "BoundsError" "By" "CanonicalIndexError" "CapturedException" "CartesianIndex" "CartesianIndices"
+    "Cchar" "Cdouble" "Cfloat" "Channel" "Char" "Cint" "Cintmax_t" "Clong" "Clonglong" "Cmd" "Colon"
+    "ColumnSlices" "Complex" "ComplexF16" "ComplexF32" "ComplexF64" "ComposedFunction"
+    "CompositeException" "ConcurrencyViolationError" "Condition" "Cptrdiff_t" "Cshort" "Csize_t"
+    "Cssize_t" "Cstring" "Cuchar" "Cuint" "Cuintmax_t" "Culong" "Culonglong" "Cushort" "Cvoid"
+    "Cwchar_t" "Cwstring" "DataType" "DenseArray" "DenseMatrix" "DenseVecOrMat" "DenseVector" "Dict"
+    "DimensionMismatch" "Dims" "DivideError" "DomainError" "EOFError" "Enum" "ErrorException"
+    "Exception" "ExponentialBackOff" "Expr" "Float16" "Float32" "Float64" "Function" "GlobalRef"
+    "HTML" "IO" "IOBuffer" "IOContext" "IOStream" "IdDict" "IndexCartesian" "IndexLinear"
+    "IndexStyle" "InexactError" "InitError" "Int" "Int128" "Int16" "Int32" "Int64" "Int8" "Integer"
+    "InterruptException" "InvalidStateException" "Irrational" "KeyError" "LazyString" "LinRange"
+    "LineNumberNode" "LinearIndices" "LoadError" "Lt" "MIME" "Matrix" "Method" "MethodError"
+    "Missing" "MissingException" "Module" "NTuple" "NamedTuple" "Nothing" "Number" "Ordering"
+    "OrdinalRange" "OutOfMemoryError" "OverflowError" "Pair" "ParseError" "PartialQuickSort" "Perm"
+    "PermutedDimsArray" "Pipe" "ProcessFailedException" "Ptr" "QuoteNode" "Rational" "RawFD"
+    "ReadOnlyMemoryError" "Real" "ReentrantLock" "Ref" "Regex" "RegexMatch" "Returns"
+    "ReverseOrdering" "RoundingMode" "RowSlices" "SegmentationFault" "Set" "Signed" "Slices" "Some"
+    "SpinLock" "StackFrame" "StackOverflowError" "StackTrace" "Stateful" "StepRange" "StepRangeLen"
+    "StridedArray" "StridedMatrix" "StridedVecOrMat" "StridedVector" "String" "StringIndexError"
+    "SubArray" "SubString" "SubstitutionString" "Symbol" "SystemError" "Task" "TaskFailedException"
+    "Text" "TextDisplay" "Timer" "Tmstruct" "Tuple" "Type" "TypeError" "TypeVar" "UInt" "UInt128"
+    "UInt16" "UInt32" "UInt64" "UInt8" "UndefInitializer" "UndefKeywordError" "UndefRefError"
+    "UndefVarError" "Union" "UnionAll" "UnitRange" "Unsigned" "Val" "VecElement" "VecOrMat" "Vector"
+    "VersionNumber" "WeakKeyDict" "WeakRef"))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "begin" "end")
+  (#has-ancestor? @variable.builtin index_expression))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "begin" "end")
+  (#has-ancestor? @variable.builtin range_expression))
+
 
 ; --------
 ; Keywords
 ; --------
 
-(function_definition 
-  ["function" "end"] @keyword.function)
+[
+  "global"
+  "local"
+] @keyword
+
+(compound_statement
+  [
+    "begin"
+    "end"
+  ] @keyword)
+
+(quote_statement
+  [
+    "quote"
+    "end"
+  ] @keyword)
+
+(let_statement
+  [
+    "let"
+    "end"
+  ] @keyword)
 
 (if_statement
-  ["if" "end"] @keyword.control.conditional)
-(elseif_clause
-  ["elseif"] @keyword.control.conditional)
-(else_clause
-  ["else"] @keyword.control.conditional)
-(ternary_expression
-  ["?" ":"] @keyword.control.conditional)
+  [
+    "if"
+    "end"
+  ] @keyword.control.conditional)
 
-(for_statement
-  ["for" "end"] @keyword.control.repeat)
-(while_statement
-  ["while" "end"] @keyword.control.repeat)
-(break_statement) @keyword.control.repeat
-(continue_statement) @keyword.control.repeat
-(for_binding
-  "in" @keyword.control.repeat)
-(for_clause
-  "for" @keyword.control.repeat)
+(elseif_clause
+  "elseif" @keyword.control.conditional)
+
+(else_clause
+  "else" @keyword.control.conditional)
+
+(if_clause
+  "if" @keyword.control.conditional) ; `if` clause in comprehensions
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @keyword.control.conditional)
 
 (try_statement
-  ["try" "end" ] @keyword.control.exception)
+  [
+    "try"
+    "end"
+  ] @keyword.control.exception)
+
 (finally_clause
   "finally" @keyword.control.exception)
+
 (catch_clause
   "catch" @keyword.control.exception)
 
-[
-  "export"
-  "import"
-  "using"
-] @keyword.control.import
+(for_statement
+  [
+    "for"
+    "end"
+  ] @keyword.control.repeat)
+
+(while_statement
+  [
+    "while"
+    "end"
+  ] @keyword.control.repeat)
+
+(for_clause
+  "for" @keyword.control.repeat)
 
 [
-  "abstract"
-  "baremodule"
-  "begin"
+  (break_statement)
+  (continue_statement)
+] @keyword.control.repeat
+
+(module_definition
+  [
+    "module"
+    "baremodule"
+    "end"
+  ] @keyword.control.import)
+
+(import_statement
+  [
+    "import"
+    "using"
+  ] @keyword.control.import)
+
+(import_alias
+  "as" @keyword.control.import)
+
+(export_statement
+  "export" @keyword.control.import)
+
+(selected_import
+  ":" @punctuation.delimiter)
+
+(struct_definition
+  [
+    "struct"
+    "end"
+  ] @keyword)
+
+(macro_definition
+  [
+    "macro"
+    "end"
+  ] @keyword)
+
+(function_definition
+  [
+    "function"
+    "end"
+  ] @keyword.function)
+
+(do_clause
+  [
+    "do"
+    "end"
+  ] @keyword.function)
+
+(return_statement
+  "return" @keyword.control.return)
+
+[
   "const"
-  "do"
-  "end"
-  "let"
-  "macro"
-  "module"
   "mutable"
-  "primitive"
-  "quote"
-  "return"
-  "struct"
-  "type"
-  "where"
-] @keyword
-
-; TODO: fix this
-((identifier) @keyword (match? @keyword "global|local"))
+] @keyword.storage.modifier
 
 ; ---------
 ; Operators
@@ -239,13 +390,33 @@
 
 [
   (operator)
-  "::"
-  "<:"
-  ":"
-  "=>"
-  "..."
-  "$"
+  "="
+  "∈"
 ] @operator
+
+(adjoint_expression
+  "'" @operator)
+
+(range_expression
+  ":" @operator)
+
+((operator) @keyword.operator
+  (#any-of? @keyword.operator "in" "isa"))
+
+(for_binding
+  "in" @keyword.operator)
+
+(where_clause
+  "where" @keyword.operator)
+
+(where_expression
+  "where" @keyword.operator)
+
+(binary_expression
+  (_)
+  (operator) @operator
+  (identifier) @function
+  (#any-of? @operator "|>" ".|>"))
 
 ; ------------
 ; Punctuations
@@ -255,40 +426,58 @@
   "."
   "," 
   ";"
+  "::"
+  "->"
 ] @punctuation.delimiter
 
+"..." @punctuation.special
+
 [
-  "["
-  "]"
   "("
   ")" 
+  "["
+  "]"
   "{" 
   "}"
 ] @punctuation.bracket
 
-; ---------------------
-; Remaining identifiers
-; ---------------------
+; ---------
+; Literals
+; ---------
 
-(const_statement
-  (variable_declaration
-    . (identifier) @constant))
+(boolean_literal) @constant.builtin.boolean
 
-; SCREAMING_SNAKE_CASE
+(integer_literal) @constant.numeric.integer
+
+(float_literal) @constant.numeric.float
+
 (
-  (identifier) @constant
-  (match? @constant "^[A-Z][A-Z0-9_]*$"))
+  ((identifier) @constant.numeric.float)
+  (#match? @constant.numeric.float "^((Inf|NaN)(16|32|64)?)$"))
 
-; remaining identifiers that start with capital letters should be types (PascalCase)
 (
-  (identifier) @type
-  (match? @type "^[A-Z]"))
+  ((identifier) @constant.builtin)
+  (#match? @constant.builtin "^(nothing|missing|undef)$"))
 
-; Field expressions are either module content or struct fields.
-; Module types and constants should already be captured, so this
-; assumes the remaining identifiers to be struct fields.
-(field_expression
-  (_)
-  (identifier) @variable.other.member)
+(character_literal) @constant.character
 
-(identifier) @variable
+(escape_sequence) @constant.character.escape
+
+(string_literal) @string
+
+(prefixed_string_literal
+  prefix: (identifier) @function.macro) @string
+
+(command_literal) @string
+
+(prefixed_command_literal
+  prefix: (identifier) @function.macro) @string
+
+; ---------
+; Comments
+; ---------
+
+[
+  (line_comment)
+  (block_comment)
+] @comment

--- a/runtime/queries/julia/indents.scm
+++ b/runtime/queries/julia/indents.scm
@@ -2,15 +2,39 @@
   (struct_definition)
   (macro_definition)
   (function_definition)
-  (compound_expression)
-  (let_statement)
+  (compound_statement)
   (if_statement)
+  (try_statement)
   (for_statement)
   (while_statement)
+  (let_statement)
+  (quote_statement)
   (do_clause)
-  (parameter_list)
+  (assignment)
+  (for_binding)
+  (call_expression)
+  (parenthesized_expression)
+  (tuple_expression)
+  (comprehension_expression)
+  (matrix_expression)
+  (vector_expression)
 ] @indent
 
 [
   "end"
+  ")"
+  "]"
+  "}"
 ] @outdent
+
+(argument_list
+  . (_) @anchor
+  (#set! "scope" "tail")) @align
+
+(parameter_list
+  . (_) @anchor
+  (#set! "scope" "tail")) @align
+
+(curly_expression
+  . (_) @anchor
+  (#set! "scope" "tail")) @align

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -9,7 +9,8 @@
       (primitive_definition)
       (abstract_definition)
       (struct_definition)
-      (assignment_expression)
+      (short_function_definition)
+      (assignment)
       (const_statement)
     ])
   (#set! injection.language "markdown"))
@@ -22,9 +23,16 @@
   (#set! injection.language "comment"))
 
 (
+  [
+    (command_literal)
+    (prefixed_command_literal)
+  ] @injection.content
+  (#set! injection.language "sh"))
+
+(
   (prefixed_string_literal
     prefix: (identifier) @function.macro) @injection.content
-  (#eq? @function.macro "re")
+  (#eq? @function.macro "r")
   (#set! injection.language "regex"))
 
 (

--- a/runtime/queries/julia/locals.scm
+++ b/runtime/queries/julia/locals.scm
@@ -2,43 +2,100 @@
 ; Definitions
 ; -----------
 
-; Imports
-(import_statement
+; Variables
+(assignment
   (identifier) @local.definition)
-  
+
+(assignment
+  (tuple_expression
+    (identifier) @local.definition))
+
 ; Constants
 (const_statement
-  (variable_declaration
+  (assignment
     . (identifier) @local.definition))
+
+; let/const bindings
+(let_binding
+  (identifier) @local.definition)
+
+(let_binding
+  (tuple_expression
+    (identifier) @local.definition))
+
+; For bindings
+(for_binding
+  (identifier) @local.definition)
+
+(for_binding
+  (tuple_expression
+    (identifier) @local.definition))
+
+; Types
+(struct_definition
+  name: (identifier) @local.definition)
+
+(abstract_definition
+  name: (identifier) @local.definition)
+
+(abstract_definition
+  name: (identifier) @local.definition)
+
+(type_parameter_list
+  (identifier) @local.definition)
+
+; Module imports
+(import_statement
+  (identifier) @local.definition)
 
 ; Parameters
 (parameter_list
   (identifier) @local.definition)
 
-(typed_parameter
-  . (identifier) @local.definition)
-
-(optional_parameter .
+(optional_parameter
+  .
   (identifier) @local.definition)
 
 (slurp_parameter
   (identifier) @local.definition)
 
-(function_expression
-  . (identifier) @local.definition)
- 
-; ------
-; Scopes
-; ------
+(typed_parameter
+  parameter: (identifier) @local.definition
+  (_))
 
-[
-  (function_definition)
-  (short_function_definition)
-  (macro_definition)
-] @local.scope
+; Single parameter arrow function
+(function_expression
+  .
+  (identifier) @local.definition)
+
+; Function/macro definitions
+(function_definition
+  name: (identifier) @local.definition) @local.scope
+
+(short_function_definition
+  name: (identifier) @local.definition) @local.scope
+
+(macro_definition
+  name: (identifier) @local.definition) @local.scope
 
 ; ----------
 ; References
 ; ----------
 
 (identifier) @local.reference
+ 
+; ------
+; Scopes
+; ------
+
+[
+  (for_statement)
+  (while_statement)
+  (try_statement)
+  (catch_clause)
+  (finally_clause)
+  (let_statement)
+  (quote_statement)
+  (do_clause)
+] @local.scope 
+


### PR DESCRIPTION
This PR updates the parser to the latest version, and adapts the queries accordingly. Some changes were also brought from `nvim-treesitter`’s queries as well.

In light of the reversing of the queries (#9458), the order has also been changed. It tried to mimick the sections of the previous queries, while also following those of [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries/julia) to ease future updates (the diff will be more useful).

Everything seems to be working. There is just a tiny issue with indentation after compound blocks or for-loops. Specifically, the outdent after them should not happen.  For example, the cursor on the line ends up here:

```julia
function f()
    for i in 1:10
    end
|
end
```
While it should end up like so:

```julia
function f()
    for i in 1:10
    end
    |
end
```

~~This worked before (on 23.10, but not on master), and the indent queries remain more or less the same, so I don’t see what should be changed. From my tests, it seems recurring in other languages like `fish` that finish indent scopes with a keyword that is not indented. Any help is welcome!~~

I found out about the indentation heuristic, and the peculiar indent seems to be from it. So, not an issue with the PR. It would still be better if we could have the hybrid indentation (the default) while avoiding the outdent after the `end`.

Also, it would be nice if those who worked on the queries previously could take a look to see whether everything is working and whether they are fine with the new structure.

Closes #7309 