### PR TITLE
docs: new Getting Started page

### DIFF
--- a/book/custom.css
+++ b/book/custom.css
@@ -18,7 +18,7 @@ html {
 
 .chapter .section li.chapter-item {
   line-height: inherit;
-  padding: .5rem .5rem 0 .5rem;
+  padding: 0.5rem 0.5rem 0 0.5rem;
 }
 
 .content {
@@ -28,12 +28,24 @@ html {
 }
 
 /* 2 1.75 1.5 1.25 1 .875 */
-.content h1 { font-size: 2em }
-.content h2 { font-size: 1.75em }
-.content h3 { font-size: 1.5em }
-.content h4 { font-size: 1.25em }
-.content h5 { font-size: 1em }
-.content h6 { font-size: .875em }
+.content h1 {
+  font-size: 2em;
+}
+.content h2 {
+  font-size: 1.75em;
+}
+.content h3 {
+  font-size: 1.5em;
+}
+.content h4 {
+  font-size: 1.25em;
+}
+.content h5 {
+  font-size: 1em;
+}
+.content h6 {
+  font-size: 0.875em;
+}
 
 .content h1,
 .content h2,
@@ -41,7 +53,36 @@ html {
 .content h4 {
   font-weight: 500;
   margin-top: 1.275em;
-  margin-bottom: .875em;
+  margin-bottom: 0.875em;
+}
+
+aside {
+  --space: 1.25rem;
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+  padding-left: var(--space);
+  color: var(--fg);
+  padding-bottom: var(--space);
+  /* TODO: use a custom color here */
+  border-left: 4px solid var(--links);
+  position: relative;
+  color: var(--fg);
+  background-color: var(--quote-bg);
+  padding-top: 4rem;
+  &::before {
+    font-weight: bold;
+    position: absolute;
+    top: var(--space);
+    left: var(--space);
+  }
+}
+
+/* TODO: customize border color based on aside type */
+aside.tip::before {
+  content: "💡 Tip";
+}
+aside.note::before {
+  content: "ℹ️ Note";
 }
 
 .content p,
@@ -49,11 +90,11 @@ html {
 .content ul,
 .content table {
   margin-top: 0;
-  margin-bottom: .875em;
+  margin-bottom: 0.875em;
 }
 
 .content ul li {
-  margin-bottom: .25rem;
+  margin-bottom: 0.25rem;
 }
 
 .content ul {
@@ -62,18 +103,18 @@ html {
 
 .content ul ul,
 .content ol ul {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 
 .content li p {
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
 }
 
 blockquote {
   margin: 1.5rem 0;
   padding: 1rem 1.5rem;
   color: var(--fg);
-  opacity: .9;
+  opacity: 0.9;
   background-color: var(--quote-bg);
   border-left: 4px solid var(--quote-border);
   border-top: none;
@@ -89,7 +130,7 @@ table {
 }
 
 table thead th {
-  padding: .75rem;
+  padding: 0.75rem;
   text-align: left;
   font-weight: 500;
   line-height: 1.5;
@@ -97,7 +138,7 @@ table thead th {
 }
 
 table td {
-  padding: .75rem;
+  padding: 0.75rem;
   border: none;
 }
 
@@ -141,13 +182,13 @@ code.hljs {
   --icons-hover: #b7b9cc;
 
   /* --links: #a4a0e8; */
-  --links: #ECCDBA;
+  --links: #eccdba;
 
   --inline-code-color: hsl(48.7, 7.8%, 70%);
 
   --theme-popup-bg: #161923;
   --theme-popup-border: #737480;
-  --theme-hover: rgba(0, 0, 0, .2);
+  --theme-hover: rgba(0, 0, 0, 0.2);
 
   --quote-bg: #281733;
   --quote-border: hsl(226, 15%, 22%);
@@ -165,6 +206,12 @@ code.hljs {
   --searchresults-border-color: #5c5c68;
   --searchresults-li-bg: #242430;
   --search-mark-bg: #a2cff5;
+}
+
+:where(.colibri) kbd {
+  border-color: hsl(48.7, 7.8%, 25%);
+  color: hsl(48.7, 7.8%, 70%);
+  background-color: #2f1e2e;
 }
 
 .colibri .content .header {

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Package Managers](./package-managers.md)
   - [Building from source](./building-from-source.md)
 - [Usage](./usage.md)
+  - [Getting Started](./getting-started.md)
   - [Registers](./registers.md)
   - [Surround](./surround.md)
   - [Textobjects](./textobjects.md)

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,309 @@
+# Getting Started
+
+To get started check out the [installation instructions](/install.md) in order to follow along with the tutorial.
+
+### Opening a file
+
+Create a new text file and open it with Helix by running `hx file.txt`.
+
+In the bottom left corner, you'll notice a `NOR`, which indicates that you are currently in Normal mode. 
+
+In this mode, typing letters like <kbd>e</kbd> and <kbd>n</kbd> won't insert them as text, but rather have specific _commands_ which we will explore later.
+
+To actually insert some text, press <kbd>i</kbd>, which is the command to get into Insert mode, indicated by the `INS` in the bottom-left corner. 
+
+In Insert mode, the letters you type will be inserted directly into the document.
+
+Try it out by writing `Hello helix!`.
+
+```
+Hello helix!
+```
+
+To get back into Normal mode press <kbd>Esc</kbd>. This will change the color of your cursor and you will see `NOR` again, indicating that you are in normal mode now.
+
+### Movement
+
+To move your cursor you could use arrow keys, both in Normal and Insert modes:
+
+- <kbd>↑</kbd> move cursor up
+- <kbd>↓</kbd> move cursor down
+- <kbd>→</kbd> moves cursor right
+- <kbd>←</kbd> moves cursor left
+
+However, this isn't encouraged due to the fact that hand will be doing a lot of back-and-forth movement between the arrow keys and the keyboard.
+
+Instead, it is recommended to rest your fingers on the "home row", which is comprised of the row of keys `a s d f g h j k l`.
+
+Instead of stretching to reach the arrow keys, use normal mode and <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> to move your cursor:
+
+- <kbd>h</kbd>: moves cursor 1 character to the left.
+- <kbd>j</kbd>: moves cursor 1 line above.
+- <kbd>k</kbd>: moves cursor 1 line below.
+- <kbd>l</kbd>: moves cursor 1 character to the right.
+
+Try holding down <kbd>h</kbd> and <kbd>l</kbd> to move horizontally across the text you just wrote!
+
+<aside class="tip">
+
+The <kbd>Esc</kbd> key is quite far away from the home row on most keyboards. Due to this fact, many people remap <kbd>Caps Lock</kbd> to <kbd>Esc</kbd>.
+
+You can find out how to do this in [Remap Caps Lock to Escape](/help/recipes#remap-caps-lock-to-escape).
+
+</aside>
+
+### Paste
+
+We only have one line of text, so let's duplicate it several times. Type:
+
+- <kbd>x</kbd>, which will select the entire line.
+- <kbd>y</kbd>, which will _**y**ank_ (copy) the selection to clipboard.
+- <kbd>p</kbd>, which will paste the contents of the selection after the cursor.
+
+Spam <kbd>p</kbd> a few times to create several lines.
+
+```
+Hello helix!
+Hello helix!
+Hello helix!
+Hello helix!
+Hello helix!
+```
+
+Now you can try using the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> motions to traverse the text!
+
+### Word-based Movement
+
+Let's say we want to replace one of the `helix` words with `world`. To do this, place your cursor on one of the <kbd>h</kbd> letters.
+
+<kbd>e</kbd> is a motion which moves to the _**e**nd_ of the current word. Type <kbd>e</kbd> and it will move your cursor to the end of the `helix`.
+
+It doesn't just move your cursor there, though. The entire `helix` word becomes highlighted.
+
+If we now press <kbd>b</kbd>, which moves to the _**b**eginning_ of the current word, it'll move us back to where we just were.
+
+Try this out a few times, press <kbd>e</kbd> and then <kbd>b</kbd> to select various sections of the text. If you want to remove your selection press <kbd>;</kbd>.
+
+### Selection-first Approach
+
+Helix's philosophy is that each **action** will act on a selection.
+
+Every time text is modified (an **action**), you will fully anticipate the result -- because you can clearly see the area of text which is highlighted, and thus will be modified.
+
+For example, if we currently have the word `helix` selected, we can change it to `world` by pressing <kbd>c</kbd>.
+
+<kbd>c</kbd> removes the contents of the current selection and places us in Insert mode, where you can then write your new word. Exit back to Normal mode by pressing <kbd>esc</kbd>.
+
+### Delete
+
+The <kbd>d</kbd> command deletes the current selection and copies what has been deleted into a clipboard.
+
+Let's test it out by doing the following:
+
+1. Select the line we just changed with <kbd>x</kbd>.
+
+1. <kbd>d</kbd> to delete this line.
+
+1. Spam <kbd>p</kbd> a few times to create some duplicates.
+
+Let's remove all of our previous `Hello helix!` by doing the following for each `Hello helix!` line:
+
+1. Select the line with <kbd>x</kbd>.
+1. <kbd>d</kbd> to delete it.
+
+### Undo and Redo
+
+What if we made a mistake, and want to go back? The <kbd>u</kbd> command will _**u**ndo_ our most recent action. It's similar to <kbd>Ctrl</kbd> + <kbd>z</kbd> in other editors.
+
+Try pressing down <kbd>u</kbd> a few times to get to our previous state, before we made all those modifications.
+
+<kbd>U</kbd> is similar to <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>z</kbd> in other editors. It will _undo the last undo_. It's the inverse of <kbd>u</kbd>.
+
+Press <kbd>U</kbd> until we get back to our most recent state.
+
+### Checkpoint
+
+Feel free to make modifications to your file using the commands we have learned so far:
+
+- <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> moves 1 character left, down, up and right.
+- <kbd>i</kbd> enters Insert mode.
+- <kbd>esc</kbd> enters Normal mode.
+- <kbd>x</kbd> selects the entire line.
+- <kbd>y</kbd> yanks the selection.
+- <kbd>p</kbd> pastes the recently copied selection.
+- <kbd>e</kbd> selects and moves to the end of the current word.
+- <kbd>b</kbd> selects and moves to the beginning of the current word.
+- <kbd>;</kbd> removes the extra selection.
+- <kbd>d</kbd> deletes the current selection, without exiting Normal mode.
+- <kbd>c</kbd> changes the current selection, by deleting it and entering Insert mode.
+- <kbd>u</kbd> will undo the most recent change.
+- <kbd>U</kbd> will undo the most recent undo.
+
+Once you are happy with your modifications, enter Normal mode and type <kbd>:</kbd>.
+
+<kbd>:</kbd> enters _command mode_, which has commands you type out.
+
+- `:w` will _**w**rite_ the current file.
+- `:q` will _**q**uit_ the current file.
+- `:q!` will quit without saving.
+- `:wq` will both write and quit.
+
+## More Commands
+
+Let's try out more Helix commands! Open the file again with `hx file.txt`. Select the entire file by pressing <kbd>%</kbd>
+
+Now, delete the selection with <kbd>d</kbd>.
+
+### Goto Word
+
+Using <kbd>b</kbd> to go to the beginning of the word and <kbd>e</kbd> to go to the end is useful if you are already at the word you want. But if you are far away, a very powerful command is _**g**oto **w**ord_ -- <kbd>gw</kbd>.
+
+Let's say we have the following file:
+
+```
+The plates will
+and the clouds will
+The sun will
+and the clouds will
+and the moon will
+```
+
+<kbd>gw</kbd> will create two letters at the start of every word in sight. When you type those two letters, you instantly jump to the specified word.
+
+Let's say we want to jump to the `plates` word. The first two characters have been replaced by `at` and highlighted. If we write `at`, we will highlight that word!
+
+### Replace
+
+You can also replace a selection with contents of a register.
+
+1. Select the `moon` word by using <kbd>gw</kbd> and yank it with <kbd>y</kbd>.
+2. Select the `sun` word and replace it with `moon` with <kbd>R</kbd>.
+
+### Search
+
+Go to the first line by using <kbd>gg</kbd>.
+
+To search for a word, use <kbd>/</kbd> command. Type `will` which is going to highlight the next `will` keyword, and then <kbd>Enter ↵</kbd> to select it.
+
+Since there are several `will`s in the text, you can cycle between them:
+
+- <kbd>n</kbd> cycles to the next match.
+- <kbd>N</kbd> cycles to the previous match.
+
+### More ways to enter Insert Mode
+
+Select the `clouds` word using <kbd>gw</kbd>. If you press <kbd>i</kbd>, you will go into insert mode at the beginning of the selection. There are also 5 more ways to enter Insert mode:
+
+- <kbd>a</kbd> for _**append**_ go into insert mode at the end of the selection
+- <kbd>I</kbd> go into insert mode at the beginning of the current line
+- <kbd>A</kbd> to append at the end of the current line
+- <kbd>o</kbd> add a newline below and go into insert mode
+- <kbd>O</kbd> add a newline above and go into insert mode
+
+Try all of them out!
+
+### Registers
+
+Helix has a concept called _registers_, which is like having many clipboards at once.
+
+To interact with them, prefix yank and delete commands with a <kbd>"</kbd> and then the name of the register.
+
+For example, the contents of the system clipboard are stored inside the `+` register.
+
+<aside class="note">
+
+On linux, you may need a clipboard provider like [xclip](https://github.com/astrand/xclip) to use the system clipboard.
+
+</aside>
+
+1. Paste the following content into the file with <kbd>"+p</kbd>:
+
+   ```
+   The plates will
+   and the clouds will
+   The sun will
+   and the moon will
+   ```
+
+1. Navigate to the last line by using <kbd>ge</kbd> for _**g**oto end_.
+
+1. Select the last line with <kbd>x</kbd> and then yank it with <kbd>y</kbd>.
+
+1. Navigate to the second line by using <kbd>2gg</kbd>.
+1. Select the second line by using <kbd>x</kbd> and then yank into into the <kbd>e</kbd> register with <kbd>"ey</kbd>.
+
+1. Navigate to the third line by using <kbd>3gg</kbd>.
+1. Paste what we copied previously by using <kbd>p</kbd>.
+
+Notice how we haven't pasted the 2nd line's contents, but rather the last lines'? Because we yanked the 2nd line's contents into the <kbd>e</kbd> register. To paste from it, use <kbd>"ep</kbd>.
+
+- <kbd>"</kbd> signals to the editor that we are going to use a register.
+- <kbd>e</kbd> uses the <kbd>e</kbd> register.
+- <kbd>p</kbd> pastes contents of the <kbd>e</kbd> register.
+
+Take note of the fact that when we press <kbd>p</kbd>, it pastes the contents of the register _after_ the line. To paste _before_, we undo with <kbd>u</kbd> and use <kbd>P</kbd> to paste before.
+
+### Move to characters
+
+You can also search for individual characters by using <kbd>t</kbd>, which stands for _**t**ill_.
+
+1. Copy the text below
+
+   ```
+   Twilight fades; stars—whispering, bold—
+   "Hope," they hum; yet shadows unfold...
+   Life? A riddle—endless! Who'll dare,
+   to seek; to dream: to wander—where?
+   ```
+
+1. Select the entire file with <kbd>%</kbd>
+1. Override the selection by using <kbd>Space</kbd> + <kbd>R</kbd>.
+
+<aside class="tip">
+
+Instead of writing <kbd>"+</kbd> to interact with the system clipboard every time, you can also prefix paste and delete motion with <kbd>Space</kbd>. For example, <kbd>Space</kbd> + <kbd>p</kbd> has the same effect as <kbd>"+p</kbd>.
+
+</aside>
+
+Go to the first line with <kbd>gg</kbd> and use <kbd>t;</kbd> to go to the next semicolon. Repeat this several several times.
+
+To move in the opposite direction, use <kbd>T;</kbd> to the previous semicolon.
+
+Using <kbd>t</kbd> and <kbd>T</kbd> motions will move your cursor _to just before_ the next or the previous occurrence of the character.
+
+For example, <kbd>te</kbd> to go to the next e. <kbd>T"</kbd> to go to just before the previous double-quote.
+
+The <kbd>f</kbd> for _**f**ind_ is similar to <kbd>t</kbd>, but instead it places your cursor _at_ the occurrence of the character. Try using <kbd>f;</kbd> several times. <kbd>F</kbd> goes the opposite way.
+
+<aside class="tip">
+
+By using <kbd>Alt</kbd> + <kbd>.</kbd>, you can repeat the last <kbd>t</kbd>, <kbd>T</kbd>, <kbd>f</kbd> or <kbd>F</kbd> motion.
+
+</aside>
+
+### Counts
+
+Each motion also accepts an optional _count_, which defaults to 1 if you don't provide it.
+
+- For example, use <kbd>2f;</kbd> which would be the same as <kbd>f;f;</kbd>.
+- Or <kbd>7b</kbd> which would be the same as <kbd>bbbbbbb</kbd>.
+
+### Page Navigation
+
+Currently the text is fairly short, but we can fix that. Select everything with <kbd>%</kbd>, yank <kbd>y</kbd> and then paste it 100 times with <kbd>100p</kbd>. This will create a very big file.
+
+We can use these commands to scroll large chunks of text at once:
+
+- <kbd>Ctrl</kbd> + <kbd>d</kbd> to scroll down half a page
+- <kbd>Ctrl</kbd> + <kbd>u</kbd> to scroll up half a page
+
+---
+
+## Next steps
+
+Now you know the basics of movement in Helix, it's time to learn about the more advanced features Helix provides.
+
+- Explore advanced text manipulation techniques, such as [surrounds](surround.md) and [text objects](textobjects.md).
+- (TODO: port this page from[helix-editor.vercel.app](helix-editor.vercel.app)) Make full use of Helix's powerful editing model by understanding how to use [multiple cursor and macros](#)
+- Learn how to [enable language support](/usage/language-support)[languages.md] and auto-formatters.
+

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -10,7 +10,7 @@ In the bottom left corner, you'll notice a `NOR`, which indicates that you are c
 
 In this mode, typing letters like <kbd>e</kbd> and <kbd>n</kbd> won't insert them as text, but rather have specific _commands_ which we will explore later.
 
-To actually insert some text, press <kbd>i</kbd>, which is the command to get into Insert mode, indicated by the `INS` in the bottom-left corner. 
+To actually insert some text, press <kbd>i</kbd>, which is the command to get into **Ins**ert mode, indicated by the `INS` in the bottom-left corner. 
 
 In Insert mode, the letters you type will be inserted directly into the document.
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -6,7 +6,7 @@ To get started check out the [installation instructions](/install.md) in order t
 
 Create a new text file and open it with Helix by running `hx file.txt`.
 
-In the bottom left corner, you'll notice a `NOR`, which indicates that you are currently in Normal mode. 
+In the bottom left corner, you'll notice a `NOR`, which indicates that you are currently in **Nor**mal mode. 
 
 In this mode, typing letters like <kbd>e</kbd> and <kbd>n</kbd> won't insert them as text, but rather have specific _commands_ which we will explore later.
 


### PR DESCRIPTION
This is a part of a series of pull requests to port the new docs from https://helix-editor.vercel.app into the mdbook

This PR:
- Ports the "Getting Started" section
- Adds styles for `kbd` 
- Adds CSS for custom asides, like `aside class="tip"`. I think this is needed because I'm currently seeing that each "note" is hard coded

my plan at the moment is to make a separate PR for each of the 7 "Getting Started" pages on https://helix-editor.vercel.app one after the other