### PR TITLE
Add formatters for Elm, Haskell, Python, and TypeScript

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -764,6 +764,11 @@ roots = [ "package.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "typescript-language-server" ]
+formatter = { command = "prettier" }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 
 [language.debugger]
@@ -792,6 +797,11 @@ roots = [ "package.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "typescript-language-server" ]
+formatter = { command = "prettier" }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -806,6 +816,11 @@ roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "typescript-language-server" ]
+formatter = { command = 'prettier', args = ["--parser", "typescript"] }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -839,6 +854,11 @@ roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "typescript-language-server" ]
+formatter = { command = "prettier", args = ["--parser", "typescript"] }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -896,6 +916,10 @@ shebangs = ["python", "uv"]
 roots = ["pyproject.toml", "setup.py", "poetry.lock", "pyrightconfig.json"]
 comment-token = "#"
 language-servers = ["ruff", "jedi", "pylsp"]
+formatter = { command = "ruff", args = ["format"]}
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "black", args = ["-"] }
 # TODO: pyls needs utf-8 offsets
 indent = { tab-width = 4, unit = "    " }
 
@@ -1385,6 +1409,7 @@ roots = ["Setup.hs", "stack.yaml", "cabal.project"]
 comment-token = "--"
 block-comment-tokens = { start = "{-", end = "-}" }
 language-servers = [ "haskell-language-server" ]
+formatter = { command = "ormolu" }
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
@@ -1845,6 +1870,7 @@ auto-format = true
 comment-token = "--"
 block-comment-tokens = { start = "{-", end = "-}" }
 language-servers = [ "elm-language-server" ]
+formatter = { command = "elm-format", args = ["--stdin"] }
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
@@ -3841,6 +3867,11 @@ language-servers = [
     "vscode-eslint-language-server",
     "ember-language-server",
 ]
+formatter = { command = "prettier" }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -3865,6 +3896,11 @@ language-servers = [
     "vscode-eslint-language-server",
     "ember-language-server",
 ]
+formatter = { command = "prettier", args = ["--parser", "typescript"] }
+# Alternative formatters (for your own `languages.toml` file in ~/.config/helix`
+# replace the line above with one below)
+# formatter = { command = "biome", args = ["format"] }
+# formatter = { command = "deno", args = ["format"] }
 indent = { tab-width = 2, unit = "  " }
 grammar = "typescript"
 


### PR DESCRIPTION
This commit adds `elm-format` for Elm, `ormolu` for Haskell, `ruff` for Python, and `prettier` for TypeScript, Javascript, TSX, JSX, etc.