### PR TITLE
fix(editor): prevent overflow in count modifier

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -938,7 +938,11 @@ impl EditorView {
             // If the count is already started and the input is a number, always continue the count.
             (key!(i @ '0'..='9'), Some(count)) => {
                 let i = i.to_digit(10).unwrap() as usize;
-                cxt.editor.count = NonZeroUsize::new(count.get() * 10 + i);
+                let count = count.get() * 10 + i;
+                if count > 100_000_000 {
+                    return;
+                }
+                cxt.editor.count = NonZeroUsize::new(count);
             }
             // A non-zero digit will start the count if that number isn't used by a keymap.
             (key!(i @ '1'..='9'), None) if !self.keymaps.contains_key(mode, event) => {


### PR DESCRIPTION
Current behavior allowed a user to input a more than reasonable value for count, where it could grow till the full value was larger than the allotted render width, and could eventually overflow.

This pull request takes guidance from this [comment](https://github.com/helix-editor/helix/issues/10922#issuecomment-2160779267) by @the-mikedavis and caps the value to be below 100,000,000. This would leave the full value viewable and prevent any overflow.

There were other options, such as converting to a string first to check the length, and then dropping the digit that would grow past the allotted render width, keeping a rolling in-render value, but this would add an allocation each time even when not going beyond the selected size.

Ultimately, it was decided that this would be a low percentage issue, and thus not worth an allocation or complexity something like that would add.

To note, the render width is 15 characters wide. 100,000,000 was chosen from guidance, but 999,999,999,999,999 would be the highest value within the 15 character size constraint.

Current:
![master_overflow_behavior](https://github.com/helix-editor/helix/assets/12489689/2d068751-b25e-4dc1-bb1a-efcffb3b0292)

PR:
![helix_term_prevent_overflow](https://github.com/helix-editor/helix/assets/12489689/c8c13047-2a30-4a46-8025-821cdcc2bb92)

Fixes: #10922
