### PR TITLE
`&Option<T>` -> `Option<&T>`

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -157,8 +157,8 @@ impl Client {
         )
     }
 
-    pub fn starting_request_args(&self) -> &Option<Value> {
-        &self.starting_request_args
+    pub fn starting_request_args(&self) -> Option<&Value> {
+        self.starting_request_args.as_ref()
     }
 
     pub async fn tcp_process(

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -422,7 +422,7 @@ fn build_tree_sitter_library(
         }
     }
 
-    let recompile = needs_recompile(&library_path, &parser_path, &scanner_path)
+    let recompile = needs_recompile(&library_path, &parser_path, scanner_path.as_ref())
         .context("Failed to compare source and binary timestamps")?;
 
     if !recompile {
@@ -568,7 +568,7 @@ fn build_tree_sitter_library(
 fn needs_recompile(
     lib_path: &Path,
     parser_c_path: &Path,
-    scanner_path: &Option<PathBuf>,
+    scanner_path: Option<&PathBuf>,
 ) -> Result<bool> {
     if !lib_path.exists() {
         return Ok(true);

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -123,7 +123,7 @@ impl Client {
                 {
                     client.add_workspace_folder(
                         root_uri,
-                        &workspace_folders_caps.change_notifications,
+                        workspace_folders_caps.change_notifications.as_ref(),
                     );
                 }
             });
@@ -136,7 +136,10 @@ impl Client {
             .and_then(|cap| cap.workspace_folders.as_ref())
             .filter(|cap| cap.supported.unwrap_or(false))
         {
-            self.add_workspace_folder(root_uri, &workspace_folders_caps.change_notifications);
+            self.add_workspace_folder(
+                root_uri,
+                workspace_folders_caps.change_notifications.as_ref(),
+            );
             true
         } else {
             // the server doesn't support multi workspaces, we need a new client
@@ -147,7 +150,7 @@ impl Client {
     fn add_workspace_folder(
         &self,
         root_uri: Option<lsp::Url>,
-        change_notifications: &Option<OneOf<bool, String>>,
+        change_notifications: Option<&OneOf<bool, String>>,
     ) {
         // root_uri is None just means that there isn't really any LSP workspace
         // associated with this file. For servers that support multiple workspaces
@@ -162,7 +165,7 @@ impl Client {
         self.workspace_folders
             .lock()
             .push(workspace_for_uri(root_uri.clone()));
-        if &Some(OneOf::Left(false)) == change_notifications {
+        if Some(&OneOf::Left(false)) == change_notifications {
             // server specifically opted out of DidWorkspaceChange notifications
             // let's assume the server will request the workspace folders itself
             // and that we can therefore reuse the client (but are done now)


### PR DESCRIPTION
Full explanation: ["Choose the Right Option"](https://youtu.be/6c7pZYP_iIE) by [Logan Smith](https://youtube.com/@_noisecode)

[NPO](https://doc.rust-lang.org/std/option#representation)

TLDR:
- internal APIs are less likely to break, as implementation details aren't exposed
- flexibility
- memory optimizations