### PR TITLE
Add vale language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -98,6 +98,7 @@ terraform-ls = { command = "terraform-ls", args = ["serve"] }
 texlab = { command = "texlab" }
 typespec = { command = "tsp-server", args = ["--stdio"] }
 vala-language-server = { command = "vala-language-server" }
+vale-ls = { command = "vale-ls" }
 vhdl_ls = { command = "vhdl_ls", args = [] }
 vlang-language-server = { command = "v-analyzer" }
 vscode-css-language-server = { command = "vscode-css-language-server", args = ["--stdio"], config = { provideFormatter = true, css = { validate = { enable = true } } } }


### PR DESCRIPTION
It is now the best spelling and grammar option as `ltex-ls` is slow and uses a lot of RAM, I added a WIKI about it: https://github.com/helix-editor/helix/wiki/Language-Server-Configurations#vale-ls

I don't know why there was no new line at the end of the file before, but Helix adds one.