### PR TITLE
docs: Mention sudo in macports installation snippet

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -121,7 +121,7 @@ brew install helix
 ### MacPorts
 
 ```sh
-port install helix
+sudo port install helix
 ```
 
 ## Windows


### PR DESCRIPTION
macports requires SUDO to install things.

![Screen Shot 2024-12-25 at 3 16 45 AM](https://github.com/user-attachments/assets/c7eacef9-728b-4800-a72f-890a925f5aad)
![Screen Shot 2024-12-25 at 3 17 10 AM](https://github.com/user-attachments/assets/7d8bf04e-9df7-435e-9c15-d6f03847b892)
