### PR TITLE
fix: report correct amount of files opened and improved error message when Helix can't parse directory as file

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -175,7 +175,7 @@ impl Application {
                     nr_of_files += 1;
                     if file.is_dir() {
                         return Err(anyhow::anyhow!(
-                            "expected a path to file, found a directory. (to open a directory pass it as first argument)"
+                            "expected a path to file, but found a directory: {file:?}. (to open a directory pass it as first argument)"
                         ));
                     } else {
                         // If the user passes in either `--vsplit` or
@@ -189,6 +189,7 @@ impl Application {
                             Some(Layout::Horizontal) => Action::HorizontalSplit,
                             None => Action::Load,
                         };
+                        let old_id = editor.buf_id_by_path(&file);
                         let doc_id = match editor.open(&file, action) {
                             // Ignore irregular files during application init.
                             Err(DocumentOpenError::IrregularFile) => {
@@ -196,7 +197,13 @@ impl Application {
                                 continue;
                             }
                             Err(err) => return Err(anyhow::anyhow!(err)),
-                            Ok(doc_id) => doc_id,
+                            Ok(doc_id) => {
+                                // We can't open more than 1 buffer for 1 file, in this case we already have opened this file previously
+                                if old_id == Some(doc_id) {
+                                    nr_of_files -= 1;
+                                }
+                                doc_id
+                            }
                         };
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -189,7 +189,7 @@ impl Application {
                             Some(Layout::Horizontal) => Action::HorizontalSplit,
                             None => Action::Load,
                         };
-                        let old_id = editor.buf_id_by_path(&file);
+                        let old_id = editor.document_id_by_path(&file);
                         let doc_id = match editor.open(&file, action) {
                             // Ignore irregular files during application init.
                             Err(DocumentOpenError::IrregularFile) => {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -197,13 +197,12 @@ impl Application {
                                 continue;
                             }
                             Err(err) => return Err(anyhow::anyhow!(err)),
-                            Ok(doc_id) => {
-                                // We can't open more than 1 buffer for 1 file, in this case we already have opened this file previously
-                                if old_id == Some(doc_id) {
-                                    nr_of_files -= 1;
-                                }
+                            // We can't open more than 1 buffer for 1 file, in this case we already have opened this file previously
+                            Ok(doc_id) if old_id == Some(doc_id) => {
+                                nr_of_files -= 1;
                                 doc_id
                             }
+                            Ok(doc_id) => doc_id,
                         };
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -154,8 +154,7 @@ FLAGS:
     });
 
     // TODO: use the thread local executor to spawn the application task separately from the work pool
-    let mut app =
-        Application::new(args, config, lang_loader).context("unable to create new application")?;
+    let mut app = Application::new(args, config, lang_loader).context("unable to start Helix")?;
 
     let exit_code = app.run(&mut EventStream::new()).await?;
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1719,7 +1719,7 @@ impl Editor {
     }
 
     pub fn document_id_by_path(&self, path: &Path) -> Option<DocumentId> {
-        self.document_by_path(&path).map(|doc| doc.id)
+        self.document_by_path(path).map(|doc| doc.id)
     }
 
     // ??? possible use for integration tests

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1718,10 +1718,14 @@ impl Editor {
         Ok(doc_id)
     }
 
+    pub fn buf_id_by_path(&self, path: &Path) -> Option<DocumentId> {
+        self.document_by_path(&path).map(|doc| doc.id)
+    }
+
     // ??? possible use for integration tests
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
-        let id = self.document_by_path(&path).map(|doc| doc.id);
+        let id = self.buf_id_by_path(&path);
 
         let id = if let Some(id) = id {
             id

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1718,14 +1718,14 @@ impl Editor {
         Ok(doc_id)
     }
 
-    pub fn buf_id_by_path(&self, path: &Path) -> Option<DocumentId> {
+    pub fn document_id_by_path(&self, path: &Path) -> Option<DocumentId> {
         self.document_by_path(&path).map(|doc| doc.id)
     }
 
     // ??? possible use for integration tests
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
-        let id = self.buf_id_by_path(&path);
+        let id = self.document_id_by_path(&path);
 
         let id = if let Some(id) = id {
             id


### PR DESCRIPTION
When you open two of the same file with `hx README:6 README:8`, it will say `Opened 2 files` even though only 1 file will be opened (with 1 buffer). This PR fixes that, it will say `Opened 1 file` now.

---

The PR also provides context when Helix can't parse a directory as a file. For example, if you do `hx README.md helix-term` helix will think that `helix-term` is a file, and since it's a directory you will see an error message:

```
Error: unable to create new application

Caused by:
    expected a path to file, found a directory. (to open a directory pass it as first argument)
```

With this PR the error message is improved now:

```
Error: unable to start Helix

Caused by:
    expected a path to file, but found a directory: "/home/e/r/helix/helix-term". (to open a directory pass it as first argument)
```

This could happen accidentally, for example if I run `hx *` I might intuitively think that it'll open each file, but it also opens directories

(note: I also changed `unable to create new application` as I don't think it makes sense for someone who has no idea of Helix's internals)