### PR TITLE
queries/nix: add injections for nim writers

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -127,6 +127,16 @@
   (#set! injection.language "haskell")
   (#set! injection.combined))
 
+; pkgs.writers.writeNim[Bin] name attrs content
+(apply_expression
+  (apply_expression
+    function: (apply_expression
+      function: ((_) @_func)))
+    argument: (indented_string_expression (string_fragment) @injection.content)
+  (#match? @_func "(^|\\.)writeNim(Bin)?$")
+  (#set! injection.language "nim")
+  (#set! injection.combined))
+
 ; pkgs.writers.writeJS[Bin] name attrs content
 (apply_expression
   (apply_expression


### PR DESCRIPTION
This adds syntax highlighting for inline Nim source in Nix files when using
`writers.writeNim` and `writers.writeNimBin`, introduced in nixpkgs in
https://github.com/NixOS/nixpkgs/pull/338857
