### PR TITLE
Update

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -480,7 +480,7 @@
  Note: Whenever you delete or change text, Helix will copy the
        altered text. Use Alt-d / Alt-c instead to avoid this.
  Note: Helix doesn't share the system clipboard by default. Type
-       Space + y / p to yank / paste on the system's clipboard.
+       Space + y to yank / p to paste on the system's clipboard.
 
 =================================================================
 =                     4.3 SEARCHING IN FILE                     =


### PR DESCRIPTION
I would like to propose this change in `hx --tutor`, because I feel like the current version might be a bit confusing on first read.
Due to the placement of the slashes (/), one might read this as / **p to yank** /.
This had originally tripped me up as well,and I feel like this small change might fix that, while still keeping the text concise.

Please do let me know, if this goes against some style that's been agreed upong within Helix.

Thanks! :)