### PR TITLE
fix: simplify text reflowing strategy to improve language compatibility

### DIFF
--- a/helix-core/src/wrap.rs
+++ b/helix-core/src/wrap.rs
@@ -4,6 +4,8 @@ use textwrap::{Options, WordSplitter::NoHyphenation};
 /// Given a slice of text, return the text re-wrapped to fit it
 /// within the given width.
 pub fn reflow_hard_wrap(text: &str, text_width: usize) -> SmartString<LazyCompact> {
-    let options = Options::new(text_width).word_splitter(NoHyphenation);
+    let options = Options::new(text_width)
+        .word_splitter(NoHyphenation)
+        .word_separator(textwrap::WordSeparator::AsciiSpace);
     textwrap::refill(text, options).into()
 }


### PR DESCRIPTION
The the way the `textwrap` crate is configured results in the reflow command utilizing a more sophisticated word separator (`WordSeparator::UnicodeBreakProperties`). As there is currently no mechanism for language-aware reflowing, this approach results in issues like links breaking from their labels in Markdown (#12003). Explicitly using the simpler ASCII space separator addresses this issue and, in my opinion, serves as a better default behavior.