### PR TITLE
Set  tags color in monokai theme

### DIFF
--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -1,5 +1,7 @@
 # Author: Shafkath Shuhan <shafkathshuhannyc@gmail.com>
 
+"tag" = { fg = "tag" }
+
 "namespace" = { fg = "type" }
 "module" = { fg = "type" }
 
@@ -116,3 +118,4 @@ cursor = "#a6a6a6"
 inactive_cursor = "#878b91"
 widget = "#1e1f1c"
 selection = "#414339"
+tag = "#F92672"


### PR DESCRIPTION
Fixes #11866 

Sets monokai (and related themes like molokai) tag color.
Uses same color as vscode monokai theme for tags names = #F92672.


![imagen](https://github.com/user-attachments/assets/5f155906-7d32-441e-a567-41b707eadd72)
