### PR TITLE
feat(themes): add ruler for `adwaita-dark`

### DIFF
--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -82,6 +82,7 @@
 "ui.help" = { bg = "libadwaita_dark_alt" }
 "ui.text" = "light_4"
 "ui.virtual" = "dark_1"
+"ui.virtual.ruler" = { bg = "libadwaita_popup"}
 "ui.menu" = { fg = "light_4", bg = "libadwaita_popup" }
 "ui.menu.selected" = { fg = "light_4", bg = "blue_5" }
 "ui.menu.scroll" = { fg = "light_7", bg = "dark_3" }


### PR DESCRIPTION
Issue from: https://www.reddit.com/r/HelixEditor/comments/1bxxri4/helix_themes_and_vertical_or_column_rulers_dont/

![alacritty_7jqDHrOXPt](https://github.com/helix-editor/helix/assets/12489689/81b9fd50-24e8-4ef4-8fc3-cd80a895da97)
