### PR TITLE
Make Helix.appdata.xml spec-compliant

### DIFF
--- a/contrib/Helix.appdata.xml
+++ b/contrib/Helix.appdata.xml
@@ -6,27 +6,26 @@
   <name>Helix</name>
   <summary>A post-modern text editor</summary>
   <summary xml:lang="ar">مُحَرِّرُ نُصُوصٍ سَابِقٌ لِعَهدِه</summary>
+  <developer id="com.helix_editor">
+    <name>Blaž Hrastnik</name>
+  </developer>
 
   <description>
     <p>
       Helix is a terminal-based text editor inspired by Kakoune / Neovim and written in Rust.
     </p>
-    <ul>
-      <li>Vim-like modal editing</li>
-      <li>Multiple selections</li>
-      <li>Built-in language server support</li>
-      <li>Smart, incremental syntax highlighting and code editing via tree-sitter</li>
-    </ul>
-  </description>
-  <description xml:lang="ar">
-    <p>
+    <p xml:lang="ar">
       مُحَرِّرُ نُصُوصٍ يَعمَلُ فِي الطَّرَفِيَّة، مُستَلهَمٌ مِن Kakoune وَ Neovim وَمَكتُوبٌ بِلُغَةِ رَست البَرمَجِيَّة.
     </p>
     <ul>
-      <li>تَحرِيرٌ وَضعِيٌّ شَبيهٌ بِـVim</li>
-      <li>تَحدِيدَاتٌ لِلنَّصِ مُتَعَدِّدَة</li>
-      <li>دَعْمٌ مُدمَجٌ لِخَوادِمِ اللُّغَات</li>
-      <li>تَحرِيرُ التَّعلِيمَاتِ البَّرمَجِيَّةِ مَعَ تَمييزٍ لِلتَّركِيبِ النَّحُويِّ بِواسِطَةِ tree-sitter</li>
+      <li>Vim-like modal editing</li>
+      <li xml:lang="ar">تَحرِيرٌ وَضعِيٌّ شَبيهٌ بِـVim</li>
+      <li>Multiple selections</li>
+      <li xml:lang="ar">تَحدِيدَاتٌ لِلنَّصِ مُتَعَدِّدَة</li>
+      <li>Built-in language server support</li>
+      <li xml:lang="ar">دَعْمٌ مُدمَجٌ لِخَوادِمِ اللُّغَات</li>
+      <li>Smart, incremental syntax highlighting and code editing via tree-sitter</li>
+      <li xml:lang="ar">تَحرِيرُ التَّعلِيمَاتِ البَّرمَجِيَّةِ مَعَ تَمييزٍ لِلتَّركِيبِ النَّحُويِّ بِواسِطَةِ tree-sitter</li>
     </ul>
   </description>
 
@@ -74,9 +73,9 @@
     </release>
   </releases>
 
-  <requires>
+  <recommends>
     <control>keyboard</control>
-  </requires>
+  </recommends>
 
   <categories>
     <category>Utility</category>


### PR DESCRIPTION
The `<description>` tag shouldn't be translated, but instead the individual paragraphs. This is kind of weird imo, but a spec is a spec i guess. 

The `<developer>` tag is required. I just put "The Helix Community" in there, but maybe just put @archseer by name?

It turns out, the `<requires>` tag actually means that the app can't even be installed without that control. What this should be is `<recommends>`.