### PR TITLE
Update picker headers styling in Darcula themes

### DIFF
--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -29,7 +29,7 @@
 "ui.bufferline" = { fg = "grey04", bg = "grey00" }
 "ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
 "ui.picker.header.column" = { fg = "grey05", modifiers = ["italic", "bold"] }
-"ui.picker.header.column.active" = { fg = "grey05", modifiers = ["italic", "bold"] }
+"ui.picker.header.column.active" = { fg = "grey05", bg = "grey03", modifiers = ["italic", "bold"] }
 
 "operator" = "grey05"
 "variable" = "white"

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -28,6 +28,8 @@
 "ui.virtual.jump-label" = { fg = "lightblue", modifiers = ["italic", "bold"] }
 "ui.bufferline" = { fg = "grey04", bg = "grey00" }
 "ui.bufferline.active" = { fg = "grey07", bg = "grey02" }
+"ui.picker.header.column" = { fg = "grey05", modifiers = ["italic", "bold"] }
+"ui.picker.header.column.active" = { fg = "grey05", modifiers = ["italic", "bold"] }
 
 "operator" = "grey05"
 "variable" = "white"


### PR DESCRIPTION
Before:
![hx_b](https://github.com/user-attachments/assets/fdc21222-5bd1-44c3-a468-feb150b32602)
After:
![hx after2](https://github.com/user-attachments/assets/fc10084b-f4e4-4c55-bd23-c3bc425c6acf)


Changes based on https://github.com/helix-editor/helix/pull/11477