### PR TITLE
Add find in next command for character pairs

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -428,6 +428,23 @@ mod test {
     }
 
     #[test]
+    fn test_find_inside_next_quote() {
+        #[rustfmt::skip]
+        let (doc, selection, expectations) =
+            rope_with_selections_and_expectations(
+                "some 'nested 'quoted' text' on this 'line'\n'and this one'",
+                " ^   _       _                            \n              "
+            );
+
+        assert_eq!(2, expectations.len());
+        assert_eq!(
+            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), FindType::Next)
+                .expect("find should succeed"),
+            (expectations[0], expectations[1])
+        )
+    }
+
+    #[test]
     fn test_find_nth_pairs_pos_inside_quote_ambiguous() {
         #[rustfmt::skip]
         let (doc, selection, _) =

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -7,6 +7,7 @@ use crate::chars::{categorize_char, char_is_whitespace, CharCategory};
 use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
 use crate::line_ending::rope_is_line_ending;
 use crate::movement::Direction;
+use crate::surround::FindType;
 use crate::syntax::LanguageConfiguration;
 use crate::Range;
 use crate::{surround, Syntax};
@@ -204,9 +205,15 @@ pub fn textobject_pair_surround(
     range: Range,
     textobject: TextObject,
     ch: char,
-    count: usize,
+    find_type: FindType,
 ) -> Range {
-    textobject_pair_surround_impl(syntax, slice, range, textobject, Some(ch), count)
+    textobject_pair_surround_impl(
+        syntax,
+        slice,
+        range,
+        textobject,
+        FindVariant::Char((ch, find_type)),
+    )
 }
 
 pub fn textobject_pair_surround_closest(
@@ -216,7 +223,18 @@ pub fn textobject_pair_surround_closest(
     textobject: TextObject,
     count: usize,
 ) -> Range {
-    textobject_pair_surround_impl(syntax, slice, range, textobject, None, count)
+    textobject_pair_surround_impl(
+        syntax,
+        slice,
+        range,
+        textobject,
+        FindVariant::Closest(count),
+    )
+}
+
+enum FindVariant {
+    Char((char, FindType)),
+    Closest(usize),
 }
 
 fn textobject_pair_surround_impl(
@@ -224,12 +242,15 @@ fn textobject_pair_surround_impl(
     slice: RopeSlice,
     range: Range,
     textobject: TextObject,
-    ch: Option<char>,
-    count: usize,
+    find_variant: FindVariant,
 ) -> Range {
-    let pair_pos = match ch {
-        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
-        None => surround::find_nth_closest_pairs_pos(syntax, slice, range, count),
+    let pair_pos = match find_variant {
+        FindVariant::Char((ch, find_type)) => {
+            surround::find_nth_pairs_pos(slice, ch, range, find_type)
+        }
+        FindVariant::Closest(count) => {
+            surround::find_nth_closest_pairs_pos(syntax, slice, range, count)
+        }
     };
     pair_pos
         .map(|(anchor, head)| match textobject {
@@ -576,8 +597,14 @@ mod test {
             let slice = doc.slice(..);
             for &case in scenario {
                 let (pos, objtype, expected_range, ch, count) = case;
-                let result =
-                    textobject_pair_surround(None, slice, Range::point(pos), objtype, ch, count);
+                let result = textobject_pair_surround(
+                    None,
+                    slice,
+                    Range::point(pos),
+                    objtype,
+                    ch,
+                    FindType::Count(count),
+                );
                 assert_eq!(
                     result,
                     expected_range.into(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5452,20 +5452,26 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject, find_nex
         textobject::TextObject::Around => "Match around",
         _ => return,
     };
-    let help_text = [
-        ("w", "Word"),
-        ("W", "WORD"),
-        ("p", "Paragraph"),
-        ("t", "Type definition (tree-sitter)"),
-        ("f", "Function (tree-sitter)"),
-        ("a", "Argument/parameter (tree-sitter)"),
-        ("c", "Comment (tree-sitter)"),
-        ("T", "Test (tree-sitter)"),
-        ("e", "Data structure entry (tree-sitter)"),
-        ("m", "Closest surrounding pair (tree-sitter)"),
-        ("g", "Change"),
-        (" ", "... or any character acting as a pair"),
-    ];
+    let help_text = if find_next {
+        [(" ", "Any character acting as a pair")].to_vec()
+    } else {
+        [
+            ("w", "Word"),
+            ("W", "WORD"),
+            ("p", "Paragraph"),
+            ("t", "Type definition (tree-sitter)"),
+            ("f", "Function (tree-sitter)"),
+            ("a", "Argument/parameter (tree-sitter)"),
+            ("c", "Comment (tree-sitter)"),
+            ("T", "Test (tree-sitter)"),
+            ("e", "Data structure entry (tree-sitter)"),
+            ("m", "Closest surrounding pair (tree-sitter)"),
+            ("g", "Change"),
+            ("n", "Next ..."),
+            (" ", "... or any character acting as a pair"),
+        ]
+        .to_vec()
+    };
 
     cx.editor.autoinfo = Some(Info::new(title, &help_text));
 }


### PR DESCRIPTION
Adds the ability to match inside/around the next matching character pair: for instance, with the cursor as `█` below:

```rust
█ let x = [bar];
```

typing `min[` would select the contents of the array (i.e. `bar`).


https://github.com/helix-editor/helix/assets/54135831/420993e0-08d5-4394-be68-068ed6b57a8f

I have only implemented matching in next matching characters (and not the remainder of matching options e.g. word, function etc.) as I wanted to confirm that my approach was okay - once there is agreement on an approach I can implement the remainder, either in this PR or separate PRs.

Partially resolves https://github.com/helix-editor/helix/discussions/10567