### PR TITLE
Restore disabled grammars

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1,8 +1,6 @@
 # Language support configuration.
 # See the languages documentation: https://docs.helix-editor.com/master/languages.html
 
-use-grammars = { except = [ "hare", "wren", "gemini" ] }
-
 [language-server]
 
 als = { command = "als" }


### PR DESCRIPTION
This change reverts <https://github.com/helix-editor/helix/pull/9316>, which disables grammars hosted on sr.ht. The outage of sr.ht on January 2024 had been addressed and [its post-mortem](https://sourcehut.org/blog/2024-01-19-outage-post-mortem/) was published on their blog.