### PR TITLE
feat: update bash grammar to latest tree-sitter-bash rev

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -934,7 +934,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "bash"
-source = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "275effdfc0edce774acf7d481f9ea195c6c403cd" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "f8fb3274f72a30896075585b32b0c54cad65c086" }
 
 [[language]]
 name = "php"

--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -7,45 +7,33 @@
 
 (command_name) @function
 
-(variable_name) @variable.other.member
+(variable_name) @property
 
 [
-  "if"
-  "then"
-  "else"
-  "elif"
-  "fi"
   "case"
-  "in"
-  "esac"
-] @keyword.control.conditional
-
-[
-  "for"
   "do"
   "done"
+  "elif"
+  "else"
+  "esac"
+  "export"
+  "fi"
+  "for"
+  "function"
+  "if"
+  "in"
   "select"
+  "then"
+  "unset"
   "until"
   "while"
-] @keyword.control.repeat
-
-[
-  "declare"
-  "typeset"
-  "export"
-  "readonly"
-  "local"
-  "unset"
-  "unsetenv"
 ] @keyword
-
-"function" @keyword.function
 
 (comment) @comment
 
 (function_definition name: (word) @function)
 
-(file_descriptor) @constant.numeric.integer
+(file_descriptor) @number
 
 [
   (command_substitution)
@@ -60,7 +48,6 @@
   ">>"
   "<"
   "|"
-  (expansion_flags)
 ] @operator
 
 (

--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -7,33 +7,45 @@
 
 (command_name) @function
 
-(variable_name) @property
+(variable_name) @variable.other.member
 
 [
+  "if"
+  "then"
+  "else"
+  "elif"
+  "fi"
   "case"
+  "in"
+  "esac"
+] @keyword.control.conditional
+
+[
+  "for"
   "do"
   "done"
-  "elif"
-  "else"
-  "esac"
-  "export"
-  "fi"
-  "for"
-  "function"
-  "if"
-  "in"
   "select"
-  "then"
-  "unset"
   "until"
   "while"
+] @keyword.control.repeat
+
+[
+  "declare"
+  "typeset"
+  "export"
+  "readonly"
+  "local"
+  "unset"
+  "unsetenv"
 ] @keyword
+
+"function" @keyword.function
 
 (comment) @comment
 
 (function_definition name: (word) @function)
 
-(file_descriptor) @number
+(file_descriptor) @constant.numeric.integer
 
 [
   (command_substitution)


### PR DESCRIPTION
This PR addresses #3151 

![image](https://github.com/helix-editor/helix/assets/8350496/27ec5c3e-caf8-43ae-8c50-cd60e525dfef)

I have set the rev for the bash grammar to the latest commit hash on master for [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash), and have updated the runtime/queries/bash/highlights.scm to the latest for the updated grammar as well.
