### PR TITLE
chore: Update slint tree-sitter grammar to version 1.9

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2471,7 +2471,7 @@ language-servers = [ "slint-lsp" ]
 
 [[grammar]]
 name = "slint"
-source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "34ccfd58d3baee7636f62d9326f32092264e8407" }
+source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "f11da7e62051ba8b9d4faa299c26de8aeedfc1cd" }
 
 [[language]]
 name = "task"


### PR DESCRIPTION
Bump the commit to the tree-sitter corresponding to the latest Slint release.