### PR TITLE
Use latexindent as a latex formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1036,6 +1036,8 @@ file-types = ["tex", "sty", "cls", "Rd", "bbx", "cbx"]
 comment-token = "%"
 language-servers = [ "texlab" ]
 indent = { tab-width = 4, unit = "\t" }
+formatter = { command = "latexindent", args = [ "-m" ] }
+auto-format = true
 
 [[grammar]]
 name = "latex"

--- a/languages.toml
+++ b/languages.toml
@@ -1037,7 +1037,6 @@ comment-token = "%"
 language-servers = [ "texlab" ]
 indent = { tab-width = 4, unit = "\t" }
 formatter = { command = "latexindent", args = [ "-m" ] }
-auto-format = true
 
 [[grammar]]
 name = "latex"


### PR DESCRIPTION
This change adds `latexindent` script as a $\LaTeX$ formatter.

One thing to take into notice is that `latexindent` sometimes is not present in `$PATH` and can have Perl's `.pl` extension.
This can be easly fixed with a symlink though.