### PR TITLE
Swift: disable `auto-format` and added `.swift-format` highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 helix-term/rustfmt.toml
 result
 runtime/grammars
+.DS_Store

--- a/languages.toml
+++ b/languages.toml
@@ -451,6 +451,7 @@ file-types = [
   "avsc",
   "ldtk",
   "ldtkl",
+  { glob = ".swift-format" },
 ]
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true
@@ -1967,7 +1968,6 @@ roots = [ "Package.swift" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 formatter = { command = "swift-format" }
-auto-format = true
 language-servers = [ "sourcekit-lsp" ]
 
 [[grammar]]


### PR DESCRIPTION
Based on [this comment](https://github.com/helix-editor/helix/pull/12052#issuecomment-2473955089) I've disabled the auto-formatting for Swift because there is not a community-wide formatter that's been settled on as the standard yet. There is an ['official'](https://github.com/swiftlang/swift-format) one, but it seems to be rarely used currently and there is [community-built](https://github.com/nicklockwood/SwiftFormat) one that can also be used. Also, Xcode doesnt have formatting built-in, which is very annoying (and the re-indent defaults to 4-space tabbing but the official formatter does 2-space??? anyway). I think it's worth sticking to the official one as the built in, still, but auto-formatting I dont think is the way to go here.