### PR TITLE
Added keys to insert/append a file path

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -98,6 +98,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `Ctrl-x`    | Decrement object (number) under cursor                               | `decrement`               |
 | `Q`         | Start/stop macro recording to the selected register (experimental)   | `record_macro`            |
 | `q`         | Play back a recorded macro from the selected register (experimental) | `replay_macro`            |
+| `@`         | Insert selected file path before each selection                      | `insert_file_path`        |
+| `Alt-@`     | Insert selected file path after each selection                       | `append_file_path`        |
 
 #### Shell
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -328,6 +328,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "!" => shell_insert_output,
         "A-!" => shell_append_output,
         "$" => shell_keep_pipe,
+        "@" => insert_file_path,
+        "A-@" => append_file_path,
         "C-z" => suspend,
 
         "C-a" => increment,

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -445,6 +445,41 @@ async fn test_delete_char_forward() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_multiselection_file_path_commands() -> anyhow::Result<()> {
+    // insert_file_path
+    test((
+        indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "},
+        "@/some/path",
+        indoc! {"\
+            #[|/some/path]#lorem
+            #(|/some/path)#ipsum
+            #(|/some/path)#dolor
+            "},
+    ))
+    .await?;
+
+    // append_file_path
+    test((
+        indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "},
+        "<A-@>/some/path",
+        indoc! {"\
+            lorem#[|/some/path]#
+            ipsum#(|/some/path)#
+            dolor#(|/some/path)#
+            "},
+    ))
+    .await?;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_insert_with_indent() -> anyhow::Result<()> {
     const INPUT: &str = indoc! { "
         #[f|]#n foo() {


### PR DESCRIPTION
Fixes  #11544

Ran :
- `cargo clippy`
- `cargo test --workspace`
- `cargo run` (for manual testing)
- `cargo xtask docgen && mdbook serve` (for manual documentation checking)

Created a test for the feature.