### PR TITLE
Disable hard link integration test on Android

### DIFF
--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -650,6 +650,7 @@ async fn test_symlink_write_relative() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "android"))]
 async fn test_hardlink_write() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
 


### PR DESCRIPTION
Non-rooted Android typically doesn't have permission to use hard links at all, so this test fails on Android.
