### PR TITLE
Add ltex-ls-plus language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -56,6 +56,7 @@ koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
 kotlin-language-server = { command = "kotlin-language-server" }
 lean = { command = "lean", args = [ "--server", "--memory=1024" ] }
 ltex-ls = { command = "ltex-ls" }
+ltex-ls-plus = { command = "ltex-ls-plus" }
 markdoc-ls = { command = "markdoc-ls", args = ["--stdio"] }
 markdown-oxide = { command = "markdown-oxide" }
 marksman = { command = "marksman", args = ["server"] }


### PR DESCRIPTION
There is a new fork of `ltex-ls` that looks like it will become the new version as the old seems unmaintained for a long time now, I am not sure if I should delete the old `ltex-ls` or wait?

https://github.com/ltex-plus/ltex-ls-plus
https://github.com/ltex-plus/ltex-ls-plus/releases

Neovim just added it: https://github.com/neovim/nvim-lspconfig/pull/3442