### PR TITLE
White and Black & Black and White

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 helix-term/rustfmt.toml
 result
 runtime/grammars
+.DS_Store

--- a/runtime/themes/black_and_white.toml
+++ b/runtime/themes/black_and_white.toml
@@ -40,9 +40,9 @@
 "ui.selection"                    = { bg = "secondary", underline = { style = "curl" } }
 "ui.selection.primary"            = { bg = "primary", underline = { style = "curl" }}
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
-"ui.statusline.insert"            = {  modifiers = ["bold"] }
-"ui.statusline.normal"            = {  modifiers = ["bold"] }
-"ui.statusline.select"            = {  modifiers = ["bold"] }
+"ui.statusline.insert"            = { modifiers = ["bold"] }
+"ui.statusline.normal"            = { modifiers = ["bold"] }
+"ui.statusline.select"            = { modifiers = ["bold"] }
 "ui.text"                         = { fg = "foreground" }
 "ui.text.focus"                   = { fg = "foreground" }
 "ui.virtual.inlay-hint.parameter" = { modifiers = ["italic", "dim"] }

--- a/runtime/themes/black_and_white.toml
+++ b/runtime/themes/black_and_white.toml
@@ -1,0 +1,140 @@
+# Author: ChiefMateStarbuck <septimusguy@gmail.com>
+
+"annotation"                      = { fg = "foreground" }
+
+"attribute"                       = { fg = "foreground", modifiers = ["italic"] }
+
+"comment"                         = { fg = "foreground" }
+"comment.block"                   = { fg = "foreground" }
+"comment.block.documentation"     = { fg = "foreground" }
+"comment.line"                    = { fg = "foreground" }
+
+"constant"                        = { fg = "foreground" }
+"constant.builtin"                = { fg = "foreground" }
+"constant.builtin.boolean"        = { fg = "foreground" }
+"constant.character"              = { fg = "foreground" }
+"constant.character.escape"       = { fg = "foreground" }
+"constant.macro"                  = { fg = "foreground" }
+"constant.numeric"                = { fg = "foreground" }
+"constructor"                     = { fg = "foreground" }
+
+"definition"                      = { underline = { color = "foreground" } }
+"diagnostic"                      = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.hint"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.warning"              = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.error"                = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.info"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.unnecessary"          = { modifiers = ["dim"] }
+"diagnostic.deprecated"           = { modifiers = ["crossed_out"] }
+
+"error"                           = { fg = "foreground" }
+"hint"                            = { fg = "foreground" }
+"info"                            = { fg = "foreground" }
+"warning"                         = { fg = "foreground" }
+
+"diff.delta"                      = { fg = "foreground" }
+"diff.minus"                      = { fg = "foreground" }
+"diff.plus"                       = { fg = "foreground" }
+
+"function"                        = { fg = "foreground" }
+"function.builtin"                = { fg = "foreground" }
+"function.call"                   = { fg = "foreground" }
+"function.macro"                  = { fg = "foreground" }
+"function.method"                 = { fg = "foreground" }
+
+"keyword"                         = { fg = "foreground" }
+"keyword.control.conditional"     = { fg = "foreground" }
+"keyword.control.exception"       = { fg = "foreground" }
+"keyword.control.import"          = { fg = "foreground" }
+"keyword.control.repeat"          = { fg = "foreground" }
+"keyword.directive"               = { fg = "foreground" }
+"keyword.function"                = { fg = "foreground" }
+"keyword.operator"                = { fg = "foreground" }
+"keyword.return"                  = { fg = "foreground" }
+"keyword.storage"                 = { fg = "foreground" }
+"keyword.storage.modifier"        = { fg = "foreground" }
+"keyword.storage.type"            = { fg = "foreground", modifiers = ["italic"] }
+
+"label"                           = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "foreground", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "foreground", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "foreground", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "foreground" }
+"markup.link.url"                 = { fg = "foreground" }
+"markup.list"                     = { fg = "foreground" }
+"markup.quote"                    = { fg = "foreground", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "foreground" }
+
+"special"                         = { fg = "foreground" }
+
+"string"                          = { fg = "foreground" }
+"string.regexp"                   = { fg = "foreground" }
+"string.special"                  = { fg = "foreground" }
+"string.symbol"                   = { fg = "foreground" }
+
+"tag"                             = { fg = "foreground" }
+"tag.attribute"                   = { fg = "foreground" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "foreground", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "foreground" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"ui.background"                   = { fg = "foreground", bg = "background" }
+"ui.cursor"                       = { fg = "background", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.insert"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.match"                 = { fg = "foreground", bg = "primary" }
+"ui.cursor.normal"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
+"ui.cursorline.primary"           = { bg = "primary" }
+"ui.debug"                        = { fg = "foreground" }
+"ui.help"                         = { fg = "foreground", bg = "background" }
+"ui.highlight.frameline"          = { fg = "foreground", bg = "background" }
+"ui.linenr"                       = { fg = "foreground" }
+"ui.linenr.selected"              = { fg = "foreground" }
+"ui.menu"                         = { fg = "foreground", bg = "background" }
+"ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
+"ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
+"ui.popup"                        = { fg = "foreground", bg = "background" }
+"ui.selection"                    = { bg = "gray", underline = { style = "curl" } }
+"ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
+"ui.statusline"                   = { fg = "background", bg = "foreground" }
+"ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
+"ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.statusline.normal"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.statusline.select"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.bufferline"                   = { fg = "background", bg = "foreground"}
+"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.text"                         = { fg = "foreground" }
+"ui.text.focus"                   = { fg = "foreground" }
+"ui.virtual.indent-guide"         = { fg = "foreground" }
+"ui.virtual.inlay-hint"           = { fg = "foreground" }
+"ui.virtual.inlay-hint.parameter" = { fg = "foreground", modifiers = ["italic", "dim"] }
+"ui.virtual.inlay-hint.type"      = { fg = "foreground", modifiers = ["italic", "dim"] }
+"ui.virtual.jump-label"           = { fg = "foreground", modifiers = ["bold"] }
+"ui.virtual.ruler"                = { bg = "foreground" }
+"ui.virtual.backgroundspace"      = { fg = "foreground" }
+"ui.virtual.wrap"                 = { fg = "foreground" }
+"ui.window"                       = { fg = "foreground" }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "foreground", modifiers = ["bold"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "foreground", modifiers = ["bold"] }
+
+[palette]
+foreground = "#ffffff"
+background = "#000000"
+primary    = "#bababa"
+secondary  = "#959595"

--- a/runtime/themes/black_and_white.toml
+++ b/runtime/themes/black_and_white.toml
@@ -88,12 +88,12 @@
 "type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
 
 "ui.background"                   = { fg = "foreground", bg = "background" }
-"ui.cursor"                       = { fg = "background", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.match"                 = { fg = "foreground", bg = "primary" }
-"ui.cursor.normal"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.primary.insert"        = { fg = "foreground", bg = "primary" }
+"ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.insert"                = { fg = "secondary", bg  = "primary", modifiers  = ["dim"] }
+"ui.cursor.match"                 = { fg = "secondary", bg  = "primary" }
+"ui.cursor.normal"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "foceground", bg = "primary" }
 "ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
 "ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
 "ui.cursorline.primary"           = { bg = "primary" }
@@ -106,7 +106,7 @@
 "ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
 "ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
 "ui.popup"                        = { fg = "foreground", bg = "background" }
-"ui.selection"                    = { bg = "gray", underline = { style = "curl" } }
+"ui.selection"                    = { bg = "foreground", underline = { style = "curl" } }
 "ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
 "ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
@@ -137,4 +137,4 @@
 foreground = "#ffffff"
 background = "#000000"
 primary    = "#bababa"
-secondary  = "#959595"
+secondary  = "#555555"

--- a/runtime/themes/black_and_white.toml
+++ b/runtime/themes/black_and_white.toml
@@ -1,137 +1,57 @@
 # Author: ChiefMateStarbuck <septimusguy@gmail.com>
 
-"annotation"                      = { fg = "foreground" }
+"attribute"                       = { modifiers = ["italic"] }
 
-"attribute"                       = { fg = "foreground", modifiers = ["italic"] }
-
-"comment"                         = { fg = "foreground" }
-"comment.block"                   = { fg = "foreground" }
-"comment.block.documentation"     = { fg = "foreground" }
-"comment.line"                    = { fg = "foreground" }
-
-"constant"                        = { fg = "foreground" }
-"constant.builtin"                = { fg = "foreground" }
-"constant.builtin.boolean"        = { fg = "foreground" }
-"constant.character"              = { fg = "foreground" }
-"constant.character.escape"       = { fg = "foreground" }
-"constant.macro"                  = { fg = "foreground" }
-"constant.numeric"                = { fg = "foreground" }
-"constructor"                     = { fg = "foreground" }
-
-"definition"                      = { underline = { color = "foreground" } }
-"diagnostic"                      = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.hint"                 = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.warning"              = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.error"                = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.info"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic"                      = { underline = { style = "curl" } }
+"diagnostic.hint"                 = { underline = { style = "curl" } }
+"diagnostic.warning"              = { underline = { style = "curl" } }
+"diagnostic.error"                = { underline = { style = "curl" } }
+"diagnostic.info"                 = { underline = { style = "curl" } }
 "diagnostic.unnecessary"          = { modifiers = ["dim"] }
 "diagnostic.deprecated"           = { modifiers = ["crossed_out"] }
 
-"error"                           = { fg = "foreground" }
-"hint"                            = { fg = "foreground" }
-"info"                            = { fg = "foreground" }
-"warning"                         = { fg = "foreground" }
+"keyword.storage.type"            = { modifiers = ["italic"] }
 
-"diff.delta"                      = { fg = "foreground" }
-"diff.minus"                      = { fg = "foreground" }
-"diff.plus"                       = { fg = "foreground" }
-
-"function"                        = { fg = "foreground" }
-"function.builtin"                = { fg = "foreground" }
-"function.call"                   = { fg = "foreground" }
-"function.macro"                  = { fg = "foreground" }
-"function.method"                 = { fg = "foreground" }
-
-"keyword"                         = { fg = "foreground" }
-"keyword.control.conditional"     = { fg = "foreground" }
-"keyword.control.exception"       = { fg = "foreground" }
-"keyword.control.import"          = { fg = "foreground" }
-"keyword.control.repeat"          = { fg = "foreground" }
-"keyword.directive"               = { fg = "foreground" }
-"keyword.function"                = { fg = "foreground" }
-"keyword.operator"                = { fg = "foreground" }
-"keyword.return"                  = { fg = "foreground" }
-"keyword.storage"                 = { fg = "foreground" }
-"keyword.storage.modifier"        = { fg = "foreground" }
-"keyword.storage.type"            = { fg = "foreground", modifiers = ["italic"] }
-
-"label"                           = { fg = "foreground" }
-
-"markup.bold"                     = { fg = "foreground", modifiers = ["bold"] }
-"markup.heading"                  = { fg = "foreground", modifiers = ["bold"] }
-"markup.italic"                   = { fg = "foreground", modifiers = ["italic"] }
-"markup.link.text"                = { fg = "foreground" }
-"markup.link.url"                 = { fg = "foreground" }
-"markup.list"                     = { fg = "foreground" }
-"markup.quote"                    = { fg = "foreground", modifiers = ["italic"] }
-"markup.raw"                      = { fg = "foreground" }
+"markup.bold"                     = { modifiers = ["bold"] }
+"markup.heading"                  = { modifiers = ["bold"] }
+"markup.italic"                   = { modifiers = ["italic"] }
+"markup.quote"                    = { modifiers = ["italic"] }
 "markup.strikethrough"            = { modifiers = ["crossed_out"] }
 
-"punctuation"                     = { fg = "foreground" }
-"punctuation.bracket"             = { fg = "foreground" }
-"punctuation.delimiter"           = { fg = "foreground" }
-"punctuation.special"             = { fg = "foreground" }
+"type"                            = { modifiers = ["italic"] }
+"type.enum.variant"               = { modifiers = ["italic"] }
 
-"special"                         = { fg = "foreground" }
-
-"string"                          = { fg = "foreground" }
-"string.regexp"                   = { fg = "foreground" }
-"string.special"                  = { fg = "foreground" }
-"string.symbol"                   = { fg = "foreground" }
-
-"tag"                             = { fg = "foreground" }
-"tag.attribute"                   = { fg = "foreground" }
-"tag.delimiter"                   = { fg = "foreground" }
-
-"type"                            = { fg = "foreground", modifiers = ["italic"] }
-"type.builtin"                    = { fg = "foreground" }
-"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
-
-"ui.background"                   = { fg = "foreground", bg = "background" }
-"ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "primary", bg  = "secondary", modifiers  = ["dim"] }
-"ui.cursor.match"                 = { fg = "primary", bg  = "secondary" }
-"ui.cursor.normal"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.background"                   = { bg = "background" }
+"ui.bufferline"                   = { fg = "background", bg = "foreground"}
+"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.cursor"                       = { bg = "primary"}
+"ui.cursor.insert"                = { bg = "primary"}
+"ui.cursor.match"                 = { bg = "primary"}
+"ui.cursor.normal"                = { bg = "primary"}
+"ui.cursor.select"                = { bg = "primary"}
 "ui.cursor.primary.insert"        = { fg = "background", bg = "foreground" }
 "ui.cursor.primary.normal"        = { fg = "background", bg = "foreground" }
 "ui.cursor.primary.select"        = { fg = "background", bg = "foreground" }
 "ui.cursorline.primary"           = { bg = "primary" }
-"ui.debug"                        = { fg = "foreground" }
-"ui.help"                         = { fg = "foreground", bg = "background" }
-"ui.highlight.frameline"          = { fg = "foreground", bg = "background" }
 "ui.linenr"                       = { fg = "foreground" }
-"ui.linenr.selected"              = { fg = "foreground" }
-"ui.menu"                         = { fg = "foreground", bg = "background" }
-"ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
-"ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
+"ui.menu"                         = { fg = "background", bg = "foreground" }
+"ui.menu.selected"                = { fg = "foreground", bg = "background"}
 "ui.popup"                        = { fg = "foreground", bg = "background" }
 "ui.selection"                    = { bg = "secondary", underline = { style = "curl" } }
-"ui.selection.primary"            = { fg = "foreground", bg = "primary", underline = { style = "curl" }}
+"ui.selection.primary"            = { bg = "primary", underline = { style = "curl" }}
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
-"ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
-"ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.statusline.normal"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.statusline.select"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.bufferline"                   = { fg = "background", bg = "foreground"}
-"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.statusline.insert"            = {  modifiers = ["bold"] }
+"ui.statusline.normal"            = {  modifiers = ["bold"] }
+"ui.statusline.select"            = {  modifiers = ["bold"] }
 "ui.text"                         = { fg = "foreground" }
 "ui.text.focus"                   = { fg = "foreground" }
-"ui.virtual.indent-guide"         = { fg = "foreground" }
-"ui.virtual.inlay-hint"           = { fg = "foreground" }
-"ui.virtual.inlay-hint.parameter" = { fg = "foreground", modifiers = ["italic", "dim"] }
-"ui.virtual.inlay-hint.type"      = { fg = "foreground", modifiers = ["italic", "dim"] }
-"ui.virtual.jump-label"           = { fg = "foreground", modifiers = ["bold"] }
-"ui.virtual.ruler"                = { bg = "foreground" }
-"ui.virtual.backgroundspace"      = { fg = "foreground" }
-"ui.virtual.wrap"                 = { fg = "foreground" }
-"ui.window"                       = { fg = "foreground" }
+"ui.virtual.inlay-hint.parameter" = { modifiers = ["italic", "dim"] }
+"ui.virtual.inlay-hint.type"      = { modifiers = ["italic", "dim"] }
+"ui.virtual.jump-label"           = { modifiers = ["bold"] }
 
-"variable"                        = { fg = "foreground" }
-"variable.builtin"                = { fg = "foreground", modifiers = ["bold"] }
-"variable.other"                  = { fg = "foreground" }
-"variable.other.member"           = { fg = "foreground" }
-"variable.parameter"              = { fg = "foreground", modifiers = ["bold"] }
+
+"variable.builtin"                = { modifiers = ["bold"] }
+"variable.parameter"              = { modifiers = ["bold"] }
 
 [palette]
 foreground = "#ffffff"

--- a/runtime/themes/black_and_white.toml
+++ b/runtime/themes/black_and_white.toml
@@ -89,13 +89,13 @@
 
 "ui.background"                   = { fg = "foreground", bg = "background" }
 "ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "secondary", bg  = "primary", modifiers  = ["dim"] }
-"ui.cursor.match"                 = { fg = "secondary", bg  = "primary" }
-"ui.cursor.normal"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
-"ui.cursor.primary.insert"        = { fg = "foceground", bg = "primary" }
-"ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
-"ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.insert"                = { fg = "primary", bg  = "secondary", modifiers  = ["dim"] }
+"ui.cursor.match"                 = { fg = "primary", bg  = "secondary" }
+"ui.cursor.normal"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "background", bg = "foreground" }
+"ui.cursor.primary.normal"        = { fg = "background", bg = "foreground" }
+"ui.cursor.primary.select"        = { fg = "background", bg = "foreground" }
 "ui.cursorline.primary"           = { bg = "primary" }
 "ui.debug"                        = { fg = "foreground" }
 "ui.help"                         = { fg = "foreground", bg = "background" }
@@ -106,8 +106,8 @@
 "ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
 "ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
 "ui.popup"                        = { fg = "foreground", bg = "background" }
-"ui.selection"                    = { bg = "foreground", underline = { style = "curl" } }
-"ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
+"ui.selection"                    = { bg = "secondary", underline = { style = "curl" } }
+"ui.selection.primary"            = { fg = "foreground", bg = "primary", underline = { style = "curl" }}
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
 "ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
 "ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }

--- a/runtime/themes/white_and_black.toml
+++ b/runtime/themes/white_and_black.toml
@@ -89,13 +89,13 @@
 
 "ui.background"                   = { fg = "foreground", bg = "background" }
 "ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "secondary", bg  = "primary", modifiers  = ["dim"] }
-"ui.cursor.match"                 = { fg = "secondary", bg  = "primary" }
-"ui.cursor.normal"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
-"ui.cursor.primary.insert"        = { fg = "foceground", bg = "primary" }
-"ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
-"ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.insert"                = { fg = "primary", bg  = "secondary", modifiers  = ["dim"] }
+"ui.cursor.match"                 = { fg = "primary", bg  = "secondary" }
+"ui.cursor.normal"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "background", bg = "foreground" }
+"ui.cursor.primary.normal"        = { fg = "background", bg = "foreground" }
+"ui.cursor.primary.select"        = { fg = "background", bg = "foreground" }
 "ui.cursorline.primary"           = { bg = "primary" }
 "ui.debug"                        = { fg = "foreground" }
 "ui.help"                         = { fg = "foreground", bg = "background" }
