### PR TITLE
Prevent `:move` overwriting destination & Add `:move!` to force overwrite

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -86,5 +86,6 @@
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
 | `:move` | Move the current buffer and its corresponding file to a different path |
+| `:move!` | Force move the current buffer and its corresponding file to a different path, overwriting the destination. |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -85,7 +85,7 @@
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
-| `:move` | Move the current buffer and its corresponding file to a different path |
+| `:move` | Move the current buffer and its corresponding file to a different path. |
 | `:move!` | Force move the current buffer and its corresponding file to a different path, overwriting the destination. |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3120,7 +3120,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "move",
         aliases: &[],
-        doc: "Move the current buffer and its corresponding file to a different path",
+        doc: "Move the current buffer and its corresponding file to a different path.",
         fun: move_buffer,
         signature: CommandSignature::positional(&[completers::filename]),
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2431,6 +2431,19 @@ fn move_buffer(
     move_buffer_impl(cx, args.first().unwrap(), false)
 }
 
+fn force_move_buffer(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(args.len() == 1, format!(":move! takes one argument"));
+    move_buffer_impl(cx, args.first().unwrap(), true)
+}
+
 fn yank_diagnostic(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -3109,6 +3122,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Move the current buffer and its corresponding file to a different path",
         fun: move_buffer,
+        signature: CommandSignature::positional(&[completers::filename]),
+    },
+    TypableCommand {
+        name: "move!",
+        aliases: &[],
+        doc: "Force move the current buffer and its corresponding file to a different path, overwriting the destination.",
+        fun: force_move_buffer,
         signature: CommandSignature::positional(&[completers::filename]),
     },
     TypableCommand {


### PR DESCRIPTION
If you run the old `:move` command with a path that already exists, that file will be overwritten without warning.

**Example:**
```bash
echo "hello world" > a
echo "bye world" > b

hx b
# the run: `:move a`

cat a
# output: bye world
```

In this **PR** moving to an existing destination will display the following: ```Destination already exists. Use `:move!` to overwrite```.

I have also added the `:move!` command which behaves the same as the old move, overwriting the destination.