### PR TITLE
Raise MSRV to 1.74

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -740,7 +740,7 @@ fn init_indent_query<'a, 'b>(
 
         crate::syntax::PARSER.with(|ts_parser| {
             let mut ts_parser = ts_parser.borrow_mut();
-            let mut cursor = ts_parser.cursors.pop().unwrap_or_else(QueryCursor::new);
+            let mut cursor = ts_parser.cursors.pop().unwrap_or_default();
             let query_result = query_indents(
                 query,
                 syntax,

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -21,7 +21,7 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::{HashMap, HashSet, VecDeque},
-    fmt::{self, Display},
+    fmt::{self, Display, Write},
     hash::{Hash, Hasher},
     mem::replace,
     path::{Path, PathBuf},
@@ -729,8 +729,11 @@ pub fn read_query(language: &str, filename: &str) -> String {
         .replace_all(&query, |captures: &regex::Captures| {
             captures[1]
                 .split(',')
-                .map(|language| format!("\n{}\n", read_query(language, filename)))
-                .collect::<String>()
+                .fold(String::new(), |mut output, language| {
+                    // `write!` to a String cannot fail.
+                    write!(output, "\n{}\n", read_query(language, filename)).unwrap();
+                    output
+                })
         })
         .to_string()
 }
@@ -1245,7 +1248,7 @@ impl Syntax {
         PARSER.with(|ts_parser| {
             let ts_parser = &mut ts_parser.borrow_mut();
             ts_parser.parser.set_timeout_micros(1000 * 500); // half a second is pretty generours
-            let mut cursor = ts_parser.cursors.pop().unwrap_or_else(QueryCursor::new);
+            let mut cursor = ts_parser.cursors.pop().unwrap_or_default();
             // TODO: might need to set cursor range
             cursor.set_byte_range(0..usize::MAX);
             cursor.set_match_limit(TREE_SITTER_MATCH_LIMIT);
@@ -1419,7 +1422,7 @@ impl Syntax {
                 // Reuse a cursor from the pool if available.
                 let mut cursor = PARSER.with(|ts_parser| {
                     let highlighter = &mut ts_parser.borrow_mut();
-                    highlighter.cursors.pop().unwrap_or_else(QueryCursor::new)
+                    highlighter.cursors.pop().unwrap_or_default()
                 });
 
                 // The `captures` iterator borrows the `Tree` and the `QueryCursor`, which

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -378,7 +378,9 @@ impl ChangeSet {
             macro_rules! map {
                 ($map: expr, $i: expr) => {
                     loop {
-                        let Some((pos, assoc)) = positions.peek_mut() else { return; };
+                        let Some((pos, assoc)) = positions.peek_mut() else {
+                            return;
+                        };
                         if **pos < old_pos {
                             // Positions are not sorted, revert to the last Operation that
                             // contains this position and continue iterating from there.
@@ -405,7 +407,10 @@ impl ChangeSet {
                             debug_assert!(old_pos <= **pos, "Reverse Iter across changeset works");
                             continue 'outer;
                         }
-                        let Some(new_pos) = $map(**pos, *assoc) else { break; };
+                        #[allow(clippy::redundant_closure_call)]
+                        let Some(new_pos) = $map(**pos, *assoc) else {
+                            break;
+                        };
                         **pos = new_pos;
                         positions.next();
                     }

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -36,7 +36,7 @@ fn test_treesitter_indent_rust_helix() {
         .unwrap();
     let files = String::from_utf8(files.stdout).unwrap();
 
-    let ignored_files = vec![
+    let ignored_files = [
         // Contains many macros that tree-sitter does not parse in a meaningful way and is otherwise not very interesting
         "helix-term/src/health.rs",
     ];
@@ -45,6 +45,7 @@ fn test_treesitter_indent_rust_helix() {
         if ignored_files.contains(&file) {
             continue;
         }
+        #[allow(clippy::single_range_in_vec_init)]
         let ignored_lines: Vec<Range<usize>> = match file {
             "helix-term/src/application.rs" => vec![
                 // We can't handle complicated indent rules inside macros (`json!` in this case) since

--- a/helix-lsp/src/file_event.rs
+++ b/helix-lsp/src/file_event.rs
@@ -139,7 +139,7 @@ impl Handler {
                         registration_id
                     );
 
-                    let entry = state.entry(client_id).or_insert_with(ClientState::default);
+                    let entry = state.entry(client_id).or_default();
                     entry.client = client;
 
                     let mut builder = GlobSetBuilder::new();

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -678,7 +678,7 @@ impl Registry {
     pub fn remove_by_id(&mut self, id: LanguageServerId) {
         let Some(client) = self.inner.remove(id) else {
             log::error!("client was already removed");
-            return
+            return;
         };
         self.file_event_handler.remove_client(id);
         let instances = self

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -724,7 +724,7 @@ impl Application {
                     }
                     Notification::PublishDiagnostics(mut params) => {
                         let path = match params.uri.to_file_path() {
-                            Ok(path) => helix_stdx::path::normalize(&path),
+                            Ok(path) => helix_stdx::path::normalize(path),
                             Err(_) => {
                                 log::error!("Unsupported file URI: {}", params.uri);
                                 return;

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -111,7 +111,9 @@ impl AsyncHook for ResolveTimeout {
     }
 
     fn finish_debounce(&mut self) {
-        let Some(request) = self.next_request.take() else { return };
+        let Some(request) = self.next_request.take() else {
+            return;
+        };
         let (tx, rx) = helix_event::cancelation();
         self.in_flight = Some((tx, request.item.clone()));
         tokio::spawn(request.execute(rx));

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -119,8 +119,7 @@ pub fn request_signature_help(
         // Do not show the message if signature help was invoked
         // automatically on backspace, trigger characters, etc.
         if invoked == SignatureHelpInvoked::Manual {
-            editor
-                .set_error("No configured language server supports signature-help");
+            editor.set_error("No configured language server supports signature-help");
         }
         return;
     };
@@ -300,11 +299,11 @@ fn signature_help_post_insert_char_hook(
     let (view, doc) = current!(cx.editor);
     // TODO support multiple language servers (not just the first that is found), likely by merging UI somehow
     let Some(language_server) = doc
-            .language_servers_with_feature(LanguageServerFeature::SignatureHelp)
-            .next()
-        else {
-            return Ok(());
-        };
+        .language_servers_with_feature(LanguageServerFeature::SignatureHelp)
+        .next()
+    else {
+        return Ok(());
+    };
 
     let capabilities = language_server.capabilities();
 

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -145,8 +145,8 @@ fn status(repo: &Repository, f: impl Fn(Result<FileChange>) -> bool) -> Result<(
 
     for item in status_iter {
         let Ok(item) = item.map_err(|err| f(Err(err.into()))) else {
-                continue;
-            };
+            continue;
+        };
         let change = match item {
             Item::Modification {
                 rela_path, status, ..

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -123,7 +123,7 @@ impl Registers {
                     _ => unreachable!(),
                 };
                 let contents = self.clipboard_provider.get_contents(clipboard_type)?;
-                let saved_values = self.inner.entry(name).or_insert_with(Vec::new);
+                let saved_values = self.inner.entry(name).or_default();
 
                 if !contents_are_saved(saved_values, &contents) {
                     anyhow::bail!("Failed to push to register {name}: clipboard does not match register contents");
@@ -140,7 +140,7 @@ impl Registers {
                 Ok(())
             }
             _ => {
-                self.inner.entry(name).or_insert_with(Vec::new).push(value);
+                self.inner.entry(name).or_default().push(value);
                 Ok(())
             }
         }

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -233,7 +233,9 @@ fn read_from_clipboard<'a>(
             // If we're pasting the same values that we just yanked, re-use
             // the saved values. This allows pasting multiple selections
             // even when yanked to a clipboard.
-            let Some(values) = saved_values else { return RegisterValues::new(iter::once(contents.into())) };
+            let Some(values) = saved_values else {
+                return RegisterValues::new(iter::once(contents.into()));
+            };
 
             if contents_are_saved(values, &contents) {
                 RegisterValues::new(values.iter().map(Cow::from).rev())

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -560,7 +560,7 @@ impl Tree {
             id
         } else {
             // extremely crude, take the last item
-            let (key, _) = self.traverse().rev().next().unwrap();
+            let (key, _) = self.traverse().next_back().unwrap();
             key
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.74.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
The changes are basically all cosmetic: 1.74 has a few new clippy lints to address (mostly using `or_default`/`unwrap_or_default` rather than explicit defaults), and the formatter now formats let-else.

Connects https://github.com/helix-editor/helix/pull/10704