### PR TITLE
feat: add command `modified_buffer_picker` which only shows modified buffers

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -284,6 +284,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `f`     | Open file picker                                                        | `file_picker`                              |
 | `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`         |
 | `b`     | Open buffer picker                                                      | `buffer_picker`                            |
+| `B`     | Open buffer picker for modified buffers only                            | `modified_buffer_picker`                   |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
 | `g`     | Open changed file picker                                                | `changed_file_picker`                      |
 | `G`     | Debug (experimental)                                                    | N/A                                        |

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -222,6 +222,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "f" => file_picker,
             "F" => file_picker_in_current_directory,
             "b" => buffer_picker,
+            "B" => modified_buffer_picker,
             "j" => jumplist_picker,
             "s" => symbol_picker,
             "S" => workspace_symbol_picker,


### PR DESCRIPTION
I've mapped it to `<space>B`, since `<space>b` is for all buffers