### PR TITLE
tree-sitter: Update SHA of parser fro the slint language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2373,7 +2373,7 @@ language-servers = [ "slint-lsp" ]
 
 [[grammar]]
 name = "slint"
-source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "0701312b74b87fe20e61aa662ba41c5815b5d428" }
+source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "4a0558cc0fcd7a6110815b9bbd7cc12d7ab31e74" }
 
 [[language]]
 name = "task"


### PR DESCRIPTION
There has been a new release with a few minor tweaks to the parser. The queries are fine still.