@@ -106,8 +106,8 @@
 "ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
 "ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
 "ui.popup"                        = { fg = "foreground", bg = "background" }
-"ui.selection"                    = { bg = "foreground", underline = { style = "curl" } }
-"ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
+"ui.selection"                    = { bg = "secondary", underline = { style = "curl" } }
+"ui.selection.primary"            = { bg = "primary", underline = { style = "curl" }, modifiers = ["dim"] }
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
 "ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
 "ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
@@ -136,5 +136,5 @@
 [palette]
 foreground = "#000000"
 background = "#ffffff"
-primary    = "#cccccc"
-secondary  = "#d5dbdb"
+primary    = "#c9c9c9"
+secondary  = "#e3e1e1"

--- a/runtime/themes/white_and_black.toml
+++ b/runtime/themes/white_and_black.toml
@@ -1,137 +1,57 @@
 # Author: ChiefMateStarbuck <septimusguy@gmail.com>
 
-"annotation"                      = { fg = "foreground" }
+"attribute"                       = { modifiers = ["italic"] }
 
-"attribute"                       = { fg = "foreground", modifiers = ["italic"] }
-
-"comment"                         = { fg = "foreground" }
-"comment.block"                   = { fg = "foreground" }
-"comment.block.documentation"     = { fg = "foreground" }
-"comment.line"                    = { fg = "foreground" }
-
-"constant"                        = { fg = "foreground" }
-"constant.builtin"                = { fg = "foreground" }
-"constant.builtin.boolean"        = { fg = "foreground" }
-"constant.character"              = { fg = "foreground" }
-"constant.character.escape"       = { fg = "foreground" }
-"constant.macro"                  = { fg = "foreground" }
-"constant.numeric"                = { fg = "foreground" }
-"constructor"                     = { fg = "foreground" }
-
-"definition"                      = { underline = { color = "foreground" } }
-"diagnostic"                      = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.hint"                 = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.warning"              = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.error"                = { underline = { color = "foreground", style = "curl" } }
-"diagnostic.info"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic"                      = { underline = { style = "curl" } }
+"diagnostic.hint"                 = { underline = { style = "curl" } }
+"diagnostic.warning"              = { underline = { style = "curl" } }
+"diagnostic.error"                = { underline = { style = "curl" } }
+"diagnostic.info"                 = { underline = { style = "curl" } }
 "diagnostic.unnecessary"          = { modifiers = ["dim"] }
 "diagnostic.deprecated"           = { modifiers = ["crossed_out"] }
 
