### PR TITLE
Nullspace rendering: limiting the text view width

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -213,8 +213,7 @@ impl EditorView {
 
         let gutter_width = view.gutter_offset(doc);
         if gutter_width > 0 {
-            let mut gutter_area = inner.with_width(gutter_width);
-            gutter_area.x -= gutter_width;
+            let gutter_area = inner.with_width(gutter_width).shift_left(gutter_width);
 
             Self::render_gutter(
                 editor,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -112,7 +112,7 @@ impl EditorView {
                 .clip_bottom(1);
 
                 let null_style = theme
-                    .try_get("ui.null")
+                    .try_get("ui.nullspace")
                     .or_else(|| Some(theme.get("ui.linenr")))
                     .unwrap();
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -164,6 +164,8 @@ impl EditorView {
             decorations.add_decoration(line_decoration);
         }
 
+        let view_offset = doc.view_offset(view.id);
+
         let syntax_highlights =
             Self::doc_syntax_highlights(doc, view_offset.anchor, inner.height, theme);
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -93,7 +93,51 @@ impl EditorView {
         let theme = &editor.theme;
         let config = editor.config();
 
-        let view_offset = doc.view_offset(view.id);
+        if config.nullspace.enable {
+            let gutter_width = view.gutter_offset(doc);
+            let text_width = config.text_width as u16;
+
+            let view_width = text_width + gutter_width;
+
+            if view_width < view.area.width {
+                let null_width = (area.width - view_width) / 2;
+
+                let null_l = area.with_width(null_width).clip_bottom(1);
+                let null_r = Rect::new(
+                    area.x + view_width + null_width,
+                    area.y,
+                    area.width - view_width - null_width,
+                    area.height,
+                )
+                .clip_bottom(1);
+
+                let null_style = theme
+                    .try_get("ui.null")
+                    .or_else(|| Some(theme.get("ui.linenr")))
+                    .unwrap();
+
+                fn fill_area(s: &mut Surface, r: Rect, c: char) {
+                    for y in r.top()..r.bottom() {
+                        for x in r.left()..r.right() {
+                            let cell = s.get_mut(x, y).unwrap();
+                            cell.symbol.clear();
+                            cell.symbol.push(c);
+                        }
+                    }
+                }
+
+                // We currently on use the first char in the 'pattern'
+                // but in future I would like to use the whole string
+                // to render nicer patterns.
+                let c = config.nullspace.pattern.chars().nth(0).unwrap();
+
+                fill_area(surface, null_l, c);
+                fill_area(surface, null_r, c);
+
+                surface.set_style(null_l, null_style);
+                surface.set_style(null_r, null_style);
+            }
+        }
 
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
@@ -165,13 +209,16 @@ impl EditorView {
             }
         }
 
-        let gutter_overflow = view.gutter_offset(doc) == 0;
-        if !gutter_overflow {
+        let gutter_width = view.gutter_offset(doc);
+        if gutter_width > 0 {
+            let mut gutter_area = inner.with_width(gutter_width);
+            gutter_area.x -= gutter_width;
+
             Self::render_gutter(
                 editor,
                 doc,
                 view,
-                view.area,
+                gutter_area,
                 theme,
                 is_focused & self.terminal_focused,
                 &mut decorations,
@@ -201,6 +248,7 @@ impl EditorView {
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
         ));
+
         render_document(
             surface,
             inner,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -315,6 +315,8 @@ pub struct Config {
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
     pub rulers: Vec<u16>,
     #[serde(default)]
+    pub nullspace: NullspaceConfig,
+    #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
@@ -700,6 +702,22 @@ impl std::str::FromStr for GutterType {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
+pub struct NullspaceConfig {
+    pub enable: bool,
+    pub pattern: String,
+}
+
+impl Default for NullspaceConfig {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            pattern: String::from("╲"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct WhitespaceConfig {
     pub render: WhitespaceRender,
     pub characters: WhitespaceCharacters,
@@ -960,6 +978,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
+            nullspace: NullspaceConfig::default(),
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -710,7 +710,7 @@ pub struct NullspaceConfig {
 impl Default for NullspaceConfig {
     fn default() -> Self {
         Self {
-            enable: true,
+            enable: false,
             pattern: String::from("╲"),
         }
     }

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -153,6 +153,22 @@ impl Rect {
         }
     }
 
+    // Returns a new Rect shifted left.
+    pub fn shift_left(self, shift: u16) -> Rect {
+        Rect {
+            x: self.x - shift,
+            ..self
+        }
+    }
+
+    // Returns a new Rect shifted left.
+    pub fn shift_right(self, shift: u16) -> Rect {
+        Rect {
+            x: self.x + shift,
+            ..self
+        }
+    }
+
     // Returns a new Rect with height reduced from the bottom.
     // This does _not_ change the `y` coordinate.
     pub fn clip_bottom(self, height: u16) -> Rect {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -191,7 +191,25 @@ impl View {
     }
 
     pub fn inner_area(&self, doc: &Document) -> Rect {
-        self.area.clip_left(self.gutter_offset(doc)).clip_bottom(1) // -1 for statusline
+        let config = doc.config.load();
+        let gutter_width = self.gutter_offset(doc);
+
+        if config.nullspace.enable {
+            let text_width = config.text_width as u16;
+            let view_width = gutter_width + text_width;
+
+            if self.area.width > view_width {
+                let null_width = (self.area.width - view_width) / 2;
+
+                return self
+                    .area
+                    .clip_left(gutter_width + null_width)
+                    .clip_bottom(1)
+                    .with_width(text_width.min(self.area.width));
+            }
+        }
+
+        self.area.clip_left(gutter_width).clip_bottom(1) // -1 for statusline
     }
 
     pub fn inner_height(&self) -> usize {


### PR DESCRIPTION
Allow the text (and gutter) to centre into the view when rendering.

![image](https://github.com/user-attachments/assets/dfc1b0ef-648a-4998-ab35-e46ebbce0ef2)

### Style
Can be styled with `ui.nullspace` (falls-back to `ui.linenr`).

### config.toml
```TOML
[editor]
nullspace.enable = true
nullspace.pattern = "/" # optional (only uses first char for now)
```

Uses option `text_width` as the limiting-width of the text area.

### Known Issues
* Clicking in *nullspace* toggles breakpoints on that line
* Mouse scroll in *nullspace* does not scroll the doc

### Potential Improvements
* Mouse drag in *nullspace* to select multiple lines
* Use all chars in the pattern, inc. newlines for juicy patterns