### PR TITLE
lock unicode width

### DIFF
--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -23,7 +23,11 @@ ropey = { version = "1.6.1", default-features = false, features = ["simd"] }
 smallvec = "1.13"
 smartstring = "1.0.1"
 unicode-segmentation = "1.11"
-unicode-width = "0.1"
+# unicode-width is changing width definitions
+# that both break our logic and disagree with common
+# width definitions in terminals, we need to replace it.
+# For now lets lock the version to avoid 
+unicode-width = "=0.1.12"
 unicode-general-category = "0.6"
 slotmap.workspace = true
 tree-sitter.workspace = true

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -26,7 +26,8 @@ unicode-segmentation = "1.11"
 # unicode-width is changing width definitions
 # that both break our logic and disagree with common
 # width definitions in terminals, we need to replace it.
-# For now lets lock the version to avoid 
+# For now lets lock the version to avoid rendering glitches
+# when installing without `--locked`
 unicode-width = "=0.1.12"
 unicode-general-category = "0.6"
 slotmap.workspace = true


### PR DESCRIPTION
Cargo automatically bumbs the patch version when installed with `cargo install`
without the locked flag. That creates weird rendering artifacts as unicode-width changes width definitions in a minor release (in a way incompatible with our logic and most terminals). I have my own version of this crate taht I created a long time ago that we should switch to at some point.
