### PR TITLE
feat: remap "add cursor above" to D instead of Alt-C

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -127,7 +127,7 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `,`                   | Keep only the primary selection                                   | `keep_primary_selection`             |
 | `Alt-,`               | Remove the primary selection                                      | `remove_primary_selection`           |
 | `C`                   | Copy selection onto the next line (Add cursor below)              | `copy_selection_on_next_line`        |
-| `Alt-C`               | Copy selection onto the previous line (Add cursor above)          | `copy_selection_on_prev_line`        |
+| `D`                   | Copy selection onto the previous line (Add cursor above)          | `copy_selection_on_prev_line`        |
 | `(`                   | Rotate main selection backward                                    | `rotate_selections_backward`         |
 | `)`                   | Rotate main selection forward                                     | `rotate_selections_forward`          |
 | `Alt-(`               | Rotate selection contents backward                                | `rotate_selection_contents_backward` |

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -75,7 +75,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "A-c" => change_selection_noyank,
 
         "C" => copy_selection_on_next_line,
-        "A-C" => copy_selection_on_prev_line,
+        "D" => copy_selection_on_prev_line,
 
 
         "s" => select_regex,


### PR DESCRIPTION
There have been several discussions that people would prefer if the editor did not make any default Alt-* keymappings: 
- [Discussion](https://github.com/helix-editor/helix/discussions/6853)
- [Reddit Post](https://www.reddit.com/r/HelixEditor/comments/1730bm5/anyone_hates_the_alt_key/)
- [Reddit Post](https://www.reddit.com/r/HelixEditor/comments/1bvlggg/remapping_alt_key/)
- [Discussion](https://github.com/helix-editor/helix/discussions?discussions_q=is%3Aopen+alt&page=3)

So this PR is going to help a little bit with that.

I remapped `Alt-C` (`copy_selection_on_prev_line`) to `D` because it adds a cursor above, and `D` is above the `C` key.

`Alt-C` requires 3 keystrokes (alt, shift, C) and is uncomfortable to type

To me, it makes sense that `D` and `C` will be together. The `C` which adds a cursor below, is lower. And `D` which adds a cursor above, is above `C`. I think there is logic to that.

D is also not mapped to anything at the moment.

This is just my opinion and if you have a better place to put this keymap then please let me know! I feel like the alt-* keymappings should be gradually removed
