### PR TITLE
Add textobjects for XML, HTML and jsx

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -104,7 +104,7 @@
 | hocon | ✓ | ✓ | ✓ |  |
 | hoon | ✓ |  |  |  |
 | hosts | ✓ |  |  |  |
-| html | ✓ |  |  | `vscode-html-language-server`, `superhtml` |
+| html | ✓ | ✓ |  | `vscode-html-language-server`, `superhtml` |
 | htmldjango | ✓ |  |  | `djlsp`, `vscode-html-language-server`, `superhtml` |
 | hurl | ✓ | ✓ | ✓ |  |
 | hyprlang | ✓ |  | ✓ | `hyprls` |
@@ -270,7 +270,7 @@
 | wit | ✓ |  | ✓ |  |
 | wren | ✓ | ✓ | ✓ |  |
 | xit | ✓ |  |  |  |
-| xml | ✓ |  | ✓ |  |
+| xml | ✓ | ✓ | ✓ |  |
 | xtc | ✓ |  |  |  |
 | yaml | ✓ | ✓ | ✓ | `yaml-language-server`, `ansible-language-server` |
 | yara | ✓ |  |  | `yls` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -267,6 +267,8 @@
 | `goto_prev_comment` | Goto previous comment | normal: `` [c ``, select: `` [c `` |
 | `goto_next_test` | Goto next test | normal: `` ]T ``, select: `` ]T `` |
 | `goto_prev_test` | Goto previous test | normal: `` [T ``, select: `` [T `` |
+| `goto_next_xml_element` | Goto next (X)HTML element | normal: `` ]x ``, select: `` ]x `` |
+| `goto_prev_xml_element` | Goto previous (X)HTML element | normal: `` [x ``, select: `` [x `` |
 | `goto_next_entry` | Goto next pairing | normal: `` ]e ``, select: `` ]e `` |
 | `goto_prev_entry` | Goto previous pairing | normal: `` [e ``, select: `` [e `` |
 | `goto_next_paragraph` | Goto next paragraph | normal: `` ]p ``, select: `` ]p `` |

--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -28,6 +28,8 @@ The following [captures][tree-sitter-captures] are recognized:
 | `comment.around`   |
 | `entry.inside`     |
 | `entry.around`     |
