### PR TITLE
languages: Add `ssh_config.d/*.conf` as a glob for sshclientconfig

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2203,7 +2203,7 @@ source = { git = "https://github.com/staysail/tree-sitter-meson", rev = "32a83e8
 [[language]]
 name = "sshclientconfig"
 scope = "source.sshclientconfig"
-file-types = [{ glob = ".ssh/config" }, { glob = "/etc/ssh/ssh_config" }]
+file-types = [{ glob = ".ssh/config" }, { glob = "/etc/ssh/ssh_config" }, { glob = "ssh_config.d/*.conf" } ]
 comment-token = "#"
 
 [[grammar]]


### PR DESCRIPTION
The ssh_config format supports a config file fragment inclusion mechanism by using the `Include` directive. Some Linux distros such as Debian, Ubuntu, and distros derived from Debian/Ubuntu specify `Include /etc/ssh/ssh_config.d/*.conf` in their default /etc/ssh/ssh_config config file [0]. Similarly, ssh users can also use this directive in their ~/.ssh/config file, for instance specifying `Include ssh_config.d/*.conf` to include all files matching the glob `~/.ssh/ssh_config.d/*.conf` into their ssh client configuration.

This commit adds the glob `ssh_config.d/*.conf` to the sshclientconfig language so that these config file fragments will be detected.

[0] https://salsa.debian.org/ssh-team/openssh/-/blob/e9f52d3c18a4bb5e2055bcec0cf08abfb137ea2c/debian/patches/debian-config.patch#L126