### PR TITLE
Downgrade unicode-width to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "url"


### PR DESCRIPTION
unicode-width 0.1.13 contains some fixes that change the widths of line endings, which breaks some assumptions in helix-tui, causing some rendering artifacts. We can downgrade to remove the rendering errors for now.

Fixes https://github.com/helix-editor/helix/issues/10950