### PR TITLE
feat: Use custom character to draw editor rulers

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -42,6 +42,7 @@
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
+| `ruler-char` | Specifies the character used to display the rulers. When unset, the rulers will be indicated by a subtle background or style change, depending on the theme in use | `none` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -307,6 +307,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
+| `ui.virtual.ruler.char`           | Ruler columns, ([only if `editor.ruler-char` is set][editor-section]                           |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
 | `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -314,6 +314,8 @@ pub struct Config {
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
     pub rulers: Vec<u16>,
+    /// Character used to draw the rulers when specified. If `None`, rulers are drawn using style only.
+    pub ruler_char: Option<char>,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
@@ -963,6 +965,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
+            ruler_char: None,
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),


### PR DESCRIPTION
This PR allows selecting custom character to draw editor rulers and it contains fixes and improvements on PR https://github.com/helix-editor/helix/pull/9256

#### Differences from previous PR

1. No unnecessary formatting changes
2. No unnecessary string [allocation](https://github.com/helix-editor/helix/pull/9256/files#diff-408ac3559e5a464e3cce528ed57e0bf48453d28c95212437790ac5dec0f450beR268) for every character drawn
3. Separate theme key (`ui.virtual.ruler.char`) if `editor.ruler-char` is set to allow using different styles for "background ruler" and "character ruler"
4. Ruler character is drawn under the text

#### Screenshot

Default theme with config

```toml
[editor]
  rulers = [ 40, 60 ]
  ruler-char = "¦"
```

![image](https://github.com/user-attachments/assets/a6fbc0c4-2fde-4e46-9d2b-c74c75599b1d)