### PR TITLE
chore: add "ui.virtual.jump-label" to serika-dark theme

### DIFF
--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -53,6 +53,7 @@
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.ruler" = { bg = "grey2" } 
 "ui.virtual.inlay-hint" = { fg = "grey2", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { fg = "nasty-red", modifiers = ["bold"] }
 
 "hint" = "blue"
 "info" = "aqua"


### PR DESCRIPTION
<img width="612" alt="Screenshot 2024-10-17 at 3 20 44 PM" src="https://github.com/user-attachments/assets/717bdd95-8ae5-4d77-b68d-0c4dbb3f8479">