### PR TITLE
language: Add pest support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -141,6 +141,7 @@
 | passwd | ✓ |  |  |  |
 | pem | ✓ |  |  |  |
 | perl | ✓ | ✓ | ✓ | `perlnavigator` |
+| pest | ✓ | ✓ | ✓ | `pest-language-server` |
 | php | ✓ | ✓ | ✓ | `intelephense` |
 | php-only | ✓ |  |  |  |
 | pkgbuild | ✓ | ✓ | ✓ | `pkgbuild-language-server`, `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -67,6 +67,7 @@ openscad-lsp = { command = "openscad-lsp", args = ["--stdio"] }
 pasls = { command = "pasls", args = [] }
 pbkit = { command = "pb", args = [ "lsp" ] }
 perlnavigator = { command = "perlnavigator", args= ["--stdio"] }
+pest-language-server = { command = "pest-language-server" }
 prisma-language-server = { command = "prisma-language-server", args = ["--stdio"] }
 purescript-language-server = { command = "purescript-language-server", args = ["--stdio"] }
 pylsp = { command = "pylsp" }
@@ -3558,3 +3559,23 @@ language-servers = []
 [[grammar]]
 name = "move"
 source = { git = "https://github.com/tzakian/tree-sitter-move", rev = "8bc0d1692caa8763fef54d48068238d9bf3c0264" }
+
+[[language]]
+name = "pest"
+scope = "source.pest"
+injection-regex = "pest"
+file-types = ["pest"]
+comment-tokens = ["//", "///", "//!"]
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+language-servers = ["pest-language-server"]
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+
+[[grammar]]
+name = "pest"
+source = { git = "https://github.com/pest-parser/tree-sitter-pest", rev = "a8a98a824452b1ec4da7f508386a187a2f234b85" }

--- a/runtime/queries/pest/highlights.scm
+++ b/runtime/queries/pest/highlights.scm
@@ -1,0 +1,49 @@
+(line_comment) @comment
+(block_comment) @comment
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+((identifier) @variable)
+((builtin) @type.builtin)
+((const) @constant)
+
+[
+  (string)
+  (character)
+] @string
+
+[
+  "_"
+  "@"
+  "$"
+]@keyword.storage.modifier
+
+[
+  "~"
+  "|"
+  "="
+  "+"
+  "*"
+  "&"
+  "^"
+  "!"
+  "?"
+  ".."
+] @operator
+
+[
+  "PUSH"
+  "PEEK"
+  "POP"
+  "SOI"
+  "EOI"
+  "ANY"
+] @keyword
+

--- a/runtime/queries/pest/indents.scm
+++ b/runtime/queries/pest/indents.scm
@@ -1,0 +1,9 @@
+[
+  (expression)
+] @indent
+
+[
+  "]"
+  "}"
+  ")"
+] @outdent

--- a/runtime/queries/pest/injections.scm
+++ b/runtime/queries/pest/injections.scm
@@ -1,0 +1,7 @@
+((line_comment) @injection.content
+ (#set! injection.language "comment")
+ (#set! injection.include-children))
+
+((block_comment) @injection.content
+ (#set! injection.language "comment")
+ (#set! injection.include-children))

--- a/runtime/queries/pest/textobjects.scm
+++ b/runtime/queries/pest/textobjects.scm
@@ -1,0 +1,8 @@
+(grammar_rule (_) @class.inside) @class.around
+(term (_) @entry.inside) @entry.around
+
+(line_comment) @comment.inside
+(line_comment)+ @comment.around
+
+(block_comment) @comment.inside
+(block_comment)+ @comment.around


### PR DESCRIPTION
Add  [pest-parser](https://github.com/pest-parser) Support.

- [pest-language-server](https://github.com/pest-parser/pest-ide-tools)
- [tree-sitter-pest](https://github.com/pest-parser/tree-sitter-pest)

close #7878