### PR TITLE
Update hyprland langugauge file type.

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3610,7 +3610,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-ld", rev = "0e9695ae0
 name = "hyprlang"
 scope = "source.hyprlang"
 roots = ["hyprland.conf"]
-file-types = [ { glob = "hyprland.conf" }, { glob = "hyprpaper.conf" }, { glob = "hypridle.conf" }, { glob = "hyprlock.conf" } ]
+file-types = [ { glob = "hypr/*.conf" }]
 comment-token = "#"
 grammar = "hyprlang"
 language-servers = ["hyprls"]


### PR DESCRIPTION
Previously it was hardcoded to some files, this change will make all hypr/*.conf to use hyprlang. 