### PR TITLE
Fixed ECMAScript private member highlighting

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -179,6 +179,7 @@ We use a similar set of scopes as
   - `parameter` - Function parameters
   - `other`
     - `member` - Fields of composite data types (e.g. structs, unions)
+      - `private` - Private fields that use a unique syntax (currently just ECMAScript-based languages)
 
 - `label`
 
@@ -206,6 +207,7 @@ We use a similar set of scopes as
 - `function`
   - `builtin`
   - `method`
+    - `private` - Private methods that use a unique syntax (currently just ECMAScript-based languages)
   - `macro`
   - `special` (preprocessor in C)
 

--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -29,14 +29,23 @@
   name: (identifier) @function)
 (method_definition
   name: (property_identifier) @function.method)
+(method_definition
+  name: (private_property_identifier) @function.method.private)
 
 (pair
   key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+(pair
+  key: (private_property_identifier) @function.method.private
   value: [(function) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
     property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+(assignment_expression
+  left: (member_expression
+    property: (private_property_identifier) @function.method.private)
   right: [(function) (arrow_function)])
 
 (variable_declarator
@@ -64,6 +73,9 @@
 (call_expression
   function: (member_expression
     property: (property_identifier) @function.method))
+(call_expression
+  function: (member_expression
+    property: (private_property_identifier) @function.method.private))
 
 ; Variables
 ;----------
@@ -74,6 +86,7 @@
 ;-----------
 
 (property_identifier) @variable.other.member
+(private_property_identifier) @variable.other.member.private
 (shorthand_property_identifier) @variable.other.member
 (shorthand_property_identifier_pattern) @variable.other.member
 


### PR DESCRIPTION
It's bugged me that private members haven't been highlighted in editor I've used so far, so I've added the queries to allow actually restyling. Currently, they're targeted as a `.private` child under `variable.other.member` and `function.method` so that they automatically take on the existing highlighting properly while being individually style-able. This was a personal preference, since it would match other langs which don't colour public & private methods/field differently while allowing the unique syntax of JS to be taken advantage of, however there's 2 other options that could also work:

- Remove all the `.private` parts and match other langs exactly
- Rename to not be a child and instead standalone (eg `variable.other.private-member`) to preserve the current lack of styling

Example code that shows what syntax it now highlights:
```ts
export class Test {
  regularField: string = "working highlights";

  #privateField: string = "fixed with these changes";
}
```
Funnily enough, even GitHub doesn't handle private props properly. Not sure if that's an oversight or a stylistic choice, but it bugs the hell out of me.