### PR TITLE
remove unused import

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -34,7 +34,7 @@ use log::{debug, error, info, warn};
 use std::io::stdout;
 use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 
-use anyhow::{Context, Error};
+use anyhow::{Error};
 
 use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
 #[cfg(not(windows))]


### PR DESCRIPTION
fixes this during compilation
```rust
warning: unused import: `Context`
  --> helix-term\src\application.rs:37:14
   |
37 | use anyhow::{Context, Error};
   |              ^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```