### PR TITLE
Add a command that displays current hx version

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -88,3 +88,4 @@
 | `:move` | Move the current buffer and its corresponding file to a different path |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |
+| `:version` | Display current hx version |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2523,6 +2523,21 @@ fn read(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
     Ok(())
 }
 
+fn hx_version(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .set_status(format!("Currnet hx version: {}", env!("CARGO_PKG_VERSION")));
+
+    return Ok(());
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "quit",
@@ -3143,6 +3158,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         doc: "Load a file into buffer",
         fun: read,
         signature: CommandSignature::positional(&[completers::filename]),
+    },
+    TypableCommand {
+        name: "version",
+        aliases: &[],
+        doc: "Display current hx version",
+        fun: hx_version,
+        signature: CommandSignature::none(),
     },
 ];
 


### PR DESCRIPTION
I had an idea to add a typed command that displays current hx version in the info bar at the bottom.

This command provides a couple of small quality of life improvements:

- Fixes a mess that happens when troubleshooting with a few helix builds/installations/instances
- Offers quick access to essential information without the need to go and check installed version
- Simplifies the troubleshooting process by allowing to easily verify the current Helix version while diagnosing and resolving issues
- Enhances efficiency by reducing the time and effort required to gather basic system information, allowing to focus on resolving potential issues faster

It looks like this:
![image](https://github.com/user-attachments/assets/f92767d6-affb-44ed-8444-677bdeb88ddd)

![image](https://github.com/user-attachments/assets/b03851b4-43c2-4e98-9555-b7fd9ae3fb72)

I'm new to this project and I already love it ❤️