### PR TITLE
feat(themes): add `ui.text.directory` to nightfox

### DIFF
--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -12,6 +12,7 @@
 "ui.gutter" = { fg = "fg3" } # Left gutter for diagnostics and breakpoints.
 
 "ui.text" = { fg = "fg1" } # Default text color.
+"ui.text.directory" = { fg = "blue-bright" } # Directory names in prompt completion.
 "ui.text.focus" = { bg = "sel1", fg = "fg1" } # Selection highlight in buffer-picker or file-picker.
 "ui.text.info" = { fg = "fg2", bg = "sel0" } # Info popup contents (space mode menu).
 


### PR DESCRIPTION
Applies the same text foreground color as nightfox.nvim over directory names (references: [1](https://github.com/EdenEast/nightfox.nvim/blob/7557f26defd093c4e9bc17f28b08403f706f5a44/lua/nightfox/group/editor.lua#L18), [2](https://github.com/EdenEast/nightfox.nvim/blob/7557f26defd093c4e9bc17f28b08403f706f5a44/lua/nightfox/palette/nightfox.lua#L68)).

Current:
![nightfox-ui-text-directory-current](https://github.com/user-attachments/assets/cbd527ac-9adb-4a64-a5b9-5189b25fbfd1)

Updated:
![nightfox-ui-text-directory-updated](https://github.com/user-attachments/assets/1fd51c68-9f32-414d-a856-537158344bb5)