### PR TITLE
perf(commands): swap shell output `as_ref` + `clone` with `take`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5754,8 +5754,8 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let mut shell_output: Option<Tendril> = None;
     let mut offset = 0isize;
     for range in selection.ranges() {
-        let output = if let Some(output) = shell_output.as_ref() {
-            output.clone()
+        let output = if let Some(output) = shell_output.take() {
+            output
         } else {
             let fragment = range.slice(text);
             match shell_impl(shell, cmd, pipe.then(|| fragment.into())) {


### PR DESCRIPTION
Current `as_ref` + `clone` combo is just to deal with lifetime issues of the loop. Instead, `take` can take ownership directly, without having to clone . This can improve performance for particularly large shell output.