### PR TITLE
Allow theming directory prompt completions

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -305,7 +305,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.focus`                   | The currently selected line in the picker                                                      |
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
-| `ui.text.directory`               | Color of directories                                                                           |
+| `ui.text.directory`               | Directory names in prompt completion                                                           |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -36,7 +36,6 @@ For inspiration, you can find the default `theme.toml`
 user-submitted themes
 [here](https://github.com/helix-editor/helix/blob/master/runtime/themes).
 
-
 ## The details of theme creation
 
 ### Color palettes
@@ -62,7 +61,7 @@ are listed below. The `[palette]` section in the config file takes precedence
 over it and is merged into the default palette.
 
 | Color Name      |
-| ---             |
+| --------------- |
 | `default`       |
 | `black`         |
 | `red`           |
@@ -86,17 +85,17 @@ over it and is merged into the default palette.
 The following values may be used as modifier, provided they are supported by
 your terminal emulator.
 
-| Modifier             |
-| ---                  |
-| `bold`               |
-| `dim`                |
-| `italic`             |
-| `underlined`         |
-| `slow_blink`         |
-| `rapid_blink`        |
-| `reversed`           |
-| `hidden`             |
-| `crossed_out`        |
+| Modifier      |
+| ------------- |
+| `bold`        |
+| `dim`         |
+| `italic`      |
+| `underlined`  |
+| `slow_blink`  |
+| `rapid_blink` |
+| `reversed`    |
+| `hidden`      |
+| `crossed_out` |
 
 > 💡 The `underlined` modifier is deprecated and only available for backwards compatibility.
 > Its behavior is equivalent to setting `underline.style="line"`.
@@ -106,14 +105,13 @@ your terminal emulator.
 One of the following values may be used as a value for `underline.style`, providing it is
 supported by your terminal emulator.
 
-| Modifier       |
-| ---            |
-| `line`         |
-| `curl`         |
-| `dashed`       |
-| `dotted`       |
-| `double_line`  |
-
+| Modifier      |
+| ------------- |
+| `line`        |
+| `curl`        |
+| `dashed`      |
+| `dotted`      |
+| `double_line` |
 
 ### Inheritance
 
@@ -154,6 +152,7 @@ We use a similar set of scopes as
 - `constructor`
 
 - `constant` (TODO: constant.other.placeholder for `%v`)
+
   - `builtin` Special constants provided by the language (`true`, `false`, `nil` etc)
     - `boolean`
   - `character`
@@ -163,6 +162,7 @@ We use a similar set of scopes as
     - `float`
 
 - `string` (TODO: string.quoted.{single, double}, string.raw/.unquoted)?
+
   - `regexp` - Regular expressions
   - `special`
     - `path`
@@ -170,11 +170,13 @@ We use a similar set of scopes as
     - `symbol` - Erlang/Elixir atoms, Ruby symbols, Clojure keywords
 
 - `comment` - Code comments
+
   - `line` - Single line comments (`//`)
   - `block` - Block comments (e.g. (`/* */`)
     - `documentation` - Documentation comments (e.g. `///` in Rust)
 
 - `variable` - Variables
+
   - `builtin` - Reserved language variables (`self`, `this`, `super`, etc.)
   - `parameter` - Function parameters
   - `other`
@@ -184,11 +186,13 @@ We use a similar set of scopes as
 - `label`
 
 - `punctuation`
+
   - `delimiter` - Commas, colons
   - `bracket` - Parentheses, angle brackets, etc.
   - `special` - String interpolation brackets.
 
 - `keyword`
+
   - `control`
     - `conditional` - `if`, `else`
     - `repeat` - `for`, `while`, `loop`
@@ -205,6 +209,7 @@ We use a similar set of scopes as
 - `operator` - `||`, `+=`, `>`
 
 - `function`
+
   - `builtin`
   - `method`
     - `private` - Private methods that use a unique syntax (currently just ECMAScript-based languages)
@@ -212,6 +217,7 @@ We use a similar set of scopes as
   - `special` (preprocessor in C)
 
 - `tag` - Tags (e.g. `<body>` in HTML)
+
   - `builtin`
 
 - `namespace`
@@ -219,6 +225,7 @@ We use a similar set of scopes as
 - `special`
 
 - `markup`
+
   - `heading`
     - `marker`
     - `1`, `2`, `3`, `4`, `5`, `6` - heading text for h1 through h6
@@ -265,9 +272,8 @@ These scopes are used for theming the editor interface:
       - `completion` - for completion doc popup UI
       - `hover` - for hover popup UI
 
-
 | Key                               | Notes                                                                                          |
-| ---                               | ---                                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `ui.background`                   |                                                                                                |
 | `ui.background.separator`         | Picker separator below input line                                                              |
 | `ui.cursor`                       |                                                                                                |
@@ -305,6 +311,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.focus`                   | The currently selected line in the picker                                                      |
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
+| `ui.text.directory`               | Style for directories which show on autocomplete with `:edit`                                  |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -36,6 +36,7 @@ For inspiration, you can find the default `theme.toml`
 user-submitted themes
 [here](https://github.com/helix-editor/helix/blob/master/runtime/themes).
 
+
 ## The details of theme creation
 
 ### Color palettes
@@ -61,7 +62,7 @@ are listed below. The `[palette]` section in the config file takes precedence
 over it and is merged into the default palette.
 
 | Color Name      |
-| --------------- |
+| ---             |
 | `default`       |
 | `black`         |
 | `red`           |
@@ -85,17 +86,17 @@ over it and is merged into the default palette.
 The following values may be used as modifier, provided they are supported by
 your terminal emulator.
 
-| Modifier      |
-| ------------- |
-| `bold`        |
-| `dim`         |
-| `italic`      |
-| `underlined`  |
-| `slow_blink`  |
-| `rapid_blink` |
-| `reversed`    |
-| `hidden`      |
-| `crossed_out` |
+| Modifier             |
+| ---                  |
+| `bold`               |
+| `dim`                |
+| `italic`             |
+| `underlined`         |
+| `slow_blink`         |
+| `rapid_blink`        |
+| `reversed`           |
+| `hidden`             |
+| `crossed_out`        |
 
 > 💡 The `underlined` modifier is deprecated and only available for backwards compatibility.
 > Its behavior is equivalent to setting `underline.style="line"`.
@@ -105,13 +106,14 @@ your terminal emulator.
 One of the following values may be used as a value for `underline.style`, providing it is
 supported by your terminal emulator.
 
-| Modifier      |
-| ------------- |
-| `line`        |
-| `curl`        |
-| `dashed`      |
-| `dotted`      |
-| `double_line` |
+| Modifier       |
+| ---            |
+| `line`         |
+| `curl`         |
+| `dashed`       |
+| `dotted`       |
+| `double_line`  |
+
 
 ### Inheritance
 
@@ -152,7 +154,6 @@ We use a similar set of scopes as
 - `constructor`
 
 - `constant` (TODO: constant.other.placeholder for `%v`)
-
   - `builtin` Special constants provided by the language (`true`, `false`, `nil` etc)
     - `boolean`
   - `character`
@@ -162,7 +163,6 @@ We use a similar set of scopes as
     - `float`
 
 - `string` (TODO: string.quoted.{single, double}, string.raw/.unquoted)?
-
   - `regexp` - Regular expressions
   - `special`
     - `path`
@@ -170,13 +170,11 @@ We use a similar set of scopes as
     - `symbol` - Erlang/Elixir atoms, Ruby symbols, Clojure keywords
 
 - `comment` - Code comments
-
   - `line` - Single line comments (`//`)
   - `block` - Block comments (e.g. (`/* */`)
     - `documentation` - Documentation comments (e.g. `///` in Rust)
 
 - `variable` - Variables
-
   - `builtin` - Reserved language variables (`self`, `this`, `super`, etc.)
   - `parameter` - Function parameters
   - `other`
@@ -186,13 +184,11 @@ We use a similar set of scopes as
 - `label`
 
 - `punctuation`
-
   - `delimiter` - Commas, colons
   - `bracket` - Parentheses, angle brackets, etc.
   - `special` - String interpolation brackets.
 
 - `keyword`
-
   - `control`
     - `conditional` - `if`, `else`
     - `repeat` - `for`, `while`, `loop`
@@ -209,7 +205,6 @@ We use a similar set of scopes as
 - `operator` - `||`, `+=`, `>`
 
 - `function`
-
   - `builtin`
   - `method`
     - `private` - Private methods that use a unique syntax (currently just ECMAScript-based languages)
@@ -217,7 +212,6 @@ We use a similar set of scopes as
   - `special` (preprocessor in C)
 
 - `tag` - Tags (e.g. `<body>` in HTML)
-
   - `builtin`
 
 - `namespace`
@@ -225,7 +219,6 @@ We use a similar set of scopes as
 - `special`
 
 - `markup`
-
   - `heading`
     - `marker`
     - `1`, `2`, `3`, `4`, `5`, `6` - heading text for h1 through h6
@@ -272,8 +265,9 @@ These scopes are used for theming the editor interface:
       - `completion` - for completion doc popup UI
       - `hover` - for hover popup UI
 
+
 | Key                               | Notes                                                                                          |
-| --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| ---                               | ---                                                                                            |
 | `ui.background`                   |                                                                                                |
 | `ui.background.separator`         | Picker separator below input line                                                              |
 | `ui.cursor`                       |                                                                                                |
@@ -311,7 +305,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.focus`                   | The currently selected line in the picker                                                      |
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
-| `ui.text.directory`               | Style for directories which show on autocomplete with `:edit`                                  |
+| `ui.text.directory`               | Color of directories which show in autocomplete on `:edit`                                     |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -305,7 +305,7 @@ These scopes are used for theming the editor interface:
 | `ui.text.focus`                   | The currently selected line in the picker                                                      |
 | `ui.text.inactive`                | Same as `ui.text` but when the text is inactive (e.g. suggestions)                             |
 | `ui.text.info`                    | The key: command text in `ui.popup.info` boxes                                                 |
-| `ui.text.directory`               | Color of directories which show in autocomplete on `:edit`                                     |
+| `ui.text.directory`               | Color of directories                                                                           |
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2164,7 +2164,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
             completions
                 .iter()
                 .filter(|comp| comp.starts_with(input))
-                .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone()), None))
+                .map(|comp| (0.., Span::raw(comp.clone())))
                 .collect()
         },
         move |cx, regex, event| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2164,7 +2164,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
             completions
                 .iter()
                 .filter(|comp| comp.starts_with(input))
-                .map(|comp| (0.., Span::raw(comp.clone())))
+                .map(|comp| (0.., comp.clone().into()))
                 .collect()
         },
         move |cx, regex, event| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2164,7 +2164,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
             completions
                 .iter()
                 .filter(|comp| comp.starts_with(input))
-                .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone())))
+                .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone()), None))
                 .collect()
         },
         move |cx, regex, event| {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3178,7 +3178,7 @@ pub(super) fn command_mode(cx: &mut Context) {
                     false,
                 )
                 .into_iter()
-                .map(|(name, _)| (0.., name.into()))
+                .map(|(name, _)| (0.., name.into(), None))
                 .collect()
             } else {
                 // Otherwise, use the command's completer and the last shellword
@@ -3197,13 +3197,13 @@ pub(super) fn command_mode(cx: &mut Context) {
                 {
                     completer(editor, word)
                         .into_iter()
-                        .map(|(range, file)| {
+                        .map(|(range, file, style)| {
                             let file = shellwords::escape(file);
 
                             // offset ranges to input
                             let offset = input.len() - word_len;
                             let range = (range.start + offset)..;
-                            (range, file)
+                            (range, file, style)
                         })
                         .collect()
                 } else {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3178,7 +3178,7 @@ pub(super) fn command_mode(cx: &mut Context) {
                     false,
                 )
                 .into_iter()
-                .map(|(name, _)| (0.., name.into(), None))
+                .map(|(name, _)| (0.., Span::raw(name)))
                 .collect()
             } else {
                 // Otherwise, use the command's completer and the last shellword
@@ -3197,13 +3197,13 @@ pub(super) fn command_mode(cx: &mut Context) {
                 {
                     completer(editor, word)
                         .into_iter()
-                        .map(|(range, file, style)| {
-                            let file = shellwords::escape(file);
+                        .map(|(range, mut file)| {
+                            file.content = shellwords::escape(file.content);
 
                             // offset ranges to input
                             let offset = input.len() - word_len;
                             let range = (range.start + offset)..;
-                            (range, file, style)
+                            (range, file)
                         })
                         .collect()
                 } else {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3178,7 +3178,7 @@ pub(super) fn command_mode(cx: &mut Context) {
                     false,
                 )
                 .into_iter()
-                .map(|(name, _)| (0.., Span::raw(name)))
+                .map(|(name, _)| (0.., name.into()))
                 .collect()
             } else {
                 // Otherwise, use the command's completer and the last shellword

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -291,7 +291,7 @@ pub mod completers {
 
         fuzzy_match(input, names, true)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name)))
+            .map(|(name, _)| ((0..), name.into()))
             .collect()
     }
 
@@ -307,7 +307,7 @@ pub mod completers {
 
         fuzzy_match(input, names, false)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name)))
+            .map(|(name, _)| ((0..), name.into()))
             .collect()
     }
 
@@ -372,7 +372,7 @@ pub mod completers {
 
         fuzzy_match(input, language_ids, false)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name.to_owned())))
+            .map(|(name, _)| ((0..), name.to_owned().into()))
             .collect()
     }
 
@@ -388,7 +388,7 @@ pub mod completers {
 
         fuzzy_match(input, commands, false)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name.to_owned())))
+            .map(|(name, _)| ((0..), name.to_owned().into()))
             .collect()
     }
 
@@ -545,7 +545,7 @@ pub mod completers {
 
         fuzzy_match(input, iter, false)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name)))
+            .map(|(name, _)| ((0..), name.into()))
             .collect()
     }
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -512,7 +512,8 @@ pub mod completers {
             PathBuf::from_str(file.as_ref())
                 .ok()
                 .filter(|path| path.is_dir())
-                .map(|_| editor.theme.get("ui.text.focus"))
+                // TODO: use a custom theme key e.g. "ui.text.directory"
+                .map(|_| editor.theme.get("function"))
         };
 
         // if empty, return a list of dirs and files in current dir

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -506,11 +506,11 @@ pub mod completers {
             }) // TODO: unwrap or skip
             .filter(|path| !path.is_empty());
 
+        // TODO: use a custom theme key e.g. "ui.text.directory"
         let directory_color = editor.theme.get("function");
 
         let style_from_file = |file: Cow<'_, str>| {
             if file.ends_with('/') {
-                // TODO: use a custom theme key e.g. "ui.text.directory"
                 Some(directory_color)
             } else {
                 None

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -508,12 +508,15 @@ pub mod completers {
             }) // TODO: unwrap or skip
             .filter(|path| !path.is_empty());
 
+        let directory_color = editor.theme.get("function");
+
         let style_from_file = |file: Cow<'_, str>| {
-            PathBuf::from_str(file.as_ref())
-                .ok()
-                .filter(|path| path.is_dir())
+            if file.ends_with("/") {
                 // TODO: use a custom theme key e.g. "ui.text.directory"
-                .map(|_| editor.theme.get("function"))
+                Some(directory_color)
+            } else {
+                None
+            }
         };
 
         // if empty, return a list of dirs and files in current dir

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -277,12 +277,12 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
 }
 
 pub mod completers {
+    use super::Utf8PathBuf;
     use crate::ui::prompt::Completion;
-    use crate::ui::Utf8PathBuf;
     use helix_core::fuzzy::fuzzy_match;
     use helix_core::syntax::LanguageServerFeature;
     use helix_view::document::SCRATCH_BUFFER_NAME;
-    use helix_view::theme::{self};
+    use helix_view::theme;
     use helix_view::{editor::Config, Editor};
     use once_cell::sync::Lazy;
     use std::borrow::Cow;
@@ -495,7 +495,7 @@ pub mod completers {
                         return None;
                     }
 
-                    let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
+                    let is_dir = entry.file_type().is_some_and(|entry| entry.is_dir());
 
                     let path = entry.path();
                     let mut path = if is_tilde {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -507,8 +507,7 @@ pub mod completers {
             }) // TODO: unwrap or skip
             .filter(|path| !path.is_empty());
 
-        // TODO: use a custom theme key e.g. "ui.text.directory"
-        let directory_color = editor.theme.get("function");
+        let directory_color = editor.theme.get("ui.text.directory");
 
         let style_from_file = |file: Cow<'static, str>| {
             if file.ends_with(std::path::MAIN_SEPARATOR) {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -274,8 +274,6 @@ pub mod completers {
     use helix_view::{editor::Config, Editor};
     use once_cell::sync::Lazy;
     use std::borrow::Cow;
-    use std::path::PathBuf;
-    use std::str::FromStr;
 
     pub type Completer = fn(&Editor, &str) -> Vec<Completion>;
 
@@ -511,7 +509,7 @@ pub mod completers {
         let directory_color = editor.theme.get("function");
 
         let style_from_file = |file: Cow<'_, str>| {
-            if file.ends_with("/") {
+            if file.ends_with('/') {
                 // TODO: use a custom theme key e.g. "ui.text.directory"
                 Some(directory_color)
             } else {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -290,7 +290,7 @@ pub mod completers {
 
         fuzzy_match(input, names, true)
             .into_iter()
-            .map(|(name, _)| ((0..), name))
+            .map(|(name, _)| ((0..), name, None))
             .collect()
     }
 
@@ -306,7 +306,7 @@ pub mod completers {
 
         fuzzy_match(input, names, false)
             .into_iter()
-            .map(|(name, _)| ((0..), name.into()))
+            .map(|(name, _)| ((0..), name.into(), None))
             .collect()
     }
 
@@ -336,7 +336,7 @@ pub mod completers {
 
         fuzzy_match(input, &*KEYS, false)
             .into_iter()
-            .map(|(name, _)| ((0..), name.into()))
+            .map(|(name, _)| ((0..), name.into(), None))
             .collect()
     }
 
@@ -371,7 +371,7 @@ pub mod completers {
 
         fuzzy_match(input, language_ids, false)
             .into_iter()
-            .map(|(name, _)| ((0..), name.to_owned().into()))
+            .map(|(name, _)| ((0..), name.to_owned().into(), None))
             .collect()
     }
 
@@ -387,7 +387,7 @@ pub mod completers {
 
         fuzzy_match(input, commands, false)
             .into_iter()
-            .map(|(name, _)| ((0..), name.to_owned().into()))
+            .map(|(name, _)| ((0..), name.to_owned().into(), None))
             .collect()
     }
 
@@ -511,13 +511,13 @@ pub mod completers {
             let range = (input.len().saturating_sub(file_name.len()))..;
             fuzzy_match(&file_name, files, true)
                 .into_iter()
-                .map(|(name, _)| (range.clone(), name))
+                .map(|(name, _)| (range.clone(), name, None))
                 .collect()
 
             // TODO: complete to longest common match
         } else {
-            let mut files: Vec<_> = files.map(|file| (end.clone(), file)).collect();
-            files.sort_unstable_by(|(_, path1), (_, path2)| path1.cmp(path2));
+            let mut files: Vec<_> = files.map(|file| (end.clone(), file, None)).collect();
+            files.sort_unstable_by(|(_, path1, _), (_, path2, _)| path1.cmp(path2));
             files
         }
     }
@@ -532,7 +532,7 @@ pub mod completers {
 
         fuzzy_match(input, iter, false)
             .into_iter()
-            .map(|(name, _)| ((0..), name.into()))
+            .map(|(name, _)| ((0..), name.into(), None))
             .collect()
     }
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -350,7 +350,6 @@ pub mod completers {
         input: &str,
         git_ignore: bool,
     ) -> Vec<Completion> {
-        // styles are not lost here
         filename_impl(editor, input, git_ignore, |entry| {
             let is_dir = entry.file_type().map_or(false, |entry| entry.is_dir());
 
@@ -533,7 +532,6 @@ pub mod completers {
                 .map(|file| (end.clone(), style_from_file(file)))
                 .collect();
             files.sort_unstable_by(|(_, path1), (_, path2)| path1.content.cmp(&path2.content));
-            // ok, so the Styles get correctly applied
             files
         }
     }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -450,11 +450,10 @@ impl Prompt {
                 self.completion.iter().enumerate().skip(offset).take(items)
             {
                 let is_selected = Some(i) == self.selection;
-                let has_custom_style = completion.style != Style::default();
 
                 let completion_item_style = if is_selected {
                     selected_color
-                } else if has_custom_style {
+                } else if completion.style != Style::default() {
                     completion.style
                 } else {
                     default_completion_color

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -401,7 +401,7 @@ impl Prompt {
         let theme = &cx.editor.theme;
         let prompt_color = theme.get("ui.text");
         let completion_color = theme.get("ui.menu");
-        // let selected_color = theme.get("ui.menu.selected");
+        let selected_color = theme.get("ui.menu.selected");
         let suggestion_color = theme.get("ui.text.inactive");
         let background = theme.get("ui.background");
         // completion
@@ -451,7 +451,7 @@ impl Prompt {
                 let completion_color = style.unwrap_or(completion_color);
 
                 let color = if Some(i) == self.selection {
-                    completion_color.invert()
+                    selected_color
                 } else {
                     completion_color
                 };

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -445,9 +445,11 @@ impl Prompt {
             let mut row = 0;
             let mut col = 0;
 
-            for (i, (_range, completion, _style)) in
+            for (i, (_range, completion, style)) in
                 self.completion.iter().enumerate().skip(offset).take(items)
             {
+                let completion_color = style.unwrap_or(completion_color);
+
                 let color = if Some(i) == self.selection {
                     completion_color.invert()
                 } else {

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -5,7 +5,6 @@ use helix_core::syntax;
 use helix_view::document::Mode;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
-use helix_view::theme::Style;
 use std::sync::Arc;
 use std::{borrow::Cow, ops::RangeFrom};
 use tui::buffer::Buffer as Surface;
@@ -401,7 +400,7 @@ impl Prompt {
     pub fn render_prompt(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let theme = &cx.editor.theme;
         let prompt_color = theme.get("ui.text");
-        let default_completion_color = theme.get("ui.menu");
+        let completion_color = theme.get("ui.menu");
         let selected_color = theme.get("ui.menu.selected");
         let suggestion_color = theme.get("ui.text.inactive");
         let background = theme.get("ui.background");
@@ -453,10 +452,8 @@ impl Prompt {
 
                 let completion_item_style = if is_selected {
                     selected_color
-                } else if completion.style != Style::default() {
-                    completion.style
                 } else {
-                    default_completion_color
+                    completion_color.patch(completion.style)
                 };
 
                 surface.set_stringn(

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -449,14 +449,13 @@ impl Prompt {
             for (i, (_range, completion)) in
                 self.completion.iter().enumerate().skip(offset).take(items)
             {
-                let completion_color = if completion.style == Style::default() {
-                    completion_color
-                } else {
-                    completion.style
-                };
+                let is_selected = Some(i) == self.selection;
+                let has_custom_style = completion.style != Style::default();
 
-                let color = if Some(i) == self.selection {
+                let completion_item_style = if is_selected {
                     selected_color
+                } else if has_custom_style {
+                    completion.style
                 } else {
                     completion_color
                 };
@@ -466,8 +465,9 @@ impl Prompt {
                     area.y + row,
                     &completion.content,
                     col_width.saturating_sub(1) as usize,
-                    color,
+                    completion_item_style,
                 );
+
                 row += 1;
                 if row > area.height - 1 {
                     row = 0;

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -663,7 +663,7 @@ impl Component for Prompt {
                     .editor
                     .registers
                     .iter_preview()
-                    .map(|(ch, preview)| (0.., Span::raw(format!("{} {}", ch, &preview))))
+                    .map(|(ch, preview)| (0.., format!("{} {}", ch, &preview).into()))
                     .collect();
                 self.next_char_handler = Some(Box::new(|prompt, c, context| {
                     prompt.insert_str(

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -401,7 +401,7 @@ impl Prompt {
     pub fn render_prompt(&self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let theme = &cx.editor.theme;
         let prompt_color = theme.get("ui.text");
-        let completion_color = theme.get("ui.menu");
+        let default_completion_color = theme.get("ui.menu");
         let selected_color = theme.get("ui.menu.selected");
         let suggestion_color = theme.get("ui.text.inactive");
         let background = theme.get("ui.background");
@@ -457,7 +457,7 @@ impl Prompt {
                 } else if has_custom_style {
                     completion.style
                 } else {
-                    completion_color
+                    default_completion_color
                 };
 
                 surface.set_stringn(

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -508,23 +508,6 @@ impl Style {
         self
     }
 
-    /// Inverts the background and foreground
-    ///
-    /// ## Examples
-    ///
-    /// ```rust
-    /// # use helix_view::graphics::{Color, Style};
-    /// let style = Style::default().bg(Color::Blue).fg(Color::Red);
-    /// let inverted = Style::default().bg(Color::Red).fg(Color::Blue);
-    /// assert_eq!(style.invert(), inverted);
-    /// ```
-    pub const fn invert(mut self) -> Style {
-        let bg = self.bg;
-        self.bg = self.fg;
-        self.fg = bg;
-        self
-    }
-
     /// Changes the underline color.
     ///
     /// ## Examples

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -508,6 +508,23 @@ impl Style {
         self
     }
 
+    /// Inverts the background and foreground
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use helix_view::graphics::{Color, Style};
+    /// let style = Style::default().bg(Color::Blue).fg(Color::Red);
+    /// let inverted = Style::default().bg(Color::Red).fg(Color::Blue);
+    /// assert_eq!(style.invert(), inverted);
+    /// ```
+    pub const fn invert(mut self) -> Style {
+        let bg = self.bg;
+        self.bg = self.fg;
+        self.fg = bg;
+        self
+    }
+
     /// Changes the underline color.
     ///
     /// ## Examples

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -86,6 +86,7 @@
 "ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "overlay1" }
+"ui.text.directory" = { fg = "blue" }
 
 "ui.virtual" = "overlay0"
 "ui.virtual.ruler" = { bg = "surface0" }

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -72,6 +72,7 @@
 "ui.bufferline.background"   = { bg = "background" }
 "ui.text"                    = { fg = "text" }
 "ui.text.focus"              = { fg = "white" }
+"ui.text.directory"          = { fg = "blue3" }
 "ui.virtual.whitespace"      = { fg = "#3e3e3d" }
 "ui.virtual.ruler"           = { bg = "borders" }
 "ui.virtual.indent-guide"    = { fg = "dark_gray4" }

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -118,6 +118,7 @@
 "ui.statusline.select"            = { fg    = "black",           bg = "cyan",          modifiers = ["bold"] }
 "ui.text"                         = { fg    = "foreground"                                                  }
 "ui.text.focus"                   = { fg    = "cyan"                                                        }
+"ui.text.directory"               = { fg    = "cyan"                                                        }
 "ui.virtual.indent-guide"         = { fg    = "indent"                                                      }
 "ui.virtual.inlay-hint"           = { fg    = "cyan"                                                        }
 "ui.virtual.inlay-hint.parameter" = { fg    = "cyan",            modifiers = ["italic", "dim"]              }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -42,6 +42,7 @@
 "ui.statusline.select" = { fg = "background_dark", bg = "purple" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "cyan" }
+"ui.text.directory" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
 "ui.virtual.jump-label" = { fg = "pink", modifiers = ["bold"] }
 "ui.virtual.ruler" = { bg = "background_dark" }

--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -59,6 +59,7 @@ label = "scale.red.3"
 "ui.text" = { fg = "fg.muted" }
 "ui.text.focus" = { fg = "fg.default" }
 "ui.text.inactive" = "fg.subtle"
+"ui.text.directory" = { fg = "scale.blue.2" }
 "ui.virtual" = { fg = "scale.gray.6" }
 "ui.virtual.ruler" = { bg = "canvas.subtle" }
 "ui.virtual.jump-label" = { fg = "scale.red.2", modifiers = ["bold"] }

--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -59,6 +59,7 @@ label = "scale.red.5"
 "ui.text" = { fg = "fg.muted" }
 "ui.text.focus" = { fg = "fg.default" }
 "ui.text.inactive" = "fg.subtle"
+"ui.text.directory" = { fg = "scale.blue.4" }
 "ui.virtual" = { fg = "scale.gray.2" }
 "ui.virtual.ruler" = { bg = "canvas.subtle" }
 

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -106,6 +106,7 @@
 "ui.statusline.select" = { fg = "bg1", bg = "orange1", modifiers = ["bold"] }
 
 "ui.text" = { fg = "fg1" }
+"ui.text.directory" = { fg = "blue1" }
 "ui.virtual.inlay-hint" = { fg = "gray" }
 "ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
 "ui.virtual.ruler" = { bg = "bg1" }

--- a/runtime/themes/material_deep_ocean.toml
+++ b/runtime/themes/material_deep_ocean.toml
@@ -60,6 +60,7 @@
 
 "ui.background" = { bg = "bg", fg = "text" }
 "ui.text" = { fg = "text" }
+"ui.text.directory" = { fg = "blue" }
 
 "ui.statusline" = { bg = "bg", fg = "text" }
 "ui.statusline.inactive" = { bg = "bg", fg = "disabled" }

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -36,6 +36,7 @@
 "ui.text" = { fg = "text" }
 "ui.text.focus" = { bg = "overlay" }
 "ui.text.info" = { fg = "subtle" }
+"ui.text.directory" = { fg = "iris" }
 
 "ui.virtual.jump-label" = { fg = "love", modifiers = ["bold"] }
 "ui.virtual.ruler" = { bg = "overlay" }

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -89,6 +89,7 @@ hint = { fg = "hint" }
 "ui.text.focus" = { bg = "bg-focus" }
 "ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
 "ui.text.info" = { bg = "bg-menu", fg = "fg" }
+"ui.text.directory" = { fg = "cyan" }
 "ui.virtual.ruler" = { bg = "fg-gutter" }
 "ui.virtual.whitespace" = { fg = "fg-gutter" }
 "ui.virtual.inlay-hint" = {  bg = "bg-inlay", fg = "teal" }

--- a/theme.toml
+++ b/theme.toml
@@ -55,6 +55,7 @@ label = "honey"
 "ui.text" = { fg = "lavender" }
 "ui.text.focus" = { fg = "white" }
 "ui.text.inactive" = "sirocco"
+"ui.text.directory" = { fg = "lilac" }
 "ui.virtual" = { fg = "comet" }
 "ui.virtual.ruler" = { bg = "bossanova" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }


### PR DESCRIPTION
Currently, directories and files both use the same color. This makes it hard to distinguish between them. This PR adds the ability to pass custom styles to prompt items.

## Before

![image](https://github.com/user-attachments/assets/51aae193-acd1-4b83-a1eb-cf63ba05e86e)


## After
![image](https://github.com/user-attachments/assets/a0ce839f-32b1-4ee4-babc-3a378402b36c)

---

This PR adds `ui.text.directory` theme key for many themes. Screenshots of themes' base colors

<details>

<summary>
Screenshots of themes which are inherited from
</summary>

All themes in bullet points will show new colors for directories. 2nd level bullet point themes inherit from 1st level, so I only screenshot 1st level bullet point themes

- `catppuccin_mocha`
  - `catppuccin_latte`
  - `catppuccin_frappe`
  - `catppuccin_macchiato`

![image](https://github.com/user-attachments/assets/5e266ec7-f430-4af2-b9f9-14614b036833)

- `dark_plus`

![image](https://github.com/user-attachments/assets/8ab2f540-256f-4f0f-b98f-0e10cc38dfda)

- `dracula`

![image](https://github.com/user-attachments/assets/e36fbc1c-7b7c-4e90-89f5-470e5a1e7917)

- `dracula_at_night`

![image](https://github.com/user-attachments/assets/7e655410-0143-4c63-a6f7-95b1486c248b)

- `github_light`
  - `github_light_dimmed`
  - `github_light_colorblind`
  - `github_light_tritanopia`
  - `github_light_high_constrast`

![image](https://github.com/user-attachments/assets/93993102-5f51-483c-a5d1-56ff04e1ac0e)


- `github_dark`
  - `github_dark_dimmed`
  - `github_dark_colorblind`
  - `github_dark_tritanopia`
  - `github_dark_high_constrast`

![image](https://github.com/user-attachments/assets/b38a0db2-a3bd-4ead-8bfd-34f2fde149af)


- `gruvbox`
  - `gruvbox_light`
  - `gruvbox_light_hard`
  - `gruvbox_light_soft`
  - `gruvbox_dark_hard`
  - `gruvbox_dark_soft`

![image](https://github.com/user-attachments/assets/12f8a863-5985-49b7-98f5-4287ecb3a51c)


- `material_deep_ocean`
  - `material_darker`
  - `material_oceanic`
  - `material_palenight`

![image](https://github.com/user-attachments/assets/3e41aa83-15ab-4fa5-9326-f5263a0cf125)


- `rose_pine`
  - `rose_pine_dawn`
  - `rose_pine_moon`

![image](https://github.com/user-attachments/assets/64d63c33-a48c-4850-aacb-b69ebd1275e7)


- `tokyonight`
  - `tokyonight_day`
  - `tokyonight_moon`
  - `tokyonight_storm`

![image](https://github.com/user-attachments/assets/9f581bab-1f94-44e0-bbe1-d372a0b825f9)

- `default`

![image](https://github.com/user-attachments/assets/e599fb91-b3fd-4765-bb1d-c955a662d2cb)


</details>