### PR TITLE
fix(picker): no longer `trim` search pattern

### DIFF
--- a/helix-term/src/ui/picker/query.rs
+++ b/helix-term/src/ui/picker/query.rs
@@ -58,11 +58,16 @@ impl PickerQuery {
             () => {
                 let key = field.take().unwrap_or(primary_field);
 
+                // Trims one space from the end, enabling leading and trailing
+                // spaces in search patterns, while also retaining spaces as separators
+                // between column filters.
+                let pat = text.strip_suffix(' ').unwrap_or(&text);
+
                 if let Some(pattern) = fields.get_mut(key) {
                     pattern.push(' ');
-                    pattern.push_str(text.trim());
+                    pattern.push_str(pat);
                 } else {
-                    fields.insert(key.clone(), text.trim().to_string());
+                    fields.insert(key.clone(), pat.to_string());
                 }
                 text.clear();
             };


### PR DESCRIPTION

With this as an example:
```rust
1 fn main() {
2    let _ = 1 > 2;
3    let _ = match 1 {
4        1 => 2,
5        _ => unreachable!(),
6    };
7 }
```
When looking to match ` > 2`, local search correctly only matches line 2. Global search was trimming the pattern and so would match line 2, but also line 4.

Fixes #11404