### PR TITLE
Add Rust formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -237,6 +237,7 @@ block-comment-tokens = [
 ]
 language-servers = [ "rust-analyzer" ]
 indent = { tab-width = 4, unit = "    " }
+formatter = { command = "rustfmt", args = ["-q"] }
 persistent-diagnostic-sources = ["rustc", "clippy"]
 
 [language.auto-pairs]


### PR DESCRIPTION
Should Rust code be formatted via `rustfmt` instead of LSP ? If so, here is my PR :)
PS: Hm, maybe there is a problem with Rust editions