### PR TITLE
Add jump-label to Cyan Light theme

### DIFF
--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -98,9 +98,12 @@
 "ui.help" = { fg = "shade06", bg = "shade01" }
 "ui.text" = "shade05"
 "ui.text.focus" = { fg = "shade07", bg = "light_blue" }
+
 "ui.virtual" = "shade03"
 "ui.virtual.ruler" = { bg = "shade01" }
 "ui.virtual.inlay-hint" = { fg = "shade03_darker" }
+"ui.virtual.jump-label" = { fg = "shade07", bg = "shade01", modifiers = ["bold" ] }
+
 "ui.menu" = { fg = "shade05", bg = "shade01" }
 "ui.menu.selected" = { fg = "shade07", bg = "light_blue" }
 
@@ -108,6 +111,7 @@
 "info" = "light_blue"
 "warning" = "orange"
 "error" = "red"
+
 "diagnostic" = { modifiers = [] }
 "diagnostic.hint" = { underline = { color = "shade04", style = "line" } }
 "diagnostic.info" = { underline = { color = "light_blue", style = "line" } }


### PR DESCRIPTION
Add Jump Label styles to Cyan Light theme

## Before
![jump-labels-current](https://github.com/helix-editor/helix/assets/302837/eb862df5-0f3f-4773-80e1-e405e19819e3)

## After
![jump-labels-updated](https://github.com/helix-editor/helix/assets/302837/f1841b0f-1952-45a1-a901-e72ae63e2470)
