### PR TITLE
docs: improve `last_picker` docs

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -293,7 +293,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                            |
 | `a`     | Apply code action (**LSP**)                                             | `code_action`                              |
 | `h`     | Select symbol references (**LSP**)                                      | `select_references_to_symbol_under_cursor` |
-| `'`     | Open last fuzzy picker                                                  | `last_picker`                              |
+| `'`     | Open last picker, preserving selected entry                             | `last_picker`                              |
 | `w`     | Enter [window mode](#window-mode)                                       | N/A                                        |
 | `c`     | Comment/uncomment selections                                            | `toggle_comments`                          |
 | `C`     | Block comment/uncomment selections                                      | `toggle_block_comments`                    |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -337,7 +337,7 @@ impl MappableCommand {
         workspace_symbol_picker, "Open workspace symbol picker",
         diagnostics_picker, "Open diagnostic picker",
         workspace_diagnostics_picker, "Open workspace diagnostic picker",
-        last_picker, "Open last picker",
+        last_picker, "Open last picker, preserving selected entry",
         insert_at_line_start, "Insert at start of line",
         insert_at_line_end, "Insert at end of line",
         open_below, "Open new line below selection",


### PR DESCRIPTION
- Consistency: Before it was described as "fuzzy" in place but not another.
  All the pickers seem to be fuzzy pickers, so remove that word for consistency.

- Clarity: Document how it's different from other pickers and adds value
  by restoring the selected entry when it opens-- a valuable feature to make
  more discoverable.
