### PR TITLE
Add support for Amber-lang

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -3,6 +3,7 @@
 | ada | ✓ | ✓ |  | `ada_language_server` |
 | adl | ✓ | ✓ | ✓ |  |
 | agda | ✓ |  |  |  |
+| amber | ✓ |  |  |  |
 | astro | ✓ |  |  |  |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ | ✓ | ✓ | `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -3931,3 +3931,14 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "spade"
 source = { git = "https://gitlab.com/spade-lang/tree-sitter-spade/", rev = "4d5b141017c61fe7e168e0a5c5721ee62b0d9572" }
+
+[[language]]
+name = "amber"
+scope = "source.ab"
+file-types = ["ab"]
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "amber"
+source = { git = "https://github.com/amber-lang/tree-sitter-amber", rev = "c6df3ec2ec243ed76550c525e7ac3d9a10c6c814" }

--- a/runtime/queries/amber/brackets.scm
+++ b/runtime/queries/amber/brackets.scm
@@ -1,0 +1,6 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)
+("$" @open "$" @close)
+
+(interpolation "{" @open "}" @close)

--- a/runtime/queries/amber/brackets.scm
+++ b/runtime/queries/amber/brackets.scm
@@ -1,6 +1,0 @@
-("[" @open "]" @close)
-("{" @open "}" @close)
-("\"" @open "\"" @close)
-("$" @open "$" @close)
-
-(interpolation "{" @open "}" @close)

--- a/runtime/queries/amber/highlights.scm
+++ b/runtime/queries/amber/highlights.scm
@@ -42,11 +42,11 @@
 (handler) @keyword
 (block) @punctuation.delimiter
 (variable_init) @keyword
-(variable_assignment) @delimiter
+(variable_assignment) @punctuation.delimiter
 (variable) @variable
 (escape_sequence) @constant.character.escape
 (type_name_symbol) @type
-(interpolation) @delimiter
+(interpolation) @punctuation.delimiter
 (reference) @keyword
 (preprocessor_directive) @comment
 (shebang) @comment

--- a/runtime/queries/amber/highlights.scm
+++ b/runtime/queries/amber/highlights.scm
@@ -1,0 +1,60 @@
+(comment) @comment
+
+[
+    "if"
+    "loop"
+    "for"
+    "return"
+    "fun"
+    "else"
+    "then"
+    "break"
+    "continue"
+    "and"
+    "or"
+    "not"
+    "let"
+    "pub"
+    "main"
+    "echo"
+    "exit"
+    "fun"
+    "import"
+    "from"
+    "as"
+    "in"
+    "fail"
+    "failed"
+    "silent"
+    "nameof"
+    "is"
+    "unsafe"
+    "trust"
+] @keyword
+
+; Literals
+(boolean) @constant.builtin.boolean
+(number) @constant.numeric
+(null) @constant.numeric
+(string) @string
+(status) @keyword
+(command) @string
+(handler) @keyword
+(block) @delimeter
+(variable_init) @keyword
+(variable_assignment) @delimiter
+(variable) @variable
+(escape_sequence) @constant.character.escape
+(type_name_symbol) @type
+(interpolation) @delimiter
+(reference) @keyword
+(preprocessor_directive) @comment
+(shebang) @comment
+(function_definition
+    name: (variable) @function.method)
+(function_call
+    name: (variable) @function.method)
+(import_statement
+    "pub" @keyword
+    "import" @keyword
+    "from" @keyword)

--- a/runtime/queries/amber/highlights.scm
+++ b/runtime/queries/amber/highlights.scm
@@ -40,7 +40,7 @@
 (status) @keyword
 (command) @string
 (handler) @keyword
-(block) @delimeter
+(block) @punctuation.delimiter
 (variable_init) @keyword
 (variable_assignment) @delimiter
 (variable) @variable


### PR DESCRIPTION
A screenshot of [install.ab](https://github.com/amber-lang/amber/blob/master/setup/install.ab):

![image](https://github.com/user-attachments/assets/8bb74884-dd1c-4c53-9af5-dcbf5fbe9e4e)

The query files are from https://github.com/amber-lang/amber-zed/tree/b49e5a877872a7feb321723ca55bbd70f4e376b5/languages/amber.

Closes #12001