### PR TITLE
Remove duplicate keyword highlight for Python 'and'

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -204,7 +204,6 @@
 (for_in_clause "in" @keyword.control)
 
 [
-  "and"
   "async"
   "class"
   "exec"


### PR DESCRIPTION
Fixes inconsistency in Python highlighting