### PR TITLE
Opening a file at its last line will match going to the last line

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -207,7 +207,7 @@ impl Application {
                 // align the view to center after all files are loaded,
                 // does not affect views without pos since it is at the top
                 let (view, doc) = current!(editor);
-                align_view(doc, view, Align::Center);
+                align_view(doc, view, Align::Bottom);
             } else {
                 editor.new_file(Action::VerticalSplit);
             }


### PR DESCRIPTION
Closes #9704

Changing the enum variant from `Align::Center` to `Align::Bottom` enables the same behaviour as going to the last line manually `g e`, when opening a file at its last line while respecting `scrolloff`.