### PR TITLE
signature: use the suggested LSP signature when changed

### DIFF
--- a/helix-term/src/ui/lsp.rs
+++ b/helix-term/src/ui/lsp.rs
@@ -27,6 +27,7 @@ pub struct SignatureHelp {
     language: String,
     config_loader: Arc<ArcSwap<syntax::Loader>>,
     active_signature: usize,
+    lsp_signature: Option<usize>,
     signatures: Vec<Signature>,
 }
 
@@ -37,18 +38,24 @@ impl SignatureHelp {
         language: String,
         config_loader: Arc<ArcSwap<syntax::Loader>>,
         active_signature: usize,
+        lsp_signature: Option<usize>,
         signatures: Vec<Signature>,
     ) -> Self {
         Self {
             language,
             config_loader,
             active_signature,
+            lsp_signature,
             signatures,
         }
     }
 
     pub fn active_signature(&self) -> usize {
         self.active_signature
+    }
+
+    pub fn lsp_signature(&self) -> Option<usize> {
+        self.lsp_signature
     }
 
     pub fn visible_popup(compositor: &mut Compositor) -> Option<&mut Popup<Self>> {


### PR DESCRIPTION
some LSPs does update the active signature and some not. To make both worlds happy, make the active signature more intelligent.

1. SignatureHelp store now the suggested lsp_signature
2. if the lsp_signature changes then use it
3. otherwise use the last signature from the old popup
4. in case the old signature doesn't exist anymore, show the last signature