### PR TITLE
Gruvbox light theme. Fix cursorline readability after #10773.

### DIFF
--- a/runtime/themes/gruvbox_light.toml
+++ b/runtime/themes/gruvbox_light.toml
@@ -6,6 +6,7 @@ inherits = "gruvbox"
 
 "ui.cursor.primary" = { modifiers = ["reversed"] }
 "ui.cursor.match" = { bg = "bg2" }
+"ui.cursorline" = { bg = "bg1" }
 
 [palette]
 bg0 = "#fbf1c7" # main background


### PR DESCRIPTION
Religious Gruvbox light user here. @Chirikumbrah recently made a number of excellent tweaks to the base Gruvbox theme (#10773). One of these has had the unfortunate effect of turning the non-primary cursor line dark, making the text of the current line unreadable due to poor contrast. This is shown in the 'before' panel of the image below.

This PR sets things right by overriding the non-primary cursor background in the Gruvbox Light variant (which propagates to the other Light variants through inheritance.) The result is shown in the 'after' panel.

![gruvbox_light_fixed_cursorline](https://github.com/helix-editor/helix/assets/15968876/3452237f-4792-472e-8010-9c10009a5b60)

---


Question for @Chirikumbrah: I see you've defined a special `bg0_s = "#32302f"` (dark0_soft in gruvbox.nvim) for the cursorline. This is the same color as the background in Gruvbox Dark Soft, meaning that the non-primary cursorline doesn't appear when using that variant. Do you think we should a) drop bg0_s altogether or b) specify a separate `"ui.cursorline"` in the Dark Soft variant, so that it appears again? I ask because, if we keep bg0_s, it would probably be more consistent if I defined a separate bg0_s in the Light theme (light0_soft in gruvbox.nvim, to be specific).