### PR TITLE
feat(solidity): add textobject queries for solidity

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -160,7 +160,7 @@
 | smali | ✓ |  | ✓ |  |
 | smithy | ✓ |  |  | `cs` |
 | sml | ✓ |  |  |  |
-| solidity | ✓ |  |  | `solc` |
+| solidity | ✓ | ✓ |  | `solc` |
 | spicedb | ✓ |  |  |  |
 | sql | ✓ |  |  |  |
 | sshclientconfig | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1754,7 +1754,7 @@ language-servers = [ "solc" ]
 
 [[grammar]]
 name = "solidity"
-source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "5cb506ae419c4ad620c77210fd47500d3d169dbc" }
+source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "08338dcee32603383fcef08f36321900bb7a354b" }
 
 [[language]]
 name = "gleam"

--- a/languages.toml
+++ b/languages.toml
@@ -1754,7 +1754,7 @@ language-servers = [ "solc" ]
 
 [[grammar]]
 name = "solidity"
-source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "9004b86531cb424bd379424cf7266a4585f2af7d" }
+source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "5cb506ae419c4ad620c77210fd47500d3d169dbc" }
 
 [[language]]
 name = "gleam"

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -1,8 +1,3 @@
-; identifiers
-; -----------
-(identifier) @variable
-(yul_identifier) @variable
-
 ; Pragma
 (pragma_directive) @tag
 (solidity_version_comparison_operator _ @tag)
@@ -217,3 +212,8 @@
   "delete"
   "new"
 ] @keyword.operator
+
+; identifiers
+; -----------
+(identifier) @variable
+(yul_identifier) @variable

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -217,5 +217,7 @@
 
 ; identifiers
 ; -----------
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(this|msg|block|tx)$"))
 (identifier) @variable
 (yul_identifier) @variable

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -31,6 +31,7 @@
 (type_name) @type
 (primitive_type) @type
 (user_defined_type (identifier) @type)
+(type_alias (identifier) @type)
 
 ; Color payable in payable address conversion as type and not as keyword
 (payable_conversion_expression "payable" @type)

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -80,7 +80,7 @@
 
 ; Function parameters
 (call_struct_argument name: (identifier) @field)
-(event_paramater name: (identifier) @variable.parameter)
+(event_parameter name: (identifier) @variable.parameter)
 (parameter name: (identifier) @variable.parameter)
 
 ; Yul functions
@@ -159,7 +159,7 @@
 "import" @keyword.control.import
 (import_directive "as" @keyword.control.import)
 (import_directive "from" @keyword.control.import)
-(event_paramater "indexed" @keyword) ; TODO fix spelling once fixed upstream
+(event_parameter "indexed" @keyword)
 
 ; Punctuation
 

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -94,6 +94,7 @@
 ; Keywords
 (meta_type_expression "type" @keyword)
 [
+ "abstract"
  "pragma"
  "contract"
  "interface"

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -7,6 +7,9 @@
 (fallback_receive_definition
   body: (_) @function.inside) @function.around
 
+(yul_function_definition
+  (yul_block) @function.inside) @function.around
+
 (function_definition 
   ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
 

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -40,6 +40,9 @@
 (emit_statement
   ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
 
+(revert_arguments
+  ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (struct_declaration
   body: (_) @class.inside) @class.around
 

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -25,6 +25,9 @@
 (error_declaration 
   ((error_parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
 
+(call_expression
+  ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (struct_declaration
   body: (_) @class.inside) @class.around
 

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -37,6 +37,9 @@
 (variable_declaration_tuple
   ((variable_declaration) @parameter.inside . ","? @parameter.around) @parameter.around)
 
+(emit_statement
+  ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (struct_declaration
   body: (_) @class.inside) @class.around
 

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -25,8 +25,14 @@
 (error_declaration 
   ((error_parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
 
+(call_argument
+  ((call_struct_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (call_expression
   ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(variable_declaration_tuple
+  ((variable_declaration) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (struct_declaration
   body: (_) @class.inside) @class.around

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -1,0 +1,36 @@
+(function_definition
+  body: (_) @function.inside) @function.around
+
+(constructor_definition
+  body: (_) @function.inside) @function.around
+
+(fallback_receive_definition
+  body: (_) @function.inside) @function.around
+
+(function_definition 
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(constructor_definition 
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(return_type_definition 
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(modifier_definition 
+  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(event_definition 
+  ((event_parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(error_declaration 
+  ((error_parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(struct_declaration
+  body: (_) @class.inside) @class.around
+
+(enum_declaration
+  body: (_) @class.inside) @class.around
+
+(comment) @comment.inside
+
+(comment)+ @comment.around


### PR DESCRIPTION
This PR adds textobject queries for the solidity language. In order to enable some of the queries, some upstream work has been done on the tree-sitter grammar.

This PR updates the grammar version and fixes a few highlight queries, as well as adds new queries for textobjects.

Fixes:
- spelling mistake in `event_parameter`
- precedence of `@variable` vs other identifiers

Additions:
- Textobject queries
- Type alias highlight query
- `abstract` keyword
- Variable builtins for `this`, `msg`, `block`and `tx` identifiers
