### PR TITLE
add `try` keyword to rust highlights

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -125,6 +125,7 @@
   "match"
   "if"
   "else"
+  "try"
 ] @keyword.control.conditional
 
 [


### PR DESCRIPTION
`try` keyword can be used in nightly rustc after 2018 edition.
```rust
#![feature(try_blocks)]

fn main() {
    let res: Option<i32> = try {
        let a = Some(1)?;
        a
    };
    println!("{res:?}");
}
```