### PR TITLE
added support for vim goto paragraph keybindings

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -26,6 +26,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "home" => goto_line_start,
         "end" => goto_line_end,
 
+        "{" => goto_prev_paragraph,
+        "}" => goto_next_paragraph,
+
         "w" => move_next_word_start,
         "b" => move_prev_word_start,
         "e" => move_next_word_end,


### PR DESCRIPTION
Added vim default keybindings (e.g. '{}') for navigating paragraphs.

The reasons for doing so are A) it doesn't interfere with any existing keybindings or functionality B) it improves quality of life and navigation speed C) it's a feature which vim/nvim users are used to D) there is currently no way for users to configure this option themselves. The convention of S-[/S-] was tried, but found this was less intuitive and more error prone.

While I work to improve the customization for remapping brackets and braces, I think users (especially those coming from vim/nvim) will appreciate the addition of this useful, familiar, and sensible default.