### PR TITLE
Fix some odin highlights

### DIFF
--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -4,9 +4,12 @@
 ] @keyword.directive
 
 [
-  "import"
-  "package"
+ "package"
 ] @namespace
+
+[
+  "import" 
+] @keyword.control.import
 
 [
   "foreign"
@@ -200,7 +203,7 @@
 
 (struct . (identifier) @type)
 
-(field_type . (identifier) "." (identifier) @type)
+(field_type . (identifier) @keyword.storage.type "." (identifier) @type)
 
 (bit_set_type (identifier) @type ";")
 
@@ -247,6 +250,8 @@
 (foreign_block (identifier) @namespace)
 
 (using_statement (identifier) @namespace)
+
+(import_declaration (identifier) @keyword.storage.type)
 
 ; Parameters
 


### PR DESCRIPTION
Some of the odin highlights seemed wrong or lacking, like the import names were not being matched:

```odin

// color both "rl" here to same value
import rl "vendor:raylib"

...

rl.Vector3
```

Import color was also not being used correctly