### PR TITLE
Truncate statusline widgets

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -121,6 +121,16 @@ pub fn render_statusline<'a>(context: &mut RenderContext, width: usize) -> Spans
         statusline.append(&mut right);
     } else if left_area_width <= width {
         statusline.append(&mut left);
+    } else {
+        // `left` is too large to fit, even alone. We need to truncate it.
+        // FIXME: A similar logic should be applied to `right` as well.
+        let mut truncated_width = 0usize;
+        for el in left.into_iter() {
+            if truncated_width + el.width() <= width {
+                truncated_width += el.width();
+                statusline.push(el);
+            }
+        }
     }
 
     statusline.into()


### PR DESCRIPTION
Closes #10078.

Keeping PR as draft as the current solution while technically fixes #10078 it is incomplete nonetheless. For example, it would not fix the right side overflowing.

The current fix simply discards the last few elements from `statusline.left` until the remaining widgets can be fully rendered.
The center and right sections are still hidden, though. I'll try to make it show as many widgets as possible, then open the PR for merging.

The issue is that a smarter layout strategy is required, that can reconcile which widgets to render given the constraints. 
The current mess of if-else statements have proven to be inadequate, and I apologize for that.

A long-term solution could take a leaf out of Flutter's [book](https://docs.flutter.dev/ui/layout/constraints), where the status line would be broken up into sub-widgets and layout widgets. The render function could then reconcile the constraints against each child widget:

 1. Each widget receives the maximum allowed size it can occupy and returns the preferred size (based on children, text length, etc). Text widgets can use this info to truncate themselves, layout widgets can compute spacing, etc.
 2. Each widget then receives a Surface and target position to draw themselves/their children at.

This worked out pretty well for flutter and requires no backtracking (like we sorta need to with the current implementation). As a matter of fact, View already does something similar with gutters.