-"error"                           = { fg = "foreground" }
-"hint"                            = { fg = "foreground" }
-"info"                            = { fg = "foreground" }
-"warning"                         = { fg = "foreground" }
+"keyword.storage.type"            = { modifiers = ["italic"] }
 
-"diff.delta"                      = { fg = "foreground" }
-"diff.minus"                      = { fg = "foreground" }
-"diff.plus"                       = { fg = "foreground" }
-
-"function"                        = { fg = "foreground" }
-"function.builtin"                = { fg = "foreground" }
-"function.call"                   = { fg = "foreground" }
-"function.macro"                  = { fg = "foreground" }
-"function.method"                 = { fg = "foreground" }
-
-"keyword"                         = { fg = "foreground" }
-"keyword.control.conditional"     = { fg = "foreground" }
-"keyword.control.exception"       = { fg = "foreground" }
-"keyword.control.import"          = { fg = "foreground" }
-"keyword.control.repeat"          = { fg = "foreground" }
-"keyword.directive"               = { fg = "foreground" }
-"keyword.function"                = { fg = "foreground" }
-"keyword.operator"                = { fg = "foreground" }
-"keyword.return"                  = { fg = "foreground" }
-"keyword.storage"                 = { fg = "foreground" }
-"keyword.storage.modifier"        = { fg = "foreground" }
-"keyword.storage.type"            = { fg = "foreground", modifiers = ["italic"] }
-
-"label"                           = { fg = "foreground" }
-
-"markup.bold"                     = { fg = "foreground", modifiers = ["bold"] }
-"markup.heading"                  = { fg = "foreground", modifiers = ["bold"] }
-"markup.italic"                   = { fg = "foreground", modifiers = ["italic"] }
-"markup.link.text"                = { fg = "foreground" }
-"markup.link.url"                 = { fg = "foreground" }
-"markup.list"                     = { fg = "foreground" }
-"markup.quote"                    = { fg = "foreground", modifiers = ["italic"] }
-"markup.raw"                      = { fg = "foreground" }
+"markup.bold"                     = { modifiers = ["bold"] }
+"markup.heading"                  = { modifiers = ["bold"] }
+"markup.italic"                   = { modifiers = ["italic"] }
+"markup.quote"                    = { modifiers = ["italic"] }
 "markup.strikethrough"            = { modifiers = ["crossed_out"] }
 