+| `xml-element.inside` |
+| `xml-element.around` |
 
 [Example query files][textobject-examples] can be found in the helix GitHub repository.
 

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -350,7 +350,7 @@ These mappings are in the style of [vim-unimpaired](https://github.com/tpope/vim
 
 | Key      | Description                                  | Command                 |
 | -----    | -----------                                  | -------                 |
-| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`        | 
+| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`        |
 | `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`        |
 | `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`        |
 | `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`       |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -348,30 +348,32 @@ Displays the signature of the selected completion item. Remapping currently not 
 
 These mappings are in the style of [vim-unimpaired](https://github.com/tpope/vim-unimpaired).
 
-| Key      | Description                                  | Command               |
-| -----    | -----------                                  | -------               |
-| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`      |
-| `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`      |
-| `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`      |
-| `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`     |
-| `]f`     | Go to next function (**TS**)                 | `goto_next_function`  |
-| `[f`     | Go to previous function (**TS**)             | `goto_prev_function`  |
-| `]t`     | Go to next type definition (**TS**)          | `goto_next_class`     |
-| `[t`     | Go to previous type definition (**TS**)      | `goto_prev_class`     |
-| `]a`     | Go to next argument/parameter (**TS**)       | `goto_next_parameter` |
-| `[a`     | Go to previous argument/parameter (**TS**)   | `goto_prev_parameter` |
-| `]c`     | Go to next comment (**TS**)                  | `goto_next_comment`   |
-| `[c`     | Go to previous comment (**TS**)              | `goto_prev_comment`   |
-| `]T`     | Go to next test (**TS**)                     | `goto_next_test`      |
-| `[T`     | Go to previous test (**TS**)                 | `goto_prev_test`      |
-| `]p`     | Go to next paragraph                         | `goto_next_paragraph` |
-| `[p`     | Go to previous paragraph                     | `goto_prev_paragraph` |
-| `]g`     | Go to next change                            | `goto_next_change`    |
-| `[g`     | Go to previous change                        | `goto_prev_change`    |
-| `]G`     | Go to last change                            | `goto_last_change`    |
-| `[G`     | Go to first change                           | `goto_first_change`   |
-| `]Space` | Add newline below                            | `add_newline_below`   |
-| `[Space` | Add newline above                            | `add_newline_above`   |
+| Key      | Description                                  | Command                 |
+| -----    | -----------                                  | -------                 |
+| `]d`     | Go to next diagnostic (**LSP**)              | `goto_next_diag`        | 
+| `[d`     | Go to previous diagnostic (**LSP**)          | `goto_prev_diag`        |
+| `]D`     | Go to last diagnostic in document (**LSP**)  | `goto_last_diag`        |
+| `[D`     | Go to first diagnostic in document (**LSP**) | `goto_first_diag`       |
+| `]f`     | Go to next function (**TS**)                 | `goto_next_function`    |
+| `[f`     | Go to previous function (**TS**)             | `goto_prev_function`    |
+| `]t`     | Go to next type definition (**TS**)          | `goto_next_class`       |
+| `[t`     | Go to previous type definition (**TS**)      | `goto_prev_class`       |
+| `]a`     | Go to next argument/parameter (**TS**)       | `goto_next_parameter`   |
+| `[a`     | Go to previous argument/parameter (**TS**)   | `goto_prev_parameter`   |
+| `]c`     | Go to next comment (**TS**)                  | `goto_next_comment`     |
+| `[c`     | Go to previous comment (**TS**)              | `goto_prev_comment`     |
+| `]T`     | Go to next test (**TS**)                     | `goto_next_test`        |
+| `[T`     | Go to previous test (**TS**)                 | `goto_prev_test`        |
+| `]p`     | Go to next paragraph                         | `goto_next_paragraph`   |
+| `[p`     | Go to previous paragraph                     | `goto_prev_paragraph`   |
+| `]g`     | Go to next change                            | `goto_next_change`      |
+| `[g`     | Go to previous change                        | `goto_prev_change`      |
+| `]G`     | Go to last change                            | `goto_last_change`      |
+| `[G`     | Go to first change                           | `goto_first_change`     |
+| `[x`     | Go to next (X)HTML element                   | `goto_next_xml_element` |
+| `]x`     | Go to previous (X)HTML element               | `goto_prev_xml_element` |
+| `]Space` | Add newline below                            | `add_newline_below`     |
+| `[Space` | Add newline above                            | `add_newline_above`     |
 
 ## Insert mode
 

--- a/book/src/textobjects.md
+++ b/book/src/textobjects.md
@@ -24,6 +24,7 @@ function or block of code.
 | `c`                    | Comment                  |
 | `T`                    | Test                     |
 | `g`                    | Change                   |
+| `x`                    | (X)HTML element          |
 
 > 💡 `f`, `t`, etc. need a tree-sitter grammar active for the current
 document and a special tree-sitter query file to work properly. [Only

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5885,11 +5885,11 @@ fn goto_prev_test(cx: &mut Context) {
 }
 
 fn goto_next_xml_element(cx: &mut Context) {
-    goto_ts_object_impl(cx, "xml_element", Direction::Forward)
+    goto_ts_object_impl(cx, "xml-element", Direction::Forward)
 }
 
 fn goto_prev_xml_element(cx: &mut Context) {
-    goto_ts_object_impl(cx, "xml_element", Direction::Backward)
+    goto_ts_object_impl(cx, "xml-element", Direction::Backward)
 }
 
 fn goto_next_entry(cx: &mut Context) {
@@ -5959,7 +5959,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'c' => textobject_treesitter("comment", range),
                         'T' => textobject_treesitter("test", range),
                         'e' => textobject_treesitter("entry", range),
-                        'x' => textobject_treesitter("xml_element", range),
+                        'x' => textobject_treesitter("xml-element", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
                         'm' => textobject::textobject_pair_surround_closest(
                             doc.syntax(),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -565,6 +565,8 @@ impl MappableCommand {
         goto_prev_comment, "Goto previous comment",
         goto_next_test, "Goto next test",
         goto_prev_test, "Goto previous test",
+        goto_next_xml_element, "Goto next (X)HTML element",
+        goto_prev_xml_element, "Goto previous (X)HTML element",
         goto_next_entry, "Goto next pairing",
         goto_prev_entry, "Goto previous pairing",
         goto_next_paragraph, "Goto next paragraph",
@@ -5882,6 +5884,14 @@ fn goto_prev_test(cx: &mut Context) {
     goto_ts_object_impl(cx, "test", Direction::Backward)
 }
 
+fn goto_next_xml_element(cx: &mut Context) {
+    goto_ts_object_impl(cx, "xml_element", Direction::Forward)
+}
+
+fn goto_prev_xml_element(cx: &mut Context) {
+    goto_ts_object_impl(cx, "xml_element", Direction::Backward)
+}
+
 fn goto_next_entry(cx: &mut Context) {
     goto_ts_object_impl(cx, "entry", Direction::Forward)
 }
@@ -5949,6 +5959,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'c' => textobject_treesitter("comment", range),
                         'T' => textobject_treesitter("test", range),
                         'e' => textobject_treesitter("entry", range),
+                        'x' => textobject_treesitter("xml_element", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
                         'm' => textobject::textobject_pair_surround_closest(
                             doc.syntax(),
@@ -5993,6 +6004,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         ("e", "Data structure entry (tree-sitter)"),
         ("m", "Closest surrounding pair (tree-sitter)"),
         ("g", "Change"),
+        ("x", "X(HTML) element (tree-sitter)"),
         (" ", "... or any character acting as a pair"),
     ];
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -120,6 +120,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "e" => goto_prev_entry,
             "T" => goto_prev_test,
             "p" => goto_prev_paragraph,
+            "x" => goto_prev_xml_element,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -134,6 +135,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "e" => goto_next_entry,
             "T" => goto_next_test,
             "p" => goto_next_paragraph,
+            "x" => goto_next_xml_element,
             "space" => add_newline_below,
         },
 

--- a/runtime/queries/_jsx/textobjects.scm
+++ b/runtime/queries/_jsx/textobjects.scm
@@ -1,0 +1,7 @@
+; See runtime/queries/ecma/README.md for more info.
+
+(jsx_self_closing_element) @xml_element.around @xml_element.inside
+
+(jsx_element (jsx_opening_element) (_)* @xml_element.inside (jsx_closing_element))
+
+(jsx_element) @xml_element.around

--- a/runtime/queries/_jsx/textobjects.scm
+++ b/runtime/queries/_jsx/textobjects.scm
@@ -1,7 +1,7 @@
 ; See runtime/queries/ecma/README.md for more info.
 
-(jsx_self_closing_element) @xml_element.around @xml_element.inside
+(jsx_self_closing_element) @xml-element.around @xml-element.inside
 
-(jsx_element (jsx_opening_element) (_)* @xml_element.inside (jsx_closing_element))
+(jsx_element (jsx_opening_element) (_)* @xml-element.inside (jsx_closing_element))
 
-(jsx_element) @xml_element.around
+(jsx_element) @xml-element.around

--- a/runtime/queries/html/textobjects.scm
+++ b/runtime/queries/html/textobjects.scm
@@ -1,9 +1,9 @@
-(script_element (start_tag) (_) @xml_element.inside (end_tag))  @xml_element.around
+(script_element (start_tag) (_) @xml-element.inside (end_tag))  @xml-element.around
 
-(style_element (start_tag) (_) @xml_element.inside (end_tag)) @xml_element.around 
+(style_element (start_tag) (_) @xml-element.inside (end_tag)) @xml-element.around
 
-(element (start_tag) (_)* @xml_element.inside (end_tag))
+(element (start_tag) (_)* @xml-element.inside (end_tag))
 
-(element) @xml_element.around  
+(element) @xml-element.around
 
-(comment) @comment.around   
+(comment) @comment.around

--- a/runtime/queries/html/textobjects.scm
+++ b/runtime/queries/html/textobjects.scm
@@ -1,0 +1,9 @@
+(script_element (start_tag) (_) @xml_element.inside (end_tag))  @xml_element.around
+
+(style_element (start_tag) (_) @xml_element.inside (end_tag)) @xml_element.around 
+
+(element (start_tag) (_)* @xml_element.inside (end_tag))
+
+(element) @xml_element.around  
+
+(comment) @comment.around   

--- a/runtime/queries/jsx/textobjects.scm
+++ b/runtime/queries/jsx/textobjects.scm
@@ -1,9 +1,3 @@
 ; See runtime/queries/ecma/README.md for more info.
 
 ; inherits: _jsx,_javascript,ecma
-
-(jsx_self_closing_element) @xml_element.around @xml_element.inside
-
-(jsx_element (jsx_opening_element) (_)* @xml_element.inside (jsx_closing_element))
-
-(jsx_element) @xml_element.around

--- a/runtime/queries/jsx/textobjects.scm
+++ b/runtime/queries/jsx/textobjects.scm
@@ -1,3 +1,9 @@
 ; See runtime/queries/ecma/README.md for more info.
 
 ; inherits: _jsx,_javascript,ecma
+
+(jsx_self_closing_element) @xml_element.around @xml_element.inside
+
+(jsx_element (jsx_opening_element) (_)* @xml_element.inside (jsx_closing_element))
+
+(jsx_element) @xml_element.around

--- a/runtime/queries/xml/textobjects.scm
+++ b/runtime/queries/xml/textobjects.scm
@@ -1,5 +1,5 @@
-(element (start_tag) (_)* @xml_element.inside (end_tag))
+(element (start_tag) (_)* @xml-element.inside (end_tag))
 
-(element) @xml_element.around
+(element) @xml-element.around
 
-(comment) @comment.around   
+(comment) @comment.around

--- a/runtime/queries/xml/textobjects.scm
+++ b/runtime/queries/xml/textobjects.scm
@@ -1,0 +1,5 @@
+(element (start_tag) (_)* @xml_element.inside (end_tag))
+
+(element) @xml_element.around
+
+(comment) @comment.around   


### PR DESCRIPTION
Building on the work done by @ff2400t this adds text-objects to select xml-like elements in html, jsx and xml files.

Fixes: #6682 

The behaviour is consistent with other text-objects in helix. It is however not consistent with vim's tag textobject:

```html
<p>
  <span> inner_span </span>
</p>
```

If the cursor is on `<span>` `vit` would select ` inner_span ` in vim.
In Helix `mix` will select `  <span> inner_span </span>`
If the cursor is actually inside the tag, both solutions work the same.

I think despite the difference to vim this textobject is very useful and would love to see it in my daily work.