### PR TITLE
Implement splitting vertically with syncing

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1117,6 +1117,7 @@ pub enum Action {
     Replace,
     HorizontalSplit,
     VerticalSplit,
+    VerticalSplitSync,
 }
 
 impl Action {
@@ -1591,6 +1592,7 @@ impl Editor {
                         }
                     }
                 }
+                self.tree.remove_sync_view(view_id);
 
                 self.replace_document_in_view(view_id, id);
 
@@ -1623,6 +1625,20 @@ impl Editor {
                 let doc = doc_mut!(self, &id);
                 doc.ensure_view_init(view_id);
                 doc.mark_as_focused();
+            }
+            Action::VerticalSplitSync => {
+                // copy the current view, unless there is no view yet
+                let view = self
+                    .tree
+                    .try_get(self.tree.focus)
+                    .filter(|v| id == v.doc) // Different Document
+                    .cloned()
+                    .unwrap_or_else(|| View::new(id, self.config().gutters.clone()));
+                let view_id = self.tree.split_extend(view);
+                // initialize selection for view
+                let doc = doc_mut!(self, &id);
+                doc.ensure_view_init(view_id);
+                //doc.mark_as_focused();
             }
         }
 


### PR DESCRIPTION
Here is a rewritten version of the text:

Implementing Sync VSplit Views (#7031)
Overview

The current implementation of the split view works as follows:

When a scroll event occurs, the editor's tree calls a function that synchronizes the views by scrolling the other panes to match the current view. This ensures that the left and right panes remain in sync, with the right view being a page down from the left view.
Limitations and Future Directions

Currently, I have limited the number of synced views to 2 per document, as unfocused views react to the focused views' scrolling actions. This is a simple implementation to get started with.

At this stage, the command cannot be used with different documents, but it could be changed in the future to support side-by-side scrolling of different files.

I have two questions regarding this implementation:

    From a usability perspective, should I synchronize scrolling on searches?
    How can I best initialize the new view to be a page down, as it will only start synchronizing on the first user scroll, which I find jarring?

I also noticed that I left some logging code inside, which I need to remove.

Any other feedback would be appreciated.
I especially would love to know a better way to write swap_sync_views implementation is entirely decided by what the borrow checker wants.

