### PR TITLE
fix: removed explict default config file from swift-format

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1966,7 +1966,7 @@ file-types = ["swift", "swiftinterface"]
 roots = [ "Package.swift" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-formatter = { command = "swift-format", args = [ "--configuration", ".swift-format"] }
+formatter = { command = "swift-format" }
 auto-format = true
 language-servers = [ "sourcekit-lsp" ]
 


### PR DESCRIPTION
This is the [default file name](https://github.com/swiftlang/swift-format/blob/main/Documentation/Configuration.md), and explicitly providing it as an argument causes an error if the file does not exist.

Also, just a QQ: how come some langs have `auto-format` enabled and some dont? Surely all off by default (to be the least annoying) would make more sense? At the least, having all the langs 1 way or the other would be more consistent to me.