### PR TITLE
CI/AppImage: Make anylinux appimage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,8 +203,17 @@ jobs:
               --appdir "$APP.AppDir" -d contrib/Helix.desktop \
               -i contrib/helix.png --output appimage
 
-          mv "$APP-$VERSION-$ARCH.AppImage" \
-              "$APP-$VERSION-$ARCH.AppImage.zsync" dist
+          # anylinux appimage
+          APPIMAGETOOL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - \
+          | sed 's/[()",{} ]/\n/g' | grep -oi 'https.*continuous.*tool.*86_64.*mage$')
+          wget -q "$APPIMAGETOOL" -O ./appimagetool
+          chmod +x ./appimagetool
+          "$APP-$VERSION-$ARCH.AppImage" --appimage-extract
+          ./appimagetool -s deploy squashfs-root/usr/share/applications/Helix.desktop
+          ARCH=x86_64 VERSION="$VERSION-anylinux" ./appimagetool -s squashfs-root
+          mv *anylinux*AppImage dist
+          mv "$APP"-*-"$ARCH.AppImage".AppImage \
+              "$APP"-*-"$ARCH.AppImage".AppImage.zsync dist
 
       - name: Build archive
         shell: bash


### PR DESCRIPTION
Uses this [appimagetool ](https://github.com/probonopd/go-appimage)which has a deploy everything mode that bundles glibc in the appimage that makes the appimage be able to run in any distro, be it very old distros or even musl distros. It also uses a static runtime which prevents the no libfuse2 issues in newer distros.

Note that I'm not replacing the existing appimage made with linuxdeploy, I'm adding an extra one, because go-appimage doesn't support the same arguments as linuxdeploy and also because there is a regression that the new appimage runtime has a hardcoded path to `/usr/bin/fusermount*` which means that some distros that keep `/bin` and `/usr/bin` separated might have trouble launching the appimage unless `fusermount` is symlinked to `/usr/bin` or the `FUSERMOUNT_PROG` env variable is set.

Fixes #11103