### PR TITLE
fix: Lean language server consuming excessive memory

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -49,7 +49,7 @@ jsonnet-language-server = { command = "jsonnet-language-server", args= ["-t", "-
 julia = { command = "julia", timeout = 60, args = [ "--startup-file=no", "--history-file=no", "--quiet", "-e", "using LanguageServer; runserver()", ] }
 koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
 kotlin-language-server = { command = "kotlin-language-server" }
-lean = { command = "lean", args = [ "--server" ] }
+lean = { command = "lean", args = [ "--server", "--memory=1024" ] }
 ltex-ls = { command = "ltex-ls" }
 markdoc-ls = { command = "markdoc-ls", args = ["--stdio"] }
 markdown-oxide = { command = "markdown-oxide" }


### PR DESCRIPTION
Apparently, the Lean process spawned by the language server can use excessive memory in certain situations. Even on very simple code files. That caused my system to freeze. See: https://github.com/leanprover/lean4/issues/5321 . The language server accepts a CLI flag for limiting memory use. I set it to 1024MB, which might be a bit arbitrary, but definitely prevents the system from freezing. The language server seems to respect this limit. So it does not just crash when the limit is reached. Instead it even provides linting, which code lines cause this excessive memory use.