### PR TITLE
Update Hare grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2055,7 +2055,7 @@ indent = { tab-width = 8, unit = "\t" }
 
 [[grammar]]
 name = "hare"
-source = { git = "https://git.sr.ht/~ecmma/tree-sitter-hare", rev = "2495958aaf3f93581c87ec020164255e80655331" }
+source = { git = "https://git.sr.ht/~ecs/tree-sitter-hare", rev = "07035a248943575444aa0b893ffe306e1444c0ab" }
 
 [[language]]
 name = "devicetree"

--- a/runtime/queries/hare/highlights.scm
+++ b/runtime/queries/hare/highlights.scm
@@ -1,22 +1,5 @@
-[
-  "f32"
-  "f64"
-  "i16"
-  "i32"
-  "i64"
-  "i8"
-  "int"
-  "rune"
-  "str"
-  "u16"
-  "u32"
-  "u64"
-  "u8"
-  "uint"
-  "uintptr"
-  "void"
-] @type
-
+(type) @type
+(type "const" @type)
 
 [
   "else"
@@ -36,28 +19,23 @@
   "break"
 ] @keyword.control.repeat
 
-[
-  "return"
-  "yield"
-] @keyword.control.return
+"return" @keyword.control.return
 
 [
   "abort"
   "assert"
 ] @keyword.control.exception
 
-[
-  "def"
-  "fn"
-] @keyword.function
+"fn" @keyword.function
 
 [
   "alloc"
   "append"
   "as"
   "bool"
-  "char"
+  "case"
   "const"
+  "def"
   "defer"
   "delete"
   "enum"
@@ -68,12 +46,13 @@
   "match"
   "nullable"
   "offset"
-  "size"
-  "static"
   "struct"
   "type"
   "union"
+  "yield"
 ] @keyword
+
+"static" @keyword.storage.modifier
 
 [
   "."  
@@ -137,15 +116,17 @@
   "null"
   "true"
 ] @constant.builtin
+(literal "void") @constant.builtin
 
-(string_constant) @string
+(string_literal) @string
 (escape_sequence) @constant.character.escape
-(rune_constant) @string
-(integer_constant) @constant.numeric.integer 
-(floating_constant) @constant.numeric.float
+(rune_literal) @string
+(integer_literal) @constant.numeric.integer
+(floating_literal) @constant.numeric.float
 
 (call_expression
   (postfix_expression) @function)
+(size_expression "size" @function.builtin)
 
 (function_declaration
   name: (identifier) @function)
@@ -158,4 +139,4 @@
 (fndec_attrs) @special
 
 (identifier) @variable
-
+(struct_union_field (name)) @variable

--- a/runtime/queries/hare/locals.scm
+++ b/runtime/queries/hare/locals.scm
@@ -1,20 +1,19 @@
-(unit) @local.scope
+(sub_unit) @local.scope
 
 (function_declaration) @local.scope
+(compound_expression) @local.scope
 
 (global_binding
   (identifier) @local.definition)
-(constant_binding 
+(constant_binding
   (identifier) @local.definition)
-(type_bindings
+(type_binding
   (identifier) @local.definition)
 
 (function_declaration
-  (prototype
-    (parameter_list
-      (parameters
-        (parameter
-          (name) @local.definition)))))
+  (identifier) @local.definition)
+(function_declaration
+  (parameter (name) @local.definition))
 
 (identifier) @local.reference
 


### PR DESCRIPTION
This change uses <https://git.sr.ht/~ecs/tree-sitter-hare/> that is up-to-date and linked from the official documentation.