### PR TITLE
fix(clippy): clippy 1.83 lints

### DIFF
--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -346,7 +346,7 @@ pub struct RopeGraphemes<'a> {
     cursor: GraphemeCursor,
 }
 
-impl<'a> fmt::Debug for RopeGraphemes<'a> {
+impl fmt::Debug for RopeGraphemes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RopeGraphemes")
             .field("text", &self.text)
@@ -358,7 +358,7 @@ impl<'a> fmt::Debug for RopeGraphemes<'a> {
     }
 }
 
-impl<'a> RopeGraphemes<'a> {
+impl RopeGraphemes<'_> {
     #[must_use]
     pub fn new(slice: RopeSlice) -> RopeGraphemes {
         let mut chunks = slice.chunks();
@@ -423,7 +423,7 @@ pub struct RevRopeGraphemes<'a> {
     cursor: GraphemeCursor,
 }
 
-impl<'a> fmt::Debug for RevRopeGraphemes<'a> {
+impl fmt::Debug for RevRopeGraphemes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RevRopeGraphemes")
             .field("text", &self.text)
@@ -435,7 +435,7 @@ impl<'a> fmt::Debug for RevRopeGraphemes<'a> {
     }
 }
 
-impl<'a> RevRopeGraphemes<'a> {
+impl RevRopeGraphemes<'_> {
     #[must_use]
     pub fn new(slice: RopeSlice) -> RevRopeGraphemes {
         let (mut chunks, mut cur_chunk_start, _, _) = slice.chunks_at_byte(slice.len_bytes());
@@ -542,7 +542,7 @@ impl<'a> From<&'a str> for GraphemeStr<'a> {
     }
 }
 
-impl<'a> From<String> for GraphemeStr<'a> {
+impl From<String> for GraphemeStr<'_> {
     fn from(g: String) -> Self {
         let len = g.len();
         let ptr = Box::into_raw(g.into_bytes().into_boxed_slice()) as *mut u8;

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -386,7 +386,7 @@ enum IndentCaptureType<'a> {
     Align(RopeSlice<'a>),
 }
 
-impl<'a> IndentCaptureType<'a> {
+impl IndentCaptureType<'_> {
     fn default_scope(&self) -> IndentScope {
         match self {
             IndentCaptureType::Indent | IndentCaptureType::IndentAlways => IndentScope::Tail,

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -660,7 +660,7 @@ impl Selection {
     pub fn fragments<'a>(
         &'a self,
         text: RopeSlice<'a>,
-    ) -> impl DoubleEndedIterator<Item = Cow<'a, str>> + ExactSizeIterator<Item = Cow<str>> + 'a
+    ) -> impl DoubleEndedIterator<Item = Cow<'a, str>> + ExactSizeIterator<Item = Cow<'a, str>>
     {
         self.ranges.iter().map(move |range| range.fragment(text))
     }
@@ -744,7 +744,7 @@ pub struct LineRangeIter<'a> {
     text: RopeSlice<'a>,
 }
 
-impl<'a> Iterator for LineRangeIter<'a> {
+impl Iterator for LineRangeIter<'_> {
     type Item = (usize, usize);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -619,7 +619,7 @@ pub enum CapturedNode<'a> {
     Grouped(Vec<Node<'a>>),
 }
 
-impl<'a> CapturedNode<'a> {
+impl CapturedNode<'_> {
     pub fn start_byte(&self) -> usize {
         match self {
             Self::Single(n) => n.start_byte(),
@@ -1852,7 +1852,7 @@ struct HighlightIterLayer<'a> {
     depth: u32,
 }
 
-impl<'a> fmt::Debug for HighlightIterLayer<'a> {
+impl fmt::Debug for HighlightIterLayer<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HighlightIterLayer").finish()
     }
@@ -2109,7 +2109,7 @@ impl HighlightConfiguration {
     }
 }
 
-impl<'a> HighlightIterLayer<'a> {
+impl HighlightIterLayer<'_> {
     // First, sort scope boundaries by their byte offset in the document. At a
     // given position, emit scope endings before scope beginnings. Finally, emit
     // scope boundaries from deeper layers first.
@@ -2247,7 +2247,7 @@ fn intersect_ranges(
     result
 }
 
-impl<'a> HighlightIter<'a> {
+impl HighlightIter<'_> {
     fn emit_event(
         &mut self,
         offset: usize,
@@ -2302,7 +2302,7 @@ impl<'a> HighlightIter<'a> {
     }
 }
 
-impl<'a> Iterator for HighlightIter<'a> {
+impl Iterator for HighlightIter<'_> {
     type Item = Result<HighlightEvent, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/helix-core/src/syntax/tree_cursor.rs
+++ b/helix-core/src/syntax/tree_cursor.rs
@@ -217,7 +217,7 @@ impl<'a> TreeCursor<'a> {
 
     /// Returns an iterator over the children of the node the TreeCursor is on
     /// at the time this is called.
-    pub fn children(&'a mut self) -> ChildIter {
+    pub fn children(&'a mut self) -> ChildIter<'a> {
         let parent = self.node();
 
         ChildIter {
@@ -229,7 +229,7 @@ impl<'a> TreeCursor<'a> {
 
     /// Returns an iterator over the named children of the node the TreeCursor is on
     /// at the time this is called.
-    pub fn named_children(&'a mut self) -> ChildIter {
+    pub fn named_children(&'a mut self) -> ChildIter<'a> {
         let parent = self.node();
 
         ChildIter {

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -211,7 +211,7 @@ impl<A, M> Layer<'_, A, M> {
 }
 
 impl<'a, A, M> From<(&'a [A], M)> for Layer<'a, A, M> {
-    fn from((annotations, metadata): (&'a [A], M)) -> Layer<A, M> {
+    fn from((annotations, metadata): (&'a [A], M)) -> Layer<'a, A, M> {
         Layer {
             annotations,
             current_index: Cell::new(0),

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -769,7 +769,7 @@ impl<'a> ChangeIterator<'a> {
     }
 }
 
-impl<'a> Iterator for ChangeIterator<'a> {
+impl Iterator for ChangeIterator<'_> {
     type Item = Change;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/helix-lsp-types/src/completion.rs
+++ b/helix-lsp-types/src/completion.rs
@@ -497,7 +497,6 @@ pub struct CompletionItem {
     /// insertText is ignored.
     ///
     /// Most editors support two different operation when accepting a completion item. One is to insert a
-
     /// completion text and the other is to replace an existing text with a completion text. Since this can
     /// usually not predetermined by a server it can report both ranges. Clients need to signal support for
     /// `InsertReplaceEdits` via the `textDocument.completion.insertReplaceSupport` client capability

--- a/helix-lsp/src/jsonrpc.rs
+++ b/helix-lsp/src/jsonrpc.rs
@@ -137,7 +137,7 @@ impl Serialize for Version {
 
 struct VersionVisitor;
 
-impl<'v> Visitor<'v> for VersionVisitor {
+impl Visitor<'_> for VersionVisitor {
     type Value = Version;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/helix-parsec/src/lib.rs
+++ b/helix-parsec/src/lib.rs
@@ -43,7 +43,7 @@ pub trait Parser<'a> {
 #[doc(hidden)]
 impl<'a, F, T> Parser<'a> for F
 where
-    F: Fn(&'a str) -> ParseResult<T>,
+    F: Fn(&'a str) -> ParseResult<'a, T>,
 {
     type Output = T;
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -98,7 +98,7 @@ pub struct Context<'a> {
     pub jobs: &'a mut Jobs,
 }
 
-impl<'a> Context<'a> {
+impl Context<'_> {
     /// Push a new component onto the compositor.
     pub fn push_layer(&mut self, component: Box<dyn Component>) {
         self.callback

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -27,7 +27,7 @@ pub struct Context<'a> {
     pub jobs: &'a mut Jobs,
 }
 
-impl<'a> Context<'a> {
+impl Context<'_> {
     /// Waits on all pending jobs, and then tries to flush all pending write
     /// operations for all documents.
     pub fn block_try_flush_writes(&mut self) -> anyhow::Result<()> {

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -346,10 +346,6 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let win_height = area.height as usize;
 
-        const fn div_ceil(a: usize, b: usize) -> usize {
-            (a + b - 1) / b
-        }
-
         let rows = options
             .iter()
             .map(|option| option.format(&self.editor_data));
@@ -390,7 +386,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let scroll_style = theme.get("ui.menu.scroll");
         if !fits {
-            let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
+            let scroll_height = win_height.pow(2).div_ceil(len).min(win_height);
             let scroll_line = (win_height - scroll_height) * scroll
                 / std::cmp::max(1, len.saturating_sub(win_height));
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -72,7 +72,7 @@ impl<'a> From<&'a Path> for PathOrId<'a> {
     }
 }
 
-impl<'a> From<DocumentId> for PathOrId<'a> {
+impl From<DocumentId> for PathOrId<'_> {
     fn from(v: DocumentId) -> Self {
         Self::Id(v)
     }

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -344,12 +344,8 @@ impl<T: Component> Component for Popup<T> {
             let fits = len <= win_height;
             let scroll_style = cx.editor.theme.get("ui.menu.scroll");
 
-            const fn div_ceil(a: usize, b: usize) -> usize {
-                (a + b - 1) / b
-            }
-
             if !fits {
-                let scroll_height = div_ceil(win_height.pow(2), len).min(win_height);
+                let scroll_height = win_height.pow(2).div_ceil(len).min(win_height);
                 let scroll_line = (win_height - scroll_height) * scroll
                     / std::cmp::max(1, len.saturating_sub(win_height));
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -415,7 +415,8 @@ impl Prompt {
         let cols = std::cmp::max(1, area.width / max_len);
         let col_width = (area.width.saturating_sub(cols)) / cols;
 
-        let height = ((self.completion.len() as u16 + cols - 1) / cols)
+        let height = (self.completion.len() as u16)
+            .div_ceil(cols)
             .min(10) // at most 10 rows (or less)
             .min(area.height.saturating_sub(1));
 

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -212,7 +212,7 @@ impl<'a> From<Cow<'a, str>> for Span<'a> {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Spans<'a>(pub Vec<Span<'a>>);
 
-impl<'a> Spans<'a> {
+impl Spans<'_> {
     /// Returns the width of the underlying string.
     ///
     /// ## Examples

--- a/helix-tui/src/widgets/block.rs
+++ b/helix-tui/src/widgets/block.rs
@@ -123,7 +123,7 @@ impl<'a> Block<'a> {
     }
 }
 
-impl<'a> Widget for Block<'a> {
+impl Widget for Block<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         if area.area() == 0 {
             return;

--- a/helix-tui/src/widgets/paragraph.rs
+++ b/helix-tui/src/widgets/paragraph.rs
@@ -129,7 +129,7 @@ impl<'a> Paragraph<'a> {
     }
 }
 
-impl<'a> Widget for Paragraph<'a> {
+impl Widget for Paragraph<'_> {
     fn render(mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
         let text_area = match self.block.take() {

--- a/helix-tui/src/widgets/reflow.rs
+++ b/helix-tui/src/widgets/reflow.rs
@@ -39,7 +39,7 @@ impl<'a, 'b> WordWrapper<'a, 'b> {
     }
 }
 
-impl<'a, 'b> LineComposer<'a> for WordWrapper<'a, 'b> {
+impl<'a> LineComposer<'a> for WordWrapper<'a, '_> {
     fn next_line(&mut self) -> Option<(&[StyledGrapheme<'a>], u16)> {
         if self.max_line_width == 0 {
             return None;
@@ -152,7 +152,7 @@ impl<'a, 'b> LineTruncator<'a, 'b> {
     }
 }
 
-impl<'a, 'b> LineComposer<'a> for LineTruncator<'a, 'b> {
+impl<'a> LineComposer<'a> for LineTruncator<'a, '_> {
     fn next_line(&mut self) -> Option<(&[StyledGrapheme<'a>], u16)> {
         if self.max_line_width == 0 {
             return None;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -34,7 +34,7 @@ pub struct Cell<'a> {
     style: Style,
 }
 
-impl<'a> Cell<'a> {
+impl Cell<'_> {
     /// Set the `Style` of this cell.
     pub fn style(mut self, style: Style) -> Self {
         self.style = style;
@@ -351,7 +351,7 @@ impl TableState {
 }
 
 // impl<'a> StatefulWidget for Table<'a> {
-impl<'a> Table<'a> {
+impl Table<'_> {
     // type State = TableState;
 
     pub fn render_table(
@@ -486,7 +486,7 @@ fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect, truncate: bool) {
     }
 }
 
-impl<'a> Widget for Table<'a> {
+impl Widget for Table<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let mut state = TableState::default();
         Table::render_table(self, area, buf, &mut state, false);

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -307,13 +307,13 @@ impl<'a> Iterator for RegisterValues<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for RegisterValues<'a> {
+impl DoubleEndedIterator for RegisterValues<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a> ExactSizeIterator for RegisterValues<'a> {
+impl ExactSizeIterator for RegisterValues<'_> {
     fn len(&self) -> usize {
         self.iter.len()
     }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -705,7 +705,7 @@ impl<'a> Iterator for Traverse<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Traverse<'a> {
+impl DoubleEndedIterator for Traverse<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             let key = self.stack.pop()?;


### PR DESCRIPTION
Lots of lifetime elisions/unneeded lifetime specifiers. Manual implimentation of `div_ceil` changed to the stdlib one. Doc comment block that was not connected to the rest of the block.