### PR TITLE
Add missing hyprlang support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3366,7 +3366,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-ld", rev = "0e9695ae0
 name = "hyprlang"
 scope = "source.hyprlang"
 roots = ["hyprland.conf"]
-file-types = [ { glob = "hyprland.conf"} ]
+file-types = [ { glob = "hyprland.conf" }, { glob = "hyprpaper.conf" }, { glob = "hypridle.conf" }, { glob = "hyprlock.conf" } ]
 comment-token = "#"
 grammar = "hyprlang"
 


### PR DESCRIPTION
`hyprpaper.conf`, `hyprlock.conf` and `hypridle.conf` were incorrectly identified as hocon
This supports them for the hyprland configuration language

![screenshot](https://github.com/helix-editor/helix/assets/101881095/66c63fba-7588-4bde-b35b-ab16e82d88ad)
