### PR TITLE
Add RPM Spec file language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -173,6 +173,7 @@
 | rmarkdown | ✓ |  | ✓ | `R` |
 | robot | ✓ |  |  | `robotframework_ls` |
 | ron | ✓ |  | ✓ |  |
+| rpmspec | ✓ |  |  | `rpm_lsp_server` |
 | rst | ✓ |  |  |  |
 | ruby | ✓ | ✓ | ✓ | `solargraph` |
 | rust | ✓ | ✓ | ✓ | `rust-analyzer` |

--- a/languages.toml
+++ b/languages.toml
@@ -159,6 +159,9 @@ inlayHints.discriminantHints.enable = "fieldless"
 inlayHints.lifetimeElisionHints.enable = "skip_trivial"
 inlayHints.typeHints.hideClosureInitialization = false
 
+[language-server.rpm-spec-language-server]
+command = "rpm_lsp_server"
+args = ["--stdio"]
 
 [language-server.typescript-language-server]
 command = "typescript-language-server"
@@ -3786,3 +3789,14 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "thrift"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-thrift" , rev = "68fd0d80943a828d9e6f49c58a74be1e9ca142cf" }
+
+[[language]]
+name = "rpmspec"
+scope = "source.rpmspec"
+comment-token = "#"
+file-types = ["spec"]
+language-servers = ["rpm-spec-language-server"]
+
+[[grammar]]
+name = "rpmspec"
+source = { git = "https://gitlab.com/cryptomilk/tree-sitter-rpmspec", rev = "22298ebd815ce77b97d893b79c95c784448c4e05" }

--- a/runtime/queries/rpmspec/highlights.scm
+++ b/runtime/queries/rpmspec/highlights.scm
@@ -1,0 +1,74 @@
+(variable_name) @variable
+
+(macro_definition) @keyword.directive.define
+(macro_invocation) @keyword.function
+(macro_expansion) @keyword
+
+[
+  (tag)
+  (dependency_tag)
+] @type.definition
+
+[
+  (integer)
+  (float)
+] @number
+
+(comment) @comment
+(string) @string
+
+(if_statement) @keyword
+
+[
+  "%description"
+  "%package"
+  (files)
+  (changelog)
+] @type.definition
+
+[
+  (prep_scriptlet)
+  (generate_buildrequires)
+  (conf_scriptlet)
+  (build_scriptlet)
+  (install_scriptlet)
+  (check_scriptlet)
+  (clean_scriptlet)
+] @function.builtin
+
+[
+  "%artifact"
+  "%attr"
+  "%config"
+  "%dir"
+  "%doc"
+  "%docdir"
+  "%ghost"
+  "%license"
+  "%missingok"
+  "%readme"
+] @keyword.type
+
+;[
+;  "!="
+;  "<"
+;  "<="
+;  "=="
+;  ">"
+;  ">="
+;  "&&"
+;  "||"
+;] @operator
+
+[
+  "%if"
+  "%ifarch"
+  "%ifos"
+  "%ifnarch"
+  "%ifnos"
+  "%elif"
+  "%elifarch"
+  "%elifos"
+  "%else"
+  "%endif"
+] @keyword.conditional


### PR DESCRIPTION
This adds language support for RPM spec files. The language server works fine. ~~Tree-Sitter grammar support doesn't though. I'm not sure why nor how to debug this.~~ Edit: I missed the queries section in the documentation. Syntax highlighting works fine now.
