### PR TITLE
Trim all trailing whitespace on insert_newline

### DIFF
--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -2,6 +2,7 @@ use helix_term::application::Application;
 
 use super::*;
 
+mod insert;
 mod movement;
 mod write;
 

--- a/helix-term/tests/test/commands/insert.rs
+++ b/helix-term/tests/test/commands/insert.rs
@@ -51,3 +51,71 @@ async fn insert_newline_trim_trailing_whitespace() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_newline_continue_line_comment() -> anyhow::Result<()> {
+    // `insert_newline` continues a single line comment
+    test((
+        indoc! {"\
+            // Hello world!#[|
+            ]#
+            "},
+        ":lang rust<ret>i<ret>",
+        indoc! {"\
+            // Hello world!
+            // #[|
+            ]#
+            "},
+    ))
+    .await?;
+
+    // The comment is not continued if the cursor is before the comment token. (Note that we
+    // are entering insert-mode with `I`.)
+    test((
+        indoc! {"\
+            // Hello world!#[|
+            ]#
+            "},
+        ":lang rust<ret>I<ret>",
+        indoc! {"\
+            \n#[/|]#/ Hello world!
+            "},
+    ))
+    .await?;
+
+    // `insert_newline` again clears the whitespace on the first continued comment and continues
+    // the comment again.
+    test((
+        indoc! {"\
+            // Hello world!
+            // #[|
+            ]#
+            "},
+        ":lang rust<ret>i<ret>",
+        indoc! {"\
+            // Hello world!
+            //
+            // #[|
+            ]#
+            "},
+    ))
+    .await?;
+
+    // Line comment continuation and trailing whitespace is also trimmed when using
+    // `insert_newline` in the middle of a comment.
+    test((
+        indoc! {"\
+            //·hello····#[|·]#····world
+            "}
+        .replace('·', " "),
+        ":lang rust<ret>i<ret>",
+        indoc! {"\
+            //·hello
+            //·#[|·]#····world
+            "}
+        .replace('·', " "),
+    ))
+    .await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/commands/insert.rs
+++ b/helix-term/tests/test/commands/insert.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_newline_trim_trailing_whitespace() -> anyhow::Result<()> {
+    // Trailing whitespace is trimmed.
+    test((
+        indoc! {"\
+            hello·······#[|
+            ]#world
+            "}
+        .replace('·', " "),
+        "i<ret>",
+        indoc! {"\
+            hello
+            #[|
+            ]#world
+            "}
+        .replace('·', " "),
+    ))
+    .await?;
+
+    // Whitespace that would become trailing is trimmed too.
+    test((
+        indoc! {"\
+            hello········#[|w]#orld
+            "}
+        .replace('·', " "),
+        "i<ret>",
+        indoc! {"\
+            hello
+            #[|w]#orld
+            "}
+        .replace('·', " "),
+    ))
+    .await?;
+
+    // Only whitespace before the cursor is trimmed.
+    test((
+        indoc! {"\
+            hello········#[|·]#····world
+            "}
+        .replace('·', " "),
+        "i<ret>",
+        indoc! {"\
+            hello
+            #[|·]#····world
+            "}
+        .replace('·', " "),
+    ))
+    .await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/languages/yaml.rs
+++ b/helix-term/tests/test/languages/yaml.rs
@@ -795,7 +795,7 @@ async fn auto_indent() -> anyhow::Result<()> {
             "##},
             "i<ret>",
             indoc! {"\
-                foo: 
+                foo:
                   #[|b]#ar
             "},
         ),


### PR DESCRIPTION
This is like https://github.com/helix-editor/helix/pull/4854 but works on any trailing whitespace. The fast-lane for an entire line being whitespace (#4854) is kept as-is. The idea is to work well with #10996: you should be able to hit `<ret>` twice when starting on a comment line and the middle commented line should not have trailing whitespace.

For example before:

```rust
//·Comment⏎
//·⏎
//·|⏎
```

after:

```rust
//·Comment⏎
//⏎
//·|⏎
```

This happens to fix the first case mentioned in https://github.com/helix-editor/helix/issues/12165