### PR TITLE
fix: Respect workspace-lsp-roots on doc opening

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -803,7 +803,11 @@ impl Registry {
                     }
 
                     if let Some((_, client)) = clients.iter().enumerate().find(|(i, client)| {
-                        client.try_add_doc(&language_config.roots, root_dirs, doc_path, *i == 0)
+                        let manual_roots = language_config
+                            .workspace_lsp_roots
+                            .as_deref()
+                            .unwrap_or(root_dirs);
+                        client.try_add_doc(&language_config.roots, manual_roots, doc_path, *i == 0)
                     }) {
                         return Some((name.to_owned(), Ok(client.clone())));
                     }


### PR DESCRIPTION
When a new language server is started, `find_lsp_workspace` is called with `LanguageConfiguration::workspace_lsp_roots` as the `root_dirs` argument.

This behavior is different when a new document is opened. `find_lsp_workspace` is called with `editor::Config::workspace_lsp_roots` which is never set.

This leads to a bug where `workspace-lsp-roots` is not respected when opening a new document. This commit fixes this bug.

I don't quite understand why the field `editor::Config::workspace_lsp_roots` exists when it is never used. Is it something LSP specific?

I'm also happy to change this PR if someone can point me into the right direction if the current fix is wrong.

Thanks a lot!

Closes helix-editor/helix#12222