### PR TITLE
Fix: Svelte queries

### DIFF
--- a/runtime/queries/svelte/highlights.scm
+++ b/runtime/queries/svelte/highlights.scm
@@ -1,6 +1,11 @@
 ; Special identifiers
 ;--------------------
 
+(tag_name) @tag
+(attribute_name) @variable.other.member
+(erroneous_end_tag_name) @error
+(comment) @comment
+
 ; TODO:
 ((element (start_tag (tag_name) @_tag) (text) @markup.heading)
  (#match? @_tag "^(h[0-9]|title)$"))
@@ -27,11 +32,6 @@
    (attribute_name) @_attr
    (quoted_attribute_value (attribute_value) @markup.link.url))
  (#match? @_attr "^(href|src)$"))
-
-(tag_name) @tag
-(attribute_name) @variable.other.member
-(erroneous_end_tag_name) @error
-(comment) @comment
 
 [
   (attribute_value)


### PR DESCRIPTION
Fix for syntax highlighting in svelte, its currently not working correctly for certain tags.

Im not familiar with scheme but it seems (tag_name) and a few others were being used before having the correct highlight applied so moving them to the top of the file seems to fix the issue.

Before:
<img src="https://i.imgur.com/2yrwhQf.png" />

After:
<img src="https://i.imgur.com/a4ywJlO.png" />
