### PR TITLE
refactor(themes): removed `ui.highlight` effects from `solarized_dark`

### DIFF
--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -79,8 +79,6 @@
 "ui.text" = { fg = "base1" }
 # 影响 picker列表选中, 快捷键帮助窗口文本
 "ui.text.focus" = { fg = "blue", modifiers = ["bold"]}
-# file picker中， 预览的当前选中项
-"ui.highlight" = { fg = "red", modifiers = ["bold", "italic", "underlined"] }
 
 # 主光标/selectio
 "ui.cursor.primary" = { fg = "base03", bg = "base1" }


### PR DESCRIPTION
Issue from: https://www.reddit.com/r/HelixEditor/comments/1bxxri4/comment/kyfu9je/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

Before:
![solar_dark_before](https://github.com/helix-editor/helix/assets/12489689/b6ca7bcd-3337-4b28-8e00-636d895ce4cd)

After:
![solarized_dark_after](https://github.com/helix-editor/helix/assets/12489689/bf34faa4-a879-4fd6-b73b-cf9f72238b06)
