### PR TITLE
Use default clipboard provider for wezterm connect

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -143,7 +143,12 @@ mod external {
                     .is_some()
             }
 
-            if env_var_is_set("WAYLAND_DISPLAY")
+            if env_var_is_set("WEZTERM_UNIX_SOCKET")
+                && binary_exists("wezterm")
+                && !(env_var_is_set("TMUX") && binary_exists("tmux"))
+            {
+                Self::Termcode
+            } else if env_var_is_set("WAYLAND_DISPLAY")
                 && binary_exists("wl-copy")
                 && binary_exists("wl-paste")
             {

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -143,10 +143,11 @@ mod external {
                     .is_some()
             }
 
-            if env_var_is_set("WEZTERM_UNIX_SOCKET")
-                && binary_exists("wezterm")
-                && !(env_var_is_set("TMUX") && binary_exists("tmux"))
-            {
+            if binary_exists("termux-clipboard-set") && binary_exists("termux-clipboard-get") {
+                Self::Termux
+            } else if env_var_is_set("TMUX") && binary_exists("tmux") {
+                Self::Tmux
+            } else if env_var_is_set("WEZTERM_UNIX_SOCKET") && binary_exists("wezterm") {
                 Self::Termcode
             } else if env_var_is_set("WAYLAND_DISPLAY")
                 && binary_exists("wl-copy")
@@ -161,11 +162,6 @@ mod external {
                 && is_exit_success("xsel", &["-o", "-b"])
             {
                 Self::XSel
-            } else if binary_exists("termux-clipboard-set") && binary_exists("termux-clipboard-get")
-            {
-                Self::Termux
-            } else if env_var_is_set("TMUX") && binary_exists("tmux") {
-                Self::Tmux
             } else if binary_exists("win32yank.exe") {
                 Self::Win32Yank
             } else if cfg!(feature = "term") {


### PR DESCRIPTION
In wezterm, they had their own method (wezterm connect) to run wezterm daemon on the remote that uses ssh as a channel
> reference: https://wezfurlong.org/wezterm/multiplexing.html#ssh-domains

Because of that, default env such as `WAYLAND_DISPLAY` & `DISPLAY` is still exist, so when we run helix through wezterm connect and yank selections to clipboard (`<space>y`) it doesn't do anything (somehow in my case helix will just hang? idk why)

Therefore we need to check for `WEZTERM_UNIX_SOCKET` before anything else, and just use fallback provider for that, so we can copy to clipboard even with wezterm connect :tada: 

Thanks!