### PR TITLE
Add an option to disable .gitignore when completing paths in the prompt

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -39,6 +39,7 @@
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `true` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
+| `command-git-ignore` | Whether to read `.gitignore` when listing paths in the command prompt | `true` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |
 | `auto-format` | Enable automatic formatting on save[^3] | `true` |

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -522,7 +522,7 @@ pub mod completers {
     }
 
     pub fn filename(editor: &Editor, input: &str) -> Vec<Completion> {
-        filename_with_git_ignore(editor, input, true)
+        filename_with_git_ignore(editor, input, editor.config().command_git_ignore)
     }
 
     pub fn filename_with_git_ignore(
@@ -571,7 +571,7 @@ pub mod completers {
     }
 
     pub fn directory(editor: &Editor, input: &str) -> Vec<Completion> {
-        directory_with_git_ignore(editor, input, true)
+        directory_with_git_ignore(editor, input, editor.config().command_git_ignore)
     }
 
     pub fn directory_with_git_ignore(
@@ -649,6 +649,8 @@ pub mod completers {
             .hidden(false)
             .follow_links(false) // We're scanning over depth 1
             .git_ignore(git_ignore)
+            .git_global(git_ignore)
+            .git_exclude(git_ignore)
             .max_depth(Some(1))
             .build()
             .filter_map(|file| {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -312,6 +312,8 @@ pub struct Config {
     pub cursorcolumn: bool,
     #[serde(deserialize_with = "deserialize_gutter_seq_or_struct")]
     pub gutters: GutterConfig,
+    /// Whether .gitignore should be read when listing paths in the command prompt. Defaults to true.
+    pub command_git_ignore: bool,
     /// Middle click paste support. Defaults to true.
     pub middle_click_paste: bool,
     /// Automatic insertion of pairs to parentheses, brackets,
@@ -1105,6 +1107,7 @@ impl Default for Config {
             cursorline: false,
             cursorcolumn: false,
             gutters: GutterConfig::default(),
+            command_git_ignore: true,
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,


### PR DESCRIPTION
This PR introduces an option (`editor.command-git-ignore`, defaulting to `true`) that allows `.gitignore` to be skipped when listing paths in the command prompt.

I keep `.gitignore` enabled in the file picker for quick file access, and then use `:open` when I need to edit an ignored file. I'm regularly getting tripped up by the prompt's default behaviour; when I'm typing the path of an existing file, tab-completion fails if the path is in `.gitignore`. 
