### PR TITLE
Add CSV language and syntax highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3860,3 +3860,12 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "cylc"
 source = { git = "https://github.com/elliotfontaine/tree-sitter-cylc", rev = "30dd40d9bf23912e4aefa93eeb4c7090bda3d0f6" }
+
+[[language]]
+name = "csv"
+file-types = ["csv"]
+scope = "source.csv"
+
+[[grammar]]
+name = "csv"
+source = { git = "https://github.com/weartist/rainbow-csv-tree-sitter", rev = "d3dbf916446131417e4c2ea9eb8591b23b466d27" }

--- a/runtime/queries/csv/highlights.scm
+++ b/runtime/queries/csv/highlights.scm
@@ -1,0 +1,8 @@
+(first)@type
+(second)@function
+(third)@constant
+(fourth)@operator
+(fifth)@type
+(sixth)@function
+(seventh)@constant
+


### PR DESCRIPTION
Adds language configuration, grammar and highlight queries for CSV files. Tried to match the highlighting colors with [bat](https://github.com/sharkdp/bat) and those seem to work with many different helix themes.