### PR TITLE
Sync latest Catppuccin themes changes

### DIFF
--- a/runtime/themes/catppuccin_frappe.toml
+++ b/runtime/themes/catppuccin_frappe.toml
@@ -1,7 +1,6 @@
 inherits = "catppuccin_mocha"
 
 [palette]
-# catppuccin palette colors
 rosewater = "#f2d5cf"
 flamingo = "#eebebe"
 pink = "#f4b8e4"
@@ -16,7 +15,6 @@ sky = "#99d1db"
 sapphire = "#85c1dc"
 blue = "#8caaee"
 lavender = "#babbf1"
-
 text = "#c6d0f5"
 subtext1 = "#b5bfe2"
 subtext0 = "#a5adce"
@@ -26,13 +24,11 @@ overlay0 = "#737994"
 surface2 = "#626880"
 surface1 = "#51576d"
 surface0 = "#414559"
-
 base = "#303446"
 mantle = "#292c3c"
 crust = "#232634"
 
-# derived colors by blending existing palette colors
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
-secondary_cursor_normal = "#9193be"
+secondary_cursor_normal = "#9192be"
 secondary_cursor_insert = "#83a275"

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -1,7 +1,6 @@
 inherits = "catppuccin_mocha"
 
 [palette]
-# catppuccin palette colors
 rosewater = "#dc8a78"
 flamingo = "#dd7878"
 pink = "#ea76cb"
@@ -16,7 +15,6 @@ sky = "#04a5e5"
 sapphire = "#209fb5"
 blue = "#1e66f5"
 lavender = "#7287fd"
-
 text = "#4c4f69"
 subtext1 = "#5c5f77"
 subtext0 = "#6c6f85"
@@ -26,13 +24,11 @@ overlay0 = "#9ca0b0"
 surface2 = "#acb0be"
 surface1 = "#bcc0cc"
 surface0 = "#ccd0da"
-
 base = "#eff1f5"
 mantle = "#e6e9ef"
 crust = "#dce0e8"
 
-# derived colors by blending existing palette colors
-cursorline = "#e9ebf1"
-secondary_cursor = "#e2a99e"
-secondary_cursor_normal = "#98a7fb"
-secondary_cursor_insert = "#75b868"
+cursorline = "#e8ecf1"
+secondary_cursor = "#e1a99d"
+secondary_cursor_normal = "#97a7fb"
+secondary_cursor_insert = "#74b867"

--- a/runtime/themes/catppuccin_macchiato.toml
+++ b/runtime/themes/catppuccin_macchiato.toml
@@ -1,7 +1,6 @@
 inherits = "catppuccin_mocha"
 
 [palette]
-# catppuccin palette colors
 rosewater = "#f4dbd6"
 flamingo = "#f0c6c6"
 pink = "#f5bde6"
@@ -16,7 +15,6 @@ sky = "#91d7e3"
 sapphire = "#7dc4e4"
 blue = "#8aadf4"
 lavender = "#b7bdf8"
-
 text = "#cad3f5"
 subtext1 = "#b8c0e0"
 subtext0 = "#a5adcb"
@@ -26,13 +24,11 @@ overlay0 = "#6e738d"
 surface2 = "#5b6078"
 surface1 = "#494d64"
 surface0 = "#363a4f"
-
 base = "#24273a"
 mantle = "#1e2030"
 crust = "#181926"
 
-# derived colors by blending existing palette colors
 cursorline = "#303347"
-secondary_cursor = "#b6a5a7"
-secondary_cursor_normal = "#8b90bf"
-secondary_cursor_insert = "#7fa47a"
+secondary_cursor = "#b6a6a7"
+secondary_cursor_normal = "#8b91bf"
+secondary_cursor_insert = "#80a57a"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -1,19 +1,22 @@
 # Syntax highlighting
 # -------------------
+"attribute" = "yellow"
+
 "type" = "yellow"
+"type.enum.variant" = "teal"
 
 "constructor" = "sapphire"
 
 "constant" = "peach"
-"constant.builtin" = "peach"
 "constant.character" = "teal"
 "constant.character.escape" = "pink"
 
 "string" = "green"
-"string.regexp" = "peach"
+"string.regexp" = "pink"
 "string.special" = "blue"
+"string.special.symbol" = "red"
 
-"comment" = { fg = "overlay1", modifiers = ["italic"] }
+"comment" = { fg = "overlay2", modifiers = ["italic"] }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
@@ -26,7 +29,6 @@
 "punctuation.special" = "sky"
 
 "keyword" = "mauve"
-"keyword.storage.modifier.ref" = "teal"
 "keyword.control.conditional" = { fg = "mauve", modifiers = ["italic"] }
 
 "operator" = "sky"
@@ -34,10 +36,9 @@
 "function" = "blue"
 "function.macro" = "mauve"
 
-"tag" = "mauve"
-"attribute" = "blue"
+"tag" = "blue"
 
-"namespace" = { fg = "blue", modifiers = ["italic"] }
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
 
 "special" = "blue" # fuzzy highlight
 
@@ -51,8 +52,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "rosewater", modifiers = ["underlined"] }
+"markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 
@@ -70,8 +70,8 @@
 "ui.statusline" = { fg = "subtext1", bg = "mantle" }
 "ui.statusline.inactive" = { fg = "surface2", bg = "mantle" }
 "ui.statusline.normal" = { fg = "base", bg = "lavender", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "base", bg = "green", modifiers = ["bold"] }
-"ui.statusline.select" = { fg = "base", bg = "flamingo", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "base", bg = "green", modifiers = ["bold"]  }
+"ui.statusline.select" = { fg = "base", bg = "flamingo", modifiers = ["bold"]  }
 
 "ui.popup" = { fg = "text", bg = "surface0" }
 "ui.window" = { fg = "crust" }
@@ -88,7 +88,7 @@
 "ui.virtual" = "overlay0"
 "ui.virtual.ruler" = { bg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
-"ui.virtual.inlay-hint" = { fg = "overlay0", bg = "base" }
+"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
 "ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }
 
 "ui.selection" = { bg = "surface1" }
@@ -116,8 +116,6 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
-"diagnostic.unnecessary" = { modifiers = ["dim"] }
-"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "red"
 warning = "yellow"
@@ -125,7 +123,6 @@ info = "sky"
 hint = "teal"
 
 [palette]
-# catppuccin palette colors
 rosewater = "#f5e0dc"
 flamingo = "#f2cdcd"
 pink = "#f5c2e7"
@@ -140,7 +137,6 @@ sky = "#89dceb"
 sapphire = "#74c7ec"
 blue = "#89b4fa"
 lavender = "#b4befe"
-
 text = "#cdd6f4"
 subtext1 = "#bac2de"
 subtext0 = "#a6adc8"
@@ -150,13 +146,11 @@ overlay0 = "#6c7086"
 surface2 = "#585b70"
 surface1 = "#45475a"
 surface0 = "#313244"
-
 base = "#1e1e2e"
 mantle = "#181825"
 crust = "#11111b"
 
-# derived colors by blending existing palette colors
 cursorline = "#2a2b3c"
 secondary_cursor = "#b5a6a8"
 secondary_cursor_normal = "#878ec0"
-secondary_cursor_insert = "#7da87e"
+secondary_cursor_insert = "#7ea87f"


### PR DESCRIPTION
Closes #10903. Updates the vendored Catppuccin themes with changes from https://github.com/catppuccin/helix.