### PR TITLE
feat(themes): add `jump-label` style for nightfox

### DIFF
--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -34,6 +34,7 @@
 "ui.virtual.whitespace" = { fg = "bg3" } # Whitespace markers in editing area.
 "ui.virtual.indent-guide" = { fg = "black" } # Vertical indent width guides
 "ui.virtual.inlay-hint" = { fg = "comment", bg = "bg2" } # Default style for inlay hints of all kinds
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold"] } # Style for virtual jump labels
 
 "ui.statusline" = { fg = "fg2", bg = "bg0" } # Status line.
 "ui.statusline.inactive" = { fg = "fg3", bg = "bg0" } # Status line in unfocused windows.


### PR DESCRIPTION
Add `jump-label` style for nightfox theme, _inspired_ by their [integration with hop.nvim](https://github.com/EdenEast/nightfox.nvim/blob/main/lua/nightfox/group/modules/hop.lua). The first key styling (`HopNextKey1`)  is applied to Helix's `jump-label` fully, since there isn't per key styling support.

Current:
![nighfox-jump-label-style-default](https://github.com/helix-editor/helix/assets/12203476/b57e8a29-5e4a-4f6f-8665-e9a365156e8d)

Updated:
![nighfox-jump-label-style-updated](https://github.com/helix-editor/helix/assets/12203476/068579ee-5ad3-4ec2-9b02-27e845692b88)