### PR TITLE
Implement register history and access using a picker.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
+ "rand",
  "rustix",
  "serde",
  "serde_json",
@@ -1893,6 +1894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +1949,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2447,7 +2447,7 @@ fn yank_diagnostic(
         bail!("No diagnostics under primary selection");
     }
 
-    cx.editor.registers.write(reg, diag)?;
+    cx.editor.registers.push_many(reg, &diag)?;
     cx.editor.set_status(format!(
         "Yanked {n} diagnostic{} to register {reg}",
         if n == 1 { "" } else { "s" }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -149,12 +149,13 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
         "y" => yank,
         // yank_all
-        "p" => paste_after,
+        "p" => paste_picker_after,
         // paste_all
-        "P" => paste_before,
+        "P" => paste_picker_before,
 
         "Q" => record_macro,
         "q" => replay_macro,
+        "A-q" => replay_macro_picker,
 
         ">" => indent,
         "<" => unindent,

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -186,11 +186,94 @@ async fn test_multi_selection_paste() -> anyhow::Result<()> {
             #(|ipsum)#
             #(|dolor)#
             "},
-        "yp",
+        "ypp",
         indoc! {"\
             lorem#[|lorem]#
             ipsum#(|ipsum)#
             dolor#(|dolor)#
+            "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_selection_paste_using_named_register() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "},
+        r#""ay"ap0"#,
+        indoc! {"\
+            lorem#[|lorem]#
+            ipsum#(|ipsum)#
+            dolor#(|dolor)#
+            "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_register_paste() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+            #[|lorem]#ipsumdolor
+            "},
+        // This shows both pick first (0) and double p working.
+        r#""ay,;xygl"ap0pp"#,
+        indoc! {"\
+            loremipsumdolorlorem
+            #[loremipsumdolor
+            |]#
+            "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_macro_replay() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+            #[|l]#orem
+            ipsum
+            dolor
+            "},
+        "QxdQq",
+        indoc! {"\
+            #[d|]#olor
+            "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_macro_replay_picker() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+            #[|l]#orem
+            ipsum
+            dolor
+            sit amet
+            "},
+        concat!(
+            "QxdQ",   // Record selecting and deleting a line.
+            "Qw~Q",   // Record selecting a word and swapping its case.
+            "j",      // Move down a line.
+            "<A-q>1", // replay-macro-picker, select 1 (the 2 entry, aka the first macro recorded)
+            "q"       // replay-macro, replay most recently recorded macro.
+        ),
+        indoc! {"\
+            IPSUM
+            #[SIT |]#amet
             "},
     ))
     .await?;

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -60,3 +60,4 @@ rustix = { version = "0.38", features = ["fs"] }
 
 [dev-dependencies]
 helix-tui = { path = "../helix-tui" }
+rand = "*"

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -65,4 +65,12 @@ impl Info {
         infobox.width = 30; // copied content could be very long
         infobox
     }
+
+    pub fn from_selected_register(registers: &Registers, register: char) -> Self {
+        let title = "Collected bits";
+        let body = registers.preview_for(register);
+        let mut infobox = Self::new(title, &body);
+        infobox.width = 30; // copied content could be very long
+        infobox
+    }
 }

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, collections::HashMap, iter};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, VecDeque},
+    iter,
+};
 
 use anyhow::Result;
 use helix_core::NATIVE_LINE_ENDING;
@@ -27,7 +31,7 @@ pub struct Registers {
     /// Values are stored in reverse order when inserted with `Registers::write`.
     /// The order is reversed again in `Registers::read`. This allows us to
     /// efficiently prepend new values in `Registers::push`.
-    inner: HashMap<char, Vec<String>>,
+    inner: HashMap<char, Register>,
     clipboard_provider: Box<dyn ClipboardProvider>,
     pub last_search_register: char,
 }
@@ -71,76 +75,76 @@ impl Registers {
 
                 Some(RegisterValues::new(iter::once(path)))
             }
