### PR TITLE
chore: add "ui.virtual.jump-label" to solarized colorschemes

### DIFF
--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -42,6 +42,7 @@
 
 "ui.virtual.whitespace" = { fg = "base01" }
 "ui.virtual.inlay-hint" = { fg = "base01", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 # 行号栏
 "ui.linenr" = { fg = "base0", bg = "base02" }

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -43,6 +43,7 @@
 
 "ui.virtual.whitespace" = { fg = "base01" }
 "ui.virtual.inlay-hint" = { fg = "base01", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 # 行号栏
 # line number column


### PR DESCRIPTION
I don't know if there are any recommendations, but red works for me - stands out, and I'm an exclusive solarized-dark user.