### PR TITLE
contrib: add nushell completions

### DIFF
--- a/contrib/completion/hx.nu
+++ b/contrib/completion/hx.nu
@@ -1,0 +1,25 @@
+# Completions for Helix: <https://github.com/helix-editor/helix>
+#
+# NOTE: the `+N` syntax is not supported in Nushell (https://github.com/nushell/nushell/issues/13418)
+#       so it has not been specified here and will not be proposed in the autocompletion of Nushell.
+#       The help message won't be overriden though, so it will still be present here
+
+def health_categories [] { ["all", "clipboard", "languages"] }
+
+def grammar_categories [] { ["fetch", "build"] }
+
+# A post-modern text editor.
+export extern hx [
+    --help(-h),                                 # Prints help information
+    --tutor,                                    # Loads the tutorial
+    --health: string@health_categories = "all", # Checks for potential errors in editor setup
+    --grammar(-g): string@grammar_categories,   # Fetches or builds tree-sitter grammars listed in `languages.toml`
+    --config(-c): glob,                         # Specifies a file to use for configuration
+    -v,                                         # Increases logging verbosity each use for up to 3 times
+    --log: glob,                                # Specifies a file to use for logging
+    --version(-V),                              # Prints version information
+    --vsplit,                                   # Splits all given files vertically into different windows
+    --hsplit,                                   # Splits all given files horizontally into different windows
+    --working-dir(-w): glob,                    # Specify an initial working directory
+    ...files: glob,                             # Sets the input file to use, position can also be specified via file[:row[:col]]
+]


### PR DESCRIPTION
See the note at the top of the file, it's not perfect, but it does 99% of the job:

### Completions

Toplevel:

<img width="614" alt="Top level tab-completions in nushell" src="https://github.com/user-attachments/assets/827a83e4-5158-4f00-9d2b-15d0b22e1da8">

`--heath` completions:

<img width="386" alt="Tab completions for --health" src="https://github.com/user-attachments/assets/485f2579-edf0-4aa6-a476-122b0ac2ba4b">

`--grammar` completions:

<img width="236" alt="Tab completions for --grammar" src="https://github.com/user-attachments/assets/d8a2f88a-25c9-47dc-a5fe-7505a3d59da8">
