### PR TITLE
Bugfixes panic when resizing

### DIFF
--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -155,10 +155,8 @@ impl Component for SignatureHelp {
 
         let sig = &self.signatures[self.active_signature];
 
-        if PADDING >= viewport.1 || PADDING >= viewport.0 {
-            return None;
-        }
-        let max_text_width = (viewport.0 - PADDING).min(120);
+        // Min width: 10, Max width: 120
+        let max_text_width = viewport.0.saturating_sub(PADDING).min(120).max(10);
 
         let signature_text = crate::ui::markdown::highlighted_code_block(
             sig.signature.as_str(),

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -135,9 +135,20 @@ impl<T: Component> Popup<T> {
         let width = child_size.0.min(viewport.width);
         let height = child_size.1.min(viewport.height.saturating_sub(2)); // add some spacing in the viewport
 
-        let position = self
-            .position
-            .get_or_insert_with(|| editor.cursor().0.unwrap_or_default());
+        let position = if let Some(position) = self.position {
+            // check if the position is still inside the viewport
+            if position.row as u16 >= viewport.y
+                && (position.row as u16) < (viewport.y + viewport.height)
+                && position.col as u16 >= viewport.x
+                && (position.col as u16) < (viewport.x + viewport.width)
+            {
+                position
+            } else {
+                editor.cursor().0.unwrap_or_default()
+            }
+        } else {
+            editor.cursor().0.unwrap_or_default()
+        };
 
         // if there's a orientation preference, use that
         // if we're on the top part of the screen, do below


### PR DESCRIPTION
3ce8fac6c8b586fb14c8484c2d56436d4d68f673 popup: bugfix: reset the position to the cursor when outside the viewport
    
    while resizing, if the position is outside the view, then the program
    panics. check the position and reset it to the cursor position

357733590d451aebe15d053c85e70c855616e0f0  SignatureHelp: bugfix: introduce minimum width of 10
    
    required_size shouldn't return None. Introduce minimum width so that the
    height can be calculated