### PR TITLE
languages(v): use vlang/v-analyzer instead of v-analyzer/v-analyzer

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2286,7 +2286,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "v"
-source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "ef4243a0cbae726be94bb7a2a89e32ebc99856e9"}
+source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "e14fdf6e661b10edccc744102e4ccf0b187aa8ad"}
 
 [[language]]
 name = "verilog"

--- a/languages.toml
+++ b/languages.toml
@@ -2286,7 +2286,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "v"
-source = {git = "https://github.com/v-analyzer/v-analyzer", subpath = "tree_sitter_v", rev = "e14fdf6e661b10edccc744102e4ccf0b187aa8ad"}
+source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "ef4243a0cbae726be94bb7a2a89e32ebc99856e9"}
 
 [[language]]
 name = "verilog"


### PR DESCRIPTION
there are 2 repos for v-analyzer, but one that belongs to v-analyzer (org) is outdated.

- https://github.com/v-analyzer/v-analyzer/
- https://github.com/vlang/v-analyzer/
