### PR TITLE
stable sort lsp edits

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -503,7 +503,7 @@ pub mod util {
     ) -> Transaction {
         // Sort edits by start range, since some LSPs (Omnisharp) send them
         // in reverse order.
-        edits.sort_unstable_by_key(|edit| edit.range.start);
+        edits.sort_by_key(|edit| edit.range.start);
 
         // Generate a diff if the edit is a full document replacement.
         #[allow(clippy::collapsible_if)]

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1360,7 +1360,7 @@ fn compute_inlay_hints_for_view(
 
             // Most language servers will already send them sorted but ensure this is the case to
             // avoid errors on our end.
-            hints.sort_unstable_by_key(|inlay_hint| inlay_hint.position);
+            hints.sort_by_key(|inlay_hint| inlay_hint.position);
 
             let mut padding_before_inlay_hints = Vec::new();
             let mut type_inlay_hints = Vec::new();


### PR DESCRIPTION
Closes #11174

The lsp spec specifies that if there are multiple edits at the same position (overlaps are forbidden) that text should be inserted in the order send by the LS. The unstable sort we are using essentially made the order in these cases practically undeterminstic. Using a stable sort tkeeps the order of edits from the sever.

This is mostly orthogonal to the nvim related issues mentioned in the issue description (our transactions atomically apply multiple edits while nvim has to apply the edits in reverse since it doesn't have an equivalent API).
