### PR TITLE
fix: correctly reset inlay hints when stopping or restarting LSPs for a document

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1495,6 +1495,8 @@ fn lsp_stop(
         for doc in cx.editor.documents_mut() {
             if let Some(client) = doc.remove_language_server_by_name(ls_name) {
                 doc.clear_diagnostics(Some(client.id()));
+                doc.reset_all_inlay_hints();
+                doc.inlay_hints_oudated = true;
             }
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1356,6 +1356,7 @@ impl Editor {
         let doc = doc_mut!(self, &doc_id);
         let diagnostics = Editor::doc_diagnostics(&self.language_servers, &self.diagnostics, doc);
         doc.replace_diagnostics(diagnostics, &[], None);
+        doc.reset_all_inlay_hints();
     }
 
     /// Launch a language server for a given document


### PR DESCRIPTION
Stopping or restarting an LSP currently does not cleanup the inlay hints for the documents.

They're correctly recomputed later in the restart case *if the restarted LSP supports them*: changing the binary and restarting can change that behaviour (e.g. after an update, which is reason to call `:lsp-restart` on an open document)