### PR TITLE
Keep ViewPosition consistent when a Document is edited from different Views, and on buffer switching

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -394,21 +394,12 @@ impl Application {
         self.editor.refresh_config();
 
         // reset view position in case softwrap was enabled/disabled
-        let mut view_position_resets = Vec::new();
         let scrolloff = self.editor.config().scrolloff;
         for (view, _) in self.editor.tree.views() {
-            let doc = &self.editor.documents[&view.doc];
-
+            let doc = doc_mut!(self.editor, &view.doc);
             if let Some(offset) = view.offset_coords_to_in_view_center::<false>(doc, scrolloff) {
-                view_position_resets.push((offset, view.id, view.doc));
+                doc.view_data_mut(view.id).view_position = offset
             }
-        }
-        for (offset, view_id, doc_id) in view_position_resets {
-            self.editor
-                .document_mut(doc_id)
-                .unwrap()
-                .view_data_mut(view_id)
-                .view_position = offset;
         }
     }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -397,9 +397,7 @@ impl Application {
         let scrolloff = self.editor.config().scrolloff;
         for (view, _) in self.editor.tree.views() {
             let doc = doc_mut!(self.editor, &view.doc);
-            if let Some(offset) = view.offset_coords_to_in_view_center::<false>(doc, scrolloff) {
-                doc.view_data_mut(view.id).view_position = offset
-            }
+            view.ensure_cursor_in_view(doc, scrolloff);
         }
     }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -394,10 +394,21 @@ impl Application {
         self.editor.refresh_config();
 
         // reset view position in case softwrap was enabled/disabled
+        let mut view_position_resets = Vec::new();
         let scrolloff = self.editor.config().scrolloff;
-        for (view, _) in self.editor.tree.views_mut() {
+        for (view, _) in self.editor.tree.views() {
             let doc = &self.editor.documents[&view.doc];
-            view.ensure_cursor_in_view(doc, scrolloff)
+
+            if let Some(offset) = view.offset_coords_to_in_view_center::<false>(doc, scrolloff) {
+                view_position_resets.push((offset, view.id, view.doc));
+            }
+        }
+        for (offset, view_id, doc_id) in view_position_resets {
+            self.editor
+                .document_mut(doc_id)
+                .unwrap()
+                .view_data_mut(view_id)
+                .view_position = offset;
         }
     }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1683,14 +1683,14 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     let doc_text = doc.text().slice(..);
     let viewport = view.inner_area(doc);
     let text_fmt = doc.text_format(viewport.width, None);
-    let annotations = view.text_annotations(&*doc, None);
     (view_offset.anchor, view_offset.vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         view_offset.anchor,
         view_offset.vertical_offset as isize + offset,
         0,
         &text_fmt,
-        &annotations,
+        // &annotations,
+        &view.text_annotations(&*doc, None),
     );
     doc.set_view_offset(view.id, view_offset);
 
@@ -5236,14 +5236,13 @@ fn align_view_middle(cx: &mut Context) {
         return;
     }
     let doc_text = doc.text().slice(..);
-    let annotations = view.text_annotations(doc, None);
     let pos = doc.selection(view.id).primary().cursor(doc_text);
     let pos = visual_offset_from_block(
         doc_text,
         doc.view_offset(view.id).anchor,
         pos,
         &text_fmt,
-        &annotations,
+        &view.text_annotations(doc, None),
     )
     .0;
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1724,7 +1724,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
         return;
     }
 
