### PR TITLE
feat(themes): add rulers for themes missing them

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -29,6 +29,7 @@
 "namespace" = "magenta"
 "ui.help" = { fg = "white", bg = "black" }
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
+"ui.virtual.ruler" = { bg = "black" }
 
 "markup.heading" = "blue"
 "markup.list" = "red"

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -3,6 +3,7 @@
 "ui.background" = { bg = "base00" }
 "ui.virtual.whitespace" = "base03"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
+"ui.virtual.ruler" = { bg = "base01" }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base01", bg = "base04" }
 "ui.linenr" = { fg = "base03", bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -14,6 +14,7 @@
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "base03"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
+"ui.virtual.ruler" = { bg = "base01" }
 "ui.text" = "base05"
 "operator" = "base05"
 "ui.text.focus" = "base05"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -15,6 +15,7 @@
 "ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "light-gray"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
+"ui.virtual.ruler" = { bg = "black" }
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"

--- a/runtime/themes/horizon-dark.toml
+++ b/runtime/themes/horizon-dark.toml
@@ -29,6 +29,7 @@ namespace = "orange"
 "ui.selection" = { bg = "selection" }
 "ui.virtual.indent-guide" = { fg = "gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
+"ui.virtual.ruler" = { bg ="dark-bg" }
 "ui.statusline" = { bg = "dark-bg", fg = "light-gray" }
 "ui.popup" = { bg = "dark-bg", fg = "orange" }
 "ui.help" = { bg = "dark-bg", fg = "orange" }

--- a/runtime/themes/mellow.toml
+++ b/runtime/themes/mellow.toml
@@ -79,6 +79,7 @@
 "ui.text.focus" = { fg = "fg" }
 
 "ui.virtual" = { fg = "gray02" }
+"ui.virtual.ruler" = { bg ="gray02" }
 "ui.virtual.indent-guide" = { fg = "gray02" }
 "ui.virtual.inlay-hint" = { fg = "gray04" }
 

--- a/runtime/themes/poimandres.toml
+++ b/runtime/themes/poimandres.toml
@@ -58,6 +58,7 @@ string = { fg = "brightMint" }
 "ui.text.inactive" = "darkerGray"
 "ui.virtual" = { fg = "darkerGray.b0" }
 "ui.virtual.indent-guide" = "#303442"
+"ui.virtual.ruler" = { bg ="selection" }
 
 "ui.selection" = { bg = "focus" }
 "ui.selection.primary" = { bg = "selection" }

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -90,7 +90,7 @@
 "ui.selection.primary" = { bg = "base015" }
 
 "ui.virtual.indent-guide" = { fg = "base02" }
-"ui.virtual.ruler" = { fg = "red" }
+"ui.virtual.ruler" = { bg = "base02" }
 
 # normal模式的光标
 "ui.cursor" = {fg = "base02", bg = "cyan"}

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -91,9 +91,6 @@
 # 影响 picker列表选中, 快捷键帮助窗口文本
 # Affects picker list selection, shortcut key help window text
 "ui.text.focus" = { fg = "blue", modifiers = ["bold"]}
-# file picker中， 预览的当前选中项
-# In file picker, the currently selected item of the preview
-"ui.highlight" = { fg = "red", modifiers = ["bold", "italic", "underlined"] }
 
 # 主光标/selection
 # main cursor/selection

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -104,7 +104,7 @@
 "ui.selection.primary" = { bg = "base015" }
 
 "ui.virtual.indent-guide" = { fg = "base02" }
-"ui.virtual.ruler" = { fg = "red" }
+"ui.virtual.ruler" = { bg = "base02" }
 
 # normal模式的光标
 # normal mode cursor

--- a/runtime/themes/varua.toml
+++ b/runtime/themes/varua.toml
@@ -67,6 +67,7 @@
 "ui.statusline.select" = { bg = "blue", fg = "bg2" }
 "ui.virtual.wrap" = { fg = "grey0" }
 "ui.virtual.inlay-hint" = { fg = "grey1" }
+"ui.virtual.ruler" = { bg = "bg2"}
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/vim_dark_high_contrast.toml
+++ b/runtime/themes/vim_dark_high_contrast.toml
@@ -15,6 +15,7 @@
 "ui.text.focus" = { fg = "yellow" }
 "ui.virtual.wrap" = { fg = "dark-blue" }
 "ui.virtual.indent-guide" = { fg = "dark-blue" }
+"ui.virtual.ruler" = { bg = "dark-white" }
 "ui.window" = { bg = "dark-white" }
 
 "diagnostic.error" = { bg = "dark-red" }

--- a/theme.toml
+++ b/theme.toml
@@ -40,7 +40,7 @@ label = "honey"
 "diff.minus" = "#f22c86"
 "diff.delta" = "#6f44f0"
 
-# TODO: diferentiate doc comment
+# TODO: differentiate doc comment
 # concat (ERROR) @error.syntax and "MISSING ;" selectors for errors
 
 "ui.background" = { bg = "midnight" }

--- a/theme.toml
+++ b/theme.toml
@@ -56,6 +56,7 @@ label = "honey"
 "ui.text.focus" = { fg = "white" }
 "ui.text.inactive" = "sirocco"
 "ui.virtual" = { fg = "comet" }
+"ui.virtual.ruler" = { bg = "revolver" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }
 
 "ui.virtual.indent-guide" = { fg = "comet" }


### PR DESCRIPTION
As talked about [here](https://github.com/helix-editor/helix/pull/10260#issuecomment-2043089551), I went through and searched for any `ui.virtual.ruler` using `fg`.

```shell
rg -iN '\"ui.virtual.ruler\"?\s=?\s\{?\sfg?\s=?\s\"\w+"?\s\}' runtime/themes/
```
After these changes the above grep yields no results.

Along the way, I addressed other issues brought up in #5721, and added rulers to themes that didn't have one. For those where the ruler was invisible, there is now one that shows up, and for those where the ruler was bright red, it should now match the theme better.

`default`:
![default_ruler](https://github.com/helix-editor/helix/assets/12489689/d0119fe7-272e-4f28-89dd-0f6c5990c8a1)

`solarized_dark`:
![solarized_dark_ruler](https://github.com/helix-editor/helix/assets/12489689/08cb98b4-2272-4dc1-b1a3-d459e77d7677)

`solarized_light`:
![solarized_light_ruler](https://github.com/helix-editor/helix/assets/12489689/c21a481e-598e-4aaa-9ae5-2bec2fee384a)

`horizon-dark`:
![horizon-dark_ruler](https://github.com/helix-editor/helix/assets/12489689/6dd18d13-2bd5-40de-803f-035b52cc4ee8)

`mellow`:
![mellow_ruler](https://github.com/helix-editor/helix/assets/12489689/eec32e92-d0be-4838-8ca2-4cdbb70dfc00)

`poimandres`:
![poimandres_ruler](https://github.com/helix-editor/helix/assets/12489689/daa8432d-317c-4b6c-a11b-6cc47f62328d)

`poimandres-storm`:
![poimandres-storm_ruler](https://github.com/helix-editor/helix/assets/12489689/7cc04ab7-2634-4be2-92bb-2798b6add61b)

`varua`:
![varua_ruler](https://github.com/helix-editor/helix/assets/12489689/237567b6-a327-45b3-892a-355397c5148e)

`vim_dark_high_contrast`:
![vim_dark_high_constrast_ruler](https://github.com/helix-editor/helix/assets/12489689/e44a9c2b-9ce9-40d1-839f-7df818fd3bc7)

`base16_default`:
![base16_default_ruler](https://github.com/helix-editor/helix/assets/12489689/f5c327e4-1d5e-4425-b581-b8c965c1c410)

`base16_default_dark`:
![base16_default_dark_ruler](https://github.com/helix-editor/helix/assets/12489689/8b9cac12-7d97-4445-942a-2806332e272f)

`base16_default_light`:
![base16_default_light_ruler](https://github.com/helix-editor/helix/assets/12489689/0b05401b-6b55-474b-9b3c-07a958bb5703)

`base16_default_terminal`:
![base16_default_terminal_ruler](https://github.com/helix-editor/helix/assets/12489689/f5123b52-ed9d-4764-bda2-a8a820725a5f)

I also took the liberty and normalized the change in #10261 for `solzarized_light`

Closes: #5721