### PR TITLE
language: add comment token for java files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1183,6 +1183,7 @@ file-types = ["java", "jav", "pde"]
 roots = ["pom.xml", "build.gradle", "build.gradle.kts"]
 language-servers = [ "jdtls" ]
 indent = { tab-width = 2, unit = "  " }
+comment-token = "//"
 
 [[grammar]]
 name = "java"


### PR DESCRIPTION
Was introduced from https://github.com/helix-editor/helix/pull/12080 since the default comment got changed.
Fixes https://github.com/helix-editor/helix/issues/12265