### PR TITLE
inlay hints at end of line

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1778,20 +1778,22 @@ impl Document {
         use helix_core::diagnostic::{Range, Severity::*};
 
         // TODO: convert inside server
-        let start =
-            if let Some(start) = lsp_pos_to_pos(text, diagnostic.range.start, offset_encoding) {
-                start
-            } else {
-                log::warn!("lsp position out of bounds - {:?}", diagnostic);
-                return None;
-            };
-
-        let end = if let Some(end) = lsp_pos_to_pos(text, diagnostic.range.end, offset_encoding) {
-            end
+        let start = if let Some(start) =
+            lsp_pos_to_pos(text, diagnostic.range.start, offset_encoding, false)
+        {
+            start
         } else {
             log::warn!("lsp position out of bounds - {:?}", diagnostic);
             return None;
         };
+
+        let end =
+            if let Some(end) = lsp_pos_to_pos(text, diagnostic.range.end, offset_encoding, false) {
+                end
+            } else {
+                log::warn!("lsp position out of bounds - {:?}", diagnostic);
+                return None;
+            };
 
         let severity = diagnostic.severity.map(|severity| match severity {
             lsp::DiagnosticSeverity::ERROR => Error,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -420,6 +420,12 @@ pub struct LspConfig {
     pub display_signature_help_docs: bool,
     /// Display inlay hints
     pub display_inlay_hints: bool,
+    /// force inlay type hints to end of line
+    pub force_type_hints_eol: bool,
+    /// force parameter hints to end of line
+    pub force_parameter_hints_eol: bool,
+    /// force other hints to end of line
+    pub force_other_hints_eol: bool,
     /// Whether to enable snippet support
     pub snippets: bool,
     /// Whether to include declaration in the goto reference query
@@ -436,6 +442,9 @@ impl Default for LspConfig {
             display_inlay_hints: false,
             snippets: true,
             goto_reference_include_declaration: true,
+            force_type_hints_eol: false,
+            force_parameter_hints_eol: false,
+            force_other_hints_eol: false,
         }
     }
 }


### PR DESCRIPTION
Adds config options to force hints to the end of the line
 - `force-type-hints-eol`
 - `force-parameter-hints-eol`
 - `force-other-hints-eol`
all false by default

this doesnt include tests or documentation at the moment
this doesnt check if hints overlap, in which case helix only shows one

works best if the lsp provides hint types, if it doesnt the hint falls under the other category