### PR TITLE
Fix repology links pt 2

### DIFF
--- a/master/package-managers.html
+++ b/master/package-managers.html
@@ -207,7 +207,7 @@
 </ul>
 </li>
 </ul>
-<p><a href="https://repology.org/project/helix/versions"><img src="https://repology.org/badge/vertical-allrepos/helix.svg" alt="Packaging status" /></a></p>
+<p><a href="https://repology.org/project/helix-editor/versions"><img src="https://repology.org/badge/vertical-allrepos/helix-editor.svg" alt="Packaging status" /></a></p>
 <h2 id="linux"><a class="header" href="#linux">Linux</a></h2>
 <p>The following third party repositories are available:</p>
 <h3 id="ubuntu"><a class="header" href="#ubuntu">Ubuntu</a></h3>

--- a/master/package-managers.html
+++ b/master/package-managers.html
@@ -207,7 +207,7 @@
 </ul>
 </li>
 </ul>
-<p><a href="https://repology.org/project/helix-editor/versions"><img src="https://repology.org/badge/vertical-allrepos/helix-editor.svg" alt="Packaging status" /></a></p>
+<p><a href="https://repology.org/project/helix/versions"><img src="https://repology.org/badge/vertical-allrepos/helix.svg" alt="Packaging status" /></a></p>
 <h2 id="linux"><a class="header" href="#linux">Linux</a></h2>
 <p>The following third party repositories are available:</p>
 <h3 id="ubuntu"><a class="header" href="#ubuntu">Ubuntu</a></h3>

--- a/package-managers.html
+++ b/package-managers.html
@@ -207,7 +207,7 @@
 </ul>
 </li>
 </ul>
-<p><a href="https://repology.org/project/helix/versions"><img src="https://repology.org/badge/vertical-allrepos/helix.svg" alt="Packaging status" /></a></p>
+<p><a href="https://repology.org/project/helix-editor/versions"><img src="https://repology.org/badge/vertical-allrepos/helix-editor.svg" alt="Packaging status" /></a></p>
 <h2 id="linux"><a class="header" href="#linux">Linux</a></h2>
 <p>The following third party repositories are available:</p>
 <h3 id="ubuntu"><a class="header" href="#ubuntu">Ubuntu</a></h3>

--- a/print.html
+++ b/print.html
@@ -232,7 +232,7 @@ The runtime location can be overriden via the HELIX_RUNTIME environment variable
 </ul>
 </li>
 </ul>
-<p><a href="https://repology.org/project/helix/versions"><img src="https://repology.org/badge/vertical-allrepos/helix.svg" alt="Packaging status" /></a></p>
+<p><a href="https://repology.org/project/helix-editor/versions"><img src="https://repology.org/badge/vertical-allrepos/helix-editor.svg" alt="Packaging status" /></a></p>
 <h2 id="linux"><a class="header" href="#linux">Linux</a></h2>
 <p>The following third party repositories are available:</p>
 <h3 id="ubuntu"><a class="header" href="#ubuntu">Ubuntu</a></h3>


### PR DESCRIPTION
Repology has renamed the package from `helix` to `helix-editor`. This causes a redirect on the website but the SVG needs an update in order to render. Connects helix-editor#11877