-            '*' | '+' => Some(read_from_clipboard(
-                self.clipboard_provider.as_ref(),
-                self.inner.get(&name),
-                match name {
-                    '+' => ClipboardType::Clipboard,
-                    '*' => ClipboardType::Selection,
-                    _ => unreachable!(),
-                },
-            )),
-            _ => self
-                .inner
-                .get(&name)
-                .map(|values| RegisterValues::new(values.iter().map(Cow::from).rev())),
-        }
-    }
-
-    pub fn write(&mut self, name: char, mut values: Vec<String>) -> Result<()> {
-        match name {
-            '_' => Ok(()),
-            '#' | '.' | '%' => Err(anyhow::anyhow!("Register {name} does not support writing")),
             '*' | '+' => {
-                self.clipboard_provider.set_contents(
-                    values.join(NATIVE_LINE_ENDING.as_str()),
+                let Some(register) = self.inner.get(&name) else { return None; };
+                Some(register.read_from_clipboard(
+                    self.clipboard_provider.as_ref(),
                     match name {
                         '+' => ClipboardType::Clipboard,
                         '*' => ClipboardType::Selection,
                         _ => unreachable!(),
                     },
-                )?;
-                values.reverse();
-                self.inner.insert(name, values);
-                Ok(())
+                ))
             }
+            _ => self.inner.get(&name).map(|register| register.value()),
+        }
+    }
+
+    pub fn read_nth(&self, name: char, index: usize) -> Result<Option<RegisterValues<'_>>> {
+        match name {
+            '_' | '#' | '.' | '%' | '*' | '+' => Err(anyhow::anyhow!(
+                "Register {name} does not allow indexed access"
+            )),
+            _ => Ok(self
+                .inner
+                .get(&name)
+                .and_then(|register| register.nth(index))),
+        }
+    }
+
+    pub fn push_many(&mut self, name: char, values: &Vec<String>) -> Result<()> {
+        match name {
+            '_' => Ok(()),
+            '#' | '.' | '%' => Err(anyhow::anyhow!("Register {name} does not support writing")),
             _ => {
-                values.reverse();
-                self.inner.insert(name, values);
+                if name == '*' || name == '+' {
+                    self.clipboard_provider.set_contents(
+                        values.join(NATIVE_LINE_ENDING.as_str()),
+                        match name {
+                            '+' => ClipboardType::Clipboard,
+                            '*' => ClipboardType::Selection,
+                            _ => unreachable!(),
+                        },
+                    )?;
+                }
+                let register = self.inner.entry(name).or_insert_with(Register::default);
+                register.write(values);
                 Ok(())
             }
         }
     }
 
