### PR TITLE
Exclude EOL repos from the Repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note: Only certain languages have indentation definitions at the moment. Check
 
 [Installation documentation](https://docs.helix-editor.com/install.html).
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg?exclude_unsupported=1)](https://repology.org/project/helix/versions)
 
 # Contributing
 


### PR DESCRIPTION
This change excludes EOL repos from the Repology packaging status badge.

| Before: | After: |
| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| ![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg) | ![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg?exclude_unsupported=1) |