### PR TITLE
tree-sitter: update Inko grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2721,7 +2721,7 @@ formatter = { command = "inko", args = ["fmt", "-"] }
 
 [[grammar]]
 name = "inko"
-source = { git = "https://github.com/inko-lang/tree-sitter-inko", rev = "6983354c13a14bc621d7a3619f1790149e901187" }
+source = { git = "https://github.com/inko-lang/tree-sitter-inko", rev = "7860637ce1b43f5f79cfb7cc3311bf3234e9479f" }
 
 [[language]]
 name = "bicep"


### PR DESCRIPTION
This includes some parsing fixes (see [here](https://github.com/inko-lang/tree-sitter-inko/compare/6983354c13a14bc621d7a3619f1790149e901187...7860637ce1b43f5f79cfb7cc3311bf3234e9479f)).