### PR TITLE
update shebangs language configuration for Tcl

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3477,7 +3477,7 @@ name = "tcl"
 scope = "source.tcl"
 injection-regex = "tcl"
 file-types = [ "tcl" ]
-shebangs = [ "tclish", "jimsh", "wish" ]
+shebangs = [ "tclsh", "tclish", "jimsh", "wish" ]
 comment-token = '#'
 
 [[grammar]]


### PR DESCRIPTION
The primary executable that comes with Tcl is `tclsh`. Not really sure what `tclish` is, as I initially thought it was a typo. However, there seems to be references to it based on a quick search (e.g. [here](https://wiki.tcl-lang.org/page/Tclish) and [here](https://tclish.sourceforge.net/)), so maybe it's a valid executable that I just haven't been aware of. I was hesitant to replace it and instead opted to just add `tclsh`.