### PR TITLE
Tombstone LSP clients stopped with `:lsp-stop`

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -675,7 +675,7 @@ impl Registry {
 
     pub fn remove_by_id(&mut self, id: LanguageServerId) {
         let Some(client) = self.inner.remove(id) else {
-            log::error!("client was already removed");
+            log::debug!("client was already removed");
             return;
         };
         self.file_event_handler.remove_client(id);


### PR DESCRIPTION
Currently if you stop language server(s) for a file with `:lsp-stop` and then open another file from that language, the language server(s) will be restarted. Instead of removing the language server info entirely when we `:lsp-stop`, we can replace the records in the registry with a "tombstone" which prevents automatic restarts by `Registry::get`.

Closes #11319 