### PR TITLE
Replaced handwritten parser with clap library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +218,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "clipboard-win"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +281,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "content_inspector"
@@ -1290,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "helix-core"
 version = "24.3.0"
 dependencies = [
@@ -1423,6 +1523,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
+ "clap",
  "content_inspector",
  "crossterm",
  "fern",
@@ -2259,6 +2360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2657,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -70,6 +70,7 @@ serde = { version = "1.0", features = ["derive"] }
 # ripgrep for global search
 grep-regex = "0.1.12"
 grep-searcher = "0.1.13"
+clap = { version = "4.5.4", features = ["derive"] }
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -1,149 +1,126 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use clap::builder::PossibleValue;
 use helix_core::Position;
+use helix_loader::VERSION_AND_GIT_HASH;
 use helix_view::tree::Layout;
-use std::path::{Path, PathBuf};
+use std::{convert::Infallible, path::PathBuf, str::FromStr};
 
-#[derive(Default)]
+#[derive(clap::Parser)]
+#[command(author, version = VERSION_AND_GIT_HASH, about, long_about = None)]
 pub struct Args {
-    pub display_help: bool,
-    pub display_version: bool,
-    pub health: bool,
-    pub health_arg: Option<String>,
-    pub load_tutor: bool,
-    pub fetch_grammars: bool,
-    pub build_grammars: bool,
-    pub split: Option<Layout>,
+    #[arg(
+        long,
+        default_missing_value = "all",
+        value_names = ["CATEGORY"],
+        help = "Checks for potential errors in editor setup. CATEGORY can be a language or one of 'clipboard', 'languages' or 'all'. 'all' is the default if not specified."
+    )]
+    pub health: Option<HealthCheckCategory>,
+    #[arg(long, help = "Loads the tutorial")]
+    pub tutor: bool,
+    #[arg(
+        value_enum,
+        long = "grammar",
+        value_names = ["ACTION"],
+        help = "Fetches or builds tree-sitter grammars listed in languages.toml"
+    )]
+    pub grammar_action: Option<GrammarsAction>,
+    #[arg(
+        value_enum,
+        long,
+        value_names = ["LAYOUT"],
+        help = "Splits all given files vertically or horizontally into different windows"
+    )]
+    pub split: Option<Split>,
+    #[arg(short, long, default_value = "0", help = "Sets logging verbosity")]
     pub verbosity: u64,
+    #[arg(long = "log", help = "Specifies a file to use for logging")]
     pub log_file: Option<PathBuf>,
+    #[arg(
+        long = "config",
+        short = 'c',
+        help = "Specifies a file to use for configuration"
+    )]
     pub config_file: Option<PathBuf>,
-    pub files: Vec<(PathBuf, Position)>,
+    #[arg(
+        long = "working-dir",
+        short,
+        help = "Specify an initial working directory"
+    )]
     pub working_directory: Option<PathBuf>,
+    #[arg(
+        help = "Sets the input file to use, position can also be specified via file[:row[:col]]"
+    )]
+    pub files: Vec<FileWithPosition>,
 }
 
