### PR TITLE
Add Prolog tree-sitter grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -175,7 +175,7 @@
 | ponylang | ✓ | ✓ | ✓ |  |
 | powershell | ✓ |  |  |  |
 | prisma | ✓ | ✓ |  | `prisma-language-server` |
-| prolog |  |  |  | `swipl` |
+| prolog | ✓ |  | ✓ | `swipl` |
 | protobuf | ✓ | ✓ | ✓ | `buf`, `pb`, `protols` |
 | prql | ✓ |  |  |  |
 | purescript | ✓ | ✓ |  | `purescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -1500,6 +1500,10 @@ comment-token = "%"
 block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "swipl" ]
 
+[[grammar]]
+name = "prolog"
+source = { git = "https://codeberg.org/foxy/tree-sitter-prolog", subpath = "grammars/prolog", rev = "93c69d2f84d8a167c0a3f4a8d51ccefe365a4dc8" }
+
 [[language]]
 name = "tsq"
 scope = "source.tsq"

--- a/languages.toml
+++ b/languages.toml
@@ -1502,7 +1502,7 @@ language-servers = [ "swipl" ]
 
 [[grammar]]
 name = "prolog"
-source = { git = "https://codeberg.org/foxy/tree-sitter-prolog", subpath = "grammars/prolog", rev = "93c69d2f84d8a167c0a3f4a8d51ccefe365a4dc8" }
+source = { git = "https://codeberg.org/foxy/tree-sitter-prolog", subpath = "grammars/prolog", rev = "d8d415f6a1cf80ca138524bcc395810b176d40fa" }
 
 [[language]]
 name = "tsq"

--- a/runtime/queries/prolog/folds.scm
+++ b/runtime/queries/prolog/folds.scm
@@ -1,0 +1,6 @@
+[
+  (directive_term)
+  (clause_term)
+  (arg_list)
+  (list_notation)
+] @fold

--- a/runtime/queries/prolog/highlights.scm
+++ b/runtime/queries/prolog/highlights.scm
@@ -1,0 +1,46 @@
+(comment) @comment @spell
+
+(atom) @constant
+
+((atom) @boolean
+  (#eq? @boolean "true"))
+
+((atom) @boolean
+  (#eq? @boolean "false"))
+
+(functional_notation
+  function: (atom) @function.call)
+
+(integer) @number
+
+(float_number) @number.float
+
+(directive_head) @operator
+
+(operator_notation
+  operator: _ @operator)
+
+[
+ (open)
+ (open_ct)
+ (close)
+ (open_list)
+ "|"
+ (close_list)
+ (open_curly)
+ (close_curly)
+] @punctuation.bracket
+
+[
+ (arg_list_separator)
+ (comma)
+ (end)
+ (list_notation_separator)
+] @punctuation.delimiter
+
+(operator_notation
+  operator: (semicolon) @punctuation.delimiter)
+
+(double_quoted_list_notation) @string
+
+(variable_term) @variable

--- a/runtime/queries/prolog/highlights.scm
+++ b/runtime/queries/prolog/highlights.scm
@@ -3,10 +3,7 @@
 (atom) @constant
 
 ((atom) @constant.builtin.boolean
-  (#eq? @constant.builtin.boolean "true"))
-
-((atom) @constant.builtin.boolean
-  (#eq? @constant.builtin.boolean "false"))
+  (#any-of? @constant.builtin.boolean "true" "false"))
 
 (functional_notation
   function: (atom) @function)

--- a/runtime/queries/prolog/highlights.scm
+++ b/runtime/queries/prolog/highlights.scm
@@ -2,18 +2,18 @@
 
 (atom) @constant
 
-((atom) @boolean
-  (#eq? @boolean "true"))
+((atom) @constant.builtin.boolean
+  (#eq? @constant.builtin.boolean "true"))
 
-((atom) @boolean
-  (#eq? @boolean "false"))
+((atom) @constant.builtin.boolean
+  (#eq? @constant.builtin.boolean "false"))
 
 (functional_notation
-  function: (atom) @function.call)
+  function: (atom) @function)
 
-(integer) @number
+(integer) @constant.numeric.integer
 
-(float_number) @number.float
+(float_number) @constant.numeric.float
 
 (directive_head) @operator
 

--- a/runtime/queries/prolog/highlights.scm
+++ b/runtime/queries/prolog/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment @spell
+(comment) @comment
 
 (atom) @constant
 

--- a/runtime/queries/prolog/indents.scm
+++ b/runtime/queries/prolog/indents.scm
@@ -1,0 +1,16 @@
+(directive_term) @indent.zero
+
+(clause_term) @indent.zero
+
+(functional_notation
+  (atom)
+  (open_ct) @indent.begin
+  (close) @indent.end)
+
+(list_notation
+  (open_list) @indent.begin
+  (close_list) @indent.end)
+
+(curly_bracketed_notation
+  (open_curly) @indent.begin
+  (close_curly) @indent.end)

--- a/runtime/queries/prolog/indents.scm
+++ b/runtime/queries/prolog/indents.scm
@@ -1,16 +1,12 @@
-(directive_term) @indent.zero
-
-(clause_term) @indent.zero
-
 (functional_notation
   (atom)
-  (open_ct) @indent.begin
-  (close) @indent.end)
+  (open_ct) @indent
+  (close) @outdent)
 
 (list_notation
-  (open_list) @indent.begin
-  (close_list) @indent.end)
+  (open_list) @indent
+  (close_list) @outdent)
 
 (curly_bracketed_notation
-  (open_curly) @indent.begin
-  (close_curly) @indent.end)
+  (open_curly) @indent
+  (close_curly) @outdent)

--- a/runtime/queries/prolog/injections.scm
+++ b/runtime/queries/prolog/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This PR adds a tree-sitter grammar for Prolog. It uses https://codeberg.org/foxy/tree-sitter-prolog, a fork/rewrite of https://github.com/Rukiza/tree-sitter-prolog.

I've probably made a mistake in how the `runtime/queries/prolog/*` files should be done, sorry about that! The changes in this PR seem to be working for me, though I'd appreciate it if others could try it out and ensure it works for them.