### PR TITLE
chore: add "ui.virtual.jump-label" to gruber-darker theme

### DIFF
--- a/runtime/themes/gruber-darker.toml
+++ b/runtime/themes/gruber-darker.toml
@@ -67,6 +67,7 @@
 "ui.virtual.ruler" = { bg = "bg1" }
 "ui.virtual.inlay-hint" = { fg = "bg7" }
 "ui.virtual.wrap" = { fg = "bg2" }
+"ui.virtual.jump-label" = { fg = "red3", modifiers = ["bold"] }
 
 "diagnostic.warning" = { underline = { color = "orange1", style = "dashed" } }
 "diagnostic.error" = { underline = { color = "red3", style = "dashed" } }


### PR DESCRIPTION
<img width="702" alt="Screenshot 2024-08-21 at 11 43 34 AM" src="https://github.com/user-attachments/assets/15fa11ab-cd72-4458-91e0-6fb45a5194d9">