### PR TITLE
feat(themes): jump-label for modus themes

### DIFF
--- a/runtime/themes/modus_operandi.toml
+++ b/runtime/themes/modus_operandi.toml
@@ -80,6 +80,7 @@ punctuation = "fg-dim"
 "ui.virtual" = "bg-active"
 "ui.virtual.ruler" = { bg = "bg-dim" }
 "ui.virtual.inlay-hint" = { fg = "fg-dim", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "yellow-cooler", modifiers = ["bold"] }
 
 "ui.selection" = { fg = "fg-main", bg = "bg-inactive" }
 "ui.selection.primary" = { fg = "fg-main", bg = "bg-active" }

--- a/runtime/themes/modus_vivendi.toml
+++ b/runtime/themes/modus_vivendi.toml
@@ -83,6 +83,7 @@ punctuation = "fg-dim"
 "ui.virtual" = "bg-active"
 "ui.virtual.ruler" = { bg = "bg-dim" }
 "ui.virtual.inlay-hint" = { fg = "fg-dim", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "yellow-cooler", modifiers = ["bold"] }
 
 "ui.selection" = { fg = "fg-main", bg = "bg-inactive" }
 "ui.selection.primary" = { fg = "fg-main", bg = "bg-active" }


### PR DESCRIPTION
Add styling for jump-labels for modus themes. I couldn't find any official approach here so picking `yellow-cooler`. `cooler` is used for other meta highlights by modus and yellow seems to be used the least - only warnings, so there's little chance of colliding with other highlights.
