### PR TITLE
Fixed a typo in the error message

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -126,7 +126,7 @@ pub fn config_dir() -> PathBuf {
 
 pub fn cache_dir() -> PathBuf {
     // TODO: allow env var override
-    let strategy = choose_base_strategy().expect("Unable to find the config directory!");
+    let strategy = choose_base_strategy().expect("Unable to find the cache directory!");
     let mut path = strategy.cache_dir();
     path.push("helix");
     path


### PR DESCRIPTION
Hello,

I found what seems to be a typo in the code in [`cache_dir()`](https://github.com/helix-editor/helix/blob/master/helix-loader/src/lib.rs#L127) in helix-loader/src/lib.rs.
It appears to be identical to the code defined above it for [`config_dir()`](https://github.com/helix-editor/helix/blob/master/helix-loader/src/lib.rs#L119).

I would appreciate it if you could verify.
Thank you.

