### PR TITLE
lang(json): make field key highlighting consistent with toml and yaml

### DIFF
--- a/runtime/queries/json/highlights.scm
+++ b/runtime/queries/json/highlights.scm
@@ -4,8 +4,9 @@
 ] @constant.builtin.boolean
 (null) @constant.builtin
 (number) @constant.numeric
+
 (pair
-  key: (_) @keyword)
+  key: (_) @variable.other.member)
 
 (string) @string
 (escape_sequence) @constant.character.escape

--- a/runtime/queries/json5/highlights.scm
+++ b/runtime/queries/json5/highlights.scm
@@ -1,11 +1,20 @@
-(string) @string
-
-(identifier) @constant
-
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+(null) @constant.builtin
 (number) @constant.numeric
 
-(null) @constant.builtin
+(member
+  name: (_) @variable.other.member)
 
-[(true) (false)] @constant.builtin.boolean
-
+(string) @string
 (comment) @comment
+
+"," @punctuation.delimiter
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket


### PR DESCRIPTION
This PR makes `json` and `json5` highlighting more consistent with `yaml` and `toml` by using `@variable.other.member` for member keys. Aside from being consistent with yaml and toml, this key simply makes sense in this context so it should be more consistent across all languages.