### PR TITLE
Improve LSP workspace/applyEdit by keeping the editor from switching to normal mode when loading a Document

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1544,7 +1544,9 @@ impl Editor {
             return;
         }
 
-        self.enter_normal_mode();
+        if !matches!(action, Action::Load) {
+            self.enter_normal_mode();
+        }
 
         match action {
             Action::Replace => {


### PR DESCRIPTION
When an existing Document is opened with `Editor::open(path, Action::Load)`, this causes `Editor::switch` to be called.
This in turn resets the mode of the editor to normal mode, even if the loaded Document is not even in the current buffer.
To my knowledge this is only an issue in combination with the LSP `workspace/applyEdit` functionality.
Language servers that heavily utilize `applyEdit` make using helix nearly impossible, as typing and selecting is constantly interrupted by unexpected mode changes.