### PR TITLE
Add bufferline and cursorline colors to vim dark theme

### DIFF
--- a/runtime/themes/vim_dark_high_contrast.toml
+++ b/runtime/themes/vim_dark_high_contrast.toml
@@ -1,7 +1,10 @@
 "ui.background" = { bg = "black" }
+"ui.bufferline" = { bg = "black" }
+"ui.bufferline.active" = { fg = "light-magenta", bg = "dark-magenta" }
 "ui.cursor" = { fg = "green", modifiers = ["reversed"] }
 "ui.cursor.match" = { fg = "light-cyan", bg = "dark-cyan" }
 "ui.cursor.primary" = { fg = "light-green", modifiers = ["reversed"] }
+"ui.cursorline.primary" = { bg = "gray" }
 "ui.menu" = { bg = "dark-white" }
 "ui.menu.selected" = { fg = "yellow" }
 "ui.popup" = { bg = "dark-white" }
@@ -50,6 +53,7 @@
 black = "#000000"
 red = "#ed5f74"
 green = "#1ea672"
+gray = "#111111"
 yellow = "#d97917"
 blue = "#688ef1"
 magenta = "#c96ed0"


### PR DESCRIPTION
In the "vim dark high contrast" theme, I have set the bufferline and cursorline colors, so it does the following:
1. the currently active buffer is easily recognizable (just like in the other themes)
2. the current line has a slightly lighter color than the bg

Without fix:
![Without fix](https://github.com/helix-editor/helix/assets/9989266/597cbd28-7109-49c0-98a7-fd2b30d7e7bb)

With fix:
![With fix](https://github.com/helix-editor/helix/assets/9989266/0ebbaffd-1e8c-44ab-8f3f-fb6dc1f6a1ff)

