### PR TITLE
picker: add sort option (#11021)

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -160,6 +160,7 @@ All git related options are only enabled in a git repository.
 |`git-ignore` | Enables reading `.gitignore` files | `true`
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
 |`git-exclude` | Enables reading `.git/info/exclude` files | `true`
+|`sort` | Enables sorting entries by file name | `true`
 |`max-depth` | Set with an integer value for maximum depth to recurse | Unset by default
 
 Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -188,9 +188,12 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> Picker
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
-        .sort_by_file_name(|name1, name2| name1.cmp(name2))
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks));
+
+    if config.file_picker.sort {
+        walk_builder.sort_by_file_name(|name1, name2| name1.cmp(name2));
+    }
 
     walk_builder.add_custom_ignore_filename(helix_loader::config_dir().join("ignore"));
     walk_builder.add_custom_ignore_filename(".helix/ignore");

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -195,6 +195,8 @@ pub struct FilePickerConfig {
     /// Enables reading `.git/info/exclude` files.
     /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to true.
     pub git_exclude: bool,
+    /// Weather to sort picker entries by file name. Defaults to true.
+    pub sort: bool,
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
@@ -211,6 +213,7 @@ impl Default for FilePickerConfig {
             git_ignore: true,
             git_global: true,
             git_exclude: true,
+            sort: true,
             max_depth: None,
         }
     }


### PR DESCRIPTION
Closes #11021 
As of now only an option to toggle sorting has been added. 
**TBD:** Parallel traversal should be used if sorting is disabled