### PR TITLE
Make git revision available for nix flake builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,8 @@
               cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
               installShellCompletion contrib/completion/hx.{bash,fish,zsh}
             '';
+            # set git revision for nix flake builds, see 'git_hash' in helix-loader/build.rs
+            HELIX_NIX_BUILD_REV = self.rev or self.dirtyRev or null;
           });
         helix = makeOverridableHelix self.packages.${system}.helix-unwrapped {};
         default = self.packages.${system}.helix;

--- a/helix-loader/build.rs
+++ b/helix-loader/build.rs
@@ -20,7 +20,8 @@ fn main() {
         .output()
         .ok()
         .filter(|output| output.status.success())
-        .and_then(|x| String::from_utf8(x.stdout).ok());
+        .and_then(|x| String::from_utf8(x.stdout).ok())
+        .or_else(|| option_env!("HELIX_NIX_BUILD_REV").map(|s| s.to_string()));
 
     let calver = get_calver();
     let version: Cow<_> = match &git_hash {


### PR DESCRIPTION
Sets new `HELIX_NIX_BUILD_REV` in nix flake builds, with value inserted if `git rev-parse HEAD` fails.

Discussed previously here: https://github.com/helix-editor/helix/issues/1700 (I guess back then neither `self.rev` nor `self.dirtyRev` were available.)