### PR TITLE
fix :move panic when starting a new language server

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -772,9 +772,6 @@ impl Client {
         new_path: &Path,
         is_dir: bool,
     ) -> Option<impl Future<Output = std::result::Result<(), Error>>> {
-        if !self.is_initialized() {
-            return None;
-        }
         let capabilities = self.file_operations_intests();
         if !capabilities.did_rename.has_interest(new_path, is_dir) {
             return None;

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -772,6 +772,9 @@ impl Client {
         new_path: &Path,
         is_dir: bool,
     ) -> Option<impl Future<Output = std::result::Result<(), Error>>> {
+        if !self.is_initialized() {
+            return None;
+        }
         let capabilities = self.file_operations_intests();
         if !capabilities.did_rename.has_interest(new_path, is_dir) {
             return None;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1376,6 +1376,11 @@ impl Editor {
         }
         let is_dir = new_path.is_dir();
         for ls in self.language_servers.iter_clients() {
+            // A new language server might have been started in `set_doc_path` and won't
+            // be initialized yet. Skip the `did_rename` notification for this server.
+            if !ls.is_initialized() {
+                continue;
+            }
             if let Some(notification) = ls.did_rename(old_path, &new_path, is_dir) {
                 tokio::spawn(notification);
             };


### PR DESCRIPTION
Fix for #11384

I am unsure if this is the best way to fix it. But it does work.