### PR TITLE
Add support for `jjdescription` files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -96,6 +96,7 @@
 | java | ✓ | ✓ | ✓ | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jinja | ✓ |  |  |  |
+| jjdescription | ✓ |  |  |  |
 | jsdoc | ✓ |  |  |  |
 | json | ✓ | ✓ | ✓ | `vscode-json-language-server` |
 | json5 | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3203,6 +3203,19 @@ grammar = "jinja2"
 name = "jinja2"
 source = { git = "https://github.com/varpeti/tree-sitter-jinja2", rev = "a533cd3c33aea6acb0f9bf9a56f35dcfe6a8eb53" }
 
+[[language]]
+name = "jjdescription"
+scope = "jj.description"
+file-types = [{ glob = "*.jjdescription" }]
+comment-token = "JJ:"
+indent = { tab-width = 2, unit = "  " }
+rulers = [51, 73]
+text-width = 72
+
+[[grammar]]
+name = "jjdescription"
+source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "2ddec6cad07b366aee276a608e1daa2c29d3caf2" }
+
 [[grammar]]
 name = "wren"
 source = { git = "https://git.sr.ht/~jummit/tree-sitter-wren", rev = "6748694be32f11e7ec6b5faeb1b48ca6156d4e06" }

--- a/runtime/queries/jjdescription/highlights.scm
+++ b/runtime/queries/jjdescription/highlights.scm
@@ -1,0 +1,8 @@
+(text) @string
+(filepath) @string.special.path
+
+(change type: "A" @diff.plus)
+(change type: "D" @diff.minus)
+(change type: "M" @diff.delta)
+
+(comment) @comment


### PR DESCRIPTION
Basic highlighting support for `jjdescription` files.
Language rules are copied from `git-commit` as they're essentially the same thing currently.

Default theme preview:
![image](https://github.com/user-attachments/assets/dfa82964-8956-4bfd-93e5-08dcd6f79ede)
