### PR TITLE
Add comment injection to typst queries

### DIFF
--- a/runtime/queries/typst/injections.scm
+++ b/runtime/queries/typst/injections.scm
@@ -5,3 +5,6 @@
 	lang: (ident) @injection.language
   (blob) @injection.content)
 
+((comment)
+	@injection.content
+	(#set! injection.language "comment"))


### PR DESCRIPTION
Previously, comments in Typst files would not get any comment highlighting. This PR adds the injection query for comments in the Typst language.

An example of a Typst file after this change:
![image](https://github.com/helix-editor/helix/assets/137803093/cd14ccc1-ee04-4a23-a94c-0c83b3a00994)
