### PR TITLE
Fix logic to update version when HEAD changes.

### DIFF
--- a/helix-loader/build.rs
+++ b/helix-loader/build.rs
@@ -50,6 +50,7 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
+        .map(|x| x.trim().to_string())
     else {
         return;
     };
@@ -67,6 +68,7 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
+        .map(|x| x.trim().to_string())
     else {
         return;
     };


### PR DESCRIPTION
Fixes #10855.

The loader build.rs tries to determine when HEAD changes,
so it can re-run and update the embedded version.

It was shelling out to do this, and capturing a trailing newline,
so it always thought HEAD did not exist.

I confirmed that if I update helix-term, helix-loader rebuilds and updates the commit hash:

```
[rcorre@midgar helix]$ git rev-parse --short HEAD
e24eed2c
[rcorre@midgar helix]$ hx --version
helix 24.3 (e24eed2c)
[rcorre@midgar helix]$ hx helix-term/src/main.rs
[rcorre@midgar helix]$ git cma "test changing helix-term"
[fix-version cbb68bab] test changing helix-term
 1 file changed, 1 insertion(+)
[rcorre@midgar helix]$ cargo install --path helix-term --locked
  Installing helix-term v24.3.0 (/home/rcorre/src/helix/helix-term)
    Updating crates.io index
   Compiling helix-loader v24.3.0 (/home/rcorre/src/helix/helix-loader)
   Compiling helix-term v24.3.0 (/home/rcorre/src/helix/helix-term)
   ... snip ...
[rcorre@midgar helix]$ git rev-parse --short HEAD
cbb68bab
[rcorre@midgar helix]$ hx --version
helix 24.3 (cbb68bab)
```
