### PR TITLE
feat: change comment string for mdx files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1624,6 +1624,11 @@ name = "markdown"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "62516e8c78380e3b51d5b55727995d2c511436d8", subpath = "tree-sitter-markdown" }
 
 [[language]]
+name = "markdown"
+file-types = [ "mdx" ]
+block-comment-tokens = { start = "{/*", end = "*/}" } 
+
+[[language]]
 name = "markdown.inline"
 scope = "source.markdown.inline"
 injection-regex = "markdown\\.inline"


### PR DESCRIPTION
`<!--` and `-->` are not valid comment in MDX, you have to use `{/*` and `*/}`

![image](https://github.com/user-attachments/assets/06a60816-33fb-41df-965d-c3912f17227e)
