### PR TITLE
Make disabling the statusline possible

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -82,6 +82,7 @@ Statusline elements can be defined as follows:
 
 ```toml
 [editor.statusline]
+enable = true
 left = ["mode", "spinner"]
 center = ["file-name"]
 right = ["diagnostics", "selections", "position", "file-encoding", "file-line-ending", "file-type"]
@@ -94,6 +95,7 @@ The `[editor.statusline]` key takes the following sub-keys:
 
 | Key           | Description | Default |
 | ---           | ---         | ---     |
+| `enable`      | Enables the statusline. Setting this to false will hide it completely | `true` |
 | `left`        | A list of elements aligned to the left of the statusline | `["mode", "spinner", "file-name", "read-only-indicator", "file-modification-indicator"]` |
 | `center`      | A list of elements aligned to the middle of the statusline | `[]` |
 | `right`       | A list of elements aligned to the right of the statusline | `["diagnostics", "selections", "register", "position", "file-encoding"]` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -220,15 +220,18 @@ impl EditorView {
 
         Self::render_diagnostics(doc, view, inner, surface, theme);
 
-        let statusline_area = view
-            .area
-            .clip_top(view.area.height.saturating_sub(1))
-            .clip_bottom(1); // -1 from bottom to remove commandline
+        let use_statusline = config.statusline.enable;
+        if use_statusline {
+            let statusline_area = view
+                .area
+                .clip_top(view.area.height.saturating_sub(1))
+                .clip_bottom(1); // -1 from bottom to remove commandline
 
-        let mut context =
-            statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
+            let mut context =
+                statusline::RenderContext::new(editor, doc, view, is_focused, &self.spinners);
 
-        statusline::render(&mut context, statusline_area, surface);
+            statusline::render(&mut context, statusline_area, surface);
+        }
     }
 
     pub fn render_rulers(
@@ -1476,7 +1479,11 @@ impl Component for EditorView {
         };
 
         // -1 for commandline and -1 for bufferline
-        let mut editor_area = area.clip_bottom(1);
+        let mut editor_area = area;
+        let use_statusline = config.statusline.enable;
+        if use_statusline {
+            editor_area = editor_area.clip_bottom(1);
+        }
         if use_bufferline {
             editor_area = editor_area.clip_top(1);
         }

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -10,6 +10,12 @@ impl Component for Info {
         let text_style = cx.editor.theme.get("ui.text.info");
         let popup_style = cx.editor.theme.get("ui.popup.info");
 
+        let mut statusline_height = 0;
+        let use_statusline = cx.editor.config().statusline.enable;
+        if use_statusline {
+            statusline_height = 2;
+        }
+
         // Calculate the area of the terminal to modify. Because we want to
         // render at the bottom right, we use the viewport's width and height
         // which evaluate to the most bottom right coordinate.
@@ -17,7 +23,7 @@ impl Component for Info {
         let height = self.height + 2; // +2 for border
         let area = viewport.intersection(Rect::new(
             viewport.width.saturating_sub(width),
-            viewport.height.saturating_sub(height + 2), // +2 for statusline
+            viewport.height.saturating_sub(height + statusline_height), // +2 for statusline
             width,
             height,
         ));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -452,6 +452,7 @@ pub struct SearchConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct StatusLineConfig {
+    pub enable: bool,
     pub left: Vec<StatusLineElement>,
     pub center: Vec<StatusLineElement>,
     pub right: Vec<StatusLineElement>,
@@ -464,6 +465,7 @@ impl Default for StatusLineConfig {
         use StatusLineElement as E;
 
         Self {
+            enable: true,
             left: vec![
                 E::Mode,
                 E::Spinner,
@@ -1549,7 +1551,7 @@ impl Editor {
                     .try_get(self.tree.focus)
                     .filter(|v| id == v.doc) // Different Document
                     .cloned()
-                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
+                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone(), self.config().statusline.clone()));
                 let view_id = self.tree.split(
                     view,
                     match action {
@@ -1723,7 +1725,7 @@ impl Editor {
                 .map(|(&doc_id, _)| doc_id)
                 .next()
                 .unwrap_or_else(|| self.new_document(Document::default(self.config.clone())));
-            let view = View::new(doc_id, self.config().gutters.clone());
+            let view = View::new(doc_id, self.config().gutters.clone(), self.config().statusline.clone());
             let view_id = self.tree.insert(view);
             let doc = doc_mut!(self, &doc_id);
             doc.ensure_view_init(view_id);

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -338,7 +338,7 @@ mod tests {
 
     use super::*;
     use crate::document::Document;
-    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig};
+    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig, StatusLineConfig};
     use crate::graphics::Rect;
     use crate::DocumentId;
     use arc_swap::ArcSwap;
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn test_default_gutter_widths() {
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -371,7 +371,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(DocumentId::default(), gutters, StatusLineConfig::default());
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -389,7 +389,7 @@ mod tests {
             line_numbers: GutterLineNumbersConfig { min_width: 10 },
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(DocumentId::default(), gutters, StatusLineConfig::default());
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("abc\n\tdef");
@@ -411,7 +411,7 @@ mod tests {
             line_numbers: GutterLineNumbersConfig { min_width: 1 },
         };
 
-        let mut view = View::new(DocumentId::default(), gutters);
+        let mut view = View::new(DocumentId::default(), gutters, StatusLineConfig::default());
         view.area = Rect::new(40, 40, 40, 40);
 
         let rope = Rope::from_str("a\nb");

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -723,7 +723,7 @@ impl<'a> DoubleEndedIterator for Traverse<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::editor::GutterConfig;
+    use crate::editor::{GutterConfig, StatusLineConfig};
     use crate::DocumentId;
 
     #[test]
@@ -734,22 +734,22 @@ mod test {
             width: 180,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
 
         // Tree in test
@@ -790,28 +790,28 @@ mod test {
         });
 
         let doc_l0 = DocumentId::default();
-        let mut view = View::new(doc_l0, GutterConfig::default());
+        let mut view = View::new(doc_l0, GutterConfig::default(), StatusLineConfig::default());
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
         let l0 = tree.focus;
 
         let doc_r0 = DocumentId::default();
-        let view = View::new(doc_r0, GutterConfig::default());
+        let view = View::new(doc_r0, GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
         let r0 = tree.focus;
 
         tree.focus = l0;
 
         let doc_l1 = DocumentId::default();
-        let view = View::new(doc_l1, GutterConfig::default());
+        let view = View::new(doc_l1, GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Horizontal);
         let l1 = tree.focus;
 
         tree.focus = l0;
 
         let doc_l2 = DocumentId::default();
-        let view = View::new(doc_l2, GutterConfig::default());
+        let view = View::new(doc_l2, GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
         let l2 = tree.focus;
 
@@ -906,19 +906,19 @@ mod test {
             width: tree_area_width,
             height: 80,
         });
-        let mut view = View::new(DocumentId::default(), GutterConfig::default());
+        let mut view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Horizontal);
 
         tree.remove(tree.focus);
 
-        let view = View::new(DocumentId::default(), GutterConfig::default());
+        let view = View::new(DocumentId::default(), GutterConfig::default(), StatusLineConfig::default());
         tree.split(view, Layout::Vertical);
 
         // Make sure that we only have one level in the tree.


### PR DESCRIPTION
Many of us use Helix as a terminal based text editor rather than a full-fledged IDE. Having the option to hide the statusline would give additional space for those who may not need the information provided by the statusline.

Issue related to this PR: #8180 