### PR TITLE
small fix syntax highlighting in vue.js files

### DIFF
--- a/runtime/queries/vue/highlights.scm
+++ b/runtime/queries/vue/highlights.scm
@@ -6,25 +6,13 @@
 
 (attribute
   (attribute_name) @attribute
-  (quoted_attribute_value
-    (attribute_value) @string)?
-)
-
- (attribute
-  (attribute_name) @attribute
-)
-
- (attribute
-   (attribute_name) @attribute
-   "=" @attribute_name
-   (#eq? @attribute_name "=")
-) @attribute
-
- (directive_attribute
-  (directive_name) @keyword
-  "=" @attribute_name
-  (#eq? @attribute_name "=")
- ) @attribute.empty
+  [(attribute_value) (quoted_attribute_value)]? @string)
+ 
+(directive_attribute
+  (directive_name) @attribute
+  (directive_argument)? @attribute
+  (directive_modifiers)? @attribute
+  [(attribute_value) (quoted_attribute_value)]? @string) 
 
 (comment) @comment
 
@@ -36,4 +24,5 @@
   "}}"
   "/>" 
 ] @punctuation.bracket
+"=" @punctuation.delimiter
 

--- a/runtime/queries/vue/highlights.scm
+++ b/runtime/queries/vue/highlights.scm
@@ -7,8 +7,24 @@
 (attribute
   (attribute_name) @attribute
   (quoted_attribute_value
-    (attribute_value) @string)
+    (attribute_value) @string)?
 )
+
+ (attribute
+  (attribute_name) @attribute
+)
+
+ (attribute
+   (attribute_name) @attribute
+   "=" @attribute_name
+   (#eq? @attribute_name "=")
+) @attribute
+
+ (directive_attribute
+  (directive_name) @keyword
+  "=" @attribute_name
+  (#eq? @attribute_name "=")
+ ) @attribute.empty
 
 (comment) @comment
 
@@ -18,4 +34,6 @@
   "</"
   "{{"
   "}}"
+  "/>" 
 ] @punctuation.bracket
+


### PR DESCRIPTION
This is my first "serious" PR request - please, advice as to what to do to get it merged.
It fixes some minor syntax highlighting in Vue.js files.
In the preview you can see the "before" and "after", but there is still work to be done in the <style> part with SCSS, I was just writing queries for the first time today, kind of hard.

Also, when "commenting a line" (`<space-c>`) - it incorrectly infers the type of comment to make. In `.vue` files it always comments as if it is an html, but it has to comment `//` for js/ts and `/* */` for CSS/SCSS. Is that because of the lack of Tree Sitter queries or internal problem?
Thank you
![before](https://github.com/user-attachments/assets/99ffd082-2859-44e7-bc89-e2fc34d82163)
![after](https://github.com/user-attachments/assets/ea644ee6-040b-417b-bd66-f38566dea70a)
