### PR TITLE
Add `:theme-open` command to open theme TOML files.

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -32,6 +32,7 @@
 | `:cquit`, `:cq` | Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2). |
 | `:cquit!`, `:cq!` | Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2). |
 | `:theme` | Change the editor theme (show current theme if no name specified). |
+| `:theme-open` | Open the theme's TOML file (open current theme's TOML file if no name specified). |
 | `:yank-join` | Yank joined selections. A separator can be provided as first argument. Default value is newline. |
 | `:clipboard-yank` | Yank main selection into system clipboard. |
 | `:clipboard-yank-join` | Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Write;
 use std::ops::Deref;
 
@@ -897,6 +898,27 @@ fn theme(
         }
     };
 
+    Ok(())
+}
+
+fn theme_open(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let theme_name = args
+        .first()
+        .map(Borrow::borrow)
+        .unwrap_or_else(|| cx.editor.theme.name());
+    let theme_path = cx
+        .editor
+        .theme_loader
+        .path(theme_name, &mut HashSet::new())?;
+    cx.editor.open(&theme_path, Action::Replace)?;
     Ok(())
 }
 
@@ -2681,6 +2703,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Change the editor theme (show current theme if no name specified).",
         fun: theme,
         signature: CommandSignature::positional(&[completers::theme]),
+    },
+    TypableCommand {
+        name: "theme-open",
+        aliases: &[],
+        doc: "Open the theme's TOML file (open current theme's TOML file if no name specified).",
+        fun: theme_open,
+        signature: CommandSignature::positional(&[completers::editable_themes]),
     },
     TypableCommand {
         name: "yank-join",

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -284,13 +284,24 @@ pub mod completers {
             .collect()
     }
 
+    pub fn editable_themes(_editor: &Editor, input: &str) -> Vec<Completion> {
+        get_theme_completions(input, false)
+    }
+
     pub fn theme(_editor: &Editor, input: &str) -> Vec<Completion> {
+        get_theme_completions(input, true)
+    }
+
+    fn get_theme_completions(input: &str, include_defaults: bool) -> Vec<Completion> {
         let mut names = theme::Loader::read_names(&helix_loader::config_dir().join("themes"));
         for rt_dir in helix_loader::runtime_dirs() {
             names.extend(theme::Loader::read_names(&rt_dir.join("themes")));
         }
-        names.push("default".into());
-        names.push("base16_default".into());
+
+        if include_defaults {
+            names.push("default".into());
+            names.push("base16_default".into());
+        }
         names.sort();
         names.dedup();
 

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -160,7 +160,7 @@ impl Loader {
     /// Returns the path to the theme with the given name
     ///
     /// Ignores paths already visited and follows directory priority order.
-    fn path(&self, name: &str, visited_paths: &mut HashSet<PathBuf>) -> Result<PathBuf> {
+    pub fn path(&self, name: &str, visited_paths: &mut HashSet<PathBuf>) -> Result<PathBuf> {
         let filename = format!("{}.toml", name);
 
         let mut cycle_found = false; // track if there was a path, but it was in a cycle


### PR DESCRIPTION
I don't think anything like this exists?

This is a nice to have if you like to hack on your own (or the pre-existing) themes. Rather than having to type `:o ~/.config/helix/themes/...` every time, you can just type `:theme-open` and you get all the same autocompletion that the `:theme` command gives you (minus the default themes as those don't have associated files).