### PR TITLE
reduce log noise on file writes

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1084,17 +1084,13 @@ impl Document {
             Some(path) => match path.metadata() {
                 Ok(metadata) => match metadata.modified() {
                     Ok(mtime) => mtime,
-                    Err(e) => {
-                        log::error!(
-                            "Using system time instead of fs' mtime: not supported on this platform: {e}"
-                        );
+                    Err(err) => {
+                        log::debug!("Could not fetch file system's mtime, falling back to current system time: {}", err);
                         SystemTime::now()
                     }
                 },
-                Err(e) => {
-                    log::error!(
-                        "Using system time instead of fs' mtime: failed to read file's metadata: {e}"
-                    );
+                Err(err) => {
+                    log::debug!("Could not fetch file system's mtime, falling back to current system time: {}", err);
                     SystemTime::now()
                 }
             },


### PR DESCRIPTION
On platforms which don't support fetching file system mod times, this error message gets printed on every single file write, which is really not helpful. So, reduce the log level to debug.

Also slightly modify the error message to be a bit more generic; there are reasons other than platform support that fetching metadata can fail.