### PR TITLE
allow configuring smart tab to always trigger completion instead

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3759,7 +3759,7 @@ pub mod insert {
     }
 
     use helix_core::auto_pairs;
-    use helix_view::editor::SmartTabConfig;
+    use helix_view::editor::{SmartTabConfig, SmartTabMode};
 
     pub fn insert_char(cx: &mut Context, c: char) {
         let (view, doc) = current_ref!(cx.editor);
@@ -3784,10 +3784,10 @@ pub mod insert {
         let (view, doc) = current_ref!(cx.editor);
         let view_id = view.id;
 
-        if matches!(
-            cx.editor.config().smart_tab,
-            Some(SmartTabConfig { enable: true, .. })
-        ) {
+        if let Some(SmartTabConfig {
+            enable: true, mode, ..
+        }) = &cx.editor.config().smart_tab
+        {
             let cursors_after_whitespace = doc.selection(view_id).ranges().iter().all(|range| {
                 let cursor = range.cursor(doc.text().slice(..));
                 let current_line_num = doc.text().char_to_line(cursor);
@@ -3797,7 +3797,10 @@ pub mod insert {
             });
 
             if !cursors_after_whitespace {
-                move_parent_node_end(cx);
+                match mode {
+                    SmartTabMode::MoveParentNodeEnd => move_parent_node_end(cx),
+                    SmartTabMode::Completion => completion(cx),
+                }
                 return;
             }
         }

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -274,6 +274,7 @@ impl<T: Item + 'static> Component for Menu<T> {
                 Some(SmartTabConfig {
                     enable: true,
                     supersede_menu: true,
+                    ..
                 })
             )
         {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -343,6 +343,7 @@ pub struct Config {
 pub struct SmartTabConfig {
     pub enable: bool,
     pub supersede_menu: bool,
+    pub mode: SmartTabMode,
 }
 
 impl Default for SmartTabConfig {
@@ -350,8 +351,16 @@ impl Default for SmartTabConfig {
         SmartTabConfig {
             enable: true,
             supersede_menu: false,
+            mode: SmartTabMode::MoveParentNodeEnd,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum SmartTabMode {
+    MoveParentNodeEnd,
+    Completion,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
it's always been pretty difficult to reliably use tab to select completions - if autocompletion is enabled, it's very easy to press tab before the autocomplete menu loads, which previously just inserted a literal tab and now jumps the cursor around unexpectedly. i'd really like to be able to use tab solely for completion, and this accomplishes that pretty well. the main thing i'm unsure about here is how the configuration should work here - it feels like this would be a lot simpler if i could just map the smart tab action to an arbitrary command, but MappableCommand is defined in helix-term, so it's not available to use as part of the editor.smart-tab config section which is defined in helix-view. that said, there aren't really that many other actions that really make sense to be triggered by smart tab, so maybe this is fine? we could also potentially replace `enable: true` with `mode: InsertTab` or something along those lines, but i don't really have strong feelings either way there.