### PR TITLE
Update HTML highlights

### DIFF
--- a/runtime/queries/html/highlights.scm
+++ b/runtime/queries/html/highlights.scm
@@ -1,13 +1,39 @@
 (tag_name) @tag
-(erroneous_end_tag_name) @tag.error
 (doctype) @constant
 (attribute_name) @attribute
 (comment) @comment
 
-[
-  "\""
-  (attribute_value)
-] @string
+((attribute
+  (attribute_name) @_attr
+  (quoted_attribute_value (attribute_value) @markup.link.url))
+ (#any-of? @_attr "href" "src"))
+
+((element
+  (start_tag
+    (tag_name) @_tag)
+  (text) @markup.link.label)
+  (#eq? @_tag "a"))
+
+((attribute
+  (quoted_attribute_value) @string))
+
+((element
+  (start_tag
+    (tag_name) @_tag)
+  (text) @markup.bold)
+  (#any-of? @_tag "strong" "b"))
+
+((element
+  (start_tag
+    (tag_name) @_tag)
+  (text) @markup.italic)
+  (#any-of? @_tag "em" "i"))
+
+((element
+  (start_tag
+    (tag_name) @_tag)
+  (text) @markup.strikethrough)
+  (#any-of? @_tag "s" "del"))
 
 [
   "<"

--- a/runtime/queries/html/highlights.scm
+++ b/runtime/queries/html/highlights.scm
@@ -1,4 +1,5 @@
 (tag_name) @tag
+(erroneous_end_tag_name) @error
 (doctype) @constant
 (attribute_name) @attribute
 (comment) @comment
@@ -14,8 +15,7 @@
   (text) @markup.link.label)
   (#eq? @_tag "a"))
 
-((attribute
-  (quoted_attribute_value) @string))
+(attribute [(attribute_value) (quoted_attribute_value)] @string)
 
 ((element
   (start_tag


### PR DESCRIPTION
@the-mikedavis Please reference our discussion https://github.com/helix-editor/helix/discussions/11392

Quick question before I mark this ready... I want to add:

```
((element
  (start_tag
    (tag_name) @_tag)
  (text) @markup.underline)
  (#eq? @_tag "u"))
```
but there is no Helix equivalent to `@markup.underline`, what do you advise? Add the modifier? Not sure of best practice, it would loose it's semantic meaning adding a modifier rather than a proper scope?

I think I cracked the precedence problem by replacing:

```
[
  "\""
  (attribute_value)
] @string
```
with
```
((attribute
  (quoted_attribute_value) @string))
```
Is the original some kind of old fashioned way of doing it?

I experimented with the order and it now seems to make no difference, so I just placed it in the order that made most sense, having the link related highlights in one place.

In Neovim it had an additional priority statement:
```
((attribute
  (quoted_attribute_value) @string)
  (#set! priority 99))
```
but in my testing of HTML and Markdown the priority statement made no difference, can you see a reason to keep it?

> (erroneous_end_tag_name) @tag.error

Seems to reference a tag that does not exist in Helix, so I deleted it. The rest is copied from Neovim with any references changed to the Helix equivalents.

I think HTML looks much better now, at least in the themes that support the tags. Please double check it, I am still learning about highlights.