### PR TITLE
Update repology URL after change from helix to helix-editor

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -17,7 +17,7 @@
   - [Chocolatey](#chocolatey)
   - [MSYS2](#msys2)
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix-editor/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/helix-editor.svg)](https://repology.org/project/helix-editor/versions)
 
 ## Linux
 

--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -17,7 +17,7 @@
   - [Chocolatey](#chocolatey)
   - [MSYS2](#msys2)
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/helix.svg)](https://repology.org/project/helix-editor/versions)
 
 ## Linux
 


### PR DESCRIPTION
At the moment we have the following, when clicked it does a redirect:

![image](https://github.com/user-attachments/assets/e8d01636-7af0-4d2f-92d0-d16fc8d4ac28)

It needs back-porting asap as site is currently broken.