### PR TITLE
Fix heredoc highlights and add ansi_c_string highlights in bash queries

### DIFF
--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -1,9 +1,14 @@
 [
   (string)
   (raw_string)
+  (ansi_c_string)
   (heredoc_body)
-  (heredoc_start)
 ] @string
+
+[
+  (heredoc_start)
+  (heredoc_end)
+] @label
 
 (command_name) @function
 


### PR DESCRIPTION
1. `ansi_c_string` was missing as a string type
2. `heredoc_start` was wrongly a string, and `heredoc_end` was missing.

I have fixed these issue, I chose to use `@label`for heredoc following Neovim.

## before

![Screenshot from 2024-07-09 20-09-36](https://github.com/helix-editor/helix/assets/12832280/30e89cda-f3c9-4cda-8b82-6a56d429a44d)

## after

![Screenshot from 2024-07-09 20-10-02](https://github.com/helix-editor/helix/assets/12832280/46528777-c525-4901-adbf-f03bc072594c)
