### PR TITLE
Add default key binding for file_picker_in_current_buffer_directory

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -221,6 +221,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "space" => { "Space"
             "f" => file_picker,
             "F" => file_picker_in_current_directory,
+            "%" => file_picker_in_current_buffer_directory,
             "b" => buffer_picker,
             "j" => jumplist_picker,
             "s" => symbol_picker,


### PR DESCRIPTION
Opening the file picker relative the current buffer is a useful command without a default binding.

This PR binds it to <space>% by default, where % is a mnemonic to relate the name of the register
holding the current file name. This does not conflict with any other default bindings.

Previously, a default binding for this command was discussed in:

https://github.com/helix-editor/helix/pull/3052

At the bottom, an example of how to bind a key to this feature gained 25 hearts:
https://github.com/helix-editor/helix/issues/3052#issuecomment-1509848268

Clearly it's a feature that users are interested in discovering.

While this does at one more item to the popular "space" menu, opening other files is one of the most
common editor actions.

This binding arguably adds more value than file_picker_in_current_directory, as the current directory is likely to equal the workspace root, and file_picker seems to fallback to
the current directory if there's no LSP root if I understand correctly.

By contrast, the location of the current buffer will vary all over the source tree, it seems
fairly common to work wither files nearby in tree.
