### PR TITLE
Return document display name from the `%` special register

### DIFF
--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -5,7 +5,6 @@ use helix_core::NATIVE_LINE_ENDING;
 
 use crate::{
     clipboard::{get_clipboard_provider, ClipboardProvider, ClipboardType},
-    document::SCRATCH_BUFFER_NAME,
     Editor,
 };
 
@@ -61,14 +60,7 @@ impl Registers {
                 Some(RegisterValues::new(doc.selection(view.id).fragments(text)))
             }
             '%' => {
-                let doc = doc!(editor);
-
-                let path = doc
-                    .path()
-                    .as_ref()
-                    .map(|p| p.to_string_lossy())
-                    .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
-
+                let path = doc!(editor).display_name();
                 Some(RegisterValues::new(iter::once(path)))
             }
             '*' | '+' => Some(read_from_clipboard(


### PR DESCRIPTION
This matches Kakoune's behavior. Its '%' special register returns the current buffer's "display path" which is the same as our `Document::display_name`: a relative path, or a path with a tilde (if the path is under the home dir) or an absolute path otherwise, and `SCRATCH_BUFFER_NAME` if the doc has no path.