### PR TITLE
specify direction for select_prev_sibling and select_next_sibling

### DIFF
--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -666,7 +666,7 @@ async fn tree_sitter_motions_work_across_injections() -> anyhow::Result<()> {
         (
             "<script>let #[|x]# = 1;</script>",
             "<A-n>",
-            "<script>let x #[|=]# 1;</script>",
+            "<script>let x #[=|]# 1;</script>",
         ),
     )
     .await?;


### PR DESCRIPTION
Use `Direction::Forward` for `select_next_sibling` and `Direction::Backward` for `select_prev_sibling` instead of inheriting the direction from the original selection / range.

Reference - https://github.com/helix-editor/helix/issues/4612#issuecomment-2068028963