### PR TITLE
fix typo in tutor's 10.4 SPLITTING SELECTIONS section

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -1084,7 +1084,7 @@ lines.
 
  1. Move the cursor to the line under ---.
  2. Type xx / 2x to select the lines.
- 3. Type S then \. |! Enter (note the spaces after . and !).
+ 3. Type S then \. |! Enter (note the spaces after . and |).
     This effectively splits the selection into sentences at each
     dot or exclamation mark.
  4. Press Alt-; to reverse the selections.

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -1084,7 +1084,7 @@ lines.
 
  1. Move the cursor to the line under ---.
  2. Type xx / 2x to select the lines.
- 3. Type S then \. |! Enter (note the spaces after . and |).
+ 3. Type S then \. |! Enter (note the space after . and |).
     This effectively splits the selection into sentences at each
     dot or exclamation mark.
  4. Press Alt-; to reverse the selections.


### PR DESCRIPTION
Fix small typo in the regex explanation.