### PR TITLE
Fix panic when drawing at the edge of the screen.

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -433,7 +433,7 @@ impl<'a> TextRenderer<'a> {
             Grapheme::Newline => &self.newline,
         };
 
-        let in_bounds = self.column_in_bounds(position.col + width - 1);
+        let in_bounds = self.column_in_bounds(position.col, width);
 
         if in_bounds {
             self.surface.set_string(
@@ -452,7 +452,6 @@ impl<'a> TextRenderer<'a> {
             );
             self.surface.set_style(rect, style);
         }
-
         if *is_in_indent_area && !is_whitespace {
             *last_indent_level = position.col;
             *is_in_indent_area = false;
@@ -461,8 +460,8 @@ impl<'a> TextRenderer<'a> {
         width
     }
 
-    pub fn column_in_bounds(&self, colum: usize) -> bool {
-        self.offset.col <= colum && colum < self.viewport.width as usize + self.offset.col
+    pub fn column_in_bounds(&self, colum: usize, width: usize) -> bool {
+        self.offset.col <= colum && colum + width <= self.offset.col + self.viewport.width as usize
     }
 
     /// Overlay indentation guides ontop of a rendered line

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -164,7 +164,7 @@ impl Decoration for Cursor<'_> {
         renderer: &mut TextRenderer,
         grapheme: &FormattedGrapheme,
     ) -> usize {
-        if renderer.column_in_bounds(grapheme.visual_pos.col)
+        if renderer.column_in_bounds(grapheme.visual_pos.col, grapheme.width())
             && renderer.offset.row < grapheme.visual_pos.row
         {
             let position = grapheme.visual_pos - renderer.offset;

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -98,7 +98,7 @@ impl Renderer<'_, '_> {
     fn draw_eol_diagnostic(&mut self, diag: &Diagnostic, row: u16, col: usize) -> u16 {
         let style = self.styles.severity_style(diag.severity());
         let width = self.renderer.viewport.width;
-        if !self.renderer.column_in_bounds(col + 1) {
+        if !self.renderer.column_in_bounds(col + 1, 1) {
             return 0;
         }
         let col = (col - self.renderer.offset.col) as u16;


### PR DESCRIPTION
When pressing tab at the edge of the screen, Helix panics in debug mode subtracting position.col - self.offset.col.

I don't fully understand the logic here, but if cut_off_start < width, then self.offset.col - position.col < width (from the definition of cut_off_start), and so self.position.col + width > self.offset.col, meaning in_bounds is true and the second condition is currently unreachable.

I believe these conditions should be reversed so that the logic for rendering partially visible characters can apply properly.