### PR TITLE
Add diff injections for jjdescription tree-sitter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3319,7 +3319,7 @@ text-width = 72
 
 [[grammar]]
 name = "jjdescription"
-source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "23dd3dd18ee29bdd761642511aa314215801afd8" }
+source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "d09205b52b5a0165b588a793e366c1116468d86f" }
 
 [[language]]
 name = "jq"

--- a/runtime/queries/jjdescription/injections.scm
+++ b/runtime/queries/jjdescription/injections.scm
@@ -1,0 +1,3 @@
+(((scissors_inner) @injection.content)
+ (#set! injection.include-children)
+ (#set! injection.language "diff"))


### PR DESCRIPTION
https://github.com/jj-vcs/jj/pull/5155

https://github.com/kareigu/tree-sitter-jjdescription/pull/2

Contingent on both of the above landing.

Unsure where these should live. `git-commit` has them in the helix repo, and not the tree-sitter repo. It looks like they need to be inlined into helix to be used in helix (by default), unsure if other projects would benefit from having them in the tree-sitter repo.