### PR TITLE
Fix language configuration for .conf files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3463,7 +3463,11 @@ source = { git = "https://github.com/urbit-pilled/tree-sitter-hoon", rev = "1d5d
 [[language]]
 name = "hocon"
 scope = "source.conf"
-file-types = ["conf"]
+file-types = [
+  { glob = "**/src/*/resources/**/*.conf" },
+  { glob = "*scalafmt*.conf" },
+  { glob = "*scalafix*.conf" },
+]
 comment-token = "#"
 auto-format = true
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Tweaks HOCON language configuration to only match `.conf` files located under `src/*/resources/` (usually `main `or `test`). This aligns with the convention in JVM projects, where HOCON is most commonly used. Also adds support for recognizing Scalafmt and Scalafix config files.

Closes  https://github.com/helix-editor/helix/issues/12120