### PR TITLE
Add Jump Label Follow Blacklist

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -51,6 +51,7 @@
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |
 | `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`
 | `jump-label-alphabet` | The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. | `"abcdefghijklmnopqrstuvwxyz"`
+| `jump-label-follow-blacklist` | Used to remove jump label combinations that are hard to type. For example, to make the labels "fj" and "fy" not used, set this option to `{ f = "jy" }` | `{}`
 | `end-of-line-diagnostics` | Minimum severity of diagnostics to render at the end of the line. Set to `disable` to disable entirely. Refer to the setting about `inline-diagnostics` for more details | "disable"
 
 ### `[editor.statusline]` Section

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -21,7 +21,7 @@ use helix_lsp::{Call, LanguageServerId};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use std::{
-    borrow::Cow,
+    borrow::{Borrow, Cow},
     cell::Cell,
     collections::{BTreeMap, HashMap, HashSet},
     fs,
@@ -342,9 +342,115 @@ pub struct Config {
         deserialize_with = "deserialize_alphabet"
     )]
     pub jump_label_alphabet: Vec<char>,
+    // characters not allowed to follow each starting character
+    pub jump_label_follow_blacklist: JumpLabelFollowBlacklist,
     /// Display diagnostic below the line they occur.
     pub inline_diagnostics: InlineDiagnosticsConfig,
     pub end_of_line_diagnostics: DiagnosticFilter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JumpLabelFollowBlacklist(HashMap<char, Vec<char>>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JumpLabelLookup {
+    pub alphabet: Vec<char>,
+    pub follow_whitelist: HashMap<char, Vec<char>>,
+}
+
+impl JumpLabelFollowBlacklist {
+    pub fn get(&self, c: char) -> Option<&Vec<char>> {
+        self.0.get(&c)
+    }
+
+    pub fn get_allow_list(&self, alphabet: &Vec<char>) -> JumpLabelLookup {
+        let follow_whitelist: HashMap<_, _> = alphabet
+            .iter()
+            .filter_map(|c| {
+                let unique_chars: HashSet<_> = alphabet.iter().copied().collect();
+                let blacklist_chars: Option<HashSet<_>> =
+                    self.get(*c).and_then(|v| Some(v.iter().copied().collect()));
+
+                let whitelist_chars = if let Some(blacklist_chars) = blacklist_chars {
+                    unique_chars
+                        .symmetric_difference(&blacklist_chars)
+                        .map(|c| *c)
+                        .collect()
+                } else {
+                    alphabet.clone()
+                };
+
+                if whitelist_chars.len() > 0 {
+                    Some((*c, whitelist_chars))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let alphabet = alphabet
+            .iter()
+            .filter_map(|c| {
+                if follow_whitelist.contains_key(c) {
+                    Some(*c)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        JumpLabelLookup {
+            alphabet,
+            follow_whitelist,
+        }
+    }
+}
+
+impl Serialize for JumpLabelFollowBlacklist {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0
+            .iter()
+            .map(|(k, v)| (*k, v.iter().collect::<String>()))
+            .collect::<HashMap<_, _>>()
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for JumpLabelFollowBlacklist {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let map = HashMap::<char, String>::deserialize(deserializer)?;
+
+        let map = map
+            .into_iter()
+            .map(|(k, v)| {
+                let chars: Vec<_> = v.chars().collect();
+                let unique_chars: HashSet<_> = chars.iter().copied().collect();
+                if unique_chars.len() != chars.len() {
+                    return Err(<D::Error as Error>::custom(
+                        "jump-label-follow-blacklist lists must contain unique characters",
+                    ));
+                }
+
+                Ok((k, chars))
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?;
+
+        Ok(Self(map))
+    }
+}
+
+impl Default for JumpLabelFollowBlacklist {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -980,6 +1086,7 @@ impl Default for Config {
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
+            jump_label_follow_blacklist: JumpLabelFollowBlacklist::default(),
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Disable,
         }


### PR DESCRIPTION
This is a new option solving the same problem I was trying to solve in #11884 of the labels generated by the jump label system often being difficult to type. The solution implemented by this PR for the problem is a new option called jump-label-follow-blacklist which defaults to empty so that if this hasn't been a problem for someone their config doesn't need to change. The option can be set to any map of letters to lists of letters that shouldn't follow it in the jump label (for example, setting `jump-label-follow-blacklist : { r: "wx" }` would mean that the pairs "rw" and "rx" won't show up in your jump labels). This is as configurable as a feature like this can possibly be, I think fairly ergonomic to use (easier to list keys that shouldn't go together than all the keys that should), and means no changes in configuration for people who don't want to use it.