### PR TITLE
Fix bug preventing toggling key with a single value

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1953,8 +1953,8 @@ fn toggle_option(
         }
         Value::String(ref value) => {
             ensure!(
-                args.len() > 2,
-                "Bad arguments. For string configurations use: `:toggle key val1 val2 ...`",
+                args.len() >= 2,
+                "Bad arguments. For string configurations use: `:toggle key val1 [val2 ...]`",
             );
 
             Value::String(
@@ -1968,8 +1968,8 @@ fn toggle_option(
         }
         Value::Number(ref value) => {
             ensure!(
-                args.len() > 2,
-                "Bad arguments. For number configurations use: `:toggle key val1 val2 ...`",
+                args.len() >= 2,
+                "Bad arguments. For number configurations use: `:toggle key val1 [val2 ...]`",
             );
 
             Value::Number(


### PR DESCRIPTION
It's not possible to toggle a key with a single value, such as with

```
:toggle inline-diagnostics.cursor-line warning
```

The above results in the following error:

```
Bad arguments. For string configurations use: `:toggle key val1 val2 ...
```

It looks like the intention behind settings multiple values was to allow cycling between a set of options, but this shouldn't prevent the use of `:toggle` to set a key to a single value. This PR fixes that.