### PR TITLE
chore: clean up clippy lints

### DIFF
--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -75,9 +75,9 @@ impl From<(&char, &char)> for Pair {
 
 impl AutoPairs {
     /// Make a new AutoPairs set with the given pairs and default conditions.
-    pub fn new<'a, V: 'a, A>(pairs: V) -> Self
+    pub fn new<'a, V, A>(pairs: V) -> Self
     where
-        V: IntoIterator<Item = A>,
+        V: IntoIterator<Item = A> + 'a,
         A: Into<Pair>,
     {
         let mut auto_pairs = HashMap::new();

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -265,7 +265,7 @@ fn is_first_in_line(node: Node, text: RopeSlice, new_line_byte_pos: Option<usize
 /// This is usually constructed in one of 2 ways:
 /// - Successively add indent captures to get the (added) indent from a single line
 /// - Successively add the indent results for each line
-/// The string that this indentation defines starts with the string contained in the align field (unless it is None), followed by:
+///   The string that this indentation defines starts with the string contained in the align field (unless it is None), followed by:
 /// - max(0, indent - outdent) tabs, if tabs are used for indentation
 /// - max(0, indent - outdent)*indent_width spaces, if spaces are used for indentation
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
@@ -457,7 +457,7 @@ fn query_indents<'a>(
         // Skip matches where not all custom predicates are fulfilled
         if !query.general_predicates(m.pattern_index).iter().all(|pred| {
             match pred.operator.as_ref() {
-                "not-kind-eq?" => match (pred.args.get(0), pred.args.get(1)) {
+                "not-kind-eq?" => match (pred.args.first(), pred.args.get(1)) {
                     (
                         Some(QueryPredicateArg::Capture(capture_idx)),
                         Some(QueryPredicateArg::String(kind)),
@@ -473,7 +473,7 @@ fn query_indents<'a>(
                     }
                 },
                 "same-line?" | "not-same-line?" => {
-                    match (pred.args.get(0), pred.args.get(1)) {
+                    match (pred.args.first(), pred.args.get(1)) {
                         (
                             Some(QueryPredicateArg::Capture(capt1)),
                             Some(QueryPredicateArg::Capture(capt2))
@@ -495,7 +495,7 @@ fn query_indents<'a>(
                         }
                     }
                 }
-                "one-line?" | "not-one-line?" => match pred.args.get(0) {
+                "one-line?" | "not-one-line?" => match pred.args.first() {
                     Some(QueryPredicateArg::Capture(capture_idx)) => {
                         let node = m.nodes_for_capture_index(*capture_idx).next();
 
@@ -786,6 +786,7 @@ fn init_indent_query<'a, 'b>(
 /// - The line after the node. This is defined by:
 ///   - The scope `tail`.
 ///   - The scope `all` if this node is not the first node on its line.
+///
 /// Intuitively, `all` applies to everything contained in this node while `tail` applies to everything except for the first line of the node.
 /// The indents from different nodes for the same line are then combined.
 /// The result [Indentation] is simply the sum of the [Indentation] for all lines.

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1431,8 +1431,11 @@ impl Syntax {
                 // The `captures` iterator borrows the `Tree` and the `QueryCursor`, which
                 // prevents them from being moved. But both of these values are really just
                 // pointers, so it's actually ok to move them.
-                let cursor_ref =
-                    unsafe { mem::transmute::<_, &'static mut QueryCursor>(&mut cursor) };
+                let cursor_ref = unsafe {
+                    mem::transmute::<&mut tree_sitter::QueryCursor, &mut tree_sitter::QueryCursor>(
+                        &mut cursor,
+                    )
+                };
 
                 // if reusing cursors & no range this resets to whole range
                 cursor_ref.set_byte_range(range.clone().unwrap_or(0..usize::MAX));
@@ -1737,7 +1740,7 @@ pub(crate) fn generate_edits(
 }
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{iter, mem, ops, str, usize};
+use std::{iter, mem, ops, str};
 use tree_sitter::{
     Language as Grammar, Node, Parser, Point, Query, QueryCaptures, QueryCursor, QueryError,
     QueryMatch, Range, TextProvider, Tree,

--- a/helix-stdx/src/faccess.rs
+++ b/helix-stdx/src/faccess.rs
@@ -295,21 +295,21 @@ mod imp {
         let mut privileges_length = std::mem::size_of::<PRIVILEGE_SET>() as u32;
         let mut result = 0;
 
-        let mut mapping = GENERIC_MAPPING {
+        let mapping = GENERIC_MAPPING {
             GenericRead: FILE_GENERIC_READ,
             GenericWrite: FILE_GENERIC_WRITE,
             GenericExecute: FILE_GENERIC_EXECUTE,
             GenericAll: FILE_ALL_ACCESS,
         };
 
-        unsafe { MapGenericMask(&mut mode, &mut mapping) };
+        unsafe { MapGenericMask(&mut mode, &mapping) };
 
         if unsafe {
             AccessCheck(
                 *sd.descriptor(),
                 *token.as_handle(),
                 mode,
-                &mut mapping,
+                &mapping,
                 &mut privileges,
                 &mut privileges_length,
                 &mut granted_access,

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -66,18 +66,16 @@ mod windows_rc {
             .output();
 
         match find_reg_key {
-            Err(find_reg_key) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to run registry query: {}", find_reg_key),
-                ))
-            }
+            Err(find_reg_key) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to run registry query: {}", find_reg_key),
+            )),
             Ok(find_reg_key) => {
                 if find_reg_key.status.code().unwrap() != 0 {
-                    return Err(io::Error::new(
+                    Err(io::Error::new(
                         io::ErrorKind::Other,
                         "Can not find Windows SDK",
-                    ));
+                    ))
                 } else {
                     let lines = String::from_utf8(find_reg_key.stdout)
                         .expect("Should be able to parse the output");

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -35,7 +35,9 @@ use log::{debug, error, info, warn};
 use std::io::stdout;
 use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 
-use anyhow::{Context, Error};
+#[cfg(not(windows))]
+use anyhow::Context;
+use anyhow::Error;
 
 use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
 #[cfg(not(windows))]

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -34,7 +34,7 @@ use crate::{
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashSet},
-    fmt::Write,
+    fmt::{Display, Write},
     future::Future,
     path::Path,
 };
@@ -832,13 +832,13 @@ pub enum ApplyEditErrorKind {
     // InvalidEdit,
 }
 
-impl ToString for ApplyEditErrorKind {
-    fn to_string(&self) -> String {
+impl Display for ApplyEditErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ApplyEditErrorKind::DocumentChanged => "document has changed".to_string(),
-            ApplyEditErrorKind::FileNotFound => "file not found".to_string(),
-            ApplyEditErrorKind::UnknownURISchema => "URI schema not supported".to_string(),
-            ApplyEditErrorKind::IoError(err) => err.to_string(),
+            ApplyEditErrorKind::DocumentChanged => f.write_str("document has changed"),
+            ApplyEditErrorKind::FileNotFound => f.write_str("file not found"),
+            ApplyEditErrorKind::UnknownURISchema => f.write_str("URI schema not supported"),
+            ApplyEditErrorKind::IoError(err) => f.write_str(&format!("{err}")),
         }
     }
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2498,7 +2498,7 @@ fn read(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> 
     ensure!(!args.is_empty(), "file name is expected");
     ensure!(args.len() == 1, "only the file name is expected");
 
-    let filename = args.get(0).unwrap();
+    let filename = args.first().unwrap();
     let path = PathBuf::from(filename.to_string());
     ensure!(
         path.exists() && path.is_file(),

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -117,10 +117,9 @@ FLAGS:
     setup_logging(args.verbosity).context("failed to initialize logging")?;
 
     // Before setting the working directory, resolve all the paths in args.files
-    for (path, _) in args.files.iter_mut() {
-        *path = helix_stdx::path::canonicalize(&path);
+    for (path, _) in &mut args.files {
+        *path = helix_stdx::path::canonicalize(&*path);
     }
-
     // NOTE: Set the working directory early so the correct configuration is loaded. Be aware that
     // Application::new() depends on this logic so it must be updated if this changes.
     if let Some(path) = &args.working_directory {

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -5,7 +5,7 @@
 //! - A single line string where all graphemes have the same style is represented by a [`Span`].
 //! - A single line string where each grapheme may have its own style is represented by [`Spans`].
 //! - A multiple line string where each grapheme may have its own style is represented by a
-//! [`Text`].
+//!   [`Text`].
 //!
 //! These types form a hierarchy: [`Spans`] is a collection of [`Span`] and each line of [`Text`]
 //! is a [`Spans`].

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1245,7 +1245,7 @@ impl Document {
     /// Initializes a new selection and view_data for the given view
     /// if it does not already have them.
     pub fn ensure_view_init(&mut self, view_id: ViewId) {
-        if self.selections.get(&view_id).is_none() {
+        if !self.selections.contains_key(&view_id) {
             self.reset_selection(view_id);
         }
 

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -37,7 +37,7 @@ pub async fn select_thread_id(editor: &mut Editor, thread_id: ThreadId, force: b
     debugger.thread_id = Some(thread_id);
     fetch_stack_trace(debugger, thread_id).await;
 
-    let frame = debugger.stack_frames[&thread_id].get(0).cloned();
+    let frame = debugger.stack_frames[&thread_id].first().cloned();
     if let Some(frame) = &frame {
         jump_to_stack_frame(editor, frame);
     }

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::editor::Action;
 use crate::Editor;
 use crate::{DocumentId, ViewId};
@@ -73,13 +75,13 @@ impl From<helix_core::uri::UrlConversionError> for ApplyEditErrorKind {
     }
 }
 
-impl ToString for ApplyEditErrorKind {
-    fn to_string(&self) -> String {
+impl Display for ApplyEditErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ApplyEditErrorKind::DocumentChanged => "document has changed".to_string(),
-            ApplyEditErrorKind::FileNotFound => "file not found".to_string(),
-            ApplyEditErrorKind::InvalidUrl(err) => err.to_string(),
-            ApplyEditErrorKind::IoError(err) => err.to_string(),
+            ApplyEditErrorKind::DocumentChanged => f.write_str("document has changed"),
+            ApplyEditErrorKind::FileNotFound => f.write_str("file not found"),
+            ApplyEditErrorKind::InvalidUrl(err) => f.write_str(&format!("{err}")),
+            ApplyEditErrorKind::IoError(err) => f.write_str(&format!("{err}")),
         }
     }
 }


### PR DESCRIPTION
Using `clippy 1.80.0`. Cleans up some that were windows only.

There was one left over:
```shell
warning: accessing first element with `args.get(0)`
    --> helix-term\src\commands\typed.rs:2501:20
     |
2501 |     let filename = args.get(0).unwrap();
     |                    ^^^^^^^^^^^ help: try: `args.first()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
     = note: `#[warn(clippy::get_first)]` on by default
```

But this is addressed in #11149.