### PR TITLE
set nixfmt as the default formatter for nix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -866,6 +866,8 @@ shebangs = []
 comment-token = "#"
 language-servers = [ "nil" ]
 indent = { tab-width = 2, unit = "  " }
+formatter = { command = "nixfmt" }
+auto-format = true
 
 [[grammar]]
 name = "nix"


### PR DESCRIPTION
sets the default formatter for nix to `nixfmt` and enables auto-formatting.

closes https://github.com/helix-editor/helix/issues/10803