### PR TITLE
chore(msrv): bump MSRV from 1.70 to 1.76

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@1.76
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -38,8 +38,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@1.76
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -70,8 +70,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@1.76
         with:
           components: rustfmt, clippy
 
@@ -98,8 +98,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@1.76
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ categories = ["editor"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
-rust-version = "1.70"
+rust-version = "1.76"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.76.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
At the time of this post this is the most recent firefox MSRV.
![image](https://github.com/user-attachments/assets/1c4eaa1a-7e3c-442d-912b-accfe8d6c5e3)
