### PR TITLE
add support for jump labels in tokyonight themes

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -92,6 +92,7 @@ hint = { fg = "hint" }
 "ui.virtual.ruler" = { bg = "fg-gutter" }
 "ui.virtual.whitespace" = { fg = "fg-gutter" }
 "ui.virtual.inlay-hint" = {  bg = "bg-inlay", fg = "teal" }
+"ui.virtual.jump-label" = {  fg = "orange", modifiers = ["bold"] }
 "ui.window" = { fg = "border", modifiers = ["bold"] }
 
 [palette]


### PR DESCRIPTION
Does what it says on the tin


tokyonight:

![tokyonight](https://github.com/helix-editor/helix/assets/173299/3a7b90e5-5dc5-4db4-9050-d3755d4ae7f7)

tokyonight_day:

![tokyonight_day](https://github.com/helix-editor/helix/assets/173299/5aee5b08-df5b-408e-a9f1-b6ab9f4a88a5)

tokyonight_moon:

![tokyonight_moon](https://github.com/helix-editor/helix/assets/173299/8fa6b4e2-fba6-473d-87d8-7f93f13ebb62)

tokyonight_storm:

![tokyonight_storm](https://github.com/helix-editor/helix/assets/173299/0709069d-477e-4939-a8a1-df7624550fcf)
