### PR TITLE
Add file browser

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -100,6 +100,9 @@
 | `file_picker` | Open file picker | normal: `` <space>f ``, select: `` <space>f `` |
 | `file_picker_in_current_buffer_directory` | Open file picker at current buffer's directory |  |
 | `file_picker_in_current_directory` | Open file picker at current working directory | normal: `` <space>F ``, select: `` <space>F `` |
+| `file_browser` | Open file browser in workspace root | normal: `` <space>e ``, select: `` <space>e `` |
+| `file_browser_in_current_buffer_directory` | Open file browser at current buffer's directory | normal: `` <space>E ``, select: `` <space>E `` |
+| `file_browser_in_current_directory` | Open file browser at current working directory |  |
 | `code_action` | Perform code action | normal: `` <space>a ``, select: `` <space>a `` |
 | `buffer_picker` | Open buffer picker | normal: `` <space>b ``, select: `` <space>b `` |
 | `jumplist_picker` | Open jumplist picker | normal: `` <space>j ``, select: `` <space>j `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2994,7 +2994,7 @@ fn file_browser(cx: &mut Context) {
             .set_error("Current working directory does not exist");
         return;
     }
-    let picker = ui::file_browser(cwd, &cx.editor.config());
+    let picker = ui::file_browser(cwd);
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -393,7 +393,7 @@ impl MappableCommand {
         file_picker, "Open file picker",
         file_picker_in_current_buffer_directory, "Open file picker at current buffer's directory",
         file_picker_in_current_directory, "Open file picker at current working directory",
-        file_browser, "Open file browser at current buffer's directory",
+        file_browser, "Open file browser at current working directory",
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
@@ -2994,8 +2994,9 @@ fn file_browser(cx: &mut Context) {
             .set_error("Current working directory does not exist");
         return;
     }
-    let picker = ui::file_browser(cwd);
-    cx.push_layer(Box::new(overlaid(picker)));
+    if let Ok(picker) = ui::file_browser(cwd) {
+        cx.push_layer(Box::new(overlaid(picker)));
+    }
 }
 
 fn buffer_picker(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2996,7 +2996,7 @@ fn file_browser(cx: &mut Context) {
         return;
     }
 
-    if let Ok(picker) = ui::file_browser(root) {
+    if let Ok(picker) = ui::file_browser(root, cx.editor) {
         cx.push_layer(Box::new(overlaid(picker)));
     }
 }
@@ -3023,7 +3023,7 @@ fn file_browser_in_current_buffer_directory(cx: &mut Context) {
         }
     };
 
-    if let Ok(picker) = ui::file_browser(path) {
+    if let Ok(picker) = ui::file_browser(path, cx.editor) {
         cx.push_layer(Box::new(overlaid(picker)));
     }
 }
@@ -3036,7 +3036,7 @@ fn file_browser_in_current_directory(cx: &mut Context) {
         return;
     }
 
-    if let Ok(picker) = ui::file_browser(cwd) {
+    if let Ok(picker) = ui::file_browser(cwd, cx.editor) {
         cx.push_layer(Box::new(overlaid(picker)));
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -393,6 +393,7 @@ impl MappableCommand {
         file_picker, "Open file picker",
         file_picker_in_current_buffer_directory, "Open file picker at current buffer's directory",
         file_picker_in_current_directory, "Open file picker at current working directory",
+        file_browser, "Open file browser at current buffer's directory",
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
@@ -2983,6 +2984,17 @@ fn file_picker_in_current_directory(cx: &mut Context) {
         return;
     }
     let picker = ui::file_picker(cwd, &cx.editor.config());
+    cx.push_layer(Box::new(overlaid(picker)));
+}
+
+fn file_browser(cx: &mut Context) {
+    let cwd = helix_stdx::env::current_working_dir();
+    if !cwd.exists() {
+        cx.editor
+            .set_error("Current working directory does not exist");
+        return;
+    }
+    let picker = ui::file_browser(cwd, &cx.editor.config());
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2995,8 +2995,14 @@ fn file_browser(cx: &mut Context) {
     let path = match doc_dir {
         Some(path) => path,
         None => {
-            cx.editor.set_error("Current buffer has no path or parent");
-            return;
+            let cwd = helix_stdx::env::current_working_dir();
+            if !cwd.exists() {
+                cx.editor.set_error(
+                    "Current buffer has no parent and current working directory does not exist",
+                );
+                return;
+            }
+            cwd
         }
     };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -393,7 +393,9 @@ impl MappableCommand {
         file_picker, "Open file picker",
         file_picker_in_current_buffer_directory, "Open file picker at current buffer's directory",
         file_picker_in_current_directory, "Open file picker at current working directory",
-        file_browser, "Open file browser at current buffer's directory",
+        file_browser, "Open file browser in workspace root",
+        file_browser_in_current_buffer_directory, "Open file browser at current buffer's directory",
+        file_browser_in_current_directory, "Open file browser at current working directory",
         code_action, "Perform code action",
         buffer_picker, "Open buffer picker",
         jumplist_picker, "Open jumplist picker",
@@ -2988,6 +2990,18 @@ fn file_picker_in_current_directory(cx: &mut Context) {
 }
 
 fn file_browser(cx: &mut Context) {
+    let root = find_workspace().0;
+    if !root.exists() {
+        cx.editor.set_error("Workspace directory does not exist");
+        return;
+    }
+
+    if let Ok(picker) = ui::file_browser(root) {
+        cx.push_layer(Box::new(overlaid(picker)));
+    }
+}
+
+fn file_browser_in_current_buffer_directory(cx: &mut Context) {
     let doc_dir = doc!(cx.editor)
         .path()
         .and_then(|path| path.parent().map(|path| path.to_path_buf()));
@@ -3002,11 +3016,27 @@ fn file_browser(cx: &mut Context) {
                 );
                 return;
             }
+            cx.editor.set_error(
+                "Current buffer has no parent, opening file browser in current working directory",
+            );
             cwd
         }
     };
 
     if let Ok(picker) = ui::file_browser(path) {
+        cx.push_layer(Box::new(overlaid(picker)));
+    }
+}
+
+fn file_browser_in_current_directory(cx: &mut Context) {
+    let cwd = helix_stdx::env::current_working_dir();
+    if !cwd.exists() {
+        cx.editor
+            .set_error("Current working directory does not exist");
+        return;
+    }
+
+    if let Ok(picker) = ui::file_browser(cwd) {
         cx.push_layer(Box::new(overlaid(picker)));
     }
 }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -222,6 +222,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "space" => { "Space"
             "f" => file_picker,
             "F" => file_picker_in_current_directory,
+            "e" => file_browser,
+            "E" => file_browser_in_current_buffer_directory,
             "b" => buffer_picker,
             "j" => jumplist_picker,
             "s" => symbol_picker,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -278,7 +278,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 }
 
 pub fn file_browser(root: PathBuf) -> Result<FilePicker, std::io::Error> {
-    let root = root.canonicalize()?;
+    let root = helix_stdx::path::canonicalize(root);
     let directory_content = directory_content(&root)?;
 
     let columns = [PickerColumn::new(

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -303,11 +303,11 @@ pub fn file_browser(root: PathBuf, editor: &Editor) -> Result<FileBrowser, std::
         (root, directory_style),
         move |cx, (path, is_dir): &(PathBuf, bool), action| {
             if *is_dir {
-                let owned_path = path.clone();
+                let new_root = helix_stdx::path::normalize(path);
                 let callback = Box::pin(async move {
                     let call: Callback =
                         Callback::EditorCompositor(Box::new(move |editor, compositor| {
-                            if let Ok(picker) = file_browser(owned_path, editor) {
+                            if let Ok(picker) = file_browser(new_root, editor) {
                                 compositor.push(Box::new(overlay::overlaid(picker)));
                             }
                         }));

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -30,6 +30,7 @@ pub use text::Text;
 
 use helix_view::Editor;
 
+use std::path::Path;
 use std::{error::Error, path::PathBuf};
 
 struct Utf8PathBuf {
@@ -274,6 +275,58 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
         });
     }
     picker
+}
+
+pub fn file_browser(root: PathBuf, _config: &helix_view::editor::Config) -> FilePicker {
+    let directory_content = directory_content(&root);
+
+    let columns = [PickerColumn::new(
+        "path",
+        |item: &PathBuf, root: &PathBuf| {
+            item.strip_prefix(root)
+                .unwrap_or(item)
+                .to_string_lossy()
+                .into()
+        },
+    )];
+    let picker = Picker::new(columns, 0, [], root, move |cx, path: &PathBuf, action| {
+        if let Err(e) = cx.editor.open(path, action) {
+            let err = if let Some(err) = e.source() {
+                format!("{}", err)
+            } else {
+                format!("unable to open \"{}\"", path.display())
+            };
+            cx.editor.set_error(err);
+        }
+    })
+    .with_preview(|_editor, path| Some((path.as_path().into(), None)));
+    let injector = picker.injector();
+
+    if let Ok(files) = directory_content {
+        for file in files {
+            if injector.push(file).is_err() {
+                break;
+            }
+        }
+    }
+    picker
+}
+
+fn directory_content(path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(path)?.flatten() {
+        let entry_path = entry.path();
+        if entry.path().is_dir() {
+            dirs.push(entry_path);
+        } else {
+            files.push(entry_path);
+        }
+    }
+    dirs.sort();
+    files.sort();
+    dirs.extend(files);
+    Ok(dirs)
 }
 
 pub mod completers {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -278,6 +278,7 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 }
 
 pub fn file_browser(root: PathBuf) -> Result<FilePicker, std::io::Error> {
+    let root = root.canonicalize()?;
     let directory_content = directory_content(&root)?;
 
     let columns = [PickerColumn::new(
@@ -335,8 +336,15 @@ fn directory_content(path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
     }
     dirs.sort();
     files.sort();
-    dirs.extend(files);
-    Ok(dirs)
+
+    let mut content = Vec::new();
+    if path.parent().is_some() {
+        log::warn!("{}", path.to_string_lossy());
+        content.insert(0, path.join(".."));
+    }
+    content.extend(dirs);
+    content.extend(files);
+    Ok(content)
 }
 
 pub mod completers {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -85,6 +85,7 @@ pub type FileLocation<'a> = (PathOrId<'a>, Option<(usize, usize)>);
 
 pub enum CachedPreview {
     Document(Box<Document>),
+    Directory(Vec<String>),
     Binary,
     LargeFile,
     NotFound,
@@ -106,12 +107,20 @@ impl Preview<'_, '_> {
         }
     }
 
+    fn dir_content(&self) -> Option<&Vec<String>> {
+        match self {
+            Preview::Cached(CachedPreview::Directory(dir_content)) => Some(dir_content),
+            _ => None,
+        }
+    }
+
     /// Alternate text to show for the preview.
     fn placeholder(&self) -> &str {
         match *self {
             Self::EditorDocument(_) => "<Invalid file location>",
             Self::Cached(preview) => match preview {
                 CachedPreview::Document(_) => "<Invalid file location>",
+                CachedPreview::Directory(_) => "<Invalid directory location>",
                 CachedPreview::Binary => "<Binary file>",
                 CachedPreview::LargeFile => "<File too large to preview>",
                 CachedPreview::NotFound => "<File not found>",
@@ -584,33 +593,52 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 }
 
                 let path: Arc<Path> = path.into();
-                let data = std::fs::File::open(&path).and_then(|file| {
-                    let metadata = file.metadata()?;
-                    // Read up to 1kb to detect the content type
-                    let n = file.take(1024).read_to_end(&mut self.read_buffer)?;
-                    let content_type = content_inspector::inspect(&self.read_buffer[..n]);
-                    self.read_buffer.clear();
-                    Ok((metadata, content_type))
-                });
-                let preview = data
-                    .map(
-                        |(metadata, content_type)| match (metadata.len(), content_type) {
-                            (_, content_inspector::ContentType::BINARY) => CachedPreview::Binary,
-                            (size, _) if size > MAX_FILE_SIZE_FOR_PREVIEW => {
-                                CachedPreview::LargeFile
+                let preview = std::fs::metadata(&path)
+                    .and_then(|metadata| {
+                        if metadata.is_dir() {
+                            let files = super::directory_content(&path)?;
+                            let file_names: Vec<_> = files
+                                .iter()
+                                .filter_map(|file| file.file_name())
+                                .map(|name| name.to_string_lossy().into_owned())
+                                .collect();
+                            Ok(CachedPreview::Directory(file_names))
+                        } else if metadata.is_file() {
+                            if metadata.len() > MAX_FILE_SIZE_FOR_PREVIEW {
+                                return Ok(CachedPreview::LargeFile);
                             }
-                            _ => Document::open(&path, None, None, editor.config.clone())
-                                .map(|doc| {
+                            let content_type = std::fs::File::open(&path).and_then(|file| {
+                                // Read up to 1kb to detect the content type
+                                let n = file.take(1024).read_to_end(&mut self.read_buffer)?;
+                                let content_type =
+                                    content_inspector::inspect(&self.read_buffer[..n]);
+                                self.read_buffer.clear();
+                                Ok(content_type)
+                            })?;
+                            if content_type.is_binary() {
+                                return Ok(CachedPreview::Binary);
+                            }
+                            Document::open(&path, None, None, editor.config.clone()).map_or(
+                                Err(std::io::Error::new(
+                                    std::io::ErrorKind::NotFound,
+                                    "Cannot open document",
+                                )),
+                                |doc| {
                                     // Asynchronously highlight the new document
                                     helix_event::send_blocking(
                                         &self.preview_highlight_handler,
                                         path.clone(),
                                     );
-                                    CachedPreview::Document(Box::new(doc))
-                                })
-                                .unwrap_or(CachedPreview::NotFound),
-                        },
-                    )
+                                    Ok(CachedPreview::Document(Box::new(doc)))
+                                },
+                            )
+                        } else {
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "Neither a dir, nor a file",
+                            ))
+                        }
+                    })
                     .unwrap_or(CachedPreview::NotFound);
                 self.preview_cache.insert(path.clone(), preview);
                 Some((Preview::Cached(&self.preview_cache[&path]), range))
@@ -844,6 +872,20 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                     doc
                 }
                 _ => {
+                    if let Some(dir_content) = preview.dir_content() {
+                        for (i, entry) in dir_content.iter().take(inner.height as usize).enumerate()
+                        {
+                            surface.set_stringn(
+                                inner.x,
+                                inner.y + i as u16,
+                                entry,
+                                inner.width as usize,
+                                text,
+                            );
+                        }
+                        return;
+                    }
+
                     let alt_text = preview.placeholder();
                     let x = inner.x + inner.width.saturating_sub(alt_text.len() as u16) / 2;
                     let y = inner.y + inner.height / 2;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -599,8 +599,14 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                             let files = super::directory_content(&path)?;
                             let file_names: Vec<_> = files
                                 .iter()
-                                .filter_map(|file| file.file_name())
-                                .map(|name| name.to_string_lossy().into_owned())
+                                .filter_map(|file| {
+                                    let name = file.file_name()?.to_string_lossy();
+                                    if file.is_dir() {
+                                        Some(format!("{}/", name))
+                                    } else {
+                                        Some(name.into_owned())
+                                    }
+                                })
                                 .collect();
                             Ok(CachedPreview::Directory(file_names))
                         } else if metadata.is_file() {


### PR DESCRIPTION
This is a minimal implementation of the file browser, which would probably cover a lot of requirements in #200. The whole thing works analogous to the https://github.com/nvim-telescope/telescope-file-browser.nvim as suggested in [this comment](https://github.com/helix-editor/helix/issues/200#issuecomment-1340815804). Even though the resolution of the discussion seems to be "file tree/browser is too hard, it should be implemented as a plugin", I feel like my changes are quite small and natural to be considered for adding to the core nonetheless.

The implementation simply builds on the existing file picker and only modifies 3 files, so the added maintenance burden should be quite small. The code itself is not particularly elegant (in my rather inexperienced opinion), but I did not want to over-complicate things. This is also the reason why some features might be missing.

Feel free to modify this PR or simply make suggestions, I'd be happy to improve it. This is also my first PR here, so sorry if I miss anything.