### PR TITLE
Switch to Hare grammar on GitHub

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1,7 +1,7 @@
 # Language support configuration.
 # See the languages documentation: https://docs.helix-editor.com/master/languages.html
 
-use-grammars = { except = [ "hare", "wren", "gemini" ] }
+use-grammars = { except = [ "wren", "gemini" ] }
 
 [language-server]
 
@@ -2055,7 +2055,7 @@ indent = { tab-width = 8, unit = "\t" }
 
 [[grammar]]
 name = "hare"
-source = { git = "https://git.sr.ht/~ecs/tree-sitter-hare", rev = "07035a248943575444aa0b893ffe306e1444c0ab" }
+source = { git = "https://github.com/omasanori/tree-sitter-hare", rev = "4af5d82cf9ec39f67cb1db5b7a9269d337406592" }
 
 [[language]]
 name = "devicetree"


### PR DESCRIPTION
The idea is to migrate https://github.com/tree-sitter-grammars/tree-sitter-hare so that we can enable Hare support by default. (See https://github.com/helix-editor/helix/pull/9316 for backgrounds.) However, that grammar lacks support for newer syntax. For now, this PR points to my personal fork for ease of development. It will become ready once upstream becomes up-to-date.