### PR TITLE
helix-view:move_path create target directory on move

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1370,6 +1370,10 @@ impl Editor {
                 log::error!("failed to apply workspace edit: {err:?}")
             }
         }
+        // Create the target directory if it doesn't exist. fs::rename won't do that implicitly.
+        if let Some(parent) = new_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
         fs::rename(old_path, &new_path)?;
         if let Some(doc) = self.document_by_path(old_path) {
             self.set_doc_path(doc.id(), &new_path);


### PR DESCRIPTION
First contribution correct me on anything or everything.

Resolves  #11536

Test commands:

:open new_file.txt
:move kung/foo/panda.txt

Note: I do think that the move_path command should also be able to handle being passed a directory name, that currently results in `Could not move file: Is a directory (os error 21)`
It felt like a behavioral change so I didn't include it here. I could amend this pull request with that fix as well.