### PR TITLE
improving the file saving procedure

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -574,7 +574,7 @@ impl Application {
             doc_save_event.revision
         );
 
-        doc.set_last_saved_revision(doc_save_event.revision);
+        doc.set_last_saved_revision(doc_save_event.revision, doc_save_event.save_time);
 
         let lines = doc_save_event.text.len_lines();
         let bytes = doc_save_event.text.len_bytes();

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -104,6 +104,7 @@ impl Serialize for Mode {
 #[derive(Debug, Clone)]
 pub struct DocumentSavedEvent {
     pub revision: usize,
+    pub save_time: SystemTime,
     pub doc_id: DocumentId,
     pub path: PathBuf,
     pub text: Rope,
@@ -960,6 +961,11 @@ impl Document {
             }
             .await;
 
+            let save_time = match fs::metadata(&write_path).await {
+                Ok(metadata) => metadata.modified().map_or(SystemTime::now(), |mtime| mtime),
+                Err(_) => SystemTime::now(),
+            };
+
             if let Some(backup) = backup {
                 if write_result.is_err() {
                     // restore backup
@@ -982,6 +988,7 @@ impl Document {
 
             let event = DocumentSavedEvent {
                 revision: current_rev,
+                save_time,
                 doc_id,
                 path,
                 text: text.clone(),
@@ -1040,6 +1047,26 @@ impl Document {
         }
     }
 
+    pub fn pickup_last_saved_time(&mut self) {
+        self.last_saved_time = match self.path.as_mut().unwrap().metadata() {
+            Ok(metadata) => match metadata.modified() {
+                Ok(mtime) => mtime,
+                Err(_) => {
+                    log::error!(
+                        "Use a system time instead of fs' mtime not supported on this platform"
+                    );
+                    SystemTime::now()
+                }
+            },
+            Err(e) => {
+                log::error!(
+                    "Use a system time instead of fs' mtime: failed to file's metadata: {e}"
+                );
+                SystemTime::now()
+            }
+        };
+    }
+
     // Detect if the file is readonly and change the readonly field if necessary (unix only)
     pub fn detect_readonly(&mut self) {
         // Allows setting the flag for files the user cannot modify, like root files
@@ -1077,9 +1104,7 @@ impl Document {
         self.apply(&transaction, view.id);
         self.append_changes_to_history(view);
         self.reset_modified();
-
-        self.last_saved_time = SystemTime::now();
-
+        self.pickup_last_saved_time();
         self.detect_indent_and_line_ending();
 
         match provider_registry.get_diff_base(&path) {
@@ -1118,6 +1143,7 @@ impl Document {
         self.path = path;
 
         self.detect_readonly();
+        self.pickup_last_saved_time();
     }
 
     /// Set the programming language for the file and load associated data (e.g. highlighting)
@@ -1581,7 +1607,7 @@ impl Document {
     }
 
     /// Set the document's latest saved revision to the given one.
-    pub fn set_last_saved_revision(&mut self, rev: usize) {
+    pub fn set_last_saved_revision(&mut self, rev: usize, save_time: SystemTime) {
         log::debug!(
             "doc {} revision updated {} -> {}",
             self.id,
@@ -1589,7 +1615,7 @@ impl Document {
             rev
         );
         self.last_saved_revision = rev;
-        self.last_saved_time = SystemTime::now();
+        self.last_saved_time = save_time;
     }
 
     /// Get the document's latest saved revision.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2084,7 +2084,7 @@ impl Editor {
                 };
 
                 let doc = doc_mut!(self, &save_event.doc_id);
-                doc.set_last_saved_revision(save_event.revision);
+                doc.set_last_saved_revision(save_event.revision, save_event.save_time);
             }
         }
 


### PR DESCRIPTION
Now helix should use fs' mtime instead of system time, that fixes problems with out-of-sync network filesystems
Use another file to write before replace origin, that gives a little more "good" behavior in case of write failure
Prevent overwrite origin file if origin is changed while write

this change includes https://github.com/helix-editor/helix/pull/11142