### PR TITLE
Add a warning in docs about conflicts with terminal default key bindings.

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -24,6 +24,8 @@
 
 > 💡 Mappings marked (**TS**) require a tree-sitter grammar for the file type.
 
+> ⚠️ Some terminals' default key mappings conflict with Helix's. If any of the mappings described on this page do not work as expected, check your terminal's mappings to ensure they do not conflict. See the (wiki)[https://github.com/helix-editor/helix/wiki/Terminal-Support] for known conflicts.
+
 ## Normal mode
 
 Normal mode is the default mode when you launch helix. You can return to it from other modes by pressing the `Escape` key.


### PR DESCRIPTION
Briefly call out to readers that some terminals may have default key mappings that aren't compatible with Helix and point them to the wiki where known conflicts are logged. I've already added a line to the [Windows Terminal section](https://github.com/helix-editor/helix/wiki/Terminal-Support#key-mappings) about Ctrl-v bindings not working by default due to that terminal's default “Paste” binding.

Conflicting mappings were a problem for me with Windows Terminal: https://github.com/helix-editor/helix/discussions/10295#discussion-6476795 Since it was on the list of supported terminals in the wiki, I expected it to “just work™”, so when Ctrl-v mappings didn't, I initially raised an issue about it. Having a call-out like this, plus documentation of known conflicts on the wiki, would help users like me who encounter similar issues.