### PR TITLE
fix(clippy): `doc_lazy_continuation`

### DIFF
--- a/helix-lsp-types/src/inline_value.rs
+++ b/helix-lsp-types/src/inline_value.rs
@@ -132,6 +132,7 @@ pub struct InlineValueEvaluatableExpression {
 /// - directly as a text value (class InlineValueText).
 /// - as a name to use for a variable lookup (class InlineValueVariableLookup)
 /// - as an evaluatable expression (class InlineValueEvaluatableExpression)
+///
 /// The InlineValue types combines all inline value types into one type.
 ///
 /// @since 3.17.0


### PR DESCRIPTION
Fixes lints for 1.81.0 rust. This could have been a lint warning for earlier versions, as the lsp-types crate I think was only recently vendored? But this would fix it up till now, regardless.