### PR TITLE
docs: update nixos link to official wiki

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -63,7 +63,7 @@ in the AUR, which builds the master branch.
 Helix is available in [nixpkgs](https://github.com/nixos/nixpkgs) through the `helix` attribute,
 the unstable channel usually carries the latest release.
 
-Helix is also available as a [flake](https://nixos.wiki/wiki/Flakes) in the project
+Helix is also available as a [flake](https://wiki.nixos.org/wiki/Flakes) in the project
 root. Use `nix develop` to spin up a reproducible development shell. Outputs are
 cached for each push to master using [Cachix](https://www.cachix.org/). The
 flake is configured to automatically make use of this cache assuming the user


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: https://github.com/NixOS/foundation/issues/113