### PR TITLE
fix off by one error for completion-replace option

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -284,7 +284,8 @@ pub mod util {
                 .chars_at(cursor)
                 .skip(1)
                 .take_while(|ch| chars::char_is_word(*ch))
-                .count();
+                .count()
+                + 1;
         }
         (start, end)
     }


### PR DESCRIPTION
closes  #9799

was originally not able to pin this down since the provided doc file didn't contain any information. But this was very easy to reproduce with python. Turns out to be a simple off by one by error that slipped trough since almost every fully featured lsp only sends full edits.
