### PR TITLE
Expose all flake outputs through flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,4 +5,4 @@ let
     sha256 = "sha256:1qc703yg0babixi6wshn5wm2kgl5y1drcswgszh4xxzbrwkk9sv7";
   };
 in
-  (import compat {src = ./.;}).defaultNix.default
+  (import compat {src = ./.;}).defaultNix


### PR DESCRIPTION
Currently, the `default.nix` for Helix only exposes a single package which is always built for `builtins.currentSystem`, the system where the Nix code is being evaluated. If you aren't using flakes, there's not an easy way to build Helix for a different system.

This change instead does what most other users of `flake-compat` do in `default.nix`: expose all of the flake's outputs. This allows consumers to use the package for a specific system if they need to by doing something like `(import helix).packages.${system}.helix`. And the current behavior is still accessible by doing `(import helix).default` instead of `import helix` as you currently can.