### PR TITLE
adding support for jujutsu VCS inside find_workspace resolution

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -225,7 +225,7 @@ pub fn merge_toml_values(left: toml::Value, right: toml::Value, merge_depth: usi
 /// Used as a ceiling dir for LSP root resolution, the filepicker and potentially as a future filewatching root
 ///
 /// This function starts searching the FS upward from the CWD
-/// and returns the first directory that contains either `.git`, `.svn` or `.helix`.
+/// and returns the first directory that contains either `.git`, `.svn`, `.jj` or `.helix`.
 /// If no workspace was found returns (CWD, true).
 /// Otherwise (workspace, false) is returned
 pub fn find_workspace() -> (PathBuf, bool) {
@@ -233,6 +233,7 @@ pub fn find_workspace() -> (PathBuf, bool) {
     for ancestor in current_dir.ancestors() {
         if ancestor.join(".git").exists()
             || ancestor.join(".svn").exists()
+            || ancestor.join(".jj").exists()
             || ancestor.join(".helix").exists()
         {
             return (ancestor.to_owned(), false);


### PR DESCRIPTION
Hey ! 

This PR add support for detecting [Jujutsu VCS](https://github.com/martinvonz/jj) repos as the workspace directory !

Hope it can be integrated into Helix :)