### PR TITLE
add new theme keys for LSP diagnostic tags

### DIFF
--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -24,6 +24,8 @@
 "diagnostic.error" = {bg="red", fg="white", modifiers=["bold"]}
 "diagnostic.warning" = {bg="orange", fg="black", modifiers=["bold"]}
 "diagnostic.hint" = {fg="gray", modifiers=["bold"]}
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "black", bg = "acme_bar_bg" }
 "ui.bufferline.active" = { fg = "black", bg = "acme_bg" }
 "diff.plus" = {fg = "green"}

--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -98,6 +98,8 @@
 "diagnostic.info" = { fg = "purple_2", modifiers = ["dim"] }
 "diagnostic.error" = { fg = "red_4", modifiers = ["underlined"] }
 "diagnostic.warning" = { fg = "yellow_2", modifiers = ["underlined"] }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.bufferline" = { fg = "dark_2", bg = "libadwaita_dark" }
 "ui.bufferline.active" = { fg = "light_4", bg = "libadwaita_dark_alt" }

--- a/runtime/themes/amberwood.toml
+++ b/runtime/themes/amberwood.toml
@@ -95,6 +95,8 @@
 "ui.menu.scroll" = { fg = "gray04", bg = "gray01" }
 
 diagnostic = { modifiers = ["underlined"] }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = "yellow"
 error = "error"

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -19,6 +19,8 @@
 "diagnostic.info" = { underline = { style = "line" } }
 "diagnostic" = { underline = { style = "line", color = "my_gray5" }, bg = "my_black"}
 "diagnostic.warning" = { underline = { style = "curl", color = "my_yellow2" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "diff.delta" = "my_gray5"
 "diff.minus" = "my_red"
 "diff.plus" = "my_green"

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -66,6 +66,8 @@
 "diagnostic.info"= { underline = { color = "blue", style="curl"} }
 "diagnostic.warning"= { underline = { color = "yellow", style="curl"} }
 "diagnostic.error"= { underline = { color = "red", style="curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
 "ui.debug" = { fg = "orange", bg = "background" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -66,6 +66,8 @@
 "diagnostic.info"= { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning"= { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error"= { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
 "ui.debug" = { fg = "orange", bg = "background" }

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -66,6 +66,8 @@
 "diagnostic.info"= { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning"= { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error"= { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
 "ui.debug" = { fg = "orange", bg = "background" }

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -77,6 +77,8 @@
 "diagnostic.error" = { underline = { color = "bogster-lred", style = "curl"} }
 "diagnostic.info" = { underline = { color = "bogster-teal", style = "curl"} }
 "diagnostic.hint" = { underline = { color = "bogster-blue", style = "curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 bogster-yellow = "#dcb659"

--- a/runtime/themes/bogster_light.toml
+++ b/runtime/themes/bogster_light.toml
@@ -77,6 +77,8 @@
 "diagnostic.error" = { underline = { color = "bogster-lred", style = "curl"} }
 "diagnostic.info" = { underline = { color = "bogster-teal", style = "curl"} }
 "diagnostic.hint" = { underline = { color = "bogster-blue", style = "curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 bogster-orange = "#dc7759"

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -67,6 +67,8 @@
 "diagnostic.error" = { underline = { color = "gold", style = "curl"} }
 "diagnostic.info" = { underline = { color = "lilac", style = "curl"} }
 "diagnostic.hint" = { underline = { color = "lilac", style = "curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 berry = "#3A2A4D"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -116,6 +116,8 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "red"
 warning = "yellow"

--- a/runtime/themes/curzon.toml
+++ b/runtime/themes/curzon.toml
@@ -75,6 +75,8 @@ label = "label"
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "warning", style = "curl" } }
 "diagnostic.error" = { underline = { color = "error", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = "warning"
 error = "#f43f5e"

--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -117,6 +117,8 @@
 "diagnostic.info" = { underline = { color = "light_blue", style = "line" } }
 "diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 shade00 = "#f2f3f7"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -76,6 +76,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl"} }
 "diagnostic.info" = { underline = { color = "grey05", style = "curl"} }
 "diagnostic.hint" = { underline = { color = "grey05", style = "curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "info" = "grey05"
 "hint" = "grey05"

--- a/runtime/themes/dark_high_contrast.toml
+++ b/runtime/themes/dark_high_contrast.toml
@@ -54,6 +54,8 @@
 "diagnostic.hint" = { underline = { color = "yellow", style = "dashed" } }
 "diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "info" = "white" 
 "hint" = "yellow"
 "warning" = "orange"

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -78,6 +78,8 @@
 'diagnostic.error'= { underline = { color = 'red', style = "curl"} }
 'diagnostic.info'= { underline = { color = 'blue', style = "curl"} }
 'diagnostic.warning'= { underline = { color = 'yellow', style = "curl"} }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 'special' = { fg = 'orange' }
 

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -26,6 +26,8 @@
 "diagnostic.warning"              = { underline = { color = "yellow",          style = "curl"             } }
 "diagnostic.error"                = { underline = { color = "red",             style = "curl"             } }
 "diagnostic.info"                 = { underline = { color = "cyan",            style = "curl"             } }
+"diagnostic.unnecessary"          = { modifiers = ["dim"]                                                   }
+"diagnostic.deprecated"           = { modifiers = ["crossed_out"]                                           }
 
 "error"                           = { fg    = "red"                                                         }
 "hint"                            = { fg    = "purple"                                                      }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -49,6 +49,9 @@
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }
 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
 "markup.heading" = { fg = "purple", modifiers = ["bold"] }
 "markup.list" = "cyan"
 "markup.bold" = { fg = "orange", modifiers = ["bold"] }

--- a/runtime/themes/emacs.toml
+++ b/runtime/themes/emacs.toml
@@ -87,6 +87,8 @@
 "diagnostic.warning" = { underline = { color = "dark_orange", style = "curl" } }
 "diagnostic.info" = { underline = { color = "forest_green", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "dark_cyan", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 black = "#000000"

--- a/runtime/themes/everblush.toml
+++ b/runtime/themes/everblush.toml
@@ -79,6 +79,8 @@
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
 "diagnostic.info" = { underline = { style = "curl", color = "blue" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "green" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "special" = { fg = "red-light" }
 
 "markup.heading" = { fg = "blue", modifiers = ["bold"] }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -111,6 +111,8 @@
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -110,6 +110,8 @@
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 

--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -68,6 +68,8 @@
 "diagnostic.error" = { underline = { color = "ferra_ember", style = "curl" } }
 "diagnostic.info" = { underline = { color = "ferra_blush", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "ferra_blush", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 ferra_night = "#2b292d"

--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -25,6 +25,8 @@
 "diagnostic.info" = { underline = { color = "orange_text", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "orange_text", style = "curl" } }
 "diagnostic.error" = { underline = { color = "diff_delete", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "info" = { fg = "orange_text", bg = "orange_bg" }
 "hint" = { modifiers = ["bold"] }

--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -105,6 +105,8 @@
 "diagnostic.info" = { underline = { color = "#A366C4", style = "line" } }
 "diagnostic.warning" = { underline = { color = "#FACB66", style = "line" } }
 "diagnostic.error" = { underline = { color = "#FF5269", style = "line" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 "White" = "#ffffff"

--- a/runtime/themes/flexoki_light.toml
+++ b/runtime/themes/flexoki_light.toml
@@ -30,6 +30,8 @@
 "diagnostic.info" = { underline = { color = "bl", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "ye", style = "curl" } }
 "diagnostic.error" = { underline = { color = "re", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "hint" = { fg = "bl", modifiers = ["bold"] }
 "info" = { fg = "ye", modifiers = ["bold"] }
 "warning" = { fg = "or", modifiers = ["bold"] }

--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -78,6 +78,8 @@ label = "scale.red.3"
 "diagnostic.info" = { underline = { color = "accent.fg", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "attention.fg", style = "curl" } }
 "diagnostic.error" = { underline = { color = "danger.fg", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 hint = "success.fg"
 info = "accent.fg"

--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -78,6 +78,8 @@ label = "scale.red.5"
 "diagnostic.info" = { underline = { color = "accent.fg", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "attention.fg", style = "curl" } }
 "diagnostic.error" = { underline = { color = "danger.fg", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 hint = "success.fg"
 info = "accent.fg"

--- a/runtime/themes/gruber-darker.toml
+++ b/runtime/themes/gruber-darker.toml
@@ -72,6 +72,8 @@
 "diagnostic.error" = { underline = { color = "red3", style = "dashed" } }
 "diagnostic.info" = { underline = { color = "aqua1", style = "dashed" } }
 "diagnostic.hint" = { underline = { color = "blue0", style = "dashed" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "markup.heading" = { fg = "aqua1", modifiers = ["bold"] }
 "markup.bold" = { modifiers = ["bold"] }

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -71,6 +71,8 @@
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }
 "diagnostic.info" = { underline = { color = "aqua1", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "blue1", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "markup.heading" = "aqua1"
 "markup.bold" = { modifiers = ["bold"] }

--- a/runtime/themes/heisenberg.toml
+++ b/runtime/themes/heisenberg.toml
@@ -63,6 +63,8 @@
 "diagnostic.info" = { underline = {color = "crystal_blue", style = "curl" } }
 "diagnostic.warning" = { underline = {color = "vapor_yellow", style = "curl" } }
 "diagnostic.error" = { underline = {color = "chili_powder_red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "gray", bg = "background" }
 "ui.bufferline.active" = { fg = "foreground", bg = "dark_gray" }
 

--- a/runtime/themes/hex_steel.toml
+++ b/runtime/themes/hex_steel.toml
@@ -64,6 +64,8 @@
 "diagnostic.warning" = { underline = { color = "warning", style = "curl" } }
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "display", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "error" = { fg = "error", modifiers = ["bold"] }
 "warning" = { fg = "warning", modifiers = ["bold"] }

--- a/runtime/themes/horizon-dark.toml
+++ b/runtime/themes/horizon-dark.toml
@@ -45,6 +45,8 @@ namespace = "orange"
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostics.error" = { underline = { color = "red", style = "curl" } }
 "diagnostics.warning" = { underline = { color = "orange", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = { fg = "orange", modifiers = ["bold"] }
 error = { fg = "red", modifiers = ["bold"] }

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -73,3 +73,5 @@
 "diagnostic.error" = { underline = { color = "#D74E50", style = "curl" } }
 "diagnostic.info" = { underline = { color = "#839A53", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "#A6B6CE", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }

--- a/runtime/themes/jellybeans.toml
+++ b/runtime/themes/jellybeans.toml
@@ -99,6 +99,8 @@
 "diagnostic.info" = { underline = { color = "blue_accent", style = "line" } }
 "diagnostic.warning" = { underline = { color = "yellow_accent", style = "line" } }
 "diagnostic.error" = { underline = { color = "red_error", style = "line" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 background = "#151515"

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -52,6 +52,8 @@
 "diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "waveAqua1", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "samuraiRed"
 warning = "roninYellow"

--- a/runtime/themes/kaolin-dark.toml
+++ b/runtime/themes/kaolin-dark.toml
@@ -44,6 +44,8 @@
 "diagnostic.warning" = { underline = { style = "curl", color = "warn" } }
 "diagnostic.info" = { underline = { style = "curl", color = "info" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "hint" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.background" = { bg = "bg0" }
 "ui.linenr" = { fg = "gray0" }

--- a/runtime/themes/material_deep_ocean.toml
+++ b/runtime/themes/material_deep_ocean.toml
@@ -95,6 +95,9 @@ error = "error"
 info = "blue"
 hint = "purple"
 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
 [palette]
 bg = "#0f111a"
 text = "#a6accd"

--- a/runtime/themes/meliora.toml
+++ b/runtime/themes/meliora.toml
@@ -58,6 +58,8 @@
 "diagnostic.warning" = { underline = { color = "orange", style = "curl" } }
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "magenta", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "error" = { fg = "red" }
 "warning" = { fg = "orange" }

--- a/runtime/themes/mellow.toml
+++ b/runtime/themes/mellow.toml
@@ -99,6 +99,8 @@
 "diagnostic.error" = { underline = { color = "bright_red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "bright_blue", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "bright_cyan", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = "bright_yellow"
 error = "bright_red"

--- a/runtime/themes/merionette.toml
+++ b/runtime/themes/merionette.toml
@@ -63,6 +63,8 @@
 "diagnostic.hint" = { underline = { color = "white0", style = "double_line" } }
 "diagnostic.info" = { underline = { color = "blue0", style = "double_line" } }
 "diagnostic.warning" = { underline = { color = "green1", style = "double_line" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "markup.bold" = { modifiers = ["bold"] }
 "markup.heading" = { fg = "orange1", modifiers = ["bold"] }

--- a/runtime/themes/modus_operandi.toml
+++ b/runtime/themes/modus_operandi.toml
@@ -99,6 +99,8 @@ punctuation = "fg-dim"
 "diagnostic.warning" = { underline = { color = "yellow-intense", style = "curl" } }
 "diagnostic.info" = { underline = { color = "cyan-intense", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "blue-intense", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "red"
 warning = "yellow-warmer"

--- a/runtime/themes/modus_vivendi.toml
+++ b/runtime/themes/modus_vivendi.toml
@@ -102,6 +102,8 @@ punctuation = "fg-dim"
 "diagnostic.warning" = { underline = { color = "yellow-intense", style = "curl" } }
 "diagnostic.info" = { underline = { color = "cyan-intense", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "blue-intense", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "red"
 warning = "yellow-warmer"

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -96,6 +96,8 @@
 "diagnostic.error" = { underline = { color = "#f48771", style = "curl" } }
 "diagnostic.info" = { underline = { color = "#75beff", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "#eeeeb3", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 type = "#A6E22E"

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -100,6 +100,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
 "markup.heading" = "green"

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -97,6 +97,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
 "markup.heading" = "green"

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -100,6 +100,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
 "markup.heading" = "green"

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -97,6 +97,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
 "markup.heading" = "green"

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -97,6 +97,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "base8", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "base8", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # markup highlight, no need for `markup.raw` and `markup.list`, make them to be default
 "markup.heading" = "green"

--- a/runtime/themes/monokai_soda.toml
+++ b/runtime/themes/monokai_soda.toml
@@ -14,6 +14,8 @@
 "diagnostic.error" = { underline = { style = "curl", color = "pink" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "orange" } }
 "diagnostic.info" = { underline = { style = "curl", color = "white" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 ## Diffs
 "diff.plus" = "green"

--- a/runtime/themes/naysayer.toml
+++ b/runtime/themes/naysayer.toml
@@ -25,6 +25,8 @@
 "diagnostic.error" = { bg = "error", fg = "text", modifiers = ["bold"] }
 "diagnostic.warning" = { bg = "warning", fg = "text", modifiers = ["bold"] }
 "diagnostic.hint" = { bg = "cyan", modifiers = ["bold"] }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.bufferline" = { fg = "text", bg = "bg" }
 "ui.bufferline.active" = { fg = "text", bg = "bg", modifiers = ['underlined'] }
 "ui.gutter.selected" = { bg = "highlight-line", modifiers = ["bold"] }

--- a/runtime/themes/new_moon.toml
+++ b/runtime/themes/new_moon.toml
@@ -96,6 +96,8 @@
 
 "diagnostic.error".underline = { color = "red", style = "curl" }
 "diagnostic".underline = { color = "yellow", style = "curl" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 darkest = "#2d2d2d"

--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -10,6 +10,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "paleblue", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # UI
 'ui.background' = { fg = 'foreground', bg = 'background' }

--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -76,6 +76,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } } #	Diagnostics error (editing area)
 "diagnostic.info" = { underline = { color = "blue", style = "curl" } } #	Diagnostics info (editing area)
 "diagnostic.hint" = { underline = { color = "green", style = "curl" } } #	Diagnostics hint (editing area)
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 
 # SYNTAX HIGHLIGHTING

--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -17,6 +17,8 @@
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
 "diagnostic.info" = { underline = { color = "mid-blue", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "light-green", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # UI ==============================
 # For styling helix itself.

--- a/runtime/themes/noctis_bordo.toml
+++ b/runtime/themes/noctis_bordo.toml
@@ -59,6 +59,8 @@
 "diagnostic.hint" = { underline = { color = "base03", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "base09", style = "curl" } }
 "diagnostic.error" = { underline = { color = "base08", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.gutter" = { bg = "base01" }
 "info" = "base0D"

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -24,6 +24,8 @@
 "info" = "nord8"
 "diagnostic.warning" = { underline = { color = "nord13", style = "curl" } }
 "warning" = "nord13"
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # Diffs
 "diff.delta" = "nord13"

--- a/runtime/themes/nord_light.toml
+++ b/runtime/themes/nord_light.toml
@@ -35,6 +35,8 @@
 "diagnostic.warning" = { underline = { color = "nord13", style = "curl" } }
 "diagnostic.info" = { underline = { color = "nord13", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "nord13", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "constant.numeric" = {fg="nord15"}
 "constant.builtin" = {fg="nord15"}

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -45,6 +45,8 @@
 "diagnostic.hint".underline = { color = "green", style = "curl" } 
 "diagnostic.warning".underline = { color = "yellow", style = "curl" } 
 "diagnostic.error".underline = { color = "red", style = "curl" } 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -46,6 +46,8 @@
 "diagnostic.hint".underline = { color = "green", style = "curl" } 
 "diagnostic.warning".underline = { color = "yellow", style = "curl" } 
 "diagnostic.error".underline = { color = "red", style = "curl" } 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }

--- a/runtime/themes/onelight.toml
+++ b/runtime/themes/onelight.toml
@@ -163,6 +163,8 @@
 "diagnostic.hint" = { underline = { color = "green", style = "dashed" } }
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }

--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -49,6 +49,8 @@
 "diagnostic.error".underline = { color = "bright1", style = "curl" }
 "diagnostic.info".underline = { color = "bright4", style = "curl" }
 "diagnostic.hint".underline = { color = "bright6", style = "curl" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 # Tree-sitter scopes for syntax highlighting
 "attribute" = "bright4"

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -47,6 +47,8 @@ error = "red"
 "diagnostic.info".underline = { color = "sky", style = "curl" } 
 "diagnostic.warning".underline = { color = "yellow", style = "curl" } 
 "diagnostic.error".underline = { color = "red", style = "curl" } 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.background" = { bg = "shade" }
 "ui.background.separator" = "sky"

--- a/runtime/themes/poimandres.toml
+++ b/runtime/themes/poimandres.toml
@@ -76,6 +76,8 @@ string = { fg = "brightMint" }
 "diagnostic.info" = { underline = { color = "lightBlue", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "brightYellow", style = "curl" } }
 "diagnostic.error" = { underline = { color = "hotRed", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 hint = "lowerMint"
 info = "lightBlue"

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -12,6 +12,8 @@ error = { fg = 'redE', modifiers = ['bold'] }
 'diagnostic.hint'.underline = { color = 'yellowH', style = 'curl' } 
 'diagnostic.warning'.underline = { color = 'orangeW', style = 'curl' } 
 'diagnostic.error'.underline = { color = 'redE', style = 'curl' } 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 'ui.background' = { bg = 'brownN' }
 'ui.window' = { bg = 'brownH', fg = 'brownD' } 
 'ui.gutter' = { bg = 'brownU' }

--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -107,6 +107,8 @@
 "diagnostic.error".underline = { color = "bright_red", style = "curl" } 
 "diagnostic.info".underline = { color = "bright_blue", style = "curl" } 
 "diagnostic.hint".underline = { color = "bright_cyan", style = "curl" } 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = "bright_yellow"
 error = "bright_red"

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -64,6 +64,8 @@
 "diagnostic.info" = { underline = { color = "foam", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "gold", style = "curl" } }
 "diagnostic.error" = { underline = { color = "love", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "special" = "rose"
 
 "attribute" = "iris"

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -63,6 +63,8 @@
 "diagnostic.info" = { underline = { style = "curl", color = "aqua" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
 "diagnostic.error" = { underline = { style = "curl", color = "nasty-red" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "diff.plus" = { fg = "green" }
 "diff.delta" = { fg = "orange" }

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -63,6 +63,8 @@
 "diagnostic.info" = { underline = { style = "curl", color = "aqua" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
 "diagnostic.error" = { underline = { style = "curl", color = "nasty-red" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "diff.plus" = { fg = "bg_green" }
 "diff.delta" = { fg = "bg_blue" }

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -79,6 +79,9 @@
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }
 
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
 "markup.heading" = { fg = "purple", modifiers = ["bold"] }
 "markup.link.label" = { fg = "blue", modifiers = ["italic"] }
 "markup.list" = "cyan"

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -109,6 +109,8 @@
 "diagnostic.error" = { underline = { style = "curl", color = "red" } }
 "diagnostic.info" = { underline = { style = "curl", color = "blue" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "base01" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 # 深色 越来越深

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -126,6 +126,8 @@
 "diagnostic.error" = { underline = { style = "curl", color = "red" } }
 "diagnostic.info" = { underline = { style = "curl", color = "blue" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "base01" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 
 [palette]

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -85,6 +85,8 @@ error = { fg = 'red', bg = 'bg2', modifiers = ['bold'] }
 "diagnostic.hint" = { underline = { style = "curl", color = "blue" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
 "diagnostic.error" = { underline = { style = "curl", color = "red" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 
 

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -78,6 +78,8 @@
 "diagnostic.error" = { underline = { style = "curl", color = "#e0211d" } }
 "diagnostic.info" = { underline = { style = "curl", color = "theme_yellow" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "bg2" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 base = "#655370"

--- a/runtime/themes/starlight.toml
+++ b/runtime/themes/starlight.toml
@@ -85,6 +85,8 @@
 "diagnostic.warning"  = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info"     = { underline = { color = "blue", style = "curl" } }
 "diagnostic.hint"     = { underline = { color = "blue", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "info"     = "blue"
 "hint"     = "blue"

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -65,6 +65,8 @@ hint = { fg = "hint" }
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow"} }
 "diagnostic.info" = { underline = { style = "curl", color = "info"} }
 "diagnostic.hint" = { underline = { style = "curl", color = "hint" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.background" = { bg = "bg", fg = "fg" }
 "ui.cursor" = { modifiers = ["reversed"] }

--- a/runtime/themes/ttox.toml
+++ b/runtime/themes/ttox.toml
@@ -29,3 +29,5 @@
 "diagnostic.warning" = { fg = "black", bg = "light-yellow" }
 "diagnostic.error" = { fg = "black", bg = "light-red" }
 "diagnostic.hint" = { fg = "black", bg = "light-blue" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }

--- a/runtime/themes/varua.toml
+++ b/runtime/themes/varua.toml
@@ -76,6 +76,8 @@
 "diagnostic.info" = { underline = { style = "curl", color = "aqua" } }
 "diagnostic.warning" = { underline = { style = "curl", color = "yellow" } }
 "diagnostic.error" = { underline = { style = "curl", color = "red" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 [palette]
 bg0 = "#282828"

--- a/runtime/themes/vim_dark_high_contrast.toml
+++ b/runtime/themes/vim_dark_high_contrast.toml
@@ -21,6 +21,8 @@
 "diagnostic.warning" = { bg = "dark-yellow" }
 "diagnostic.hint" = { bg = "dark-cyan" }
 "diagnostic.info" = { bg = "dark-white" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "warning" = { fg = "yellow", bg = "dark-yellow" }
 "error" = { fg = "red", bg = "dark-red" }
 "info" = { fg = "default", bg = "dark-white" }

--- a/runtime/themes/voxed.toml
+++ b/runtime/themes/voxed.toml
@@ -75,6 +75,8 @@ label = "yellow"
 "diagnostic.info" = { underline = { color = "sglow", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "redish", style = "curl" } }
 "diagnostic.error" = { underline = { color = "bpink", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 warning = "bpink"
 error = "bsienna"

--- a/runtime/themes/yellowed.toml
+++ b/runtime/themes/yellowed.toml
@@ -111,6 +111,8 @@
 "diagnostic.error"                = { underline = { color = "error", style = "curl" } }
 "diagnostic.info"                 = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint"                 = { underline = { color = "hint", style = "curl" } }
+"diagnostic.unnecessary"          = { modifiers = ["dim"] }
+"diagnostic.deprecated"           = { modifiers = ["crossed_out"] }
 
 [palette]
 # interface

--- a/runtime/themes/zed_onedark.toml
+++ b/runtime/themes/zed_onedark.toml
@@ -42,6 +42,8 @@
 "diagnostic.hint".underline = { color = "green", style = "curl" }
 "diagnostic.warning".underline = { color = "yellow", style = "curl" }
 "diagnostic.error".underline = { color = "red", style = "curl" }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "info" = { fg = "blue", modifiers = ["bold"] }
 "hint" = { fg = "green", modifiers = ["bold"] }
 "warning" = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/zenburn.toml
+++ b/runtime/themes/zenburn.toml
@@ -45,6 +45,8 @@
 
 "diagnostic" = {bg = "statusbg"}
 "diagnostic.error" = { fg = "errorfg", bg = "errorbg"}
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 "ui.gutter" = { bg = "statusbg" }
 "hint" = {fg = "numeric", bg = "statusbg"}
 "warning" = "numeric"


### PR DESCRIPTION
Hello, 

I noticed that the new LSP Diagnostic theme keys (#9780) have been added only to a few themes (#9949, #9967). 

So, I've tried to add them to the remaining themes (under `helix/runtime/themes/`) excluding the inherited themes (i.e. themes with `inherits` property).

Screenshot: `gruvbox_dark_hard`
![image](https://github.com/helix-editor/helix/assets/54745129/1c5f7ff5-42d9-4aa9-9b2c-23cbaa31d0b0)

|Summary:|||
|:-|-:|:-|
| Total Themes | 134 | (under `helix/runtime/themes/`) |
| Inherited Themes | 44 | (skipped) |
| Themes with latest diagnostic tags | 2 | (skipped) - `jetbrains_dark.toml`, `dark_plus.toml`|
| **Modified Themes** | **83** | (skipped) - `base16_` (4 files) and `term16_` (1 file)  |

Note: Looks like the following themes do not contain any diagnostic theme keys (apart from the ones I added) - `dracula_at_night.toml`, `material_deep_ocean.toml`, `snazzy.toml`

(Edit01: moved the 'Note' out of table to fix formatting)
(Edit02: updated the summary)

Thanks