### PR TITLE
feat: option to Merge statusline and Command line into 1 line

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -479,6 +479,7 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub merge_with_commandline: bool,
 }
 
 impl Default for StatusLineConfig {
@@ -503,6 +504,7 @@ impl Default for StatusLineConfig {
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            merge_with_commandline: true,
         }
     }
 }


### PR DESCRIPTION
Having the command line and the statusline each take 2 rows may not be desirable to all.

As far as I'm aware, Kakoune and Neovim both offer the option to merge these two lines into a single line:
- If there is a status message to be displayed, it replaces the bottom statusline

The biggest problem is that since the status message is almost always empty, it takes up an entire line at the bottom of the screen which could be used by actual text instead.

I added this feature into Helix aswell. 

To enable it, run `:toggle statusline.merge-with-commandline` or add this into `config.toml`:

```toml
[editor.statusline]
merge-with-commandline: true
```

<details>
<summary>
Before vs After
</summary>

## Before

![image](https://github.com/user-attachments/assets/9f7de191-4d15-4623-af94-26f1fbfeb86a)

## After

![image](https://github.com/user-attachments/assets/4fcd66ba-b6a8-4f5f-b2bc-0cc7227247b1)

</details>

Supersedes https://github.com/helix-editor/helix/pull/12020
Closes https://github.com/helix-editor/helix/discussions/7934