### PR TITLE
Add support for Xena OpenAutomation files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -215,6 +215,7 @@
 | wren | ✓ | ✓ | ✓ |  |
 | xit | ✓ |  |  |  |
 | xml | ✓ |  | ✓ |  |
+| xtc | ✓ |  |  |  |
 | yaml | ✓ |  | ✓ | `yaml-language-server`, `ansible-language-server` |
 | yuck | ✓ |  |  |  |
 | zig | ✓ | ✓ | ✓ | `zls` |

--- a/languages.toml
+++ b/languages.toml
@@ -3531,3 +3531,14 @@ comment-token = "#"
 [[grammar]]
 name = "ldif"
 source = { git = "https://github.com/kepet19/tree-sitter-ldif", rev = "0a917207f65ba3e3acfa9cda16142ee39c4c1aaa" }
+
+[[language]]
+name = "xtc"
+scope = "source.xtc"
+# Accept Xena Traffic Configuration, Xena Port Configuration and Xena OpenAutomation
+file-types = [ "xtc", "xpc", "xoa" ]
+comment-token = ";"
+
+[[grammar]]
+name = "xtc"
+source = { git = "https://github.com/Alexis-Lapierre/tree-sitter-xtc", rev = "7bc11b736250c45e25cfb0215db2f8393779957e" }

--- a/runtime/queries/xtc/highlights.scm
+++ b/runtime/queries/xtc/highlights.scm
@@ -1,0 +1,27 @@
+(parameter) @keyword
+
+(change_port) @function.special
+
+(template) @variable
+
+[
+  (hex_argument)
+  (ipv4_argument)
+] @attribute
+
+(numeric_argument) @constant.numeric
+
+(index) @tag
+
+(string_literal_argument) @string
+
+(string_argument) @constant.character
+
+(comment) @comment
+
+(port_comment) @label
+
+[
+("[") 
+("]")
+] @punctuation.bracket


### PR DESCRIPTION
Add syntax highlighting for .xtc/.xoa/.xpc files.

This merge request build upon my tree sitter, tree-sitter-xtc,
visible here: https://github.com/Alexis-Lapierre/tree-sitter-xtc.

* XTC stand for Xena Traffic Configuration
* XOA stand for Xena OpenAutomation
* XPC stand for Xena Port Configuration

You can read about the scripting language here:
https://docs.xenanetworks.com/projects/xoa-cli/en/latest/index.html