### PR TITLE
Configuration for diagnostic icons

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -240,10 +240,12 @@ where
             counts
         });
 
+    let icons = context.editor.config().diagnostic_icons;
+
     if warnings > 0 {
         write(
             context,
-            "●".to_string(),
+            icons.warning.to_string(),
             Some(context.editor.theme.get("warning")),
         );
         write(context, format!(" {} ", warnings), None);
@@ -252,7 +254,7 @@ where
     if errors > 0 {
         write(
             context,
-            "●".to_string(),
+            icons.error.to_string(),
             Some(context.editor.theme.get("error")),
         );
         write(context, format!(" {} ", errors), None);

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -13,6 +13,27 @@ pub enum DiagnosticFilter {
     Enable(Severity),
 }
 
+/// The icon (character) to use for each [`Diagnostic`] level.
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[serde(default, deny_unknown_fields)]
+pub struct DiagnosticIcons {
+    pub error: char,
+    pub warning: char,
+    pub info: char,
+    pub hint: char,
+}
+
+impl Default for DiagnosticIcons {
+    fn default() -> Self {
+        Self {
+            error: '●',
+            warning: '●',
+            info: '●',
+            hint: '●',
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for DiagnosticFilter {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    annotations::diagnostics::{DiagnosticFilter, InlineDiagnosticsConfig},
+    annotations::diagnostics::{DiagnosticFilter, DiagnosticIcons, InlineDiagnosticsConfig},
     document::{
         DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
     },
@@ -345,6 +345,7 @@ pub struct Config {
     /// Display diagnostic below the line they occur.
     pub inline_diagnostics: InlineDiagnosticsConfig,
     pub end_of_line_diagnostics: DiagnosticFilter,
+    pub diagnostic_icons: DiagnosticIcons,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -982,6 +983,7 @@ impl Default for Config {
             jump_label_alphabet: ('a'..='z').collect(),
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Disable,
+            diagnostic_icons: DiagnosticIcons::default(),
         }
     }
 }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -46,16 +46,19 @@ impl GutterType {
 }
 
 pub fn diagnostic<'doc>(
-    _editor: &'doc Editor,
+    editor: &'doc Editor,
     doc: &'doc Document,
     _view: &View,
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
-    let warning = theme.get("warning");
-    let error = theme.get("error");
-    let info = theme.get("info");
-    let hint = theme.get("hint");
+    let icons = &editor.config().diagnostic_icons;
+
+    let warning = (theme.get("warning"), icons.warning);
+    let error = (theme.get("error"), icons.error);
+    let info = (theme.get("info"), icons.info);
+    let hint = (theme.get("hint"), icons.hint);
+
     let diagnostics = &doc.diagnostics;
 
     Box::new(
@@ -74,13 +77,14 @@ pub fn diagnostic<'doc>(
                             .any(|ls| ls.id() == d.provider)
                 });
             diagnostics_on_line.max_by_key(|d| d.severity).map(|d| {
-                write!(out, "●").ok();
-                match d.severity {
+                let (style, indicator) = match d.severity {
                     Some(Severity::Error) => error,
                     Some(Severity::Warning) | None => warning,
                     Some(Severity::Info) => info,
                     Some(Severity::Hint) => hint,
-                }
+                };
+                write!(out, "{}", indicator).ok();
+                style
             })
         },
     )


### PR DESCRIPTION
This is to aid accessibility.

Some themes are not great for colourblind people. With this configuration, they can easily change the icons that appear around the editor (gutter, status bar) to make them easier to distinguish!