### PR TITLE
don't manually grapheme align ts highlights

### DIFF
--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -278,23 +278,6 @@ pub fn ensure_grapheme_boundary_prev(slice: RopeSlice, char_idx: usize) -> usize
     }
 }
 
-/// Returns the passed byte index if it's already a grapheme boundary,
-/// or the next grapheme boundary byte index if not.
-#[must_use]
-#[inline]
-pub fn ensure_grapheme_boundary_next_byte(slice: RopeSlice, byte_idx: usize) -> usize {
-    if byte_idx == 0 {
-        byte_idx
-    } else {
-        // TODO: optimize so we're not constructing grapheme cursor twice
-        if is_grapheme_boundary_byte(slice, byte_idx) {
-            byte_idx
-        } else {
-            next_grapheme_boundary_byte(slice, byte_idx)
-        }
-    }
-}
-
 /// Returns whether the given char position is a grapheme boundary.
 #[must_use]
 pub fn is_grapheme_boundary(slice: RopeSlice, char_idx: usize) -> bool {

--- a/helix-stdx/src/rope.rs
+++ b/helix-stdx/src/rope.rs
@@ -3,6 +3,7 @@ use std::ops::{Bound, RangeBounds};
 pub use regex_cursor::engines::meta::{Builder as RegexBuilder, Regex};
 pub use regex_cursor::regex_automata::util::syntax::Config;
 use regex_cursor::{Input as RegexInput, RopeyCursor};
+use ropey::str_utils::byte_to_char_idx;
 use ropey::RopeSlice;
 
 pub trait RopeSliceExt<'a>: Sized {
@@ -16,6 +17,23 @@ pub trait RopeSliceExt<'a>: Sized {
     fn regex_input_at<R: RangeBounds<usize>>(self, char_range: R) -> RegexInput<RopeyCursor<'a>>;
     fn first_non_whitespace_char(self) -> Option<usize>;
     fn last_non_whitespace_char(self) -> Option<usize>;
+    /// returns the char idx of `byte_idx`, if `byte_idx` is a char boundary
+    /// this function behaves the same as `byte_to_char` but if `byte_idx` is
+    /// not a valid char boundary (so within a char) this will return the next
+    /// char index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ropey::RopeSlice;
+    /// # use helix_stdx::rope::RopeSliceExt;
+    /// let text = RopeSlice::from("😆");
+    /// for i in 1..text.len_bytes() {
+    ///     assert_eq!(text.byte_to_char(i), 0);
+    ///     assert_eq!(text.byte_to_next_char(i), 1);
+    /// }
+    /// ```
+    fn byte_to_next_char(self, byte_idx: usize) -> usize;
 }
 
 impl<'a> RopeSliceExt<'a> for RopeSlice<'a> {
@@ -74,5 +92,49 @@ impl<'a> RopeSliceExt<'a> for RopeSlice<'a> {
             .reversed()
             .position(|ch| !ch.is_whitespace())
             .map(|pos| self.len_chars() - pos - 1)
+    }
+
+    /// returns the char idx of `byte_idx`, if `byte_idx` is
+    /// a char boundary this function behaves the same as `byte_to_char`
+    fn byte_to_next_char(self, mut byte_idx: usize) -> usize {
+        let (chunk, chunk_byte_off, chunk_char_off, _) = self.chunk_at_byte(byte_idx);
+        byte_idx -= chunk_byte_off;
+        let is_char_boundary =
+            is_utf8_char_boundary(chunk.as_bytes().get(byte_idx).copied().unwrap_or(0));
+        chunk_char_off + byte_to_char_idx(chunk, byte_idx) + !is_char_boundary as usize
+    }
+}
+
+// copied from std
+#[inline]
+const fn is_utf8_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}
+
+#[cfg(test)]
+mod tests {
+    use ropey::RopeSlice;
+
+    use crate::rope::RopeSliceExt;
+
+    #[test]
+    fn next_char_at_byte() {
+        for i in 0..=6 {
+            assert_eq!(RopeSlice::from("foobar").byte_to_next_char(i), i);
+        }
+        for char_idx in 0..10 {
+            let len = "😆".len();
+            assert_eq!(
+                RopeSlice::from("😆😆😆😆😆😆😆😆😆😆").byte_to_next_char(char_idx * len),
+                char_idx
+            );
+            for i in 1..=len {
+                assert_eq!(
+                    RopeSlice::from("😆😆😆😆😆😆😆😆😆😆").byte_to_next_char(char_idx * len + i),
+                    char_idx + 1
+                );
+            }
+        }
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -12,9 +12,7 @@ use crate::{
 
 use helix_core::{
     diagnostic::NumberOrString,
-    graphemes::{
-        ensure_grapheme_boundary_next_byte, next_grapheme_boundary, prev_grapheme_boundary,
-    },
+    graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
     syntax::{self, HighlightEvent},
     text_annotations::TextAnnotations,
@@ -315,26 +313,14 @@ impl EditorView {
                 let iter = syntax
                     // TODO: range doesn't actually restrict source, just highlight range
                     .highlight_iter(text.slice(..), Some(range), None)
-                    .map(|event| event.unwrap())
-                    .map(move |event| match event {
-                        // TODO: use byte slices directly
-                        // convert byte offsets to char offset
-                        HighlightEvent::Source { start, end } => {
-                            let start =
-                                text.byte_to_char(ensure_grapheme_boundary_next_byte(text, start));
-                            let end =
-                                text.byte_to_char(ensure_grapheme_boundary_next_byte(text, end));
-                            HighlightEvent::Source { start, end }
-                        }
-                        event => event,
-                    });
+                    .map(|event| event.unwrap());
 
                 Box::new(iter)
             }
             None => Box::new(
                 [HighlightEvent::Source {
-                    start: text.byte_to_char(range.start),
-                    end: text.byte_to_char(range.end),
+                    start: range.start,
+                    end: range.end,
                 }]
                 .into_iter(),
             ),


### PR DESCRIPTION
Closes #6645

I have known the root cause of #6645 for a while: The c grammar has a bug where it sometimes creates non-grapheme aligned highlight spans when cealing with unicode characters like emojois.

This caused crashes because our grapheme alignment code couldn't deal with non-char aligned offsets. I think that is the right (potentially only valid) choice for doing grapheme alignment. 

In our case it was unfortunate as it leads to crashes. I also wanted to get rid of this grapheme alignment anyway because we already render the text one grapheme at a time, so it's really unnecessary to do this. However, in the past it wasn't possible to remove the alignment because the additional highlight iterators merged on top of the base iterator were using char indexing/grapheme aligned indexes. Just switching the TS iterator would have caused highlighting bugs.

However, recently the overlay and base highlights were decoupled so now the base highlights are seperate, and it was possible to convert the base iterator to using byte indexing instead
