### PR TITLE
feat: `log::error!` status message if it is too long

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1590,30 +1590,15 @@ impl Component for EditorView {
                 cx.editor.theme.get("ui.text")
             };
 
-            if status_msg.len() <= area.width.into() {
-                surface.set_string(
-                    area.x,
-                    area.y + area.height.saturating_sub(1),
-                    status_msg,
-                    style,
-                );
-            } else {
-                let status_msg_box = async move {
-                    let call: job::Callback = Callback::EditorCompositor(Box::new(
-                        move |editor: &mut Editor, compositor: &mut Compositor| {
-                            if let Some((contents, _)) = &editor.status_msg {
-                                let contents = StyledText::new(contents.to_string(), style);
-
-                                let popup = Popup::new("hover", contents).auto_close(true);
-                                compositor.replace_or_push("hover", popup);
-                            }
-                        },
-                    ));
-                    Ok(call)
-                };
-
-                cx.jobs.callback(status_msg_box)
-            }
+            surface.set_string(
+                area.x,
+                area.y + area.height.saturating_sub(1),
+                status_msg,
+                style,
+            );
+            if status_msg.len() <= area.width.into() && *severity == Severity::Error {
+                log::error!("Status bar could not fit this error message: {status_msg}");
+            };
         }
 
         if area.width.saturating_sub(status_msg_width as u16) > key_width {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,17 +1,15 @@
 use crate::{
     commands::{self, OnKeyCallback, OnKeyCallbackKind},
-    compositor::{Component, Compositor, Context, Event, EventResult},
+    compositor::{Component, Context, Event, EventResult},
     events::{OnModeSwitch, PostCommand},
     handlers::completion::CompletionItem,
-    job::{self, Callback},
     key,
     keymap::{KeymapResult, Keymaps},
     ui::{
         document::{render_document, LinePos, TextRenderer},
-        markdown::StyledText,
         statusline,
         text_decorations::{self, Decoration, DecorationManager, InlineDiagnostics},
-        Completion, Popup, ProgressSpinners,
+        Completion, ProgressSpinners,
     },
 };
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,15 +1,16 @@
 use crate::{
     commands::{self, OnKeyCallback, OnKeyCallbackKind},
-    compositor::{Component, Context, Event, EventResult},
+    compositor::{Component, Compositor, Context, Event, EventResult},
     events::{OnModeSwitch, PostCommand},
     handlers::completion::CompletionItem,
+    job::{self, Callback},
     key,
     keymap::{KeymapResult, Keymaps},
     ui::{
         document::{render_document, LinePos, TextRenderer},
         statusline,
         text_decorations::{self, Decoration, DecorationManager, InlineDiagnostics},
-        Completion, ProgressSpinners,
+        Completion, Markdown, Popup, ProgressSpinners,
     },
 };
 
@@ -1588,12 +1589,30 @@ impl Component for EditorView {
                 cx.editor.theme.get("ui.text")
             };
 
-            surface.set_string(
-                area.x,
-                area.y + area.height.saturating_sub(1),
-                status_msg,
-                style,
-            );
+            if status_msg.len() <= area.width.into() {
+                surface.set_string(
+                    area.x,
+                    area.y + area.height.saturating_sub(1),
+                    status_msg,
+                    style,
+                );
+            } else {
+                let status_msg_box = async move {
+                    let call: job::Callback = Callback::EditorCompositor(Box::new(
+                        move |editor: &mut Editor, compositor: &mut Compositor| {
+                            if let Some((contents, _)) = &editor.status_msg {
+                                let contents =
+                                    Markdown::new(contents.to_string(), editor.syn_loader.clone());
+                                let popup = Popup::new("hover", contents).auto_close(true);
+                                compositor.replace_or_push("hover", popup);
+                            }
+                        },
+                    ));
+                    Ok(call)
+                };
+
+                cx.jobs.callback(status_msg_box)
+            }
         }
 
         if area.width.saturating_sub(status_msg_width as u16) > key_width {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -8,9 +8,10 @@ use crate::{
     keymap::{KeymapResult, Keymaps},
     ui::{
         document::{render_document, LinePos, TextRenderer},
+        markdown::StyledText,
         statusline,
         text_decorations::{self, Decoration, DecorationManager, InlineDiagnostics},
-        Completion, Markdown, Popup, ProgressSpinners,
+        Completion, Popup, ProgressSpinners,
     },
 };
 
@@ -1601,8 +1602,8 @@ impl Component for EditorView {
                     let call: job::Callback = Callback::EditorCompositor(Box::new(
                         move |editor: &mut Editor, compositor: &mut Compositor| {
                             if let Some((contents, _)) = &editor.status_msg {
-                                let contents =
-                                    Markdown::new(contents.to_string(), editor.syn_loader.clone());
+                                let contents = StyledText::new(contents.to_string(), style);
+
                                 let popup = Popup::new("hover", contents).auto_close(true);
                                 compositor.replace_or_push("hover", popup);
                             }

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -5,7 +5,7 @@ use tui::{
     text::{Span, Spans, Text},
 };
 
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -126,45 +126,6 @@ pub struct Markdown {
     config_loader: Arc<ArcSwap<syntax::Loader>>,
 }
 
-pub struct StyledText {
-    text: tui::text::Text<'static>,
-}
-
-impl StyledText {
-    pub fn new(contents: String, style: Style) -> Self {
-        let spans: Vec<Spans<'static>> = contents
-            .lines()
-            .map(|line| Spans::from(vec![Span::styled(Cow::Owned(line.to_string()), style)]))
-            .collect();
-
-        let text = Text::from(spans);
-
-        Self { text }
-    }
-}
-
-impl Component for StyledText {
-    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        use tui::widgets::{Paragraph, Widget, Wrap};
-
-        let par = Paragraph::new(&self.text)
-            .wrap(Wrap { trim: false })
-            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
-
-        let margin = Margin::all(1);
-        par.render(area.inner(margin), surface);
-    }
-
-    fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
-        let padding = 2;
-
-        let max_text_width = (viewport.0.saturating_sub(padding)).min(120);
-        let (width, height) = crate::ui::text::required_size(&self.text, max_text_width);
-
-        Some((width + padding, height + padding))
-    }
-}
-
 // TODO: pre-render and self reference via Pin
 // better yet, just use Tendril + subtendril for references
 

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -5,7 +5,7 @@ use tui::{
     text::{Span, Spans, Text},
 };
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 
@@ -124,6 +124,45 @@ pub struct Markdown {
     contents: String,
 
     config_loader: Arc<ArcSwap<syntax::Loader>>,
+}
+
+pub struct StyledText {
+    text: tui::text::Text<'static>,
+}
+
+impl StyledText {
+    pub fn new(contents: String, style: Style) -> Self {
+        let spans: Vec<Spans<'static>> = contents
+            .lines()
+            .map(|line| Spans::from(vec![Span::styled(Cow::Owned(line.to_string()), style)]))
+            .collect();
+
+        let text = Text::from(spans);
+
+        Self { text }
+    }
+}
+
+impl Component for StyledText {
+    fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        use tui::widgets::{Paragraph, Widget, Wrap};
+
+        let par = Paragraph::new(&self.text)
+            .wrap(Wrap { trim: false })
+            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
+
+        let margin = Margin::all(1);
+        par.render(area.inner(margin), surface);
+    }
+
+    fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
+        let padding = 2;
+
+        let max_text_width = (viewport.0.saturating_sub(padding)).min(120);
+        let (width, height) = crate::ui::text::required_size(&self.text, max_text_width);
+
+        Some((width + padding, height + padding))
+    }
 }
 
 // TODO: pre-render and self reference via Pin


### PR DESCRIPTION
When a status error message is too long, output it into the log file.

This is needed because sometimes it can be hard to read the error message