### PR TITLE
theme: everblush -  statusline colours

### DIFF
--- a/runtime/themes/everblush.toml
+++ b/runtime/themes/everblush.toml
@@ -61,7 +61,7 @@
 "ui.statusline.inactive" = { fg = "foreground", bg = "background" }
 "ui.statusline.normal" = { fg = "white", bg = "background" }
 "ui.statusline.insert" = { fg = "blue", bg = "background" }
-"ui.statusline.select" = { fg = "cyan", bg = "magenta" }
+"ui.statusline.select" = { fg = "magenta", bg = "background" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "blue" }
 "ui.virtual.ruler" = { bg = "cursorline" }


### PR DESCRIPTION
changes the statusline colors for SELECT mode in the Everblush theme.
the previous colours seem to be incorrect and quite ugly (sorry!).
I chose the magenta over the cyan (colours that were already present) as it has more contrast with the existing INSERT colour.
the statusline colours are now inline with eachother, all having the background be the 'background' colour, with varying foregrounds.

images below for before and after:

normal:
![Screenshot 2024-04-13 222639](https://github.com/helix-editor/helix/assets/124311484/fd7df70c-4794-4951-87bd-a0dec76ecd11)

insert:
![Screenshot 2024-04-13 222649](https://github.com/helix-editor/helix/assets/124311484/f954d62c-6a18-4452-ba38-cd47ab4f1de5)

before - select:
![Screenshot 2024-04-13 222709](https://github.com/helix-editor/helix/assets/124311484/89b8cf41-e7fc-415f-ae52-88ffa502c061)

after - select:
![Screenshot 2024-04-13 222652](https://github.com/helix-editor/helix/assets/124311484/4f9e5491-91be-4382-a7f5-f723432a5390)
