### PR TITLE
Deduplicate command names in generated LSP support doc

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -1,6 +1,6 @@
 | Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Default LSP |
 | --- | --- | --- | --- | --- |
-| ada | ✓ | ✓ |  | `ada_language_server`, `ada_language_server` |
+| ada | ✓ | ✓ |  | `ada_language_server` |
 | adl | ✓ | ✓ | ✓ |  |
 | agda | ✓ |  |  |  |
 | astro | ✓ |  |  |  |

--- a/xtask/src/docgen.rs
+++ b/xtask/src/docgen.rs
@@ -1,9 +1,9 @@
 use crate::helpers;
 use crate::path;
 use crate::DynError;
-
 use helix_term::commands::TYPABLE_COMMAND_LIST;
 use helix_term::health::TsFeature;
+use std::collections::HashSet;
 use std::fs;
 
 pub const TYPABLE_COMMANDS_MD_OUTPUT: &str = "typable-cmd.md";
@@ -95,14 +95,25 @@ pub fn lang_features() -> Result<String, DynError> {
                 .to_owned(),
             );
         }
-        row.push(
-            lc.language_servers
-                .iter()
-                .filter_map(|ls| config.language_server.get(&ls.name))
-                .map(|s| md_mono(&s.command.clone()))
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
+        let mut seen_commands = HashSet::new();
+        let mut commands = String::new();
+        for ls_config in lc
+            .language_servers
+            .iter()
+            .filter_map(|ls| config.language_server.get(&ls.name))
+        {
+            let command = &ls_config.command;
+            if !seen_commands.insert(command) {
+                continue;
+            }
+
+            if !commands.is_empty() {
+                commands.push_str(", ");
+            }
+
+            commands.push_str(&md_mono(command));
+        }
+        row.push(commands);
 
         md.push_str(&md_table_row(&row));
         row.clear();


### PR DESCRIPTION
Using unique from itertools::Itertools function to clear out and duplicate string entries. Tested on my ARM64 Windows 11 system with mdbook and generated via xtask docgen.