### PR TITLE
Add command to open recently closed files

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -3,8 +3,8 @@
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o` | Open a file from disk into the current view. |
+| `:open-recent`, `:or` | Open the most recently closed file. |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
-| `:buffer-open-recent`, `:bor` | Open the most recently closed file. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Force close all buffers but the currently focused one. |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -4,6 +4,7 @@
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o` | Open a file from disk into the current view. |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
+| `:buffer-open-recent`, `:bor` | Open the most recently closed file. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Force close all buffers but the currently focused one. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -167,7 +167,7 @@ fn buffer_close_by_ids_impl(
     let closed_docs = docs_to_close
         .iter()
         .filter_map(|(doc_path, doc_id)| {
-            if !modified_ids.contains(&doc_id) {
+            if !modified_ids.contains(doc_id) {
                 Some(doc_path.clone())
             } else {
                 None
@@ -243,7 +243,7 @@ fn buffer_close(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
-fn buffer_open_recent(
+fn open_recent(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
     event: PromptEvent,
@@ -2554,18 +2554,18 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         signature: CommandSignature::all(completers::filename),
     },
     TypableCommand {
+        name: "open-recent",
+        aliases: &["or"],
+        doc: "Open the most recently closed file.",
+        fun: open_recent,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
         name: "buffer-close",
         aliases: &["bc", "bclose"],
         doc: "Close the current buffer.",
         fun: buffer_close,
         signature: CommandSignature::all(completers::buffer),
-    },
-    TypableCommand {
-        name: "buffer-open-recent",
-        aliases: &["bor"],
-        doc: "Open the most recently closed file.",
-        fun: buffer_open_recent,
-        signature: CommandSignature::none(),
     },
     TypableCommand {
         name: "buffer-close!",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2563,7 +2563,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "buffer-open-recent",
         aliases: &["bor"],
-        doc: "Open the most recently closed file",
+        doc: "Open the most recently closed file.",
         fun: buffer_open_recent,
         signature: CommandSignature::none(),
     },

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -103,7 +103,7 @@ async fn test_buffer_close_concurrent() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_buffer_open_recent() -> anyhow::Result<()> {
+async fn test_open_recent() -> anyhow::Result<()> {
     let file1 = tempfile::NamedTempFile::new()?;
     let file2 = tempfile::NamedTempFile::new()?;
     let mut app = helpers::AppBuilder::new()
@@ -149,7 +149,7 @@ async fn test_buffer_open_recent() -> anyhow::Result<()> {
                 }),
             ),
             (
-                Some(":bor<ret>"),
+                Some(":or<ret>"),
                 Some(&|app| {
                     assert!(!app.editor.is_err());
                     assert_eq!(1, app.editor.last_opened_docs.len());
@@ -163,7 +163,7 @@ async fn test_buffer_open_recent() -> anyhow::Result<()> {
                 }),
             ),
             (
-                Some(":bor<ret>"),
+                Some(":or<ret>"),
                 Some(&|app| {
                     assert!(!app.editor.is_err());
                     assert_eq!(0, app.editor.last_opened_docs.len());
@@ -177,7 +177,7 @@ async fn test_buffer_open_recent() -> anyhow::Result<()> {
                 }),
             ),
             (
-                Some(":bor<ret>"),
+                Some(":or<ret>"),
                 Some(&|app| {
                     assert!(app.editor.is_err());
                     assert_eq!(0, app.editor.last_opened_docs.len());

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -946,6 +946,12 @@ pub struct LastOpenedDocs {
     paths: VecDeque<PathBuf>,
 }
 
+impl Default for LastOpenedDocs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LastOpenedDocs {
     pub fn new() -> Self {
         let paths = VecDeque::with_capacity(LAST_OPENED_DOCS_MAX_LEN);
@@ -954,6 +960,10 @@ impl LastOpenedDocs {
 
     pub fn len(&self) -> usize {
         self.paths.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
     }
 
     pub fn pop_back(&mut self) -> Option<PathBuf> {
@@ -2149,7 +2159,7 @@ impl Editor {
             .collect::<Vec<_>>();
 
         self.last_opened_docs.retain(|doc_path| {
-            !closed_docs.contains(doc_path) && !currently_opened_paths.contains(&doc_path)
+            !closed_docs.contains(doc_path) && !currently_opened_paths.contains(doc_path)
         });
         self.last_opened_docs.extend(closed_docs);
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -22,7 +22,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use std::{
     borrow::Cow,
     cell::Cell,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     fs,
     io::{self, stdin},
     num::NonZeroUsize,
@@ -1012,6 +1012,9 @@ pub struct Editor {
     pub handlers: Handlers,
 
     pub mouse_down_range: Option<Range>,
+
+    /// the most recently opened docs that have since been closed, with newly closed docs added to the end
+    pub last_opened_docs: VecDeque<PathBuf>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1129,6 +1132,7 @@ impl Editor {
             cursor_cache: Cell::new(None),
             handlers,
             mouse_down_range: None,
+            last_opened_docs: VecDeque::new(),
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1013,7 +1013,7 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
 
-    /// the most recently opened docs that have since been closed, with newly closed docs added to the end
+    /// The most recently opened docs that have since been closed, with newly closed docs added to the end.
     pub last_opened_docs: VecDeque<PathBuf>,
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1017,6 +1017,8 @@ pub struct Editor {
     pub last_opened_docs: VecDeque<PathBuf>,
 }
 
+pub const LAST_OPENED_DOCS_MAX_LEN: i8 = 100;
+
 pub type Motion = Box<dyn Fn(&mut Editor)>;
 
 #[derive(Debug)]

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -19,7 +19,6 @@ use helix_core::{
 use std::{
     collections::{HashMap, VecDeque},
     fmt,
-    path::{Path, PathBuf},
 };
 
 const JUMP_LIST_CAPACITY: usize = 30;
@@ -122,8 +121,6 @@ pub struct View {
     // uses two docs because we want to be able to swap between the
     // two last modified docs which we need to manually keep track of
     pub last_modified_docs: [Option<DocumentId>; 2],
-    /// the most recently opened docs that have since been closed, with newly closed docs added to the end
-    pub last_opened_docs: Vec<PathBuf>,
     /// used to store previous selections of tree-sitter objects
     pub object_selections: Vec<Selection>,
     /// all gutter-related configuration settings, used primarily for gutter rendering
@@ -159,7 +156,6 @@ impl View {
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
             docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
-            last_opened_docs: Vec::new(),
             object_selections: Vec::new(),
             gutters,
             doc_revisions: HashMap::new(),

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -19,6 +19,7 @@ use helix_core::{
 use std::{
     collections::{HashMap, VecDeque},
     fmt,
+    path::{Path, PathBuf},
 };
 
 const JUMP_LIST_CAPACITY: usize = 30;
@@ -121,6 +122,8 @@ pub struct View {
     // uses two docs because we want to be able to swap between the
     // two last modified docs which we need to manually keep track of
     pub last_modified_docs: [Option<DocumentId>; 2],
+    /// the most recently opened docs that have since been closed, with newly closed docs added to the end
+    pub last_opened_docs: Vec<PathBuf>,
     /// used to store previous selections of tree-sitter objects
     pub object_selections: Vec<Selection>,
     /// all gutter-related configuration settings, used primarily for gutter rendering
@@ -156,6 +159,7 @@ impl View {
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
             docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
+            last_opened_docs: Vec::new(),
             object_selections: Vec::new(),
             gutters,
             doc_revisions: HashMap::new(),


### PR DESCRIPTION
This PR adds a command `open-recent` (with alias `or`) to open the most recently closed file. A maximum of 100 files are maintained in the `last_opened_docs` state to minimise memory usage.

https://github.com/helix-editor/helix/assets/54135831/111af104-31d9-4141-8669-094bd4021c78