### PR TITLE
Add angular language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -8,6 +8,7 @@ use-grammars = { except = [ "hare", "wren", "gemini" ] }
 als = { command = "als" }
 ada-language-server = { command = "ada_language_server" }
 ada-gpr-language-server = {command = "ada_language_server", args = ["--language-gpr"]}
+angular = {command = "ngserver", args = ["--stdio", "--tsProbeLocations", ".", "--ngProbeLocations", ".",]}
 awk-language-server = { command = "awk-language-server" }
 bash-language-server = { command = "bash-language-server", args = ["start"] }
 bass = { command = "bass", args = ["--lsp"] }


### PR DESCRIPTION
Following intruction to enable it
Install <code>@angular/language-server</code> with npm
```
npm i -g @angular/language-server
```
Install <code>@angular/language-service</code> as dev dependencies in project
```
npm i -D @angular/language-service
```
Add <code>angular</code> to language-servers html and typescript in languages.toml
```TOML
[[language]]
name ="html"
language-servers = ["angular","vscode-html-language-server"]

[[language]]
name = "typescript"
language-servers = ["angular","typescript-language-server"]
```

Auto completion and error checking
![IMG_20240405_095410](https://github.com/helix-editor/helix/assets/73488521/b1dcc09d-3525-4506-81c0-66e877e1c859)

Goto reference and goto definition
![IMG_20240405_095452](https://github.com/helix-editor/helix/assets/73488521/bcae03d5-899e-4ede-bc7a-a8634ec0f946)

Related to #4861