### PR TITLE
refactor(commands): trim end of `pipe`-like output

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5760,6 +5760,7 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
             let fragment = range.slice(text);
             match shell_impl(shell, cmd, pipe.then(|| fragment.into())) {
                 Ok(result) => {
+                    let result = Tendril::from(result.trim_end());
                     if !pipe {
                         shell_output = Some(result.clone());
                     }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -209,13 +209,10 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             "},
         "|echo foo<ret>",
         indoc! {"\
-            #[|foo\n]#
-            
-            #(|foo\n)#
-            
-            #(|foo\n)#
-            
-            "},
+            #[|foo]#
+            #(|foo)#
+            #(|foo)#"
+        },
     ))
     .await?;
 
@@ -228,12 +225,9 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             "},
         "!echo foo<ret>",
         indoc! {"\
-            #[|foo\n]#
-            lorem
-            #(|foo\n)#
-            ipsum
-            #(|foo\n)#
-            dolor
+            #[|foo]#lorem
+            #(|foo)#ipsum
+            #(|foo)#dolor
             "},
     ))
     .await?;
@@ -247,12 +241,9 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             "},
         "<A-!>echo foo<ret>",
         indoc! {"\
-            lorem#[|foo\n]#
-            
-            ipsum#(|foo\n)#
-            
-            dolor#(|foo\n)#
-            
+            lorem#[|foo]#
+            ipsum#(|foo)#
+            dolor#(|foo)#
             "},
     ))
     .await?;


### PR DESCRIPTION
Current `pipe`-like commands, `pipe`, `insert-output`, and `append-output`, return directly what `stdout` had, which usually includes a newline. This can limit its efficiency in the editor as when someone would want to run the same command on many selections, the additional whitespace can become cumbersome to manually trim.

This PR trims all whitespace from the end of the output. This was mainly chosen do to the simplicity of the change, but even when testing an iteration where only a single newline was removed, it felt more inline with expectations and so was chosen for the final change.

 `pipe:exa`

```diff
base16_theme.toml
book
Cargo.lock
Cargo.toml
CHANGELOG.md
contrib
default.nix
docs
Files
flake.lock
flake.nix
grammars.nix
helix-core
helix-dap
helix-event
helix-loader
helix-lsp
helix-parsec
helix-stdx
helix-term
helix-tui
helix-vcs
helix-view
languages.toml
LICENSE
logo.svg
logo_dark.svg
logo_light.svg
README.md
runtime
rust-toolchain.toml
rustfmt.toml
screenshot.png
shell.nix
target
theme.toml
xtask
-       
```
Closes: https://github.com/helix-editor/helix/issues/10912