### PR TITLE
suggest `xdg-utils` to install `*.desktop`

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -146,7 +146,8 @@ provided `.desktop` and icon files to their correct folders:
 
 ```sh
 cp contrib/Helix.desktop -- "$HOME/.local/share/applications"
-xdg-icon-resource install --novendor --size 256 contrib/helix.png
+cp contrib/helix.png -- "$HOME/.icons" # or "$HOME/.local/share/icons"
+#xdg-icon-resource install --novendor --size 256 contrib/helix.png
 ```
 
 To use another terminal than the system default, you can modify the `.desktop`

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -145,8 +145,8 @@ you can configure Helix to show up in the application menu by copying the
 provided `.desktop` and icon files to their correct folders:
 
 ```sh
-cp contrib/Helix.desktop ~/.local/share/applications
-cp contrib/helix.png ~/.icons # or ~/.local/share/icons
+xdg-desktop-icon install --novendor contrib/Helix.desktop
+xdg-icon-resource install --novendor --size 256 contrib/helix.png
 ```
 
 To use another terminal than the system default, you can modify the `.desktop`

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -145,7 +145,7 @@ you can configure Helix to show up in the application menu by copying the
 provided `.desktop` and icon files to their correct folders:
 
 ```sh
-xdg-desktop-icon install --novendor contrib/Helix.desktop
+cp contrib/Helix.desktop -- "$HOME/.local/share/applications"
 xdg-icon-resource install --novendor --size 256 contrib/helix.png
 ```
 


### PR DESCRIPTION
This seems more cross-platform, despite depending on a package that isn't `coreutils`.

> [!note]
> It seems `--size` can't be omitted