-impl Args {
-    pub fn parse_args() -> Result<Args> {
-        let mut args = Args::default();
-        let mut argv = std::env::args().peekable();
-        let mut line_number = 0;
+#[derive(Clone)]
+pub enum HealthCheckCategory {
+    All,
+    Specified(String),
+}
 
-        argv.next(); // skip the program, we don't care about that
+impl FromStr for HealthCheckCategory {
+    type Err = Infallible;
 
-        while let Some(arg) = argv.next() {
-            match arg.as_str() {
-                "--" => break, // stop parsing at this point treat the remaining as files
-                "--version" => args.display_version = true,
-                "--help" => args.display_help = true,
-                "--tutor" => args.load_tutor = true,
-                "--vsplit" => match args.split {
-                    Some(_) => anyhow::bail!("can only set a split once of a specific type"),
-                    None => args.split = Some(Layout::Vertical),
-                },
-                "--hsplit" => match args.split {
-                    Some(_) => anyhow::bail!("can only set a split once of a specific type"),
-                    None => args.split = Some(Layout::Horizontal),
-                },
-                "--health" => {
-                    args.health = true;
-                    args.health_arg = argv.next_if(|opt| !opt.starts_with('-'));
-                }
-                "-g" | "--grammar" => match argv.next().as_deref() {
-                    Some("fetch") => args.fetch_grammars = true,
-                    Some("build") => args.build_grammars = true,
-                    _ => {
-                        anyhow::bail!("--grammar must be followed by either 'fetch' or 'build'")
-                    }
-                },
-                "-c" | "--config" => match argv.next().as_deref() {
-                    Some(path) => args.config_file = Some(path.into()),
-                    None => anyhow::bail!("--config must specify a path to read"),
-                },
-                "--log" => match argv.next().as_deref() {
-                    Some(path) => args.log_file = Some(path.into()),
-                    None => anyhow::bail!("--log must specify a path to write"),
-                },
-                "-w" | "--working-dir" => match argv.next().as_deref() {
-                    Some(path) => {
-                        args.working_directory = if Path::new(path).is_dir() {
-                            Some(PathBuf::from(path))
-                        } else {
-                            anyhow::bail!(
-                                "--working-dir specified does not exist or is not a directory"
-                            )
-                        }
-                    }
-                    None => {
-                        anyhow::bail!("--working-dir must specify an initial working directory")
-                    }
-                },
-                arg if arg.starts_with("--") => {
-                    anyhow::bail!("unexpected double dash argument: {}", arg)
-                }
-                arg if arg.starts_with('-') => {
-                    let arg = arg.get(1..).unwrap().chars();
-                    for chr in arg {
-                        match chr {
-                            'v' => args.verbosity += 1,
-                            'V' => args.display_version = true,
-                            'h' => args.display_help = true,
-                            _ => anyhow::bail!("unexpected short arg {}", chr),
-                        }
-                    }
-                }
-                arg if arg.starts_with('+') => {
-                    match arg[1..].parse::<usize>() {
-                        Ok(n) => line_number = n.saturating_sub(1),
-                        _ => args.files.push(parse_file(arg)),
-                    };
-                }
-                arg => args.files.push(parse_file(arg)),
-            }
+    fn from_str(arg: &str) -> Result<Self, Self::Err> {
+        if arg == "all" {
+            return Ok(Self::All);
         }
 
-        // push the remaining args, if any to the files
-        for arg in argv {
-            args.files.push(parse_file(&arg));
-        }
-
-        if let Some(file) = args.files.first_mut() {
-            if line_number != 0 {
-                file.1.row = line_number;
-            }
-        }
-
-        Ok(args)
+        Ok(Self::Specified(arg.to_string()))
     }
 }
 
-/// Parse arg into [`PathBuf`] and position.
-pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
-    let def = || (PathBuf::from(s), Position::default());
-    if Path::new(s).exists() {
-        return def();
+#[derive(clap::ValueEnum, Clone)]
+pub enum GrammarsAction {
+    Fetch,
+    Build,
+}
+
+#[derive(Clone, Copy)]
+pub struct Split(pub Layout);
+
+impl clap::ValueEnum for Split {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self(Layout::Vertical), Self(Layout::Horizontal)]
     }
-    split_path_row_col(s)
-        .or_else(|| split_path_row(s))
-        .unwrap_or_else(def)
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        let value = match self.0 {
+            Layout::Horizontal => "horizontal",
+            Layout::Vertical => "vertical",
+        };
+
+        Some(PossibleValue::new(value))
+    }
 }
 
-/// Split file.rs:10:2 into [`PathBuf`], row and col.
-///
-/// Does not validate if file.rs is a file or directory.
-fn split_path_row_col(s: &str) -> Option<(PathBuf, Position)> {
-    let mut s = s.rsplitn(3, ':');
-    let col: usize = s.next()?.parse().ok()?;
-    let row: usize = s.next()?.parse().ok()?;
-    let path = s.next()?.into();
-    let pos = Position::new(row.saturating_sub(1), col.saturating_sub(1));
-    Some((path, pos))
+#[derive(Clone)]
+pub struct FileWithPosition {
+    pub path: PathBuf,
+    pub position: Position,
 }
 
-/// Split file.rs:10 into [`PathBuf`] and row.
-///
-/// Does not validate if file.rs is a file or directory.
-fn split_path_row(s: &str) -> Option<(PathBuf, Position)> {
-    let (path, row) = s.rsplit_once(':')?;
-    let row: usize = row.parse().ok()?;
-    let path = path.into();
-    let pos = Position::new(row.saturating_sub(1), 0);
-    Some((path, pos))
+impl FromStr for FileWithPosition {
+    type Err = anyhow::Error;
+
+    fn from_str(arg: &str) -> Result<Self> {
+        const FILE_POSITION_DELIMETER: char = ':';
+
+        let mut arg = arg.split(FILE_POSITION_DELIMETER);
+        let file = PathBuf::from(arg.next().unwrap());
+
+        let mut next_position_number = || arg.next().map(str::parse).unwrap_or(Ok(0));
+        let position = {
+            let row = next_position_number().map_err(|_| anyhow!("Invalid row"))?;
+            let column = next_position_number().map_err(|_| anyhow!("Invalid column"))?;
+
+            Position::new(row, column)
+        };
+
+        Ok(Self {
+            path: file,
+            position,
+        })
+    }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -57,7 +57,6 @@ use insert::*;
 use movement::Movement;
 
 use crate::{
-    args,
     compositor::{self, Component, Compositor},
     filter_picker_entry,
     job::Callback,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 use std::ops::Deref;
 
+use crate::args::FileWithPosition;
 use crate::job::Job;
 
 use super::*;
@@ -109,7 +110,10 @@ fn open(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
 
     ensure!(!args.is_empty(), "wrong argument count");
     for arg in args {
-        let (path, pos) = args::parse_file(arg);
+        let FileWithPosition {
+            path,
+            position: pos,
+        } = arg.parse()?;
         let path = helix_stdx::path::expand_tilde(path);
         // If the path is a directory, open a file picker on that directory and update the status
         // message

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -7,6 +7,8 @@ use helix_loader::grammar::load_runtime_file;
 use helix_view::clipboard::get_clipboard_provider;
 use std::io::Write;
 
+use crate::args::HealthCheckCategory;
+
 #[derive(Copy, Clone)]
 pub enum TsFeature {
     Highlight,
@@ -369,17 +371,18 @@ fn probe_treesitter_feature(lang: &str, feature: TsFeature) -> std::io::Result<(
     Ok(())
 }
 
-pub fn print_health(health_arg: Option<String>) -> std::io::Result<()> {
-    match health_arg.as_deref() {
-        Some("languages") => languages_all()?,
-        Some("clipboard") => clipboard()?,
-        None | Some("all") => {
-            general()?;
-            clipboard()?;
-            writeln!(std::io::stdout().lock())?;
-            languages_all()?;
+pub fn print_health(health: HealthCheckCategory) -> std::io::Result<()> {
+    if let HealthCheckCategory::Specified(category) = health {
+        match category.as_str() {
+            "languages" => languages_all()?,
+            "clipboard" => clipboard()?,
+            _ => language(category)?,
         }
-        Some(lang) => language(lang.to_string())?,
+        return Ok(());
     }
-    Ok(())
+
+    general()?;
+    clipboard()?;
+    writeln!(std::io::stdout().lock())?;
+    languages_all()
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.74.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
By replacing handwritten parser with clap library, the code is more readable and simple, also clap provides help page generation so there's no need to modify hard-coded page when adding new arguments.