### PR TITLE
Add `move_buffer_{left,right,start,end}` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "helix-stdx",
  "helix-tui",
  "helix-vcs",
+ "indexmap",
  "libc",
  "log",
  "once_cell",

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -119,6 +119,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "e" => goto_prev_entry,
             "T" => goto_prev_test,
             "p" => goto_prev_paragraph,
+            "[" => move_buffer_left,
+            "{" => move_buffer_start,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -133,6 +135,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "e" => goto_next_entry,
             "T" => goto_next_test,
             "p" => goto_next_paragraph,
+            "]" => move_buffer_right,
+            "}" => move_buffer_end,
             "space" => add_newline_below,
         },
 

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -51,6 +51,7 @@ log = "~0.4"
 
 parking_lot = "0.12.3"
 thiserror.workspace = true
+indexmap = "2.5.0"
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4", features = ["std"] }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -18,6 +18,7 @@ use helix_vcs::DiffProviderRegistry;
 use futures_util::stream::select_all::SelectAll;
 use futures_util::{future, StreamExt};
 use helix_lsp::{Call, LanguageServerId};
+use indexmap::IndexMap;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use std::{
@@ -1015,7 +1016,7 @@ pub struct Editor {
     pub mode: Mode,
     pub tree: Tree,
     pub next_document_id: DocumentId,
-    pub documents: BTreeMap<DocumentId, Document>,
+    pub documents: IndexMap<DocumentId, Document>,
 
     // We Flatten<> to resolve the inner DocumentSavedEventFuture. For that we need a stream of streams, hence the Once<>.
     // https://stackoverflow.com/a/66875668
@@ -1164,7 +1165,7 @@ impl Editor {
             mode: Mode::Normal,
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),
-            documents: BTreeMap::new(),
+            documents: IndexMap::new(),
             saves: HashMap::new(),
             save_queue: SelectAll::new(),
             write_count: 0,
@@ -1595,7 +1596,7 @@ impl Editor {
                     // Copy `doc.id` into a variable before calling `self.documents.remove`, which requires a mutable
                     // borrow, invalidating direct access to `doc.id`.
                     let id = doc.id;
-                    self.documents.remove(&id);
+                    self.documents.shift_remove(&id);
 
                     // Remove the scratch buffer from any jumplists
                     for (view, _) in self.tree.views_mut() {
@@ -1796,7 +1797,7 @@ impl Editor {
             }
         }
 
-        self.documents.remove(&doc_id);
+        self.documents.shift_remove(&doc_id);
 
         // If the document we removed was visible in all views, we will have no more views. We don't
         // want to close the editor just for a simple buffer close, so we need to create a new view

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1939,6 +1939,13 @@ impl Editor {
         self.documents.values_mut()
     }
 
+    #[inline]
+    pub fn focused_document_index(&self) -> usize {
+        self.documents
+            .get_index_of(&view!(self).doc)
+            .expect("focused document should always be present")
+    }
+
     pub fn document_by_path<P: AsRef<Path>>(&self, path: P) -> Option<&Document> {
         self.documents()
             .find(|doc| doc.path().map(|p| p == path.as_ref()).unwrap_or(false))


### PR DESCRIPTION
Closes #10278.
Default mapping: (let me know if you have better ideas)
- `move_buffer_left`: `[[`
- `move_buffer_right`: `]]`
- `move_buffer_start`: `[{`
- `move_buffer_end`: `]}`

#10077 was already closed as "encourag[ing] a more gui/mouse driven tab like workflow" but this is an even smaller and very straight-forward implementation.
If the Helix team truly wants to discourage this type of workflow this badly, why leave the `gn`/`gp` commands in?
#10278 shows there are a lot of users that would like this in Helix and personally at least I feel like I can get around faster by ordering my buffers spatially than by searching for them in a normally hidden menu every time I want to get to a different one.
With the ordered approach I just always know where my file is, it doesn't keep changing, so I know exactly which commands I need to use to get to it, without opening the buffer picker and scanning through it.

## Implementation
I added `indexmap` as a dependency for a simple drop-in-place implementation.
I believe that a `Vec` should really be enough instead of any `HashMap`-like container, but after no responses from the team to [my question](https://github.com/helix-editor/helix/discussions/10278#discussioncomment-9040148) on this matter, and a lot of friction in my attempts to switch a `HashMap` with a `Vec` due to how many places it was used in, I decided it's better to add a dependency than give up on this feature.
`goto_buffer` (used by `goto_buffer_prev`, `goto_buffer_next`) is also now noticeably faster with very high `count`s (which was never a real use case but)
