### PR TITLE
languages: update templ

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3196,7 +3196,7 @@ language-servers = [ "templ" ]
 
 [[grammar]]
 name = "templ"
-source = { git = "https://github.com/vrischmann/tree-sitter-templ", rev = "ea56ac0655243490a4929a988f4eaa91dfccc995" }
+source = { git = "https://github.com/vrischmann/tree-sitter-templ", rev = "db662414ccd6f7c78b1e834e7abe11c224b04759" }
 
 [[language]]
 name = "dbml"

--- a/runtime/queries/templ/highlights.scm
+++ b/runtime/queries/templ/highlights.scm
@@ -1,28 +1,9 @@
-(package_identifier) @namespace
+; inherits: go
 
-(parameter_declaration (identifier) @variable.parameter)
-(variadic_parameter_declaration (identifier) @variable.parameter)
-
-(function_declaration
-  name: (identifier) @function)
-
-(type_spec name: (type_identifier) @type)
-(type_identifier) @type
-(field_identifier) @variable.other.member
-(identifier) @variable
-
-; Function calls
-
-(call_expression
-  function: (identifier) @function)
-
-(call_expression
-  function: (selector_expression
-    field: (field_identifier) @function))
-
-;
-; These are Templ specific
-;
+(css_declaration
+  name: (css_identifier) @function)
+(script_declaration
+  name: (script_identifier) @function)
 
 (component_declaration
   name: (component_identifier) @function)
@@ -42,6 +23,8 @@
 
 (css_property
   name: (css_property_name) @attribute)
+(css_property
+  value: (css_property_value) @constant)
 
 (expression) @function.method
 (dynamic_class_attribute_value) @function.method
@@ -56,35 +39,11 @@
 ] @operator
 
 [
-  "func"
-  "var"
-  "const"
   "templ"
   "css"
   "type"
-  "struct"
-  "range"
   "script"
 ] @keyword.storage.type
-
-[
-  "return"
-] @keyword.control.return
-
-[
-  "import"
-  "package"
-] @keyword.control.import
-
-[
-  "else"
-  "case"
-  "switch"
-  "if"
-  "default"
-] @keyword.control.conditional
-
-"for" @keyword.control.repeat
 
 [
   (interpreted_string_literal)


### PR DESCRIPTION
Update the templ grammar. Fixes a lot of bugs, new syntax support.

Most of the highlight syntax can be removed because it's inherited from the go highlights.