### PR TITLE
Documented ulimit fix for error during integration tests

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,6 +53,10 @@ Existing tests can be used as examples. Helpers can be found in
 [helpers.rs][helpers.rs]. The log level can be set with the `HELIX_LOG_LEVEL`
 environment variable, e.g. `HELIX_LOG_LEVEL=debug cargo integration-test`.
 
+Contributors using MacOS might encounter `Too many open files (os error 24)`
+failures while running integration tests. This can be resolved by increasing
+the default value (e.g. to `10240` from `256`) by running `ulimit -n 10240`.
+
 ## Minimum Stable Rust Version (MSRV) Policy
 
 Helix follows the MSRV of Firefox.


### PR DESCRIPTION
On MacOS Sonoma 14.5 with an M1 Pro chip, I ran into errors such as the one below for having "Too many open files"

```
---- test::commands::write::test_write_scratch_no_path_fails stdout ----
thread 'test::commands::write::test_write_scratch_no_path_fails' panicked at helix-term/tests/test/commands/write.rs:297:7:
Failed building the Runtime: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
```

This causes the tests to fail. AFAICT there's nowhere in the docs for "code contributor errata", so I hope this is the appropriate place for this note :) 