### PR TITLE
update to newest rescript treesitter library and queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1758,7 +1758,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "rescript"
-source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "467dcf99f68c47823d7b378779a6b282d7ef9782" }
+source = { git = "https://github.com/rescript-lang/tree-sitter-rescript", rev = "5e2a44a9d886b0a509f5bfd0437d33b4871fbac5" }
 
 [[language]]
 name = "erlang"

--- a/runtime/queries/rescript/highlights.scm
+++ b/runtime/queries/rescript/highlights.scm
@@ -10,10 +10,9 @@
 [
   (type_identifier)
   (unit_type)
+  (list)
+  (list_pattern)
 ] @type
-
-(list ["list{" "}"] @type)
-(list_pattern ["list{" "}"] @type)
 
 [
   (variant_identifier)
@@ -72,14 +71,16 @@
 ; single parameter with no parens
 (function parameter: (value_identifier) @variable.parameter)
 
+; first-level descructuring (required for nvim-tree-sitter as it only matches direct
+; children and the above patterns do not match destructuring patterns in NeoVim)
+(parameter (tuple_pattern (tuple_item_pattern (value_identifier) @variable.parameter)))
+(parameter (array_pattern (value_identifier) @variable.parameter))
+(parameter (record_pattern (value_identifier) @variable.parameter))
+
 ; Meta
 ;-----
 
-[
- "@"
- "@@"
- (decorator_identifier)
-] @keyword.directive
+(decorator_identifier) @keyword.directive
 
 (extension_identifier) @keyword
 ("%") @keyword
@@ -87,7 +88,7 @@
 ; Misc
 ;-----
 
-; (subscript_expression index: (string) @attribute)
+(subscript_expression index: (string) @attribute)
 (polyvar_type_pattern "#" @constant)
 
 [
@@ -101,18 +102,21 @@
   "external"
   "let"
   "module"
+  "mutable"
   "private"
   "rec"
   "type"
   "and"
   "assert"
-  "async"
   "await"
   "with"
-  "unpack"
-] @keyword.storage.type
+  "lazy"
+  "constraint"
+] @keyword
 
-"mutable" @keyword.storage.modifier
+((function "async" @keyword.storage))
+
+(module_unpack "unpack" @keyword)
 
 [
   "if"
@@ -169,6 +173,7 @@
   "->"
   "|>"
   ":>"
+  "+="
   (uncurry)
 ] @operator
 

--- a/runtime/queries/rescript/injections.scm
+++ b/runtime/queries/rescript/injections.scm
@@ -1,8 +1,29 @@
-((comment) @injection.content
- (#set! injection.language "comment"))
+((comment) @injection.content (#set! injection.language "comment"))
 
-((raw_js) @injection.content
- (#set! injection.language "javascript"))
+; %re
+(extension_expression
+  (extension_identifier) @_name
+  (#eq? @_name "re")
+  (expression_statement (_) @injection.content (#set! injection.language "regex")))
 
-((raw_gql) @injection.content
- (#set! injection.language "graphql"))
+; %raw
+(extension_expression
+  (extension_identifier) @_name
+  (#eq? @_name "raw")
+  (expression_statement
+    (_ (_)  @injection.content (#set! injection.language "javascript"))))
+
+; %graphql
+(extension_expression
+  (extension_identifier) @_name
+  (#eq? @_name "graphql")
+  (expression_statement
+    (_ (_) @injection.content (#set! injection.language "graphql"))))
+
+; %relay
+(extension_expression
+  (extension_identifier) @_name
+  (#eq? @_name "relay")
+  (expression_statement
+    (_ (_) @injection.content (#set! injection.language "graphql") )))
+

--- a/runtime/queries/rescript/locals.scm
+++ b/runtime/queries/rescript/locals.scm
@@ -1,7 +1,7 @@
 (switch_expression) @local.scope
-(if_expression) @local.scope
 
 ; Definitions
 ;------------
-(type_declaration) @local.defintion
-(let_binding) @local.defintion
+(type_declaration) @local.definition
+(let_binding) @local
+(module_declaration) @local.namespace

--- a/runtime/queries/rescript/locals.scm
+++ b/runtime/queries/rescript/locals.scm
@@ -3,5 +3,5 @@
 ; Definitions
 ;------------
 (type_declaration) @local.definition
-(let_binding) @local
-(module_declaration) @local.namespace
+(let_binding) @local.definition
+(module_declaration) @local.definition

--- a/runtime/queries/rescript/textobjects.scm
+++ b/runtime/queries/rescript/textobjects.scm
@@ -1,7 +1,7 @@
 ; Classes (modules)
 ;------------------
 
-(module_declaration definition: ((_) @class.inside)) @class.around
+(module_binding definition: ((_) @class.inside)) @class.around
 
 ; Blocks
 ;-------


### PR DESCRIPTION
The official rescript org tree-sitter repo now includes generated files, helix can depend on it directly.

This MR points to the newest version of the repo, and updates the queries to match the new tree-sitter grammar (coppied from https://github.com/rescript-lang/tree-sitter-rescript/tree/main/queries/rescript)