### PR TITLE
Documentation comments for both Python and Rust

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -111,6 +111,9 @@
 
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float
+(expression_statement (string) @content
+	(#match? @content "^\"\"\"")
+) @comment.block.documentation
 (comment) @comment
 (string) @string
 (escape_sequence) @constant.character.escape

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -30,6 +30,7 @@
   (string_literal)
   (raw_string_literal)
 ] @string
+(line_comment (doc_comment)) @comment.documentation
 [
   (line_comment)
   (block_comment)

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -31,6 +31,7 @@
   (raw_string_literal)
 ] @string
 (line_comment (doc_comment)) @comment.documentation
+(block_comment (doc_comment)) @comment.block.documentation
 [
   (line_comment)
   (block_comment)


### PR DESCRIPTION
Someone asked in the Matrix chat yesterday about documentation comments in Python🐍.  And I accidentally learned how tree-sitter syntax highlighting works to get doc comments working.  
While I was there I figured I may as well do it for Rust🦀 too!

****

Rust documentation comments are
```rust
/// this is a documentation comment
```
and have the tree-sitter scopes:
`["source_file", "impl_item", "declaration_list", "line_comment", "doc_comment"]`

So adding a search for line_comments that contain doc_comments lets us isolate them and then themes can target `@comment.documentation`

****

Python documentation comments are
```python
"""
   This is a documentation comment (and also a valid string)
"""
```
Tree-Sitter scopes:
`["module", "expression_statement", "string", "string_content"]`

Because the doc comments are also valid strings the suggested code looks for expression_statements that contain strings and that start with `"""`.

Regular `"""` strings aren't affected because they're `assignment > string` instead of `expression_statement > string`

****

Thank you! 😃