### PR TITLE
add `insert_character_interactive` command

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -398,6 +398,7 @@ impl MappableCommand {
         insert_tab, "Insert tab char",
         insert_newline, "Insert newline char",
         insert_char_interactive, "Insert an interactively-chosen char",
+        append_char_interactive, "Append an interactively-chosen char",
         delete_char_backward, "Delete previous char",
         delete_char_forward, "Delete next char",
         delete_word_backward, "Delete previous word",
@@ -3820,7 +3821,20 @@ pub mod insert {
         doc.apply(&transaction, view.id);
     }
 
+    pub fn append_char_interactive(cx: &mut Context) {
+        // Save the current mode, so we can restore it later.
+        let mode = cx.editor.mode;
+        append_mode(cx);
+        insert_selection_interactive(cx, mode);
+    }
+
     pub fn insert_char_interactive(cx: &mut Context) {
+        let mode = cx.editor.mode;
+        insert_mode(cx);
+        insert_selection_interactive(cx, mode);
+    }
+
+    fn insert_selection_interactive(cx: &mut Context, old_mode: Mode) {
         let count = cx.count();
 
         // need to wait for next key
@@ -3845,6 +3859,8 @@ pub mod insert {
                 key!(Tab) => insert_tab_impl(cx, count),
                 _ => (),
             };
+            // Restore the old mode.
+            cx.editor.mode = old_mode;
         });
     }
 


### PR DESCRIPTION
this command inserts a character of the user's choice underneath the current cursor, without exiting normal mode. multiple cursors and more than 1 counts are handled correctly.

i chose `C-y` for the default mapping because it doesn't conflict with anything else. i would have preferred `C-i` (i for insert), but that conflicts with `jump_forward`; and additionally most terminals do not distinguish `C-i` from `tab`, so it's not a good choice for the default.

this command does not have a precedent in vim or kakoune to my knowledge, but at least vim allows replicating it with remap command (https://superuser.com/questions/581572/insert-single-character-in-vim), while helix currently does not, since there's no way to say "a character entered by the user".

i wasn't sure what to do when inserting multiple newlines, so that just panics for now. presumably only the last one should get indentation and all the rest should be blank lines?

here is a demo of it working (click for video): [![an asciinema recording of me opening helix, selecting 4 lines at once, and inserting 5 semicolons into each without exiting normal mode](https://github.com/user-attachments/assets/93fe48f6-9063-4983-a633-5534ae544202)](https://asciinema.org/a/9HfoIksm8MyrFWyutn94J0FYT)