### PR TITLE
feat: add tag around selection, change surrounding tag and delete surrounding tag

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -205,6 +205,50 @@ pub fn find_matching_bracket_plaintext(doc: RopeSlice, cursor_pos: usize) -> Opt
     None
 }
 
+// fn create_rename_prompt(
+//     editor: &Editor,
+//     prefill: String,
+//     history_register: Option<char>,
+//     language_server_id: Option<LanguageServerId>,
+// ) -> Box<ui::Prompt> {
+//     let prompt = ui::Prompt::new(
+//         "rename-to:".into(),
+//         history_register,
+//         ui::completers::none,
+//         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
+//             if event != PromptEvent::Validate {
+//                 return;
+//             }
+//             let (view, doc) = current!(cx.editor);
+
+//             let Some(language_server) = doc
+//                 .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
+//                 .find(|ls| language_server_id.map_or(true, |id| id == ls.id()))
+//             else {
+//                 cx.editor
+//                     .set_error("No configured language server supports symbol renaming");
+//                 return;
+//             };
+
+//             let offset_encoding = language_server.offset_encoding();
+//             let pos = doc.position(view.id, offset_encoding);
+//             let future = language_server
+//                 .rename_symbol(doc.identifier(), pos, input.to_string())
+//                 .unwrap();
+
+//             match block_on(future) {
+//                 Ok(edits) => {
+//                     let _ = cx.editor.apply_workspace_edit(offset_encoding, &edits);
+//                 }
+//                 Err(err) => cx.editor.set_error(err.to_string()),
+//             }
+//         },
+//     )
+//     .with_line(prefill, editor);
+
+//     Box::new(prompt)
+// }
+
 /// Returns the open and closing chars pair. If not found in
 /// [`BRACKETS`] returns (ch, ch).
 ///

--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -205,50 +205,6 @@ pub fn find_matching_bracket_plaintext(doc: RopeSlice, cursor_pos: usize) -> Opt
     None
 }
 
