### PR TITLE
dockerfile: bump tree-sitter grammar to gain support for heredocs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1703,7 +1703,7 @@ language-servers = [ "docker-langserver" ]
 
 [[grammar]]
 name = "dockerfile"
-source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = "8ee3a0f7587b2bd8c45c8cb7d28bd414604aec62" }
+source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = "087daa20438a6cc01fa5e6fe6906d77c869d19fe" }
 
 [[language]]
 name = "docker-compose"

--- a/runtime/queries/dockerfile/highlights.scm
+++ b/runtime/queries/dockerfile/highlights.scm
@@ -19,6 +19,8 @@
 	"SHELL"
 	"MAINTAINER"
 	"CROSS_BUILD"
+	(heredoc_marker)
+	(heredoc_end)
 ] @keyword
 
 [
@@ -35,7 +37,12 @@
 	(image_digest
 		"@" @punctuation.special))
 
-(double_quoted_string) @string
+[
+	(double_quoted_string)
+	(single_quoted_string)
+	(json_string)
+	(heredoc_line)
+] @string
 
 (expansion
   [


### PR DESCRIPTION
The diff between the two versions is here:

https://github.com/camdencheek/tree-sitter-dockerfile/compare/8ee3a0f7587b2bd8c45c8cb7d28bd414604aec62...087daa20438a6cc01fa5e6fe6906d77c869d19fe

fixes: https://github.com/helix-editor/helix/issues/3166