-"punctuation"                     = { fg = "foreground" }
-"punctuation.bracket"             = { fg = "foreground" }
-"punctuation.delimiter"           = { fg = "foreground" }
-"punctuation.special"             = { fg = "foreground" }
+"type"                            = { modifiers = ["italic"] }
+"type.enum.variant"               = { modifiers = ["italic"] }
 
-"special"                         = { fg = "foreground" }
-
-"string"                          = { fg = "foreground" }
-"string.regexp"                   = { fg = "foreground" }
-"string.special"                  = { fg = "foreground" }
-"string.symbol"                   = { fg = "foreground" }
-
-"tag"                             = { fg = "foreground" }
-"tag.attribute"                   = { fg = "foreground" }
-"tag.delimiter"                   = { fg = "foreground" }
-
-"type"                            = { fg = "foreground", modifiers = ["italic"] }
-"type.builtin"                    = { fg = "foreground" }
-"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
-
-"ui.background"                   = { fg = "foreground", bg = "background" }
-"ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "primary", bg  = "secondary", modifiers  = ["dim"] }
-"ui.cursor.match"                 = { fg = "primary", bg  = "secondary" }
-"ui.cursor.normal"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "primary", bg  = "secondary", modifiers = ["dim"] }
+"ui.background"                   = { bg = "background" }
+"ui.bufferline"                   = { fg = "background", bg = "foreground"}
+"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.cursor"                       = { bg = "primary"}
+"ui.cursor.insert"                = { bg = "primary"}
+"ui.cursor.match"                 = { bg = "primary"}
+"ui.cursor.normal"                = { bg = "primary"}
+"ui.cursor.select"                = { bg = "primary"}
 "ui.cursor.primary.insert"        = { fg = "background", bg = "foreground" }
 "ui.cursor.primary.normal"        = { fg = "background", bg = "foreground" }
 "ui.cursor.primary.select"        = { fg = "background", bg = "foreground" }
 "ui.cursorline.primary"           = { bg = "primary" }
