### PR TITLE
Improve readability of diagnostics in Darcula themes

### DIFF
--- a/runtime/themes/darcula-solid.toml
+++ b/runtime/themes/darcula-solid.toml
@@ -14,3 +14,7 @@ grey01 = "#1f1f1f"
 grey02 = "#323232"
 grey03 = "#555555"
 grey04 = "#a8a8a8"
+
+dimred = "#642e18"
+dimorange = "#ae662a"
+dimgrey = "#777777"

--- a/runtime/themes/darcula-solid.toml
+++ b/runtime/themes/darcula-solid.toml
@@ -16,5 +16,3 @@ grey03 = "#555555"
 grey04 = "#a8a8a8"
 
 dimred = "#642e18"
-dimorange = "#ae662a"
-dimgrey = "#777777"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -73,10 +73,10 @@
 "diff.delta" = "grey"
 "diff.minus" = "red"
 
-"diagnostic.warning" = { underline = { color = "orange", style = "curl"} }
-"diagnostic.error" = { underline = { color = "red", style = "curl"} }
-"diagnostic.info" = { underline = { color = "grey05", style = "curl"} }
-"diagnostic.hint" = { underline = { color = "grey05", style = "curl"} }
+"diagnostic.warning" = { underline = { color = "dimorange", style = "curl"} }
+"diagnostic.error" = { underline = { color = "dimred", style = "curl"} }
+"diagnostic.info" = { underline = { color = "dimgrey", style = "curl"} }
+"diagnostic.hint" = { underline = { color = "dimgrey", style = "dashed"} }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
@@ -100,9 +100,12 @@ white = "#d0d0d0"
 yellow = "#eedd82"
 orange = "#cc7832"
 darkred = "#a34a27"
+dimred = "#7a371d"
+dimorange = "#ae662a"
 purple = "#9876aa"
 green = "#32cd32"
 grey = "#808080"
+dimgrey = "#777777"
 darkgreen = "#629755"
 lightblue = "#6897bb"
 blue = "#104158"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -75,7 +75,7 @@
 
 "diagnostic.warning" = { underline = { color = "dimorange", style = "curl"} }
 "diagnostic.error" = { underline = { color = "dimred", style = "curl"} }
-"diagnostic.info" = { underline = { color = "dimgrey", style = "curl"} }
+"diagnostic.info" = { underline = { color = "dimgrey", style = "dashed"} }
 "diagnostic.hint" = { underline = { color = "dimgrey", style = "dashed"} }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }


### PR DESCRIPTION
Use dimmer diagnostic colors in Darcula themes.

Specially with long errors current bright colors can make text quickly very hard to read when marked by diagnostic underlines.

## Warnings: orange -> dim orange
### Old
![darcula_solid_dimorange_old](https://github.com/helix-editor/helix/assets/24444379/102eb51c-f439-4578-84f6-249e1e1d66c8)
### New
![darcula_solid_dimorange_new](https://github.com/helix-editor/helix/assets/24444379/e668522d-8dd9-451c-b6ec-fd4edaa723e5)
![darcula_dimorange_new](https://github.com/helix-editor/helix/assets/24444379/10ef1dc3-ac61-484a-84bd-52b5a8d42037)

## Errors: red -> dim red
### Old
![darcula_solid_dimred_old](https://github.com/helix-editor/helix/assets/24444379/5e9a1eb0-e065-4d2d-aa41-3488c70f7363)
### New
![darcula_solid_dimred_new](https://github.com/helix-editor/helix/assets/24444379/c5a67479-10c6-475b-af7a-8da60bf99182)
![darcula_dimred_new](https://github.com/helix-editor/helix/assets/24444379/e75c8f52-967d-42c0-9446-38e110430581)

## Info and hints: light grey -> dashed dim grey
### Old
![darcula_solid_dimgrey_old](https://github.com/helix-editor/helix/assets/24444379/7a6b0614-3e92-4733-b214-346a515866f9)
### New
![darcula_solid_dimgrey_new](https://github.com/helix-editor/helix/assets/24444379/a1e7f5dd-2bc5-4c75-99c5-b7ec01c331ad)