-    let view_offset = doc.view_data(view.id).unwrap().view_position;
+    let view_offset = doc.view_data(view.id).view_position;
 
     let mut head;
     match direction {
@@ -5134,7 +5134,7 @@ fn split(editor: &mut Editor, action: Action) {
     let (view, doc) = current!(editor);
     let id = doc.id();
     let selection = doc.selection(view.id).clone();
-    let offset = doc.view_data(view.id).unwrap().view_position;
+    let offset = doc.view_data(view.id).view_position;
 
     editor.switch(id, action);
 
@@ -5242,7 +5242,7 @@ fn align_view_middle(cx: &mut Context) {
     let pos = doc.selection(view.id).primary().cursor(doc_text);
     let pos = visual_offset_from_block(
         doc_text,
-        doc.view_data(view.id).unwrap().view_position.anchor,
+        doc.view_data(view.id).view_position.anchor,
         pos,
         &text_fmt,
         &annotations,
@@ -6133,8 +6133,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
 
     // This is not necessarily exact if there is virtual text like soft wrap.
     // It's ok though because the extra jump labels will not be rendered.
-    let start =
-        text.line_to_char(text.char_to_line(doc.view_data(view.id).unwrap().view_position.anchor));
+    let start = text.line_to_char(text.char_to_line(doc.view_data(view.id).view_position.anchor));
     let end = text.line_to_char(view.estimate_last_doc_line(doc) + 1);
 
     let primary_selection = doc.selection(view.id).primary();

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1301,7 +1301,6 @@ fn compute_inlay_hints_for_view(
     let view_height = view.inner_height();
     let first_visible_line = doc_text.char_to_line(
         doc.view_data(view_id)
-            .unwrap()
             .view_position
             .anchor
             .min(doc_text.len_chars()),

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1299,7 +1299,13 @@ fn compute_inlay_hints_for_view(
     // than computing all the hints for the full file (which could be dozens of time
     // longer than the view is).
     let view_height = view.inner_height();
-    let first_visible_line = doc_text.char_to_line(view.offset.anchor.min(doc_text.len_chars()));
+    let first_visible_line = doc_text.char_to_line(
+        doc.view_data(view_id)
+            .unwrap()
+            .view_position
+            .anchor
+            .min(doc_text.len_chars()),
+    );
     let first_line = first_visible_line.saturating_sub(view_height);
     let last_line = first_visible_line
         .saturating_add(view_height.saturating_mul(2))

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1299,12 +1299,8 @@ fn compute_inlay_hints_for_view(
     // than computing all the hints for the full file (which could be dozens of time
     // longer than the view is).
     let view_height = view.inner_height();
-    let first_visible_line = doc_text.char_to_line(
-        doc.view_data(view_id)
-            .view_position
-            .anchor
-            .min(doc_text.len_chars()),
-    );
+    let first_visible_line =
+        doc_text.char_to_line(doc.view_offset(view_id).anchor.min(doc_text.len_chars()));
     let first_line = first_visible_line.saturating_sub(view_height);
     let last_line = first_visible_line
         .saturating_add(view_height.saturating_mul(2))

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1589,7 +1589,6 @@ fn tree_sitter_highlight_name(
             // Calculate viewport byte ranges:
             let row = text.char_to_line(
                 doc.view_data(view.id)
-                    .unwrap()
                     .view_position
                     .anchor
                     .min(text.len_chars()),

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1587,12 +1587,7 @@ fn tree_sitter_highlight_name(
         // Query the same range as the one used in syntax highlighting.
         let range = {
             // Calculate viewport byte ranges:
-            let row = text.char_to_line(
-                doc.view_data(view.id)
-                    .view_position
-                    .anchor
-                    .min(text.len_chars()),
-            );
+            let row = text.char_to_line(doc.view_offset(view.id).anchor.min(text.len_chars()));
             // Saturating subs to make it inclusive zero indexing.
             let last_line = text.len_lines().saturating_sub(1);
             let height = view.inner_area(doc).height;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1587,7 +1587,13 @@ fn tree_sitter_highlight_name(
         // Query the same range as the one used in syntax highlighting.
         let range = {
             // Calculate viewport byte ranges:
-            let row = text.char_to_line(view.offset.anchor.min(text.len_chars()));
+            let row = text.char_to_line(
+                doc.view_data(view.id)
+                    .unwrap()
+                    .view_position
+                    .anchor
+                    .min(text.len_chars()),
+            );
             // Saturating subs to make it inclusive zero indexing.
             let last_line = text.len_lines().saturating_sub(1);
             let height = view.inner_area(doc).height;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -93,6 +93,8 @@ impl EditorView {
         let theme = &editor.theme;
         let config = editor.config();
 
+        let view_offset = doc.view_data(view.id).unwrap().view_position;
+
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
 
@@ -119,13 +121,13 @@ impl EditorView {
         }
 
         let syntax_highlights =
-            Self::doc_syntax_highlights(doc, view.offset.anchor, inner.height, theme);
+            Self::doc_syntax_highlights(doc, view_offset.anchor, inner.height, theme);
 
         let mut overlay_highlights =
-            Self::empty_highlight_iter(doc, view.offset.anchor, inner.height);
+            Self::empty_highlight_iter(doc, view_offset.anchor, inner.height);
         let overlay_syntax_highlights = Self::overlay_syntax_highlights(
             doc,
-            view.offset.anchor,
+            view_offset.anchor,
             inner.height,
             &text_annotations,
         );
@@ -203,7 +205,7 @@ impl EditorView {
             surface,
             inner,
             doc,
-            view.offset,
+            view_offset,
             &text_annotations,
             syntax_highlights,
             overlay_highlights,
@@ -259,11 +261,13 @@ impl EditorView {
             .and_then(|config| config.rulers.as_ref())
             .unwrap_or(editor_rulers);
 
+        let view_offset = doc.view_data(view.id).unwrap().view_position;
+
         rulers
             .iter()
             // View might be horizontally scrolled, convert from absolute distance
             // from the 1st column to relative distance from left of viewport
-            .filter_map(|ruler| ruler.checked_sub(1 + view.offset.horizontal_offset as u16))
+            .filter_map(|ruler| ruler.checked_sub(1 + view_offset.horizontal_offset as u16))
             .filter(|ruler| ruler < &viewport.width)
             .map(|ruler| viewport.clip_left(ruler).with_width(1))
             .for_each(|area| surface.set_style(area, ruler_theme))
@@ -825,6 +829,7 @@ impl EditorView {
         let inner_area = view.inner_area(doc);
 
         let selection = doc.selection(view.id);
+        let view_offset = doc.view_data(view.id).unwrap().view_position;
         let primary = selection.primary();
         let text_format = doc.text_format(viewport.width, None);
         for range in selection.iter() {
@@ -835,11 +840,11 @@ impl EditorView {
                 visual_offset_from_block(text, cursor, cursor, &text_format, text_annotations).0;
 
             // if the cursor is horizontally in the view
-            if col >= view.offset.horizontal_offset
-                && inner_area.width > (col - view.offset.horizontal_offset) as u16
+            if col >= view_offset.horizontal_offset
+                && inner_area.width > (col - view_offset.horizontal_offset) as u16
             {
                 let area = Rect::new(
-                    inner_area.x + (col - view.offset.horizontal_offset) as u16,
+                    inner_area.x + (col - view_offset.horizontal_offset) as u16,
                     view.area.y,
                     1,
                     view.area.height,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -93,7 +93,7 @@ impl EditorView {
         let theme = &editor.theme;
         let config = editor.config();
 
-        let view_offset = doc.view_data(view.id).view_position;
+        let view_offset = doc.view_offset(view.id);
 
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
@@ -261,7 +261,7 @@ impl EditorView {
             .and_then(|config| config.rulers.as_ref())
             .unwrap_or(editor_rulers);
 
-        let view_offset = doc.view_data(view.id).view_position;
+        let view_offset = doc.view_offset(view.id);
 
         rulers
             .iter()
@@ -829,7 +829,7 @@ impl EditorView {
         let inner_area = view.inner_area(doc);
 
         let selection = doc.selection(view.id);
-        let view_offset = doc.view_data(view.id).view_position;
+        let view_offset = doc.view_offset(view.id);
         let primary = selection.primary();
         let text_format = doc.text_format(viewport.width, None);
         for range in selection.iter() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -93,7 +93,7 @@ impl EditorView {
         let theme = &editor.theme;
         let config = editor.config();
 
-        let view_offset = doc.view_data(view.id).unwrap().view_position;
+        let view_offset = doc.view_data(view.id).view_position;
 
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
@@ -261,7 +261,7 @@ impl EditorView {
             .and_then(|config| config.rulers.as_ref())
             .unwrap_or(editor_rulers);
 
-        let view_offset = doc.view_data(view.id).unwrap().view_position;
+        let view_offset = doc.view_data(view.id).view_position;
 
         rulers
             .iter()
@@ -829,7 +829,7 @@ impl EditorView {
         let inner_area = view.inner_area(doc);
 
         let selection = doc.selection(view.id);
-        let view_offset = doc.view_data(view.id).unwrap().view_position;
+        let view_offset = doc.view_data(view.id).view_position;
         let primary = selection.primary();
         let text_format = doc.text_format(viewport.width, None);
         for range in selection.iter() {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -83,7 +83,7 @@ pub fn raw_regex_prompt(
     let (view, doc) = current!(cx.editor);
     let doc_id = view.doc;
     let snapshot = doc.selection(view.id).clone();
-    let offset_snapshot = doc.view_data(view.id).unwrap().view_position;
+    let offset_snapshot = doc.view_data(view.id).view_position;
     let config = cx.editor.config();
 
     let mut prompt = Prompt::new(

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -83,7 +83,7 @@ pub fn raw_regex_prompt(
     let (view, doc) = current!(cx.editor);
     let doc_id = view.doc;
     let snapshot = doc.selection(view.id).clone();
-    let offset_snapshot = doc.view_data(view.id).view_position;
+    let offset_snapshot = doc.view_offset(view.id);
     let config = cx.editor.config();
 
     let mut prompt = Prompt::new(
@@ -95,7 +95,7 @@ pub fn raw_regex_prompt(
                 PromptEvent::Abort => {
                     let (view, doc) = current!(cx.editor);
                     doc.set_selection(view.id, snapshot.clone());
-                    doc.view_data_mut(view.id).view_position = offset_snapshot;
+                    doc.set_view_offset(view.id, offset_snapshot);
                 }
                 PromptEvent::Update | PromptEvent::Validate => {
                     // skip empty input
@@ -136,7 +136,7 @@ pub fn raw_regex_prompt(
                         Err(err) => {
                             let (view, doc) = current!(cx.editor);
                             doc.set_selection(view.id, snapshot.clone());
-                            doc.view_data_mut(view.id).view_position = offset_snapshot;
+                            doc.set_view_offset(view.id, offset_snapshot);
 
                             if event == PromptEvent::Validate {
                                 let callback = async move {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -83,7 +83,7 @@ pub fn raw_regex_prompt(
     let (view, doc) = current!(cx.editor);
     let doc_id = view.doc;
     let snapshot = doc.selection(view.id).clone();
-    let offset_snapshot = view.offset;
+    let offset_snapshot = doc.view_data(view.id).unwrap().view_position;
     let config = cx.editor.config();
 
     let mut prompt = Prompt::new(
@@ -95,7 +95,7 @@ pub fn raw_regex_prompt(
                 PromptEvent::Abort => {
                     let (view, doc) = current!(cx.editor);
                     doc.set_selection(view.id, snapshot.clone());
-                    view.offset = offset_snapshot;
+                    doc.view_data_mut(view.id).view_position = offset_snapshot;
                 }
                 PromptEvent::Update | PromptEvent::Validate => {
                     // skip empty input
@@ -136,7 +136,7 @@ pub fn raw_regex_prompt(
                         Err(err) => {
                             let (view, doc) = current!(cx.editor);
                             doc.set_selection(view.id, snapshot.clone());
-                            view.offset = offset_snapshot;
+                            doc.view_data_mut(view.id).view_position = offset_snapshot;
 
                             if event == PromptEvent::Validate {
                                 let callback = async move {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -133,7 +133,7 @@ pub struct Document {
     pub(crate) id: DocumentId,
     text: Rope,
     selections: HashMap<ViewId, Selection>,
-    pub view_data: HashMap<ViewId, ViewData>,
+    view_data: HashMap<ViewId, ViewData>,
 
     /// Inlay hints annotations for the document, by view.
     ///
@@ -661,7 +661,7 @@ impl Document {
             selections: HashMap::default(),
             inlay_hints: HashMap::default(),
             inlay_hints_oudated: false,
-            view_data: Default::default(), // TODO: verify this is what we want
+            view_data: Default::default(),
             indent_style: DEFAULT_INDENT,
             line_ending,
             restore_cursor: false,
@@ -1197,9 +1197,7 @@ impl Document {
             self.reset_selection(view_id);
         }
 
-        if self.view_data(view_id).is_none() {
-            self.view_data.insert(view_id, ViewData::default());
-        }
+        self.view_data_mut(view_id);
     }
 
     /// Mark document as recent used for MRU sorting
@@ -1775,8 +1773,13 @@ impl Document {
         &self.selections
     }
 
-    pub fn view_data(&self, view_id: ViewId) -> Option<&ViewData> {
+    pub(crate) fn get_view_data(&self, view_id: ViewId) -> Option<&ViewData> {
         self.view_data.get(&view_id)
+    }
+    pub fn view_data(&self, view_id: ViewId) -> &ViewData {
+        self.view_data
+            .get(&view_id)
+            .expect("This should only be called after ensure_view_init")
     }
 
     pub fn view_data_mut(&mut self, view_id: ViewId) -> &mut ViewData {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1773,17 +1773,26 @@ impl Document {
         &self.selections
     }
 
-    pub(crate) fn get_view_data(&self, view_id: ViewId) -> Option<&ViewData> {
-        self.view_data.get(&view_id)
-    }
-    pub fn view_data(&self, view_id: ViewId) -> &ViewData {
+    fn view_data(&self, view_id: ViewId) -> &ViewData {
         self.view_data
             .get(&view_id)
             .expect("This should only be called after ensure_view_init")
     }
 
-    pub fn view_data_mut(&mut self, view_id: ViewId) -> &mut ViewData {
+    fn view_data_mut(&mut self, view_id: ViewId) -> &mut ViewData {
         self.view_data.entry(view_id).or_default()
+    }
+
+    pub(crate) fn get_view_offset(&self, view_id: ViewId) -> Option<ViewPosition> {
+        Some(self.view_data.get(&view_id)?.view_position)
+    }
+
+    pub fn view_offset(&self, view_id: ViewId) -> ViewPosition {
+        self.view_data(view_id).view_position
+    }
+
+    pub fn set_view_offset(&mut self, view_id: ViewId, new_offset: ViewPosition) {
+        self.view_data_mut(view_id).view_position = new_offset;
     }
 
     pub fn relative_path(&self) -> Option<Cow<Path>> {
@@ -2063,7 +2072,7 @@ impl Document {
 
 #[derive(Debug, Default)]
 pub struct ViewData {
-    pub view_position: ViewPosition,
+    view_position: ViewPosition,
 }
 
 #[derive(Clone, Debug)]

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1898,8 +1898,8 @@ impl Editor {
 
     pub fn ensure_cursor_in_view(&mut self, id: ViewId) {
         let config = self.config();
-        let view = self.tree.get(id).clone();
-        let doc = self.document_mut(view.doc).unwrap();
+        let view = self.tree.get(id);
+        let doc = doc_mut!(self, &view.doc);
         view.ensure_cursor_in_view(doc, config.scrolloff)
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -10,7 +10,6 @@ use crate::{
     register::Registers,
     theme::{self, Theme},
     tree::{self, Tree},
-    view::ViewPosition,
     Document, DocumentId, View, ViewId,
 };
 use dap::StackFrame;
@@ -1532,18 +1531,8 @@ impl Editor {
         let scrolloff = self.config().scrolloff;
         let view = self.tree.get_mut(current_view);
 
-        if let Some(old_doc) = self.documents.get_mut(&view.doc) {
-            old_doc.view_data_mut(current_view).view_position = view.offset;
-        }
-
         view.doc = doc_id;
         let doc = doc_mut!(self, &doc_id);
-
-        view.offset = if let Some(view_data) = doc.view_data(current_view) {
-            view_data.view_position
-        } else {
-            ViewPosition::default()
-        };
 
         doc.ensure_view_init(view.id);
         view.sync_changes(doc);
@@ -1909,8 +1898,8 @@ impl Editor {
 
     pub fn ensure_cursor_in_view(&mut self, id: ViewId) {
         let config = self.config();
-        let view = self.tree.get_mut(id);
-        let doc = &self.documents[&view.doc];
+        let view = self.tree.get(id).clone();
+        let doc = self.document_mut(view.doc).unwrap();
         view.ensure_cursor_in_view(doc, config.scrolloff)
     }
 

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -61,14 +61,13 @@ pub fn align_view(doc: &mut Document, view: &View, align: Align) {
     };
 
     let text_fmt = doc.text_format(viewport.width, None);
-    let annotations = view.text_annotations(doc, None);
     (view_offset.anchor, view_offset.vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         cursor,
         -(relative as isize),
         0,
         &text_fmt,
-        &annotations,
+        &view.text_annotations(doc, None),
     );
     doc.set_view_offset(view.id, view_offset);
 }

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -52,6 +52,7 @@ pub fn align_view(doc: &mut Document, view: &View, align: Align) {
     let cursor = doc.selection(view.id).primary().cursor(doc_text);
     let viewport = view.inner_area(doc);
     let last_line_height = viewport.height.saturating_sub(1);
+    let mut view_offset = doc.view_offset(view.id);
 
     let relative = match align {
         Align::Center => last_line_height / 2,
@@ -61,7 +62,7 @@ pub fn align_view(doc: &mut Document, view: &View, align: Align) {
 
     let text_fmt = doc.text_format(viewport.width, None);
     let annotations = view.text_annotations(doc, None);
-    let (new_anchor, new_vertical_offset) = char_idx_at_visual_offset(
+    (view_offset.anchor, view_offset.vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         cursor,
         -(relative as isize),
@@ -69,9 +70,7 @@ pub fn align_view(doc: &mut Document, view: &View, align: Align) {
         &text_fmt,
         &annotations,
     );
-    let view_data = doc.view_data_mut(view.id);
-    view_data.view_position.anchor = new_anchor;
-    view_data.view_position.vertical_offset = new_vertical_offset;
+    doc.set_view_offset(view.id, view_offset);
 }
 
 pub use document::Document;

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Align {
     Bottom,
 }
 
-pub fn align_view(doc: &Document, view: &mut View, align: Align) {
+pub fn align_view(doc: &mut Document, view: &View, align: Align) {
     let doc_text = doc.text().slice(..);
     let cursor = doc.selection(view.id).primary().cursor(doc_text);
     let viewport = view.inner_area(doc);
@@ -61,7 +61,7 @@ pub fn align_view(doc: &Document, view: &mut View, align: Align) {
 
     let text_fmt = doc.text_format(viewport.width, None);
     let annotations = view.text_annotations(doc, None);
-    (view.offset.anchor, view.offset.vertical_offset) = char_idx_at_visual_offset(
+    let (new_anchor, new_vertical_offset) = char_idx_at_visual_offset(
         doc_text,
         cursor,
         -(relative as isize),
@@ -69,6 +69,9 @@ pub fn align_view(doc: &Document, view: &mut View, align: Align) {
         &text_fmt,
         &annotations,
     );
+    let view_data = doc.view_data_mut(view.id);
+    view_data.view_position.anchor = new_anchor;
+    view_data.view_position.vertical_offset = new_vertical_offset;
 }
 
 pub use document::Document;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -486,7 +486,7 @@ impl View {
                 doc,
                 cursor,
                 width,
-                self.offset.horizontal_offset,
+                doc.view_offset(self.id).horizontal_offset,
                 config,
             ));
         }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -234,7 +234,7 @@ impl View {
         doc: &Document,
         scrolloff: usize,
     ) -> Option<ViewPosition> {
-        let view_offset = doc.view_data(self.id)?.view_position;
+        let view_offset = doc.get_view_data(self.id)?.view_position;
         let doc_text = doc.text().slice(..);
         let viewport = self.inner_area(doc);
         let vertical_viewport_end = view_offset.vertical_offset + viewport.height as usize;
@@ -351,7 +351,6 @@ impl View {
         let doc_text = doc.text().slice(..);
         let line = doc_text.char_to_line(
             doc.view_data(self.id)
-                .unwrap()
                 .view_position
                 .anchor
                 .min(doc_text.len_chars()),
@@ -369,15 +368,11 @@ impl View {
         let viewport = self.inner_area(doc);
         let text_fmt = doc.text_format(viewport.width, None);
         let annotations = self.text_annotations(doc, None);
-        let view_offset = doc.view_data(self.id).unwrap().view_position;
+        let view_offset = doc.view_data(self.id).view_position;
 
         // last visual line in view is trivial to compute
-        let visual_height = doc
-            .view_data(self.id)
-            .unwrap()
-            .view_position
-            .vertical_offset
-            + viewport.height as usize;
+        let visual_height =
+            doc.view_data(self.id).view_position.vertical_offset + viewport.height as usize;
 
         // fast path when the EOF is not visible on the screen,
         if self.estimate_last_doc_line(doc) < doc_text.len_lines() - 1 {
@@ -410,7 +405,7 @@ impl View {
         text: RopeSlice,
         pos: usize,
     ) -> Option<Position> {
-        let view_offset = doc.view_data(self.id).unwrap().view_position;
+        let view_offset = doc.view_data(self.id).view_position;
 
         let viewport = self.inner_area(doc);
         let text_fmt = doc.text_format(viewport.width, None);
@@ -544,7 +539,7 @@ impl View {
         ignore_virtual_text: bool,
     ) -> Option<usize> {
         let text = doc.text().slice(..);
-        let view_offset = doc.view_data(self.id).unwrap().view_position;
+        let view_offset = doc.view_data(self.id).view_position;
 
         let text_row = row as usize + view_offset.vertical_offset;
         let text_col = column as usize + view_offset.horizontal_offset;


### PR DESCRIPTION
Supersedes #7568, fixes #7355.

Since view offsets can no longer be initialised in `View::new()`, I moved them next to selection initialisation in `doc.ensure_view_init(view_id)`. I was a little concerned about all those unwraps on `doc.view_data(view_id)` (those functions are infallible and don't have a mutable reference to doc, so there's no way to ensure view_data is initialised in there), but in theory it should be panic-safe, as long as `doc.ensure_view_init(view_id)` is called for every new view, which it is. It was missing from some test cases, since they didn't seem to need selections, but it's added even to those now.