-    pub fn push(&mut self, name: char, mut value: String) -> Result<()> {
+    pub fn push(&mut self, name: char, value: &str) -> Result<()> {
         match name {
             '_' => Ok(()),
             '#' | '.' | '%' => Err(anyhow::anyhow!("Register {name} does not support pushing")),
             '*' | '+' => {
-                let clipboard_type = match name {
-                    '+' => ClipboardType::Clipboard,
-                    '*' => ClipboardType::Selection,
-                    _ => unreachable!(),
-                };
-                let contents = self.clipboard_provider.get_contents(clipboard_type)?;
-                let saved_values = self.inner.entry(name).or_insert_with(Vec::new);
-
-                if !contents_are_saved(saved_values, &contents) {
-                    anyhow::bail!("Failed to push to register {name}: clipboard does not match register contents");
-                }
-
-                saved_values.push(value.clone());
-                if !contents.is_empty() {
-                    value.push_str(NATIVE_LINE_ENDING.as_str());
-                }
-                value.push_str(&contents);
-                self.clipboard_provider
-                    .set_contents(value, clipboard_type)?;
-
-                Ok(())
+                let register = self.inner.entry(name).or_insert_with(Register::default);
+                register
+                    .save_clipboard_contents(
+                        &mut self.clipboard_provider,
+                        match name {
+                            '+' => ClipboardType::Clipboard,
+                            '*' => ClipboardType::Selection,
+                            _ => unreachable!(),
+                        },
+                        value,
+                    )
+                    .map_err(|err| anyhow::anyhow!("Failed to push to register {name}: {err}"))
             }
             _ => {
-                self.inner.entry(name).or_insert_with(Vec::new).push(value);
+                let register = self.inner.entry(name).or_insert_with(Register::default);
+                register.push(value);
                 Ok(())
             }
         }
@@ -150,19 +154,16 @@ impl Registers {
         self.read(name, editor).and_then(|mut values| values.next())
     }
 
-    pub fn last<'a>(&'a self, name: char, editor: &'a Editor) -> Option<Cow<'a, str>> {
-        self.read(name, editor).and_then(|values| values.last())
-    }
-
-    pub fn iter_preview(&self) -> impl Iterator<Item = (char, &str)> {
+    pub fn iter_preview(&self) -> impl Iterator<Item = (char, String)> + '_ {
         self.inner
             .iter()
             .filter(|(name, _)| !matches!(name, '*' | '+'))
-            .map(|(name, values)| {
-                let preview = values
-                    .last()
-                    .and_then(|s| s.lines().next())
-                    .unwrap_or("<empty>");
+            .map(|(name, register)| {
+                let preview = register
+                    .value()
+                    .next()
+                    .and_then(|s| s.lines().next().map(String::from))
+                    .unwrap_or("<empty>".to_string());
 
                 (*name, preview)
             })
@@ -175,8 +176,8 @@ impl Registers {
                     ('+', "<system clipboard>"),
                     ('*', "<primary clipboard>"),
                 ]
-                .iter()
-                .copied(),
+                .into_iter()
+                .map(|(c, s)| (c, s.to_string())),
             )
     }
 
@@ -221,37 +222,177 @@ impl Registers {
     pub fn clipboard_provider_name(&self) -> Cow<str> {
         self.clipboard_provider.name()
     }
+
+    pub fn preview_for(&self, name: char) -> Vec<(String, String)> {
+        match name {
+            '*' | '+' | '_' | '#' | '.' | '%' => Vec::default(),
+            _ => self
+                .inner
+                .get(&name)
+                .map_or_else(Vec::default, |register| register.preview()),
+        }
+    }
 }
 
-fn read_from_clipboard<'a>(
-    provider: &dyn ClipboardProvider,
-    saved_values: Option<&'a Vec<String>>,
-    clipboard_type: ClipboardType,
-) -> RegisterValues<'a> {
-    match provider.get_contents(clipboard_type) {
-        Ok(contents) => {
-            // If we're pasting the same values that we just yanked, re-use
-            // the saved values. This allows pasting multiple selections
-            // even when yanked to a clipboard.
-            let Some(values) = saved_values else { return RegisterValues::new(iter::once(contents.into())) };
+/// Register contents are stored as Strings in a Vec that is treated like a queue.
+/// New elements are pushed on and pulled off from the end of the Vec for
+/// performance and drained from the front.
+#[derive(Default, Debug)]
+struct Register {
+    contents: Vec<String>,
+    lengths: VecDeque<usize>,
+}
 
-            if contents_are_saved(values, &contents) {
-                RegisterValues::new(values.iter().map(Cow::from).rev())
-            } else {
-                RegisterValues::new(iter::once(contents.into()))
+impl Register {
+    fn iter(&self) -> RegisterIterator {
+        RegisterIterator::new(self)
+    }
+
+    fn value(&self) -> RegisterValues<'_> {
+        self.iter().next().map_or_else(
+            || RegisterValues::new(iter::empty()),
+            |items| RegisterValues::new(items.into_iter()),
+        )
+    }
+
+    fn nth(&self, index: usize) -> Option<RegisterValues<'_>> {
+        let index = index.min(self.lengths.len().saturating_sub(1));
+        let mut it = self.iter();
+        it.nth(index)
+            .map(|items| RegisterValues::new(items.into_iter()))
+    }
+
+    fn pop_oldest(&mut self) -> Option<RegisterValues<'_>> {
+        match self.lengths.pop_front() {
+            Some(oldest_length) => Some(RegisterValues::new(
+                self.contents.drain(0..oldest_length).rev().map(Cow::from),
+            )),
+            None => {
+                if !self.contents.is_empty() {
+                    log::debug!("Register has no lengths but some contents!!");
+                }
+                None
             }
         }
-        Err(err) => {
-            log::error!(
-                "Failed to read {} clipboard: {err}",
-                match clipboard_type {
-                    ClipboardType::Clipboard => "system",
-                    ClipboardType::Selection => "primary",
-                }
-            );
+    }
 
-            RegisterValues::new(iter::empty())
+    // TODO: expose this as something like registers.pop() -> Option<RegisterValues>
+    // to then be exposed by a command.
+    #[allow(dead_code)]
+    fn pop_recent(&mut self) -> Option<RegisterValues<'_>> {
+        match self.lengths.pop_back() {
+            Some(recent_length) => {
+                let end = self.contents.len();
+                let start = end - recent_length;
+
+                Some(RegisterValues::new(
+                    self.contents.drain(start..end).rev().map(Cow::from),
+                ))
+            }
+            None => {
+                if !self.contents.is_empty() {
+                    log::debug!("Register has no lengths but some contents!!");
+                }
+                None
+            }
         }
+    }
+
+    fn write(&mut self, values: &Vec<String>) {
+        if self.lengths.len() >= 16 {
+            // Limit the number of captured elements to 16.
+            self.pop_oldest();
+        }
+        self.contents.extend(values.iter().rev().cloned());
+        self.lengths.push_back(values.len());
+    }
+
+    fn push(&mut self, value: &str) {
+        if self.lengths.len() >= 16 {
+            // Limit the number of captured elements to 16.
+            self.pop_oldest();
+        }
+        self.contents.push(value.to_string());
+        self.lengths.push_back(1);
+    }
+
+    fn read_from_clipboard<'a>(
+        &'a self,
+        provider: &dyn ClipboardProvider,
+        clipboard_type: ClipboardType,
+    ) -> RegisterValues<'a> {
+        match provider.get_contents(clipboard_type) {
+            Ok(contents) => {
+                // If we're pasting the same values that we just yanked, re-use
+                // the saved values. This allows pasting multiple selections
+                // even when yanked to a clipboard.
+
+                if contents_are_saved(&self.contents, &contents) {
+                    return self.value();
+                }
+                RegisterValues::new(iter::once(contents.into()))
+            }
+            Err(err) => {
+                log::error!(
+                    "Failed to read {} clipboard: {err}",
+                    match clipboard_type {
+                        ClipboardType::Clipboard => "system",
+                        ClipboardType::Selection => "primary",
+                    }
+                );
+
+                RegisterValues::new(iter::empty())
+            }
+        }
+    }
+
+    fn save_clipboard_contents(
+        &mut self,
+        clipboard_provider: &mut Box<dyn ClipboardProvider>,
+        clipboard_type: ClipboardType,
+        value: &str,
+    ) -> Result<()> {
+        let contents = clipboard_provider.get_contents(clipboard_type)?;
+
+        if contents_are_saved(&self.contents, &contents) {
+            let mut value = value.to_string();
+            self.push(&value);
+            if !contents.is_empty() {
+                value.push_str(NATIVE_LINE_ENDING.as_str());
+            }
+            value.push_str(&contents);
+
+            clipboard_provider.set_contents(value, clipboard_type)?;
+        }
+        Ok(())
+    }
+
+    /// Return the first string of each element of contents.
+    /// Will show <empty> if there are not.
+    fn preview(&self) -> Vec<(String, String)> {
+        if self.lengths.is_empty() {
+            return vec![];
+        }
+
+        // Yes, this could use the iter() definition. However, that builds
+        // vectors we don't need. Is this worth the maintainence? Not sure.
+        let mut previous = 0;
+        self.lengths
+            .iter()
+            .rev()
+            .enumerate()
+            .map(|(index, count)| {
+                let mut remaining = self.contents.iter().rev().skip(previous);
+                previous += count;
+                // As with the comment in next(), these unwraps are safe
+                // because each is guaranteed to have a value.
+                let first_value = remaining.next().unwrap();
+                let line = first_value.lines().next().unwrap();
+                // Safe unwrap. Can never be more than 16 values.
+                let ch = char::from_digit(index as u32, 16).unwrap();
+                (ch.to_string(), String::from(line))
+            })
+            .collect()
     }
 }
 
