### PR TITLE
Remove outdated comment about key binding being disabled

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -89,7 +89,7 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `"` `<reg>` | Select a register to yank to or paste from                           | `select_register`         |
 | `>`         | Indent selection                                                     | `indent`                  |
 | `<`         | Unindent selection                                                   | `unindent`                |
-| `=`         | Format selection (currently nonfunctional/disabled) (**LSP**)        | `format_selections`       |
+| `=`         | Format selection (**LSP**)                                           | `format_selections`       |
 | `d`         | Delete selection                                                     | `delete_selection`        |
 | `Alt-d`     | Delete selection, without yanking                                    | `delete_selection_noyank` |
 | `c`         | Change selection (delete and enter insert mode)                      | `change_selection`        |


### PR DESCRIPTION
I just used the `=` binding to format a selection in a CSS file in helix 23.10 (5931a46c) so removing this comment as outdated.