### PR TITLE
Add curly single and double quotes to BRACKETS

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -9,11 +9,13 @@ use crate::Syntax;
 const MAX_PLAINTEXT_SCAN: usize = 10000;
 const MATCH_LIMIT: usize = 16;
 
-pub const BRACKETS: [(char, char); 7] = [
+pub const BRACKETS: [(char, char); 9] = [
     ('(', ')'),
     ('{', '}'),
     ('[', ']'),
     ('<', '>'),
+    ('‘', '’'),
+    ('“', '”'),
     ('«', '»'),
     ('「', '」'),
     ('（', '）'),


### PR DESCRIPTION
Closes #10966.

The change works fine on my computer. I'm not sure what, if anything, else I should be checking.

Thanks to @the-mikedavis for pointing out where to make this change.