### PR TITLE
Add `is not` and `not in` to python syntax

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -215,9 +215,11 @@
 [
   "and"
   "or"
+  "not in"
   "in"
   "not"
   "del"
+  "is not"
   "is"
 ] @keyword.operator
 


### PR DESCRIPTION
Fixes #10585. It appears if statements only support a single keyword operator between operands. To fix this, I added `is not` and `not in` as separate keywords.