### PR TITLE
fix: correctly open URLs surrounded by `<>`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1207,7 +1207,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             true,
         );
         // Trims some surrounding chars so that the actual file is opened.
-        let surrounding_chars: &[_] = &['\'', '"', '(', ')'];
+        let surrounding_chars: &[_] = &['\'', '"', '(', ')', '<', '>'];
         paths.clear();
         paths.push(
             current_word


### PR DESCRIPTION
`rustoc` can warn about "naked" links that are not surrounded by `<>`. When fixing the link, `helix` becomes unable to open the URL, instead opening a file named `<URL>`.

Since I couldn't think of a single case where a file starting or ending with `<>` would happen since shells use those as control characters and tend to discourage that pattern, I simply added to the trim list.