### PR TITLE
add `:edit` and `:e` as aliases for `:open`

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2537,7 +2537,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "open",
-        aliases: &["o"],
+        aliases: &["o", "edit", "e"],
         doc: "Open a file from disk into the current view.",
         fun: open,
         signature: CommandSignature::all(completers::filename),


### PR DESCRIPTION
Vim supports these, and i can't think of any reason helix would want to have a different meaning for `:edit` than `:open`.

note that it is not possible to add this manually in helix configuration until https://github.com/helix-editor/helix/issues/4423 is fixed.

docs: https://vimhelp.org/editing.txt.html#%3Aedit