### PR TITLE
Add support to ignore .svn and .hg directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 helix-term/rustfmt.toml
 result
 runtime/grammars
+.svn/
+.hg/


### PR DESCRIPTION
Skips .svn or .hg file tracking when used with those version controls