### PR TITLE
Don't block the UI for prompt completions

### DIFF
--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -382,6 +382,15 @@ impl<'a> Token<'a> {
             is_terminated: true,
         }
     }
+
+    pub fn deep_clone(&self) -> Token<'static> {
+        Token {
+            kind: self.kind,
+            content_start: self.content_start,
+            content: Cow::Owned(self.content.to_string()),
+            is_terminated: self.is_terminated,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -15,7 +15,7 @@ use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
 use helix_view::expansion;
 use serde_json::Value;
-use ui::completers::{self, Completer};
+use ui::completers::{self, Completer, CompletionResult};
 
 #[derive(Clone)]
 pub struct TypableCommand {
@@ -4138,7 +4138,7 @@ fn command_line_doc(input: &str) -> Option<Cow<'_, str>> {
     Some(Cow::Owned(doc))
 }
 
-fn complete_command_line(editor: &Editor, input: &str) -> Vec<ui::prompt::Completion> {
+fn complete_command_line(editor: &Editor, input: &str) -> CompletionResult {
     let (command, rest, complete_command) = command_line::split(input);
 
     if complete_command {
@@ -4153,7 +4153,7 @@ fn complete_command_line(editor: &Editor, input: &str) -> Vec<ui::prompt::Comple
     } else {
         TYPABLE_COMMAND_MAP
             .get(command)
-            .map_or_else(Vec::new, |cmd| {
+            .map_or(CompletionResult::Immediate(Vec::new()), |cmd| {
                 let args_offset = command.len() + 1;
                 complete_command_args(editor, cmd.signature, &cmd.completer, rest, args_offset)
             })
@@ -4166,7 +4166,7 @@ pub fn complete_command_args(
     completer: &CommandCompleter,
     input: &str,
     offset: usize,
-) -> Vec<ui::prompt::Completion> {
+) -> CompletionResult {
     use command_line::{CompletionState, ExpansionKind, Tokenizer};
 
     // TODO: completion should depend on the location of the cursor instead of the end of the
@@ -4206,7 +4206,7 @@ pub fn complete_command_args(
 
     // Don't complete on closed tokens, for example after writing a closing double quote.
     if token.is_terminated {
-        return Vec::new();
+        return CompletionResult::Immediate(Vec::new());
     }
 
     match token.kind {
@@ -4221,10 +4221,15 @@ pub fn complete_command_args(
                         .expect("completion state to be positional");
                     let completer = completer.for_argument_number(n);
 
-                    completer(editor, &token.content)
-                        .into_iter()
-                        .map(|(range, span)| quote_completion(&token, range, span, offset))
-                        .collect()
+                    completer(editor, &token.content).map({
+                        let token = token.deep_clone();
+                        move |completions| {
+                            completions
+                                .into_iter()
+                                .map(|(range, span)| quote_completion(&token, range, span, offset))
+                                .collect()
+                        }
+                    })
                 }
                 CompletionState::Flag(_) => fuzzy_match(
                     token.content.trim_start_matches('-'),
@@ -4260,7 +4265,7 @@ pub fn complete_command_args(
         TokenKind::Expansion(ExpansionKind::Variable) => {
             complete_variable_expansion(&token.content, offset + token.content_start)
         }
-        TokenKind::Expansion(ExpansionKind::Unicode) => Vec::new(),
+        TokenKind::Expansion(ExpansionKind::Unicode) => CompletionResult::Immediate(Vec::new()),
         TokenKind::Expansion(ExpansionKind::Register) => {
             complete_register_expansion(editor, &token.content, offset + token.content_start)
         }
@@ -4323,7 +4328,7 @@ fn complete_expand(
     token: &Token,
     completer: Option<&Completer>,
     offset: usize,
-) -> Vec<ui::prompt::Completion> {
+) -> CompletionResult {
     use command_line::{ExpansionKind, Tokenizer};
 
     let mut start = 0;
@@ -4368,15 +4373,20 @@ fn complete_expand(
 
     match completer {
         // If no expansions were found and an argument is being completed,
-        Some(completer) if start == 0 => completer(editor, &token.content)
-            .into_iter()
-            .map(|(range, span)| quote_completion(token, range, span, offset))
-            .collect(),
-        _ => Vec::new(),
+        Some(completer) if start == 0 => completer(editor, &token.content).map({
+            let token = token.deep_clone();
+            move |completions| {
+                completions
+                    .into_iter()
+                    .map(|(range, span)| quote_completion(&token, range, span, offset))
+                    .collect()
+            }
+        }),
+        _ => CompletionResult::Immediate(Vec::new()),
     }
 }
 
-fn complete_variable_expansion(content: &str, offset: usize) -> Vec<ui::prompt::Completion> {
+fn complete_variable_expansion(content: &str, offset: usize) -> CompletionResult {
     use expansion::Variable;
 
     fuzzy_match(
@@ -4393,7 +4403,7 @@ fn complete_register_expansion(
     editor: &Editor,
     content: &str,
     offset: usize,
-) -> Vec<ui::prompt::Completion> {
+) -> CompletionResult {
     let register_names: Vec<String> = editor
         .registers
         .iter_preview()
@@ -4405,7 +4415,7 @@ fn complete_register_expansion(
         .collect()
 }
 
-fn complete_expansion_kind(content: &str, offset: usize) -> Vec<ui::prompt::Completion> {
+fn complete_expansion_kind(content: &str, offset: usize) -> CompletionResult {
     use command_line::ExpansionKind;
 
     fuzzy_match(

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -4399,11 +4399,7 @@ fn complete_variable_expansion(content: &str, offset: usize) -> CompletionResult
     .collect()
 }
 
-fn complete_register_expansion(
-    editor: &Editor,
-    content: &str,
-    offset: usize,
-) -> CompletionResult {
+fn complete_register_expansion(editor: &Editor, content: &str, offset: usize) -> CompletionResult {
     let register_names: Vec<String> = editor
         .registers
         .iter_preview()

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -18,6 +18,7 @@ mod text_decorations;
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
+use crate::ui::completers::CompletionResult;
 pub use completion::Completion;
 pub use editor::EditorView;
 use helix_stdx::rope;
@@ -53,7 +54,7 @@ pub fn prompt(
     cx: &mut crate::commands::Context,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
-    completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
+    completion_fn: impl FnMut(&Editor, &str) -> CompletionResult + 'static,
     callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
 ) {
     let mut prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn);
@@ -62,24 +63,11 @@ pub fn prompt(
     cx.push_layer(Box::new(prompt));
 }
 
-pub fn prompt_with_input(
-    cx: &mut crate::commands::Context,
-    prompt: std::borrow::Cow<'static, str>,
-    input: String,
-    history_register: Option<char>,
-    completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
-    callback_fn: impl FnMut(&mut crate::compositor::Context, &str, PromptEvent) + 'static,
-) {
-    let prompt = Prompt::new(prompt, history_register, completion_fn, callback_fn)
-        .with_line(input, cx.editor);
-    cx.push_layer(Box::new(prompt));
-}
-
 pub fn regex_prompt(
     cx: &mut crate::commands::Context,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
-    completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
+    completion_fn: impl FnMut(&Editor, &str) -> CompletionResult + 'static,
     fun: impl Fn(&mut crate::compositor::Context, rope::Regex, PromptEvent) + 'static,
 ) {
     raw_regex_prompt(
@@ -94,7 +82,7 @@ pub fn raw_regex_prompt(
     cx: &mut crate::commands::Context,
     prompt: std::borrow::Cow<'static, str>,
     history_register: Option<char>,
-    completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
+    completion_fn: impl FnMut(&Editor, &str) -> CompletionResult + 'static,
     fun: impl Fn(&mut crate::compositor::Context, rope::Regex, &str, PromptEvent) + 'static,
 ) {
     let (view, doc) = current!(cx.editor);
@@ -431,13 +419,40 @@ pub mod completers {
     use std::collections::BTreeSet;
     use tui::text::Span;
 
-    pub type Completer = fn(&Editor, &str) -> Vec<Completion>;
-
-    pub fn none(_editor: &Editor, _input: &str) -> Vec<Completion> {
-        Vec::new()
+    pub enum CompletionResult {
+        Immediate(Vec<Completion>),
+        Callback(Box<dyn FnOnce() -> Vec<Completion> + Send + Sync>),
     }
 
-    pub fn buffer(editor: &Editor, input: &str) -> Vec<Completion> {
+    fn callback(f: impl FnOnce() -> Vec<Completion> + Send + Sync + 'static) -> CompletionResult {
+        CompletionResult::Callback(Box::new(f))
+    }
+
+    impl CompletionResult {
+        pub fn map(
+            self,
+            f: impl FnOnce(Vec<Completion>) -> Vec<Completion> + Send + Sync + 'static,
+        ) -> CompletionResult {
+            match self {
+                CompletionResult::Immediate(v) => CompletionResult::Immediate(f(v)),
+                CompletionResult::Callback(v) => callback(move || f(v())),
+            }
+        }
+    }
+
+    impl FromIterator<Completion> for CompletionResult {
+        fn from_iter<T: IntoIterator<Item = Completion>>(items: T) -> Self {
+            Self::Immediate(items.into_iter().collect())
+        }
+    }
+
+    pub type Completer = fn(&Editor, &str) -> CompletionResult;
+
+    pub fn none(_editor: &Editor, _input: &str) -> CompletionResult {
+        CompletionResult::Immediate(Vec::new())
+    }
+
+    pub fn buffer(editor: &Editor, input: &str) -> CompletionResult {
         let names = editor.documents.values().map(|doc| {
             doc.relative_path()
                 .map(|p| p.display().to_string().into())
@@ -450,20 +465,23 @@ pub mod completers {
             .collect()
     }
 
-    pub fn theme(_editor: &Editor, input: &str) -> Vec<Completion> {
-        let mut names = theme::Loader::read_names(&helix_loader::config_dir().join("themes"));
-        for rt_dir in helix_loader::runtime_dirs() {
-            names.extend(theme::Loader::read_names(&rt_dir.join("themes")));
-        }
-        names.push("default".into());
-        names.push("base16_default".into());
-        names.sort();
-        names.dedup();
+    pub fn theme(_editor: &Editor, input: &str) -> CompletionResult {
+        let input = String::from(input);
+        callback(move || {
+            let mut names = theme::Loader::read_names(&helix_loader::config_dir().join("themes"));
+            for rt_dir in helix_loader::runtime_dirs() {
+                names.extend(theme::Loader::read_names(&rt_dir.join("themes")));
+            }
+            names.push("default".into());
+            names.push("base16_default".into());
+            names.sort();
+            names.dedup();
 
-        fuzzy_match(input, names, false)
-            .into_iter()
-            .map(|(name, _)| ((0..), name.into()))
-            .collect()
+            fuzzy_match(&input, names, false)
+                .into_iter()
+                .map(|(name, _)| ((0..), name.into()))
+                .collect()
+        })
     }
 
     /// Recursive function to get all keys from this value and add them to vec
@@ -483,7 +501,7 @@ pub mod completers {
     }
 
     /// Completes names of language servers which are running for the current document.
-    pub fn active_language_servers(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn active_language_servers(editor: &Editor, input: &str) -> CompletionResult {
         let language_servers = doc!(editor).language_servers().map(|ls| ls.name());
 
         fuzzy_match(input, language_servers, false)
@@ -494,7 +512,7 @@ pub mod completers {
 
     /// Completes names of language servers which are configured for the language of the current
     /// document.
-    pub fn configured_language_servers(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn configured_language_servers(editor: &Editor, input: &str) -> CompletionResult {
         let language_servers = doc!(editor)
             .language_config()
             .into_iter()
@@ -507,7 +525,7 @@ pub mod completers {
             .collect()
     }
 
-    pub fn setting(_editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn setting(_editor: &Editor, input: &str) -> CompletionResult {
         static KEYS: Lazy<Vec<String>> = Lazy::new(|| {
             let mut keys = Vec::new();
             let json = serde_json::json!(Config::default());
@@ -521,7 +539,7 @@ pub mod completers {
             .collect()
     }
 
-    pub fn filename(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn filename(editor: &Editor, input: &str) -> CompletionResult {
         filename_with_git_ignore(editor, input, true)
     }
 
@@ -529,7 +547,7 @@ pub mod completers {
         editor: &Editor,
         input: &str,
         git_ignore: bool,
-    ) -> Vec<Completion> {
+    ) -> CompletionResult {
         filename_impl(editor, input, git_ignore, |entry| {
             if entry.path().is_dir() {
                 FileMatch::AcceptIncomplete
@@ -539,7 +557,7 @@ pub mod completers {
         })
     }
 
-    pub fn language(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn language(editor: &Editor, input: &str) -> CompletionResult {
         let text: String = "text".into();
 
         let loader = editor.syn_loader.load();
@@ -554,7 +572,7 @@ pub mod completers {
             .collect()
     }
 
-    pub fn lsp_workspace_command(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn lsp_workspace_command(editor: &Editor, input: &str) -> CompletionResult {
         let commands = doc!(editor)
             .language_servers_with_feature(LanguageServerFeature::WorkspaceCommand)
             .flat_map(|ls| {
@@ -570,7 +588,7 @@ pub mod completers {
             .collect()
     }
 
-    pub fn directory(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn directory(editor: &Editor, input: &str) -> CompletionResult {
         directory_with_git_ignore(editor, input, true)
     }
 
@@ -578,7 +596,7 @@ pub mod completers {
         editor: &Editor,
         input: &str,
         git_ignore: bool,
-    ) -> Vec<Completion> {
+    ) -> CompletionResult {
         filename_impl(editor, input, git_ignore, |entry| {
             if entry.path().is_dir() {
                 FileMatch::Accept
@@ -605,121 +623,125 @@ pub mod completers {
         input: &str,
         git_ignore: bool,
         filter_fn: F,
-    ) -> Vec<Completion>
+    ) -> CompletionResult
     where
-        F: Fn(&ignore::DirEntry) -> FileMatch,
+        F: Fn(&ignore::DirEntry) -> FileMatch + Send + Sync + 'static,
     {
         // Rust's filename handling is really annoying.
 
         use ignore::WalkBuilder;
         use std::path::Path;
 
-        let is_tilde = input == "~";
-        let path = helix_stdx::path::expand_tilde(Path::new(input));
-
-        let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
-            (path, None)
-        } else {
-            let is_period = (input.ends_with((format!("{}.", std::path::MAIN_SEPARATOR)).as_str())
-                && input.len() > 2)
-                || input == ".";
-            let file_name = if is_period {
-                Some(String::from("."))
-            } else {
-                path.file_name()
-                    .and_then(|file| file.to_str().map(|path| path.to_owned()))
-            };
-
-            let path = if is_period {
-                path
-            } else {
-                match path.parent() {
-                    Some(path) if !path.as_os_str().is_empty() => Cow::Borrowed(path),
-                    // Path::new("h")'s parent is Some("")...
-                    _ => Cow::Owned(helix_stdx::env::current_working_dir()),
-                }
-            };
-
-            (path, file_name)
-        };
-
-        let end = input.len()..;
-
-        let files = WalkBuilder::new(&dir)
-            .hidden(false)
-            .follow_links(false) // We're scanning over depth 1
-            .git_ignore(git_ignore)
-            .max_depth(Some(1))
-            .build()
-            .filter_map(|file| {
-                file.ok().and_then(|entry| {
-                    let fmatch = filter_fn(&entry);
-
-                    if fmatch == FileMatch::Reject {
-                        return None;
-                    }
-
-                    let path = entry.path();
-                    let is_dir = path.is_dir();
-                    let file_type = entry.file_type();
-                    let is_symlink = file_type.is_some_and(|ft| ft.is_symlink());
-                    let mut path = if is_tilde {
-                        // if it's a single tilde an absolute path is displayed so that when `TAB` is pressed on
-                        // one of the directories the tilde will be replaced with a valid path not with a relative
-                        // home directory name.
-                        // ~ -> <TAB> -> /home/user
-                        // ~/ -> <TAB> -> ~/first_entry
-                        path.to_path_buf()
-                    } else {
-                        path.strip_prefix(&dir).unwrap_or(path).to_path_buf()
-                    };
-
-                    if fmatch == FileMatch::AcceptIncomplete {
-                        path.push("");
-                    }
-
-                    let path = path.into_os_string().into_string().ok()?;
-                    Some(Utf8PathBuf {
-                        path,
-                        is_dir,
-                        is_symlink,
-                    })
-                })
-            }) // TODO: unwrap or skip
-            .filter(|path| !path.path.is_empty());
-
+        let input = String::from(input);
         let directory_color = editor.theme.get("ui.text.directory");
         let symlink_color = editor.theme.get("ui.text.symlink");
 
-        let style_from_file = |file: Utf8PathBuf| {
-            if file.is_symlink {
-                Span::styled(file.path, symlink_color)
-            } else if file.is_dir {
-                Span::styled(file.path, directory_color)
+        callback(move || {
+            let is_tilde = input == "~";
+            let path = helix_stdx::path::expand_tilde(Path::new(&input));
+
+            let (dir, file_name) = if input.ends_with(std::path::MAIN_SEPARATOR) {
+                (path, None)
             } else {
-                Span::raw(file.path)
+                let is_period = (input
+                    .ends_with((format!("{}.", std::path::MAIN_SEPARATOR)).as_str())
+                    && input.len() > 2)
+                    || input == ".";
+                let file_name = if is_period {
+                    Some(String::from("."))
+                } else {
+                    path.file_name()
+                        .and_then(|file| file.to_str().map(|path| path.to_owned()))
+                };
+
+                let path = if is_period {
+                    path
+                } else {
+                    match path.parent() {
+                        Some(path) if !path.as_os_str().is_empty() => Cow::Borrowed(path),
+                        // Path::new("h")'s parent is Some("")...
+                        _ => Cow::Owned(helix_stdx::env::current_working_dir()),
+                    }
+                };
+
+                (path, file_name)
+            };
+
+            let end = input.len()..;
+
+            let files = WalkBuilder::new(&dir)
+                .hidden(false)
+                .follow_links(false) // We're scanning over depth 1
+                .git_ignore(git_ignore)
+                .max_depth(Some(1))
+                .build()
+                .filter_map(|file| {
+                    file.ok().and_then(|entry| {
+                        let fmatch = filter_fn(&entry);
+
+                        if fmatch == FileMatch::Reject {
+                            return None;
+                        }
+
+                        let path = entry.path();
+                        let is_dir = path.is_dir();
+                        let file_type = entry.file_type();
+                        let is_symlink = file_type.is_some_and(|ft| ft.is_symlink());
+                        let mut path = if is_tilde {
+                            // if it's a single tilde an absolute path is displayed so that when `TAB` is pressed on
+                            // one of the directories the tilde will be replaced with a valid path not with a relative
+                            // home directory name.
+                            // ~ -> <TAB> -> /home/user
+                            // ~/ -> <TAB> -> ~/first_entry
+                            path.to_path_buf()
+                        } else {
+                            path.strip_prefix(&dir).unwrap_or(path).to_path_buf()
+                        };
+
+                        if fmatch == FileMatch::AcceptIncomplete {
+                            path.push("");
+                        }
+
+                        let path = path.into_os_string().into_string().ok()?;
+                        Some(Utf8PathBuf {
+                            path,
+                            is_dir,
+                            is_symlink,
+                        })
+                    })
+                }) // TODO: unwrap or skip
+                .filter(|path| !path.path.is_empty());
+
+            let style_from_file = |file: Utf8PathBuf| {
+                if file.is_symlink {
+                    Span::styled(file.path, symlink_color)
+                } else if file.is_dir {
+                    Span::styled(file.path, directory_color)
+                } else {
+                    Span::raw(file.path)
+                }
+            };
+
+            // if empty, return a list of dirs and files in current dir
+            if let Some(file_name) = file_name {
+                let range = (input.len().saturating_sub(file_name.len()))..;
+                fuzzy_match(&file_name, files, true)
+                    .into_iter()
+                    .map(|(name, _)| (range.clone(), style_from_file(name)))
+                    .collect()
+
+                // TODO: complete to longest common match
+            } else {
+                let mut files: Vec<_> = files
+                    .map(|file| (end.clone(), style_from_file(file)))
+                    .collect();
+                files.sort_unstable_by(|(_, path1), (_, path2)| path1.content.cmp(&path2.content));
+                files
             }
-        };
-
-        // if empty, return a list of dirs and files in current dir
-        if let Some(file_name) = file_name {
-            let range = (input.len().saturating_sub(file_name.len()))..;
-            fuzzy_match(&file_name, files, true)
-                .into_iter()
-                .map(|(name, _)| (range.clone(), style_from_file(name)))
-                .collect()
-
-            // TODO: complete to longest common match
-        } else {
-            let mut files: Vec<_> = files
-                .map(|file| (end.clone(), style_from_file(file)))
-                .collect();
-            files.sort_unstable_by(|(_, path1), (_, path2)| path1.content.cmp(&path2.content));
-            files
-        }
+        })
     }
 
-    pub fn register(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn register(editor: &Editor, input: &str) -> CompletionResult {
         let iter = editor
             .registers
             .iter_preview()
@@ -733,7 +755,7 @@ pub mod completers {
             .collect()
     }
 
-    pub fn program(_editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn program(_editor: &Editor, input: &str) -> CompletionResult {
         static PROGRAMS_IN_PATH: Lazy<BTreeSet<String>> = Lazy::new(|| {
             // Go through the entire PATH and read all files into a set.
             let Some(path) = std::env::var_os("PATH") else {
@@ -762,7 +784,7 @@ pub mod completers {
     }
 
     /// This expects input to be a raw string of arguments, because this is what Signature's raw_after does.
-    pub fn repeating_filenames(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn repeating_filenames(editor: &Editor, input: &str) -> CompletionResult {
         let token = match Tokenizer::new(input, false).last() {
             Some(token) => token.unwrap(),
             None => return filename(editor, input),
@@ -770,27 +792,29 @@ pub mod completers {
 
         let offset = token.content_start;
 
-        let mut completions = filename(editor, &input[offset..]);
-        for completion in completions.iter_mut() {
-            completion.0.start += offset;
-        }
-        completions
+        filename(editor, &input[offset..]).map(move |mut completions| {
+            for completion in completions.iter_mut() {
+                completion.0.start += offset;
+            }
+            completions
+        })
     }
 
-    pub fn shell(editor: &Editor, input: &str) -> Vec<Completion> {
+    pub fn shell(editor: &Editor, input: &str) -> CompletionResult {
         let (command, args, complete_command) = command_line::split(input);
 
         if complete_command {
             return program(editor, command);
         }
 
-        let mut completions = repeating_filenames(editor, args);
-        for completion in completions.iter_mut() {
-            // + 1 for separator between `command` and `args`
-            completion.0.start += command.len() + 1;
-        }
-
-        completions
+        let len = command.len();
+        repeating_filenames(editor, args).map(move |mut completions| {
+            for completion in completions.iter_mut() {
+                // + 1 for separator between `command` and `args`
+                completion.0.start += len + 1;
+            }
+            completions
+        })
     }
 }
 


### PR DESCRIPTION
The prompt handler for : commands currently blocks the UI while generating completions, which can make the editor feel laggy when using :o or :cd on networked filesystems. I was reproducing this issue using github.com/nirs/slowfs to inject a 1 second delay to readdir() calls (although in reality I experienced this issue while working in google's monorepo).

To see the difference, I recorded before and after videos of navigating a slowfs directory containing some nested directories.

Before the change: https://asciinema.org/a/yzdSZUjjnrBPAU1VcFcVAkLyu

After the change: https://asciinema.org/a/fgayEu1ZczVwqnMrAsmsvuPrJ

Fixes #11604