### PR TITLE
Add typed command "set-next-register".

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -66,6 +66,7 @@
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Goto line number. |
 | `:set-language`, `:lang` | Set the language of current buffer (show current language if no value specified). |
+| `:set-next-register` | Set next Register to char |
 | `:set-option`, `:set` | Set a config option at runtime.<br>For example to disable smart case search, use `:set search.smart-case false`. |
 | `:toggle-option`, `:toggle` | Toggle a boolean config option at runtime.<br>For example to toggle smart case search, use `:toggle search.smart-case`. |
 | `:get-option`, `:get` | Get the current value of a config option. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1965,6 +1965,30 @@ fn toggle_option(
     Ok(())
 }
 
+fn set_next_register(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(
+        args.len() == 1,
+        "Bad arguments. Usage: `:set-next-register register`"
+    );
+    ensure!(
+        args[0].len() != 1,
+        "Bad arguments. Register is a single character."
+    );
+
+    let register = args[0].chars().next();
+    cx.editor.selected_register = register;
+
+    Ok(())
+}
+
 /// Change the language of the current buffer at runtime.
 fn language(
     cx: &mut compositor::Context,
@@ -2953,6 +2977,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Set the language of current buffer (show current language if no value specified).",
         fun: language,
         signature: CommandSignature::positional(&[completers::language]),
+    },
+    TypableCommand {
+        name: "set-next-register",
+        aliases: &[],
+        doc: "Set next Register to char",
+        fun: set_next_register,
+        signature: CommandSignature::positional(&[completers::register]),
     },
     TypableCommand {
         name: "set-option",


### PR DESCRIPTION
As the name suggests it allows the user to set the register to be used by the next command just like the usual '"' binding. This is handy when crafting new keybindings because it allows commands to yank and paste without taking over the default regsiter.

This command has been making the rounds. It is helpful but it eats up the default register.

> C-j = ["extend_to_line_bounds", ":set-next-register a", "delete_selection", ":set-next-register a", "paste_after"]

Here the 'a' register is used instead.