### PR TITLE
feat: add editor.first-file-sets-work-dir config option

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1093,7 +1093,7 @@ fn change_current_directory(
         .as_ref();
     let dir = helix_stdx::path::expand_tilde(Path::new(dir));
 
-    helix_stdx::env::set_current_working_dir(dir)?;
+    helix_stdx::env::set_current_working_dir(dir, false)?;
 
     cx.editor.set_status(format!(
         "Current working directory is now {}",

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -345,6 +345,8 @@ pub struct Config {
     /// Display diagnostic below the line they occur.
     pub inline_diagnostics: InlineDiagnosticsConfig,
     pub end_of_line_diagnostics: DiagnosticFilter,
+    /// Should the first CLI arg be a file, the working directory may be set to its parent
+    pub first_file_sets_work_dir: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -979,6 +981,7 @@ impl Default for Config {
             jump_label_alphabet: ('a'..='z').collect(),
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Disable,
+            first_file_sets_work_dir: false,
         }
     }
 }


### PR DESCRIPTION
When starting helix, it already supports updating the working directory by argument or if the first argument is a directory itself. The missing piece is updating the working directory when the first argument is a file.

The user can set this in their configuration now.