### PR TITLE
feat: `:cd -` changes to the previous working directory

### DIFF
--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -37,10 +37,15 @@ pub fn current_working_dir() -> PathBuf {
     cwd
 }
 
-pub fn set_current_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
+pub fn set_current_working_dir(
+    last_cwd: &mut Option<PathBuf>,
+    path: impl AsRef<Path>,
+) -> std::io::Result<()> {
     let path = crate::path::canonicalize(path);
     std::env::set_current_dir(&path)?;
+    *last_cwd = (*CWD.read().unwrap()).clone();
     let mut cwd = CWD.write().unwrap();
+
     *cwd = Some(path);
 
     Ok(())
@@ -177,7 +182,7 @@ mod tests {
         let cwd = current_working_dir();
         assert_ne!(cwd, new_path);
 
-        set_current_working_dir(&new_path).expect("Couldn't set new path");
+        set_current_working_dir(&mut None, &new_path).expect("Couldn't set new path");
 
         let cwd = current_working_dir();
         assert_eq!(cwd, new_path);

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -7,16 +7,8 @@ use std::{
 
 use once_cell::sync::Lazy;
 
+// We keep the CWD as a static so that we can access it in places where we don't have access to the Editor
 static CWD: RwLock<Option<PathBuf>> = RwLock::new(None);
-// previous working directory, stored to allow `:cd -`
-static PREV_CWD: RwLock<Option<PathBuf>> = RwLock::new(None);
-
-fn change_cwd(new_dir: PathBuf) {
-    let mut cwd = CWD.write().unwrap();
-    let mut prev_cwd = PREV_CWD.write().unwrap();
-    *prev_cwd = cwd.clone();
-    *cwd = Some(new_dir);
-}
 
 // Get the current working directory.
 // This information is managed internally as the call to std::env::current_dir
@@ -39,7 +31,8 @@ pub fn current_working_dir() -> PathBuf {
             cwd = pwd;
         }
     }
-    change_cwd(cwd.clone());
+    let mut dst = CWD.write().unwrap();
+    *dst = Some(cwd.clone());
 
     cwd
 }
@@ -47,14 +40,10 @@ pub fn current_working_dir() -> PathBuf {
 pub fn set_current_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
     let path = crate::path::canonicalize(path);
     std::env::set_current_dir(&path)?;
-    change_cwd(path);
+    let mut cwd = CWD.write().unwrap();
+    *cwd = Some(path);
 
     Ok(())
-}
-
-pub fn previous_working_dir() -> Option<PathBuf> {
-    let prev_cwd = &*PREV_CWD.read().unwrap();
-    prev_cwd.clone()
 }
 
 pub fn env_var_is_set(env_var_name: &str) -> bool {

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -37,18 +37,12 @@ pub fn current_working_dir() -> PathBuf {
     cwd
 }
 
-pub fn set_current_working_dir(
-    last_cwd: &mut Option<PathBuf>,
-    path: impl AsRef<Path>,
-) -> std::io::Result<()> {
+pub fn set_current_working_dir(path: impl AsRef<Path>) -> std::io::Result<Option<PathBuf>> {
     let path = crate::path::canonicalize(path);
     std::env::set_current_dir(&path)?;
-    *last_cwd = (*CWD.read().unwrap()).clone();
     let mut cwd = CWD.write().unwrap();
 
-    *cwd = Some(path);
-
-    Ok(())
+    Ok(cwd.replace(path))
 }
 
 pub fn env_var_is_set(env_var_name: &str) -> bool {
@@ -182,7 +176,7 @@ mod tests {
         let cwd = current_working_dir();
         assert_ne!(cwd, new_path);
 
-        set_current_working_dir(&mut None, &new_path).expect("Couldn't set new path");
+        set_current_working_dir(&new_path).expect("Couldn't set new path");
 
         let cwd = current_working_dir();
         assert_eq!(cwd, new_path);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1091,7 +1091,7 @@ fn change_current_directory(
     }
 
     let dir = match args.first() {
-        Some(Cow::Borrowed("-")) => helix_stdx::env::previous_working_dir(),
+        Some(Cow::Borrowed("-")) => cx.editor.last_cwd,
         Some(input_path) => Some(
             helix_stdx::path::expand_tilde(Path::new(input_path.as_ref()).to_owned())
                 .deref()

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1091,7 +1091,7 @@ fn change_current_directory(
     }
 
     let dir = match args.first() {
-        Some(Cow::Borrowed("-")) => cx.editor.last_cwd,
+        Some(Cow::Borrowed("-")) => cx.editor.last_cwd.clone(),
         Some(input_path) => Some(
             helix_stdx::path::expand_tilde(Path::new(input_path.as_ref()).to_owned())
                 .deref()
@@ -1101,7 +1101,7 @@ fn change_current_directory(
     };
 
     if let Some(dir) = dir {
-        helix_stdx::env::set_current_working_dir(dir)?;
+        helix_stdx::env::set_current_working_dir(&mut cx.editor.last_cwd, dir)?;
 
         cx.editor.set_status(format!(
             "Current working directory is now {}",

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -123,10 +123,10 @@ FLAGS:
     // NOTE: Set the working directory early so the correct configuration is loaded. Be aware that
     // Application::new() depends on this logic so it must be updated if this changes.
     if let Some(path) = &args.working_directory {
-        helix_stdx::env::set_current_working_dir(&mut None, path)?;
+        helix_stdx::env::set_current_working_dir(path)?;
     } else if let Some((path, _)) = args.files.first().filter(|p| p.0.is_dir()) {
         // If the first file is a directory, it will be the working directory unless -w was specified
-        helix_stdx::env::set_current_working_dir(&mut None, path)?;
+        helix_stdx::env::set_current_working_dir(path)?;
     }
 
     let config = match Config::load_default() {

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -123,10 +123,10 @@ FLAGS:
     // NOTE: Set the working directory early so the correct configuration is loaded. Be aware that
     // Application::new() depends on this logic so it must be updated if this changes.
     if let Some(path) = &args.working_directory {
-        helix_stdx::env::set_current_working_dir(path)?;
+        helix_stdx::env::set_current_working_dir(&mut None, path)?;
     } else if let Some((path, _)) = args.files.first().filter(|p| p.0.is_dir()) {
         // If the first file is a directory, it will be the working directory unless -w was specified
-        helix_stdx::env::set_current_working_dir(path)?;
+        helix_stdx::env::set_current_working_dir(&mut None, path)?;
     }
 
     let config = match Config::load_default() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1073,6 +1073,7 @@ pub struct Editor {
     redraw_timer: Pin<Box<Sleep>>,
     last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
+    pub last_cwd: Option<PathBuf>,
 
     pub exit_code: i32,
 
@@ -1094,8 +1095,6 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
-
-    pub last_cwd: Option<PathBuf>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1208,6 +1207,7 @@ impl Editor {
             redraw_timer: Box::pin(sleep(Duration::MAX)),
             last_motion: None,
             last_completion: None,
+            last_cwd: None,
             config,
             auto_pairs,
             exit_code: 0,
@@ -1216,7 +1216,6 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
-            last_cwd: None,
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1094,6 +1094,8 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+
+    pub last_cwd: Option<PathBuf>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1214,6 +1216,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            last_cwd: None,
         }
     }
 


### PR DESCRIPTION
In https://github.com/helix-editor/helix/pull/12042#pullrequestreview-2480121674 it was suggested to also add `:cd -` to change to the *previous working directory*

- if a previous working directory exists, change to it
- if it doesn't, do nothing. This is the same behaviour as if you open a terminal and write `cd -`, it will not do anything. + displays informational message