### PR TITLE
lang(starlark): Add WORKSPACE glob.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2250,7 +2250,7 @@ source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569
 name = "starlark"
 scope = "source.starlark"
 injection-regex = "(starlark|bzl|bazel)"
-file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUILD.*" }, { glob = "Tiltfile" }]
+file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUILD.*" }, { glob = "Tiltfile" }, { glob = "WORKSPACE" }]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 grammar = "python"


### PR DESCRIPTION
In addition to BUILD files, bazel repositories contain a WORKSPACE file,
which is also written in starlark.
See https://bazel.build/reference/be/workspace.
