### PR TITLE
Small bogster theme improvements

### DIFF
--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -61,7 +61,8 @@
 "ui.virtual.ruler" = { bg = "bogster-base0" }
 "ui.virtual.jump-label" = { fg = "bogster-base0", bg = "bogster-yellow", modifiers = [ "bold" ] }
 
-"ui.selection" = { bg = "bogster-base3" }
+"ui.selection" = { bg = "bogster-base2" }
+"ui.selection.primary" = { bg = "bogster-base3" }
 "ui.cursor.match" = { fg = "bogster-base3", bg = "bogster-orange" }
 "ui.cursor" = { fg = "bogster-base5", modifiers = ["reversed"] }
 

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -59,6 +59,7 @@
 "ui.text.focus" = { fg = "bogster-fg1", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "bogster-base5"
 "ui.virtual.ruler" = { bg = "bogster-base0" }
+"ui.virtual.jump-label" = { fg = "bogster-base0", bg = "bogster-yellow", modifiers = [ "bold" ] }
 
 "ui.selection" = { bg = "bogster-base3" }
 "ui.cursor.match" = { fg = "bogster-base3", bg = "bogster-orange" }


### PR DESCRIPTION
This add two features that have not been added to Bogster from what I can tell:

- A distinct way to show jump labels.
- Primary selection highlight color (see #3842).

Here's a before / after view for the jump labels:

| Before | After |
|--------|--------|
| ![Alacritty-2024-07-28-lcCG9dyQ](https://github.com/user-attachments/assets/5ff097db-1839-4e5b-85ac-125e74998917) | ![Alacritty-2024-07-28-WEU4MrWs](https://github.com/user-attachments/assets/babb85dc-2d94-4da8-b786-822e7c01c1cf) |

And here's a before after view for the primary selection highlight:

| Before | After |
|--------|--------|
| ![Alacritty-2024-07-28-Ak5ErFFx](https://github.com/user-attachments/assets/98a5e3c7-de7e-42bd-9816-d86903937a20) | ![Alacritty-2024-07-28-E1g8x9jt](https://github.com/user-attachments/assets/72f7f9bf-b07f-4657-8372-a5cf24457660) | 

I hope this is sufficient as far as PRs go, I've been using these tweaks since 24.03, and I'm finally getting around to upstreaming them.