### PR TITLE
Improve tsq/tree-sitter-query language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -214,7 +214,7 @@
 | thrift | ✓ |  |  |  |
 | todotxt | ✓ |  |  |  |
 | toml | ✓ | ✓ |  | `taplo` |
-| tsq | ✓ |  |  |  |
+| tsq | ✓ |  |  | `ts_query_ls` |
 | tsx | ✓ | ✓ | ✓ | `typescript-language-server` |
 | twig | ✓ |  |  |  |
 | typescript | ✓ | ✓ | ✓ | `typescript-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -120,6 +120,7 @@ zls = { command = "zls" }
 blueprint-compiler = { command = "blueprint-compiler", args = ["lsp"] }
 typst-lsp = { command = "typst-lsp" }
 tinymist = { command = "tinymist" }
+ts_query_ls = { command = "ts_query_ls" }
 pkgbuild-language-server = { command = "pkgbuild-language-server" }
 helm_ls = { command = "helm_ls", args = ["serve"] }
 ember-language-server = { command = "ember-language-server", args = ["--stdio"] }
@@ -1439,14 +1440,21 @@ language-servers = [ "swipl" ]
 [[language]]
 name = "tsq"
 scope = "source.tsq"
-file-types = ["tsq"]
+file-types = [{ glob = "queries/*.scm" }, { glob = "injections.scm" },  { glob = "highlights.scm" },  { glob = "indents.scm" },  { glob = "textobjects.scm" },  { glob = "locals.scm" },  { glob = "tags.scm" }]
 comment-token = ";"
 injection-regex = "tsq"
+language-servers = ["ts_query_ls"]
+grammar = "query"
 indent = { tab-width = 2, unit = "  " }
 
+[language.auto-pairs]
+'(' = ')'
+'[' = ']'
+'"' = '"'
+
 [[grammar]]
-name = "tsq"
-source = { git = "https://github.com/the-mikedavis/tree-sitter-tsq", rev = "48b5e9f82ae0a4727201626f33a17f69f8e0ff86" }
+name = "query"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-query", rev = "a6674e279b14958625d7a530cabe06119c7a1532" }
 
 [[language]]
 name = "cmake"

--- a/runtime/queries/tsq/folds.scm
+++ b/runtime/queries/tsq/folds.scm
@@ -1,0 +1,6 @@
+[
+  (named_node)
+  (predicate)
+  (grouping)
+  (list)
+] @fold

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -1,24 +1,3 @@
-((predicate
-  name: (identifier) @_name
-  parameters:
-    (parameters
-      (string
-        "\"" @string
-        "\"" @string) @string.regexp
-      .
-      (string) .))
-  (#any-of? @_name "gsub" "not-gsub"))
-
-((comment) @keyword.directive
-  (#match? @keyword.directive "^;+\s*format\-ignore\s*$"))
-
-((program
-  .
-  (comment)*
-  .
-  (comment) @keyword.directive)
-  (#match? @keyword.directive "^;+ *extends *$"))
-
 ((program
   .
   (comment)*

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -56,10 +56,10 @@
 
 (negated_field
   "!" @operator
-  (identifier) @property)
+  (identifier) @variable.other.member)
 
 (field_definition
-  name: (identifier) @property)
+  name: (identifier) @variable.other.member)
 
 (named_node
   name: (identifier) @variable)

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -27,8 +27,8 @@
   (#match? @keyword.import "^;+ *inherits *:"))
 
 ((parameters
-  (identifier) @number)
-  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
+  (identifier) @constant.numeric)
+  (#match? @constant.numeric "^[-+]?[0-9]+(.[0-9]+)?$"))
 
 "_" @constant
 

--- a/runtime/queries/tsq/highlights.scm
+++ b/runtime/queries/tsq/highlights.scm
@@ -1,50 +1,78 @@
-; mark the string passed #match? as a regex
-(((predicate_name) @function
-  (capture)
-  (string) @string.regexp)
- (#eq? @function "#match?"))
+((predicate
+  name: (identifier) @_name
+  parameters:
+    (parameters
+      (string
+        "\"" @string
+        "\"" @string) @string.regexp
+      .
+      (string) .))
+  (#any-of? @_name "gsub" "not-gsub"))
 
-; highlight inheritance comments
-(((comment) @keyword.directive)
- (#match? @keyword.directive "^; +inherits *:"))
+((comment) @keyword.directive
+  (#match? @keyword.directive "^;+\s*format\-ignore\s*$"))
+
+((program
+  .
+  (comment)*
+  .
+  (comment) @keyword.directive)
+  (#match? @keyword.directive "^;+ *extends *$"))
+
+((program
+  .
+  (comment)*
+  .
+  (comment) @keyword.import)
+  (#match? @keyword.import "^;+ *inherits *:"))
+
+((parameters
+  (identifier) @number)
+  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
+
+"_" @constant
 
 [
-  "("
-  ")"
-  "["
-  "]"
-] @punctuation.bracket
+  "@"
+  "#"
+] @punctuation.special
 
 ":" @punctuation.delimiter
-"!" @operator
 
 [
-  (one_or_more)
-  (zero_or_one)
-  (zero_or_more)
-] @operator
+  "["
+  "]"
+  "("
+  ")"
+] @punctuation.bracket
 
-[
-  (wildcard_node)
-  (anchor)
-] @constant.builtin
+"." @operator
 
-[
-  (anonymous_leaf)
-  (string)
-] @string
+(predicate_type) @punctuation.special
+
+(quantifier) @operator
 
 (comment) @comment
 
-(field_name) @variable.other.member
+(negated_field
+  "!" @operator
+  (identifier) @property)
 
-(capture) @label
+(field_definition
+  name: (identifier) @property)
 
-((predicate_name) @function
- (#any-of? @function "#eq?" "#match?" "#any-of?" "#not-any-of?" "#is?" "#is-not?" "#not-same-line?" "#not-kind-eq?" "#set!" "#select-adjacent!" "#strip!"))
-(predicate_name) @error
+(named_node
+  name: (identifier) @variable)
+
+(predicate
+  name: (identifier) @function)
+
+(anonymous_node
+  (string) @string)
+
+(capture
+  (identifier) @type)
 
 (escape_sequence) @constant.character.escape
 
-(node_name) @tag
-(variable) @variable
+(string) @string

--- a/runtime/queries/tsq/injections.scm
+++ b/runtime/queries/tsq/injections.scm
@@ -6,5 +6,5 @@
   parameters:
     (parameters
       (string) @injection.content))
-  (#any-of? @_name "match" "not-match" "vim-match" "not-vim-match")
+  (#any-of? @_name "match" "not-match")
   (#set! injection.language "regex"))

--- a/runtime/queries/tsq/injections.scm
+++ b/runtime/queries/tsq/injections.scm
@@ -1,8 +1,10 @@
 ((comment) @injection.content
- (#set! injection.language "comment"))
+  (#set! injection.language "comment"))
 
 ((predicate
-   (predicate_name) @_predicate
-   (string) @injection.content)
- (#eq? @_predicate "#match?")
- (#set! injection.language "regex"))
+  name: (identifier) @_name
+  parameters:
+    (parameters
+      (string) @injection.content))
+  (#any-of? @_name "match" "not-match" "vim-match" "not-vim-match")
+  (#set! injection.language "regex"))


### PR DESCRIPTION
WIP adding support for tree-sitter query files (scheme-like), using https://github.com/tree-sitter-grammars/tree-sitter-query for the grammar and https://github.com/ribru17/ts_query_ls as the LSP.

## Todo

- [x] LSP
- [x] Reverse query order for precedence order difference 