### PR TITLE
Add ruler at 101 and text-width at 100 to lean in languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1078,6 +1078,8 @@ comment-token = "--"
 block-comment-tokens = { start = "/-", end = "-/" }
 language-servers = [ "lean" ]
 indent = { tab-width = 2, unit = "  " }
+rulers = [101]
+text-width = 100
 
 [language.auto-pairs]
 '(' = ')'


### PR DESCRIPTION
(Sorry for making another PR with a really small configuration change)

Reference: https://leanprover-community.github.io/contribute/style.html

> Line length
> Lines should not be longer than 100 characters. This makes files easier to read, especially on a small screen or in a small window. If you are editing with VS Code, there is a visual marker which will indicate a 100 character limit.

I think it would be helpful to also have this in helix so I added a ruler at 101 and text-width at 100.

Tell me if anything needs to be changed, thanks!