### PR TITLE
Fix ZSH completions

### DIFF
--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -1,4 +1,4 @@
-compdef _hx hx
+#compdef _hx hx
 # Zsh completion script for Helix editor
 
 _hx() {
@@ -33,4 +33,3 @@ _hx() {
 		;;
 	esac
 }
-


### PR DESCRIPTION
> > Why is #compdef _hx hx commented out?
> 
> Sorry for the drive-by comment, but it was correct before. That's zsh's tag syntax for autoloaded completion files (i.e. those in `$fpath`, which is where `brew` and other packagers place them): https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files



Based on https://github.com/helix-editor/helix/pull/11120#issuecomment-2221865789 removing the `#` was a mistake, I have replaced it.