### PR TITLE
just: Use updated grammar with recent language changes and correct highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3082,7 +3082,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/IndianBoy42/tree-sitter-just", rev = "379fbe36d1e441bc9414ea050ad0c85c9d6935ea" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "f58a8fd869035ac4653081401e6c2030251240ab" }
 
 [[language]]
 name = "gn"

--- a/runtime/queries/just/folds.scm
+++ b/runtime/queries/just/folds.scm
@@ -1,5 +1,3 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/folds.scm>
-
 ; Define collapse points
 
 ([

--- a/runtime/queries/just/highlights.scm
+++ b/runtime/queries/just/highlights.scm
@@ -1,5 +1,3 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/highlights.scm>
-
 ; This file specifies how matched syntax patterns should be highlighted
 
 [
@@ -26,34 +24,56 @@
   (identifier) @variable)
 
 (alias
-  left: (identifier) @variable)
+  name: (identifier) @variable)
 
 (assignment
-  left: (identifier) @variable)
+  name: (identifier) @variable)
+
+(shell_variable_name) @variable
 
 ; Functions
 
-(recipe_header
+(recipe
   name: (identifier) @function)
 
-(dependency
-  name: (identifier) @function)
-
-(dependency_expression
-  name: (identifier) @function)
+(recipe_dependency
+  name: (identifier) @function.call)
 
 (function_call
-  name: (identifier) @function)
+  name: (identifier) @function.builtin)
 
 ; Parameters
 
-(parameter
+(recipe_parameter
   name: (identifier) @variable.parameter)
 
 ; Namespaces
 
-(module
+(mod
   name: (identifier) @namespace)
+
+; Paths
+
+(mod
+  (path) @string.special.path)
+
+(import
+  (path) @string.special.path)
+
+; Shebangs
+
+(shebang_line) @keyword.directive
+(shebang_line
+  (shebang_shell) @string.special)
+
+
+(shell_expanded_string
+  [
+    (expansion_short_start)
+    (expansion_long_start)
+    (expansion_long_middle)
+    (expansion_long_end)
+  ] @punctuation.special)
 
 ; Operators
 
@@ -95,55 +115,31 @@
 
 ; Literals
 
-(boolean) @constant.builtin.boolean
+; Booleans are not allowed anywhere except in settings
+(setting
+  (boolean) @constant.builtin.boolean)
 
 [
   (string)
   (external_command)
 ] @string
 
-(escape_sequence) @constant.character.escape
+[
+  (escape_sequence)
+  (escape_variable_end)
+] @constant.character.escape
 
 ; Comments
 
 (comment) @comment.line
 
-(shebang) @keyword.directive
-
-; highlight known settings (filtering does not always work)
+; highlight known settings
 (setting
-  left: (identifier) @keyword
-  (#any-of? @keyword
-    "allow-duplicate-recipes"
-    "dotenv-filename"
-    "dotenv-load"
-    "dotenv-path"
-    "export"
-    "fallback"
-    "ignore-comments"
-    "positional-arguments"
-    "shell"
-    "tempdi"
-    "windows-powershell"
-    "windows-shell"))
+  name: (_) @keyword.function)
 
-; highlight known attributes (filtering does not always work)
+; highlight known attributes
 (attribute
-  (identifier) @attribute
-  (#any-of? @attribute
-    "private"
-    "allow-duplicate-recipes"
-    "dotenv-filename"
-    "dotenv-load"
-    "dotenv-path"
-    "export"
-    "fallback"
-    "ignore-comments"
-    "positional-arguments"
-    "shell"
-    "tempdi"
-    "windows-powershell"
-    "windows-shell"))
+  name: (identifier) @attribute)
 
 ; Numbers are part of the syntax tree, even if disallowed
 (numeric_error) @error

--- a/runtime/queries/just/indents.scm
+++ b/runtime/queries/just/indents.scm
@@ -1,5 +1,3 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/indents.scm>
-;
 ; This query specifies how to auto-indent logical blocks.
 ;
 ; Better documentation with diagrams is in https://docs.helix-editor.com/guides/indent.html

--- a/runtime/queries/just/injections.scm
+++ b/runtime/queries/just/injections.scm
@@ -1,5 +1,3 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/injections.scm>
-;
 ; Specify nested languages that live within a `justfile`
 
 ; ================ Always applicable ================
