### PR TITLE
Remove "true" from odinfmt line

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2133,7 +2133,7 @@ language-servers = [ "ols" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 indent = { tab-width = 4, unit = "\t" }
-formatter = { command = "odinfmt", args = [ "-stdin", "true" ] }
+formatter = { command = "odinfmt", args = [ "-stdin" ] }
 
 [language.debugger]
 name = "lldb-dap"


### PR DESCRIPTION
The `-stdin` in `odinfmt` does not take any arguments, the `true` part here just confuses the formatter, and makes it ignore `odinfmt.json` file.

Removing it fixes the issue.