### PR TITLE
Add config option for continue commenting

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -31,7 +31,7 @@
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `absolute` |
 | `cursorline` | Highlight all lines with a cursor | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
-| `continue-comment` | if helix should automatically add a (line-)comment token, if you create a new line inside a comment. | `false` |
+| `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -31,6 +31,7 @@
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `absolute` |
 | `cursorline` | Highlight all lines with a cursor | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
+| `continue-comment` | if helix should automatically add a (line-)comment token, if you create a new line inside a comment. | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
 | `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3486,7 +3486,7 @@ fn open(cx: &mut Context, open: Open) {
             )
         };
 
-        let continue_comment_token = if doc.config.load().continue_comment {
+        let continue_comment_token = if doc.config.load().continue_comments {
             doc.language_config()
                 .and_then(|config| config.comment_tokens.as_ref())
                 .and_then(|tokens| comment::get_comment_token(text, tokens, cursor_line))
@@ -3968,7 +3968,7 @@ pub mod insert {
 
             let mut new_text = String::new();
 
-            let continue_comment_token = if doc.config.load().continue_comment {
+            let continue_comment_token = if doc.config.load().continue_comments {
                 doc.language_config()
                     .and_then(|config| config.comment_tokens.as_ref())
                     .and_then(|tokens| comment::get_comment_token(text, tokens, current_line))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3486,10 +3486,13 @@ fn open(cx: &mut Context, open: Open) {
             )
         };
 
-        let continue_comment_token = doc
-            .language_config()
-            .and_then(|config| config.comment_tokens.as_ref())
-            .and_then(|tokens| comment::get_comment_token(text, tokens, cursor_line));
+        let continue_comment_token = if doc.config.load().continue_comment {
+            doc.language_config()
+                .and_then(|config| config.comment_tokens.as_ref())
+                .and_then(|tokens| comment::get_comment_token(text, tokens, cursor_line))
+        } else {
+            None
+        };
 
         let line = text.line(cursor_line);
         let indent = match line.first_non_whitespace_char() {
@@ -3965,10 +3968,13 @@ pub mod insert {
 
             let mut new_text = String::new();
 
-            let continue_comment_token = doc
-                .language_config()
-                .and_then(|config| config.comment_tokens.as_ref())
-                .and_then(|tokens| comment::get_comment_token(text, tokens, current_line));
+            let continue_comment_token = if doc.config.load().continue_comment {
+                doc.language_config()
+                    .and_then(|config| config.comment_tokens.as_ref())
+                    .and_then(|tokens| comment::get_comment_token(text, tokens, current_line))
+            } else {
+                None
+            };
 
             let (from, to, local_offs) = if let Some(idx) =
                 text.slice(line_start..pos).last_non_whitespace_char()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -304,6 +304,9 @@ pub struct Config {
     /// Whether to instruct the LSP to replace the entire word when applying a completion
     /// or to only insert new text
     pub completion_replace: bool,
+    /// `true` if helix should automatically add a (line-)comment token, if you're currently in a comment
+    /// and press `enter`.
+    pub continue_comment: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
@@ -985,6 +988,7 @@ impl Default for Config {
             },
             text_width: 80,
             completion_replace: false,
+            continue_comment: true,
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -304,9 +304,9 @@ pub struct Config {
     /// Whether to instruct the LSP to replace the entire word when applying a completion
     /// or to only insert new text
     pub completion_replace: bool,
-    /// `true` if helix should automatically add a (line-)comment token, if you're currently in a comment
+    /// `true` if helix should automatically add a line comment token if you're currently in a comment
     /// and press `enter`.
-    pub continue_comment: bool,
+    pub continue_comments: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
     pub file_picker: FilePickerConfig,
@@ -988,7 +988,7 @@ impl Default for Config {
             },
             text_width: 80,
             completion_replace: false,
-            continue_comment: true,
+            continue_comments: true,
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,


### PR DESCRIPTION
This fixes https://github.com/helix-editor/helix/issues/1730#issuecomment-2497839562

@johnbchron may I ask if you could try my PR out? My PR adds the field in the `[editor]` section. Just add a `continue-comment = false` line and you should be good to go.

I'm also wondering if it might be worth it to add a command for this: `:set-continue-comment [true/false]`