@@ -8,7 +6,7 @@
   (#set! injection.language "comment"))
 
 ; Highlight the RHS of `=~` as regex
-((regex_literal
+((regex
   (_) @injection.content)
   (#set! injection.language "regex"))
 
@@ -21,7 +19,7 @@
   (#set! injection.include-children)) @injection.content
 
 (external_command
-  (command_body) @injection.content
+  (content) @injection.content
   (#set! injection.language "bash"))
 
 ; ================ Global language specified ================
@@ -43,7 +41,7 @@
 ; they default to bash. Limitations...
 ; See https://github.com/tree-sitter/tree-sitter/issues/880 for more on that.
 
-(source_file
+(file
   (setting "shell" ":=" "[" (string) @_langstr
     (#match? @_langstr ".*(powershell|pwsh|cmd).*")
     (#set! injection.language "powershell"))
@@ -57,10 +55,10 @@
       (expression
         (value
           (external_command
-            (command_body) @injection.content))))
+            (content) @injection.content))))
   ])
 
-(source_file
+(file
   (setting "shell" ":=" "[" (string) @injection.language
     (#not-match? @injection.language ".*(powershell|pwsh|cmd).*"))
   [
@@ -73,12 +71,12 @@
       (expression
         (value
           (external_command
-            (command_body) @injection.content))))
+            (content) @injection.content))))
   ])
 
 ; ================ Recipe language specified - Helix only ================
 
 ; Set highlighting for recipes that specify a language using builtin shebang matching
 (recipe_body
-  (shebang) @injection.shebang
+  (shebang_line) @injection.shebang
   (#set! injection.include-children)) @injection.content

--- a/runtime/queries/just/locals.scm
+++ b/runtime/queries/just/locals.scm
@@ -1,5 +1,3 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/locals.scm>
-;
 ; This file tells us about the scope of variables so e.g. local
 ; variables override global functions with the same name
 
@@ -10,32 +8,29 @@
 ; Definitions
 
 (alias
-  left: (identifier) @local.definition)
+  name: (identifier) @local.definition)
 
 (assignment
-  left: (identifier) @local.definition)
-
-(module
   name: (identifier) @local.definition)
 
-(parameter
+(mod
   name: (identifier) @local.definition)
 
-(recipe_header
+(recipe_parameter
+  name: (identifier) @local.definition)
+
+(recipe
   name: (identifier) @local.definition)
 
 ; References
 
 (alias
-  right: (identifier) @local.reference)
+  name: (identifier) @local.reference)
 
 (function_call
   name: (identifier) @local.reference)
 
-(dependency
-  name: (identifier) @local.reference)
-
-(dependency_expression
+(recipe_dependency
   name: (identifier) @local.reference)
 
 (value

--- a/runtime/queries/just/textobjects.scm
+++ b/runtime/queries/just/textobjects.scm
@@ -1,18 +1,19 @@
-; From <https://github.com/IndianBoy42/tree-sitter-just/blob/6c2f018ab1d90946c0ce029bb2f7d57f56895dff/queries-flavored/helix/textobjects.scm>
-;
 ; Specify how to navigate around logical blocks in code
+
+(assert_parameters
+  ((_) @parameter.inside . ","? @parameter.around)) @parameter.around
 
 (recipe
   (recipe_body) @function.inside) @function.around
 
-(parameters
+(recipe_parameters
   ((_) @parameter.inside . ","? @parameter.around)) @parameter.around
 
-(dependency_expression
+(recipe_dependency
   (_) @parameter.inside) @parameter.around
 
 (function_call
-  arguments: (sequence
-    (expression) @parameter.inside) @parameter.around) @function.around
+  (function_parameters
+    ((_) @parameter.inside . ","? @parameter.around)) @parameter.around) @function.around
 
 (comment) @comment.around


### PR DESCRIPTION
In each example below, OLD is **left**, NEW is **right**.

All tests were made with the file https://github.com/poliorcetics/tree-sitter-just/blob/b67d9e6b80d3472f37fff95b884951b327a69f65/examples/all-items.just, on that specific commit

It's my first time writing queries (even just updating some) for tree-sitter so don't hesitate to tell me if I'm doing it wrong!

# Aliases

<img width="1366" alt="Screenshot 2024-07-31 at 02 29 02" src="https://github.com/user-attachments/assets/e272ee28-6d9a-4238-adeb-f744c6a64fef">

# Assignements

<img width="1757" alt="Screenshot 2024-07-31 at 02 29 55" src="https://github.com/user-attachments/assets/17462228-b3a8-4c94-9988-e6e25770d6ef">

# Numeric errors

<img width="1481" alt="Screenshot 2024-07-31 at 02 30 22" src="https://github.com/user-attachments/assets/84f1ef6e-e9ae-462d-b6bf-6d1960f6fc83">

# Base strings

<img width="1917" alt="Screenshot 2024-07-31 at 02 30 53" src="https://github.com/user-attachments/assets/1d795799-4cac-444c-a720-38a2cebdbfa6">

# Shell expanded strings

<img width="1935" alt="Screenshot 2024-07-31 at 02 31 13" src="https://github.com/user-attachments/assets/a17a9431-d68d-4567-82bf-90ce2db7da3c">

# Imports

<img width="1429" alt="Screenshot 2024-07-31 at 02 32 07" src="https://github.com/user-attachments/assets/88194438-76f2-4858-aa34-386aab3de55a">

# Modules

<img width="1415" alt="Screenshot 2024-07-31 at 02 32 27" src="https://github.com/user-attachments/assets/dae8c402-27a9-4048-ad4f-3b31a5578b0e">

# Recipes

<img width="1848" alt="Screenshot 2024-07-31 at 02 33 32" src="https://github.com/user-attachments/assets/019f74ea-221a-4bc3-940f-c221f6739a7b">

# Injections

<img width="1719" alt="Screenshot 2024-07-31 at 02 34 02" src="https://github.com/user-attachments/assets/90967a01-b63c-456b-81ed-3d03683522f6">

# Settings

<img width="1665" alt="Screenshot 2024-07-31 at 02 34 28" src="https://github.com/user-attachments/assets/871c3efe-4ef7-48ee-8711-770c781839e2">
