### PR TITLE
docs: remove mention that `-` requires special handling

### DIFF
--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -94,7 +94,6 @@ Special keys are encoded as follows:
 | Backspace    | `"backspace"`  |
 | Space        | `"space"`      |
 | Return/Enter | `"ret"`        |
-| \-           | `"minus"`      |
 | Left         | `"left"`       |
 | Right        | `"right"`      |
 | Up           | `"up"`         |
@@ -110,3 +109,12 @@ Special keys are encoded as follows:
 | Escape       | `"esc"`        |
 
 Keys can be disabled by binding them to the `no_op` command.
+
+All other keys such as `?`, `!`, `-` etc. can be used literally:
+
+```toml
+[keys.normal]
+"?" = ":write"
+"!" = ":write"
+"-" = ":write"
+```

--- a/book/src/remapping.md
+++ b/book/src/remapping.md
@@ -118,3 +118,5 @@ All other keys such as `?`, `!`, `-` etc. can be used literally:
 "!" = ":write"
 "-" = ":write"
 ```
+
+Note: `-` can't be used when combined with a modifier, for example `Alt` + `-` should be written as `A-minus`. `A--` is not accepted.


### PR DESCRIPTION
Since https://github.com/helix-editor/helix/pull/12191 you no longer need to use `minus`.

Also, I've added a mention that all other keys can be used literally. This is something that I personally didn't get initially as i assumed that keys like `!` require e.g. `exclam` or something like that