### PR TITLE
Adds query injection for comments in Gleam

### DIFF
--- a/runtime/queries/gleam/injections.scm
+++ b/runtime/queries/gleam/injections.scm
@@ -1,0 +1,3 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+


### PR DESCRIPTION
Noticed there wasn't an `injections.scm` for Gleam yet so I added one.