### PR TITLE
Better display of prompt on long commands

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -649,10 +649,6 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
         // -- Render the input bar:
 
-        let area = inner.clip_left(1).with_height(1);
-        // render the prompt first since it will clear its background
-        self.prompt.render(area, surface, cx);
-
         let count = format!(
             "{}{}/{}",
             if status.running || self.matcher.active_injectors() > 0 {
@@ -663,6 +659,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             snapshot.matched_item_count(),
             snapshot.item_count(),
         );
+
+        let area = inner.clip_left(1).with_height(1);
+        let line_area = area.clip_right(count.len() as u16 + 1);
+
+        // render the prompt first since it will clear its background
+        self.prompt.render(line_area, surface, cx);
+
         surface.set_stringn(
             (area.x + area.width).saturating_sub(count.len() as u16 + 1),
             area.y,

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -501,6 +501,7 @@ impl Prompt {
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
         let line_area = area.clip_left(self.prompt.len() as u16).clip_top(line);
+
         if self.line.is_empty() {
             // Show the most recently entered value as a suggestion.
             if let Some(suggestion) = self.first_history_completion(cx.editor) {
@@ -517,7 +518,15 @@ impl Prompt {
             .into();
             text.render(line_area, surface, cx);
         } else {
-            surface.set_string(line_area.x, line_area.y, self.line.clone(), prompt_color);
+            surface.set_string_truncated(
+                line_area.x,
+                line_area.y,
+                self.line.as_str(),
+                line_area.width as usize,
+                |_| prompt_color,
+                true,
+                true,
+            );
         }
     }
 }


### PR DESCRIPTION
Hello !

I sometime have very long file name to deal with, and the helix prompt is not really friendly with me.

Example: when I try to create a big file using `:open this/is/a/very/very/very/very/long/file/name/what/am/i/doing/stop/please.csv`, the prompt on my tiny screen will not display the end of the text, and I'm typing things blindly.

I have made some changes in order to improve a bit that experience, using the `set_string_truncated` method available and very convenient way to shorten long text.

So far so good, I can happily type my long filenames.
![test-2](https://github.com/user-attachments/assets/1af8470c-a435-41f3-9479-b92b8412cd7e)


However you might notice that not everything is perfect. I don't like the fact the cursor does not stick to the end of the text and is escaping away. I would like to change that as well. I tried to handle that correctly in the latest commit.

I'm not 100% satisfied by how the cursor is managed currently, not everything is working well, especially with movements like `ctrl+a` that goes back to the beginning. I guess this will require some change in the `set_string_truncated` method from above to be able to display a string from a given anchor point, and not using the start/end as the anchor point. I'm still exploring anyway and will welcome any feedback on the current state of the PR :pray: 