### PR TITLE
Include .yml files in Helm chart templates

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3514,7 +3514,7 @@ scope = "source.helm"
 roots = ["Chart.yaml"]
 comment-token = "#"
 language-servers = ["helm_ls"]
-file-types = [ { glob = "templates/*.yaml" }, { glob = "templates/_*.tpl"}, { glob = "templates/NOTES.txt" } ]
+file-types = [ { glob = "templates/*.yaml" }, { glob = "templates/*.yml" }, { glob = "templates/_*.tpl"}, { glob = "templates/NOTES.txt" } ]
 
 [[language]]
 name = "glimmer"


### PR DESCRIPTION
Currently, files in a Helm Chart's `templates/` directory ending with the `yml` extensions do not use the `helm` language but the default `yaml`. This PR fixes that, by also adding `.yml` files to the `helm` language.