### PR TITLE
Add koka language server and update grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -100,7 +100,7 @@
 | julia | ✓ | ✓ | ✓ | `julia` |
 | just | ✓ | ✓ | ✓ |  |
 | kdl | ✓ | ✓ | ✓ |  |
-| koka | ✓ |  | ✓ |  |
+| koka | ✓ |  | ✓ | `koka` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
 | latex | ✓ | ✓ |  | `texlab` |
 | ld | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -45,6 +45,7 @@ intelephense = { command = "intelephense", args = ["--stdio"] }
 jdtls = { command = "jdtls" }
 jsonnet-language-server = { command = "jsonnet-language-server", args= ["-t", "--lint"] }
 julia = { command = "julia", timeout = 60, args = [ "--startup-file=no", "--history-file=no", "--quiet", "-e", "using LanguageServer; runserver()", ] }
+koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
 kotlin-language-server = { command = "kotlin-language-server" }
 lean = { command = "lean", args = [ "--server" ] }
 ltex-ls = { command = "ltex-ls" }
@@ -3263,10 +3264,11 @@ injection-regex = "koka"
 file-types = ["kk"]
 comment-token = "//"
 indent = { tab-width = 8, unit = "  " }
+language-servers = ["koka"]
 
 [[grammar]]
 name = "koka"
-source = { git = "https://github.com/mtoohey31/tree-sitter-koka", rev = "2527e152d4b6a79fd50aebd8d0b4b4336c94a034" }
+source = { git = "https://github.com/mtoohey31/tree-sitter-koka", rev = "96d070c3700692858035f3524cc0ad944cef2594" }
 
 [[language]]
 name = "tact"

--- a/runtime/queries/koka/highlights.scm
+++ b/runtime/queries/koka/highlights.scm
@@ -12,18 +12,6 @@
         ])))
   ["(" (block) (fnexpr)])
 
-(ntlappexpr
-  function: (ntlappexpr
-    (atom
-      (qidentifier
-        [
-          (qvarid) @function
-          (qidop) @function
-          (identifier
-            [(varid) (idop)] @function)
-        ])))
-  ["(" (block) (fnexpr)])
-
 (appexpr
   field: (atom
     (qidentifier
@@ -36,28 +24,6 @@
 
 (appexpr
   (appexpr
-    field: (atom
-      (qidentifier
-        [
-          (qvarid) @variable
-          (qidop) @variable
-          (identifier
-            [(varid) (idop)] @variable)
-        ])))
-  "[")
-
-(ntlappexpr
-  field: (atom
-    (qidentifier
-      [
-        (qvarid) @function
-        (qidop) @function
-        (identifier
-          [(varid) (idop)] @function)
-      ])))
-
-(ntlappexpr
-  (ntlappexpr
     field: (atom
       (qidentifier
         [

--- a/runtime/queries/koka/indents.scm
+++ b/runtime/queries/koka/indents.scm
@@ -1,6 +1,5 @@
 [
   (appexpr ["[" "("]) ; Applications.
-  (ntlappexpr ["[" "("])
   (atom ["[" "("]) ; Lists and tuples.
   (program (moduledecl "{")) ; Braced module declarations.
   (funbody)


### PR DESCRIPTION
This pull request adds support for Koka's language server, and updates the grammar. The language server is built into the `koka` binary; no additional steps are required to get it working. Using the language server over stdin/stdout is supported starting in v3.1.0.