### PR TITLE
Make cd - return to previous working directory

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1082,9 +1082,17 @@ fn change_current_directory(
         .first()
         .context("target directory not provided")?
         .as_ref();
-    let dir = helix_stdx::path::expand_tilde(Path::new(dir));
 
-    helix_stdx::env::set_current_working_dir(dir)?;
+    let cwd = helix_stdx::env::current_working_dir();
+    if dir == "-" {
+        let dir = cx.editor.last_working_dir.as_ref().unwrap_or(&cwd);
+        helix_stdx::env::set_current_working_dir(dir)?;
+    } else {
+        let dir = helix_stdx::path::expand_tilde(Path::new(dir));
+        helix_stdx::env::set_current_working_dir(dir)?;
+    }
+
+    cx.editor.last_working_dir = Some(cwd);
 
     cx.editor.set_status(format!(
         "Current working directory is now {}",

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -992,6 +992,8 @@ pub struct Editor {
     last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
 
+    pub last_working_dir: Option<PathBuf>,
+
     pub exit_code: i32,
 
     pub config_events: (UnboundedSender<ConfigEvent>, UnboundedReceiver<ConfigEvent>),
@@ -1129,6 +1131,7 @@ impl Editor {
             cursor_cache: Cell::new(None),
             handlers,
             mouse_down_range: None,
+            last_working_dir: None,
         }
     }
 


### PR DESCRIPTION
Similar to the unix cd, useful if you want to change the working directory momentarily and return to the previous one