### PR TITLE
Remove special handling of line ending characters in selection replacement

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1594,12 +1594,11 @@ fn replace(cx: &mut Context) {
         if let Some(ch) = ch {
             let transaction = Transaction::change_by_selection(doc.text(), selection, |range| {
                 if !range.is_empty() {
-                    let text: String =
+                    let text: Tendril =
                         RopeGraphemes::new(doc.text().slice(range.from()..range.to()))
-                            .map(|_| -> Cow<str> { ch.into() })
+                            .map(|_g| ch)
                             .collect();
-
-                    (range.from(), range.to(), Some(text.into()))
+                    (range.from(), range.to(), Some(text))
                 } else {
                     // No change.
                     (range.from(), range.to(), None)

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -26,7 +26,7 @@ use helix_core::{
     history::UndoKind,
     increment, indent,
     indent::IndentStyle,
-    line_ending::{get_line_ending_of_str, line_end_char_index, str_is_line_ending},
+    line_ending::{get_line_ending_of_str, line_end_char_index},
     match_brackets,
     movement::{self, move_vertically_visual, Direction},
     object, pos_at_coords,
@@ -1596,14 +1596,7 @@ fn replace(cx: &mut Context) {
                 if !range.is_empty() {
                     let text: String =
                         RopeGraphemes::new(doc.text().slice(range.from()..range.to()))
-                            .map(|g| {
-                                let cow: Cow<str> = g.into();
-                                if str_is_line_ending(&cow) {
-                                    cow
-                                } else {
-                                    ch.into()
-                                }
-                            })
+                            .map(|_| -> Cow<str> { ch.into() })
                             .collect();
 
                     (range.from(), range.to(), Some(text.into()))

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -724,14 +724,14 @@ fn foo() {
 
     test((
         indoc! {"\
-            #[a|]#
+            #[a
             b
             c
             d
-            e
+            e|]#
             f
             "},
-        "4xs\\n<ret>r,",
+        "s\\n<ret>r,",
         "a#[,|]#b#(,|)#c#(,|)#d#(,|)#e\nf\n",
     ))
     .await?;

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -722,5 +722,19 @@ fn foo() {
     ))
     .await?;
 
+    test((
+        indoc! {"\
+            #[a|]#
+            b
+            c
+            d
+            e
+            f
+            "},
+        "4xs\\n<ret>r,",
+        "a#[,|]#b#(,|)#c#(,|)#d#(,|)#e\nf\n",
+    ))
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
Remove special handling of line ending characters in selection replacement which prevented newline characters from being replaced

Fixes #10725