### PR TITLE
add circom tree-sitter, syntax-highlighting, and lsp support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -19,6 +19,7 @@
 | cairo | ✓ | ✓ | ✓ | `cairo-language-server` |
 | capnp | ✓ |  | ✓ |  |
 | cel | ✓ |  |  |  |
+| circom | ✓ |  |  | `circom-lsp` |
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | comment | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -16,6 +16,7 @@ bicep-langserver = { command = "bicep-langserver" }
 bitbake-language-server = { command = "bitbake-language-server" }
 bufls = { command = "bufls", args = ["serve"] }
 cairo-language-server = { command = "cairo-language-server", args = [] }
+circom-lsp = { command = "circom-lsp" }
 cl-lsp = { command = "cl-lsp", args = [ "stdio" ] }
 clangd = { command = "clangd" }
 clojure-lsp = { command = "clojure-lsp" }
@@ -3786,3 +3787,19 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "thrift"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-thrift" , rev = "68fd0d80943a828d9e6f49c58a74be1e9ca142cf" }
+
+[[language]]
+name             = "circom"
+scope            = "source.circom"
+injection-regex  = "circom"
+file-types       = ["circom"]
+roots            = ["package.json"]
+comment-tokens   = "//"
+indent           = { tab-width = 4, unit = "    " }
+auto-format      = false
+language-servers = ["circom-lsp"]
+
+[[grammar]]
+name   = "circom"
+source = { git = "https://github.com/Decurity/tree-sitter-circom", rev = "02150524228b1e6afef96949f2d6b7cc0aaf999e" }
+

--- a/runtime/queries/circom/highlights.scm
+++ b/runtime/queries/circom/highlights.scm
@@ -1,0 +1,134 @@
+; identifiers
+; -----------
+(identifier) @variable
+
+; Pragma
+; -----------
+(pragma_directive) @tag
+
+; Include
+; -----------
+(include_directive) @include
+
+; Literals
+; --------
+
+(string) @string
+(int_literal) @number
+(comment) @comment
+
+; Definitions
+; -----------
+
+(function_definition
+  name:  (identifier) @function)
+
+(template_definition
+  name:  (identifier) @function)
+
+; Use contructor coloring for special functions
+(main_component_definition) @constructor
+
+; Invocations
+
+(call_expression . (identifier) @function)
+
+; Function parameters
+(parameter name: (identifier) @variable.parameter)
+
+
+; Members
+(member_expression property: (property_identifier) @property)
+
+
+; Tokens
+; -------
+
+; Keywords
+
+[
+ "public"
+ "signal"
+ "var"
+ "include"
+ "input"
+ "output"
+ "public"
+ "component"
+] @keyword
+
+[
+ "for"
+ "while"
+] @repeat
+
+[
+ "if"
+ "else"
+] @conditional
+
+[
+ "return"
+] @keyword.return
+
+[
+  "function"
+  "template"
+] @keyword.function
+
+
+; Punctuation
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+
+; Operators
+
+[
+  "&&"
+  "||"
+  ">>"
+  "<<"
+  "&"
+  "^"
+  "|"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "**"
+  "<"
+  "<="
+  "=="
+  "!="
+  ">="
+  ">"
+  "!"
+  "~"
+  "-"
+  "+"
+  "++"
+  "--"
+] @operator
+
+[
+  "<=="
+  "==>"
+  "<--"
+  "-->"
+  "==="
+] @assignment

--- a/runtime/queries/circom/highlights.scm
+++ b/runtime/queries/circom/highlights.scm
@@ -4,81 +4,76 @@
 
 ; Pragma
 ; -----------
-(pragma_directive) @tag
+(pragma_directive) @keyword.directive
 
 ; Include
 ; -----------
-(include_directive) @include
+(include_directive) @keyword.directive
 
 ; Literals
 ; --------
-
 (string) @string
-(int_literal) @number
+(int_literal) @constant.numeric.integer
 (comment) @comment
 
 ; Definitions
 ; -----------
