### PR TITLE
More surrounding chars to trim when `gf`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1207,14 +1207,26 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             true,
         );
         // Trims some surrounding chars so that the actual file is opened.
-        let surrounding_chars: &[_] = &['\'', '"', '(', ')'];
+        let surrounding_pairs: &[_] = &[
+            ('\'', '\''),
+            ('"', '"'),
+            ('(', ')'),
+            ('[', ']'),
+            ('{', '}'),
+            ('<', '>'),
+        ];
+        // Check pairs to prevent unnecessary trimming.
+        let current_word = current_word.fragment(text_slice);
+        let mut current_word = current_word.as_ref();
+        for (l, r) in surrounding_pairs {
+            if current_word.starts_with(*l) && current_word.ends_with(*r) {
+                current_word = current_word.trim_start_matches(*l);
+                current_word = current_word.trim_end_matches(*r);
+            }
+        }
+
         paths.clear();
-        paths.push(
-            current_word
-                .fragment(text_slice)
-                .trim_matches(surrounding_chars)
-                .to_string(),
-        );
+        paths.push(current_word.to_string());
     }
 
     for sel in paths {

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -153,6 +153,17 @@ async fn test_goto_file_impl() -> anyhow::Result<()> {
     )
     .await?;
 
+    // Don't trim unmatched pairs
+    test_key_sequence(
+        &mut AppBuilder::new().with_file(file.path(), None).build()?,
+        Some("i)one.js)<esc>%gf"),
+        Some(&|app| {
+            assert_eq!(1, match_paths(app, vec![")one.js)"]));
+        }),
+        false,
+    )
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Add `<>`, `[]`, `{}` to trim when call `gf`,  so that `gf` on `<https://github.com/helix-editor/helix>` will open the link rather than open a file. 

Also check the pair matching to prevent one side trimming. 