### PR TITLE
Synchronize files after writing

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -930,6 +930,7 @@ impl Document {
             let write_result: anyhow::Result<_> = async {
                 let mut dst = tokio::fs::File::create(&write_path).await?;
                 to_writer(&mut dst, encoding_with_bom_info, &text).await?;
+                dst.sync_all().await?;
                 Ok(())
             }
             .await;


### PR DESCRIPTION
fsync(2) is a somewhat expensive operation that flushes writes to the underlying disk/SSD. It's typically used by databases to ensure that writes survive very hard failure scenarios like your cat kicking the plug out of the wall. Synchronizing isn't automatically done by `flush`ing (from the `std::io::Write` or `tokio::io::AsyncWriteExt` traits). From the [`tokio::fs::File`] moduledocs:

> To ensure that a file is closed immediately when it is dropped, you should call `flush` before dropping it. Note that this does not ensure that the file has been fully written to disk; the operating system might keep the changes around in an in-memory buffer. See the `sync_all` method for telling the OS to write the data to disk.

This seems like a likely fix for https://github.com/helix-editor/helix/discussions/7618#discussioncomment-8450481.

[`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html