### PR TITLE
Improve tree-sitter-subtree

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -72,7 +72,7 @@
 | `:sort` | Sort ranges in selection. |
 | `:rsort` | Sort ranges in selection in reverse order. |
 | `:reflow` | Hard-wrap the current selection of lines to a given width. |
-| `:tree-sitter-subtree`, `:ts-subtree` | Display tree sitter subtree under cursor, primarily for debugging queries. |
+| `:tree-sitter-subtree`, `:ts-subtree` | Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
 | `:config-open-workspace` | Open the workspace config.toml file. |

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2692,6 +2692,8 @@ fn pretty_print_tree_impl<W: fmt::Write>(
         }
 
         write!(fmt, "({}", node.kind())?;
+    } else {
+        write!(fmt, " \"{}\"", node.kind())?;
     }
 
     // Handle children.

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2952,7 +2952,7 @@ mod test {
     #[test]
     fn test_pretty_print() {
         let source = r#"// Hello"#;
-        assert_pretty_print("rust", source, "(line_comment)", 0, source.len());
+        assert_pretty_print("rust", source, "(line_comment \"//\")", 0, source.len());
 
         // A large tree should be indented with fields:
         let source = r#"fn main() {
@@ -2962,16 +2962,16 @@ mod test {
             "rust",
             source,
             concat!(
-                "(function_item\n",
+                "(function_item \"fn\"\n",
                 "  name: (identifier)\n",
-                "  parameters: (parameters)\n",
-                "  body: (block\n",
+                "  parameters: (parameters \"(\" \")\")\n",
+                "  body: (block \"{\"\n",
                 "    (expression_statement\n",
                 "      (macro_invocation\n",
-                "        macro: (identifier)\n",
-                "        (token_tree\n",
-                "          (string_literal\n",
-                "            (string_content)))))))",
+                "        macro: (identifier) \"!\"\n",
+                "        (token_tree \"(\"\n",
+                "          (string_literal \"\"\"\n",
+                "            (string_content) \"\"\") \")\")) \";\") \"}\"))",
             ),
             0,
             source.len(),
@@ -2983,7 +2983,7 @@ mod test {
 
         // Error nodes are printed as errors:
         let source = r#"}{"#;
-        assert_pretty_print("rust", source, "(ERROR)", 0, source.len());
+        assert_pretty_print("rust", source, "(ERROR \"}\" \"{\")", 0, source.len());
 
         // Fields broken under unnamed nodes are determined correctly.
         // In the following source, `object` belongs to the `singleton_method`
@@ -2998,11 +2998,11 @@ mod test {
             "ruby",
             source,
             concat!(
-                "(singleton_method\n",
-                "  object: (self)\n",
+                "(singleton_method \"def\"\n",
+                "  object: (self) \".\"\n",
                 "  name: (identifier)\n",
                 "  body: (body_statement\n",
-                "    (true)))"
+                "    (true)) \"end\")"
             ),
             0,
             source.len(),

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3032,7 +3032,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "tree-sitter-subtree",
         aliases: &["ts-subtree"],
-        doc: "Display tree sitter subtree under cursor, primarily for debugging queries.",
+        doc: "Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.",
         fun: tree_sitter_subtree,
         signature: CommandSignature::none(),
     },


### PR DESCRIPTION
Make unnamed nodes visible in subtree view, to make it easier to debug things related to tree sitter trees.


Before             |  After
:-------------------------:|:-------------------------:
<img src="https://github.com/user-attachments/assets/74f86e4b-db0e-422f-8464-45484855cfea" alt="before" width="500"/> | <img src="https://github.com/user-attachments/assets/935138f4-abb7-4eca-9dd6-452ee14f27cf" alt="after" width="500"/>