-// fn create_rename_prompt(
-//     editor: &Editor,
-//     prefill: String,
-//     history_register: Option<char>,
-//     language_server_id: Option<LanguageServerId>,
-// ) -> Box<ui::Prompt> {
-//     let prompt = ui::Prompt::new(
-//         "rename-to:".into(),
-//         history_register,
-//         ui::completers::none,
-//         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
-//             if event != PromptEvent::Validate {
-//                 return;
-//             }
-//             let (view, doc) = current!(cx.editor);
-
-//             let Some(language_server) = doc
-//                 .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
-//                 .find(|ls| language_server_id.map_or(true, |id| id == ls.id()))
-//             else {
-//                 cx.editor
-//                     .set_error("No configured language server supports symbol renaming");
-//                 return;
-//             };
-
-//             let offset_encoding = language_server.offset_encoding();
-//             let pos = doc.position(view.id, offset_encoding);
-//             let future = language_server
-//                 .rename_symbol(doc.identifier(), pos, input.to_string())
-//                 .unwrap();
-
-//             match block_on(future) {
-//                 Ok(edits) => {
-//                     let _ = cx.editor.apply_workspace_edit(offset_encoding, &edits);
-//                 }
-//                 Err(err) => cx.editor.set_error(err.to_string()),
-//             }
-//         },
-//     )
-//     .with_line(prefill, editor);
-
-//     Box::new(prompt)
-// }
-
 /// Returns the open and closing chars pair. If not found in
 /// [`BRACKETS`] returns (ch, ch).
 ///

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5678,10 +5678,10 @@ fn surround_add(cx: &mut Context) {
     cx.on_next_key(move |cx, event| {
         let (view, doc) = current!(cx.editor);
         // surround_len is the number of new characters being added.
-        let (open, close, surround_len) = match event.char() {
+        match event.char() {
             Some(ch) => {
-                let mut open = Tendril::new();
-                let mut close = Tendril::new();
+                // let mut open = Tendril::new();
+                // let mut close = Tendril::new();
                 // let length = if ch == 'x' {
                 //     let prompt = create_surround_prompt(cx.editor, "none".into(), Some('z'));
                 //     cx.push_layer(prompt);
@@ -5692,24 +5692,29 @@ fn surround_add(cx: &mut Context) {
                 //     // Any character other than "x" will cause 2 chars to get added
                 //     2
                 // } else {
-                let (o, c) = match_brackets::get_pair(ch);
-                open.push(o);
-                close.push(c);
+                let (open, close) = match_brackets::get_pair(ch);
+                // open.push(o);
+                // close.push(c);
                 // Any character other than "x" will cause 2 chars to get added
                 // 2
+                //
+                let open = Tendril::from(open.to_string());
+                let close = Tendril::from(close.to_string());
+
+                surround_add_impl(doc, view, 2, open, close);
+                exit_select_mode(cx);
                 // };
-                (open, close, 2)
+                // (open, close, 2)
             }
-            None if event.code == KeyCode::Enter => (
-                doc.line_ending.as_str().into(),
-                doc.line_ending.as_str().into(),
-                2 * doc.line_ending.len_chars(),
-            ),
+            None if event.code == KeyCode::Enter => {
+                let open = doc.line_ending.as_str().into();
+                let close = doc.line_ending.as_str().into();
+                let length = 2 * doc.line_ending.len_chars();
+                surround_add_impl(doc, view, length, open, close);
+                exit_select_mode(cx);
+            }
             None => return,
         };
-
-        surround_add_impl(doc, view, surround_len, open, close);
-        exit_select_mode(cx);
 
         // let selection = doc.selection(view.id);
         // let mut changes = Vec::with_capacity(selection.len() * 2);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -36,7 +36,7 @@ use helix_core::{
     textobject,
     unicode::width::UnicodeWidthChar,
     visual_offset_from_block, Deletion, LineEnding, Position, Range, Rope, RopeGraphemes,
-    RopeReader, RopeSlice, Selection, SmallVec, Syntax, Tendril, Transaction,
+    RopeReader, RopeSlice, Selection, SmallVec, SmartString, Syntax, Tendril, Transaction,
 };
 use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
@@ -5616,6 +5616,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         ("a", "Argument/parameter (tree-sitter)"),
         ("c", "Comment (tree-sitter)"),
         ("T", "Test (tree-sitter)"),
+        ("x", "Tag (XML/HTML/JSX)"),
         ("e", "Data structure entry (tree-sitter)"),
         ("m", "Closest surrounding pair (tree-sitter)"),
         ("g", "Change"),
@@ -5623,6 +5624,54 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     ];
 
     cx.editor.autoinfo = Some(Info::new(title, &help_text));
+}
+
+fn create_surround_prompt(
+    editor: &Editor,
+    prefill: String,
+    history_register: Option<char>,
+) -> Box<Prompt> {
+    let prompt = Prompt::new(
+        "tag name:".into(),
+        // TODO: change this to actually be history_register
+        Some('z'),
+        ui::completers::none,
+        move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {},
+    )
+    .with_line("temp".into(), editor);
+
+    Box::new(prompt)
+}
+
+fn surround_add_impl(
+    doc: &mut Document,
+    // cx: &mut Context<'_>,
+    view: &mut View,
+    surround_len: usize,
+    open: Tendril,
+    close: Tendril,
+) {
+    let selection = doc.selection(view.id);
+    let mut changes = Vec::with_capacity(selection.len() * 2);
+    let mut ranges = SmallVec::with_capacity(selection.len());
+    let mut offs = 0;
+
+    for range in selection.iter() {
+        changes.push((range.from(), range.from(), Some(open.clone())));
+        changes.push((range.to(), range.to(), Some(close.clone())));
+
+        ranges.push(
+            Range::new(offs + range.from(), offs + range.to() + surround_len)
+                .with_direction(range.direction()),
+        );
+
+        offs += surround_len;
+    }
+
+    let transaction = Transaction::change(doc.text(), changes.into_iter())
+        .with_selection(Selection::new(ranges, selection.primary_index()));
+    doc.apply(&transaction, view.id);
+    // exit_select_mode(cx);
 }
 
 fn surround_add(cx: &mut Context) {
@@ -5633,20 +5682,23 @@ fn surround_add(cx: &mut Context) {
             Some(ch) => {
                 let mut open = Tendril::new();
                 let mut close = Tendril::new();
-                let length = if ch == 'x' {
-                    let (o, c) = match_brackets::get_pair(ch);
-                    open.push(o);
-                    close.push(c);
-                    // Any character other than "x" will cause 2 chars to get added
-                    2
-                } else {
-                    let (o, c) = match_brackets::get_pair(ch);
-                    open.push(o);
-                    close.push(c);
-                    // Any character other than "x" will cause 2 chars to get added
-                    2
-                };
-                (open, close, length)
+                // let length = if ch == 'x' {
+                //     let prompt = create_surround_prompt(cx.editor, "none".into(), Some('z'));
+                //     cx.push_layer(prompt);
+
+                //     let (o, c) = match_brackets::get_pair(ch);
+                //     open.push(o);
+                //     close.push(c);
+                //     // Any character other than "x" will cause 2 chars to get added
+                //     2
+                // } else {
+                let (o, c) = match_brackets::get_pair(ch);
+                open.push(o);
+                close.push(c);
+                // Any character other than "x" will cause 2 chars to get added
+                // 2
+                // };
+                (open, close, 2)
             }
             None if event.code == KeyCode::Enter => (
                 doc.line_ending.as_str().into(),
@@ -5656,27 +5708,30 @@ fn surround_add(cx: &mut Context) {
             None => return,
         };
 
-        let selection = doc.selection(view.id);
-        let mut changes = Vec::with_capacity(selection.len() * 2);
-        let mut ranges = SmallVec::with_capacity(selection.len());
-        let mut offs = 0;
-
-        for range in selection.iter() {
-            changes.push((range.from(), range.from(), Some(open.clone())));
-            changes.push((range.to(), range.to(), Some(close.clone())));
-
-            ranges.push(
-                Range::new(offs + range.from(), offs + range.to() + surround_len)
-                    .with_direction(range.direction()),
-            );
-
-            offs += surround_len;
-        }
-
-        let transaction = Transaction::change(doc.text(), changes.into_iter())
-            .with_selection(Selection::new(ranges, selection.primary_index()));
-        doc.apply(&transaction, view.id);
+        surround_add_impl(doc, view, surround_len, open, close);
         exit_select_mode(cx);
+
+        // let selection = doc.selection(view.id);
+        // let mut changes = Vec::with_capacity(selection.len() * 2);
+        // let mut ranges = SmallVec::with_capacity(selection.len());
+        // let mut offs = 0;
+
+        // for range in selection.iter() {
+        //     changes.push((range.from(), range.from(), Some(open.clone())));
+        //     changes.push((range.to(), range.to(), Some(close.clone())));
+
+        //     ranges.push(
+        //         Range::new(offs + range.from(), offs + range.to() + surround_len)
+        //             .with_direction(range.direction()),
+        //     );
+
+        //     offs += surround_len;
+        // }
+
+        // let transaction = Transaction::change(doc.text(), changes.into_iter())
+        //     .with_selection(Selection::new(ranges, selection.primary_index()));
+        // doc.apply(&transaction, view.id);
+        // exit_select_mode(cx);
     })
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5616,7 +5616,6 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         ("a", "Argument/parameter (tree-sitter)"),
         ("c", "Comment (tree-sitter)"),
         ("T", "Test (tree-sitter)"),
-        ("x", "Tag (XML/HTML/JSX)"),
         ("e", "Data structure entry (tree-sitter)"),
         ("m", "Closest surrounding pair (tree-sitter)"),
         ("g", "Change"),
@@ -5625,24 +5624,6 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
 
     cx.editor.autoinfo = Some(Info::new(title, &help_text));
 }
-
-// fn create_surround_prompt(
-//     editor: &Editor,
-//     prefill: String,
-//     history_register: Option<char>,
-//     callback_fn: impl FnMut(&mut compositor::Context<'_>, &str, PromptEvent) + 'static,
-// ) -> Box<Prompt> {
-//     let prompt = Prompt::new(
-//         "tag name:".into(),
-//         // TODO: change this to actually be history_register
-//         Some('z'),
-//         ui::completers::none,
-//         callback_fn,
-//     )
-//     .with_line("temp".into(), editor);
-
-//     Box::new(prompt)
-// }
 
 fn surround_add_impl(
     doc: &mut Document,
@@ -5701,7 +5682,6 @@ fn surround_add(cx: &mut Context) {
                             context.editor.mode = Mode::Normal;
                         },
                     );
-                    // .with_line(String::from("temp"), cx.editor);
                     cx.push_layer(Box::new(prompt));
                 } else {
                     let (open, close) = match_brackets::get_pair(ch);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5631,12 +5631,22 @@ fn surround_add(cx: &mut Context) {
         // surround_len is the number of new characters being added.
         let (open, close, surround_len) = match event.char() {
             Some(ch) => {
-                let (o, c) = match_brackets::get_pair(ch);
                 let mut open = Tendril::new();
-                open.push(o);
                 let mut close = Tendril::new();
-                close.push(c);
-                (open, close, 2)
+                let length = if ch == 'x' {
+                    let (o, c) = match_brackets::get_pair(ch);
+                    open.push(o);
+                    close.push(c);
+                    // Any character other than "x" will cause 2 chars to get added
+                    2
+                } else {
+                    let (o, c) = match_brackets::get_pair(ch);
+                    open.push(o);
+                    close.push(c);
+                    // Any character other than "x" will cause 2 chars to get added
+                    2
+                };
+                (open, close, length)
             }
             None if event.code == KeyCode::Enter => (
                 doc.line_ending.as_str().into(),

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -103,6 +103,7 @@ impl Prompt {
         self
     }
 
+    /// Sets the line of the prompt as if the user has typed that text manually
     pub fn set_line(&mut self, line: String, editor: &Editor) {
         let cursor = line.len();
         self.line = line;


### PR DESCRIPTION
This PR was inspired by https://github.com/helix-editor/helix/pull/11158 which adds text objects for XML, HTML and JSX tags allowing us to:
- select inside of a tag
- select the entire tag

A popular request is to add the ability to rename tags: https://github.com/helix-editor/helix/issues/966
It would also be useful to delete surrounding tag, and add a tag around a selection

This PR adds those capabilities by adding `x` under the `surround` operations, since https://github.com/helix-editor/helix/pull/11158 also uses `x`. 

---

### Change surrounding tag

1. `mrx` opens a prompt prefilled with the name tag surrounding the current selection (e.g. `span`).
1. When the user presses enter, the value of the prompt replaces the type of the tag surrounding the selection (if the user writes `div`, it'll replace `span` -> `div`)

### Delete surrounding tag

1. `mdx` deletes the closest opening and closest tag to the cursor

### Add surrounding tag

1. `msx` opens a prompt
1. When the user presses enter, the value of the prompt creates a tag around each selection of the same type (if the user writes `div`, it'll add a `<div></div>` around each selection)

### Progress

- [x] Add tag around selection `msx`
- [ ] Delete surrounding tag `mdx`
- [ ] Change surrounding tag `mrx`