### PR TITLE
feat: add config option to make statusline unobtrusive

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -131,7 +131,7 @@ pub fn raw_regex_prompt(
                             fun(cx, regex, input, event);
 
                             let (view, doc) = current!(cx.editor);
-                            view.ensure_cursor_in_view(doc, config.scrolloff);
+                            view.ensure_cursor_in_view(doc, config.scrolloff, config.statusline.unobtrusive);
                         }
                         Err(err) => {
                             let (view, doc) = current!(cx.editor);

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -49,14 +49,16 @@ pub struct RenderBuffer<'a> {
     pub right: Spans<'a>,
 }
 
-pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface) {
+pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface, unobtrusive_statusline: bool) {
     let base_style = if context.focused {
         context.editor.theme.get("ui.statusline")
     } else {
         context.editor.theme.get("ui.statusline.inactive")
     };
 
-    surface.set_style(viewport.with_height(1), base_style);
+    if !unobtrusive_statusline {
+        surface.set_style(viewport.with_height(1), base_style);
+    }
 
     let write_left = |context: &mut RenderContext, text, style| {
         append(&mut context.parts.left, text, &base_style, style)

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -56,9 +56,17 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
         context.editor.theme.get("ui.statusline.inactive")
     };
 
-    if !unobtrusive_statusline {
-        surface.set_style(viewport.with_height(1), base_style);
-    }
+    let surface_style = if unobtrusive_statusline {
+        let surface_bg = match base_style.bg {
+            Some(color) => color,
+            None => helix_view::theme::Color::Reset
+        };
+        Style::default().bg(surface_bg)
+    } else {
+        base_style
+    };
+
+    surface.set_style(viewport.with_height(1), surface_style);
 
     let write_left = |context: &mut RenderContext, text, style| {
         append(&mut context.parts.left, text, &base_style, style)

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -147,8 +147,10 @@ pub fn line_numbers<'doc>(
 ) -> GutterFn<'doc> {
     let text = doc.text().slice(..);
     let width = line_numbers_width(view, doc);
+    let config = editor.config();
+    let unobtrusive_statusline = config.statusline.unobtrusive;
 
-    let last_line_in_view = view.estimate_last_doc_line(doc);
+    let last_line_in_view = view.estimate_last_doc_line(doc, unobtrusive_statusline);
 
     // Whether to draw the line number for the last line of the
     // document or not.  We only draw it if it's not an empty line.
@@ -161,7 +163,7 @@ pub fn line_numbers<'doc>(
         .text()
         .char_to_line(doc.selection(view.id).primary().cursor(text));
 
-    let line_number = editor.config().line_number;
+    let line_number = config.line_number;
     let mode = editor.mode;
 
     Box::new(

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -68,6 +68,7 @@ pub fn jump_to_stack_frame(editor: &mut Editor, frame: &helix_dap::StackFrame) {
         return;
     }
 
+    let unobtrusive_statusline = editor.config().statusline.unobtrusive;
     let (view, doc) = current!(editor);
 
     let text_end = doc.text().len_chars().saturating_sub(1);
@@ -79,7 +80,7 @@ pub fn jump_to_stack_frame(editor: &mut Editor, frame: &helix_dap::StackFrame) {
 
     let selection = Selection::single(start.min(text_end), end.min(text_end));
     doc.set_selection(view.id, selection);
-    align_view(doc, view, Align::Center);
+    align_view(doc, view, Align::Center, unobtrusive_statusline);
 }
 
 pub fn breakpoints_changed(

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -47,10 +47,10 @@ pub enum Align {
     Bottom,
 }
 
-pub fn align_view(doc: &mut Document, view: &View, align: Align) {
+pub fn align_view(doc: &mut Document, view: &View, align: Align, unobtrusive_statusline: bool) {
     let doc_text = doc.text().slice(..);
     let cursor = doc.selection(view.id).primary().cursor(doc_text);
-    let viewport = view.inner_area(doc);
+    let viewport = view.inner_area(doc, unobtrusive_statusline);
     let last_line_height = viewport.height.saturating_sub(1);
     let mut view_offset = doc.view_offset(view.id);
 


### PR DESCRIPTION
This PR adds a new `editor.statusline.unobtrusive` (boolean) option

Previously, the statusline would always block one line of the screen. But now, if this option is set then the statusline elements will be overlaid on top of the bottom line of text without blocking that line

### Screenshots

```toml
[editor.statusline]
unobtrusive = false # default
```

<img src="https://github.com/user-attachments/assets/63c329ed-7f3b-4e09-99bd-32c063507085" width="80%">

```toml
[editor.statusline]
unobtrusive = true
```

<img src="https://github.com/user-attachments/assets/c5e2f075-826b-409f-b42c-72b60dd7f9ee" width="80%">

### Notes

- The background color of the status line gets applied regardless, this is required because otherwise with multiple vertically stacked buffers it is very hard to tell where one buffer ends and another one starts:

<img src="https://github.com/user-attachments/assets/8364efea-8f94-4693-80c4-7a6935b4b1a2" width="10%">

<img src="https://github.com/user-attachments/assets/9c4170f5-55b6-44d2-b66a-44e4bb60ed10" width="100%">

- This PR is done because of a popular request to hide the statusline: https://github.com/helix-editor/helix/discussions/7934

Since people use their text editors with other software like multiplexers, having an entire line blocking the text isn't good for integrations.

With this config, you can hide all of the status line's elements:

```toml
[editor.statusline]
unobtrusive = true
center = []
left = []
right = []
```

Most notable changes are in these files:
- In the `render` method in `helix-term/src/ui/statusline.rs:52`
- In the `inner_area` and `inner_height` methods in `helix-view/src/view.rs:193`

Most other changes were just passing the `unobtrusive_statusline` argument

- This is my first time writing any Rust code, just saying in case I broke some best practices or something :)