### PR TITLE
Make Spacebones theme picker selection more legible

### DIFF
--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -63,7 +63,7 @@
 "ui.window" = { bg = "bg1" }
 "ui.help" = { bg = "bg1", fg = "fg1" }
 "ui.text" = { fg = "fg1" }
-"ui.text.focus" = { fg = "fg1" }
+"ui.text.focus" = { fg = "fg1", modifiers = ["bold"] }
 "ui.selection" = { bg = "hl2" }
 "ui.selection.primary" = { bg = "hl1" }
 "ui.cursor.primary" = { modifiers = ["reversed"] }


### PR DESCRIPTION
I find with this theme currently it is difficult to keep track of which picker item is currently selected.  This should make it clearer.