### PR TITLE
Add editor.always-force-write option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -51,6 +51,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
+| `always-force-write` | Overwrite the current file on disk, regardless of last-modified time | `false` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. | `250` |
 | `completion-timeout` | Time in milliseconds after typing a word character before completions are shown, set to 5 for instant.  | `250` |
 | `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -383,7 +383,9 @@ fn write(
         return Ok(());
     }
 
-    write_impl(cx, args.first(), false)
+    let force = (cx.editor.config()).always_force_write;
+
+    write_impl(cx, args.first(), force)
 }
 
 fn force_write(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -336,6 +336,8 @@ pub struct Config {
         deserialize_with = "deserialize_alphabet"
     )]
     pub jump_label_alphabet: Vec<char>,
+    /// always overwrite the file on disk, don't present a warning if it's been updated since last write.
+    pub always_force_write: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -913,6 +915,7 @@ impl Default for Config {
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
+            always_force_write: false,
         }
     }
 }


### PR DESCRIPTION
The check on file last-modified check before saving is often very useful, but not always helpful in all workflows. I work on a large screen, and often don't see the warning at the bottom that a file has not updated. I've lost cumulativly several hours making this mistake.

It would help me greatly to optionally be able to disable overwrite checking.

Thanks very much for the great editor