### PR TITLE
refactor(themes): `gruvbox` warnings to `yellow1`

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -33,7 +33,7 @@
 "diff.delta" = "orange1"
 "diff.minus" = "red1"
 
-"warning" = "orange1"
+"warning" = "yellow1"
 "error" = "red1"
 "info" = "aqua1"
 "hint" = "blue1"
@@ -67,7 +67,7 @@
 "ui.virtual.wrap" = { fg = "bg2" }
 "ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
 
-"diagnostic.warning" = { underline = { color = "orange1", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow1", style = "curl" } }
 "diagnostic.error" = { underline = { color = "red1", style = "curl" } }
 "diagnostic.info" = { underline = { color = "aqua1", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "blue1", style = "curl" } }


### PR DESCRIPTION
The current choice for `orange1` came from the `CoC` setting in the [gruvbox](https://github.com/morhetz/gruvbox) repo, however, both the `ALE` and `Syntastic` settings use `yellow`. Going by majority rule, and a stated improvement by someone who uses a version of the theme, this changes the color to `yellow1` from `orange1`.

In hopes for as small a footprint as possible, and to propagate changes to maintain consistency between `gruvbox` variations, I changed the base `gruvbox` from which the others inherit. The original issue #10455 only brought up`gruvbox_light`, but having checked  checked the rest with the change, I decided it looked good to me.

`gruvbox`:
![gruvbox_warn_color](https://github.com/helix-editor/helix/assets/12489689/c33b1105-6d57-495d-b751-6c9a5be1ff13)

`gruvbox_dark_hard`:
![gruvbox_dark_hard_warn_color](https://github.com/helix-editor/helix/assets/12489689/6dce8f84-809c-48c9-af95-e6810c2d9280)

`gruvbox_dark_soft`:
![gruvbox_dark_soft_warn_color](https://github.com/helix-editor/helix/assets/12489689/cd00787e-a461-45a9-bb9b-e539bcab9017)

`gruvbox_light`:
![gruvbox_light_warn_color](https://github.com/helix-editor/helix/assets/12489689/73679966-77ec-4927-a10e-81398ec639ee)

`gruvbox_light_hard`:
![gruvbox_light_hard_warn_color](https://github.com/helix-editor/helix/assets/12489689/d6e603a2-333c-4fff-a4d1-3bc7c7cc53d9)

`gruvbox_light_soft`
![gruvbox_light_soft_warn_color](https://github.com/helix-editor/helix/assets/12489689/fad291d2-d3c4-42db-8c3c-dd11a21bcd87)

Closes: #10455