### PR TITLE
show newest options in jumplist picker first, fix docs

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -280,7 +280,8 @@ This layer is a kludge of mappings, mostly pickers.
 | `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`         |
 | `b`     | Open buffer picker                                                      | `buffer_picker`                            |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
-| `g`     | Debug (experimental)                                                    | N/A                                        |
+| `g`     | Open changed file picker                                                | `changed_file_picker`                      |
+| `G`     | Debug (experimental)                                                    | N/A                                        |
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
 | `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                            |
 | `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`                  |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2980,6 +2980,7 @@ fn jumplist_picker(cx: &mut Context) {
             .flat_map(|(view, _)| {
                 view.jumps
                     .iter()
+                    .rev()
                     .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
             })
             .collect(),

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -79,7 +79,7 @@ impl JumpList {
         self.jumps.retain(|(other_id, _)| other_id != doc_id);
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Jump> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Jump> {
         self.jumps.iter()
     }
 


### PR DESCRIPTION
These are a few patches I've collected while using Helix. Let the world finally see them.

commit 94db1511f8f7789fe7eed378d1e0407aff3bcca2 : docs: mention `<space>g` changed file picker. This was missed in the #5645

These two are personal preferences, but I think they're fair:
commit a4b5b4c16bbfc65efce7cddcd4e0c36fb0e2d4b0 : picker(jumplist): show newest options on top instead of bottom
~commit ef13bf544daec50034009291bc61030831d43ee7 : picker(global-search): append line number to found options~

You can reject them all, select only docs commit, or do whatever you want :)