### PR TITLE
Add command to select arbitrary words (similar to goto_label)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -532,6 +532,7 @@ impl MappableCommand {
         command_palette, "Open command palette",
         goto_word, "Jump to a two-character label",
         extend_to_word, "Extend to a two-character label",
+        add_selection_on_word, "Add a selction on a two-character label",
     );
 }
 
@@ -6022,6 +6023,19 @@ fn goto_word(cx: &mut Context) {
     prompt_for_label(cx, ranges, |cx, range| {
         let (view, doc) = current!(cx.editor);
         doc.set_selection(view.id, range.with_direction(Direction::Forward).into());
+    })
+}
+
+fn add_selection_on_word(cx: &mut Context) {
+    let ranges = generate_viewport_token_ranges(cx);
+    prompt_for_label(cx, ranges, |cx, range| {
+        let (view, doc) = current!(cx.editor);
+        let selection: Selection = {
+            let selection = doc.selection(view.id).clone();
+            let direction = selection.primary().direction();
+            selection.push(range.with_direction(direction))
+        };
+        doc.set_selection(view.id, selection);
     })
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -59,6 +59,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" => move_line_down,
             "." => goto_last_modification,
             "w" => goto_word,
+            "W" => add_selection_on_word,
         },
         ":" => command_mode,
 


### PR DESCRIPTION
This PR refactors the `jump_to_label` function to make it reusable for other use cases (now implemented as `prompt_for_label`), and implements a new command (`add_selection_on_word`) that allows you to add a new selection on any word, instead of replacing the current selection. It adds `gW` as a default binding for this.

I'm not happy with the names so bikeshedding is welcome.