### PR TITLE
Fix scrolling to the end within a popup

### DIFF
--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -283,16 +283,20 @@ impl<T: Component> Component for Popup<T> {
             (height + self.margin.height()).min(max_height),
         );
 
-        // re-clamp scroll offset
-        let max_offset = self.child_size.1.saturating_sub(self.size.1);
-        self.scroll = self.scroll.min(max_offset as usize);
-
         Some(self.size)
     }
 
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
         let area = self.area(viewport, cx.editor);
         self.area = area;
+
+        // required_size() calculates the popup size without taking account of self.position
+        // so we need to correct the popup height to correctly calculate the scroll
+        self.size.1 = area.height;
+
+        // re-clamp scroll offset
+        let max_offset = self.child_size.1.saturating_sub(self.size.1);
+        self.scroll = self.scroll.min(max_offset as usize);
         cx.scroll = Some(self.scroll);
 
         // clear area


### PR DESCRIPTION
when the available height for the popup is low/small, then it is not possible to scroll until the end

[this recording shows the problem](https://github.com/helix-editor/helix/assets/2721423/1ff9c7d1-795f-4d26-ad24-96af1a0470dc) (created by @thomasaarholt)
