### PR TITLE
add yd as alias for yank_diagnostic

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3063,8 +3063,8 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "yank-diagnostic",
-        aliases: &[],
-        doc: "Yank diagnostic(s) under primary cursor to register, or clipboard by default",
+        aliases: &["yd"],
+        doc: "Yank diagnostic(s) under primary cursor to register, or clipboard by default.",
         fun: yank_diagnostic,
         signature: CommandSignature::all(completers::register),
     },


### PR DESCRIPTION
adds an alias for the new command :yank_diagnostic as :yd. 