### PR TITLE
Fix multiple broken links in the documentation

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -25,7 +25,7 @@
 
 > 💡 Mappings marked (**TS**) require a tree-sitter grammar for the file type.
 
-> ⚠️ Some terminals' default key mappings conflict with Helix's. If any of the mappings described on this page do not work as expected, check your terminal's mappings to ensure they do not conflict. See the (wiki)[https://github.com/helix-editor/helix/wiki/Terminal-Support] for known conflicts.
+> ⚠️ Some terminals' default key mappings conflict with Helix's. If any of the mappings described on this page do not work as expected, check your terminal's mappings to ensure they do not conflict. See the [wiki](https://github.com/helix-editor/helix/wiki/Terminal-Support) for known conflicts.
 
 ## Normal mode
 
@@ -233,8 +233,7 @@ Jumps to various locations.
 
 Accessed by typing `m` in [normal mode](#normal-mode).
 
-See the relevant section in [Usage](./usage.md) for an explanation about
-[surround](./usage.md#surround) and [textobject](./usage.md#navigating-using-tree-sitter-textobjects) usage.
+Please refer to the relevant sections for detailed explanations about [surround](./surround.md) and [textobject](./textobjects.md).
 
 | Key              | Description                                     | Command                    |
 | -----            | -----------                                     | -------                    |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -233,7 +233,7 @@ Jumps to various locations.
 
 Accessed by typing `m` in [normal mode](#normal-mode).
 
-Please refer to the relevant sections for detailed explanations about [surround](./surround.md) and [textobject](./textobjects.md).
+Please refer to the relevant sections for detailed explanations about [surround](./surround.md) and [textobjects](./textobjects.md).
 
 | Key              | Description                                     | Command                    |
 | -----            | -----------                                     | -------                    |

--- a/book/src/syntax-aware-motions.md
+++ b/book/src/syntax-aware-motions.md
@@ -64,5 +64,3 @@ element. As a result, using `Alt-p` with a selection on `arg1` will move the
 selection to the "func" `identifier`.
 
 [lang-support]: ./lang-support.md
-[unimpaired-keybinds]: ./keymap.md#unimpaired
-[tree-sitter-nav-demo]: https://user-images.githubusercontent.com/23398472/152332550-7dfff043-36a2-4aec-b8f2-77c13eb56d6f.gif

--- a/book/src/textobjects.md
+++ b/book/src/textobjects.md
@@ -27,7 +27,7 @@ function or block of code.
 
 > 💡 `f`, `t`, etc. need a tree-sitter grammar active for the current
 document and a special tree-sitter query file to work properly. [Only
-some grammars][lang-support] currently have the query file implemented.
+some grammars](./lang-support.md) currently have the query file implemented.
 Contributions are welcome!
 
 ## Navigating using tree-sitter textobjects
@@ -37,9 +37,9 @@ possible using tree-sitter and textobject queries. For
 example to move to the next function use `]f`, to move to previous
 type use `[t`, and so on.
 
-![Tree-sitter-nav-demo][tree-sitter-nav-demo]
+![Tree-sitter-nav-demo](https://user-images.githubusercontent.com/23398472/152332550-7dfff043-36a2-4aec-b8f2-77c13eb56d6f.gif)
 
-For the full reference see the [unimpaired][unimpaired-keybinds] section of the key bind
+For the full reference see the [unimpaired](./keymap.html#unimpaired) section of the key bind
 documentation.
 
 > 💡 This feature relies on tree-sitter textobjects


### PR DESCRIPTION
This fixes some links that were somehow not caught by the linter in https://github.com/helix-editor/helix/pull/10619.

I added this one as well to keep them all together: https://github.com/helix-editor/helix/pull/10921, so you can close that if you like.

