### PR TITLE
Update tree-sitter-todotxt

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3242,7 +3242,7 @@ auto-format = true
 
 [[grammar]]
 name = "todotxt"
-source = { git = "https://github.com/arnarg/tree-sitter-todotxt", rev = "0207f6a4ab6aeafc4b091914d31d8235049a2578" }
+source = { git = "https://github.com/arnarg/tree-sitter-todotxt", rev = "3937c5cd105ec4127448651a21aef45f52d19609" }
 
 [[language]]
 name = "strace"


### PR DESCRIPTION
Update to latest commit that allows any non-whitespace character for projects, and contexts.