### PR TITLE
themes/monokai: add inlay-hint style

### DIFF
--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -83,6 +83,7 @@
 "ui.bufferline.active" = { fg = "active_text", bg = "selection", modifiers = [
   "bold",
 ] }
+"ui.virtual.inlay-hint" = { fg = "#88846F" }
 
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { fg = "active_text" }


### PR DESCRIPTION
Matching comment styling so that it doesn't get confused for actual code.