### PR TITLE
feat: `:tree-sitter-tree` command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -73,6 +73,7 @@
 | `:rsort` | Sort ranges in selection in reverse order. |
 | `:reflow` | Hard-wrap the current selection of lines to a given width. |
 | `:tree-sitter-subtree`, `:ts-subtree` | Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries. |
+| `:tree-sitter-tree`, `:ts-tree` | Display tree-sitter tree that spans the full document, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
 | `:config-open-workspace` | Open the workspace config.toml file. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2151,43 +2151,24 @@ fn tree_sitter_tree(
         return Ok(());
     }
 
-    // let (view, doc) = current_ref!(cx.editor);
+    let (_view, doc) = current_ref!(cx.editor);
 
-    let _doc = cx.editor.new_file_from_document(
-        Action::HorizontalSplit,
-        Document::from(Rope::from("Hello world"), None, cx.editor.config.clone()),
-    );
+    if let Some(syntax) = doc.syntax() {
+        let text = doc.text();
+        let from = 0;
+        let to = text.len_chars();
 
-    // if let Some(syntax) = doc.syntax() {
-    //     let primary_selection = doc.selection(view.id).primary();
-    //     let text = doc.text();
-    //     let from = text.char_to_byte(primary_selection.from());
-    //     let to = text.char_to_byte(primary_selection.to());
+        if let Some(selected_node) = syntax.descendant_for_byte_range(from, to) {
+            let mut contents = String::from("```tsq\n");
+            helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
+            contents.push_str("\n```");
 
-    // view.new_
-    // let doc = cx.editor.new_file(Action::HorizontalSplit);
-
-    // cx.editor.swap;
-
-    // if let Some(selected_node) = syntax.descendant_for_byte_range(from, to) {
-    //     let mut contents = String::from("```tsq\n");
-    //     helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
-    //     contents.push_str("\n```");
-
-    //     let callback = async move {
-    //         let call: job::Callback = Callback::EditorCompositor(Box::new(
-    //             move |editor: &mut Editor, compositor: &mut Compositor| {
-    //                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
-    //                 let popup = Popup::new("hover", contents).auto_close(true);
-    //                 compositor.replace_or_push("hover", popup);
-    //             },
-    //         ));
-    //         Ok(call)
-    //     };
-
-    //     cx.jobs.callback(callback);
-    // }
-    // }
+            cx.editor.new_file_from_document(
+                Action::VerticalSplit,
+                Document::from(Rope::from(contents), None, cx.editor.config.clone()),
+            );
+        }
+    }
 
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2142,6 +2142,9 @@ fn reflow(
     Ok(())
 }
 
+// This is a basic implementation for viewing the entire tree sitter tree of a file
+// In the future, this command could be updated such that it opens a buffer which automatically highlights the tree sitter sub-tree of where we currently have our cursor
+// And vice-versa: Moving cursor across nodes in the tree sitter tree will need to also move the cursor across the original file
 fn tree_sitter_tree(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2142,6 +2142,56 @@ fn reflow(
     Ok(())
 }
 
+fn tree_sitter_tree(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    // let (view, doc) = current_ref!(cx.editor);
+
+    let _doc = cx.editor.new_file_from_document(
+        Action::HorizontalSplit,
+        Document::from(Rope::from("Hello world"), None, cx.editor.config.clone()),
+    );
+
+    // if let Some(syntax) = doc.syntax() {
+    //     let primary_selection = doc.selection(view.id).primary();
+    //     let text = doc.text();
+    //     let from = text.char_to_byte(primary_selection.from());
+    //     let to = text.char_to_byte(primary_selection.to());
+
+    // view.new_
+    // let doc = cx.editor.new_file(Action::HorizontalSplit);
+
+    // cx.editor.swap;
+
+    // if let Some(selected_node) = syntax.descendant_for_byte_range(from, to) {
+    //     let mut contents = String::from("```tsq\n");
+    //     helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
+    //     contents.push_str("\n```");
+
+    //     let callback = async move {
+    //         let call: job::Callback = Callback::EditorCompositor(Box::new(
+    //             move |editor: &mut Editor, compositor: &mut Compositor| {
+    //                 let contents = ui::Markdown::new(contents, editor.syn_loader.clone());
+    //                 let popup = Popup::new("hover", contents).auto_close(true);
+    //                 compositor.replace_or_push("hover", popup);
+    //             },
+    //         ));
+    //         Ok(call)
+    //     };
+
+    //     cx.jobs.callback(callback);
+    // }
+    // }
+
+    Ok(())
+}
+
 fn tree_sitter_subtree(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -3042,6 +3092,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["ts-subtree"],
         doc: "Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.",
         fun: tree_sitter_subtree,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "tree-sitter-tree",
+        aliases: &["ts-tree"],
+        doc: "Display tree-sitter tree that spans the full document, primarily for debugging queries.",
+        fun: tree_sitter_tree,
         signature: CommandSignature::none(),
     },
     TypableCommand {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2159,14 +2159,17 @@ fn tree_sitter_tree(
         let to = text.len_chars();
 
         if let Some(selected_node) = syntax.descendant_for_byte_range(from, to) {
-            let mut contents = String::from("```tsq\n");
+            let mut contents = String::new();
             helix_core::syntax::pretty_print_tree(&mut contents, selected_node)?;
-            contents.push_str("\n```");
 
             cx.editor.new_file_from_document(
                 Action::VerticalSplit,
                 Document::from(Rope::from(contents), None, cx.editor.config.clone()),
             );
+
+            let (_view, doc) = current!(cx.editor);
+
+            doc.set_language_by_language_id("tsq", cx.editor.syn_loader.clone())?
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1689,7 +1689,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
Using `%` to select entire file and then using `:tree-sitter-subtree` which opens in a tiny window makes it difficult to inspect the entire tree.

It would be nice if you could open the current file's entire tree in a separate buffer. Currently this is just a **basic implementation**, which gets the current file's tree and dumps it into a new buffer. In the future the command can be updated to be more like neovim's tree sitter tree command.

![image](https://github.com/user-attachments/assets/072011b5-a72b-4738-8753-0e31b7cda9d1)
