### PR TITLE
Added missing colors to dark_high_contrast theme for XML/HTML highlighting

### DIFF
--- a/runtime/themes/dark_high_contrast.toml
+++ b/runtime/themes/dark_high_contrast.toml
@@ -83,6 +83,8 @@
 "keyword.control" = "purple"
 "function" = "yellow"
 "label" = "blue"
+"tag" = "aqua"
+"attribute" = "blue"
 
 # Markup 
 "markup.heading" = { fg = "yellow", modifiers = ["bold"], underline = { color = "yellow", style = "double_line"} }


### PR DESCRIPTION
I'd been using this theme quite a while because it looks the nicest to my dyslexia. That said, when I open up XML or HTML documents, they pretty much always show up in complete white, except for attribute values.

Finally decided to take a look at why, and added the two colors (`tag` & `attribute`) needed to make the theme actually usable with the two formats.