### PR TITLE
Document diagnostic severity levels

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -442,6 +442,8 @@ fn main() {
 | `max-wrap` | Equivalent of the `editor.soft-wrap.max-wrap` option for diagnostics.  | `20` |
 | `max-diagnostics` | Maximum number of diagnostics to render inline for a given line  | `10` |
 
+The allowed values for `cursor-line` and `other-lines` are: `error`, `warning`, `info`, `hint`.
+
 The (first) diagnostic with the highest severity that is not shown inline is rendered at the end of the line (as long as its severity is higher than the `end-of-line-diagnostics` config option):
 
 ```

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -60,7 +60,7 @@ These configuration keys are available:
 | `shebangs`            | The interpreters from the shebang line, for example `["sh", "bash"]` |
 | `roots`               | A set of marker files to look for when trying to find the workspace root. For example `Cargo.lock`, `yarn.lock` |
 | `auto-format`         | Whether to autoformat this language when saving               |
-| `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `Error`, `Warning`, `Info`, `Hint`) |
+| `diagnostic-severity` | Minimal severity of diagnostic for it to be displayed. (Allowed values: `error`, `warning`, `info`, `hint`) |
 | `comment-tokens`      | The tokens to use as a comment token, either a single token `"//"` or an array `["//", "///", "//!"]` (the first token will be used for commenting). Also configurable as `comment-token` for backwards compatibility|
 | `block-comment-tokens`| The start and end tokens for a multiline comment either an array or single table of `{ start = "/*", end = "*/"}`. The first set of tokens will be used for commenting, any pairs in the array can be uncommented |
 | `indent`              | The indent to use. Has sub keys `unit` (the text inserted into the document when indenting; usually set to N spaces or `"\t"` for tabs) and `tab-width` (the number of spaces rendered for a tab) |


### PR DESCRIPTION
Closes #11592. Use the correct spelling without the first letter as uppercase Specify which values are accepted for diagnostic severity.

Following mike's [recommendation](https://github.com/helix-editor/helix/issues/11592#issuecomment-2323369457)