### PR TITLE
Fix `cargo integration-test` for Nix flake

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+# https://github.com/flamegraph-rs/flamegraph
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,--no-rosegment", "-C", "target-cpu=native"]
+
 # we use tokio_unstable to enable runtime::Handle::id so we can separate
 # globals from multiple parallel tests. If that function ever does get removed
 # its possible to replace (with some additional overhead and effort)

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,6 @@
         if pkgs.stdenv.isLinux
         then pkgs.stdenv
         else pkgs.clangStdenv;
-      rustFlagsEnv = pkgs.lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=lld -C target-cpu=native -Clink-arg=-Wl,--no-rosegment";
       rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       craneLibMSRV = (crane.mkLib pkgs).overrideToolchain rustToolchain;
       craneLibStable = (crane.mkLib pkgs).overrideToolchain pkgs.pkgsBuildHost.rust-bin.stable.latest.default;
@@ -182,7 +181,6 @@
         shellHook = ''
           export HELIX_RUNTIME="$PWD/runtime"
           export RUST_BACKTRACE="1"
-          export RUSTFLAGS="''${RUSTFLAGS:-""} ${rustFlagsEnv}"
         '';
       };
     })


### PR DESCRIPTION
The rustflags set in the `flake.nix` is stomping on helix/.cargo/config.toml:

```
rustflags = ["--cfg", "tokio_unstable", "-C", "target-feature=-crt-static"]
```

Here is the error I was getting:

```
$ cargo integration-test
   Compiling helix-event v24.7.0 (/home/will/code/helix/helix-event)
   Compiling helix-lsp-types v0.95.1 (/home/will/code/helix/helix-lsp-types)
   Compiling toml v0.8.19
   Compiling gix-url v0.27.5
error[E0412]: cannot find type `Id` in module `tokio::runtime`
   --> helix-event/src/runtime.rs:45:64
    |
45  |         parking_lot::RwLock<hashbrown::HashMap<tokio::runtime::Id, &'static T, ahash::RandomState>>,
    |                                                                ^^ not found in `tokio::runtime`
    |
note: found an item that was configured out
   --> /home/will/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/mod.rs:371:21
    |
371 |         pub use id::Id;
    |                     ^^

error[E0599]: no method named `id` found for struct `Handle` in the current scope
  --> helix-event/src/runtime.rs:67:52
   |
67 |         let id = tokio::runtime::Handle::current().id();
   |                                                    ^^ method not found in `Handle`

   Compiling gix-submodule v0.14.0
Some errors have detailed explanations: E0412, E0599.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `helix-event` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

Can temporarily fix this by running:

```
RUSTFLAGS="--cfg tokio_unstable" cargo integration-test
```
This fixes the error because https://docs.rs/tokio/1.40.0/tokio/runtime/struct.Id.html "Available on tokio_unstable and crate feature rt only."

So this PR moves the setting of flags for Linux under `.cargo/config.toml`.

I did some digging on the history of RUSTFLAGS in the nix files:

- https://github.com/helix-editor/helix/commit/f1539cc86680935a0b2a5bbd16c64b110687cdf7
- https://github.com/helix-editor/helix/commit/d5db8929026e644fac83ba976b45b6606f0277d5
- https://github.com/helix-editor/helix/commit/df0d58e9f74befebf902fff887a14ae59746b24b