### PR TITLE
feat: add register `/` which stores the parent path of currently opened document

### DIFF
--- a/book/src/registers.md
+++ b/book/src/registers.md
@@ -44,6 +44,7 @@ Some registers have special behavior when read from and written to.
 | `#`                | Selection indices (first selection is `1`, second is `2`, etc.) | This register is not writable |
 | `.`                | Contents of the current selections | This register is not writable |
 | `%`                | Name of the current file | This register is not writable |
+| `/`                | Folder which contains the current file | This register is not writable |
 | `+`                | Reads from the system clipboard | Joins and yanks to the system clipboard |
 | `*`                | Reads from the primary clipboard | Joins and yanks to the primary clipboard |
 


### PR DESCRIPTION
This register is going to be extremely useful for the following operations:
- Creating a file next to the currently edited file with `:o <C-r>/hello.txt`
- Changing directory to the directory of the currently edited file with `:cd <C-r>/`
- Changing directory into parent directory or traveling across the file system in an easier manner. One could `:pwd` then `cd ..`, but with this you can easily see where you are going and manipulate your path

Inspired by this discussion, where it seems that this feature would really be beneficial: https://github.com/helix-editor/helix/discussions/12002