### PR TITLE
improve jump colors for github_dark themes

### DIFF
--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -61,6 +61,7 @@ label = "scale.red.3"
 "ui.text.inactive" = "fg.subtle"
 "ui.virtual" = { fg = "scale.gray.6" }
 "ui.virtual.ruler" = { bg = "canvas.subtle" }
+"ui.virtual.jump-label" = { fg = "scale.red.2", modifiers = ["bold"] }
 
 "ui.selection" = { bg = "scale.blue.8" }
 "ui.selection.primary" = { bg = "scale.blue.7" }


### PR DESCRIPTION
The colors while using the newly introduced jump feature have been bugging me, especially in the github_dark family of themes.

# Before
(I can hardly see this, especially the jump characters on selection)
<img width="543" alt="image" src="https://github.com/helix-editor/helix/assets/2946728/a6e5bd69-d748-4340-9347-e9f5c257de31">

# After

<img width="632" alt="image" src="https://github.com/helix-editor/helix/assets/2946728/37a83423-cd7e-4ed9-a46d-2e575209dab2">
