### PR TITLE
languages/rust: add `rust-script` and `cargo` shebangs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -202,6 +202,7 @@ scope = "source.rust"
 injection-regex = "rust"
 file-types = ["rs"]
 roots = ["Cargo.toml", "Cargo.lock"]
+shebangs = ["rust-script", "cargo"]
 auto-format = true
 comment-tokens = ["//", "///", "//!"]
 block-comment-tokens = [


### PR DESCRIPTION
The former is one of the more popular forks of the original idea:

https://rust-script.org/

The latter is an RFC for folding that functionality into cargo itself, available on nightly:

https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#script