### PR TITLE
Implement buffer fuzzy search

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3014,18 +3014,14 @@ fn jumplist_picker(cx: &mut Context) {
     };
 
     let picker = Picker::new(
-        cx.editor
-            .tree
-            .views()
-            .flat_map(|(view, _)| {
-                view.jumps
-                    .iter()
-                    .rev()
-                    .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
-            })
-            .collect(),
+        cx.editor.tree.views().flat_map(|(view, _)| {
+            view.jumps
+                .iter()
+                .rev()
+                .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
+        }),
         (),
-        |cx, meta, action| {
+        |cx, meta: &JumpMeta, action| {
             cx.editor.switch(meta.id, action);
             let config = cx.editor.config();
             let (view, doc) = (view_mut!(cx.editor), doc_mut!(cx.editor, &meta.id));

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -219,11 +219,14 @@ impl<T: Item + 'static> Picker<T> {
         (matcher, streamer)
     }
 
-    pub fn new(
-        options: Vec<T>,
+    pub fn new<I>(
+        options: I,
         editor_data: T::Data,
         callback_fn: impl Fn(&mut Context, &T, Action) + 'static,
-    ) -> Self {
+    ) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
         let matcher = Nucleo::new(
             Config::DEFAULT,
             Arc::new(helix_event::request_redraw),


### PR DESCRIPTION
These patches implement the `buffer_search_picker` command that shows a picker to fuzzy search in the current buffer. Note that one of the patches is cleaning up `Picker::new` method somewhat.