### PR TITLE
Fix display of multiline status messages

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -409,6 +409,8 @@ impl Buffer {
         let max_x_offset = min(self.area.right() as usize, width.saturating_add(x as usize));
 
         for s in string.graphemes(true) {
+            let s = if s == "\n" { " " } else { s };
+
             let width = s.width();
             if width == 0 {
                 continue;


### PR DESCRIPTION
When `Editor::status_msg` contains a message with a newline, this newline was previously not visible in the status line, such as in this example. The config parser error contains a newline between "boolean" and "in".

![image](https://github.com/helix-editor/helix/assets/18399125/13cc8538-9d15-45f5-a60c-7100778ed0e7)

This PR replaces newlines with spaces to fix the issue:

![image](https://github.com/helix-editor/helix/assets/18399125/77d2dadd-99dc-4b85-8c46-abcc483bec85)

Note that the `set_string_truncated_at_end` function is used in more places than just displaying the status line. From my reading of its doc-comment however, I assume that it is anyway never intended to display multiline strings, therefore I don't expect this change to have unintended consequences.

I'm not sure whether we should also replace other characters like \r and \t. In general we might have to be careful to not mess with the width calculation in other places [such as this one](https://github.com/helix-editor/helix/blob/0c8d51ee3620470c99863371518f03d5b85351d8/helix-term/src/ui/editor.rs#L1512). The `UnicodeWidthStr::width()` for \n, \r, and \t is 1 each, but replacing "\r\n" with two spaces might be undesirable. My suggestion is to just leave it at \n for now and add further replacements only when it later turns out to be useful. This should fix the most common case for now.