### PR TITLE
Wrap selection in siblings if reached boundary sibling

### DIFF
--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -42,11 +42,8 @@ pub fn select_next_sibling(syntax: &Syntax, text: RopeSlice, selection: Selectio
         text,
         selection,
         |cursor| {
-            while !cursor.goto_next_sibling() {
-                if !cursor.goto_parent() {
-                    break;
-                }
-            }
+            cursor.goto_parent_until_has_siblings();
+            cursor.goto_next_sibling_or_wrap();
         },
         Some(Direction::Forward),
     )
@@ -98,11 +95,8 @@ pub fn select_prev_sibling(syntax: &Syntax, text: RopeSlice, selection: Selectio
         text,
         selection,
         |cursor| {
-            while !cursor.goto_prev_sibling() {
-                if !cursor.goto_parent() {
-                    break;
-                }
-            }
+            cursor.goto_parent_until_has_siblings();
+            cursor.goto_prev_sibling_or_wrap();
         },
         Some(Direction::Backward),
     )


### PR DESCRIPTION
This relates to [the discussion about the feature](https://github.com/helix-editor/helix/discussions/10601). This PR implements the behavior of going to the sibling on the other end of the sequence when the boundary sibling is already selected. The initial version needs further refactoring, especially the `goto_last_child` which is an evolved copy of `goto_first_child`. The author publishes this initial version because the-mikedevis requested PR for trying out this behavior first in the [aforementioned discussion](https://github.com/helix-editor/helix/discussions/10601#discussioncomment-9230875).