### PR TITLE
Add contrast between some fg & bg colors on the curzon theme

### DIFF
--- a/runtime/themes/curzon.toml
+++ b/runtime/themes/curzon.toml
@@ -57,7 +57,7 @@ label = "label"
 
 "ui.virtual.indent-guide" = { fg = "window_color" }
 
-"ui.selection" = { bg = "#4f46e5" }
+"ui.selection" = { bg = "cursor_normal_bg_color" }
 "ui.selection.primary" = { bg = "#4f46e5" }
 "ui.cursor.select" = { bg = "cursor_normal_bg_color" }
 "ui.cursor.primary.insert" = { bg = "#f43f5e", fg = "white" }

--- a/runtime/themes/curzon.toml
+++ b/runtime/themes/curzon.toml
@@ -62,10 +62,8 @@ label = "label"
 "ui.cursor.select" = { bg = "cursor_normal_bg_color" }
 "ui.cursor.primary.insert" = { bg = "#f43f5e", fg = "white" }
 "ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
-"ui.cursorcolumn" = { bg = "cursor_normal_bg_color"}
-"ui.cursorline" = { bg = "cursor_normal_bg_color"}
 "ui.cursorline.primary" = { bg = "dark"}
-"ui.highlight" = { bg = "cursor_normal_bg_color" }
+"ui.highlight" = { bg = "#4f46e5" }
 "ui.highlight.frameline" = { bg = "#634450" }
 "ui.debug" = { fg = "#634450" }
 "ui.debug.breakpoint" = { fg = "debug_breakpoint" }

--- a/runtime/themes/curzon.toml
+++ b/runtime/themes/curzon.toml
@@ -62,8 +62,10 @@ label = "label"
 "ui.cursor.select" = { bg = "cursor_normal_bg_color" }
 "ui.cursor.primary.insert" = { bg = "#f43f5e", fg = "white" }
 "ui.cursor.match" = { fg = "#212121", bg = "#6C6999" }
+"ui.cursorcolumn" = { bg = "cursor_normal_bg_color"}
+"ui.cursorline" = { bg = "cursor_normal_bg_color"}
 "ui.cursorline.primary" = { bg = "dark"}
-"ui.highlight" = { bg = "dark" }
+"ui.highlight" = { bg = "cursor_normal_bg_color" }
 "ui.highlight.frameline" = { bg = "#634450" }
 "ui.debug" = { fg = "#634450" }
 "ui.debug.breakpoint" = { fg = "debug_breakpoint" }


### PR DESCRIPTION
### selection BEFORE
![image](https://github.com/user-attachments/assets/1f54a7f3-57ad-49b6-8349-89ecf4270c91)

### selection AFTER (I had to take a photo of the screen to show the cursor)
![image](https://github.com/user-attachments/assets/8ce2ea1e-0347-4152-a0b5-f0ca43c58fa0)

### popup search BEFORE
![image](https://github.com/user-attachments/assets/18219f31-bad4-482a-a57e-2a4abaf9f299)

### popup search AFTER
![image](https://github.com/user-attachments/assets/7d2e380c-8f3e-4d44-be41-fb9c9ffccbab)
