### PR TITLE
hyprlang: add hyprls language server

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -87,7 +87,7 @@
 | hosts | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server` |
 | hurl | ✓ | ✓ | ✓ |  |
-| hyprlang | ✓ |  | ✓ |  |
+| hyprlang | ✓ |  | ✓ | `hyprls` |
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | ini | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -41,6 +41,7 @@ fsharp-ls = { command = "fsautocomplete", config = { AutomaticWorkspaceInit = tr
 gleam = { command = "gleam", args = ["lsp"] }
 graphql-language-service = { command = "graphql-lsp", args = ["server", "-m", "stream"] }
 haskell-language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
+hyprls = { command = "hyprls" }
 idris2-lsp = { command = "idris2-lsp" }
 intelephense = { command = "intelephense", args = ["--stdio"] }
 jdtls = { command = "jdtls" }
@@ -3464,6 +3465,7 @@ roots = ["hyprland.conf"]
 file-types = [ { glob = "hyprland.conf" }, { glob = "hyprpaper.conf" }, { glob = "hypridle.conf" }, { glob = "hyprlock.conf" } ]
 comment-token = "#"
 grammar = "hyprlang"
+language-servers = ["hyprls"]
 
 [[grammar]]
 name = "hyprlang"


### PR DESCRIPTION
Adding the hyprls language server as the default one for hyprlang. I'm using it and it works just fine. Currently does not seems to have packages, so I created one for nixpkgs [here](https://github.com/NixOS/nixpkgs/pull/323392).
Edit: it was merged.

Source code: https://github.com/hyprland-community/hyprls