@@ -278,20 +419,63 @@ fn contents_are_saved(saved_values: &[String], mut contents: &str) -> bool {
     true
 }
 
-// This is a wrapper of an iterator that is both double ended and exact size,
-// and can return either owned or borrowed values. Regular registers can
-// return borrowed values while some special registers need to return owned
-// values.
+/// Iterator to walk the register contents.
+///
+/// index is the most recently accessed element.
+/// previous is the total number of strings read from contents so far. This is
+/// used to find the next one.
+struct RegisterIterator<'a> {
+    register: &'a Register,
+    index: usize,
+    previous: usize,
+}
+
+impl<'a> RegisterIterator<'a> {
+    fn new(register: &'a Register) -> Self {
+        Self {
+            register,
+            index: 0,
+            previous: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for RegisterIterator<'a> {
+    type Item = Vec<Cow<'a, str>>;
+
+    /// The mental model of how this works is:
+    ///     let count = self.register.lengths[self.index];
+    ///     let values = self.register.contents[self.previous..(self.previous + self.count)];
+    /// But this is not how it actually works because the data structure is read
+    /// from its tail.
+    ///
+    /// Retrieving the next element is done by first retrieving the length of
+    /// the element from the lengths. This is done by index lookup. Then the
+    /// number of previously read strings are skipped. Since an element can be
+    /// more than one string the contents cannot be directly accessed. Finally
+    /// the number of strings specified from lengths are returned.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.register.lengths.len() {
+            return None;
+        }
+        let count = self.register.lengths.iter().rev().nth(self.index).unwrap();
+        let remaining = self.register.contents.iter().rev().skip(self.previous);
+        let values = remaining.take(*count).map(Cow::from).collect();
+        self.previous += count;
+        self.index += 1;
+        Some(values)
+    }
+}
+
+// This is a wrapper of an iterator that can return either owned or borrowed values.
+// Regular registers can return borrowed values while some special registers need
+// to return owned values.
 pub struct RegisterValues<'a> {
