### PR TITLE
Respect mode when starting a search

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2080,6 +2080,11 @@ fn searcher(cx: &mut Context, direction: Direction) {
     let config = cx.editor.config();
     let scrolloff = config.scrolloff;
     let wrap_around = config.search.wrap_around;
+    let movement = if cx.editor.mode() == Mode::Select {
+        Movement::Extend
+    } else {
+        Movement::Move
+    };
 
     // TODO: could probably share with select_on_matches?
     let completions = search_completions(cx, Some(reg));
@@ -2104,7 +2109,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
             search_impl(
                 cx.editor,
                 &regex,
-                Movement::Move,
+                movement,
                 direction,
                 scrolloff,
                 wrap_around,


### PR DESCRIPTION
Currently the editor mode has no effect on the behavior of `search` and `rsearch`. We can pass in the right movement for the editor mode to make the behavior or `search` and `rsearch` match `search_next` and `search_prev` in select mode.

See https://github.com/helix-editor/helix/issues/5672#issuecomment-2064161299