### PR TITLE
Fix `#match?` predicates in julia queries

### DIFF
--- a/runtime/queries/julia/highlights.scm
+++ b/runtime/queries/julia/highlights.scm
@@ -7,12 +7,12 @@
 ; Remaining identifiers that start with capital letters should be types (PascalCase)
 (
   (identifier) @type
-  (match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ; SCREAMING_SNAKE_CASE
 (
   (identifier) @constant
-  (match? @constant "^[A-Z][A-Z0-9_]*$"))
+  (#match? @constant "^[A-Z][A-Z0-9_]*$"))
 
 (const_statement
   (assignment


### PR DESCRIPTION
This fixes the `#match?` queries lacking a `#` in front in Julia queries.

See https://github.com/helix-editor/helix/pull/10031#issuecomment-2119137712