### PR TITLE
Fix panic in `kill_to_end_of_line` when handling multibyte characters

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -233,15 +233,7 @@ impl Prompt {
                 position
             }
             Movement::StartOfLine => 0,
-            Movement::EndOfLine => {
-                let mut cursor =
-                    GraphemeCursor::new(self.line.len().saturating_sub(1), self.line.len(), false);
-                if let Ok(Some(pos)) = cursor.next_boundary(&self.line, 0) {
-                    pos
-                } else {
-                    self.cursor
-                }
-            }
+            Movement::EndOfLine => self.line.len(),
             Movement::None => self.cursor,
         }
     }


### PR DESCRIPTION
This PR fixed a panic that occurred when pressing <kbd>Ctrl-a</kbd> <kbd>Ctrl-k</kbd> in prompts while a multibyte string was inserted.

Before:

https://github.com/user-attachments/assets/ca6c776c-4f25-4716-bc2e-ef1c8a6a4997

After:

https://github.com/user-attachments/assets/1c5f8d25-441d-43ee-b4df-04088cd28793

