### PR TITLE
Support scrolling popup content using mouse

### DIFF
--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -146,6 +146,14 @@ impl<T: Component> Popup<T> {
         }
     }
 
+    pub fn scroll_half_page_down(&mut self) {
+        self.scroll(self.size.1 as usize / 2, true)
+    }
+
+    pub fn scroll_half_page_up(&mut self) {
+        self.scroll(self.size.1 as usize / 2, false)
+    }
+
     /// Toggles the Popup's scrollbar.
     /// Consider disabling the scrollbar in case the child
     /// already has its own.
@@ -200,11 +208,11 @@ impl<T: Component> Component for Popup<T> {
                 EventResult::Consumed(Some(close_fn))
             }
             ctrl!('d') => {
-                self.scroll(self.size.1 as usize / 2, true);
+                self.scroll_half_page_down();
                 EventResult::Consumed(None)
             }
             ctrl!('u') => {
-                self.scroll(self.size.1 as usize / 2, false);
+                self.scroll_half_page_up();
                 EventResult::Consumed(None)
             }
             _ => {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -201,7 +201,7 @@ impl<T: Component> Popup<T> {
             return EventResult::Ignored(None);
         }
 
-        return match kind {
+        match kind {
             MouseEventKind::ScrollDown if self.has_scrollbar => {
                 self.scroll_half_page_down();
                 EventResult::Consumed(None)
@@ -211,7 +211,7 @@ impl<T: Component> Popup<T> {
                 EventResult::Consumed(None)
             }
             _ => EventResult::Ignored(None),
-        };
+        }
     }
 }
 


### PR DESCRIPTION
Hey, long time no see :) This PR adds support for scrolling through the popup with the mouse as an alternative to the already existing `C-d` and `C-u` bindings. Scrolling is only done if `has_scrollbar` is `true`.

For ignoring mouse events that fall outside the frame of the popup, the rendering area `Rect` of the popup is stored in the struct. This feels hacky but I couldn't think of any other way to retrieve the area inside `handle_event()`.

---

The PR has been organized into commits that can be easily reviewed. Some commits are only concerned with moving code around with no new functionality introduced.