### PR TITLE
docs: document shell completion

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -7,6 +7,7 @@
   - [Note to packagers](#note-to-packagers)
 - [Validating the installation](#validating-the-installation)
 - [Configure the desktop shortcut](#configure-the-desktop-shortcut)
+- [Configure shell completion](#configure-shell-completion)
 
 Requirements:
 
@@ -156,3 +157,45 @@ file. For example, to use `kitty`:
 sed -i "s|Exec=hx %F|Exec=kitty hx %F|g" ~/.local/share/applications/Helix.desktop
 sed -i "s|Terminal=true|Terminal=false|g" ~/.local/share/applications/Helix.desktop
 ```
+
+### Configure shell completion
+
+You can configure shell completion for Helix by copying the completion file into your shell's completion directory.
+
+#### Bash
+
+```sh
+cp contrib/completion/hx.bash ~/.local/share/bash-completion/completions/hx
+```
+
+#### Zsh
+
+```sh
+cp contrib/completion/hx.zsh ~/.config/zsh/completions/_hx
+```
+
+Add the following in your `.zshrc` before initializing completions with `compinit`:
+
+```sh
+fpath+=~/.config/zsh/completions
+```
+
+#### Fish
+
+```sh
+cp contrib/completion/hx.fish ~/.config/fish/completions/hx.fish
+```
+
+#### Elvish
+
+```sh
+cp contrib/completion/hx.elv ~/.config/elvish/lib/hx.elv
+```
+
+Add the following in your `rc.elv`:
+
+```sh
+use hx
+```
+
+> 💡 You may need to restart your shell in order for the changes to take effect.


### PR DESCRIPTION
Hello,

This PR adds shell completion section to the docs. 

closes #3605 (As #4165 / #5534 - had already documented the Desktop shortcut section).

- I've tested the commands on Fedora 40 & Ubuntu 24.04 VMs with Helix 24.03 (AppImage).
- Zsh: To avoid adding another hidden directory to user's $HOME, I've tried to match the completion directory location with Fish.
- Elvish: I'm not familiar with this shell. However, I was able to test it out based on the completion file [comments](https://github.com/helix-editor/helix/blob/179673568df2a519fae2537fbc0053a64ecf3d8b/contrib/completion/hx.elv#L1-L3) & [official docs](https://elv.sh/ref/command.html). 

To keep this minimal, I've not included the following to the docs:
- `mkdir -p <completion-dir>`.
- Bash: Installing `bash-completion` package. (It's installed by default at least in the Distros I tested).
- Elvish: Alternate option suggested in the completion file [comments](https://github.com/helix-editor/helix/blob/179673568df2a519fae2537fbc0053a64ecf3d8b/contrib/completion/hx.elv#L1-L3).

Screenshot:
![Helix_docs_document_shell_completion](https://github.com/helix-editor/helix/assets/54745129/bc47253d-b28e-4bfc-b1e0-83a5a7c8951d)


References:
- [rustup book (Enable tab completion for Bash, Fish, Zsh, or PowerShell)](https://rust-lang.github.io/rustup/installation/index.html#enable-tab-completion-for-bash-fish-zsh-or-powershell)
- Bash: [bash-completion (FAQ)](https://github.com/scop/bash-completion?tab=readme-ov-file#faq)
- Zsh: [Docs (Completion System - Initialization)](https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Initialization)
- Fish: [Docs (Where to put completions)](https://fishshell.com/docs/current/completions.html#where-to-put-completions)
- Elvish: [Docs (RC file)](https://elv.sh/ref/command.html#rc-file), [Docs (Module search directories)](https://elv.sh/ref/command.html#module-search-directories), [Docs (User-defined modules)](https://elv.sh/ref/language.html#user-defined-modules)