### PR TITLE
feat: `j` and `k` acts like `gj` and `gk` if a count was provided

### DIFF
--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -61,7 +61,7 @@ pub fn move_vertically_visual(
     text_fmt: &TextFormat,
     annotations: &mut TextAnnotations,
 ) -> Range {
-    if !text_fmt.soft_wrap {
+    if !text_fmt.soft_wrap || count != 1 {
         return move_vertically(slice, range, dir, count, behaviour, text_fmt, annotations);
     }
     annotations.clear_line_annotations();
@@ -75,8 +75,8 @@ pub fn move_vertically_visual(
 
     // Compute the new position.
     let mut row_off = match dir {
-        Direction::Forward => count as isize,
-        Direction::Backward => -(count as isize),
+        Direction::Forward => 1,
+        Direction::Backward => -1,
     };
 
     // Compute visual offset relative to block start to avoid trasversing the block twice


### PR DESCRIPTION
This makes these motions "smarter" saving 1/3 of the amount of keystrokes

Usually counts with j and k will be used because one is using relative lines, you don't expect them to *not* ignore wrapped lines. This is a QOL change that decreases the amount of keystrokes needed to travel
