### PR TITLE
Bump tree-sitter-nickel to the latest version

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -881,7 +881,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "nickel"
-source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "e1d9337864d209898a08c26b8cd4c2dd14c15148" }
+source = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "88d836a24b3b11c8720874a1a9286b8ae838d30a" }
 
 [[language]]
 name = "nix"

--- a/runtime/queries/nickel/highlights.scm
+++ b/runtime/queries/nickel/highlights.scm
@@ -23,17 +23,19 @@
 (let_in_block
   "let" @keyword
   "rec"? @keyword
+  "in" @keyword
+)
+
+(let_binding
   pat: (pattern
     (ident) @variable
   )
-  "in" @keyword
 )
+
 (fun_expr
   "fun" @keyword.function
   pats:
-    (pattern
-      id: (ident) @variable.parameter
-    )+
+    (pattern_fun (ident) @variable.parameter)+
   "=>" @operator
 )
 (record_field) @variable.other.member


### PR DESCRIPTION
Also updates highlights query to account for changes in let bindings and patterns.