### PR TITLE
Implement horizontal and vertical position for statusline.

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -122,6 +122,8 @@ The following statusline elements can be configured:
 | `selections` | The number of active selections |
 | `primary-selection-length` | The number of characters currently in primary selection |
 | `position` | The cursor position |
+| `horizontal-position` | The cursor horizontal position |
+| `vertical-position` | The cursor vertical position |
 | `position-percentage` | The cursor position as a percentage of the total number of lines |
 | `separator` | The string defined in `editor.statusline.separator` (defaults to `"│"`) |
 | `spacer` | Inserts a space between elements (multiple/contiguous spacers may be specified) |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -149,6 +149,8 @@ fn get_render_function<'a>(
             render_primary_selection_length
         }
         helix_view::editor::StatusLineElement::Position => render_position,
+        helix_view::editor::StatusLineElement::HorizontalPosition => render_horizontal_position,
+        helix_view::editor::StatusLineElement::VerticalPosition => render_vrtical_position,
         helix_view::editor::StatusLineElement::PositionPercentage => render_position_percentage,
         helix_view::editor::StatusLineElement::TotalLineNumbers => render_total_line_numbers,
         helix_view::editor::StatusLineElement::Separator => render_separator,
@@ -317,6 +319,16 @@ fn get_position(context: &RenderContext) -> Position {
 fn render_position<'a>(context: &RenderContext) -> Spans<'a> {
     let position = get_position(context);
     Span::raw(format!(" {}:{} ", position.row + 1, position.col + 1)).into()
+}
+
+fn render_horizontal_position<'a>(context: &RenderContext) -> Spans<'a> {
+    let position = get_position(context);
+    Span::raw(format!(" {} ", position.col + 1)).into()
+}
+
+fn render_vertical_position<'a>(context: &RenderContext) -> Spans<'a> {
+    let position = get_position(context);
+    Span::raw(format!(" {} ", position.row + 1)).into()
 }
 
 fn render_total_line_numbers<'a>(context: &RenderContext) -> Spans<'a> {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -540,6 +540,12 @@ pub enum StatusLineElement {
     /// The cursor position
     Position,
 
+    /// The horizontal cursor position
+    HorizontalPosition,
+
+    /// The vertical cursor position
+    VerticalPosition,
+
     /// The separator string
     Separator,
 


### PR DESCRIPTION
As requested in https://github.com/helix-editor/helix/issues/10103, this allows the user to show only the horizontal or vertical position in the status line.