### PR TITLE
Add Koto language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -115,6 +115,7 @@
 | kdl | ✓ | ✓ | ✓ |  |
 | koka | ✓ |  | ✓ | `koka` |
 | kotlin | ✓ |  |  | `kotlin-language-server` |
+| koto | ✓ | ✓ | ✓ | `koto-ls` |
 | latex | ✓ | ✓ |  | `texlab` |
 | ld | ✓ |  | ✓ |  |
 | ldif | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -53,6 +53,7 @@ jq-lsp = { command = "jq-lsp" }
 jsonnet-language-server = { command = "jsonnet-language-server", args= ["-t", "--lint"] }
 julia = { command = "julia", timeout = 60, args = [ "--startup-file=no", "--history-file=no", "--quiet", "-e", "using LanguageServer; runserver()", ] }
 koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
+koto-ls = { command = "koto-ls" }
 kotlin-language-server = { command = "kotlin-language-server" }
 lean = { command = "lean", args = [ "--server", "--memory=1024" ] }
 ltex-ls = { command = "ltex-ls" }
@@ -3964,6 +3965,20 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "amber"
 source = { git = "https://github.com/amber-lang/tree-sitter-amber", rev = "c6df3ec2ec243ed76550c525e7ac3d9a10c6c814" }
+
+[[language]]
+name = "koto"
+scope = "source.koto"
+injection-regex = "koto"
+file-types = ["koto"]
+comment-token = "#"
+block-comment-tokens = ["#-", "-#"]
+indent = { tab-width = 2, unit = "  " }
+language-servers = ["koto-ls"]
+
+[[grammar]]
+name = "koto"
+source = { git = "https://github.com/koto-lang/tree-sitter-koto", rev = "b420f7922d0d74905fd0d771e5b83be9ee8a8a9a" }
 
 [[language]]
 name = "gpr"

--- a/runtime/queries/koto/folds.scm
+++ b/runtime/queries/koto/folds.scm
@@ -1,0 +1,9 @@
+[
+  (assign)
+  (comment)
+  (function)
+  (list)
+  (map)
+  (tuple)
+  (string)
+] @fold

--- a/runtime/queries/koto/highlights.scm
+++ b/runtime/queries/koto/highlights.scm
@@ -1,0 +1,152 @@
+[
+  "="
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "=="
+  "!="
+  "<"
+  ">"
+  "<="
+  ">="
+  ".."
+  "..="
+  "->"
+  (null_check)
+] @operator
+
+[
+  "let"
+] @keyword
+
+[
+  "and"
+  "not"
+  "or"
+] @keyword.operator
+
+[
+  "return"
+  "yield"
+] @keyword.return
+
+[
+  "if"
+  "then"
+  "else"
+  "else if"
+  "match"
+  "switch"
+] @keyword.conditional
+
+[
+  (break)
+  (continue)
+  "for"
+  "in"
+  "loop"
+  "until"
+  "while"
+] @keyword.repeat
+
+[
+  "throw"
+  "try"
+  "catch"
+  "finally"
+] @keyword.exception
+
+[
+  "export"
+  "from"
+  "import"
+  "as"
+] @keyword.import
+
+(string (interpolation ("{") @punctuation.special))
+(string (interpolation ("}") @punctuation.special))
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "|"
+] @punctuation.bracket
+
+[
+  ";"
+  ":"
+  ","
+] @punctuation.delimiter
+
+(import_module
+  (identifier) @module)
+
+(import_item
+  (identifier) @module)
+
+(export
+  (identifier) @module)
+
+(call
+  function: (identifier) @function.method)
+
+(chain
+  lookup: (identifier) @variable.other.member)
+
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+(comment) @comment
+
+(debug) @keyword.debug
+
+(string) @string
+
+(fill_char) @punctuation.delimiter
+
+(alignment) @operator
+
+(escape) @constant.character.escape
+
+(null) @constant.builtin
+
+(number) @constant.numeric
+
+(meta) @keyword.directive
+
+(meta
+  name: (identifier) @variable.other.member)
+
+(entry_inline
+  key: (identifier) @variable.other.member)
+
+(entry_block
+  key: (identifier) @variable.other.member)
+
+(self) @variable.builtin
+
+(variable
+  type: (identifier) @type)
+
+(arg
+  (_ (identifier) @variable.parameter))
+
+(ellipsis) @variable.parameter
+
+(function
+  output_type: (identifier) @type)
+
+(identifier) @variable