-    iter: Box<dyn DoubleEndedExactSizeIterator<Item = Cow<'a, str>> + 'a>,
+    iter: Box<dyn Iterator<Item = Cow<'a, str>> + 'a>,
 }
 
 impl<'a> RegisterValues<'a> {
-    fn new(
-        iter: impl DoubleEndedIterator<Item = Cow<'a, str>>
-            + ExactSizeIterator<Item = Cow<'a, str>>
-            + 'a,
-    ) -> Self {
+    fn new(iter: impl Iterator<Item = Cow<'a, str>> + 'a) -> Self {
         Self {
             iter: Box::new(iter),
         }
@@ -304,30 +488,199 @@ impl<'a> Iterator for RegisterValues<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
 }
 
-impl<'a> DoubleEndedIterator for RegisterValues<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{self, Rng};
+
+    #[test]
+    fn test_all_register_values_are_retrieved_with_iter_preview() {
+        let mut registers = Registers::default();
+        let mut lines = Vec::new();
+
+        for register in 'a'..='d' {
+            let preview_line = format!("This is register {register}");
+            let line = format!("{preview_line}\nThis is its second line not seen.");
+            assert!(registers.push(register, &line).is_ok());
+            lines.push((register, preview_line));
+        }
+
+        lines.extend_from_slice(&[
+            ('_', String::from("<empty>")),
+            ('#', String::from("<selection indices>")),
+            ('.', String::from("<selection contents>")),
+            ('%', String::from("<document path>")),
+            ('+', String::from("<system clipboard>")),
+            ('*', String::from("<primary clipboard>")),
+        ]);
+        let mut values: Vec<_> = registers.iter_preview().collect();
+        // Sorting is needed because the HashMap returns arbitrary ordering.
+        lines.sort();
+        values.sort();
+        assert_eq!(values, lines);
+    }
+
+    #[test]
+    fn test_register_remembers_first_element_pushed() {
+        let mut register = Register::default();
+        register.push("this is a test");
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, vec!["this is a test"]);
+    }
+
+    #[test]
+    fn test_register_remembers_second_element_pushed() {
+        let mut register = Register::default();
+        register.push("this is a test");
+        register.push("this is a second test");
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, vec!["this is a second test"]);
+        let values: Vec<_> = register.nth(1).unwrap().collect();
+        assert_eq!(values, vec!["this is a test"]);
+    }
+
+    #[test]
+    fn test_register_remembers_first_element_written() {
+        let mut register = Register::default();
+        let expected = vec![
+            "This is the first line.".to_string(),
+            "This is the second line.".to_string(),
+            "This is the third line".to_string(),
+        ];
+        register.write(&expected);
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn test_register_remembers_third_element_written() {
+        let mut register = Register::default();
+        let first = vec!["Junk line 1.".to_string(), "Junk line 2.".to_string()];
+        register.write(&first);
+        let second = vec![
+            "More Junk line 1.".to_string(),
+            "More Junk line 2.".to_string(),
+            "More Junk line 3.".to_string(),
+            "More Junk line 4.".to_string(),
+        ];
+        register.write(&second);
+        let expected = vec![
+            "This is the first line.".to_string(),
+            "This is the second line.".to_string(),
+            "This is the third line".to_string(),
+        ];
+        register.write(&expected);
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, expected);
+        let first_thing_pushed: Vec<_> = register.nth(2).unwrap().collect();
+        assert_eq!(first_thing_pushed, first);
+    }
+
+    #[test]
+    fn test_register_returns_correct_element_after_removing_most_recent() {
+        let mut register = Register::default();
+        let first = vec!["Junk line 1.".to_string(), "Junk line 2.".to_string()];
+        register.write(&first);
+        let second = vec![
+            "More Junk line 1.".to_string(),
+            "More Junk line 2.".to_string(),
+            "More Junk line 3.".to_string(),
+            "More Junk line 4.".to_string(),
+        ];
+        register.write(&second);
+        let third = vec![
+            "This is the first line.".to_string(),
+            "This is the second line.".to_string(),
+            "This is the third line".to_string(),
+        ];
+        register.write(&third);
+        let popped: Vec<_> = register.pop_recent().unwrap().collect();
+        assert_eq!(popped, third);
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, second);
+    }
+
+    #[test]
+    fn test_register_remembers_mixed_elements_written() {
+        let mut register = Register::default();
+        let first = vec!["Junk line 1.".to_string(), "Junk line 2.".to_string()];
+        register.write(&first);
+        let second = "More Junk line 1.";
+        register.push(second);
+        let expected = vec![
+            "This is the first line.".to_string(),
+            "This is the second line.".to_string(),
+            "This is the third line".to_string(),
+        ];
+        register.write(&expected);
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, expected);
+        let first_thing_pushed: Vec<_> = register.nth(2).unwrap().collect();
+        assert_eq!(first_thing_pushed, first);
+        let second_thing_pushed: Vec<_> = register.nth(1).unwrap().collect();
+        assert_eq!(second_thing_pushed, vec![second]);
+    }
+
+    #[test]
+    fn test_register_only_holds_16_elements() {
+        let mut register = Register::default();
+        for i in 1..=16 {
+            let item = format!("This is the {i} thing");
+            register.push(&item);
+        }
+        assert_eq!(register.lengths.len(), 16);
+        register.push("This is the last thing");
+        assert_eq!(register.lengths.len(), 16);
+        let oldest: Vec<_> = register.nth(15).unwrap().collect();
+        assert_eq!(oldest, vec!["This is the 2 thing"]);
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values, vec!["This is the last thing"]);
+    }
+
+    #[test]
+    fn test_register_only_holds_16_writes() {
+        let mut register = Register::default();
+        let mut rng = rand::thread_rng();
+        for i in 1..=17 {
+            let mut values = vec![format!("This is the {i} thing")];
+            let end = rng.gen_range(1..6);
+            for n in 0..end {
+                let next = format!("This is next {} thing", n * i);
+                values.push(next);
+            }
+            register.write(&values);
+        }
+        assert_eq!(register.lengths.len(), 16);
+        let oldest: Vec<_> = register.nth(15).unwrap().collect();
+        let oldest_initial = oldest.first().unwrap();
+        assert_eq!(oldest_initial, "This is the 2 thing");
+        let values: Vec<_> = register.value().collect();
+        assert_eq!(values.len(), *(register.lengths.back().unwrap()));
+        assert_eq!(values.first().unwrap(), "This is the 17 thing");
+    }
+
+    #[test]
+    fn test_register_preview() {
+        let mut register = Register::default();
+        let mut expected = Vec::new();
+        for i in 1..=16 {
+            let line = format!("This is the {i} thing");
+            let mut values = vec![format!("{}\nFoo", line)];
+            let index = char::from_digit(16 - i, 16).unwrap();
+            expected.push((index.to_string(), line.clone()));
+            // Extra data to demonstrate that only the first line is read.
+            for n in 0..3 {
+                let next = format!("This is next {} thing", n * i);
+                values.push(next);
+            }
+            register.write(&values);
+        }
+        // Elements are showed newest first.
+        expected.reverse();
+
+        let values: Vec<_> = register.preview();
+        assert_eq!(values, expected);
     }
 }
