### PR TITLE
Add completion/signature bindings to keymap.md

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -13,8 +13,8 @@
     - [Window mode](#window-mode)
     - [Space mode](#space-mode)
       - [Popup](#popup)
-      - [Completion Popup](#completion-popup)
-      - [Signature Popup](#signature-popup)
+      - [Completion Menu](#completion-menu)
+      - [Signature-help Popup](#signature-help-popup)
     - [Unimpaired](#unimpaired)
 - [Insert mode](#insert-mode)
 - [Select / extend mode](#select--extend-mode)
@@ -317,7 +317,7 @@ Displays documentation for item under cursor. Remapping currently not supported.
 | `Ctrl-u` | Scroll up   |
 | `Ctrl-d` | Scroll down |
 
-##### Completion Popup
+##### Completion Menu
 
 Displays documentation for the selected completion item. Remapping currently not supported.
 
@@ -326,7 +326,7 @@ Displays documentation for the selected completion item. Remapping currently not
 | `Shift-Tab`, `Ctrl-p`, `Up` | Previous entry |
 | `Tab`, `Ctrl-n`, `Down`     | Next entry     |
 
-##### Signature Popup
+##### Signature-help Popup
 
 Displays the signature of the selected completion item. Remapping currently not supported.
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -12,8 +12,9 @@
     - [Match mode](#match-mode)
     - [Window mode](#window-mode)
     - [Space mode](#space-mode)
-      - [Comment mode](#comment-mode)
       - [Popup](#popup)
+      - [Completion Popup](#completion-popup)
+      - [Signature Popup](#signature-popup)
     - [Unimpaired](#unimpaired)
 - [Insert mode](#insert-mode)
 - [Select / extend mode](#select--extend-mode)
@@ -309,12 +310,30 @@ This layer is a kludge of mappings, mostly pickers.
 
 ##### Popup
 
-Displays documentation for item under cursor.
+Displays documentation for item under cursor. Remapping currently not supported.
 
 | Key      | Description |
 | ----     | ----------- |
 | `Ctrl-u` | Scroll up   |
 | `Ctrl-d` | Scroll down |
+
+##### Completion Popup
+
+Displays documentation for the selected completion item. Remapping currently not supported.
+
+| Key                         | Description    |
+| ----                        | -----------    |
+| `Shift-Tab`, `Ctrl-p`, `Up` | Previous entry |
+| `Tab`, `Ctrl-n`, `Down`     | Next entry     |
+
+##### Signature Popup
+
+Displays the signature of the selected completion item. Remapping currently not supported.
+
+| Key     | Description        |
+| ----    | -----------        |
+| `Alt-p` | Previous signature |
+| `Alt-n` | Next signature     |
 
 #### Unimpaired
 


### PR DESCRIPTION
PR #9974 added alt-p/alt-n keybindings to scroll through signatures. This wasn't very discoverable, as it's not in the docs or the command palette.

This also removes a broken link for "comment mode" in the table of contents.