### PR TITLE
Add a highlight for the keyword.storage scope to the onedark theme

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -15,6 +15,7 @@
 "keyword.control" = { fg = "purple" }
 "keyword.control.import" = { fg = "red" }
 "keyword.directive" = { fg = "purple" }
+"keyword.storage" = { fg = "purple" }
 "label" = { fg = "purple" }
 "namespace" = { fg = "blue" }
 "operator" = { fg = "purple" }


### PR DESCRIPTION
Rust highlight queries make use of `keyword.storage` for keywords like `struct`, `enum`, and also for references, and modifiers like `mut` and `ref`.

Using a color that's different to the one used for `"variable.parameter"` (red) improves differentiation for mutable function arguments.

e.g. 

Before: 
<img width="573" alt="Screenshot 2024-09-30 at 17 21 48" src="https://github.com/user-attachments/assets/28d49ee7-5384-4e4d-96e6-a9da607e1e80">

After:
<img width="573" alt="Screenshot 2024-09-30 at 17 21 16" src="https://github.com/user-attachments/assets/21dc2a13-3962-4bb2-b3ef-e98662967abb">
