### PR TITLE
fix line_end_char_index() documentation

### DIFF
--- a/helix-core/src/line_ending.rs
+++ b/helix-core/src/line_ending.rs
@@ -195,7 +195,7 @@ pub fn get_line_ending_of_str(line: &str) -> Option<LineEnding> {
     }
 }
 
-/// Returns the char index of the end of the given line, not including its line ending.
+/// Returns the char index of the end of the given line.
 pub fn line_end_char_index(slice: &RopeSlice, line: usize) -> usize {
     slice.line_to_char(line + 1)
         - get_line_ending(&slice.line(line))


### PR DESCRIPTION
Heyhey,

I came across said function - `helix_core::line_ending::line_end_char_index()`. Its documentation states:
```
Returns the char index of the end of the given line, not including its line ending.
```

But e.g. for `"a\nb"` it returns `1`. But according to the documentation, I would expect it to return `0`, the index of the last non-newline char, `a`.

Come to think of it - if the function would return the index of the last non-newline char, it should probably return an `Option`, as a line might contain nothing except the newline character...

So my guess is that the documentation is outdated, or that my understanding of char indices is fundamentally wrong.

If the second is the case (might very well be), it would be nice to somehow adjust the doc to be more clear.