### PR TITLE
Don't auto-format todotxt files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3135,7 +3135,7 @@ name = "todotxt"
 scope = "text.todotxt"
 file-types = [{ glob = "todo.txt" }, { glob = "*.todo.txt" }, "todotxt"]
 formatter = { command = "sort" }
-auto-format = true
+auto-format = false
 
 [[grammar]]
 name = "todotxt"


### PR DESCRIPTION
For some reason, todo.txt files are auto formatted and use the `sort` command to format them. This doesn't seem like a good default and [has caused an issue for at least one user](https://www.reddit.com/r/HelixEditor/comments/1bu1l80/comment/kxqdl16/?context=3). Maybe we disable auto-formatting by default?