### PR TITLE
Add debug highlights to the dark plus theme

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -77,6 +77,9 @@
 "ui.virtual.indent-guide"    = { fg = "dark_gray4" }
 "ui.virtual.inlay-hint"      = { fg = "dark_gray5"}
 "ui.virtual.jump-label"      = { fg = "dark_gray", modifiers = ["bold"] }
+"ui.highlight.frameline"     = { bg = "#4b4b18" }
+"ui.debug.active"            = { fg = "#ffcc00" }
+"ui.debug.breakpoint"        = { fg = "#e51400" }
 "warning"                    = { fg = "gold2" }
 "error"                      = { fg = "red" }
 "info"                       = { fg = "light_blue" }


### PR DESCRIPTION
Original from VS Code online:

![image](https://github.com/helix-editor/helix/assets/12832280/abb3ca09-dcfd-4476-bcef-7bfb21f9dbb1)

New highlights for Helix:

![image](https://github.com/helix-editor/helix/assets/12832280/1f4cbe46-2ddb-488d-8974-495ad96970a3)

I grabbed the colors using Firefox dev tools, and tested this method was an accurate way of doing it with some other colors, they all matched what was already in the Helix theme. I don't see these debug colors used anywhere else, so I have not given them color names for reuse.