### PR TITLE
Remove auto-pair for single quote in SML.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2458,6 +2458,12 @@ injection-regex = "sml"
 file-types = ["sml"]
 block-comment-tokens = { start = "(*", end = "*)" }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+
 [[grammar]]
 name = "sml"
 source = { git = "https://github.com/Giorbo/tree-sitter-sml", rev = "bd4055d5554614520d4a0706b34dc0c317c6b608" }


### PR DESCRIPTION
Similar to OCaml and other ML languages, single quote is a normal character that can appear in identifiers and is also used in type parameters. It is not used for strings or character literals, which both use double quote.