### PR TITLE
Add .rbs files to ruby language configuration

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -912,6 +912,7 @@ file-types = [
   "podspec",
   "rjs",
   "rbi",
+  "rbs",
   { glob = "rakefile" },
   { glob = "gemfile" },
   { glob = "Rakefile" },


### PR DESCRIPTION
`rbs` is a kind of header file for ruby, [introduced with ruby 3.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), similar to rbi files.

More info about [rbs](https://github.com/ruby/rbs)

Adding this file to the default language configuration enables syntax highlight and some features for example by the [steep](https://github.com/soutaro/steep) language server.

Before:
<img width="353" alt="Bildschirmfoto 2024-09-27 um 08 41 13" src="https://github.com/user-attachments/assets/1098eb60-9ccf-4fb1-80f1-19e82f11680c">

After
<img width="381" alt="Bildschirmfoto 2024-09-27 um 08 38 56" src="https://github.com/user-attachments/assets/2d4e9797-1ecf-4c8a-a4ea-1249e54fff18">
