### PR TITLE
Add fsharp block comment tokens to languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3029,6 +3029,7 @@ roots = ["sln", "fsproj"]
 injection-regex = "fsharp"
 file-types = ["fs", "fsx", "fsi", "fsscript"]
 comment-token = "//"
+block-comment-tokens = { start = "(*", end = "*)" }
 indent = { tab-width = 4, unit = "    " }
 auto-format = true
 language-servers = ["fsharp-ls"]


### PR DESCRIPTION
Add block-comment-tokens property for fsharp language to utilize the recent block comments feature. F# block comments are documented [here](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#formatting-comments)