### PR TITLE
Add key concepts to `usage.md`

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -7,3 +7,27 @@ can be accessed via the command `hx --tutor` or `:tutor`.
 > 💡 Currently, not all functionality is fully documented, please refer to the
 > [key mappings](./keymap.md) list.
 
+## Modes
+
+Helix is a modal editor, meaning it has different modes for different tasks. The main modes are:
+
+* [Normal mode](./keymap.md#normal-mode): For navigation and editing commands. This is the default mode.
+* [Insert mode](./keymap.md#insert-mode): For typing text directly into the document. Access by typing `i` in normal mode.
+* [Select/extend mode](./keymap.md#select--extend-mode): For making selections and performing operations on them. Access by typing `v` in normal mode.
+
+## Buffers
+
+Buffers are in-memory representations of files. You can have multiple buffers open at once. Use [pickers](./pickers.md) or commands like `:buffer-next` and `:buffer-previous` to open buffers or switch between them.
+
+## Selection-first editing
+
+Inspired by [Kakoune](http://kakoune.org/), Helix follows the `selection → action` model. This means that whatever you are going to act on (a word, a paragraph, a line, etc.) is selected first and the action itself (delete, change, yank, etc.) comes second. A cursor is simply a single width selection.
+
+## Multiple selections
+
+Also inspired by Kakoune, multiple selections are a core mode of interaction in Helix. For example, the standard way of replacing multiple instance of a word is to first select all instances (so there is one selection per instance) and then use the change action (`c`) to edit them all at the same time.
+
+## Motions
+
+Motions are commands that move the cursor or modify selections. They're used for navigation and text manipulation. Examples include `w` to move to the next word, or `f` to find a character. See the [Movement](./keymap.md#movement) section of the keymap for more motions.
+


### PR DESCRIPTION
Inspired by some questions I've seen in Matrix (e.g., someone who did not know what buffers were despite having used Vim), I think it would be helpful to define some key terms up front to help people know what to search for to learn more.

What I take to distinguish the things I've added here is that they are important concepts, but they don't need such a long explanation that they each should get their own page. At first I was going to make this a separate page for `Key Concepts`, but Usage seems like a good spot and avoids cluttering the sidebar more.

I considered including entries for pickers and commands, but they have their own pages. For commands, I thought the distinction between typable and static commands would be especially worth explaining, but I saw that https://github.com/helix-editor/helix/pull/11152 takes care of that nicely.