### PR TITLE
tree-sitter: Update parent links on reused injection layers

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1363,13 +1363,14 @@ impl Syntax {
                 let depth = layer.depth + 1;
                 // TODO: can't inline this since matches borrows self.layers
                 for (config, ranges) in injections {
+                    let parent = Some(layer_id);
                     let new_layer = LanguageLayer {
                         tree: None,
                         config,
                         depth,
                         ranges,
                         flags: LayerUpdateFlags::empty(),
-                        parent: Some(layer_id),
+                        parent: None,
                     };
 
                     // Find an identical existing layer
@@ -1381,6 +1382,7 @@ impl Syntax {
 
                     // ...or insert a new one.
                     let layer_id = layer.unwrap_or_else(|| self.layers.insert(new_layer));
+                    self.layers[layer_id].parent = parent;
 
                     queue.push_back(layer_id);
                 }


### PR DESCRIPTION
When parsing injections, we skip adding a new layer if there is an existing layer covering the same range. When doing so we did not update the parent layer ID, so some layers could have `parent` layer IDs that pointed to a layer that no longer existed in the `layers` HopSlotMap which could cause a panic when using `A-o`.

To fix this we update the `parent` pointer for both newly created injection layers and reused ones.

Fixes #10974