### PR TITLE
refactor(commands): output `stderr` in `:sh` popup

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5708,9 +5708,7 @@ async fn shell_impl_async(
                 None => bail!("Shell command failed"),
             }
         }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        log::error!("Shell error: {stderr}");
-        stderr
+        String::from_utf8_lossy(&output.stderr)
         // Prioritize `stderr` output over `stdout`
     } else if !output.stderr.is_empty() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5708,19 +5708,16 @@ async fn shell_impl_async(
                 None => bail!("Shell command failed"),
             }
         }
-        let err = std::str::from_utf8(&output.stderr)
-            .map_err(|_| anyhow!("Process did not output valid UTF-8"))?;
-        log::error!("Shell error: {err}");
-        err
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::error!("Shell error: {stderr}");
+        stderr
         // Prioritize `stderr` output over `stdout`
     } else if !output.stderr.is_empty() {
-        let err = std::str::from_utf8(&output.stderr)
-            .map_err(|_| anyhow!("Process did not output valid UTF-8"))?;
-        log::debug!("Command printed to stderr: {err}");
-        err
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::debug!("Command printed to stderr: {stderr}");
+        stderr
     } else {
-        std::str::from_utf8(&output.stdout)
-            .map_err(|_| anyhow!("Process did not output valid UTF-8"))?
+        String::from_utf8_lossy(&output.stdout)
     };
 
     Ok(Tendril::from(output))

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2308,7 +2308,7 @@ fn run_shell_command(
                     ));
                     compositor.replace_or_push("shell", popup);
                 }
-                editor.set_status("Command succeeded");
+                editor.set_status("Command run");
             },
         ));
         Ok(call)


### PR DESCRIPTION
Rather than getting the error in the one row of the status bar, and needing to check the logs to see what the error actually was, it now outputs to the popup. This doesn't address every use case, but for when it's sufficient, its a very nice quality of life improvement. Other options could come later to improve this, like what was said [here](https://github.com/helix-editor/helix/issues/2700#issuecomment-1206328317)
> A horizontal split with a scratch buffer similar to what log does could be a good approach

But I don't see a reason not to have a quick fix for something now.

![sh_stderr_output](https://github.com/user-attachments/assets/e60d7b6e-8f5a-40d3-941a-a5ef8ead0f79)

Connects: #2700