### PR TITLE
Use latest tree-sitter-bicep, support bicepparams

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2760,7 +2760,7 @@ source = { git = "https://github.com/inko-lang/tree-sitter-inko", rev = "7860637
 [[language]]
 name = "bicep"
 scope = "source.bicep"
-file-types = ["bicep"]
+file-types = ["bicep","bicepparam"]
 auto-format = true
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
@@ -2769,7 +2769,7 @@ language-servers = [ "bicep-langserver" ]
 
 [[grammar]]
 name = "bicep"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-bicep", rev = "d8e097fcfa143854861ef737161163a09cc2916b" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-bicep", rev = "0092c7d1bd6bb22ce0a6f78497d50ea2b87f19c0" }
 
 [[language]]
 name = "qml"


### PR DESCRIPTION
Updates to the latest tree-sitter-bicep and adds support for .bicepparam
files, which can replace .parameters.json files.
