### PR TITLE
Change default theme to fix primary selection invisibility bug

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -61,15 +61,16 @@ label = "honey"
 
 "ui.virtual.indent-guide" = { fg = "comet" }
 
-"ui.selection" = { bg = "#540099" }
-"ui.selection.primary" = { bg = "#540099" }
+"ui.selection" = { bg = "violet" }
+"ui.selection.primary" = { bg = "violet_light" }
 # TODO: namespace ui.cursor as ui.selection.cursor?
-"ui.cursor.select" = { bg = "delta" }
+"ui.cursor.select" = { fg = "revolver", bg = "delta" }
 "ui.cursor.insert" = { bg = "white" }
-"ui.cursor.primary.select" = { bg = "delta" }
+"ui.cursor.primary" = { fg = "revolver", bg = "lavender" }
+"ui.cursor.primary.select" = { fg = "revolver", bg = "delta_light" }
 "ui.cursor.primary.insert" = { bg = "white" }
 "ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
-"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor" = { fg = "revolver", bg = "delta_light" }
 "ui.cursorline.primary" = { bg = "bossanova" }
 "ui.highlight" = { bg = "bossanova" }
 "ui.highlight.frameline" = { bg = "#634450" }
@@ -95,6 +96,8 @@ hint = "silver"
 white = "#ffffff"
 lilac = "#dbbfef"
 lavender = "#a4a0e8"
+violet = "#540099"
+violet_light = "#8700F5"
 comet = "#5a5977"
 bossanova = "#452859"
 midnight = "#3b224c"
@@ -110,3 +113,4 @@ honey = "#efba5d"
 apricot = "#f47868"
 lightning = "#ffcd1c"
 delta = "#6F44F0"
+delta_light = "#8B69F2"


### PR DESCRIPTION
I'm a new user who was really thrown off by #3842

I spent some time tinkering with the default theme and I think I have a patch that maintains the look of the theme and works on various types of source with varied highlighting

Normal:
![image](https://github.com/user-attachments/assets/ac7a4f2e-9bf5-45fd-ade6-d2fef438d009)
Visual mode:
![image](https://github.com/user-attachments/assets/e4f067d1-0c51-4f7e-ad4f-5920f52b1784)
Still visible when it's just cursors:
![image](https://github.com/user-attachments/assets/7b3ec2cd-84b8-439c-9cca-38ec9cadfc51)
The infamous 10.1 lesson
![image](https://github.com/user-attachments/assets/ba4c4b5d-c8c1-46f3-875f-86dc239b8248)
