### PR TITLE
Update tree-sitter-rust

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -276,7 +276,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "473634230435c18033384bebaa6d6a17c2523281" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "9c84af007b0f144954adb26b3f336495cbb320a7" }
 
 [[language]]
 name = "sway"


### PR DESCRIPTION
This closes #10904 as newer `tree-sitter-rust` versions support the shebang syntax. Except in the last release [there is a bug](https://github.com/tree-sitter/tree-sitter-rust/pull/223) that doesn't allow spaces in the shebang line (which is important), so I used the latest commit from master, which has this fixed. Considering this commit differs from a release only by this very small bugfix, I think it is okay to use.