### PR TITLE
Implement read command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -3,7 +3,6 @@
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o` | Open a file from disk into the current view. |
-| `:read`, `:r` | Load a file into buffer |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |
@@ -88,3 +87,4 @@
 | `:redraw` | Clear and re-render the whole UI |
 | `:move` | Move the current buffer and its corresponding file to a different path |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
+| `:read`, `:r` | Load a file into buffer |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -3,6 +3,7 @@
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o` | Open a file from disk into the current view. |
+| `:read`, `:r` | Load a file into buffer |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2455,19 +2455,16 @@ fn yank_diagnostic(
     Ok(())
 }
 
-fn read(
-    cx: &mut compositor::Context,
-    args: &[Cow<str>],
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn read(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
+    let scrolloff = cx.editor.config().scrolloff;
     let (view, doc) = current!(cx.editor);
 
     ensure!(!args.is_empty(), "file name is expected");
-ensure!(args.len() == 1, "only the file name is expected");
+    ensure!(args.len() == 1, "only the file name is expected");
 
     let filename = args.get(0).unwrap();
     let path = PathBuf::from(filename.to_string());

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3109,7 +3109,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         name: "read",
         aliases: &["r"],
         doc: "Load a file into buffer",
-        fun: read_file_info_buffer,
+        fun: read,
         signature: CommandSignature::positional(&[completers::filename]),
     },
 ];

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::io::BufReader;
 use std::ops::Deref;
 
 use crate::job::Job;
@@ -8,7 +9,7 @@ use super::*;
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::{line_ending, shellwords::Shellwords};
-use helix_view::document::DEFAULT_LANGUAGE_NAME;
+use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
 use serde_json::Value;
 use ui::completers::{self, Completer};
@@ -2454,6 +2455,37 @@ fn yank_diagnostic(
     Ok(())
 }
 
+fn read_file_info_buffer(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let (view, doc) = current!(cx.editor);
+
+    ensure!(!args.is_empty(), "file name is expected");
+
+    let filename = args.get(0).unwrap();
+    let path = PathBuf::from(filename.to_string());
+    if !path.exists() {
+        bail!("file doesn't exist: {}", filename);
+    }
+
+    let file = std::fs::File::open(path).map_err(|err| anyhow!("error reading file {}", err))?;
+    let mut reader = BufReader::new(file);
+    let (contents, _, _) = read_to_string(&mut reader, Some(doc.encoding()))
+        .map_err(|err| anyhow!("error reading file: {}", err))?;
+    let contents = Tendril::from(contents);
+    let selection = doc.selection(view.id);
+    let transaction = Transaction::insert(doc.text(), selection, contents);
+    doc.apply(&transaction, view.id);
+
+    Ok(())
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "quit",
@@ -3067,6 +3099,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Yank diagnostic(s) under primary cursor to register, or clipboard by default",
         fun: yank_diagnostic,
         signature: CommandSignature::all(completers::register),
+    },
+    TypableCommand {
+        name: "read",
+        aliases: &["r"],
+        doc: "Load a file into buffer",
+        fun: read_file_info_buffer,
+        signature: CommandSignature::positional(&[completers::filename]),
     },
 ];
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -644,11 +644,9 @@ async fn test_join_selections_space() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_read_file() -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
-    let expected_content = String::from("some contents");
-    let output_file = helpers::temp_file_with_contents(&expected_content)?;
-    let mut command = String::new();
-    let cmd = format!(":r {:?}<ret><esc>:w<ret>", output_file.path());
-    command.push_str(&cmd);
+    let contents_to_read = String::from("some contents");
+    let output_file = helpers::temp_file_with_contents(&contents_to_read)?;
+    let command = format!(":r {:?}<ret><esc>:w<ret>", output_file.path());
 
     test_key_sequence(
         &mut helpers::AppBuilder::new()
@@ -662,7 +660,8 @@ async fn test_read_file() -> anyhow::Result<()> {
     )
     .await?;
 
-    helpers::assert_file_has_content(file.as_file_mut(), expected_content.as_str())?;
+    let expected_contents = format!("{}\n", contents_to_read);
+    helpers::assert_file_has_content(&mut file, &expected_contents)?;
 
     Ok(())
 }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -646,13 +646,12 @@ async fn test_read_file() -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
     let contents_to_read = String::from("some contents");
     let output_file = helpers::temp_file_with_contents(&contents_to_read)?;
-    let command = format!(":r {:?}<ret><esc>:w<ret>", output_file.path());
 
     test_key_sequence(
         &mut helpers::AppBuilder::new()
             .with_file(file.path(), None)
             .build()?,
-        Some(&command),
+        Some(&format!(":r {:?}<ret><esc>:w<ret>", output_file.path())),
         Some(&|app| {
             assert!(!app.editor.is_err(), "error: {:?}", app.editor.get_status());
         }),

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -644,8 +644,8 @@ async fn test_join_selections_space() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_read_file() -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
-    let contents_to_read = String::from("some contents");
-    let output_file = helpers::temp_file_with_contents(&contents_to_read)?;
+    let contents_to_read = "some contents";
+    let output_file = helpers::temp_file_with_contents(contents_to_read)?;
 
     test_key_sequence(
         &mut helpers::AppBuilder::new()
@@ -659,7 +659,7 @@ async fn test_read_file() -> anyhow::Result<()> {
     )
     .await?;
 
-    let expected_contents = LineFeedHandling::Native.apply(&contents_to_read);
+    let expected_contents = LineFeedHandling::Native.apply(contents_to_read);
     helpers::assert_file_has_content(&mut file, &expected_contents)?;
 
     Ok(())

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -659,7 +659,7 @@ async fn test_read_file() -> anyhow::Result<()> {
     )
     .await?;
 
-    let expected_contents = format!("{}\n", contents_to_read);
+    let expected_contents = LineFeedHandling::Native.apply(&contents_to_read);
     helpers::assert_file_has_content(&mut file, &expected_contents)?;
 
     Ok(())


### PR DESCRIPTION
Resurrects https://github.com/helix-editor/helix/pull/3966/. This is 100% @idursun's work. Using `read_to_string` from https://github.com/helix-editor/helix/pull/7431.

closes https://github.com/helix-editor/helix/issues/3796