### PR TITLE
Adaptive Theme Selection Based on the Terminal Color Scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "tempfile",
+ "terminal-colorsaurus",
  "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
@@ -2373,6 +2374,31 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778d24b27585f6f92ec5d2705e7cf1710fd0ffa43262c807dfb49fa53471e95"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a5b836e7f4f81afe61b5cd399eee774f25edcfd47009a76e29f53bb6487833"
+dependencies = [
+ "cfg-if",
+ "libc",
  "windows-sys 0.59.0",
 ]
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -11,6 +11,8 @@ Example config:
 
 ```toml
 theme = "onedark"
+# Adaptive Theme
+# theme = { light = "onelight", dark = "onedark" }
 
 [editor]
 line-number = "relative"

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -1,6 +1,7 @@
 ## Themes
 
 To use a theme add `theme = "<name>"` to the top of your [`config.toml`](./configuration.md) file, or select it during runtime using `:theme <name>`.
+Alternatively, `theme = { light = "<name>", dark = "<name>" }` tries to select a theme based on the terminal color scheme. The detection should work with all major terminals including Windows Terminal (starting with v1.22).
 
 ## Creating a theme
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -113,6 +113,7 @@ impl Application {
         let theme = config
             .theme
             .as_ref()
+            .map(helix_view::theme::Config::get_active_theme)
             .and_then(|theme| {
                 theme_loader
                     .load(theme)
@@ -428,6 +429,7 @@ impl Application {
         let theme = config
             .theme
             .as_ref()
+            .map(helix_view::theme::Config::get_active_theme)
             .and_then(|theme| {
                 self.theme_loader
                     .load(theme)

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -11,7 +11,7 @@ use toml::de::Error as TomlError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
-    pub theme: Option<String>,
+    pub theme: Option<helix_view::theme::Config>,
     pub keys: HashMap<Mode, KeyTrie>,
     pub editor: helix_view::editor::Config,
 }
@@ -19,7 +19,7 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigRaw {
-    pub theme: Option<String>,
+    pub theme: Option<helix_view::theme::Config>,
     pub keys: Option<HashMap<Mode, KeyTrie>>,
     pub editor: Option<toml::Value>,
 }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -27,6 +27,7 @@ helix-vcs = { path = "../helix-vcs" }
 bitflags = "2.6"
 anyhow = "1"
 crossterm = { version = "0.28", optional = true }
+terminal-colorsaurus = "0.4"
 
 tempfile = "3.14"
 


### PR DESCRIPTION
Fixes #8899, #10281

### Overview

Introduce `theme = { light = "<name>", dark = "<name>" }` syntax inside `config.toml` to allow adaptive theme selection based on the terminal color scheme.

Theme selection is based on [terminal-colorsaurus](https://crates.io/crates/terminal-colorsaurus) which has also been used in [delta](https://github.com/dandavison/delta/pull/1615) and [bat](https://github.com/sharkdp/bat/pull/2896).

### Considerations
- If the theme detection fails, _dark mode is chosen by default_.
- The new syntax using an untagged enum ensures _existing configs remain valid_.
- Theme validation (ensuring the theme name exists) is only done for the detected theme. This would _defer errors_ if a missing theme is specified but _reduces code changes_.
- terminal-colorsaurus' code is only called in case an adaptive theme has been specified, guaranteeing practically _zero overhead for static themes_.
