### PR TITLE
Dark_Plus: Add picker highlights, update underlined modifier, and change a few settings

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -1,7 +1,7 @@
 # Author: David Else <12832280+David-Else@users.noreply.github.com>
 
 # SYNTAX
-"attribute"                 = "fn_declaration"
+"attribute"                 = "variable"
 "comment"                   = "dark_green"
 "constant"                  = "constant"
 "constant.builtin"          = "blue2"
@@ -39,10 +39,10 @@
 # MARKUP
 "markup.heading"       = { fg = "blue2", modifiers = ["bold"] }
 "markup.list"          = "blue3"
-"markup.bold"          = { fg = "blue2", modifiers = ["bold"] }
+"markup.bold"          = { modifiers = ["bold"] }
 "markup.italic"        = { modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url"      = { modifiers = ["underlined"] }
+"markup.link.url"      = { underline.style= "line" }
 "markup.link.text"     = "orange"
 "markup.quote"         = "dark_green"
 "markup.raw"           = "orange"
@@ -57,7 +57,7 @@
 # TODO: Alternate bg colour for `ui.cursor.match` and `ui.selection`.
 "ui.cursor"                  = { fg = "cursor", modifiers = ["reversed"] }
 "ui.cursor.primary"          = { fg = "cursor", modifiers = ["reversed"] }
-"ui.cursor.match"            = { bg = "#3a3d41", modifiers = ["underlined"] }
+"ui.cursor.match"            = { bg = "#3a3d41", underline.style = "line" }
 "ui.selection"               = { bg = "#3a3d41" }
 "ui.selection.primary"       = { bg = "dark_blue" }
 "ui.linenr"                  = { fg = "dark_gray" }
@@ -80,6 +80,8 @@
 "ui.highlight.frameline"     = { bg = "#4b4b18" }
 "ui.debug.active"            = { fg = "#ffcc00" }
 "ui.debug.breakpoint"        = { fg = "#e51400" }
+"ui.picker.header.column"    = { underline.style = "line" }
+"ui.picker.header.column.active" = { fg ="white", underline.style = "line" }
 "warning"                    = { fg = "gold2" }
 "error"                      = { fg = "red" }
 "info"                       = { fg = "light_blue" }


### PR DESCRIPTION
1. The first change involves updating the "attribute" color. This now matches the color scheme used in VS Code for HTML and does not appear to negatively affect other languages I tested.

### Before
![image](https://github.com/user-attachments/assets/77ce470d-b67b-41ce-ab58-33e0249ee4cf)

### After
![image](https://github.com/user-attachments/assets/d01afdd2-e22b-4a15-9a9e-86590b8e8a54)

### VS Code
![image](https://github.com/user-attachments/assets/747e75a5-befd-4725-a692-30121f04256c)

2. The second change involves the bold modifier. Previously, it changed the text to blue, which was correct for Markdown to mimic VS Code but looked unappealing in other contexts. Additionally, it was unusual since no other Markdown editor does this. Now, the text is changed to actual bold, consistent with other editors. This change might be contentious, but considering the updates to enable bold highlights in HTML (see [Helix Editor Pull Request #11400](https://github.com/helix-editor/helix/pull/11400)), having blue text stand out in HTML is undesirable and inconsistent with VS Code.

Now it looks like this:

![image](https://github.com/user-attachments/assets/7a18b5b9-bdeb-49ac-ade2-0aaf06ed658d)

![image](https://github.com/user-attachments/assets/ce529b76-2edf-4c7e-8e5a-1d6ec2296185)

3. The third change involves styling the picker. Minimal and hopefully cool, I tried with color blocks to mimic VS Code UI but it got annoying quickly. Just a simple white highlight for the active column and underline all the headings:

![image](https://github.com/user-attachments/assets/17c225bc-259a-4722-9d30-e0a980ffd7f7)

4. I updated all the `modifiers = ["underlined"]` as they are listed as 'deprecated and only available for backwards compatibility' in the docs.

VS Code theme color enthusiasts, speak now or forever hold your peace! @kirawi Just thought I would tag you in case you had any input, I know you don't use the theme anymore, but I suspect you have fond memories of your days of maintaining it and there was some strong reason for `"attribute" = "fn_declaration"`?