### PR TITLE
Use `try_lock` in `diff_handle` for Diff gutter

### DIFF
--- a/helix-vcs/src/diff.rs
+++ b/helix-vcs/src/diff.rs
@@ -75,6 +75,13 @@ impl DiffHandle {
         }
     }
 
+    pub fn try_load(&self) -> Option<Diff> {
+        self.diff.try_lock().map(|guard| Diff {
+            diff: guard,
+            inverted: self.inverted,
+        })
+    }
+
     /// Updates the document associated with this redraw handle
     /// This function is only intended to be called from within the rendering loop
     /// if called from elsewhere it may fail to acquire the render lock and panic

--- a/helix-vcs/src/diff.rs
+++ b/helix-vcs/src/diff.rs
@@ -75,13 +75,6 @@ impl DiffHandle {
         }
     }
 
-    pub fn try_load(&self) -> Option<Diff> {
-        self.diff.try_lock().map(|guard| Diff {
-            diff: guard,
-            inverted: self.inverted,
-        })
-    }
-
     /// Updates the document associated with this redraw handle
     /// This function is only intended to be called from within the rendering loop
     /// if called from elsewhere it may fail to acquire the render lock and panic

--- a/helix-vcs/src/diff/worker.rs
+++ b/helix-vcs/src/diff/worker.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use helix_core::{Rope, RopeSlice};
 use imara_diff::intern::InternedInput;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::Notify;
 use tokio::time::{timeout, timeout_at, Duration};
@@ -21,7 +21,7 @@ mod test;
 
 pub(super) struct DiffWorker {
     pub channel: UnboundedReceiver<Event>,
-    pub diff: Arc<Mutex<DiffInner>>,
+    pub diff: Arc<RwLock<DiffInner>>,
     pub new_hunks: Vec<Hunk>,
     pub diff_finished_notify: Arc<Notify>,
 }
@@ -73,7 +73,7 @@ impl DiffWorker {
     /// `self.new_hunks` is always empty after this function runs.
     /// To improve performance this function tries to reuse the allocation of the old diff previously stored in `self.line_diffs`
     fn apply_hunks(&mut self, diff_base: Rope, doc: Rope) {
-        let mut diff = self.diff.lock();
+        let mut diff = self.diff.write();
         diff.diff_base = diff_base;
         diff.doc = doc;
         swap(&mut diff.hunks, &mut self.new_hunks);

--- a/helix-vcs/src/diff/worker/test.rs
+++ b/helix-vcs/src/diff/worker/test.rs
@@ -12,7 +12,7 @@ impl DiffHandle {
         // dropping the channel terminates the task
         drop(self.channel);
         handle.await.unwrap();
-        let diff = diff.lock();
+        let diff = diff.read();
         Vec::clone(&diff.hunks)
     }
 }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -96,8 +96,7 @@ pub fn diff<'doc>(
     let added = theme.get("diff.plus.gutter");
     let deleted = theme.get("diff.minus.gutter");
     let modified = theme.get("diff.delta.gutter");
-    if let Some(diff_handle) = doc.diff_handle() {
-        let hunks = diff_handle.load();
+    if let Some(hunks) = doc.diff_handle().and_then(|d| d.try_load()) {
         let mut hunk_i = 0;
         let mut hunk = hunks.nth_hunk(hunk_i);
         Box::new(

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -96,7 +96,8 @@ pub fn diff<'doc>(
     let added = theme.get("diff.plus.gutter");
     let deleted = theme.get("diff.minus.gutter");
     let modified = theme.get("diff.delta.gutter");
-    if let Some(hunks) = doc.diff_handle().and_then(|d| d.try_load()) {
+    if let Some(diff_handle) = doc.diff_handle() {
+        let hunks = diff_handle.load();
         let mut hunk_i = 0;
         let mut hunk = hunks.nth_hunk(hunk_i);
         Box::new(


### PR DESCRIPTION
The situation currently is that `render_gutter` builds out a `Vec` of `LineDecoration`s, where `LineDecoration` is a closure. These don't get evaluated until actually rendering, so the `MutexGuard` in `diff_handle.load()` doesn't go out of scope before being accessed again.

This PR does the following:
- Adds the method `try_load() -> Option<Diff>` to `DiffHandle`, using `try_lock` to avoid deadlocks.
- Use said method in `gutter.rs` `diff()`, which will use a blank `GutterFn` instead when met with a locked `Diff`.

Fixes #11027.