### PR TITLE
Prevent improper files (like /dev/random) from being used as file arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ package.helix-term.opt-level = 2
 tree-sitter = { version = "0.22" }
 nucleo = "0.2.0"
 slotmap = "1.0.7"
+thiserror = "1.0"
 
 [workspace.package]
 version = "24.3.0"

--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -20,8 +20,8 @@ anyhow = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "net", "sync"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 fern = "0.6"

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -26,9 +26,9 @@ log = "0.4"
 lsp-types = { version = "0.95" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
 tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot", "sync"] }
 tokio-stream = "0.1.15"
 parking_lot = "0.12.2"
 arc-swap = "1"
 slotmap.workspace = true
+thiserror.workspace = true

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -9,7 +9,7 @@ use helix_lsp::{
 use helix_stdx::path::get_relative_path;
 use helix_view::{
     align_view,
-    document::{DocumentSavedEventResult, IrregularFileError},
+    document::{DocumentOpenError, DocumentSavedEventResult},
     editor::{ConfigEvent, EditorEvent},
     graphics::Rect,
     theme,
@@ -188,14 +188,13 @@ impl Application {
                         };
                         let doc_id = match editor
                             .open(&file, action)
-                            .context(format!("open '{}'", file.to_string_lossy()))
                         {
                             // Ignore irregular files during application init.
-                            Err(e) if e.is::<IrregularFileError>() => {
+                            Err(DocumentOpenError::IrregularFile) => {
                                 nr_of_files -= 1;
                                 continue;
                             }
-                            a => a,
+                            a => a.context(format!("open '{}'", file.to_string_lossy())),
                         }?;
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -9,7 +9,7 @@ use helix_lsp::{
 use helix_stdx::path::get_relative_path;
 use helix_view::{
     align_view,
-    document::DocumentSavedEventResult,
+    document::{DocumentSavedEventResult, IrregularFileError},
     editor::{ConfigEvent, EditorEvent},
     graphics::Rect,
     theme,
@@ -186,9 +186,17 @@ impl Application {
                             Some(Layout::Horizontal) => Action::HorizontalSplit,
                             None => Action::Load,
                         };
-                        let doc_id = editor
+                        let doc_id = match editor
                             .open(&file, action)
-                            .context(format!("open '{}'", file.to_string_lossy()))?;
+                            .context(format!("open '{}'", file.to_string_lossy()))
+                        {
+                            // Ignore irregular files during application init.
+                            Err(e) if e.is::<IrregularFileError>() => {
+                                nr_of_files -= 1;
+                                continue;
+                            }
+                            a => a,
+                        }?;
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If
                         // `--vsplit` or `--hsplit` are used, the file which is
@@ -199,15 +207,21 @@ impl Application {
                         doc.set_selection(view_id, pos);
                     }
                 }
-                editor.set_status(format!(
-                    "Loaded {} file{}.",
-                    nr_of_files,
-                    if nr_of_files == 1 { "" } else { "s" } // avoid "Loaded 1 files." grammo
-                ));
-                // align the view to center after all files are loaded,
-                // does not affect views without pos since it is at the top
-                let (view, doc) = current!(editor);
-                align_view(doc, view, Align::Center);
+
+                // if all files were invalid, replace with empty buffer
+                if nr_of_files == 0 {
+                    editor.new_file(Action::VerticalSplit);
+                } else {
+                    editor.set_status(format!(
+                        "Loaded {} file{}.",
+                        nr_of_files,
+                        if nr_of_files == 1 { "" } else { "s" } // avoid "Loaded 1 files." grammo
+                    ));
+                    // align the view to center after all files are loaded,
+                    // does not affect views without pos since it is at the top
+                    let (view, doc) = current!(editor);
+                    align_view(doc, view, Align::Center);
+                }
             } else {
                 editor.new_file(Action::VerticalSplit);
             }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -192,8 +192,9 @@ impl Application {
                                 nr_of_files -= 1;
                                 continue;
                             }
-                            a => a.context(format!("open '{}'", file.to_string_lossy())),
-                        }?;
+                            Err(err) => return Err(anyhow::anyhow!(err)),
+                            Ok(doc_id) => doc_id,
+                        };
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If
                         // `--vsplit` or `--hsplit` are used, the file which is

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -186,9 +186,7 @@ impl Application {
                             Some(Layout::Horizontal) => Action::HorizontalSplit,
                             None => Action::Load,
                         };
-                        let doc_id = match editor
-                            .open(&file, action)
-                        {
+                        let doc_id = match editor.open(&file, action) {
                             // Ignore irregular files during application init.
                             Err(DocumentOpenError::IrregularFile) => {
                                 nr_of_files -= 1;

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -95,13 +95,23 @@ impl Args {
                         _ => args.files.push(parse_file(arg)),
                     };
                 }
-                arg => args.files.push(parse_file(arg)),
+                arg => {
+                    let file = parse_file(arg);
+
+                    if is_proper_file(&file) {
+                        args.files.push(file)
+                    }
+                }
             }
         }
 
         // push the remaining args, if any to the files
         for arg in argv {
-            args.files.push(parse_file(&arg));
+            let file = parse_file(&arg);
+
+            if is_proper_file(&file) {
+                args.files.push(file);
+            }
         }
 
         if let Some(file) = args.files.first_mut() {
@@ -123,6 +133,11 @@ pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
     split_path_row_col(s)
         .or_else(|| split_path_row(s))
         .unwrap_or_else(def)
+}
+
+/// Ensure file is not a pipe or random
+fn is_proper_file(f: &(PathBuf, Position)) -> bool {
+    f.0.is_file() || f.0.is_symlink()
 }
 
 /// Split file.rs:10:2 into [`PathBuf`], row and col.

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -96,6 +96,7 @@ impl Args {
                     };
                 }
                 arg => args.files.push(parse_file(arg)),
+            }
         }
 
         // push the remaining args, if any to the files

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -98,7 +98,7 @@ impl Args {
                 arg => {
                     let file = parse_file(arg);
 
-                    if is_proper_file(&file) {
+                    if is_proper_path(&file) {
                         args.files.push(file)
                     }
                 }
@@ -109,7 +109,7 @@ impl Args {
         for arg in argv {
             let file = parse_file(&arg);
 
-            if is_proper_file(&file) {
+            if is_proper_path(&file) {
                 args.files.push(file);
             }
         }
@@ -135,9 +135,9 @@ pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
         .unwrap_or_else(def)
 }
 
-/// Ensure file is not a pipe or random
-fn is_proper_file(f: &(PathBuf, Position)) -> bool {
-    f.0.is_file() || f.0.is_symlink()
+/// Ensure path is not something like a pipe or /dev/random.
+fn is_proper_path(f: &(PathBuf, Position)) -> bool {
+    f.0.is_file() || f.0.is_symlink() || f.0.is_dir()
 }
 
 /// Split file.rs:10:2 into [`PathBuf`], row and col.

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -95,23 +95,12 @@ impl Args {
                         _ => args.files.push(parse_file(arg)),
                     };
                 }
-                arg => {
-                    let file = parse_file(arg);
-
-                    if is_proper_path(&file) {
-                        args.files.push(file)
-                    }
-                }
-            }
+                arg => args.files.push(parse_file(arg)),
         }
 
         // push the remaining args, if any to the files
         for arg in argv {
-            let file = parse_file(&arg);
-
-            if is_proper_path(&file) {
-                args.files.push(file);
-            }
+            args.files.push(parse_file(&arg));
         }
 
         if let Some(file) = args.files.first_mut() {
@@ -133,11 +122,6 @@ pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
     split_path_row_col(s)
         .or_else(|| split_path_row(s))
         .unwrap_or_else(def)
-}
-
-/// Ensure path is not something like a pipe or /dev/random.
-fn is_proper_path(f: &(PathBuf, Position)) -> bool {
-    f.0.is_file() || f.0.is_symlink() || f.0.is_dir()
 }
 
 /// Split file.rs:10:2 into [`PathBuf`], row and col.

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -69,6 +69,7 @@ use crate::job::{self, Jobs};
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
+    error::Error,
     fmt,
     future::Future,
     io::Read,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -29,7 +29,10 @@ pub use text::Text;
 
 use helix_view::Editor;
 
-use std::path::PathBuf;
+use std::{
+    error::Error,
+    path::PathBuf
+};
 
 pub fn prompt(
     cx: &mut crate::commands::Context,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -29,10 +29,7 @@ pub use text::Text;
 
 use helix_view::Editor;
 
-use std::{
-    error::Error,
-    path::PathBuf
-};
+use std::{error::Error, path::PathBuf};
 
 pub fn prompt(
     cx: &mut crate::commands::Context,

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -50,6 +50,7 @@ toml = "0.8"
 log = "~0.4"
 
 parking_lot = "0.12.2"
+thiserror = "1.0"
 
 
 [target.'cfg(windows)'.dependencies]

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -50,8 +50,7 @@ toml = "0.8"
 log = "~0.4"
 
 parking_lot = "0.12.2"
-thiserror = "1.0"
-
+thiserror.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.3", features = ["std"] }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -706,8 +706,7 @@ impl Document {
 
         // Open the file if it exists, otherwise assume it is a new file (and thus empty).
         let (rope, encoding, has_bom) = if path.exists() {
-            let mut file =
-                std::fs::File::open(path)?;
+            let mut file = std::fs::File::open(path)?;
             from_reader(&mut file, encoding)?
         } else {
             let line_ending: LineEnding = config.load().default_line_ending.into();

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -698,7 +698,7 @@ impl Document {
         config: Arc<dyn DynAccess<Config>>,
     ) -> Result<Self, Error> {
         // if the path is not a regular file (e.g.: /dev/random) it should not be opened
-        if !path.is_file() && !path.is_symlink() {
+        if path.exists() && !path.is_file() && !path.is_symlink() {
             return Err(anyhow::anyhow!(IrregularFileError {
                 msg: format!("Path argument must be a regular file, a directory, or a symlink.")
             }));

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -700,7 +700,7 @@ impl Document {
         // if the path is not a regular file (e.g.: /dev/random) it should not be opened
         if path.exists() && !path.is_file() && !path.is_symlink() {
             return Err(anyhow::anyhow!(IrregularFileError {
-                msg: format!("Path argument must be a regular file, a directory, or a symlink.")
+                msg: "Path argument must be a regular file, a directory, or a symlink.".to_string()
             }));
         }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Error};
+use anyhow::{anyhow, bail, Error};
 use arc_swap::access::DynAccess;
 use arc_swap::ArcSwap;
 use futures_util::future::BoxFuture;
@@ -12,6 +12,7 @@ use helix_core::text_annotations::{InlineAnnotation, Overlay};
 use helix_lsp::util::lsp_pos_to_pos;
 use helix_stdx::faccess::{copy_metadata, readonly};
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
+use thiserror;
 
 use ::parking_lot::Mutex;
 use serde::de::{self, Deserialize, Deserializer};
@@ -21,6 +22,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
@@ -117,15 +119,12 @@ pub struct SavePoint {
     revert: Mutex<Transaction>,
 }
 
-#[derive(Debug)]
-pub struct IrregularFileError {
-    msg: String,
-}
-
-impl Display for IrregularFileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.msg)
-    }
+#[derive(Debug, thiserror::Error)]
+pub enum DocumentOpenError {
+    #[error("path must be a regular file, simlink, or directory")]
+    IrregularFile,
+    #[error(transparent)]
+    IoError(#[from] io::Error),
 }
 
 pub struct Document {
@@ -391,7 +390,7 @@ fn apply_bom(encoding: &'static encoding::Encoding, buf: &mut [u8; BUF_SIZE]) ->
 pub fn from_reader<R: std::io::Read + ?Sized>(
     reader: &mut R,
     encoding: Option<&'static Encoding>,
-) -> Result<(Rope, &'static Encoding, bool), Error> {
+) -> Result<(Rope, &'static Encoding, bool), io::Error> {
     // These two buffers are 8192 bytes in size each and are used as
     // intermediaries during the decoding process. Text read into `buf`
     // from `reader` is decoded into `buf_out` as UTF-8. Once either
@@ -534,7 +533,7 @@ fn read_and_detect_encoding<R: std::io::Read + ?Sized>(
     reader: &mut R,
     encoding: Option<&'static Encoding>,
     buf: &mut [u8],
-) -> Result<(&'static Encoding, bool, encoding::Decoder, usize), Error> {
+) -> Result<(&'static Encoding, bool, encoding::Decoder, usize), io::Error> {
     let read = reader.read(buf)?;
     let is_empty = read == 0;
     let (encoding, has_bom) = encoding
@@ -696,21 +695,19 @@ impl Document {
         encoding: Option<&'static Encoding>,
         config_loader: Option<Arc<ArcSwap<syntax::Loader>>>,
         config: Arc<dyn DynAccess<Config>>,
-    ) -> Result<Self, Error> {
-        // if the path is not a regular file (e.g.: /dev/random) it should not be opened
+    ) -> Result<Self, DocumentOpenError> {
+        // If the path is not a regular file (e.g.: /dev/random) it should not be opened.
         if path
             .metadata()
             .map_or(false, |metadata| !metadata.is_file())
         {
-            return Err(anyhow::anyhow!(IrregularFileError {
-                msg: "Path argument must be a regular file, a directory, or a symlink.".to_string()
-            }));
+            return Err(DocumentOpenError::IrregularFile);
         }
 
         // Open the file if it exists, otherwise assume it is a new file (and thus empty).
         let (rope, encoding, has_bom) = if path.exists() {
             let mut file =
-                std::fs::File::open(path).context(format!("unable to open {:?}", path))?;
+                std::fs::File::open(path)?;
             from_reader(&mut file, encoding)?
         } else {
             let line_ending: LineEnding = config.load().default_line_ending.into();

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -698,7 +698,10 @@ impl Document {
         config: Arc<dyn DynAccess<Config>>,
     ) -> Result<Self, Error> {
         // if the path is not a regular file (e.g.: /dev/random) it should not be opened
-        if path.exists() && !path.is_file() && !path.is_symlink() {
+        if path
+            .metadata()
+            .map_or(false, |metadata| !metadata.is_file())
+        {
             return Err(anyhow::anyhow!(IrregularFileError {
                 msg: "Path argument must be a regular file, a directory, or a symlink.".to_string()
             }));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,6 +1,8 @@
 use crate::{
     align_view,
-    document::{DocumentSavedEventFuture, DocumentSavedEventResult, DocumentOpenError, Mode, SavePoint},
+    document::{
+        DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
+    },
     graphics::{CursorKind, Rect},
     handlers::Handlers,
     info::Info,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,6 +1,6 @@
 use crate::{
     align_view,
-    document::{DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint},
+    document::{DocumentSavedEventFuture, DocumentSavedEventResult, DocumentOpenError, Mode, SavePoint},
     graphics::{CursorKind, Rect},
     handlers::Handlers,
     info::Info,
@@ -1616,7 +1616,7 @@ impl Editor {
     }
 
     // ??? possible use for integration tests
-    pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, Error> {
+    pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
         let id = self.document_by_path(&path).map(|doc| doc.id);
 


### PR DESCRIPTION
As per the suggestions in #10726 this pull request changes the argument parsing to only add a PathBuf to args.files if it is either a file or a symlink. This has been tested on the scenarios provided in the issue and simply opens an empty buffer as if no argument was provided in those cases. (instead of freezing)