### PR TITLE
global_search: Save only the primary query to the history register

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1031,8 +1031,16 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     self.handle_prompt_change();
                 } else {
                     if let Some(option) = self.selection() {
-                        self.prompt.save_line_to_history(ctx.editor);
                         (self.callback_fn)(ctx, option, Action::Replace);
+                    }
+                    if let Some(history_register) = self.prompt.history_register() {
+                        if let Err(err) = ctx
+                            .editor
+                            .registers
+                            .push(history_register, self.primary_query().to_string())
+                        {
+                            ctx.editor.set_error(err.to_string());
+                        }
                     }
                     return close_fn(self);
                 }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -128,6 +128,10 @@ impl Prompt {
         self
     }
 
+    pub(crate) fn history_register(&self) -> Option<char> {
+        self.history_register
+    }
+
     pub(crate) fn first_history_completion<'a>(
         &'a self,
         editor: &'a Editor,
@@ -516,16 +520,6 @@ impl Prompt {
             surface.set_string(line_area.x, line_area.y, self.line.clone(), prompt_color);
         }
     }
-
-    /// Saves the current line to the configured history register, if there is one.
-    pub(crate) fn save_line_to_history(&self, editor: &mut Editor) {
-        let Some(register) = self.history_register else {
-            return;
-        };
-        if let Err(err) = editor.registers.push(register, self.line.clone()) {
-            editor.set_error(err.to_string());
-        }
-    }
 }
 
 impl Component for Prompt {
@@ -613,7 +607,14 @@ impl Component for Prompt {
                         &last_item
                     } else {
                         if last_item != self.line {
-                            self.save_line_to_history(cx.editor);
+                            // store in history
+                            if let Some(register) = self.history_register {
+                                if let Err(err) =
+                                    cx.editor.registers.push(register, self.line.clone())
+                                {
+                                    cx.editor.set_error(err.to_string());
+                                }
+                            };
                         }
 
                         &self.line


### PR DESCRIPTION
Two changes from #11209 (which this PR partially reverts):

* Save only the `Picker::primary_query` - so you don't save other parts of the query, for example `%path foo.rs` while in `global_search`.
* Move the saving out of the `if let Some(option) = self.selection()` block. So when you hit enter you save to history whether you have a selection or not. If you want to close the picker without saving to the register you can use C-c or Esc instead.

Fixes https://github.com/helix-editor/helix/issues/11214 and addresses part of https://github.com/helix-editor/helix/issues/11205#issuecomment-2233888741