### PR TITLE
Fix wrong version 24.3.0 to 24.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "helix-core"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "helix-dap"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "fern",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "helix-event"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "helix-loader"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "cc",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "helix-lsp"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1401,11 +1401,11 @@ dependencies = [
 
 [[package]]
 name = "helix-parsec"
-version = "24.3.0"
+version = "24.0.3"
 
 [[package]]
 name = "helix-stdx"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "bitflags 2.5.0",
  "dunce",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "helix-term"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "helix-tui"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "bitflags 2.5.0",
  "cassowary",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "helix-vcs"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "helix-view"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2896,7 +2896,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "xtask"
-version = "24.3.0"
+version = "24.0.3"
 dependencies = [
  "helix-core",
  "helix-loader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nucleo = "0.2.0"
 slotmap = "1.0.7"
 
 [workspace.package]
-version = "24.3.0"
+version = "24.0.3"
 edition = "2021"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 categories = ["editor"]


### PR DESCRIPTION
hx --version returns for some reason: helix 24.3

P.S. I am not sure where xtask comes from, it also has version 24.3.0 but i couldn't find anything about it's version (changed it to 24.0.3 as well).