### PR TITLE
material theme: fix statusline color

### DIFF
--- a/runtime/themes/material_deep_ocean.toml
+++ b/runtime/themes/material_deep_ocean.toml
@@ -63,9 +63,9 @@
 
 "ui.statusline" = { bg = "bg", fg = "text" }
 "ui.statusline.inactive" = { bg = "bg", fg = "disabled" }
-"ui.statusline.normal" = { bg = "accent", fg = "text" }
-"ui.statusline.insert" = { bg = "green", fg = "text" }
-"ui.statusline.select" = { bg = "purple", fg = "text" }
+"ui.statusline.normal" = { bg = "blue", fg = "bg" }
+"ui.statusline.insert" = { bg = "green", fg = "bg" }
+"ui.statusline.select" = { bg = "purple", fg = "bg" }
 
 
 "ui.selection" = { bg = "selection" }


### PR DESCRIPTION
the fg color was not really readable, and changing the accent to blue because I feel it's also an improvement to the colorscheme:

before
![image](https://github.com/helix-editor/helix/assets/40139584/fa91fec7-4a0e-4f88-b479-3f99aaf72206)
![image](https://github.com/helix-editor/helix/assets/40139584/ed522ac1-6d7e-4db4-ad66-5370237bcc90)
![image](https://github.com/helix-editor/helix/assets/40139584/381fbc70-1df3-42a3-8f8b-1067f5a510e7)


after

![image](https://github.com/helix-editor/helix/assets/40139584/ac121720-4457-432b-8755-5f3d7367f711)
![image](https://github.com/helix-editor/helix/assets/40139584/ae671e61-f894-4458-b0ec-97b6aa8709a3)
![image](https://github.com/helix-editor/helix/assets/40139584/b82262ce-e920-412e-b08e-be25a059a315)
