### PR TITLE
Completion item kinds customization support V2

### DIFF
--- a/helix-lsp-types/src/completion.rs
+++ b/helix-lsp-types/src/completion.rs
@@ -22,7 +22,7 @@ impl InsertTextFormat {
 }
 
 /// The kind of a completion entry.
-#[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize, Hash)]
 #[serde(transparent)]
 pub struct CompletionItemKind(i32);
 lsp_enum! {


### PR DESCRIPTION
Basically a better version of #9996, in order to avoid useless allocations and do less hacky ways (hopefully) in order to achieve this feature

This PR allows the user to customize the kind text shown inside the completion menu, allowing the end user to do the following:
- Change the colors of each kind individually, helping with readability of the menu
- Change the displayed text of each kind. By default helix uses the kind name in `snake_case`, the user can override with for example: `editor.completion-item-kinds.type-parameter = "..."
