### PR TITLE
Fixed headings (# / ##) in /book to match other docs

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -1,4 +1,4 @@
-# Adding new languages to Helix
+## Adding new languages to Helix
 
 In order to add a new language to Helix, you will need to follow the steps
 below.

--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -1,4 +1,4 @@
-# Adding indent queries
+## Adding indent queries
 
 Helix uses tree-sitter to correctly indent new lines. This requires a tree-
 sitter grammar and an `indent.scm` query file placed in `runtime/queries/

--- a/book/src/guides/injection.md
+++ b/book/src/guides/injection.md
@@ -1,4 +1,4 @@
-# Adding Injection Queries
+## Adding Injection Queries
 
 Writing language injection queries allows one to highlight a specific node as a different language.
 In addition to the [standard][upstream-docs] language injection options used by tree-sitter, there

--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -1,4 +1,4 @@
-# Adding textobject queries
+## Adding textobject queries
 
 Helix supports textobjects that are language specific, such as functions, classes, etc.
 These textobjects require an accompanying tree-sitter grammar and a `textobjects.scm` query file

--- a/book/src/lang-support.md
+++ b/book/src/lang-support.md
@@ -1,4 +1,4 @@
-# Language Support
+## Language Support
 
 The following languages and Language Servers are supported. To use
 Language Server features, you must first [configure][lsp-config-wiki] the

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -1,4 +1,4 @@
-# Languages
+## Languages
 
 Language-specific settings and settings for language servers are configured
 in `languages.toml` files.

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -1,4 +1,4 @@
-# Key remapping
+## Key remapping
 
 Helix currently supports one-way key remapping through a simple TOML configuration
 file. (More powerful solutions such as rebinding via commands will be

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -1,4 +1,4 @@
-# Themes
+## Themes
 
 To use a theme add `theme = "<name>"` to the top of your [`config.toml`](./configuration.md) file, or select it during runtime using `:theme <name>`.
 


### PR DESCRIPTION
Fixed single `#` headings to match the pattern:

title page - `#`
 - installation - `#`
   - package managers - `##`
   - building from source - `##`
 - usage - `#`
   - registers - `##`
   - surround - `##`
   - textobjects - `##`

etc.

Why is `commands.md` unchanged? Did it in #11152 .