### PR TITLE
Avoid ignoring newlines in multi line messages when rendering end-of-line diagnostics

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -522,8 +522,6 @@ impl<'a> TextRenderer<'a> {
         self.surface.set_style(area, style);
     }
 
-    /// Sets the style of an area **within the text viewport* this accounts
-    /// both for the renderers vertical offset and its viewport
     #[allow(clippy::too_many_arguments)]
     pub fn set_string_truncated(
         &mut self,


### PR DESCRIPTION
`set_string_truncated` renders the entire string while ignoring newlines, so if the diagnostic's message contains multiple lines then `draw_eol_diagnostic` produces output like 'first linesecond line'.

An alternative would be to reformat the message to replace newlines with spaces (or something), but I think the first line should be sufficient for end of line diagnostics.

Before:
<img width="971" alt="Screenshot 2024-10-02 at 10 13 25" src="https://github.com/user-attachments/assets/a94d8483-bff7-4a02-9b8f-02000e1859a1">

After:
<img width="971" alt="Screenshot 2024-10-02 at 10 14 49" src="https://github.com/user-attachments/assets/4ec51b3b-e795-4bba-9023-12163df99e59">

