### PR TITLE
feat: new `:toggle-diagnostics` command

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1940,8 +1940,8 @@ fn toggle_diagnostics(
     ensure!(args.is_empty(), ":toggle-diagnostics takes no arguments");
 
     let (view, _) = current!(cx.editor);
-
-    view.diagnostics_handler.toggle_diagnostics();
+    view.diagnostics_handler.toggle_active();
+    cx.editor.toggle_diagnostics();
 
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1928,6 +1928,24 @@ fn set_option(
     Ok(())
 }
 
+fn toggle_diagnostics(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(args.is_empty(), ":toggle-diagnostics takes no arguments");
+
+    let (view, _) = current!(cx.editor);
+
+    view.diagnostics_handler.toggle_diagnostics();
+
+    Ok(())
+}
+
 /// Toggle boolean config option at runtime. Access nested values by dot
 /// syntax, for example to toggle smart case search, use `:toggle search.smart-
 /// case`.
@@ -3149,6 +3167,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         fun: read,
         signature: CommandSignature::positional(&[completers::filename]),
     },
+    TypableCommand {
+        name: "toggle-diagnostics",
+        aliases: &["td"],
+        doc: "Toggle Diagnostics",
+        fun: toggle_diagnostics,
+        signature: CommandSignature::all(completers::register)
+    }
 ];
 
 pub static TYPABLE_COMMAND_MAP: Lazy<HashMap<&'static str, &'static TypableCommand>> =

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -189,19 +189,26 @@ impl EditorView {
                 primary_cursor,
             });
         }
-        let width = view.inner_width(doc);
         let config = doc.config.load();
-        let enable_cursor_line = view
-            .diagnostics_handler
-            .show_cursorline_diagnostics(doc, view.id);
-        let inline_diagnostic_config = config.inline_diagnostics.prepare(width, enable_cursor_line);
-        decorations.add_decoration(InlineDiagnostics::new(
-            doc,
-            theme,
-            primary_cursor,
-            inline_diagnostic_config,
-            config.end_of_line_diagnostics,
-        ));
+
+        if editor.show_diagnostics {
+            log::error!("{:#?}", editor.show_diagnostics);
+            let width = view.inner_width(doc);
+            let enable_cursor_line = view
+                .diagnostics_handler
+                .show_cursorline_diagnostics(doc, view.id);
+            let inline_diagnostic_config =
+                config.inline_diagnostics.prepare(width, enable_cursor_line);
+
+            decorations.add_decoration(InlineDiagnostics::new(
+                doc,
+                theme,
+                primary_cursor,
+                inline_diagnostic_config,
+                config.end_of_line_diagnostics,
+            ));
+        }
+
         render_document(
             surface,
             inner,
@@ -229,6 +236,7 @@ impl EditorView {
 
         if config.inline_diagnostics.disabled()
             && config.end_of_line_diagnostics == DiagnosticFilter::Disable
+            && editor.show_diagnostics
         {
             Self::render_diagnostics(doc, view, inner, surface, theme);
         }

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -123,6 +123,7 @@ impl Renderer<'_, '_> {
         end_col - start_col
     }
 
+    // need to toggle this
     fn draw_diagnostic(&mut self, diag: &Diagnostic, col: u16, next_severity: Option<Severity>) {
         let severity = diag.severity();
         let (sym, sym_severity) = if let Some(next_severity) = next_severity {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1049,6 +1049,8 @@ pub struct Editor {
     pub debugger_events: SelectAll<UnboundedReceiverStream<dap::Payload>>,
     pub breakpoints: HashMap<PathBuf, Vec<Breakpoint>>,
 
+    pub show_diagnostics: bool,
+
     pub syn_loader: Arc<ArcSwap<syntax::Loader>>,
     pub theme_loader: Arc<theme::Loader>,
     /// last_theme is used for theme previews. We store the current theme here,
@@ -1195,6 +1197,7 @@ impl Editor {
             breakpoints: HashMap::new(),
             syn_loader,
             theme_loader,
+            show_diagnostics: true,
             last_theme: None,
             last_selection: None,
             registers: Registers::new(Box::new(arc_swap::access::Map::new(
@@ -1326,6 +1329,10 @@ impl Editor {
 
     pub fn set_theme(&mut self, theme: Theme) {
         self.set_theme_impl(theme, ThemeAction::Set);
+    }
+
+    pub fn toggle_diagnostics(&mut self) {
+        self.show_diagnostics = !self.show_diagnostics;
     }
 
     fn set_theme_impl(&mut self, theme: Theme, preview: ThemeAction) {

--- a/helix-view/src/handlers/diagnostics.rs
+++ b/helix-view/src/handlers/diagnostics.rs
@@ -94,9 +94,6 @@ impl DiagnosticsHandler {
 }
 
 impl DiagnosticsHandler {
-    pub fn toggle_diagnostics(&mut self) {
-        self.active = !self.active;
-    }
     pub fn immediately_show_diagnostic(&self, doc: &Document, view: ViewId) {
         self.last_doc.set(doc.id());
         let cursor_line = doc
@@ -107,6 +104,11 @@ impl DiagnosticsHandler {
         self.active_generation
             .store(self.generation.get(), atomic::Ordering::Relaxed);
     }
+
+    pub fn toggle_active(&mut self) {
+        self.active = !self.active;
+    }
+
     pub fn show_cursorline_diagnostics(&self, doc: &Document, view: ViewId) -> bool {
         if !self.active {
             return false;

--- a/helix-view/src/handlers/diagnostics.rs
+++ b/helix-view/src/handlers/diagnostics.rs
@@ -94,6 +94,9 @@ impl DiagnosticsHandler {
 }
 
 impl DiagnosticsHandler {
+    pub fn toggle_diagnostics(&mut self) {
+        self.active = !self.active;
+    }
     pub fn immediately_show_diagnostic(&self, doc: &Document, view: ViewId) {
         self.last_doc.set(doc.id());
         let cursor_line = doc


### PR DESCRIPTION
Sometimes diagnostics can get in the way, and we'd like to *temporarily* hide them

this PR adds a new `:toggle-diagnostics` command, aliased to `:td`. It will hide *obtrusive* diagnostics, such as inline diagnostics or cursorline. 

It won't hide gutter symbols indicating that there are diagnostics on lines, as those aren't obtrusive and it is useful to be aware that there are diagnostics on certain lines. If we want to inspect what those diagnostics are, we can just run `:toggle-diagnostics` again.

Closes https://github.com/helix-editor/helix/issues/12154