### PR TITLE
Update dark_plus theme for inactive text and improve jump label

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -73,11 +73,12 @@
 "ui.text"                    = { fg = "text" }
 "ui.text.focus"              = { fg = "white" }
 "ui.text.directory"          = { fg = "blue3" }
+"ui.text.inactive"           = { fg = "dark_gray" }
 "ui.virtual.whitespace"      = { fg = "#3e3e3d" }
 "ui.virtual.ruler"           = { bg = "borders" }
 "ui.virtual.indent-guide"    = { fg = "dark_gray4" }
 "ui.virtual.inlay-hint"      = { fg = "dark_gray5"}
-"ui.virtual.jump-label"      = { fg = "dark_gray", modifiers = ["bold"] }
+"ui.virtual.jump-label"      = { fg = "yellow", modifiers = ["bold"] }
 "ui.highlight.frameline"     = { bg = "#4b4b18" }
 "ui.debug.active"            = { fg = "#ffcc00" }
 "ui.debug.breakpoint"        = { fg = "#e51400" }


### PR DESCRIPTION
After a @the-mikedavis [comment](https://github.com/helix-editor/helix/discussions/12279#discussioncomment-11600337) I was horrified to learn `dark_plus` had no inactive text theme. I added that and improved the jump label. Before it was set to a background colour when it wants to _jump_ out more, like other themes.

![image](https://github.com/user-attachments/assets/e68ac946-280a-4e81-b836-97afb2de066a)

![image](https://github.com/user-attachments/assets/0e507d23-fdc4-41c4-8f8b-43914fd131d6)

![image](https://github.com/user-attachments/assets/dd013649-fb5c-4512-ac76-004eb72f361d)
