### PR TITLE
revert: Use terminfo to reset terminal cursor style

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -32,21 +32,10 @@ fn vte_version() -> Option<usize> {
 }
 
 /// Describes terminal capabilities like extended underline, truecolor, etc.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 struct Capabilities {
     /// Support for undercurled, underdashed, etc.
     has_extended_underlines: bool,
-    /// Support for resetting the cursor style back to normal.
-    reset_cursor_command: String,
-}
-
-impl Default for Capabilities {
-    fn default() -> Self {
-        Self {
-            has_extended_underlines: false,
-            reset_cursor_command: "\x1B[0 q".to_string(),
-        }
-    }
 }
 
 impl Capabilities {
@@ -69,10 +58,6 @@ impl Capabilities {
                     || t.extended_cap("Su").is_some()
                     || vte_version() >= Some(5102)
                     || matches!(term_program().as_deref(), Some("WezTerm")),
-                reset_cursor_command: t
-                    .utf8_string_cap(termini::StringCapability::CursorNormal)
-                    .unwrap_or("\x1B[0 q")
-                    .to_string(),
             },
         }
     }
@@ -186,8 +171,7 @@ where
 
     fn restore(&mut self, config: Config) -> io::Result<()> {
         // reset cursor shape
-        self.buffer
-            .write_all(self.capabilities.reset_cursor_command.as_bytes())?;
+        write!(self.buffer, "\x1B[0 q")?;
         if config.enable_mouse_capture {
             execute!(self.buffer, DisableMouseCapture)?;
         }


### PR DESCRIPTION
using a terminfo's cnorm doesn't reset the cursor for many terminals, see issue: #10089