### PR TITLE
Add Carbonfox theme

### DIFF
--- a/runtime/themes/carbonfox.toml
+++ b/runtime/themes/carbonfox.toml
@@ -1,0 +1,50 @@
+# Author: github.com/ETCaton
+# License: MIT License
+# Carbonfox
+#
+# Based on Helix's Nightfox port with changes to align it to Nightfox's Carbonfox theme
+# Any 'custom' colors are replicating the result of the linear color blending done in the original
+# Neovim theme.
+# https://github.com/EdenEast/nightfox.nvim/blob/d3e8b1acc095baf57af81bb5e89fe7c4359eb619/lua/nightfox/lib/color.lua#L236-L247
+
+inherits = 'nightfox'
+
+# DIAGNOSTICS
+# For brevity: All blends here are a blend between bg1 and the fg value with factor of 0.15
+"warning"  = { fg = "magenta", bg = "#2f2939" }
+"error.bg" = "#361f29"
+"info.bg"  = "#252c39"
+"hint"     = { fg = "orange", bg = "#1c3433" }
+
+[palette]
+black          = "#282828"
+red            = "#ee5396"
+red-dim        = "#ca4780"
+green          = "#25be6a"
+green-dim      = "#1fa25a"
+yellow         = "#08bdba"
+yellow-bright  = "#2dc7c4"
+blue           = "#78a9ff"
+blue-bright    = "#8cb6ff"
+blue-dim       = "#6690d9"
+magenta        = "#be95ff"
+magenta-bright = "#c8a5ff"
+cyan           = "#33b1ff"
+cyan-bright    = "#52bdff"
+cyan-dim       = "#2b96d9"
+orange         = "#3ddbd9"
+orange-bright  = "#5ae0df"
+pink           = "#ff7eb6"
+pink-bright    = "#ff91c1"
+# spec
+bg0            = "#0c0c0c"
+bg1            = "#161616"
+bg2            = "#252525"
+bg3            = "#353535"
+bg4            = "#535353"
+fg0            = "#f9fbff"
+fg1            = "#f2f4f8"
+fg2            = "#b6b8bb"
+fg3            = "#7b7c7e"
+sel0           = "#2a2a2a"
+sel1           = "#525253"

--- a/runtime/themes/licenses/carbonfox.license
+++ b/runtime/themes/licenses/carbonfox.license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 James Simpson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
#4769 added the original Nightfox theme for EdenEast/nightfox.nvim#213, this adds the [Carbonfox theme](https://github.com/EdenEast/nightfox.nvim?tab=readme-ov-file#carbonfox)

![8e5ccdb83c0ff5f6d3d9aea920f7cb370bb9ce6a5e0747e5b08a6465ebe9b833](https://github.com/user-attachments/assets/ad75a304-22fc-4d4a-987f-ba6b3341e839)
(that image was larger than expected, cropping to the left half seems better for the wiki)
![b74d9aa2290eedfb5c7a36a012590a9b0a6144afdbffed672577672d440cb023](https://github.com/user-attachments/assets/150c78d1-224e-4b84-b3a2-1eab2331cbb5)
