### PR TITLE
Make bash completion behave normally

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -2,23 +2,31 @@
 # Bash completion script for Helix editor
 
 _hx() {
-	# $1 command name
-	# $2 word being completed
-	# $3 word preceding
+    local cur prev languages
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
 
-	case "$3" in
-	-g | --grammar)
-		COMPREPLY="$(compgen -W 'fetch build' -- $2)"
-		;;
-	--health)
-		local languages=$(hx --health |tail -n '+7' |awk '{print $1}' |sed 's/\x1b\[[0-9;]*m//g')
-		COMPREPLY="$(compgen -W """$languages""" -- $2)"
-		;;
-	*)
-		COMPREPLY="$(compgen -fd -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")"
-		;;
-	esac
+    case "$prev" in
+    -g | --grammar)
+        COMPREPLY=($(compgen -W 'fetch build' -- "$cur"))
+        return 0
+        ;;
+    --health)
+        languages=$(hx --health | tail -n '+7' | awk '{print $1}' | sed 's/\x1b\[[0-9;]*m//g')
+        COMPREPLY=($(compgen -W """$languages""" -- "$cur"))
+        return 0
+        ;;
+    esac
 
-	local IFS=$'\n'
-	COMPREPLY=($COMPREPLY)
+    case "$2" in
+    -*)
+        COMPREPLY=($(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2"""))
+        return 0
+        ;;
+    *)
+        COMPREPLY=($(compgen -fd -- """$2"""))
+        return 0
+        ;;
+    esac
 } && complete -o filenames -F _hx hx


### PR DESCRIPTION
Hi,
while I try to using helix the completion kept presenting me the flags even if I never tiped `-`.

![Screenshot from 2024-07-20 00-38-25](https://github.com/user-attachments/assets/120e7070-292c-4f18-8333-b878aa81f7bc)

Since I think this is not how completion should work I refactored so it behaves more sanely.

https://github.com/user-attachments/assets/acd49cee-d00d-432c-a654-5d025408f57a
