### PR TITLE
feat: add support for lsp workspace command arguments in prompt

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1426,19 +1426,28 @@ fn lsp_workspace_command(
         };
         cx.jobs.callback(callback);
     } else {
-        let command = args.join(" ");
+        let command = args.first().unwrap().to_string();
+
         let matches: Vec<_> = ls_id_commands
             .filter(|(_ls_id, c)| *c == &command)
             .collect();
 
         match matches.as_slice() {
             [(ls_id, _command)] => {
+                let lsp_command_args: Vec<Value> = args[1..]
+                    .iter()
+                    .map(|s| Value::String(s.to_string()))
+                    .collect();
                 execute_lsp_command(
                     cx.editor,
                     *ls_id,
                     helix_lsp::lsp::Command {
                         title: command.clone(),
-                        arguments: None,
+                        arguments: if lsp_command_args.is_empty() {
+                            None
+                        } else {
+                            Some(lsp_command_args)
+                        },
                         command,
                     },
                 );


### PR DESCRIPTION
Treat space-separated values as arguments in the prompt :

`:lsp-workspace-command lsp.Command foo bar`

Tries to execute command `lsp.Command` with the arguments [`foo`, `bar`] instead of executing `lsp.Command foo bar`.

This allows users to run lsp commands that require arguments (ex: export* with tinymist).