### PR TITLE
lsp: Gracefully ignore invalid diagnostic severity

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1920,12 +1920,15 @@ impl Document {
             return None;
         };
 
-        let severity = diagnostic.severity.map(|severity| match severity {
-            lsp::DiagnosticSeverity::ERROR => Error,
-            lsp::DiagnosticSeverity::WARNING => Warning,
-            lsp::DiagnosticSeverity::INFORMATION => Info,
-            lsp::DiagnosticSeverity::HINT => Hint,
-            severity => unreachable!("unrecognized diagnostic severity: {:?}", severity),
+        let severity = diagnostic.severity.and_then(|severity| match severity {
+            lsp::DiagnosticSeverity::ERROR => Some(Error),
+            lsp::DiagnosticSeverity::WARNING => Some(Warning),
+            lsp::DiagnosticSeverity::INFORMATION => Some(Info),
+            lsp::DiagnosticSeverity::HINT => Some(Hint),
+            severity => {
+                log::error!("unrecognized diagnostic severity: {:?}", severity);
+                None
+            }
         });
 
         if let Some(lang_conf) = language_config {


### PR DESCRIPTION
Helix panics  when the LSP server sends a diagnostic of severity 0. The nice thing about Helix being so strict in what it accepts, is that it allowed me to find [this clangd bug](https://github.com/clangd/clangd/issues/2124), but as Helix gets more mainstream, it shouldn't panic and throw away unsaved changes just because the LSP server is slightly misbehaving.