### PR TITLE
Remove ' and add ⟨⟩ in lean autopairs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1040,6 +1040,13 @@ block-comment-tokens = { start = "/-", end = "-/" }
 language-servers = [ "lean" ]
 indent = { tab-width = 2, unit = "  " }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'⟨' = '⟩'
+
 [[grammar]]
 name = "lean"
 source = { git = "https://github.com/Julian/tree-sitter-lean", rev = "d98426109258b266e1e92358c5f11716d2e8f638" }


### PR DESCRIPTION
Add an auto-pairs section to the lean configuration with ⟨⟩ and without ''
Rationale: ⟨⟩ is very commonly used for pattern matching and essentially always used in a pair, and ' is also very commonly used for denoting "prime" almost never used in a pair. If only using one ' the pairing isn't an issue, but when trying to type two, the pairing creates ''' instead, and the same issue is present when trying to type four, etc.
There were issues with 3 byte characters for pairs but they were fixed: #3964 and #3946.
Sorry if there are any issues, I'm new to this.