### PR TITLE
fix(lsp): `find_completion_range` off-by-one

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -284,10 +284,8 @@ pub mod util {
         if replace_mode {
             end += text
                 .chars_at(cursor)
-                .skip(1)
                 .take_while(|ch| chars::char_is_word(*ch))
-                .count()
-                + 1;
+                .count();
         }
         (start, end)
     }


### PR DESCRIPTION
Fixes an off-by-one error that caused index out of bounds for some LSP responses, or the eating of newlines for others. 

Fixes: #10689