### PR TITLE
helix-tui: Skip line-endings in `Buffer::set_string`

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -1,5 +1,5 @@
 use crate::text::{Span, Spans};
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::{line_ending::str_is_line_ending, unicode::width::UnicodeWidthStr};
 use std::cmp::min;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -410,7 +410,7 @@ impl Buffer {
 
         for s in string.graphemes(true) {
             let width = s.width();
-            if width == 0 {
+            if width == 0 || str_is_line_ending(s) {
                 continue;
             }
             // `x_offset + width > max_offset` could be integer overflow on 32-bit machines if we


### PR DESCRIPTION
The update of unicode-width to 0.1.13 changes the width of line endings to 1 (from 0), so we need to detect line-endings when skipping graphemes in `Buffer::set_string_truncated_at_end`.

Connects #10950