### PR TITLE
Update lang-support.md for new wiki page name

### DIFF
--- a/book/src/lang-support.md
+++ b/book/src/lang-support.md
@@ -1,7 +1,7 @@
 # Language Support
 
 The following languages and Language Servers are supported. To use
-Language Server features, you must first [install][lsp-install-wiki] the
+Language Server features, you must first [configure][lsp-config-wiki] the
 appropriate Language Server.
 
 You can check the language support in your installed helix version with `hx --health`.
@@ -11,6 +11,6 @@ Languages][adding-languages] guide for more language configuration information.
 
 {{#include ./generated/lang-support.md}}
 
-[lsp-install-wiki]: https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers
+[lsp-config-wiki]: https://github.com/helix-editor/helix/wiki/Language-Server-Configurations
 [lang-config]: ./languages.md
 [adding-languages]: ./guides/adding_languages.md


### PR DESCRIPTION
The prior URL invites you to create a new wiki page. I think https://github.com/helix-editor/helix/wiki/Language-Server-Configurations is the correct place to point to now.

There might be more issues related to changes in wiki structure that are not caught by some CI link check because of this (it's a valid URL, just not what you want to direct to lol)