### PR TITLE
Dim primary selection in kanagawa

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -8,7 +8,7 @@
 
 ## User interface
 "ui.selection" = { bg = "waveBlue2" }
-"ui.selection.primary" = { bg = "sumiInk6" }
+"ui.selection.primary" = { bg = "sumiInk5" }
 "ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
 "ui.linenr" = { fg = "sumiInk4" }
@@ -123,8 +123,7 @@ sumiInk1 = "#1F1F28"      # default background
 sumiInk2 = "#2A2A37"      # lighter background, e.g. colorcolumns, folds
 sumiInk3 = "#363646"      # lighter background, e.g. cursorline
 sumiInk4 = "#54546D"      # darker foreground, e.g. linenumbers, fold column
-sumiInk5 = "#363646"      # not used
-sumiInk6 = "#54546D"      # current selection
+sumiInk5 = "#363646"      # current selection
 waveBlue1 = "#223249"     # popup background, visual selection background
 waveBlue2 = "#2D4F67"     # popup selection background, search background
 winterGreen = "#2B3328"   # diff add background

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -8,7 +8,7 @@
 
 ## User interface
 "ui.selection" = { bg = "waveBlue2" }
-"ui.selection.primary" = { bg = "waveBlue1" }
+"ui.selection.primary" = { bg = "sumiInk6" }
 "ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
 "ui.linenr" = { fg = "sumiInk4" }
@@ -123,6 +123,8 @@ sumiInk1 = "#1F1F28"      # default background
 sumiInk2 = "#2A2A37"      # lighter background, e.g. colorcolumns, folds
 sumiInk3 = "#363646"      # lighter background, e.g. cursorline
 sumiInk4 = "#54546D"      # darker foreground, e.g. linenumbers, fold column
+sumiInk5 = "#363646"      # not used
+sumiInk6 = "#54546D"      # current selection
 waveBlue1 = "#223249"     # popup background, visual selection background
 waveBlue2 = "#2D4F67"     # popup selection background, search background
 winterGreen = "#2B3328"   # diff add background


### PR DESCRIPTION
I'm using `kanagawa` style and sometimes its pretty difficult to recognize selections:
Here is an example.


No selection:
<img width="468" alt="image" src="https://github.com/helix-editor/helix/assets/865334/8ddbc3e5-076f-4f4d-bf85-ae4f3bd14445">
Selected:
<img width="461" alt="image" src="https://github.com/helix-editor/helix/assets/865334/518c6c32-1112-48f4-bdbc-ee13ee66ccf8">

This PR adds dimming to make it a bit more obvious:

<img width="452" alt="image" src="https://github.com/helix-editor/helix/assets/865334/5c96480a-b872-4f12-85f5-188d600cfcd8">

<img width="456" alt="image" src="https://github.com/helix-editor/helix/assets/865334/eed647bb-d8ec-4554-9262-3ba2303591fb">
