### PR TITLE
Fix homebrew formula link in docs/releases.md

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,7 +31,7 @@ being published.
 * Post to reddit
     * [Example post](https://www.reddit.com/r/rust/comments/uzp5ze/helix_editor_2205_released/)
 
-[homebrew formula]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/helix.rb
+[homebrew formula]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/h/helix.rb
 
 ## Changelog Curation
 


### PR DESCRIPTION
"No contribution is too small" :smile:
The homebrew link in [docs/releases.md](https://github.com/helix-editor/helix/blob/master/docs/releases.md) is currently a 404. Updates it to the current link.