### PR TITLE
feat: add config for disable autostart LSP

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -116,6 +116,7 @@ The following statusline elements can be configured:
 | Key                   | Description                                                 | Default |
 | ---                   | -----------                                                 | ------- |
 | `enable`              | Enables LSP integration. Setting to false will completely disable language servers regardless of language settings.| `true` |
+| `autostart`           | Enables LSP autostart on file opening. Setting to false will require running the `:lsp-restart` command to manually start the language server.| `true` |
 | `display-messages`    | Display LSP progress messages below statusline[^1]          | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
 | `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -790,6 +790,7 @@ impl Registry {
         doc_path: Option<&'a std::path::PathBuf>,
         root_dirs: &'a [PathBuf],
         enable_snippets: bool,
+        autostart: bool,
     ) -> impl Iterator<Item = (LanguageServerName, Result<Arc<Client>>)> + 'a {
         language_config.language_servers.iter().filter_map(
             move |LanguageServerFeatures { name, .. }| {
@@ -806,6 +807,12 @@ impl Registry {
                         client.try_add_doc(&language_config.roots, root_dirs, doc_path, *i == 0)
                     }) {
                         return Some((name.to_owned(), Ok(client.clone())));
+                    }
+                } else {
+                    // If autostart LSP turned off, do not automatically start a client for server
+                    // Try emulate the empty clients list behavior for disable LSP
+                    if !autostart {
+                        return None;
                     }
                 }
                 match self.start_client(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -421,6 +421,8 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
 pub struct LspConfig {
     /// Enables LSP
     pub enable: bool,
+    /// Autostart LSP on open file
+    pub autostart: bool,
     /// Display LSP messagess from $/progress below statusline
     pub display_progress_messages: bool,
     /// Display LSP messages from window/showMessage below statusline
@@ -441,6 +443,7 @@ impl Default for LspConfig {
     fn default() -> Self {
         Self {
             enable: true,
+            autostart: true,
             display_progress_messages: false,
             display_messages: true,
             auto_signature_help: true,
@@ -1459,7 +1462,7 @@ impl Editor {
         // store only successfully started language servers
         let language_servers = lang.as_ref().map_or_else(HashMap::default, |language| {
             self.language_servers
-                .get(language, path.as_ref(), root_dirs, config.lsp.snippets)
+                .get(language, path.as_ref(), root_dirs, config.lsp.snippets, config.lsp.autostart)
                 .filter_map(|(lang, client)| match client {
                     Ok(client) => Some((lang, client)),
                     Err(err) => {


### PR DESCRIPTION
Add new option to configuration that prevent auto starting LSP on opening files.
For manually starting LSP execute `:lsp-restart` command.

This is useful for large projects when you need to make a quick change.
Or when you sometimes need an LSP but don't use it all the time.

It may also be helpful for these issues: #3386, #6686
Sad they're already closed🥲