### PR TITLE
helix-core: Treat underscores as word boundaries

### DIFF
--- a/helix-core/src/chars.rs
+++ b/helix-core/src/chars.rs
@@ -82,7 +82,7 @@ pub fn char_is_punctuation(ch: char) -> bool {
 
 #[inline]
 pub fn char_is_word(ch: char) -> bool {
-    ch.is_alphanumeric() || ch == '_'
+    ch.is_alphanumeric()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Currently underscores are treated as parts of words, leading to rather inconsistent behaviour where some-long-name is considered to be 3 words (and requires 3 w presses to navigate) while some_long_name is considered one word and w will jump over to end in one press.

This is (unfortunately) default vim behaviour but there already exist vim plugins changing this: https://github.com/chrisgrieser/nvim-spider

----

I appreciate this might be controversial so ideally I'd add this behind an editor config option like other editors (e.g. Zed) do. I didn't see any straightforward way to access the editor config object from helix-core however so I'd rather ask for opinions/suggestions first before trying to redo parts of the structure.