### PR TITLE
Update highlights.scm and injections.scm for blade.php files

### DIFF
--- a/runtime/queries/blade/highlights.scm
+++ b/runtime/queries/blade/highlights.scm
@@ -2,3 +2,7 @@
 (directive_start) @tag
 (directive_end) @tag
 (comment) @comment
+[
+ (bracket_start)
+ (bracket_end)
+] @punctuation.bracket

--- a/runtime/queries/blade/injections.scm
+++ b/runtime/queries/blade/injections.scm
@@ -1,9 +1,12 @@
 ((text) @injection.content
     (#set! injection.combined)
-    (#set! injection.language php))
+    (#set! injection.language "php"))
+
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ((php_only) @injection.content
-    (#set! injection.language php-only))
+    (#set! injection.language "php-only"))
 ((parameter) @injection.content
-    (#set! injection.language php-only))
+    (#set! injection.language "php-only"))
 

--- a/runtime/queries/blade/injections.scm
+++ b/runtime/queries/blade/injections.scm
@@ -7,6 +7,8 @@
 
 ((php_only) @injection.content
     (#set! injection.language "php-only"))
-((parameter) @injection.content
-    (#set! injection.language "php-only"))
+
+((parameter) @injection.content                                                                                                 
+    (#set! injection.include-children)                                                                                          
+    (#set! injection.language "php-only")) 
 


### PR DESCRIPTION
Simple pull request adding the missing, bracket theming selector for `blade.php` files

<img width="251" alt="image" src="https://github.com/helix-editor/helix/assets/11975985/96ac0809-84e5-4cd3-bbfb-f2b22bb03c84">

**VS**

<img width="227" alt="image" src="https://github.com/helix-editor/helix/assets/11975985/15046256-c9ce-4c33-914f-ab91132a1ad7">
