### PR TITLE
Add a way to only show the horizontal or vertical position in statusline

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -157,6 +157,8 @@ where
             render_primary_selection_length
         }
         helix_view::editor::StatusLineElement::Position => render_position,
+        helix_view::editor::StatusLineElement::Row => render_row,
+        helix_view::editor::StatusLineElement::Col => render_col,
         helix_view::editor::StatusLineElement::PositionPercentage => render_position_percentage,
         helix_view::editor::StatusLineElement::TotalLineNumbers => render_total_line_numbers,
         helix_view::editor::StatusLineElement::Separator => render_separator,
@@ -344,6 +346,30 @@ where
     write(
         context,
         format!(" {}:{} ", position.row + 1, position.col + 1),
+        None,
+    );
+}
+
+fn render_row<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let position = get_position(context);
+    write(
+        context,
+        format!(" {} ", position.row + 1),
+        None,
+    );
+}
+
+fn render_col<F>(context: &mut RenderContext, write: F)
+where
+    F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
+{
+    let position = get_position(context);
+    write(
+        context,
+        format!(" {} ", position.col + 1),
         None,
     );
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -551,6 +551,12 @@ pub enum StatusLineElement {
     /// The cursor position
     Position,
 
+    /// The row that the cursor is at
+    Row,
+    
+    /// The column that the cursor is at
+    Col,
+
     /// The separator string
     Separator,
 


### PR DESCRIPTION
Fixes #10282 by adding col and row components to the status line.