### PR TITLE
Documentation: Convert the links in the `.desktop` file to absolute paths to avoid potential problems

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -148,6 +148,12 @@ provided `.desktop` and icon files to their correct folders:
 cp contrib/Helix.desktop ~/.local/share/applications
 cp contrib/helix.png ~/.icons # or ~/.local/share/icons
 ```
+It is recommended to convert the links in the `.desktop` file to absolute paths to avoid potential problems:
+
+```sh
+sed -i -e "s|Exec=hx %F|Exec=$(readlink -f ~/.cargo/bin/hx) %F|g" \
+  -e "s|Icon=helix|Icon=$(readlink -f ~/.icons/helix.png)|g" ~/.local/share/applications/Helix.desktop
+```
 
 To use another terminal than the system default, you can modify the `.desktop`
 file. For example, to use `kitty`:


### PR DESCRIPTION
When following the documentation for installing the desktop files as it is, I encountered numerous issues where the Helix icon and Helix desktop integration would sometimes work and sometimes not. Diagnosing the root cause was a nightmare. Eventually, I discovered that the `.desktop` file needed absolute paths to the Helix binary and icon.

Note that kitty asks users to do the same thing: https://sw.kovidgoyal.net/kitty/binary/#desktop-integration-on-linux

```sh
# Update the paths to the kitty and its icon in the kitty desktop file(s)
sed -i "s|Icon=kitty|Icon=$(readlink -f ~)/.local/kitty.app/share/icons/hicolor/256x256/apps/kitty.png|g" ~/.local/share/applications/kitty*.desktop
sed -i "s|Exec=kitty|Exec=$(readlink -f ~)/.local/kitty.app/bin/kitty|g" ~/.local/share/applications/kitty*.desktop
```

I am aware that the next section `To use another terminal...` assumes that the user has not made this absolute path change, but it might confuse things further to add it there. I am assuming that users could work out what is going on, it would be overkill to add all possible combinations, but I would be interested in some feedback on that.