### PR TITLE
Large Gruvbox refactoring

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -65,8 +65,6 @@
 "string.symbol" = { fg = "yellow1" }
 
 "tag" = { fg = "aqua1" }
-"tag.attribute" = { fg = "purple" }
-"tag.delimiter" = { fg = "foreground" }
 
 "type" = { fg = "yellow1" }
 "type.enum.variant" = { modifiers = ["italic"] }


### PR DESCRIPTION
Not so long ago I completely switched from Dracula to Gruvbox and I decided to make it more comfortable according to [NVim Gruvbox](https://github.com/ellisonleao/gruvbox.nvim) colors.
---
I changed operator color with some other colors and disabled some bold fonts:
![image](https://github.com/helix-editor/helix/assets/78883260/f29df094-216f-4175-b3e0-cfa6cb1d1b57)

I also improved cursor/cursorline colors and made cursor color the same as the mode color. You can notice that primary cursorline is a bit lighter:
- Normal mode with multicursor:
![image](https://github.com/helix-editor/helix/assets/78883260/4ad3cc57-994c-4c61-a931-e65656820a06)

- Selection mode with multicursor:
![image](https://github.com/helix-editor/helix/assets/78883260/145cb40a-ab6f-4280-bc7e-bdd857b65116)

- Insert mode with multicursor:
![image](https://github.com/helix-editor/helix/assets/78883260/5a92d2b0-3076-427f-86b8-cc685d0f812f)

---

Now, diagnostics:
I decided to choose diagnostics colours according to their severity level:
- Hint - aqua
![image](https://github.com/helix-editor/helix/assets/78883260/31b8b98e-e815-422a-b22a-5eb7cc8b4538)

- Info - yellow
Sorry for no image but I didn't find any examples :)

- Warning - orange and Error - red
![image](https://github.com/helix-editor/helix/assets/78883260/c9d2a04b-0faf-4ba0-ae18-f48ce2af7884)

---

I hope you will like theese changes and I am open to your improvements :)