### PR TITLE
Update ZSH completions

### DIFF
--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -11,13 +11,13 @@ _hx() {
 		"-V[Prints version information]" \
 		"--version[Prints version information]" \
 		"--tutor[Loads the tutorial]" \
-		"--health[Checks for potential errors in editor setup]:language:->health" \
+		"--health[Checks for errors in editor setup]:language:->health" \
 		"-g[Fetches or builds tree-sitter grammars]:action:->grammar" \
 		"--grammar[Fetches or builds tree-sitter grammars]:action:->grammar" \
 		"--vsplit[Splits all given files vertically]" \
 		"--hsplit[Splits all given files horizontally]" \
-		"-c[Specifies a file to use for config]" \
-		"--config[Specifies a file to use for config]" \
+		"-c[Specifies a file to use for configuration]" \
+		"--config[Specifies a file to use for configuration]" \
 		"-w[Specify initial working directory]" \
 		"--working-dir[Specify initial working directory]" \
 		"--log[Specifies a file to use for logging]" \

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -11,19 +11,21 @@ _hx() {
 		"-V[Prints version information]" \
 		"--version[Prints version information]" \
 		"--tutor[Loads the tutorial]" \
-		"--health[Checks for errors in editor setup]:language:->health" \
+		"--health[Checks for potential errors in editor setup]:language:->health" \
 		"-g[Fetches or builds tree-sitter grammars]:action:->grammar" \
 		"--grammar[Fetches or builds tree-sitter grammars]:action:->grammar" \
-		"--vsplit[Splits all given files vertically into different windows]" \
-		"--hsplit[Splits all given files horizontally into different windows]" \
-		"-c[Specifies a file to use for configuration]" \
-		"--config[Specifies a file to use for configuration]" \
-		"--log[Specifies a file to write log data into]" \
+		"--vsplit[Splits all given files vertically]" \
+		"--hsplit[Splits all given files horizontally]" \
+		"-c[Specifies a file to use for config]" \
+		"--config[Specifies a file to use for config]" \
+		"-w[Specify initial working directory]" \
+		"--working-dir[Specify initial working directory]" \
+		"--log[Specifies a file to use for logging]" \
 		"*:file:_files"
 
 	case "$state" in
 	health)
-		local languages=($(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g'))
+		local languages=($(hx --health | tail -n '+11' | awk '{print $1}' | sed 's/\x1b\[[0-9;]*m//g;s/[✘✓]//g'))
 		_values 'language' $languages
 		;;
 	grammar)

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -1,4 +1,4 @@
-#compdef _hx hx
+compdef _hx hx
 # Zsh completion script for Helix editor
 
 _hx() {


### PR DESCRIPTION
1. Add working directory
2. Change some wording to make it follow https://github.com/helix-editor/helix/pull/10853 more closely
3. Increase tail to +11 as this is where the actual languages start in the output from `hx --health`
4. Filter ✘ and ✓ from the output

QUESTION: Why is `#compdef _hx hx` commented out? I have not un-commented it in case it is something to do with packaging I may not be aware of. It of course does not work until it is un-commented and will confuse people just trying to install the script themselves. Shall I un-comment it?