### PR TITLE
chore: update tree-sitter-rust to v0.21.0

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2765,10 +2765,10 @@ mod test {
             )
         };
 
-        test("quantified_nodes", 1..36);
+        test("quantified_nodes", 1..37);
         // NOTE: Enable after implementing proper node group capturing
-        // test("quantified_nodes_grouped", 1..36);
-        // test("multiple_nodes_grouped", 1..36);
+        // test("quantified_nodes_grouped", 1..37);
+        // test("multiple_nodes_grouped", 1..37);
     }
 
     #[test]
@@ -2939,7 +2939,7 @@ mod test {
 
     #[test]
     fn test_pretty_print() {
-        let source = r#"/// Hello"#;
+        let source = r#"// Hello"#;
         assert_pretty_print("rust", source, "(line_comment)", 0, source.len());
 
         // A large tree should be indented with fields:
@@ -2958,7 +2958,8 @@ mod test {
                 "      (macro_invocation\n",
                 "        macro: (identifier)\n",
                 "        (token_tree\n",
-                "          (string_literal))))))",
+                "          (string_literal\n",
+                "            (string_content)))))))",
             ),
             0,
             source.len(),

--- a/languages.toml
+++ b/languages.toml
@@ -250,7 +250,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "0431a2c60828731f27491ee9fdefe25e250ce9c9" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "473634230435c18033384bebaa6d6a17c2523281" }
 
 [[language]]
 name = "sway"

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -51,7 +51,7 @@
 (lifetime
   "'" @label
   (identifier) @label)
-(loop_label
+(label
   "'" @label
   (identifier) @label)
 


### PR DESCRIPTION
Updates tree-sitter-rust to v0.21.0. There were a number of changes since 0.20.3 ([diff](https://github.com/tree-sitter/tree-sitter-rust/compare/v0.20.3...v0.21.0)). The only breaking change  ([commit](https://github.com/tree-sitter/tree-sitter-rust/commit/99c6922d407ca9c3c1a3b7c10ac480985c3e9d47)) that I found was renaming `loop_label` node to `label`, which is addressed in the `highlights.scm` file. I haven't experienced any regressions, but it would be great if other people could try it out too before merging.