### PR TITLE
Add option to not overtype on closing pairs

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -201,18 +201,25 @@ Example:
 Enables automatic insertion of pairs to parentheses, brackets, etc. Can be a
 simple boolean value, or a specific mapping of pairs of single characters.
 
-To disable auto-pairs altogether, set `auto-pairs` to `false`:
+To disable auto-pairs altogether, set `config-type` to `false`:
 
 ```toml
-[editor]
-auto-pairs = false # defaults to `true`
+[editor.auto-pairs]
+config-type = false # defaults to `true`
+```
+
+To disable skipping over closing pairs, set `overtype` to `false`:
+
+```toml
+[editor.auto-pairs]
+overtype = false #defaults to `true`
 ```
 
 The default pairs are <code>(){}[]''""``</code>, but these can be customized by
 setting `auto-pairs` to a TOML table:
 
 ```toml
-[editor.auto-pairs]
+[editor.auto-pairs.config-type]
 '(' = ')'
 '{' = '}'
 '[' = ']'
@@ -231,7 +238,7 @@ Example `languages.toml` that adds `<>` and removes `''`
 [[language]]
 name = "rust"
 
-[language.auto-pairs]
+[language.auto-pairs.config-type]
 '(' = ')'
 '{' = '}'
 '[' = ']'

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -120,7 +120,13 @@ impl Default for AutoPairs {
 //   middle of triple quotes, and more exotic pairs like Jinja's {% %}
 
 #[must_use]
-pub fn hook(doc: &Rope, selection: &Selection, ch: char, pairs: &AutoPairs) -> Option<Transaction> {
+pub fn hook(
+    doc: &Rope,
+    selection: &Selection,
+    ch: char,
+    pairs: &AutoPairs,
+    overtype: bool,
+) -> Option<Transaction> {
     log::trace!("autopairs hook selection: {:#?}", selection);
 
     if let Some(pair) = pairs.get(ch) {
@@ -128,7 +134,7 @@ pub fn hook(doc: &Rope, selection: &Selection, ch: char, pairs: &AutoPairs) -> O
             return Some(handle_same(doc, selection, pair));
         } else if pair.open == ch {
             return Some(handle_open(doc, selection, pair));
-        } else if pair.close == ch {
+        } else if pair.close == ch && overtype {
             // && char_at pos == close
             return Some(handle_close(doc, selection, pair));
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3761,10 +3761,11 @@ pub mod insert {
         let text = doc.text();
         let selection = doc.selection(view.id);
         let auto_pairs = doc.auto_pairs(cx.editor);
+        let overtype = cx.editor.config().auto_pairs.overtype;
 
         let transaction = auto_pairs
             .as_ref()
-            .and_then(|ap| auto_pairs::hook(text, selection, c, ap))
+            .and_then(|ap| auto_pairs::hook(text, selection, c, ap, overtype))
             .or_else(|| insert(text, selection, c));
 
         let (view, doc) = current!(cx.editor);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1086,7 +1086,7 @@ impl Editor {
     ) -> Self {
         let language_servers = helix_lsp::Registry::new(syn_loader.clone());
         let conf = config.load();
-        let auto_pairs = (&conf.auto_pairs).into();
+        let auto_pairs = (&conf.auto_pairs).get_pairs();
 
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;
@@ -1168,7 +1168,7 @@ impl Editor {
     /// relevant members.
     pub fn refresh_config(&mut self) {
         let config = self.config();
-        self.auto_pairs = (&config.auto_pairs).into();
+        self.auto_pairs = (&config.auto_pairs).get_pairs();
         self.reset_idle_timer();
         self._refresh();
     }


### PR DESCRIPTION
Solution to #9595 
Vscode uses three modes(always, auto - only skip over auto generated closing pairs, and never) for autoCloseOvertype, while my implementation only uses two(always and never).