### PR TITLE
Only pluralise "buffer" when required

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -166,7 +166,7 @@ fn buffer_close_by_ids_impl(
         bail!(
             "{} unsaved buffer{} remaining: {:?}",
             modified_names.len(),
-            if modified_names.len() != 1 { "s" } else { "" },
+            if modified_names.len() == 1 { "" } else { "s" },
             modified_names,
         );
     }
@@ -661,7 +661,7 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
         bail!(
             "{} unsaved buffer{} remaining: {:?}",
             modified_names.len(),
-            if modified_names.len() != 1 { "s" } else { "" },
+            if modified_names.len() == 1 { "" } else { "s" },
             modified_names,
         );
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -164,9 +164,10 @@ fn buffer_close_by_ids_impl(
             cx.editor.switch(*first, Action::Replace);
         }
         bail!(
-            "{} unsaved buffer(s) remaining: {:?}",
+            "{} unsaved buffer{} remaining: {:?}",
             modified_names.len(),
-            modified_names
+            if modified_names.len() != 1 { "s" } else { "" },
+            modified_names,
         );
     }
 
@@ -658,9 +659,10 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
             editor.switch(*first, Action::Replace);
         }
         bail!(
-            "{} unsaved buffer(s) remaining: {:?}",
+            "{} unsaved buffer{} remaining: {:?}",
             modified_names.len(),
-            modified_names
+            if modified_names.len() != 1 { "s" } else { "" },
+            modified_names,
         );
     }
     Ok(())


### PR DESCRIPTION
Rather than showing an error of `n unsaved buffer(s) remaining: ...`, we use either `buffer` or `buffers` as required.