### PR TITLE
Add WORKSPACE.* to starlark file-types.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2355,7 +2355,7 @@ source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569
 name = "starlark"
 scope = "source.starlark"
 injection-regex = "(starlark|bzl|bazel)"
-file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUILD.*" }, { glob = "Tiltfile" }, { glob = "WORKSPACE" }]
+file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUILD.*" }, { glob = "Tiltfile" }, { glob = "WORKSPACE" }, { glob = "WORKSPACE.*" }]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 grammar = "python"


### PR DESCRIPTION
This includes the WORKSPACE.bzlmod file. See:
https://bazel.build/versions/6.0.0/build/bzlmod
https://github.com/bazelbuild/examples/blob/main/bzlmod/01-depend_on_bazel_module/WORKSPACE.bzlmod