### PR TITLE
Enabled traversing multiple buffers at once

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -819,7 +819,11 @@ fn goto_buffer(editor: &mut Editor, direction: Direction, count: usize) {
         Direction::Backward => {
             let iter = editor.documents.keys();
             // skip 'count' times past current buffer
-            let mut iter = iter.rev().cycle().skip_while(|id| *id != &current).skip(count);
+            let mut iter = iter
+                .rev()
+                .cycle()
+                .skip_while(|id| *id != &current)
+                .skip(count);
             iter.next()
         }
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -799,28 +799,28 @@ fn goto_line_start(cx: &mut Context) {
 }
 
 fn goto_next_buffer(cx: &mut Context) {
-    goto_buffer(cx.editor, Direction::Forward);
+    goto_buffer(cx.editor, Direction::Forward, cx.count());
 }
 
 fn goto_previous_buffer(cx: &mut Context) {
-    goto_buffer(cx.editor, Direction::Backward);
+    goto_buffer(cx.editor, Direction::Backward, cx.count());
 }
 
-fn goto_buffer(editor: &mut Editor, direction: Direction) {
+fn goto_buffer(editor: &mut Editor, direction: Direction, count: usize) {
     let current = view!(editor).doc;
 
     let id = match direction {
         Direction::Forward => {
             let iter = editor.documents.keys();
-            let mut iter = iter.skip_while(|id| *id != &current);
-            iter.next(); // skip current item
-            iter.next().or_else(|| editor.documents.keys().next())
+            // skip 'count' times past current buffer
+            let mut iter = iter.cycle().skip_while(|id| *id != &current).skip(count);
+            iter.next()
         }
         Direction::Backward => {
             let iter = editor.documents.keys();
-            let mut iter = iter.rev().skip_while(|id| *id != &current);
-            iter.next(); // skip current item
-            iter.next().or_else(|| editor.documents.keys().next_back())
+            // skip 'count' times past current buffer
+            let mut iter = iter.rev().cycle().skip_while(|id| *id != &current).skip(count);
+            iter.next()
         }
     }
     .unwrap();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -813,18 +813,15 @@ fn goto_buffer(editor: &mut Editor, direction: Direction, count: usize) {
         Direction::Forward => {
             let iter = editor.documents.keys();
             // skip 'count' times past current buffer
-            let mut iter = iter.cycle().skip_while(|id| *id != &current).skip(count);
-            iter.next()
+            iter.cycle().skip_while(|id| *id != &current).nth(count)
         }
         Direction::Backward => {
             let iter = editor.documents.keys();
             // skip 'count' times past current buffer
-            let mut iter = iter
-                .rev()
+            iter.rev()
                 .cycle()
                 .skip_while(|id| *id != &current)
-                .skip(count);
-            iter.next()
+                .nth(count)
         }
     }
     .unwrap();

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -309,7 +309,7 @@ fn buffer_next(
         return Ok(());
     }
 
-    goto_buffer(cx.editor, Direction::Forward);
+    goto_buffer(cx.editor, Direction::Forward, 1);
     Ok(())
 }
 
@@ -322,7 +322,7 @@ fn buffer_previous(
         return Ok(());
     }
 
-    goto_buffer(cx.editor, Direction::Backward);
+    goto_buffer(cx.editor, Direction::Backward, 1);
     Ok(())
 }
 

--- a/languages.toml
+++ b/languages.toml
@@ -2052,6 +2052,29 @@ block-comment-tokens = { start = "/*", end = "*/" }
 indent = { tab-width = 4, unit = "\t" }
 formatter = { command = "odinfmt", args = [ "-stdin", "true" ] }
 
+[language.debugger]
+name = "lldb-dap"
+transport = "stdio"
+command = "lldb-dap"
+
+[[language.debugger.templates]]
+name = "binary"
+request = "launch"
+completion = [ { name = "binary", completion = "filename" } ]
+args = { console = "internalConsole", program = "{0}" }
+
+[[language.debugger.templates]]
+name = "attach"
+request = "attach"
+completion = [ "pid" ]
+args = { console = "internalConsole", pid = "{0}" }
+
+[[language.debugger.templates]]
+name = "gdbserver attach"
+request = "attach"
+completion = [ { name = "lldb connect url", default = "connect://localhost:3333" }, { name = "file", completion = "filename" }, "pid" ]
+args = { console = "internalConsole", attachCommands = [ "platform select remote-gdb-server", "platform connect {0}", "file {1}", "attach {2}" ] }
+
 [[grammar]]
 name = "odin"
 source = { git = "https://github.com/ap29600/tree-sitter-odin", rev = "b219207e49ffca2952529d33e94ed63b1b75c4f1" }


### PR DESCRIPTION
This aims to address https://github.com/helix-editor/helix/issues/10400 and allows prefixing `gn` and `gp` commands with a number to cycle through multiple buffers.

Feedback is always welcome.

This is my first attempt at contributing to something, so go easy on me 😅