### PR TITLE
Fix mojo LSP configuration to conform to magic introduction

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -134,7 +134,7 @@
 | mermaid | ✓ |  |  |  |
 | meson | ✓ |  | ✓ | `mesonlsp` |
 | mint |  |  |  | `mint` |
-| mojo | ✓ | ✓ | ✓ | `mojo-lsp-server` |
+| mojo | ✓ | ✓ | ✓ | `magic` |
 | move | ✓ |  |  |  |
 | msbuild | ✓ |  | ✓ |  |
 | nasm | ✓ | ✓ |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -62,7 +62,7 @@ marksman = { command = "marksman", args = ["server"] }
 metals = { command = "metals", config = { "isHttpEnabled" = true, metals = { inlayHints = { typeParameters = {enable = true} , hintsInPatternMatch = {enable = true} }  } } }
 mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
 mint = { command = "mint", args = ["ls"] }
-mojo-lsp = { command = "mojo-lsp-server" }
+mojo-lsp = { command = "magic", args = ["run", "mojo-lsp-server"] }
 nil = { command = "nil" }
 nimlangserver = { command = "nimlangserver" }
 nimlsp = { command = "nimlsp" }
@@ -412,7 +412,7 @@ language-servers = [ "mojo-lsp" ]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 auto-format = true
-formatter = { command = "mojo", args = ["format", "-q", "-"]}
+formatter = { command = "magic", args = ["run", "mojo" , "format", "-q", "-"]}
 
 [[grammar]]
 name = "mojo"


### PR DESCRIPTION
fixes mojo-lsp not working due to [mojo binaries being moved to magic environment](https://docs.modular.com/magic/)

(one could also learn about modular-cli deprecation [here](https://docs.modular.com/mojo/changelog/))


using the current language configuration (mojo command)
```
hx --health mojo
Configured language servers:
  ✘ mojo-lsp-server: 'mojo-lsp-server' not found in $PATH
Configured debug adapter: None
Configured formatter: mojo
Binary for formatter: 'mojo' not found in $PATH
Highlight queries: ✓
Textobject queries: ✓
Indent queries: ✓
```

when updated to `magic` command:

```
hx --health mojo
Configured language servers:
  ✓ magic: /Users/instable/.modular/bin/magic
Configured debug adapter: None
Configured formatter: magic
Binary for formatter: /Users/instable/.modular/bin/magic
Highlight queries: ✓
Textobject queries: ✓
Indent queries: ✓
```

also tested it in a mojo project on my machine