### PR TITLE
add bufferline highlighting for flexoki themes

### DIFF
--- a/runtime/themes/flexoki_dark.toml
+++ b/runtime/themes/flexoki_dark.toml
@@ -1,6 +1,6 @@
 inherits = "flexoki_light"
 
-[palette]
+# [palette]
 tx = "#CECDC3"
 tx-2 = "#878580"
 tx-3 = "#575653"

--- a/runtime/themes/flexoki_dark.toml
+++ b/runtime/themes/flexoki_dark.toml
@@ -1,6 +1,6 @@
 inherits = "flexoki_light"
 
-# [palette]
+[palette]
 tx = "#CECDC3"
 tx-2 = "#878580"
 tx-3 = "#575653"

--- a/runtime/themes/flexoki_light.toml
+++ b/runtime/themes/flexoki_light.toml
@@ -26,6 +26,8 @@
 "ui.menu.selected" = { bg = "ui", fg = "tx" }
 "ui.debug" = { fg = "or", bg = "bg" }
 "ui.highlight.frameline" = { bg = "ye" }
+"ui.bufferline" = { fg = "tx-2", bg = "bg-2"}                      
+"ui.bufferline.active" = { fg = "ye", bg = "bg-2" }                          
 "diagnostic.hint" = { underline = { color = "bl", style = "curl" } }
 "diagnostic.info" = { underline = { color = "bl", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "ye", style = "curl" } }
@@ -36,7 +38,6 @@
 "info" = { fg = "ye", modifiers = ["bold"] }
 "warning" = { fg = "or", modifiers = ["bold"] }
 "error" = { fg = "re", modifiers = ["bold"] }
-
 "attribute" = "ye"
 "type" = "ye"
 "constructor" = "gr"
@@ -62,7 +63,6 @@
 "function" = "or"
 "tag" = "bl"
 "namespace" = "re"
-
 "markup.heading" = "or"
 "markup.list" = "ye"
 "markup.bold" = { fg = "or", modifiers = ["bold"] }
@@ -87,6 +87,7 @@ ui-2 = "#DAD8CE"
 ui = "#E6E4D9"
 bg-2 = "#F2F0E5"
 bg = "#FFFCF0"
+
 
 re = "#AF3029"
 or = "#BC5215"


### PR DESCRIPTION
simple add for bufferlines to showup on `flexoki_light` and `flexoki_dark`

Light:
<img width="395" alt="Screenshot 2024-11-28 at 1 59 46 PM" src="https://github.com/user-attachments/assets/296aa2d2-b46b-4e34-b39e-44f0b6b58789">

Dark:
<img width="338" alt="Screenshot 2024-11-28 at 2 02 04 PM" src="https://github.com/user-attachments/assets/99349f90-347e-4400-9de3-895aabacc7e9">
