### PR TITLE
Add option to show the path of the active tab in bufferline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "nucleo",
  "once_cell",
  "open",
+ "pathdiff",
  "pulldown-cmark",
  "same-file",
  "serde",

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -43,6 +43,7 @@
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
+| `expand-bufferline` | Set to `true` to show the path instead of the filename in the active bufferline tab | `false` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -72,6 +72,9 @@ serde = { version = "1.0", features = ["derive"] }
 grep-regex = "0.1.13"
 grep-searcher = "0.1.14"
 
+# to shorten paths in bufferline
+pathdiff = "0.2.1"
+
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 libc = "0.2.159"

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -30,7 +30,7 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc};
+use std::{mem::take, num::NonZeroUsize, rc::Rc, sync::Arc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
 
@@ -593,7 +593,6 @@ impl EditorView {
 
     /// Render bufferline at the top
     pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) {
-        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         surface.clear_with(
             viewport,
             editor
@@ -616,13 +615,23 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = doc
+            let name = doc
                 .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+                .and_then(|p| {
+                    if editor.config().expand_bufferline && current_doc == doc.id() {
+                        let working_directory = helix_stdx::env::current_working_dir();
+                        let relative_path = pathdiff::diff_paths(p.as_path(), &working_directory);
+                        if let Some(rel_path) = relative_path {
+                            return if rel_path.starts_with("..") {
+                                p.to_str().map(|s| s.to_owned())
+                            } else {
+                                rel_path.to_str().map(|s| s.to_owned())
+                            };
+                        }
+                    }
+                    p.file_name().and_then(|s| s.to_str()).map(|s| s.to_owned())
+                })
+                .unwrap_or(SCRATCH_BUFFER_NAME.to_owned());
 
             let style = if current_doc == doc.id() {
                 bufferline_active
@@ -630,7 +639,7 @@ impl EditorView {
                 bufferline_inactive
             };
 
-            let text = format!(" {}{} ", fname, if doc.is_modified() { "[+]" } else { "" });
+            let text = format!(" {}{} ", name, if doc.is_modified() { "[+]" } else { "" });
             let used_width = viewport.x.saturating_sub(x);
             let rem_width = surface.area.width.saturating_sub(used_width);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -318,6 +318,8 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
+    /// Expand file names in buffer line to paths when tab is focused
+    pub expand_bufferline: bool,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
@@ -965,6 +967,7 @@ impl Default for Config {
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
+            expand_bufferline: false,
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
             soft_wrap: SoftWrap {


### PR DESCRIPTION
This PR turns this:
![image](https://github.com/user-attachments/assets/272d1ac7-7022-4b3f-af93-6a7155b51ee1)
into this:
![image](https://github.com/user-attachments/assets/383307a3-4f2f-4f09-b588-d3adb63eb1ff)

The main issue is that something like #8362 is not merged. I initially wanted to expand all tabs by default, however this means that you have a about 3 tabs before you go off-screen. I came up with this solution as a way to work-around this limitation.

To not change current behavior, the entire thing is hidden behind editor.expand-bufferline, which is false by default.
