### PR TITLE
Update Snakemake language config

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3845,6 +3845,9 @@ comment-tokens = ["#", "##"]
 indent = { tab-width = 2, unit = "  " }
 language-servers = ["pylsp" ]
 
+[language.formatter]
+command = "snakefmt"
+args = ["-"]
 
 [[grammar]]
 name = "snakemake"

--- a/languages.toml
+++ b/languages.toml
@@ -3840,7 +3840,7 @@ source = { git = "https://github.com/Decurity/tree-sitter-circom", rev = "021505
 name = "snakemake"
 scope = "source.snakemake"
 roots = ["Snakefile", "config.yaml", "environment.yaml", "workflow/"]
-file-types = ["smk", "Snakefile"]
+file-types = ["smk", { glob = "Snakefile" } ]
 comment-tokens = ["#", "##"]
 indent = { tab-width = 2, unit = "  " }
 language-servers = ["pylsp" ]


### PR DESCRIPTION
1. Updated the `file-types` argument in Snakemake language definition to properly detect the language for `Snakefile`.
2. Added a formatter command for Snakemake using `snakefmt`.