### PR TITLE
Update version-typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tree-sitter = { version = "0.22" }
 nucleo = "0.2.0"
 
 [workspace.package]
-version = "24.3.0"
+version = "24.03.0"
 edition = "2021"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 categories = ["editor"]


### PR DESCRIPTION
When updating the homebrew-formula we ran into a typo in the version number. This should solve that, I think.