### PR TITLE
feat: add ocaml default formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1200,6 +1200,7 @@ scope = "source.ocaml"
 injection-regex = "ocaml"
 file-types = ["ml"]
 shebangs = ["ocaml", "ocamlrun", "ocamlscript"]
+formatter = { command = "ocamlformat", args = [ "--impl", "-" ] }
 block-comment-tokens = { start = "(*", end = "*)" }
 language-servers = [ "ocamllsp" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Hi :wave:,

I noticed that `ocamlformat`(https://github.com/ocaml-ppx/ocamlformat) which seems to be the standard is not set as the default formatter for `ocaml`. I have searched for issues around this, but didn't find any discussion on this.

Is there a specific reason ?

Else, this PR adds `ocamlformat` as the default formatter.