### PR TITLE
Add option to disable auto detection of indentation style

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -51,6 +51,7 @@ Its settings will be merged with the configuration directory `config.toml` and t
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `auto-save` | Enable automatic saving on the focus moving away from Helix. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
+| `auto-detect-indent` | Enable automatic detection of indentation style when loading a file. If disabled, the indentation style defined in the language configuration is used instead | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. | `250` |
 | `completion-timeout` | Time in milliseconds after typing a word character before completions are shown, set to 5 for instant.  | `250` |
 | `preview-completion-insert` | Whether to apply completion item instantly when selected | `true` |

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1004,7 +1004,12 @@ impl Document {
     /// configured in `languages.toml`, with a fallback to tabs if it isn't specified. Line ending
     /// is likewise auto-detected, and will remain unchanged if no line endings were detected.
     pub fn detect_indent_and_line_ending(&mut self) {
-        self.indent_style = auto_detect_indent_style(&self.text).unwrap_or_else(|| {
+        let detected_style = if self.config.load().auto_detect_indent {
+            auto_detect_indent_style(&self.text)
+        } else {
+            None
+        };
+        self.indent_style = detected_style.unwrap_or_else(|| {
             self.language_config()
                 .and_then(|config| config.indent.as_ref())
                 .map_or(DEFAULT_INDENT, |config| IndentStyle::from_str(&config.unit))

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -268,6 +268,8 @@ pub struct Config {
     pub auto_format: bool,
     /// Automatic save on focus lost. Defaults to false.
     pub auto_save: bool,
+    /// Automatic detection of indent style. Defaults to true.
+    pub auto_detect_indent: bool,
     /// Set a global text_width
     pub text_width: usize,
     /// Time in milliseconds since last keypress before idle timers trigger.
@@ -882,6 +884,7 @@ impl Default for Config {
             auto_completion: true,
             auto_format: true,
             auto_save: false,
+            auto_detect_indent: true,
             idle_timeout: Duration::from_millis(250),
             completion_timeout: Duration::from_millis(250),
             preview_completion_insert: true,


### PR DESCRIPTION
Currently, when loading a file, the indentation style is detected using a heuristic that can sometimes make mistakes (see #9556, #9822). This PR adds an `auto-detect-indent` option, which defaults to `true`, that allows users to change this behaviour. When `auto-detect-indent` is set to `false`, instead of trying to detect the indent syle, Helix will just use the ident style defined in the language configuration.