### PR TITLE
Improve readability of virtual text with 'noctis' theme

### DIFF
--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -45,10 +45,13 @@
 'ui.linenr' = {  fg = "gray"  } # Line numbers.
 'ui.linenr.selected' = { fg = "light-green", modifiers = [ "bold" ] } # Current line number.
 
-'ui.virtual' = { fg = "mid-green" } # Namespace for additions to the editing area.
+'ui.virtual' = { fg = "autocomp-green" } # Namespace for additions to the editing area.
 'ui.virtual.ruler' = { bg = "mid-green" } # Vertical rulers (colored columns in editing area).
-'ui.virtual.whitespace' = { fg = "light-gray"} # Whitespace markers in editing area.
-'ui.virtual.indent-guide' = { fg = "light-gray" } # Indentation guides.
+'ui.virtual.whitespace' = { fg = "mid-green"} # Whitespace markers in editing area.
+'ui.virtual.inlay-hint' = { fg = "autocomp-green" } # LSP inlay hints
+'ui.virtual.indent-guide' = { fg = "mid-green" } # Indentation guides.
+'ui.virtual.wrap' = { fg = "mid-green"} # Soft-wrap indicators
+'ui.virtual.jump-label' = { fg = "autocomp-green", modifiers = [ "bold" ] } # Word-jump labels
 
 'ui.statusline' = { fg = "light-green", bg = "autocomp-green"} # Status line.
 'ui.statusline.inactive' = { fg = "white", bg = "mid-green"} # Status line in unfocused windows.


### PR DESCRIPTION
This affects both `goto_word` and LSP inlay hints.
Before:
https://webaim.org/resources/contrastchecker/?fcolor=073A40&bcolor=00262A
After:
https://webaim.org/resources/contrastchecker/?fcolor=0D6772&bcolor=00262A

I just chose a similar colour from the pallet defined by noctis; Notably, the new colours still don't pass the accessibility contrast threshold for WCAG 2.0 level AA. This might be something to consider, but perhaps is acceptable as these elements are meant to not stick out.