### PR TITLE
Add an ability to hide signature help

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -431,7 +431,7 @@ impl MappableCommand {
         extend_to_first_nonwhitespace, "Extend to first non-blank in line",
         extend_to_line_end, "Extend to line end",
         extend_to_line_end_newline, "Extend to line end",
-        signature_help, "Show signature help",
+        signature_help, "Toggle signature help",
         smart_tab, "Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.",
         insert_tab, "Insert tab char",
         insert_newline, "Insert newline char",

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -171,6 +171,12 @@ pub fn show_signature_help(
 ) {
     let config = &editor.config();
 
+    if invoked == SignatureHelpInvoked::Manual 
+        && SignatureHelp::visible_popup(compositor).is_some() {
+        compositor.remove(SignatureHelp::ID);
+        return;
+    }
+
     if !(config.lsp.auto_signature_help
         || SignatureHelp::visible_popup(compositor).is_some()
         || invoked == SignatureHelpInvoked::Manual)


### PR DESCRIPTION
If you trigger signature help manually, you currently can’t hide the pop-up. This PR adds the ability to hide the signature help by calling the command again.