### PR TITLE
Add statusline errors when nothing is selected with `s`, `K`, `A-K`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4624,6 +4624,13 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
                 selection::keep_or_remove_matches(text, doc.selection(view.id), &regex, remove)
             {
                 doc.set_selection(view.id, selection);
+            } else {
+                if remove {
+                    cx.editor.set_status("no selection to remove");
+                } else {
+                    doc.reset_selection(view.id);
+                    cx.editor.set_status("no matches found");
+                }
             }
         },
     )

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1939,6 +1939,8 @@ fn select_regex(cx: &mut Context) {
                 selection::select_on_matches(text, doc.selection(view.id), &regex)
             {
                 doc.set_selection(view.id, selection);
+            } else {
+                cx.editor.set_error("nothing selected");
             }
         },
     );

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4625,12 +4625,7 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
             {
                 doc.set_selection(view.id, selection);
             } else {
-                if remove {
-                    cx.editor.set_status("no selection to remove");
-                } else {
-                    doc.reset_selection(view.id);
-                    cx.editor.set_status("no matches found");
-                }
+                cx.editor.set_error("no selections remaining");
             }
         },
     )


### PR DESCRIPTION
## Issue description

When using `keep_selections` (`K`) if we find no matches all selections are kept.
This can be confusing since we only want to keep the selections that match the regex, if no match is found the expected behavior is to keep no selection.

I've also added a status indicating this to the user, so that the user knows that the command ran as expected and no matches were found.

For the `remove_selections` this case is when all lines match so no line will be removed, I also added a status update for this.