### PR TITLE
fix char/byte index mixup in overlay rendering

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -350,7 +350,8 @@ impl EditorView {
         let text = doc.text().slice(..);
         let row = text.char_to_line(anchor.min(text.len_chars()));
 
-        let range = Self::viewport_byte_range(text, row, height);
+        let mut range = Self::viewport_byte_range(text, row, height);
+        range = text.byte_to_char(range.start)..text.byte_to_char(range.end);
 
         text_annotations.collect_overlay_highlights(range)
     }


### PR DESCRIPTION
closes #10315

this code was copy pased from elsewhere but overlay highlights use char indecies not byte indecies. One day we will use  byte indecies everywhere and avoid these mixups