### PR TITLE
book(update): add section for asdf plugin

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -2,6 +2,7 @@
 
 <!--toc:start-->
 - [Pre-built binaries](#pre-built-binaries)
+  - [Using asdf (Linux & macOS)](#using-asdf-linux--macos)
 - [Linux, macOS, Windows and OpenBSD packaging status](#linux-macos-windows-and-openbsd-packaging-status)
 - [Linux](#linux)
   - [Ubuntu](#ubuntu)
@@ -44,6 +45,17 @@ Note that:
 Download pre-built binaries from the
 [GitHub Releases page](https://github.com/helix-editor/helix/releases). Add the binary to your system's `$PATH` to use it from the command
 line.
+
+### Using asdf (Linux & macOS)
+
+There is a [community maintained plugin](https://github.com/CSergienko/asdf-helix.git) for the [asdf version manager](https://asdf-vm.com/)
+which you can use to download the pre-built binaries and shim them into your path.
+
+```sh
+asdf plugin add helix https://github.com/CSergienko/asdf-helix.git
+asdf install helix latest
+asdf global helix latest
+```
 
 ## Linux, macOS, Windows and OpenBSD packaging status
 


### PR DESCRIPTION
I have written a [plugin](https://github.com/CSergienko/asdf-helix) for the [asdf version manager](https://asdf-vm.com/) which I [mentioned on Matrix](https://matrix.to/#/!zMuVRxoqjyxyjSEBXc:matrix.org/$1MBIsGJtDsnzSyxjDfCTUXp2p0a2-_J-LnCZHIiuwFo?via=matrix.org&via=mozilla.org&via=tchncs.de) which will download Helix directly from GitHub releases, unzip the tarball, and add it onto the path.

The reasoning behind this is mainly to provide another option to install the pre-built binaries. I am using Fedora, and noticed I was a release behind. I didn't want to wait, and I didn't want to manually go downloading it or building from source. Naturally, I spent a few hours automating something that would have taken two minutes, tops.

I figured I'd submit this PR to add it to the docs as an option for other lazy people like me who might be using asdf already.

I have a few considerations which I feel need to be addressed as part of this PR:

- I wasn't sure where to place it in the book, so I stuck it underneath the section on pre-built binaries. But, I don't think it should be so prominent given the version manager in question is niche. I would say at best this should go just above "build from source", but given it is directly related to the pre-builts I will leave it to the reviewers to decide and give me some guidance.
- The nature of asdf requires the end user to audit the plugins they use with their own eyeballs. It provides no security guarantee beyond "trust me, bro" despite installing arbitrary things from the internet. On its face this would be a strong reason to decline this addition to the docs. That being said, I am happy to transfer ownership if desirable and continue maintaining it since I'll be using it anyway to install and update Helix.

