### PR TITLE
Add support for Inko

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -88,6 +88,7 @@
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | ini | ✓ |  |  |  |
+| inko | ✓ | ✓ | ✓ |  |
 | janet | ✓ |  |  |  |
 | java | ✓ | ✓ | ✓ | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2663,6 +2663,21 @@ name = "ini"
 source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "4d247fb876b4ae6b347687de4a179511bf67fcbc" }
 
 [[language]]
+name = "inko"
+auto-format = true
+scope = "source.inko"
+injection-regex = "inko"
+file-types = ["inko"]
+roots = ["inko.pkg"]
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }
+formatter = { command = "inko", args = ["fmt", "-"] }
+
+[[grammar]]
+name = "inko"
+source = { git = "https://github.com/inko-lang/tree-sitter-inko", rev = "6983354c13a14bc621d7a3619f1790149e901187" }
+
+[[language]]
 name = "bicep"
 scope = "source.bicep"
 file-types = ["bicep"]

--- a/runtime/queries/inko/highlights.scm
+++ b/runtime/queries/inko/highlights.scm
@@ -1,0 +1,193 @@
+; Brackets and operators
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ","
+  "."
+  ":"
+] @punctuation.delimiter
+
+[
+  "!="
+  "%"
+  "%="
+  "&"
+  "&="
+  "*"
+  "**"
+  "**="
+  "*="
+  "+"
+  "+="
+  "-"
+  "-="
+  "/"
+  "/="
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "<="
+  "=="
+  ">"
+  ">="
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "^"
+  "^="
+  "|"
+  "|="
+] @operator
+
+; Keywords
+[
+  "as"
+  "for"
+  "impl"
+  "let"
+  "mut"
+  "ref"
+  "uni"
+  "move"
+  "recover"
+] @keyword
+
+"fn" @keyword.function
+
+"import" @keyword.control.import
+
+[
+  "and"
+  "or"
+] @keyword.operator
+
+[
+  "class"
+  "trait"
+] @keyword.storage.type
+
+[
+  "extern"
+  (modifier)
+  (visibility)
+] @keyword.storage.modifier
+
+[
+  "loop"
+  "while"
+  (break)
+  (next)
+] @keyword.control.repeat
+
+"return" @keyword.control.return
+
+[
+  "throw"
+  "try"
+] @keyword.control.exception
+
+[
+  "case"
+  "else"
+  "if"
+  "match"
+] @keyword.control.conditional
+
+; Comments
+(line_comment) @comment.line
+
+; Literals
+(self) @variable.builtin
+
+(nil) @constant.builtin
+
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+(integer) @constant.numeric.integer
+
+(float) @constant.numeric.float
+
+(string) @string
+
+(escape_sequence) @constant.character.escape
+
+(interpolation
+  "${" @punctuation.special
+  "}" @punctuation.special)
+
+(constant) @constant
+
+; Patterns
+(integer_pattern) @constant.numeric.integer
+
+(string_pattern) @string
+
+(constant_pattern) @constant
+
+; Types
+(generic_type
+  name: _ @type)
+
+(type) @type
+
+; Imports
+(extern_import
+  path: _ @string)
+
+; Classes
+(class
+  name: _ @type)
+
+(define_field
+  name: _ @variable.other.member)
+
+; Traits
+(trait
+  name: _ @type)
+
+; Implementations
+(implement_trait
+  class: _ @type)
+
+(reopen_class
+  name: _ @type)
+
+(bound
+  name: _ @type)
+
+; Methods
+(method
+  name: _ @function)
+
+(external_function
+  name: _ @function)
+
+(argument
+  name: _ @variable.parameter)
+
+(named_argument
+  name: _ @variable.parameter)
+
+(call
+  name: _ @function)
+
+(field) @variable.other.member
+
+; Identifiers/variable references
+((identifier) @function
+  (#is-not? local))
+
+(identifier) @variable

--- a/runtime/queries/inko/indents.scm
+++ b/runtime/queries/inko/indents.scm
@@ -1,0 +1,36 @@
+[
+  (arguments)
+  (array)
+  (assign_field)
+  (assign_local)
+  (assign_receiver_field)
+  (binary)
+  (block)
+  (bounds)
+  (cast)
+  (class)
+  (class_pattern)
+  (compound_assign_field)
+  (compound_assign_local)
+  (compound_assign_receiver_field)
+  (define_constant)
+  (define_variable)
+  (grouped_expression)
+  (implement_trait)
+  (match)
+  (or_pattern)
+  (reopen_class)
+  (replace_field)
+  (replace_local)
+  (symbols)
+  (trait)
+  (tuple)
+  (tuple_pattern)
+  (type_arguments)
+] @indent
+
+[
+  ")"
+  "]"
+  "}"
+] @outdent

--- a/runtime/queries/inko/injections.scm
+++ b/runtime/queries/inko/injections.scm
@@ -1,0 +1,2 @@
+((line_comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/inko/locals.scm
+++ b/runtime/queries/inko/locals.scm
@@ -1,0 +1,10 @@
+[
+  (method)
+  (block)
+] @local.scope
+
+(argument name: _ @local.definition)
+(define_variable name: _ @local.definition)
+(named_argument name: _ @local.definition)
+
+(identifier) @local.reference

--- a/runtime/queries/inko/textobjects.scm
+++ b/runtime/queries/inko/textobjects.scm
@@ -1,0 +1,38 @@
+(class
+  body: (_) @class.inside) @class.around
+
+(trait
+  body: (_) @class.inside) @class.around
+
+(method
+  body: (_) @function.inside) @function.around
+
+(reopen_class
+  body: (_) @class.inside) @class.around
+
+(implement_trait
+  body: (_) @class.inside) @class.around
+
+(external_function
+  body: (_) @function.inside) @function.around
+
+(closure
+  body: (_) @function.inside) @function.around
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(type_arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(line_comment) @comment.inside
+
+(line_comment)+ @comment.around
+
+(array (_) @entry.around)
+
+(tuple (_) @entry.around)
+
+(tuple_pattern (_) @entry.around)
+
+(define_field (_) @entry.inside) @entry.around


### PR DESCRIPTION
This adds formatting and Tree-sitter support for Inko (https://inko-lang.org/), using the grammar located [here](https://github.com/inko-lang/tree-sitter-inko/).