### PR TITLE
Treat .prettierrc as YAML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -449,7 +449,6 @@ file-types = [
   { glob = "composer.lock" },
   { glob = ".watchmanconfig" },
   "avsc",
-  { glob = ".prettierrc" },
   "ldtk",
   "ldtkl",
 ]
@@ -1306,7 +1305,7 @@ source = { git = "https://github.com/ikatyang/tree-sitter-vue", rev = "91fe27547
 [[language]]
 name = "yaml"
 scope = "source.yaml"
-file-types = ["yml", "yaml"]
+file-types = ["yml", "yaml", { glob = ".prettierrc" }]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "yaml-language-server", "ansible-language-server" ]


### PR DESCRIPTION
Prettier treats its .prettierrc config file as "JSON or YAML". (https://prettier.io/docs/en/configuration.html)

Because all JSON is valid YAML, it is just YAML. So, Helix should treat it as YAML too.

(not sure what happened at the end of file, it wasn't even formatted well so I had to set-language text to reduce diff)