### PR TITLE
Fix finding injection layer in tree cursor with nested layers

### DIFF
--- a/helix-core/src/syntax/tree_cursor.rs
+++ b/helix-core/src/syntax/tree_cursor.rs
@@ -204,7 +204,7 @@ impl<'a> TreeCursor<'a> {
 
         self.injection_ranges[start_idx..]
             .iter()
-            .take_while(|range| range.start < end)
+            .take_while(|range| range.start < end || range.depth > 1)
             .find_map(|range| (range.start <= start).then_some(range.layer_id))
             .unwrap_or(self.root)
     }


### PR DESCRIPTION
The `take_while` should limit the ranges we consider to those that end on/after the searched `end`: the ranges are sorted by `end` ascending and if a tree has nested injection layers, the starts might be sorted in descending.

For example

```vue
<script setup lang="ts">
const foo = 'bar'.match(/foo/);
const bar = foo;
</script>
```

L2 and L3 are a typescript layer and the `/foo/` part is a small regex layer. If you used `A-o` before the regex layer you would select the entire typescript layer. The search in `layer_id_containing_byte_range` would not consider the typescript layer since the regex layer comes earlier in `injection_ranges` and that layer's start is after `end`.

The `partition_point` in the line above this change leads us to the start of the ranges where `range.end >= end` and we want to limit our search to layers where that remains true.

Fixes #11299