### PR TITLE
base16_default: add styles to newer unthemed features

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -30,6 +30,7 @@
 "ui.help" = { fg = "white", bg = "black" }
 "ui.statusline.insert" = { fg = "black", bg = "green" }
 "ui.statusline.select" = { fg = "black", bg = "blue" }
+"ui.virtual" = { fg = "gray", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "ui.virtual.ruler" = { bg = "black" }
 

--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -28,6 +28,8 @@
 "label" = "magenta"
 "namespace" = "magenta"
 "ui.help" = { fg = "white", bg = "black" }
+"ui.statusline.insert" = { fg = "black", bg = "green" }
+"ui.statusline.select" = { fg = "black", bg = "blue" }
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "ui.virtual.ruler" = { bg = "black" }
 


### PR DESCRIPTION
Currently, virtual text such as LSP inlay is impossible to distinguish from 'real' text by default; the `color-modes` option does nothing. I've added a default gray similar to comments (with italics, if supported to more easily distinguish, but we can probably assume that inlay mostly wont be inside comments). Also added `ui.statusline.insert` to match `diff.plus` and `ui.statusline.select` to match the selection colour, `ui.statusline.normal` is intentionally left unthemed.