### PR TITLE
feat: `:cd` with no args changes to home directory

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Write;
 use std::io::BufReader;
 use std::ops::Deref;
@@ -9,6 +10,7 @@ use super::*;
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::{line_ending, shellwords::Shellwords};
+use helix_stdx::path::home_dir;
 use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
 use serde_json::Value;
@@ -1087,11 +1089,14 @@ fn change_current_directory(
         return Ok(());
     }
 
-    let dir = args
-        .first()
-        .context("target directory not provided")?
-        .as_ref();
-    let dir = helix_stdx::path::expand_tilde(Path::new(dir));
+    let dir = match args.first() {
+        Some(input_path) => {
+            helix_stdx::path::expand_tilde(Path::new(input_path.as_ref()).to_owned())
+                .deref()
+                .to_path_buf()
+        }
+        None => home_dir()?.as_path().to_owned(),
+    };
 
     helix_stdx::env::set_current_working_dir(dir)?;
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::fmt::Write;
 use std::io::BufReader;
 use std::ops::Deref;


### PR DESCRIPTION
Previously, `:cd` would error if no arguments was given. This PR makes `:cd` behave as expected on unix systems, where it changes to home directory if no args are given