### PR TITLE
Update Zig's comment tokens

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1365,7 +1365,7 @@ injection-regex = "zig"
 file-types = ["zig", "zon"]
 roots = ["build.zig"]
 auto-format = true
-comment-token = "//"
+comment-tokens = ["//", "///", "//!"]
 language-servers = [ "zls" ]
 indent = { tab-width = 4, unit = "    " }
 formatter = { command = "zig" , args = ["fmt", "--stdin"] }


### PR DESCRIPTION
Hello,

This PR adds [Doc Comment](https://ziglang.org/documentation/0.13.0/#Doc-Comments) and [Top-Level Doc Comment](https://ziglang.org/documentation/0.13.0/#Top-Level-Doc-Comments) tokens to Zig's `comment-tokens`.

Related PR: #10996.

Thanks