### PR TITLE
Update fsharp tree sitter repo reference

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3136,7 +3136,7 @@ language-servers = ["fsharp-ls"]
 
 [[grammar]]
 name = "fsharp"
-source = { git = "https://github.com/kaashyapan/tree-sitter-fsharp", rev = "18da392fd9bd5e79f357abcce13f61f3a15e3951" }
+source = { git = "https://github.com/ionide/tree-sitter-fsharp", rev = "996ea9982bd4e490029f84682016b6793940113b" }
 
 [[language]]
 name = "t32"

--- a/runtime/queries/fsharp/highlights.scm
+++ b/runtime/queries/fsharp/highlights.scm
@@ -1,15 +1,175 @@
 ;; ----------------------------------------------------------------------------
 ;; Literals and comments
 
-[
-  (line_comment)
-  (block_comment)
-  (block_comment_content)
-] @comment
+(line_comment) @comment.line
 
+(block_comment) @comment.block
+
+(xml_doc) @comment.block.documentation
+
+(const
+  [
+   (_) @constant
+   (unit) @constant.builtin
+  ])
+
+(primary_constr_args (_) @variable.parameter)
+
+((identifier_pattern (long_identifier (identifier) @special))
+ (#match? @special "^\_.*"))
+
+((long_identifier
+  (identifier)+
+  .
+  (identifier) @variable.other.member))
 
 ;; ----------------------------------------------------------------------------
 ;; Punctuation
+
+(wildcard_pattern) @string.special
+
+(type_name type_name: (_) @type)
+
+[
+ (type)
+ (atomic_type)
+] @type
+
+(member_signature
+  .
+  (identifier) @function.method
+  (curried_spec
+    (arguments_spec
+      "*"* @operator
+      (argument_spec
+        (argument_name_spec
+          "?"? @special
+          name: (_) @variable.parameter)))))
+
+(union_type_case) @constant
+
+(rules
+  (rule
+    pattern: (_) @constant
+    block: (_)))
+
+(identifier_pattern
+  .
+  (_) @constant
+  .
+  (_) @variable)
+
+(fsi_directive_decl . (string) @namespace)
+
+(import_decl . (_) @namespace)
+(named_module
+  name: (_) @namespace)
+(namespace
+  name: (_) @namespace)
+(module_defn
+  .
+  (_) @namespace)
+
+(ce_expression
+  .
+  (_) @function.macro)
+
+(field_initializer
+  field: (_) @variable.other.member)
+
+(record_fields
+  (record_field
+    .
+    (identifier) @variable.other.member))
+
+(dot_expression
+  base: (_) @namespace
+  field: (_) @variable.other.member)
+
+(value_declaration_left . (_) @variable)
+
+(function_declaration_left
+  . (_) @function
+  [
+    (argument_patterns)
+    (argument_patterns (long_identifier (identifier)))
+  ] @variable.parameter)
+
+(member_defn
+  (method_or_prop_defn
+    [
+      (property_or_ident) @function
+      (property_or_ident
+        instance: (identifier) @variable.builtin
+        method: (identifier) @function.method)
+    ]
+    args: (_)* @variable.parameter))
+
+(application_expression
+  .
+  [
+    (long_identifier_or_op [
+      (long_identifier (identifier)* (identifier) @function)
+      (identifier) @function
+    ])
+    (typed_expression . (long_identifier_or_op (long_identifier (identifier)* . (identifier) @function.call)))
+    (dot_expression base: (_) @variable.other.member field: (_) @function)
+  ] @function)
+
+((infix_expression
+  .
+  (_)
+  .
+  (infix_op) @operator
+  .
+  (_) @function
+  )
+ (#eq? @operator "|>")
+ )
+
+((infix_expression
+  .
+  (_) @function
+  .
+  (infix_op) @operator
+  .
+  (_)
+  )
+ (#eq? @operator "<|")
+ )
+
+[
+  (xint)
+  (int)
+  (int16)
+  (uint16)
+  (int32)
+  (uint32)
+  (int64)
+  (uint64)
+  (nativeint)
+  (unativeint)
+] @constant.numeric.integer
+
+[
+  (ieee32)
+  (ieee64)
+  (float)
+  (decimal)
+] @constant.numeric.float
+
+(bool) @constant.builtin.boolean
+
+([
+  (string)
+  (triple_quoted_string)
+  (verbatim_string)
+  (char)
+] @string)
+
+(compiler_directive_decl) @keyword.directive
+
+(attribute) @attribute
 
 [
   "("
@@ -20,30 +180,39 @@
   "]"
   "[|"
   "|]"
+  "{|"
+  "|}"
   "[<"
   ">]"
 ] @punctuation.bracket
 
+(format_string_eval
+  [
+    "{"
+    "}"
+  ] @punctuation.special)
+
 [
-  "," 
+  ","
   ";"
 ] @punctuation.delimiter
 
 [
-  "|" 
+  "|"
   "="
   ">"
   "<"
   "-"
   "~"
+  "->"
+  "<-"
+  "&&"
+  "||"
+  ":>"
+  ":?>"
   (infix_op)
   (prefix_op)
-  (symbolic_op)
 ] @operator
-
-
-
-(attribute) @attribute
 
 [
   "if"
@@ -53,22 +222,29 @@
   "when"
   "match"
   "match!"
+] @keyword.control.conditional
+
+[
   "and"
   "or"
-  "&&"
-  "||"
-  "then"
-] @keyword.control.conditional
+  "not"
+  "upcast"
+  "downcast"
+] @keyword.operator
 
 [
   "return"
   "return!"
+  "yield"
+  "yield!"
 ] @keyword.control.return
 
 [
   "for"
   "while"
-] @keyword.control.return
+  "downto"
+  "to"
+] @keyword.control.repeat
 
 
 [
@@ -82,115 +258,93 @@
   "delegate"
   "static"
   "inline"
-  "internal"
   "mutable"
   "override"
-  "private"
-  "public"
   "rec"
+  "global"
+  (access_modifier)
 ] @keyword.storage.modifier
 
 [
-  "enum"
   "let"
   "let!"
+  "use"
+  "use!"
   "member"
-  "module"
-  "namespace"
+] @keyword.function
+
+[
+  "enum"
   "type"
-] @keyword.storage
+  "inherit"
+  "interface"
+] @keyword.storage.type
+
+(try_expression
+  [
+    "try"
+    "with"
+    "finally"
+  ] @keyword.control.exception)
+
+((identifier) @keyword.control.exception
+ (#any-of? @keyword.control.exception "failwith" "failwithf" "raise" "reraise"))
 
 [
   "as"
   "assert"
   "begin"
+  "end"
+  "done"
   "default"
+  "in"
   "do"
   "do!"
-  "done"
-  "downcast"
-  "downto"
-  "end"
   "event"
   "field"
-  "finally"
   "fun"
   "function"
   "get"
-  "global"
-  "inherit"
-  "interface"
+  "set"
   "lazy"
   "new"
-  "not"
-  "null"
   "of"
   "param"
   "property"
-  "set"
   "struct"
-  "try"
-  "upcast"
-  "use"
-  "use!"
   "val"
+  "module"
+  "namespace"
   "with"
-  "yield"
-  "yield!"
 ] @keyword
 
 [
- "true"
- "false"
- "unit"
- ] @constant.builtin
+  "null"
+] @constant.builtin
 
-[
- (type)
- (const)
-] @constant
+(match_expression "with" @keyword.control.conditional)
 
-[
- (union_type_case)
- (rules (rule (identifier_pattern)))
-] @type.enum
+((type
+  (long_identifier (identifier) @type.builtin))
+ (#any-of? @type.builtin "bool" "byte" "sbyte" "int16" "uint16" "int" "uint" "int64" "uint64" "nativeint" "unativeint" "decimal" "float" "double" "float32" "single" "char" "string" "unit"))
 
-(fsi_directive_decl (string) @namespace)
+(preproc_if
+  [
+    "#if" @keyword.directive
+    "#endif" @keyword.directive
+  ]
+  condition: (_)? @keyword.directive)
 
-[
-  (import_decl (long_identifier))
-  (named_module (long_identifier))  
-  (namespace (long_identifier))  
-  (named_module 
-    name: (long_identifier) )
-  (namespace 
-    name: (long_identifier) )
-] @namespace
+(preproc_else
+  "#else" @keyword.directive)
 
+((long_identifier
+  (identifier)+ @namespace
+  .
+  (identifier)))
 
-(dot_expression
-  base: (long_identifier_or_op) @variable.other.member
-  field: (long_identifier_or_op) @function)
+(long_identifier_or_op
+  (op_identifier) @operator)
 
-[
- ;;(value_declaration_left (identifier_pattern) ) 
- (function_declaration_left (identifier) ) 
- (call_expression (long_identifier_or_op (long_identifier)))
- ;;(application_expression (long_identifier_or_op (long_identifier)))
-] @function
-
-[
-  (string)
-  (triple_quoted_string)
-] @string
-
-[
-  (int)
-  (int16)
-  (int32)
-  (int64)
-  (float)
-  (decimal)
-] @constant.numeric
-
-
+((identifier) @namespace
+ (#any-of? @namespace "Array" "Async" "Directory" "File" "List" "Option" "Path" "Map" "Set" "Lazy" "Seq" "Task" "String" "Result" ))

--- a/runtime/queries/fsharp/injections.scm
+++ b/runtime/queries/fsharp/injections.scm
@@ -1,0 +1,8 @@
+([
+ (line_comment)
+ (block_comment_content)
+] @injection.content
+  (#set! injection.language "comment"))
+
+((xml_doc (xml_doc_content) @injection.content)
+ (#set! injection.language "xml"))

--- a/runtime/queries/fsharp/locals.scm
+++ b/runtime/queries/fsharp/locals.scm
@@ -1,25 +1,32 @@
-; Scopes
-;-------
+(identifier) @local.reference
 
 [
-  (ce_expression)
-  (module_defn)
-  (for_expression)
-  (do_expression)
-  (fun_expression)
-  (function_expression)
-  (try_expression)
-  (match_expression)
-  (elif_expression)
-  (if_expression)
+  (namespace)
+  (named_module)
+  (function_or_value_defn)
 ] @local.scope
 
-; Definitions
-;------------
+(value_declaration_left
+  .
+  [
+   (_ (identifier) @local.definition)
+   (_ (_ (identifier) @local.definition))
+   (_ (_ (_ (identifier) @local.definition)))
+   (_ (_ (_ (_ (identifier) @local.definition))))
+   (_ (_ (_ (_ (_ (identifier) @local.definition)))))
+   (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
+  ])
 
-(function_or_value_defn) @local.definition
-
-; References
-;-----------
-
-(identifier) @local.reference
+(function_declaration_left
+  .
+  ((_) @local.definition)
+  ((argument_patterns
+    [
+     (_ (identifier) @local.definition)
+     (_ (_ (identifier) @local.definition))
+     (_ (_ (_ (identifier) @local.definition)))
+     (_ (_ (_ (_ (identifier) @local.definition))))
+     (_ (_ (_ (_ (_ (identifier) @local.definition)))))
+     (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
+    ])
+  ))


### PR DESCRIPTION
The repository reference used here was a fork of the actual repository https://github.com/Nsidorenco/tree-sitter-fsharp, which has now been moved under ionide organization https://github.com/ionide/tree-sitter-fsharp, where it is in active maintenance and development.

The commit SHA is the currently latest commit from main branch.

The injections.scm is copied as is from the fsharp treesitter repo [queries](https://github.com/ionide/tree-sitter-fsharp/blame/main/queries).

The locals.scm is copied from the repo and the capture names are updated to follow the standard names:

    - Replace @local.definition.var @local.definition.function, and @local.definition.parameter with @local.definition
    - Remove (#set! "definition.function.scope" "parent")

The highlights.scm is copied as well from the fsharp treesitter repo, but modified here to match helix highlight scopes based on my best guesstimates. The changes made based on syntax highlight documentation [here](https://docs.helix-editor.com/master/themes.html#syntax-highlighting):
    
    - Remove @spell scopes
    - Split @comment into @comment.line and @comment.block
    - Replace @comment.documentation with @comment.block.documentation
    - Replace @character.special with @special
    - Replace @variable.member with @variable.other.member
    - Replace @type.definition with @type
    - Replace @function.member with @function.method
    - Replace @module with @namespace
    - Replace @constant.macro with @function.macro
    - Replace @property with @variable.other.member
    - Replace @variable.member with @variable.other.member
    - Replace @variable.parameter.builtin with @variable.builtin
    - Replace @function.call with @function
    - Replace @number with @constant.numeric.integer and @constant.numeric.float
    - Replace @boolean with @constant.builtin.boolean
    - Replace @keyword.conditional with @keyword.control.conditional
    - Replace @keyword.return with @keyword.control.return
    - Replace @keyword.repeate with @keyword.control.repeat
    - Replace @keyword.import with @keyword.control.import
    - Replace @keyword.modifier with @keyword.storage.modifier
    - Replace @keyword.type with @keyword.storage.type
    - Replace @keyword.exception with @keyword.control.exception
    - Replace @module.builtin with @namespace