### PR TITLE
feat(language): just module extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3073,7 +3073,7 @@ source = { git = "https://github.com/lefp/tree-sitter-opencl", rev = "8e1d24a570
 [[language]]
 name = "just"
 scope = "source.just"
-file-types = [{ glob = "justfile" }, { glob = "Justfile" }, { glob = ".justfile" }, { glob = ".Justfile" }]
+file-types = ["just", { glob = "justfile" }, { glob = "Justfile" }, { glob = ".justfile" }, { glob = ".Justfile" }]
 injection-regex = "just"
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }


### PR DESCRIPTION
`just` has modules (see https://github.com/casey/just#modules1190) (since 1.19, stable 1.31) which are files defined as `foo.just`, `foo/mod.just`, `foo/justfile`, or `foo/.justfile` with the latter two having any capitalization.

This pr adds the file extension `just` for `just`/`justfile`s