### PR TITLE
feat: wrap selection in tag & wrap selection in function call

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5764,7 +5764,7 @@ fn surround_add(cx: &mut Context) {
                 surround_add_impl(doc, view, length, open, close);
                 exit_select_mode(cx);
             }
-            None => return,
+            None => (),
         };
     })
 }


### PR DESCRIPTION
This PR adds 2 new keys under "Add Surrounding". Now you can use:
- `msx`: Wrap selection with a tag
- `msf`: Wrap selection with a function call

Both of those commands bring up a prompt to allow you to input what you want.

In the examples below, the whole word is selected and we input `div`.

### Before

```
textContent
```

### `msx` -- Surround selection with tag

```
<div>textContent</div>
``` 

### `msf` -- Surround selection with function call

```
div(textContent)
```

---

It implements some functionality from https://github.com/helix-editor/helix/pull/12055 because implementing "delete surrounding tag", "change surrounding tag" is more complicated

I think that wrapping selection in a tag and a function is a pretty useful feature to have, this doesn't add to many lines of code so I think it's worth adding it here.

A different PR could implement "delete surrounding function" and "change surrounding function" *if necessary*.