### PR TITLE
fix: catppuccin theme colors for checked and unchecked lists

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -52,6 +52,8 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.list.unchecked" = "overlay2"
+"markup.list.checked" = "green"
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/964fe25d-1f8c-45a2-9528-4d1c4f01217f)

After:

![image](https://github.com/user-attachments/assets/95756ec0-11fa-4917-8879-94d79d299ba4)

This is how it looks like in Neovim Catppuccin aswell.

The other 3 flavors are also updated automatically since they inherit from the one I changed