### PR TITLE
Add block comment tokens for typst

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3162,6 +3162,7 @@ scope = "source.typst"
 injection-regex = "typ(st)?"
 file-types = ["typst", "typ"]
 comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = ["tinymist", "typst-lsp"]
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
As the title suggests, tested it locally and it works as expected.