### PR TITLE
Disable crossterm's support for NO_COLOR.

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -91,6 +91,10 @@ where
     W: Write,
 {
     pub fn new(buffer: W, config: &EditorConfig) -> CrosstermBackend<W> {
+        // helix is not usable without colors, but crossterm will disable
+        // them by default if NO_COLOR is set in the environment. Override
+        // this behaviour.
+        crossterm::style::force_color_output(true);
         CrosstermBackend {
             buffer,
             capabilities: Capabilities::from_env_or_default(config),


### PR DESCRIPTION
This option allows overriding the NO_COLOR environment variable, which crossterm honors by default.

As noted in https://no-color.org/, "User-level configuration files and per-instance command-line arguments should override $NO_COLOR".