### PR TITLE
Add ability to go to the previously visited buffer (`b#` in vim)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -424,6 +424,7 @@ impl MappableCommand {
         goto_line_end, "Goto line end",
         goto_next_buffer, "Goto next buffer",
         goto_previous_buffer, "Goto previous buffer",
+        goto_previously_visited_buffer, "Goto previously visited buffer",
         goto_line_end_newline, "Goto newline at line end",
         goto_first_nonwhitespace, "Goto first non-blank in line",
         trim_selections, "Trim whitespace from selections",
@@ -886,6 +887,10 @@ fn goto_buffer(editor: &mut Editor, direction: Direction, count: usize) {
     let id = *id;
 
     editor.switch(id, Action::Replace);
+}
+
+fn goto_previously_visited_buffer(cx: &mut Context) {
+    cx.editor.switch_to_previously_visited_doc();
 }
 
 fn extend_to_line_start(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -328,6 +328,20 @@ fn buffer_previous(
     Ok(())
 }
 
+fn buffer_previously_visited(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor.switch_to_previously_visited_doc();
+
+    Ok(())
+}
+
 fn write_impl(
     cx: &mut compositor::Context,
     path: Option<&Cow<str>>,
@@ -2596,6 +2610,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["bp", "bprev"],
         doc: "Goto previous buffer.",
         fun: buffer_previous,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "buffer-previously-visited",
+        aliases: &["b#"],
+        doc: "Goto previously visited buffer.",
+        fun: buffer_previously_visited,
         signature: CommandSignature::none(),
     },
     TypableCommand {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -55,6 +55,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "m" => goto_last_modified_file,
             "n" => goto_next_buffer,
             "p" => goto_previous_buffer,
+            "#" => goto_previously_visited_buffer,
             "k" => move_line_up,
             "j" => move_line_down,
             "." => goto_last_modification,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1078,6 +1078,8 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+
+    pub previously_visited_doc: Option<DocumentId>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1195,6 +1197,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            previously_visited_doc: None,
         }
     }
 
@@ -1536,6 +1539,7 @@ impl Editor {
         let scrolloff = self.config().scrolloff;
         let view = self.tree.get_mut(current_view);
 
+        self.previously_visited_doc = Some(view.doc);
         view.doc = doc_id;
         let doc = doc_mut!(self, &doc_id);
 
@@ -1544,6 +1548,12 @@ impl Editor {
         doc.mark_as_focused();
 
         view.ensure_cursor_in_view(doc, scrolloff)
+    }
+
+    pub fn switch_to_previously_visited_doc(&mut self) {
+        if let Some(id) = self.previously_visited_doc {
+            self.switch(id, Action::Replace);
+        }
     }
 
     pub fn switch(&mut self, id: DocumentId, action: Action) {


### PR DESCRIPTION
I really like Helix - thanks for building such a nice editor!

I came from vim and found it hard to navigate buffers. I mainly missed the command `b#` that switches to the previously visited buffer. This PR adds that command along with the static alternative: `g#`. Toggling `b#` or `g#` many times alternates between the two most recent buffers.

I am unsure if this command is even desired in the editor. I simply find it useful. If not desired, feel free to close this PR. Thanks!