### PR TITLE
fix: cursor line on material themes

### DIFF
--- a/runtime/themes/material_darker.toml
+++ b/runtime/themes/material_darker.toml
@@ -13,6 +13,7 @@ disabled = "#474747"
 
 accent = "#ff9800"
 
+active = "#323232"
 highlight = "#3f3f3f"
 
 comment = "#616161"

--- a/runtime/themes/material_deep_ocean.toml
+++ b/runtime/themes/material_deep_ocean.toml
@@ -76,7 +76,7 @@
 "ui.cursor" = { bg = "highlight", fg = "white" }
 
 "ui.cursor.primary" = { bg = "white", fg = "gray" }
-"ui.cursorline.primary" = { bg = "white" }
+"ui.cursorline.primary" = { bg = "active" }
 
 "ui.virtual" = { fg = "gray" }
 "ui.virtual.ruler" = { bg = "highlight" }
@@ -114,6 +114,7 @@ disabled = "#464b5d"
 
 accent = "#84ffff"
 
+active = "#1a1c25"
 highlight = "#1f2233"
 
 comment = "#464b5d"

--- a/runtime/themes/material_oceanic.toml
+++ b/runtime/themes/material_oceanic.toml
@@ -12,6 +12,7 @@ disabled = "#415967"
 
 accent = "#009688"
 
+active = "#314549"
 highlight = "#425b67"
 
 comment = "#546e7a"

--- a/runtime/themes/material_palenight.toml
+++ b/runtime/themes/material_palenight.toml
@@ -10,6 +10,7 @@ disabled = "#515772"
 
 accent = "#ab47bc"
 
+active = "#414863"
 highlight = "#444267"
 
 comment = "#676e95"


### PR DESCRIPTION
The cursorline on material theme is white. The theme is not bad but this makes it clearly unusable :smile: 

![image](https://github.com/helix-editor/helix/assets/40139584/25c00a6b-0e43-4a24-bde0-2b21b0d0aa91)

I'm trying to make that a bit more beautiful with this PR (I took the active color from some [nvim color scheme](https://github.com/marko-cerovac/material.nvim/blob/main/lua/material/colors/init.lua) of material)