-"ui.debug"                        = { fg = "foreground" }
-"ui.help"                         = { fg = "foreground", bg = "background" }
-"ui.highlight.frameline"          = { fg = "foreground", bg = "background" }
 "ui.linenr"                       = { fg = "foreground" }
-"ui.linenr.selected"              = { fg = "foreground" }
-"ui.menu"                         = { fg = "foreground", bg = "background" }
-"ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
-"ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
+"ui.menu"                         = { fg = "background", bg = "foreground" }
+"ui.menu.selected"                = { fg = "foreground", bg = "background"}
 "ui.popup"                        = { fg = "foreground", bg = "background" }
 "ui.selection"                    = { bg = "secondary", underline = { style = "curl" } }
-"ui.selection.primary"            = { bg = "primary", underline = { style = "curl" }, modifiers = ["dim"] }
+"ui.selection.primary"            = { bg = "primary", underline = { style = "curl" }}
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
-"ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
-"ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.statusline.normal"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.statusline.select"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
-"ui.bufferline"                   = { fg = "background", bg = "foreground"}
-"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.statusline.insert"            = {  modifiers = ["bold"] }
+"ui.statusline.normal"            = {  modifiers = ["bold"] }
+"ui.statusline.select"            = {  modifiers = ["bold"] }
 "ui.text"                         = { fg = "foreground" }
 "ui.text.focus"                   = { fg = "foreground" }
