### PR TITLE
Add `:open-relative`

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -334,6 +334,16 @@ pub mod completers {
         filename_with_git_ignore(editor, input, true)
     }
 
+    pub fn filename_relative(editor: &Editor, input: &str) -> Vec<Completion> {
+        let path = doc!(editor).path().and_then(|path| path.parent());
+        let path = match path {
+            Some(path) => path.join(input),
+            None => input.into(),
+        };
+
+        filename_with_git_ignore(editor, &path.to_string_lossy(), true)
+    }
+
     pub fn filename_with_git_ignore(
         editor: &Editor,
         input: &str,


### PR DESCRIPTION
This PR addresses issue #5301 by introducing the `:open-relative` command (alias `:or`), allowing users to open or create a file relative to the current view's path. 

It includes a couple of hacks to enable completion functionality, let me know if they are a blocker.

[![asciicast](https://asciinema.org/a/654188.svg)](https://asciinema.org/a/654188)