### PR TITLE
fix(commands): change `pipe`-like output trimming

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5736,14 +5736,20 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
         let output = if let Some(output) = shell_output.as_ref() {
             output.clone()
         } else {
-            let fragment = range.slice(text);
-            match shell_impl(shell, cmd, pipe.then(|| fragment.into())) {
-                Ok(result) => {
-                    let result = Tendril::from(result.trim_end());
-                    if !pipe {
-                        shell_output = Some(result.clone());
+            let input = range.slice(text);
+            match shell_impl(shell, cmd, pipe.then(|| input.into())) {
+                Ok(mut output) => {
+                    if !input.ends_with("\n") && !output.is_empty() && output.ends_with('\n') {
+                        output.pop();
+                        if output.ends_with('\r') {
+                            output.pop();
+                        }
                     }
-                    result
+
+                    if !pipe {
+                        shell_output = Some(output.clone());
+                    }
+                    output
                 }
                 Err(err) => {
                     cx.editor.set_error(err.to_string());


### PR DESCRIPTION
Checks to see if the input ended in a newline to decide if the output should have it trimmed, if it too ended in one, and only ever trim one newline.

This follows Kakoune's [decision](https://github.com/mawww/kakoune/commit/6f135c0c8e4d4d5b66cd6b56394ad7d690a16252) [here](https://github.com/mawww/kakoune/issues/3669) to make sure **input** is not corrupted:
```cc
if (in.back() != '\n' and not out.empty() and out.back() == '\n')
    out.resize(out.length()-1, 0);
```
`pr`:
```rust
if !input.ends_with("\n") && !output.is_empty() && output.ends_with('\n') {
    output.pop();
    // windows
    if output.ends_with('\r') {
        output.pop();
    }
}
```

To note: This still trims a single newline from pipe output if the input selection does not end in a newline.

Closes: #11177