### PR TITLE
refactor(commands): `trim_end` of `sh` output

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2303,7 +2303,7 @@ fn run_shell_command(
             move |editor: &mut Editor, compositor: &mut Compositor| {
                 if !output.is_empty() {
                     let contents = ui::Markdown::new(
-                        format!("```sh\n{}\n```", output),
+                        format!("```sh\n{}\n```", output.trim_end()),
                         editor.syn_loader.clone(),
                     );
                     let popup = Popup::new("shell", contents).position(Some(


### PR DESCRIPTION
`master`
![image](https://github.com/user-attachments/assets/c9a5a251-d31f-4547-9011-607f9fa939b6)


`pr`
![image](https://github.com/user-attachments/assets/b20021af-d003-4a4e-8c0b-1aed6e3b72bf)

I have noticed that this change seems to be common for shell output, so wondering if we should just trim all shell output or keep with the scoped changes?