### PR TITLE
just: bump grammar support to Just 1.37.0

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3168,7 +3168,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "6e28fa6cba511c694247cd802d1c3b14f8d34dbb" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "180bb15d64c63585c4f65c551350048f21987bcb" }
 
 [[language]]
 name = "gn"

--- a/runtime/queries/just/highlights.scm
+++ b/runtime/queries/just/highlights.scm
@@ -3,6 +3,7 @@
 [
   "export"
   "import"
+  "unexport"
 ] @keyword.control.import
 
 "mod" @keyword.directive
@@ -18,6 +19,11 @@
   "else"
 ] @keyword.control.conditional
 
+[
+  "&&"
+  "||"
+] @operator
+
 ; Variables
 
 (value
@@ -30,6 +36,9 @@
   name: (identifier) @variable)
 
 (shell_variable_name) @variable
+
+(unexport
+  name: (identifier) @variable)
 
 ; Functions
 


### PR DESCRIPTION
Release notes at https://github.com/casey/just/releases/tag/1.37.0