### PR TITLE
FIx incorrectly spelled cfg options

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 
 [features]
 default = ["git"]
-unicode-lines = ["helix-core/unicode-lines"]
+unicode-lines = ["helix-core/unicode-lines", "helix-view/unicode-lines"]
 integration = ["helix-event/integration_test"]
 git = ["helix-vcs/git"]
 

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [features]
 default = []
 term = ["crossterm"]
+unicode-lines = []
 
 [dependencies]
 helix-stdx = { path = "../helix-stdx" }

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -90,13 +90,13 @@ pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
     }
 }
 
-#[cfg(target_os = "wasm32")]
+#[cfg(target_arch = "wasm32")]
 pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
     // TODO:
     Box::new(provider::FallbackProvider::new())
 }
 
-#[cfg(not(any(windows, target_os = "wasm32", target_os = "macos")))]
+#[cfg(not(any(windows, target_arch = "wasm32", target_os = "macos")))]
 pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
     use helix_stdx::env::{binary_exists, env_var_is_set};
     use provider::command::is_exit_success;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -386,7 +386,7 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
     })
 }
 
-#[cfg(not(any(windows, target_os = "wasm32")))]
+#[cfg(not(any(windows, target_arch = "wasm32")))]
 pub fn get_terminal_provider() -> Option<TerminalConfig> {
     use helix_stdx::env::{binary_exists, env_var_is_set};
 


### PR DESCRIPTION
While building Helix today the new lints from 

https://blog.rust-lang.org/2024/05/06/check-cfg.html

Fired for the helix-view crate. Specifically there were two things spelled incorrectly:

1. It used the unicode-lines feature, but the feature was not declared in its manifest. 
2. It used the `target_os` cfg key for wasm32 rather than `target_arch`.

I don't know enough about either of these to write tests for them. It doesn't even look to me like wasm32 is tested in ci anyways, and the `unicode-lines` feature is not enabled in CI either.

```
warning: unexpected `cfg` condition value: `wasm32`
  --> helix-view\src\clipboard.rs:93:7
   |
93 | #[cfg(target_os = "wasm32")]
   |       ^^^^^^^^^^^^^^^^^^^^
   |
   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows` and 2 more
   = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition value: `wasm32`
  --> helix-view\src\clipboard.rs:99:24
   |
99 | #[cfg(not(any(windows, target_os = "wasm32", target_os = "macos")))]
   |                        ^^^^^^^^^^^^^^^^^^^^
   |
   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows` and 2 more
   = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `wasm32`
   --> helix-view\src\editor.rs:389:24
    |
389 | #[cfg(not(any(windows, target_os = "wasm32")))]
    |                        ^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows` and 2 more
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:830:11
    |
830 |     #[cfg(feature = "unicode-lines")]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:833:11
    |
833 |     #[cfg(feature = "unicode-lines")]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:836:11
    |
836 |     #[cfg(feature = "unicode-lines")]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:846:19
    |
846 |             #[cfg(feature = "unicode-lines")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:848:19
    |
848 |             #[cfg(feature = "unicode-lines")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `unicode-lines`
   --> helix-view\src\editor.rs:850:19
    |
850 |             #[cfg(feature = "unicode-lines")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `crossterm`, `default`, `term`
    = help: consider adding `unicode-lines` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
```