### PR TITLE
chore: update cairo tree sitter + queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2081,7 +2081,7 @@ language-servers = [ "cairo-language-server" ]
 
 [[grammar]]
 name = "cairo"
-source = { git = "https://github.com/starkware-libs/tree-sitter-cairo", rev = "0596baab741ffacdc65c761d5d5ffbbeae97f033" }
+source = { git = "https://github.com/starkware-libs/tree-sitter-cairo", rev = "e3a0212261c125cb38248458cd856c0ffee2b398" }
 
 [[language]]
 name = "cpon"

--- a/runtime/queries/cairo/highlights.scm
+++ b/runtime/queries/cairo/highlights.scm
@@ -95,6 +95,12 @@
 ; -------
 ; Keywords
 ; -------
+
+(for_expression
+  "for" @keyword.control.repeat)
+
+"in" @keyword.control
+
 [
   "match"
   "if"

--- a/runtime/queries/cairo/indents.scm
+++ b/runtime/queries/cairo/indents.scm
@@ -115,4 +115,10 @@
   (#not-same-line? @expr-start @pattern-guard)
 ) @indent
 
-  
+(for_expression
+  "in" @in
+  .
+  (_) @indent
+  (#not-same-line? @in @indent)
+  (#set! "scope" "all")
+)  


### PR DESCRIPTION
The next cairo release will introduce associated impls and iterators which come with some new syntax. Update the tree-sitter to support that and the queries