### PR TITLE
Implement buffer ordering

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -582,31 +582,33 @@ impl EditorView {
         let mut x = viewport.x;
         let current_doc = view!(editor).doc;
 
-        for doc in editor.documents() {
-            let fname = doc
-                .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+        for doc_id in &editor.document_ordering {
+            if let Some(doc) = editor.documents.get(doc_id) {
+                let fname = doc
+                    .path()
+                    .unwrap_or(&scratch)
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
 
-            let style = if current_doc == doc.id() {
-                bufferline_active
-            } else {
-                bufferline_inactive
-            };
+                let style = if current_doc == doc.id() {
+                    bufferline_active
+                } else {
+                    bufferline_inactive
+                };
 
-            let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
-            let used_width = viewport.x.saturating_sub(x);
-            let rem_width = surface.area.width.saturating_sub(used_width);
+                let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
+                let used_width = viewport.x.saturating_sub(x);
+                let rem_width = surface.area.width.saturating_sub(used_width);
 
-            x = surface
-                .set_stringn(x, viewport.y, text, rem_width as usize, style)
-                .0;
+                x = surface
+                    .set_stringn(x, viewport.y, text, rem_width as usize, style)
+                    .0;
 
-            if x >= surface.area.right() {
-                break;
+                if x >= surface.area.right() {
+                    break;
+                }
             }
         }
     }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -609,6 +609,10 @@ impl EditorView {
                 if x >= surface.area.right() {
                     break;
                 }
+            } else {
+                log::error!(
+                    "document id in document ordering not found in document list, ID: {doc_id}"
+                )
             }
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1504,6 +1504,8 @@ impl Editor {
                         .position(|doc_id| doc_id == &id)
                     {
                         self.document_ordering.remove(d_idx);
+                    } else {
+                        log::error!("closed document not found in document ordering, ID: {id}")
                     }
 
                     // Remove the scratch buffer from any jumplists
@@ -1709,6 +1711,8 @@ impl Editor {
         self.documents.remove(&doc_id);
         if let Some(d_idx) = self.document_ordering.iter().position(|id| id == &doc_id) {
             self.document_ordering.remove(d_idx);
+        } else {
+            log::error!("closed document not found in document ordering, ID: {doc_id}")
         }
 
         // If the document we removed was visible in all views, we will have no more views. We don't


### PR DESCRIPTION
Closes #3707

This is WIP, but I figured I'd put it up to start gathering some feedback.

This PR implements buffer reordering, currently only supporting incrementing and decrementing the ordering of the current buffer. 

It adds a new `document_ordering` field to the `Editor` which must be kept in-sync with the actual documents in the editor (I'd be surprised if what I have currently doesn't contain any bugs that let the documents and document ordering go out-of-sync, I tried to find all the places where docs are actually added and removed) and uses the document ordering to power the way the bufferline is drawn as well as how the `goto_next_buffer` and `goto_previous_buffer` commands work.

If we're okay with the general approach I'm curious if we should add ordering to the bufferline picker or expose in some other way what the actual current ordering is, since it's no longer solely based on the document ID.


https://github.com/helix-editor/helix/assets/25966620/74953da9-c239-400f-ad9b-0b9b213f9d26

