### PR TITLE
fix: ensure view is initiated for `jump_*` commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5138,6 +5138,8 @@ fn jump_forward(cx: &mut Context) {
         }
 
         doc.set_selection(view.id, selection);
+        // Document we switch to might not have been opened in the view before
+        doc.ensure_view_init(view.id);
         view.ensure_cursor_in_view_center(doc, config.scrolloff);
     };
 }
@@ -5158,6 +5160,8 @@ fn jump_backward(cx: &mut Context) {
         }
 
         doc.set_selection(view.id, selection);
+        // Document we switch to might not have been opened in the view before
+        doc.ensure_view_init(view.id);
         view.ensure_cursor_in_view_center(doc, config.scrolloff);
     };
 }


### PR DESCRIPTION
Usually, when switching between documents, `Editor::switch` is used, but as this adds to the jumplist, the `jump_*` commands have a bespoke way of handling switching. The current implimentation forgot to ensure the view for the document like it does in `switch`:
https://github.com/helix-editor/helix/blob/e2904794749ccc709a238a10e6ee364411c2b820/helix-view/src/editor.rs#L1637-L1639

This PR adds this step.

Fixes #11508