### PR TITLE
just: update tree-sitter-grammar to support 1.36.0

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3140,7 +3140,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "f58a8fd869035ac4653081401e6c2030251240ab" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "6e28fa6cba511c694247cd802d1c3b14f8d34dbb" }
 
 [[language]]
 name = "gn"


### PR DESCRIPTION
Release notes:

- https://github.com/casey/just/releases/tag/1.35.0
- https://github.com/casey/just/releases/tag/1.36.0

Notably, this adds `[private]` attributes on modules, which the current version of the grammar cannot parse,
as well as unicode codepoint escape sequences.