-
-impl<'a> ExactSizeIterator for RegisterValues<'a> {
-    fn len(&self) -> usize {
-        self.iter.len()
-    }
-}
-
-// Each RegisterValues iterator is both double ended and exact size. We can't
-// type RegisterValues as `Box<dyn DoubleEndedIterator + ExactSizeIterator>`
-// because only one non-auto trait is allowed in trait objects. So we need to
-// create a new trait that covers both. `RegisterValues` wraps that type so that
-// trait only needs to live in this module and not be imported for all register
-// callsites.
-trait DoubleEndedExactSizeIterator: DoubleEndedIterator + ExactSizeIterator {}
-
-impl<I: DoubleEndedIterator + ExactSizeIterator> DoubleEndedExactSizeIterator for I {}


### PR DESCRIPTION
Well, technically an info panel.

All registers are now backed by a history aware datastructure. Pushing onto this datastructure will remember the most recent 16 elements. Why 16? Because the info panel selection uses a single letter so 0-F it is. Although I suspect it could be 36 and use all the alphabet. But that might be too big and if the user is heavily utilizing registers is a bunch of likely wasted space. Also, as a plus 'p' is available. More on that in a moment.

paste_before and paste_after are still there. But paste_picker_after and paste_picker_before are now the default. That could 100% flip. Setup this way made it easier to write tests.

All data sent to registers is now kept as each one stores up to the 16 element limit. An 'element' here means one or more strings.

The datastructure holding the register items is still a vector of strings. To assist with retrieving the correct data another queue keeps track of the lengths of each element pushed to the vector of contents. For example, to push 3 selections [a, b, c] each one is pushed independently and the length of "3" is saved.

As before, the contents are stored in reverse order. Reading happens from the tail.

How are registers used in Helix?

Users can push things into a register and retrieve. This is done as a string. So the contents would act like a one element vector.

Users can yank part of document. Each selection is captured as a string meaning the vector length would equal the number of selections.

Picker history for search, regexes, etc. is stashed into a register as single strings.

Macros are squashed into a string and stored.

None of that effectively changes with this PR. However, now that history exists all of the commands can act like the history of a picker. Show it, pick it. Right now, paste and macro replay use this capability through an info panel.