### PR TITLE
Show parser availability in --health [LANG]

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -300,14 +300,14 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
         lang.debugger.as_ref().map(|dap| dap.command.to_string()),
     )?;
 
-    probe_parser(lang.grammar.as_ref().unwrap_or(&lang.language_id))?;
-
     probe_protocol(
         "formatter",
         lang.formatter
             .as_ref()
             .map(|formatter| formatter.command.to_string()),
     )?;
+
+    probe_parser(lang.grammar.as_ref().unwrap_or(&lang.language_id))?;
 
     for ts_feat in TsFeature::all() {
         probe_treesitter_feature(&lang_str, *ts_feat)?
@@ -320,11 +320,9 @@ fn probe_parser(grammar_name: &str) -> std::io::Result<()> {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
 
-    use helix_loader::grammar::get_language;
-
     write!(stdout, "Tree-sitter parser: ")?;
 
-    match get_language(grammar_name) {
+    match helix_loader::grammar::get_language(grammar_name) {
         Ok(_) => writeln!(stdout, "{}", "✓".green()),
         Err(_) => writeln!(stdout, "{}", "None".yellow()),
     }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -300,6 +300,8 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
         lang.debugger.as_ref().map(|dap| dap.command.to_string()),
     )?;
 
+    probe_parser(lang.grammar.as_ref().unwrap_or(&lang.language_id))?;
+
     probe_protocol(
         "formatter",
         lang.formatter
@@ -312,6 +314,20 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+fn probe_parser(grammar_name: &str) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+
+    use helix_loader::grammar::get_language;
+
+    write!(stdout, "Tree-sitter parser: ")?;
+
+    match get_language(grammar_name) {
+        Ok(_) => writeln!(stdout, "{}", "✓".green()),
+        Err(_) => writeln!(stdout, "{}", "None".yellow()),
+    }
 }
 
 /// Display diagnostics about multiple LSPs and DAPs.


### PR DESCRIPTION
Closes #1858.
I can also add a `parser` column to the --health table for all languages, if this looks good.