### PR TITLE
Brighten nord selection highlight

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -114,7 +114,7 @@
 "ui.cursorcolumn.primary" = { bg = "nord1" }
 "ui.cursorline.primary" = { bg = "nord1" }
 
-"ui.selection" = { bg = "nord2" }
+"ui.selection" = { bg = "nord3" }
 "ui.highlight" = { fg = "nord8", bg = "nord2" }
 
 # Statusline


### PR DESCRIPTION
When "nord2" color is used in ui.selection it is almost invisible if cursorline highlighting is enabled. Changing the color to "nord3" fixes the issue.

"nord2":

<img width="973" alt="Снимок экрана 2024-04-04 в 13 18 10" src="https://github.com/helix-editor/helix/assets/230824/22233827-923d-4991-91f6-16fa18975880">

"nord3":

<img width="973" alt="Снимок экрана 2024-04-04 в 15 23 26" src="https://github.com/helix-editor/helix/assets/230824/4859cb06-9147-4188-a68a-16b7525a22fa">