-"ui.virtual.indent-guide"         = { fg = "foreground" }
-"ui.virtual.inlay-hint"           = { fg = "foreground" }
-"ui.virtual.inlay-hint.parameter" = { fg = "foreground", modifiers = ["italic", "dim"] }
-"ui.virtual.inlay-hint.type"      = { fg = "foreground", modifiers = ["italic", "dim"] }
-"ui.virtual.jump-label"           = { fg = "foreground", modifiers = ["bold"] }
-"ui.virtual.ruler"                = { bg = "foreground" }
-"ui.virtual.backgroundspace"      = { fg = "foreground" }
-"ui.virtual.wrap"                 = { fg = "foreground" }
-"ui.window"                       = { fg = "foreground" }
+"ui.virtual.inlay-hint.parameter" = { modifiers = ["italic", "dim"] }
+"ui.virtual.inlay-hint.type"      = { modifiers = ["italic", "dim"] }
+"ui.virtual.jump-label"           = { modifiers = ["bold"] }
 
-"variable"                        = { fg = "foreground" }
-"variable.builtin"                = { fg = "foreground", modifiers = ["bold"] }
-"variable.other"                  = { fg = "foreground" }
-"variable.other.member"           = { fg = "foreground" }
-"variable.parameter"              = { fg = "foreground", modifiers = ["bold"] }
+
+"variable.builtin"                = { modifiers = ["bold"] }
+"variable.parameter"              = { modifiers = ["bold"] }
 
 [palette]
 foreground = "#000000"

