### PR TITLE
feat: add diagnostic marker

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -532,6 +532,7 @@ impl<'a> TextRenderer<'a> {
         style: impl Fn(usize) -> Style, // Map a grapheme's string offset to a style
         ellipsis: bool,
         truncate_start: bool,
+        prefix: Option<char>,
     ) -> (u16, u16) {
         if (y as usize) < self.offset.row {
             return (x, y);
@@ -544,6 +545,7 @@ impl<'a> TextRenderer<'a> {
             style,
             ellipsis,
             truncate_start,
+            prefix,
         )
     }
 }

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -110,7 +110,7 @@ impl Renderer<'_, '_> {
             (end_col, _) = self.renderer.set_string_truncated(
                 self.renderer.viewport.x + draw_col,
                 row,
-                line,
+                format!("{} {}", self.config.diagnostic_marker, line).as_str(),
                 width.saturating_sub(draw_col) as usize,
                 |_| style,
                 true,

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -101,6 +101,11 @@ impl Renderer<'_, '_> {
         let start_col = (col - self.renderer.offset.col) as u16;
         let mut end_col = start_col;
         let mut draw_col = (col + 1) as u16;
+        let prefix = if self.config.diagnostic_marker.len_utf8() > 0 {
+            Some(self.config.diagnostic_marker)
+        } else {
+            None
+        };
 
         for line in diag.message.lines() {
             if !self.renderer.column_in_bounds(draw_col as usize, 1) {
@@ -110,11 +115,12 @@ impl Renderer<'_, '_> {
             (end_col, _) = self.renderer.set_string_truncated(
                 self.renderer.viewport.x + draw_col,
                 row,
-                format!("{} {}", self.config.diagnostic_marker, line).as_str(),
+                line,
                 width.saturating_sub(draw_col) as usize,
                 |_| style,
                 true,
                 false,
+                prefix,
             );
 
             draw_col = end_col - self.renderer.viewport.x + 2; // double space between lines

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -57,6 +57,7 @@ pub struct InlineDiagnosticsConfig {
     pub prefix_len: u16,
     pub max_wrap: u16,
     pub max_diagnostics: usize,
+    pub diagnostic_marker: char,
 }
 
 impl InlineDiagnosticsConfig {
@@ -115,6 +116,7 @@ impl Default for InlineDiagnosticsConfig {
             prefix_len: 1,
             max_wrap: 20,
             max_diagnostics: 10,
+            diagnostic_marker: '●',
         }
     }
 }


### PR DESCRIPTION
Related to #11864

Add a configurable marker (● by default) to separate between the line and the **end of line** diagnostic decoration.

![image](https://github.com/user-attachments/assets/0f7bc504-be81-44a5-9938-e661da6b211f)

The default is the same as the gutter symbol, maybe it should be changed, but I have seen another PR about changing the gutter, so let me know what you think!