--- a/runtime/queries/koto/highlights.scm
+++ b/runtime/queries/koto/highlights.scm
@@ -35,7 +35,7 @@
 [
   "return"
   "yield"
-] @keyword.return
+] @keyword.control.return
 
 [
   "if"
@@ -44,7 +44,7 @@
   "else if"
   "match"
   "switch"
-] @keyword.conditional
+] @keyword.control.conditional
 
 [
   (break)
@@ -54,21 +54,21 @@
   "loop"
   "until"
   "while"
-] @keyword.repeat
+] @keyword.control.repeat
 
 [
   "throw"
   "try"
   "catch"
   "finally"
-] @keyword.exception
+] @keyword.control.exception
 
 [
   "export"
   "from"
   "import"
   "as"
-] @keyword.import
+] @keyword.control.import
 
 (string (interpolation ("{") @punctuation.special))
 (string (interpolation ("}") @punctuation.special))
@@ -111,7 +111,7 @@
 
 (comment) @comment
 
-(debug) @keyword.debug
+(debug) @keyword
 
 (string) @string
 

--- a/runtime/queries/koto/indents.scm
+++ b/runtime/queries/koto/indents.scm
@@ -1,0 +1,61 @@
+[
+  (list)
+  (map)
+  (tuple)
+] @indent
+
+[
+  (for)
+  (else_if)
+  (else)
+  (match)
+  (switch)
+  (until)
+  (while)
+] @indent @extend
+
+(assign
+  "=" @indent @extend
+  !rhs
+)
+(assign
+  "=" @indent @extend
+  rhs: (_) @anchor
+  (#not-same-line? @indent @anchor)
+)
+
+(if
+  condition: (_) @indent @extend
+  !then
+)
+(if
+  condition: (_) @indent @extend
+  then: (_) @anchor
+  (#not-same-line? @indent @anchor)
+)
+
+(function
+  (args) @indent @extend
+  !body
+)
+(function
+  (args) @indent @extend
+  body: (_) @anchor
+  (#not-same-line? @indent @anchor)
+)
+
+(match_arm
+  "then" @indent @extend
+  !then
+)
+(match_arm
+  "then" @indent @extend
+  then: (_) @anchor
+  (#not-same-line? @indent @anchor)
+)
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent

--- a/runtime/queries/koto/injections.scm
+++ b/runtime/queries/koto/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/koto/locals.scm
+++ b/runtime/queries/koto/locals.scm
@@ -6,25 +6,25 @@
 
 ; Definitions
 (assign
-  lhs: (identifier) @local.definition.var)
+  lhs: (identifier) @local.definition)
 
 (variable
-  (identifier) @local.definition.var)
+  (identifier) @local.definition)
 
 (arg
-  (identifier) @local.definition.parameter)
+  (identifier) @local.definition)
 
 (arg
-  (variable (identifier)) @local.definition.parameter)
+  (variable (identifier)) @local.definition)
 
 (import_item
-  (identifier) @local.definition.import)
+  (identifier) @local.definition)
 
 (entry_block
-  (identifier) @local.definition.field)
+  (identifier) @local.definition)
 
 (entry_inline
-  (identifier) @local.definition.field)
+  (identifier) @local.definition)
 
 ; References
 (identifier) @local.reference

--- a/runtime/queries/koto/locals.scm
+++ b/runtime/queries/koto/locals.scm
@@ -1,0 +1,30 @@
+; Scopes
+(module (_) @local.scope)
+
+(function
+  body: (_) @local.scope)
+
+; Definitions
+(assign
+  lhs: (identifier) @local.definition.var)
+
+(variable
+  (identifier) @local.definition.var)
+
+(arg
+  (identifier) @local.definition.parameter)
+
+(arg
+  (variable (identifier)) @local.definition.parameter)
+
+(import_item
+  (identifier) @local.definition.import)
+
+(entry_block
+  (identifier) @local.definition.field)
+
+(entry_inline
+  (identifier) @local.definition.field)
+
+; References
+(identifier) @local.reference

--- a/runtime/queries/koto/textobjects.scm
+++ b/runtime/queries/koto/textobjects.scm
@@ -1,0 +1,38 @@
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(args
+  ((arg) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(call_args
+  ((call_arg) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(chain
+  call: (tuple
+    ((element) @parameter.inside . ","? @parameter.around) @parameter.around))
+
+(map
+  ((entry_inline) @entry.inside . ","? @entry.around) @entry.around)
+
+(map_block
+  ((entry_block) @entry.inside) @entry.around)
+
+(list
+  ((element) @entry.inside . ","? @entry.around) @entry.around)
+
+(tuple
+  (_) @entry.around)
+
+(assign
+  (meta (test))
+  (function body: (_) @test.inside)
+) @test.around
+
+(entry_block
+  key: (meta (test))
+  value: (function body: (_) @test.inside)
+) @test.around


### PR DESCRIPTION
This PR adds support for the [Koto](https://koto.dev) language, making use [tree-sitter-koto](https://github.com/koto-lang/tree-sitter-koto) and [koto-ls](https://github.com/koto-lang/koto-ls).