--- a/runtime/themes/white_and_black.toml
+++ b/runtime/themes/white_and_black.toml
@@ -88,12 +88,12 @@
 "type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
 
 "ui.background"                   = { fg = "foreground", bg = "background" }
-"ui.cursor"                       = { fg = "background", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.insert"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.match"                 = { fg = "foreground", bg = "primary" }
-"ui.cursor.normal"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.select"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
-"ui.cursor.primary.insert"        = { fg = "foreground", bg = "primary" }
+"ui.cursor"                       = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.insert"                = { fg = "secondary", bg  = "primary", modifiers  = ["dim"] }
+"ui.cursor.match"                 = { fg = "secondary", bg  = "primary" }
+"ui.cursor.normal"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "secondary", bg  = "primary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "foceground", bg = "primary" }
 "ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
 "ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
 "ui.cursorline.primary"           = { bg = "primary" }
@@ -106,7 +106,7 @@
 "ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
 "ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
 "ui.popup"                        = { fg = "foreground", bg = "background" }
-"ui.selection"                    = { bg = "gray", underline = { style = "curl" } }
+"ui.selection"                    = { bg = "foreground", underline = { style = "curl" } }
 "ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
 "ui.statusline"                   = { fg = "background", bg = "foreground" }
 "ui.statusline.inactive"          = { fg = "foreground", bg = "background" }

--- a/runtime/themes/white_and_black.toml
+++ b/runtime/themes/white_and_black.toml
@@ -1,0 +1,140 @@
+# Author: ChiefMateStarbuck <septimusguy@gmail.com>
+
+"annotation"                      = { fg = "foreground" }
+
+"attribute"                       = { fg = "foreground", modifiers = ["italic"] }
+
+"comment"                         = { fg = "foreground" }
+"comment.block"                   = { fg = "foreground" }
+"comment.block.documentation"     = { fg = "foreground" }
+"comment.line"                    = { fg = "foreground" }
+
+"constant"                        = { fg = "foreground" }
+"constant.builtin"                = { fg = "foreground" }
+"constant.builtin.boolean"        = { fg = "foreground" }
+"constant.character"              = { fg = "foreground" }
+"constant.character.escape"       = { fg = "foreground" }
+"constant.macro"                  = { fg = "foreground" }
+"constant.numeric"                = { fg = "foreground" }
+"constructor"                     = { fg = "foreground" }
+
+"definition"                      = { underline = { color = "foreground" } }
+"diagnostic"                      = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.hint"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.warning"              = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.error"                = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.info"                 = { underline = { color = "foreground", style = "curl" } }
+"diagnostic.unnecessary"          = { modifiers = ["dim"] }
+"diagnostic.deprecated"           = { modifiers = ["crossed_out"] }
+
+"error"                           = { fg = "foreground" }
+"hint"                            = { fg = "foreground" }
+"info"                            = { fg = "foreground" }
+"warning"                         = { fg = "foreground" }
+
+"diff.delta"                      = { fg = "foreground" }
+"diff.minus"                      = { fg = "foreground" }
+"diff.plus"                       = { fg = "foreground" }
+
+"function"                        = { fg = "foreground" }
+"function.builtin"                = { fg = "foreground" }
+"function.call"                   = { fg = "foreground" }
+"function.macro"                  = { fg = "foreground" }
+"function.method"                 = { fg = "foreground" }
+
+"keyword"                         = { fg = "foreground" }
+"keyword.control.conditional"     = { fg = "foreground" }
+"keyword.control.exception"       = { fg = "foreground" }
+"keyword.control.import"          = { fg = "foreground" }
+"keyword.control.repeat"          = { fg = "foreground" }
+"keyword.directive"               = { fg = "foreground" }
+"keyword.function"                = { fg = "foreground" }
+"keyword.operator"                = { fg = "foreground" }
+"keyword.return"                  = { fg = "foreground" }
+"keyword.storage"                 = { fg = "foreground" }
+"keyword.storage.modifier"        = { fg = "foreground" }
+"keyword.storage.type"            = { fg = "foreground", modifiers = ["italic"] }
+
+"label"                           = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "foreground", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "foreground", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "foreground", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "foreground" }
+"markup.link.url"                 = { fg = "foreground" }
+"markup.list"                     = { fg = "foreground" }
+"markup.quote"                    = { fg = "foreground", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "foreground" }
+
+"special"                         = { fg = "foreground" }
+
+"string"                          = { fg = "foreground" }
+"string.regexp"                   = { fg = "foreground" }
+"string.special"                  = { fg = "foreground" }
+"string.symbol"                   = { fg = "foreground" }
+
+"tag"                             = { fg = "foreground" }
+"tag.attribute"                   = { fg = "foreground" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "foreground", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "foreground" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"ui.background"                   = { fg = "foreground", bg = "background" }
+"ui.cursor"                       = { fg = "background", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.insert"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.match"                 = { fg = "foreground", bg = "primary" }
+"ui.cursor.normal"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.select"                = { fg = "foreground", bg = "primary", modifiers = ["dim"] }
+"ui.cursor.primary.insert"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.primary.normal"        = { fg = "foreground", bg = "primary" }
+"ui.cursor.primary.select"        = { fg = "foreground", bg = "primary" }
+"ui.cursorline.primary"           = { bg = "primary" }
+"ui.debug"                        = { fg = "foreground" }
+"ui.help"                         = { fg = "foreground", bg = "background" }
+"ui.highlight.frameline"          = { fg = "foreground", bg = "background" }
+"ui.linenr"                       = { fg = "foreground" }
+"ui.linenr.selected"              = { fg = "foreground" }
+"ui.menu"                         = { fg = "foreground", bg = "background" }
+"ui.menu.scroll"                  = { fg = "foreground", bg = "background" }
+"ui.menu.selected"                = { fg = "foreground", bg = "background", modifiers = ["dim"] }
+"ui.popup"                        = { fg = "foreground", bg = "background" }
+"ui.selection"                    = { bg = "gray", underline = { style = "curl" } }
+"ui.selection.primary"            = { bg = "secondary", underline = { style = "curl" }, modifiers = ["dim"] }
+"ui.statusline"                   = { fg = "background", bg = "foreground" }
+"ui.statusline.inactive"          = { fg = "foreground", bg = "background" }
+"ui.statusline.insert"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.statusline.normal"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.statusline.select"            = { fg = "foreground", bg = "background", modifiers = ["bold"] }
+"ui.bufferline"                   = { fg = "background", bg = "foreground"}
+"ui.bufferline.active"            = { fg = "foreground", bg = "background"}
+"ui.text"                         = { fg = "foreground" }
+"ui.text.focus"                   = { fg = "foreground" }
+"ui.virtual.indent-guide"         = { fg = "foreground" }
+"ui.virtual.inlay-hint"           = { fg = "foreground" }
+"ui.virtual.inlay-hint.parameter" = { fg = "foreground", modifiers = ["italic", "dim"] }
+"ui.virtual.inlay-hint.type"      = { fg = "foreground", modifiers = ["italic", "dim"] }
+"ui.virtual.jump-label"           = { fg = "foreground", modifiers = ["bold"] }
+"ui.virtual.ruler"                = { bg = "foreground" }
+"ui.virtual.backgroundspace"      = { fg = "foreground" }
+"ui.virtual.wrap"                 = { fg = "foreground" }
+"ui.window"                       = { fg = "foreground" }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "foreground", modifiers = ["bold"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "foreground", modifiers = ["bold"] }
+
+[palette]
+foreground = "#000000"
+background = "#ffffff"
+primary    = "#cccccc"
+secondary  = "#d5dbdb"


### PR DESCRIPTION
This pull request introduces two new themes, `white_and_black` and `black_and_white`, to the runtime. They are monochrome, which will help those with vision impairment. 

white_and_black is a light theme.
<img width="1800" alt="Screenshot 2024-10-13 at 10 19 21 PM" src="https://github.com/user-attachments/assets/3d09b215-e7af-4f11-a6a8-f1e17c8c605c">

black_and_white is a dark theme. 
<img width="1800" alt="Screenshot 2024-10-13 at 10 19 35 PM" src="https://github.com/user-attachments/assets/72ccc3fe-c062-4877-851a-e20c69bfe72c">
