### PR TITLE
fix: better display of prompts on long inputs

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -649,10 +649,6 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
         // -- Render the input bar:
 
-        let area = inner.clip_left(1).with_height(1);
-        // render the prompt first since it will clear its background
-        self.prompt.render(area, surface, cx);
-
         let count = format!(
             "{}{}/{}",
             if status.running || self.matcher.active_injectors() > 0 {
@@ -663,6 +659,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             snapshot.matched_item_count(),
             snapshot.item_count(),
         );
+
+        let area = inner.clip_left(1).with_height(1);
+        let line_area = area.clip_right(count.len() as u16 + 1);
+
+        // render the prompt first since it will clear its background
+        self.prompt.render(line_area, surface, cx);
+
         surface.set_stringn(
             (area.x + area.width).saturating_sub(count.len() as u16 + 1),
             area.y,
@@ -1073,7 +1076,15 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         let inner = block.inner(area);
 
         // prompt area
-        let area = inner.clip_left(1).with_height(1);
+        let render_preview =
+            self.show_preview && self.file_fn.is_some() && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
+
+        let picker_width = if render_preview {
+            area.width / 2
+        } else {
+            area.width
+        };
+        let area = inner.clip_left(1).with_height(1).with_width(picker_width);
 
         self.prompt.cursor(area, editor)
     }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -29,11 +29,13 @@ pub type DocFn = Box<dyn Fn(&str) -> Option<Cow<str>>>;
 pub struct Prompt {
     prompt: Cow<'static, str>,
     line: String,
-    line_area: Rect,
     cursor: usize,
+    // Fields used for Component callbacks and rendering:
+    line_area: Rect,
     anchor: usize,
     truncate_start: bool,
     truncate_end: bool,
+    // ---
     completion: Vec<Completion>,
     selection: Option<usize>,
     history_register: Option<char>,
@@ -85,8 +87,8 @@ impl Prompt {
         Self {
             prompt,
             line: String::new(),
-            line_area: Rect::default(),
             cursor: 0,
+            line_area: Rect::default(),
             anchor: 0,
             truncate_start: false,
             truncate_end: false,
@@ -331,7 +333,6 @@ impl Prompt {
     pub fn clear(&mut self, editor: &Editor) {
         self.line.clear();
         self.cursor = 0;
-
         self.recalculate_completion(editor);
     }
 
@@ -405,7 +406,6 @@ impl Prompt {
         let selected_color = theme.get("ui.menu.selected");
         let suggestion_color = theme.get("ui.text.inactive");
         let background = theme.get("ui.background");
-
         // completion
 
         let max_len = self

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -29,7 +29,11 @@ pub type DocFn = Box<dyn Fn(&str) -> Option<Cow<str>>>;
 pub struct Prompt {
     prompt: Cow<'static, str>,
     line: String,
+    line_area: Rect,
     cursor: usize,
+    anchor: usize,
+    truncate_start: bool,
+    truncate_end: bool,
     completion: Vec<Completion>,
     selection: Option<usize>,
     history_register: Option<char>,
@@ -81,7 +85,11 @@ impl Prompt {
         Self {
             prompt,
             line: String::new(),
+            line_area: Rect::default(),
             cursor: 0,
+            anchor: 0,
+            truncate_start: false,
+            truncate_end: false,
             completion: Vec::new(),
             selection: None,
             history_register,
@@ -323,6 +331,7 @@ impl Prompt {
     pub fn clear(&mut self, editor: &Editor) {
         self.line.clear();
         self.cursor = 0;
+
         self.recalculate_completion(editor);
     }
 
@@ -389,13 +398,14 @@ impl Prompt {
 const BASE_WIDTH: u16 = 30;
 
 impl Prompt {
-    pub fn render_prompt(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+    pub fn render_prompt(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let theme = &cx.editor.theme;
         let prompt_color = theme.get("ui.text");
         let completion_color = theme.get("ui.menu");
         let selected_color = theme.get("ui.menu.selected");
         let suggestion_color = theme.get("ui.text.inactive");
         let background = theme.get("ui.background");
+
         // completion
 
         let max_len = self
@@ -499,11 +509,20 @@ impl Prompt {
         // render buffer text
         surface.set_string(area.x, area.y + line, &self.prompt, prompt_color);
 
-        let line_area = area.clip_left(self.prompt.len() as u16).clip_top(line);
+        self.line_area = area
+            .clip_left(self.prompt.len() as u16)
+            .clip_top(line)
+            .clip_right(2);
+
         if self.line.is_empty() {
             // Show the most recently entered value as a suggestion.
             if let Some(suggestion) = self.first_history_completion(cx.editor) {
-                surface.set_string(line_area.x, line_area.y, suggestion, suggestion_color);
+                surface.set_string(
+                    self.line_area.x,
+                    self.line_area.y,
+                    suggestion,
+                    suggestion_color,
+                );
             }
         } else if let Some((language, loader)) = self.language.as_ref() {
             let mut text: ui::text::Text = crate::ui::markdown::highlighted_code_block(
@@ -514,9 +533,34 @@ impl Prompt {
                 None,
             )
             .into();
-            text.render(line_area, surface, cx);
+            text.render(self.line_area, surface, cx);
         } else {
-            surface.set_string(line_area.x, line_area.y, self.line.clone(), prompt_color);
+            if self.line.len() < self.line_area.width as usize {
+                self.anchor = 0;
+            } else if self.cursor < self.anchor {
+                self.anchor = self.cursor;
+            } else if self.cursor - self.anchor > self.line_area.width as usize {
+                self.anchor = self.cursor - self.line_area.width as usize;
+            }
+
+            self.truncate_start = self.anchor > 0;
+            self.truncate_end = self.line.len() - self.anchor > self.line_area.width as usize;
+
+            // if we keep inserting characters just before the end elipsis, we move the anchor
+            // so that those new characters are displayed
+            if self.truncate_end && self.cursor - self.anchor >= self.line_area.width as usize {
+                self.anchor += 1;
+            }
+
+            surface.set_string_anchored(
+                self.line_area.x,
+                self.line_area.y,
+                self.truncate_start,
+                self.truncate_end,
+                &self.line.as_str()[self.anchor..],
+                self.line_area.width as usize - self.truncate_end as usize,
+                |_| prompt_color,
+            );
         }
     }
 }
@@ -686,14 +730,26 @@ impl Component for Prompt {
     }
 
     fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
+        let area = area
+            .clip_left(self.prompt.len() as u16)
+            .clip_right(if self.prompt.len() > 0 { 0 } else { 2 });
+
+        let mut col = area.left() as usize
+            + UnicodeWidthStr::width(&self.line[self.anchor..self.cursor.max(self.anchor)]);
+
+        // ensure the cursor does not go beyond elipses
+        if self.truncate_end && self.cursor - self.anchor >= self.line_area.width as usize {
+            col -= 1;
+        }
+
+        if self.truncate_start && self.cursor == self.anchor {
+            col += 1;
+        }
+
         let line = area.height as usize - 1;
+
         (
-            Some(Position::new(
-                area.y as usize + line,
-                area.x as usize
-                    + self.prompt.len()
-                    + UnicodeWidthStr::width(&self.line[..self.cursor]),
-            )),
+            Some(Position::new(area.y as usize + line, col)),
             editor.config().cursor_shape.from_mode(Mode::Insert),
         )
     }


### PR DESCRIPTION
Fixes #12218

The current prompt does not manage well long inputs:
- It's not possible to navigate at the beginning of the string to modify it
- They aren't correctly scoped to their respective area and leak on other elements (especially on pickers)

I tried to refactor that a bit in order to enhance the user experience on that.

Strings are now scoped to their respective area. Ellipses are placed at the start and/or end of long strings, when needed. A user can them easily navigate through its input, whether using arrows or shortcut like `ctrl+a` or `ctrl+e`.

![here](https://github.com/user-attachments/assets/0a9b400b-a184-4191-a304-061840a81e96)


