### PR TITLE
Ignore .svn version control files

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -51,7 +51,7 @@ fn filter_picker_entry(entry: &DirEntry, root: &Path, dedup_symlinks: bool) -> b
     // in our picker.
     if matches!(
         entry.file_name().to_str(),
-        Some(".git" | ".pijul" | ".jj" | ".hg")
+        Some(".git" | ".pijul" | ".jj" | ".hg" | ".svn")
     ) {
         return false;
     }


### PR DESCRIPTION
Ignores `.svn`. This makes hx more usable with svn VC. Fixes #2406 