### PR TITLE
Fix kanagawa theme when using cursorline

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -8,7 +8,7 @@
 
 ## User interface
 "ui.selection" = { bg = "waveBlue2" }
-"ui.selection.primary" = { bg = "sumiInk5" }
+"ui.selection.primary" = { bg = "waveBlue2" }
 "ui.background" = { fg = "fujiWhite", bg = "sumiInk1" }
 
 "ui.linenr" = { fg = "sumiInk4" }
@@ -123,7 +123,6 @@ sumiInk1 = "#1F1F28"      # default background
 sumiInk2 = "#2A2A37"      # lighter background, e.g. colorcolumns, folds
 sumiInk3 = "#363646"      # lighter background, e.g. cursorline
 sumiInk4 = "#54546D"      # darker foreground, e.g. linenumbers, fold column
-sumiInk5 = "#363646"      # current selection
 waveBlue1 = "#223249"     # popup background, visual selection background
 waveBlue2 = "#2D4F67"     # popup selection background, search background
 winterGreen = "#2B3328"   # diff add background


### PR DESCRIPTION
The recent change to increase the contrast of the primary selection background (https://github.com/helix-editor/helix/pull/10094) was a good idea - previously the contrast was way too low and I'd often be sat squinting at my monitor.

Unfortunately the new ui.selection.primary colour happens to match exactly the colour used by the cursorline. On top of this, the colour `sumiInk5` is just a duplicate of `sumiInk3`.
This pull request chooses another contrastic colour (specifically `waveBlue2`) that doesn't clash with the cursorline and removes the `sumiInk5` variant:

Previously:
![image](https://github.com/helix-editor/helix/assets/24723950/77e4c35b-a712-43a7-8e4f-e5ad1616f053)
(Highlighted line is completely invisible because of the cursorline)

Now:
![image](https://github.com/helix-editor/helix/assets/24723950/a8de1974-0153-4e94-94fa-bf0a43be72a7)

Paging @mxpv and @zetashift for visibility