### PR TITLE
Revert `kanagawa` diff colour change from #11187

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -64,12 +64,9 @@ info = "dragonBlue"
 hint = "waveAqua1"
 
 ## Diff
-"diff.plus" = "winterGreen"
-"diff.plus.gutter" = "autumnGreen"
-"diff.minus" = "winterRed"
-"diff.minus.gutter" = "autumnRed"
-"diff.delta" = "winterBlue"
-"diff.delta.gutter" = "autumnYellow"
+"diff.plus" = "autumnGreen"
+"diff.minus" = "autumnRed"
+"diff.delta" = "autumnYellow"
 
 ## Syntax highlighting
 "attribute" = "waveRed"


### PR DESCRIPTION
Turns out `winter*` are meant for background colours and makes text marked as `@diff.*` really hard to read.