### PR TITLE
Added auto-pair '=' = ';' to nix language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -890,6 +890,15 @@ comment-token = "#"
 language-servers = [ "nil", "nixd" ]
 indent = { tab-width = 2, unit = "  " }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+"'" = "'"
+'"' = '"'
+'´' = '´'
+'=' = ';'
+
 [[grammar]]
 name = "nix"
 source = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "1b69cf1fa92366eefbe6863c184e5d2ece5f187d" }


### PR DESCRIPTION
After you write '=', you always have to write ';' as far as I know. Therefore, I added this as an auto-pair.