### PR TITLE
Default theme: Use different highlight color for secondary selections

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -61,7 +61,7 @@ label = "honey"
 
 "ui.virtual.indent-guide" = { fg = "comet" }
 
-"ui.selection" = { bg = "#540099" }
+"ui.selection" = { bg = "#481173" }
 "ui.selection.primary" = { bg = "#540099" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
 "ui.cursor.select" = { bg = "delta" }


### PR DESCRIPTION
Partially addresses #3842.

The new color was chosen as half-way between the primary selection's background color and the window background color. This is kind of arbitrary, and I will happily change the color if so desired.

Before:
![image](https://github.com/helix-editor/helix/assets/42248344/b46c8c6d-78ee-4e56-8a38-f4f17194f1ba)

After:
![image](https://github.com/helix-editor/helix/assets/42248344/54d93846-fe61-425b-b352-4cc45567e43d)
