### PR TITLE
Add auto-format for bash now bash language server supports formatting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -956,6 +956,7 @@ shebangs = ["sh", "bash", "dash", "zsh"]
 comment-token = "#"
 language-servers = [ "bash-language-server" ]
 indent = { tab-width = 2, unit = "  " }
+auto-format = true
 
 [[grammar]]
 name = "bash"


### PR DESCRIPTION
Since [Bash Language Server 5.3.0](https://github.com/bash-lsp/bash-language-server/blob/main/server/CHANGELOG.md#530) shfmt formatting is built in providing the user has the `shfmt` binary installed, so now auto-format can be enabled in line with other language servers that support formatting. I checked, and if `shfmt` is not installed then nothing happens when you save with `auto-format = true`.