### PR TITLE
Add :pipe-all command that pipes entire document and ignores shell output

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -280,6 +280,7 @@
 | `dap_disable_exceptions` | Disable exception breakpoints | normal: `` <space>GE ``, select: `` <space>GE `` |
 | `shell_pipe` | Pipe selections through shell command | normal: `` \| ``, select: `` \| `` |
 | `shell_pipe_to` | Pipe selections into shell command ignoring output | normal: `` <A-\|> ``, select: `` <A-\|> `` |
+| `shell_pipe_all` | Pipe entire document into shell command ignoring output. |  |
 | `shell_insert_output` | Insert shell command output before selections | normal: `` ! ``, select: `` ! `` |
 | `shell_append_output` | Append shell command output after selections | normal: `` <A-!> ``, select: `` <A-!> `` |
 | `shell_keep_pipe` | Filter selections with shell predicate | normal: `` $ ``, select: `` $ `` |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -81,6 +81,7 @@
 | `:append-output` | Run shell command, appending output after each selection. |
 | `:pipe` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
+| `:pipe-all` | Pipe entire document to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh` | Run a shell command |
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -573,6 +573,7 @@ impl MappableCommand {
         dap_disable_exceptions, "Disable exception breakpoints",
         shell_pipe, "Pipe selections through shell command",
         shell_pipe_to, "Pipe selections into shell command ignoring output",
+        shell_pipe_all, "Pipe entire document into shell command ignoring output.",
         shell_insert_output, "Insert shell command output before selections",
         shell_append_output, "Append shell command output after selections",
         shell_keep_pipe, "Filter selections with shell predicate",
@@ -5857,6 +5858,10 @@ fn shell_pipe(cx: &mut Context) {
 
 fn shell_pipe_to(cx: &mut Context) {
     shell_prompt(cx, "pipe-to:".into(), ShellBehavior::Ignore);
+}
+
+fn shell_pipe_all(cx: &mut Context) {
+    shell_prompt(cx, "pipe-all:".into(), ShellBehavior::Ignore);
 }
 
 fn shell_insert_output(cx: &mut Context) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2290,6 +2290,28 @@ fn pipe_impl(
     Ok(())
 }
 
+fn pipe_all(
+    cx: &mut compositor::Context,
+    args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(!args.is_empty(), "Shell command required");
+    let cmd = args.join(" ");
+
+    let shell = &cx.editor.config().shell;
+    let text = current!(cx.editor).1.text().slice(..);
+
+    if let Err(err) = shell_impl(shell, &cmd, Some(text.into())) {
+        cx.editor.set_error(err.to_string());
+    }
+
+    Ok(())
+}
+
 fn run_shell_command(
     cx: &mut compositor::Context,
     args: &[Cow<str>],
@@ -3099,6 +3121,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Pipe each selection to the shell command, ignoring output.",
         fun: pipe_to,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "pipe-all",
+        aliases: &[],
+        doc: "Pipe entire document to the shell command, ignoring output.",
+        fun: pipe_all,
         signature: CommandSignature::none(),
     },
     TypableCommand {


### PR DESCRIPTION
With the addition of the hopefully soon to be merged [command expansion][expansion], we can call shell commands, passing them the current file name, line, and column numbers. In combination with the amazing [shell piping commands][commands] this would allow building tools like GitHub Copilot and Copilot Chat, that can insert, replace or describe code based on the entire file context.

I did not find a way to make the current content of the unsaved buffer available to such a program though, which kind of defeats the purpose of passing line and column numbers to shell commands.

My suggestion is this:

Add a :pipe-all command that acts like the :pipe-to command but pipes the entire buffer contents to the shell command.

[expansion]: https://github.com/helix-editor/helix/pull/11164
[commands]: https://github.com/alxshine/helix/blob/89c13e66aef4afe9a90ba8705b25c4e95daf8b5a/book/src/generated/typable-cmd.md?plain=1#L71
