### PR TITLE
fix(languages): treat tsconfig.json as jsonc

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -464,7 +464,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "73076
 name = "jsonc"
 scope = "source.json"
 injection-regex = "jsonc"
-file-types = ["jsonc"]
+file-types = ["jsonc", { glob = "tsconfig.json" }]
 grammar = "json"
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true


### PR DESCRIPTION
background:

tsconfig.json allow /* comments */ as well as trailing commas.

issue:

default tsconfig.json generated with tsc --init contains comments, so helix can't handle it correctly.

solution:

treat it as jsonc.
typescript repo has jsonc-parser in devDependencies, so it probably uses jsonc parser internally too. (though I couldn't find relevant code) 

other text editors:

- VS Code treats it as JSON with Comments.
- Zed: https://github.com/zed-industries/zed/issues/14906#ref-pullrequest-2421504857