### PR TITLE
Add correct source file for TypableCommandList

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -83,7 +83,7 @@ There are three kinds of commands that can be used in keymaps:
   keys and used for movement and editing. A list of static commands is
   available in the [Keymap](./keymap.html) documentation and in the source code
   in [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs)
-  at the invocation of `static_commands!`. macro.
+  at the invocation of `static_commands!` macro.
 * Typable commands: commands that can be executed from command mode (`:`), for
   example `:write!`. See the [Commands](./commands.html) documentation for a
   list of available typeable commands or the `TypableCommandList` declaration in

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -83,7 +83,8 @@ There are three kinds of commands that can be used in keymaps:
   keys and used for movement and editing. A list of static commands is
   available in the [Keymap](./keymap.html) documentation and in the source code
   in [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs)
-  at the invocation of `static_commands!` macro and the `TypableCommandList`.
+  at the invocation of `static_commands!` macro and [`helix-term/src/commands/typed.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands/typed.rs)
+  at the `TypableCommandList`.
 * Typable commands: commands that can be executed from command mode (`:`), for
   example `:write!`. See the [Commands](./commands.html) documentation for a
   list of available typeable commands.

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -83,11 +83,11 @@ There are three kinds of commands that can be used in keymaps:
   keys and used for movement and editing. A list of static commands is
   available in the [Keymap](./keymap.html) documentation and in the source code
   in [`helix-term/src/commands.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands.rs)
-  at the invocation of `static_commands!` macro and [`helix-term/src/commands/typed.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands/typed.rs)
-  at the `TypableCommandList`.
+  at the invocation of `static_commands!`. macro.
 * Typable commands: commands that can be executed from command mode (`:`), for
   example `:write!`. See the [Commands](./commands.html) documentation for a
-  list of available typeable commands.
+  list of available typeable commands or the `TypableCommandList` declaration in
+  the source code at [`helix-term/src/commands/typed.rs`](https://github.com/helix-editor/helix/blob/master/helix-term/src/commands/typed.rs).
 * Macros: sequences of keys that are executed in order. These keybindings
   start with `@` and then list any number of keys to be executed. For example
   `@miw` can be used to select the surrounding word. For now, macro keybindings


### PR DESCRIPTION
The documentation says that static_commands and TypableCommandList are both found in helix-term/src/commands.rs, however TypableCommandList is actually in helix-term/src/commands/typed.rs. This PR is a simples fix for that.