-
 (function_definition
-  name:  (identifier) @function)
+  name:  (identifier) @keyword.function)
 
 (template_definition
-  name:  (identifier) @function)
+  name:  (identifier) @keyword.function)
 
 ; Use contructor coloring for special functions
 (main_component_definition) @constructor
 
 ; Invocations
-
 (call_expression . (identifier) @function)
 
 ; Function parameters
 (parameter name: (identifier) @variable.parameter)
 
-
 ; Members
-(member_expression property: (property_identifier) @property)
-
+(member_expression property: (property_identifier) @variable.other.member)
 
 ; Tokens
 ; -------
 
 ; Keywords
+[
+ "signal"
+ "var"
+ "component"
+] @keyword.storage.type
+
+[  "include" ] @keyword.control.import
 
 [
  "public"
- "signal"
- "var"
- "include"
  "input"
  "output"
- "public"
- "component"
-] @keyword
+ ] @keyword.storage.modifier
 
 [
  "for"
  "while"
-] @repeat
+] @keyword.control.repeat
 
 [
  "if"
  "else"
-] @conditional
+] @keyword.control.conditional
 
 [
  "return"
-] @keyword.return
+] @keyword.control.return
 
 [
   "function"
   "template"
 ] @keyword.function
 
-
 ; Punctuation
-
 [
   "("
   ")"
@@ -88,41 +83,52 @@
   "}"
 ] @punctuation.bracket
 
-
 [
   "."
   ","
 ] @punctuation.delimiter
 
-
 ; Operators
-
+; https://docs.circom.io/circom-language/basic-operators
 [
+  "?"
   "&&"
   "||"
-  ">>"
-  "<<"
-  "&"
-  "^"
-  "|"
+  "!"
+  "<" 
+  ">" 
+  "<=" 
+  ">=" 
+  "==" 
+  "!=" 
   "+"
   "-"
   "*"
-  "/"
-  "%"
   "**"
-  "<"
-  "<="
-  "=="
-  "!="
-  ">="
-  ">"
-  "!"
-  "~"
-  "-"
-  "+"
+  "/"
+  "\\"
+  "%"
+  "+="
+  "-="
+  "*="
+  "**="
+  "/="
+  "\\="
+  "%="
   "++"
   "--"
+  "&"
+  "|"
+  "~"
+  "^"
+  ">>"
+  "<<"
+  "&="
+  "|="
+  "~="
+  "^="
+  ">>="
+  "<<="
 ] @operator
 
 [
@@ -131,4 +137,4 @@
   "<--"
   "-->"
   "==="
-] @assignment
+] @operator

--- a/runtime/queries/circom/highlights.scm
+++ b/runtime/queries/circom/highlights.scm
@@ -125,7 +125,7 @@
   "<<"
   "&="
   "|="
-  "~="
+  ; "\~=" ; bug, uncomment and circom will not highlight
   "^="
   ">>="
   "<<="

--- a/runtime/queries/circom/highlights.scm
+++ b/runtime/queries/circom/highlights.scm
@@ -86,11 +86,13 @@
 [
   "."
   ","
+  ";"
 ] @punctuation.delimiter
 
 ; Operators
 ; https://docs.circom.io/circom-language/basic-operators
 [
+  "="
   "?"
   "&&"
   "||"

--- a/runtime/queries/circom/locals.scm
+++ b/runtime/queries/circom/locals.scm
@@ -1,0 +1,9 @@
+(function_definition) @local.scope
+(template_definition) @local.scope
+(main_component_definition) @local.scope
+(block_statement) @local.scope
+
+(parameter name: (identifier) @local.definition) @local.definition
+
+
+(identifier) @local.reference


### PR DESCRIPTION
This PR adds LSP and tree-sitter support for the zero-knowledge circuit language [Circom](https://docs.circom.io/).

Syntax highlighting was added three days ago in the [tree-sitter-circom](https://github.com/Decurity/tree-sitter-circom/pull/4) repo.

I have tested the changes on my machine with my local helix configuration, but not with the forked helix build. Let me know if I need to test with the forked helix binary as well.

cheers