### PR TITLE
gabydd: reverse query precedence order

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1604,7 +1604,7 @@ language-servers = [ "docker-langserver" ]
 
 [[grammar]]
 name = "dockerfile"
-source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = "8ee3a0f7587b2bd8c45c8cb7d28bd414604aec62" }
+source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = "868e44ce378deb68aac902a9db68ff82d2299dd0" }
 
 [[language]]
 name = "docker-compose"
@@ -1864,7 +1864,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "ron"
-source = { git = "https://github.com/zee-editor/tree-sitter-ron", rev = "7762d709a0f7c1f9e269d0125a2e8a7a69006146" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-ron", rev = "78938553b93075e638035f624973083451b29055" }
 
 [[language]]
 name = "robot"

--- a/runtime/queries/zig/highlights.scm
+++ b/runtime/queries/zig/highlights.scm
@@ -7,6 +7,18 @@
   (line_comment)
 ] @comment.line
 
+[
+  variable: (IDENTIFIER)
+  variable_type_function: (IDENTIFIER)
+] @variable
+
+parameter: (IDENTIFIER) @variable.parameter
+
+[
+  field_member: (IDENTIFIER)
+  field_access: (IDENTIFIER)
+] @variable.other.member
+
 ;; assume TitleCase is a type
 (
   [
@@ -36,6 +48,13 @@
   (#match? @constant "^[A-Z][A-Z_0-9]+$")
 )
 
+[
+  function_call: (IDENTIFIER)
+  function: (IDENTIFIER)
+] @function
+
+exception: "!" @keyword.control.exception
+
 ;; _
 (
   (IDENTIFIER) @variable.builtin
@@ -44,25 +63,6 @@
 
 ;; C Pointers [*c]T
 (PtrTypeStart "c" @variable.builtin)
-
-[
-  variable: (IDENTIFIER)
-  variable_type_function: (IDENTIFIER)
-] @variable
-
-parameter: (IDENTIFIER) @variable.parameter
-
-[
-  field_member: (IDENTIFIER)
-  field_access: (IDENTIFIER)
-] @variable.other.member
-
-[
-  function_call: (IDENTIFIER)
-  function: (IDENTIFIER)
-] @function
-
-exception: "!" @keyword.control.exception
 
 field_constant: (IDENTIFIER) @constant
 


### PR DESCRIPTION
this is for: #9458 I started reversing some more queries (only zig for now) and I updated the ron and dockerfile grammars to fix  query-check because they where using new node types, cue has more problems cause we are quite out of sync with the grammar so we should either revert the changes there or fully update to what tree-sitter-neovim is using