### PR TITLE
Replace uses of `lsp::Location` with a custom Location type

### DIFF
--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 /// A generic pointer to a file location.
 ///
@@ -47,6 +50,14 @@ impl TryFrom<Uri> for PathBuf {
     }
 }
 
+impl fmt::Display for Uri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct UrlConversionError {
     source: url::Url,
@@ -59,11 +70,16 @@ pub enum UrlConversionErrorKind {
     UnableToConvert,
 }
 
-impl std::fmt::Display for UrlConversionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for UrlConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             UrlConversionErrorKind::UnsupportedScheme => {
-                write!(f, "unsupported scheme in URL: {}", self.source.scheme())
+                write!(
+                    f,
+                    "unsupported scheme '{}' in URL {}",
+                    self.source.scheme(),
+                    self.source
+                )
             }
             UrlConversionErrorKind::UnableToConvert => {
                 write!(f, "unable to convert URL to file path: {}", self.source)

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -32,7 +32,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     io::Read,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{
         atomic::{self, AtomicUsize},
         Arc,
@@ -63,26 +63,12 @@ pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
 #[derive(PartialEq, Eq, Hash)]
 pub enum PathOrId<'a> {
     Id(DocumentId),
-    // See [PathOrId::from_path_buf]: this will eventually become `Path(&Path)`.
-    Path(Cow<'a, Path>),
-}
-
-impl<'a> PathOrId<'a> {
-    /// Creates a [PathOrId] from a PathBuf
-    ///
-    /// # Deprecated
-    /// The owned version of PathOrId will be removed in a future refactor
-    /// and replaced with `&'a Path`. See the caller of this function for
-    /// more details on its removal.
-    #[deprecated]
-    pub fn from_path_buf(path_buf: PathBuf) -> Self {
-        Self::Path(Cow::Owned(path_buf))
-    }
+    Path(&'a Path),
 }
 
 impl<'a> From<&'a Path> for PathOrId<'a> {
     fn from(path: &'a Path) -> Self {
-        Self::Path(Cow::Borrowed(path))
+        Self::Path(path)
     }
 }
 
@@ -581,7 +567,6 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
         match path_or_id {
             PathOrId::Path(path) => {
-                let path = path.as_ref();
                 if let Some(doc) = editor.document_by_path(path) {
                     return Some((Preview::EditorDocument(doc), range));
                 }

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -243,7 +243,7 @@ impl Editor {
         match op {
             ResourceOp::Create(op) => {
                 let uri = Uri::try_from(&op.uri)?;
-                let path = uri.as_path_buf().expect("URIs are valid paths");
+                let path = uri.as_path().expect("URIs are valid paths");
                 let ignore_if_exists = op.options.as_ref().map_or(false, |options| {
                     !options.overwrite.unwrap_or(false) && options.ignore_if_exists.unwrap_or(false)
                 });
@@ -255,13 +255,15 @@ impl Editor {
                         }
                     }
 
-                    fs::write(&path, [])?;
-                    self.language_servers.file_event_handler.file_changed(path);
+                    fs::write(path, [])?;
+                    self.language_servers
+                        .file_event_handler
+                        .file_changed(path.to_path_buf());
                 }
             }
             ResourceOp::Delete(op) => {
                 let uri = Uri::try_from(&op.uri)?;
-                let path = uri.as_path_buf().expect("URIs are valid paths");
+                let path = uri.as_path().expect("URIs are valid paths");
                 if path.is_dir() {
                     let recursive = op
                         .options
@@ -270,11 +272,13 @@ impl Editor {
                         .unwrap_or(false);
 
                     if recursive {
-                        fs::remove_dir_all(&path)?
+                        fs::remove_dir_all(path)?
                     } else {
-                        fs::remove_dir(&path)?
+                        fs::remove_dir(path)?
                     }
-                    self.language_servers.file_event_handler.file_changed(path);
+                    self.language_servers
+                        .file_event_handler
+                        .file_changed(path.to_path_buf());
                 } else if path.is_file() {
                     fs::remove_file(path)?;
                 }


### PR DESCRIPTION
The lsp location type has the lsp's URI type and a range. We can replace that with a custom type private to the lsp commands module that uses the core URI type instead.

<details><summary>Note that we can't create a helix-core Location type instead...</summary>

That type would look like:

```rust
pub struct Location {
    uri: helix_core::Uri,
    range: helix_core::Range,
}
```

But we can't convert every `lsp::Location` to this type because for definitions, references and diagnostics language servers send documents which we haven't opened yet, so we don't have the information to convert an `lsp::Range` (line+col) to a `helix_core::Range` (char indexing).

---

</details>

This cleans up the picker definitions in this file so that they can all use helpers like `jump_to_location` and `location_to_file_location` for the picker preview. It also enables some refactors to make some things cheaper:

* It removes the only use of the deprecated `PathOrId::from_path_buf` so we can drop the owned variant of that type. Now the picker preview callback never allocates.
* We can then use an `Arc<Path>` as the internal representation of `helix_core::Uri`, making it cheap to clone. We clone URIs potentially often in diagnostics and symbol pickers.

With this change we also validate URIs for LSP based pickers and goto references/definition/etc. so we don't open ones with unsupported schemes, for example https://github.com/helix-editor/helix/discussions/11484