### PR TITLE
Add injections for GraphQL and ERB in Ruby

### DIFF
--- a/runtime/queries/ruby/injections.scm
+++ b/runtime/queries/ruby/injections.scm
@@ -6,3 +6,18 @@
   (heredoc_end) @name
   (#set! injection.language "sql")) 
  (#eq? @name "SQL"))
+
+((heredoc_body
+  (heredoc_content) @injection.content
+  (heredoc_end) @name
+  (#set! injection.language "graphql"))
+ (#any-of? @name
+       "GQL"
+       "GRAPHQL"))
+
+((heredoc_body
+  (heredoc_content) @injection.content
+  (heredoc_end) @name
+  (#set! injection.language "erb"))
+ (#any-of? @name "ERB"))
+

--- a/runtime/queries/ruby/injections.scm
+++ b/runtime/queries/ruby/injections.scm
@@ -19,5 +19,5 @@
   (heredoc_content) @injection.content
   (heredoc_end) @name
   (#set! injection.language "erb"))
- (#any-of? @name "ERB"))
+ (#eq? @name "ERB"))
 


### PR DESCRIPTION
This change adds 2 new injections for Ruby heredocs, ERB and GraphQL:

<img width="440" alt="image" src="https://github.com/helix-editor/helix/assets/19535809/cca9878f-3b7a-410d-b60e-f9d73c4ddf0e">

(Realistically you probably wouldn't write a GraphQL query in a [ViewComponent](https://viewcomponent.org/) but this fits in one screenshot)