### PR TITLE
Add jump-label styling for base16 themes

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -28,6 +28,7 @@
 "label" = "magenta"
 "namespace" = "magenta"
 "ui.help" = { fg = "white", bg = "black" }
+"ui.virtual.jump-label" = { modifiers = ["underlined"] }
 
 "markup.heading" = "blue"
 "markup.list" = "red"

--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -28,7 +28,7 @@
 "label" = "magenta"
 "namespace" = "magenta"
 "ui.help" = { fg = "white", bg = "black" }
-"ui.virtual.jump-label" = { modifiers = ["underlined"] }
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 
 "markup.heading" = "blue"
 "markup.list" = "red"

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -2,7 +2,7 @@
 
 "ui.background" = { bg = "base00" }
 "ui.virtual.whitespace" = "base03"
-"ui.virtual.jump-label" = { modifiers = ["underlined"] }
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base01", bg = "base04" }
 "ui.linenr" = { fg = "base03", bg = "base01" }

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -2,6 +2,7 @@
 
 "ui.background" = { bg = "base00" }
 "ui.virtual.whitespace" = "base03"
+"ui.virtual.jump-label" = { modifiers = ["underlined"] }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base01", bg = "base04" }
 "ui.linenr" = { fg = "base03", bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -13,7 +13,7 @@
 "ui.cursor" = { fg = "base04", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "base03"
-"ui.virtual.jump-label" = { modifiers = ["underlined"] }
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "ui.text" = "base05"
 "operator" = "base05"
 "ui.text.focus" = "base05"

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -13,6 +13,7 @@
 "ui.cursor" = { fg = "base04", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "base03"
+"ui.virtual.jump-label" = { modifiers = ["underlined"] }
 "ui.text" = "base05"
 "operator" = "base05"
 "ui.text.focus" = "base05"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -14,6 +14,7 @@
 "ui.cursor" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "light-gray"
+"ui.virtual.jump-label" = { modifiers = ["underlined"] }
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -14,7 +14,7 @@
 "ui.cursor" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "light-gray"
-"ui.virtual.jump-label" = { modifiers = ["underlined"] }
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -31,6 +31,7 @@
 "ui.virtual.inlay-hint.parameter" = { fg = "white", bg = "gray"}
 "ui.virtual.inlay-hint.type" = { fg = "white", bg = "gray"}
 "ui.virtual.wrap" = "gray"
+"ui.virtual.jump-label" = { modifiers = ["underlined"] }
 
 "variable" = "light-red"
 "constant.numeric" = "yellow"

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -31,7 +31,7 @@
 "ui.virtual.inlay-hint.parameter" = { fg = "white", bg = "gray"}
 "ui.virtual.inlay-hint.type" = { fg = "white", bg = "gray"}
 "ui.virtual.wrap" = "gray"
-"ui.virtual.jump-label" = { modifiers = ["underlined"] }
+"ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 
 "variable" = "light-red"
 "constant.numeric" = "yellow"


### PR DESCRIPTION
To respect the minimalistic look of the theme and inherit the link styling from the Web platform, I kept it simple by making labels underlined.

![base16_transparen labels](https://github.com/helix-editor/helix/assets/3697104/1bf9708d-dff8-429f-a036-4eba9fa35eff)
