### PR TITLE
feat(languages): add .livemd Markdown extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1583,7 +1583,7 @@ source = { git = "https://github.com/Flakebi/tree-sitter-tablegen", rev = "568dd
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"
-file-types = ["md", "markdown", "mdx", "mkd", "mkdn", "mdwn", "mdown", "markdn", "mdtxt", "mdtext", "workbook", { glob = "PULLREQ_EDITMSG" }]
+file-types = ["md", "livemd", "markdown", "mdx", "mkd", "mkdn", "mdwn", "mdown", "markdn", "mdtxt", "mdtext", "workbook", { glob = "PULLREQ_EDITMSG" }]
 roots = [".marksman.toml"]
 language-servers = [ "marksman", "markdown-oxide" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
[Livebook](https://github.com/livebook-dev/livebook) uses a subset of Markdown for its file format, so it is, by default, supported by any Markdown language support/tooling.