### PR TITLE
correctly handle opening helix inside symlinked directory

### DIFF
--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -14,13 +14,23 @@ pub fn current_working_dir() -> PathBuf {
         return path.clone();
     }
 
-    let path = std::env::current_dir()
-        .map(crate::path::normalize)
-        .expect("Couldn't determine current working directory");
-    let mut cwd = CWD.write().unwrap();
-    *cwd = Some(path.clone());
+    // implementation of crossplatform pwd -L
+    // we want pwd -L so that symlinked directories are handeled correctly
+    let mut cwd = std::env::current_dir().expect("Couldn't determine current working directory");
 
-    path
+    let pwd = std::env::var_os("PWD");
+    #[cfg(windows)]
+    let pwd = pwd.or_else(|| std::env::var_os("CD"));
+
+    if let Some(pwd) = pwd.map(PathBuf::from) {
+        if pwd.canonicalize().ok().as_ref() == Some(&cwd) {
+            cwd = pwd;
+        }
+    }
+    let mut dst = CWD.write().unwrap();
+    *dst = Some(cwd.clone());
+
+    cwd
 }
 
 pub fn set_current_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -15,7 +15,7 @@ pub fn current_working_dir() -> PathBuf {
     }
 
     // implementation of crossplatform pwd -L
-    // we want pwd -L so that symlinked directories are handeled correctly
+    // we want pwd -L so that symlinked directories are handled correctly
     let mut cwd = std::env::current_dir().expect("Couldn't determine current working directory");
 
     let pwd = std::env::var_os("PWD");


### PR DESCRIPTION
get_current_directory alnways returns a cannonicalized path (since cwd is just a file descriptor that is passed to realpath). That means that opening any file inside a symlinked directory would show that file as an absolute path outised the cwd instead of as an relative path (since we don't cannonicalize/resolve symlinks normally). To fix that I made helix mirror the behavior of `pwd -L`. We use PWD environment variable set by the shell which has a "memory" of which symlinks were transversed with `cd`.
