### PR TITLE
Avoid sending fake Enter command to completion menu

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1353,10 +1353,6 @@ impl Component for EditorView {
                                     {
                                         consumed = true;
                                         Some(callback)
-                                    } else if let EventResult::Consumed(callback) =
-                                        completion.handle_event(&Event::Key(key!(Enter)), &mut cx)
-                                    {
-                                        Some(callback)
                                     } else {
                                         None
                                     }


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/9757