### PR TITLE
Added goto minor-mode binding for 'goto_line_end_newline'

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -42,6 +42,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "f" => goto_file,
             "h" => goto_line_start,
             "l" => goto_line_end,
+            "ret" => goto_line_end_newline,
             "s" => goto_first_nonwhitespace,
             "d" => goto_definition,
             "D" => goto_declaration,


### PR DESCRIPTION
This pr adds a `g<ret>` binding allowing jumping ahead to the line ending newline.