### PR TITLE
global_search: Save search when accepting an option

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1031,6 +1031,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     self.handle_prompt_change();
                 } else {
                     if let Some(option) = self.selection() {
+                        self.prompt.save_line_to_history(ctx.editor);
                         (self.callback_fn)(ctx, option, Action::Replace);
                     }
                     return close_fn(self);

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -516,6 +516,16 @@ impl Prompt {
             surface.set_string(line_area.x, line_area.y, self.line.clone(), prompt_color);
         }
     }
+
+    /// Saves the current line to the configured history register, if there is one.
+    pub(crate) fn save_line_to_history(&self, editor: &mut Editor) {
+        let Some(register) = self.history_register else {
+            return;
+        };
+        if let Err(err) = editor.registers.push(register, self.line.clone()) {
+            editor.set_error(err.to_string());
+        }
+    }
 }
 
 impl Component for Prompt {
@@ -603,14 +613,7 @@ impl Component for Prompt {
                         &last_item
                     } else {
                         if last_item != self.line {
-                            // store in history
-                            if let Some(register) = self.history_register {
-                                if let Err(err) =
-                                    cx.editor.registers.push(register, self.line.clone())
-                                {
-                                    cx.editor.set_error(err.to_string());
-                                }
-                            };
+                            self.save_line_to_history(cx.editor);
                         }
 
                         &self.line


### PR DESCRIPTION
The Prompt is set up to push the current line to history when hitting Enter but the Picker doesn't pass the Enter event down to the Prompt (for good reason: we don't want the Prompt's behavior of changing completions when we hit a path separator). We should save the Prompt's line to its configured history register when hitting Enter when there is a selection in the Picker.

This currently only applies to `global_search`'s Picker since it's the only Picker to use `Picker::with_history_register`.

Fixes https://github.com/helix-editor/helix/issues/11205