### PR TITLE
Add gherkin syntax highlighting

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -58,6 +58,7 @@
 | gas | ✓ | ✓ |  |  |
 | gdscript | ✓ | ✓ | ✓ |  |
 | gemini | ✓ |  |  |  |
+| gherkin | ✓ |  |  |  |
 | git-attributes | ✓ |  |  |  |
 | git-commit | ✓ | ✓ |  |  |
 | git-config | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3726,3 +3726,14 @@ grammar = "typescript"
 "{" = "}"
 "(" = ")"
 '"' = '"'
+
+[[language]]
+name = "gherkin"
+scope = "source.feature"
+file-types = ["feature"]
+comment-token = "#"
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "gherkin"
+source = { git = "https://github.com/SamyAB/tree-sitter-gherkin", rev = "43873ee8de16476635b48d52c46f5b6407cb5c09" }

--- a/runtime/queries/gherkin/highlights.scm
+++ b/runtime/queries/gherkin/highlights.scm
@@ -1,0 +1,17 @@
+[
+  (feature_keyword)
+  (rule_keyword)
+  (background_keyword)
+  (scenario_keyword)
+  (given_keyword)
+  (when_keyword)
+  (then_keyword)
+  (and_keyword)
+  (but_keyword)
+  (asterisk_keyword)
+] @keyword
+
+(tag) @function
+(doc_string) @string
+(data_table) @special
+(comment) @comment


### PR DESCRIPTION
Add tree-sitter grammar and highlights for the [gherkin language](https://cucumber.io/docs/gherkin/reference/) aka .feature files.

This is what it looks like with the `dracula` theme:
![gherkin_in_helix](https://github.com/helix-editor/helix/assets/10281632/67011843-fffa-43d4-9be8-bac2986744f2)

This was requested in https://github.com/helix-editor/helix/issues/3115 but it does not completely solve the issue as this PR does not add the LSP support.