### PR TITLE
fix: fish builtin functions are highlighted as such

### DIFF
--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -101,9 +101,6 @@
             ]
 )
 
-; non-builtin command names
-(command name: (word) @function)
-
 ; derived from builtin -n (fish 3.2.2)
 (command
   name: [
@@ -113,6 +110,9 @@
 )
 
 (test_command "test" @function.builtin)
+
+; non-builtin command names
+(command name: (word) @function)
 
 ;; Functions
 

--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -105,7 +105,7 @@
 (command
   name: [
     (word) @function.builtin
-    (#any-of? @function.builtin "abbr" "and" "argparse" "begin" "bg" "bind" "block" "break" "breakpoint" "builtin" "case" "cd" "command" "commandline" "complete" "contains" "continue" "count" "disown" "echo" "else" "emit" "end" "eval" "exec" "exit" "false" "fg" "for" "function" "functions" "history" "if" "jobs" "math" "not" "or" "path" "printf" "pwd" "random" "read" "realpath" "return" "set" "set_color" "source" "status" "string" "switch" "test" "time" "true" "type" "ulimit" "wait" "while")
+    (#any-of? @function.builtin "abbr" "alias" "and" "argparse" "begin" "bg" "bind" "block" "break" "breakpoint" "builtin" "case" "cd" "command" "commandline" "complete" "contains" "continue" "count" "disown" "echo" "else" "emit" "end" "eval" "exec" "exit" "false" "fg" "for" "function" "functions" "history" "if" "isatty" "jobs" "math" "not" "or" "path" "printf" "pwd" "random" "read" "realpath" "return" "set" "set_color" "source" "status" "string" "switch" "test" "time" "true" "type" "ulimit" "wait" "while")
   ]
 )
 

--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -101,12 +101,12 @@
             ]
 )
 
-; derived from builtin -n (fish 3.2.2)
+; derived from builtin -n (fish 3.7.1)
 (command
   name: [
-        (word) @function.builtin
-        (#any-of? @function.builtin "alias" "argparse" "bg" "bind" "block" "breakpoint" "builtin" "cd" "command" "commandline" "complete" "contains" "count" "disown" "echo" "emit" "eval" "exec" "exit" "fg" "functions" "history" "isatty" "jobs" "math" "printf" "pwd" "random" "read" "realpath" "set" "set_color" "source" "status" "string" "test" "time" "type" "ulimit" "wait")
-        ]
+    (word) @function.builtin
+    (#any-of? @function.builtin "abbr" "and" "argparse" "begin" "bg" "bind" "block" "break" "breakpoint" "builtin" "case" "cd" "command" "commandline" "complete" "contains" "continue" "count" "disown" "echo" "else" "emit" "end" "eval" "exec" "exit" "false" "fg" "for" "function" "functions" "history" "if" "jobs" "math" "not" "or" "path" "printf" "pwd" "random" "read" "realpath" "return" "set" "set_color" "source" "status" "string" "switch" "test" "time" "true" "type" "ulimit" "wait" "while")
+  ]
 )
 
 (test_command "test" @function.builtin)

--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -105,7 +105,7 @@
 (command
   name: [
         (word) @function.builtin
-        (#match? @function.builtin "^(\.|:|_|alias|argparse|bg|bind|block|breakpoint|builtin|cd|command|commandline|complete|contains|count|disown|echo|emit|eval|exec|exit|fg|functions|history|isatty|jobs|math|printf|pwd|random|read|realpath|set|set_color|source|status|string|test|time|type|ulimit|wait)$")
+        (#any-of? @function.builtin "alias" "argparse" "bg" "bind" "block" "breakpoint" "builtin" "cd" "command" "commandline" "complete" "contains" "count" "disown" "echo" "emit" "eval" "exec" "exit" "fg" "functions" "history" "isatty" "jobs" "math" "printf" "pwd" "random" "read" "realpath" "set" "set_color" "source" "status" "string" "test" "time" "type" "ulimit" "wait")
         ]
 )
 


### PR DESCRIPTION
Because in helix, queries override from the top, rather than from the bottom, the more special query should be above the non-special query.

Before this PR, all the builtin commands were highlighted as `function`. This is a bug.

Now, they are correctly highlighted as `function.builtin`, because they override the query that is now below.
