### PR TITLE
Detect and respond to terminal theme mode (light/dark) updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,11 +239,11 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crossterm"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+source = "git+https://github.com/the-mikedavis/crossterm?branch=md/theme-mode#dd0ae541da4b54f35eb93a29cd717f0e32d2ed77"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "document-features",
  "filedescriptor",
  "futures-core",
  "libc",
@@ -287,6 +287,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1865,6 +1874,12 @@ name = "litemap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ nucleo = "0.5.0"
 slotmap = "1.0.7"
 thiserror = "2.0"
 
+[patch.crates-io]
+crossterm = { git = "https://github.com/the-mikedavis/crossterm", branch = "md/theme-mode" }
+
 [workspace.package]
 version = "24.7.0"
 edition = "2021"

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,7 +1,7 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
 use helix_loader::merge_toml_values;
-use helix_view::document::Mode;
+use helix_view::{document::Mode, theme};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -11,7 +11,7 @@ use toml::de::Error as TomlError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: HashMap<Mode, KeyTrie>,
     pub editor: helix_view::editor::Config,
 }
@@ -19,7 +19,7 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigRaw {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: Option<HashMap<Mode, KeyTrie>>,
     pub editor: Option<toml::Value>,
 }

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -2,7 +2,10 @@ use std::io;
 
 use crate::{buffer::Cell, terminal::Config};
 
-use helix_view::graphics::{CursorKind, Rect};
+use helix_view::{
+    graphics::{CursorKind, Rect},
+    theme,
+};
 
 #[cfg(feature = "crossterm")]
 mod crossterm;
@@ -27,4 +30,5 @@ pub trait Backend {
     fn clear(&mut self) -> Result<(), io::Error>;
     fn size(&self) -> Result<Rect, io::Error>;
     fn flush(&mut self) -> Result<(), io::Error>;
+    fn get_theme_mode(&self) -> Option<theme::Mode>;
 }

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -164,4 +164,8 @@ impl Backend for TestBackend {
     fn flush(&mut self) -> Result<(), io::Error> {
         Ok(())
     }
+
+    fn get_theme_mode(&self) -> Option<helix_view::theme::Mode> {
+        None
+    }
 }

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -5,6 +5,7 @@ use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 
 pub use crate::keyboard::{KeyCode, KeyModifiers, MediaKeyCode, ModifierKeyCode};
+use crate::theme;
 
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 pub enum Event {
@@ -14,6 +15,7 @@ pub enum Event {
     Mouse(MouseEvent),
     Paste(String),
     Resize(u16, u16),
+    ThemeModeChanged(theme::Mode),
     IdleTimeout,
 }
 
@@ -468,6 +470,12 @@ impl From<crossterm::event::Event> for Event {
             crossterm::event::Event::FocusGained => Self::FocusGained,
             crossterm::event::Event::FocusLost => Self::FocusLost,
             crossterm::event::Event::Paste(s) => Self::Paste(s),
+            crossterm::event::Event::ThemeModeChanged(theme_mode) => {
+                Self::ThemeModeChanged(match theme_mode {
+                    crossterm::event::ThemeMode::Light => theme::Mode::Light,
+                    crossterm::event::ThemeMode::Dark => theme::Mode::Dark,
+                })
+            }
         }
     }
 }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -35,6 +35,50 @@ pub static BASE16_DEFAULT_THEME: Lazy<Theme> = Lazy::new(|| Theme {
     ..Theme::from(BASE16_DEFAULT_THEME_DATA.clone())
 });
 
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum Mode {
+    Light,
+    Dark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    light: String,
+    dark: String,
+}
+
+impl Config {
+    pub fn choose(&self, preference: Option<Mode>) -> &str {
+        match preference {
+            Some(Mode::Light) => &self.light,
+            Some(Mode::Dark) | None => &self.dark,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged, deny_unknown_fields)]
+        enum InnerConfig {
+            Constant(String),
+            Adaptive { dark: String, light: String },
+        }
+
+        let inner = InnerConfig::deserialize(deserializer)?;
+
+        let (light, dark) = match inner {
+            InnerConfig::Constant(theme) => (theme.clone(), theme),
+            InnerConfig::Adaptive { light, dark } => (light, dark),
+        };
+
+        Ok(Self { light, dark })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Loader {
     /// Theme directories to search from highest to lowest priority


### PR DESCRIPTION
https://github.com/user-attachments/assets/401ce15e-1a74-41a5-b4ad-635cb5b9dddc

Closes https://github.com/helix-editor/helix/issues/8899, https://github.com/helix-editor/helix/discussions/10281

Historically we haven't wanted to add this because querying OS theme preference required bringing in a bunch of platform-specific deps. A relatively recent [VT extension](https://github.com/contour-terminal/contour/blob/master/docs/vt-extensions/color-palette-update-notifications.md) originally proposed by the Contour terminal emulator though lets us query for the terminal's theme mode and receive updates when that changes. This can all be covered cleanly in `crossterm` with no extra deps. That extension seems to be gaining some steam with Ghostty and Kitty now supporting it on the terminal emulator side and neovim on the client side.

Theme config accepts an optional, extended form (like in https://github.com/helix-editor/helix/pull/12098):

```toml
# this is still accepted:
# theme = "ayu_dark"
theme = { dark = "ayu_dark", light = "ayu_light" }
```

On startup we query the current theme mode and subscribe to future changes, swapping when we receive an update.

On the terminal emulator side this needs a bit of setup. The latest Kitty version (v0.38.1) supports this but you also need to follow https://sw.kovidgoyal.net/kitty/kittens/themes/#change-color-themes-automatically-when-the-os-switches-between-light-and-dark

This PR needs changes upstream in crossterm - I have a branch https://github.com/the-mikedavis/crossterm/tree/md/theme-mode that I will turn into a PR.