### PR TITLE
perf: cache `Document`s relative path

### DIFF
--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -38,7 +38,6 @@ where
 ///
 /// The tilde will only be expanded when present as the first component of the path
 /// and only slash follows it.
-#[inline]
 pub fn expand_tilde<'a, P>(path: P) -> Cow<'a, Path>
 where
     P: Into<Cow<'a, Path>>,
@@ -60,7 +59,6 @@ where
 /// Normalize a path without resolving symlinks.
 // Strategy: start from the first component and move up. Canonicalize previous path,
 // join component, canonicalize new path, strip prefix and join to the final result.
-#[inline]
 pub fn normalize(path: impl AsRef<Path>) -> PathBuf {
     let mut components = path.as_ref().components().peekable();
     let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().copied() {
@@ -132,7 +130,6 @@ pub fn normalize(path: impl AsRef<Path>) -> PathBuf {
 ///
 /// This function is used instead of [`std::fs::canonicalize`] because we don't want to verify
 /// here if the path exists, just normalize it's components.
-#[inline]
 pub fn canonicalize(path: impl AsRef<Path>) -> PathBuf {
     let path = expand_tilde(path.as_ref());
     let path = if path.is_relative() {
@@ -144,7 +141,6 @@ pub fn canonicalize(path: impl AsRef<Path>) -> PathBuf {
     normalize(path)
 }
 
-#[inline]
 pub fn get_relative_path<'a, P>(path: P) -> Cow<'a, Path>
 where
     P: Into<Cow<'a, Path>>,
@@ -218,7 +214,7 @@ fn path_component_regex(windows: bool) -> String {
     // TODO: support backslash path escape on windows (when using git bash for example)
     let space_escape = if windows { r"[\^`]\s" } else { r"[\\]\s" };
     // partially baesd on what's allowed in an url but with some care to avoid
-    // false positivies (like any kind of brackets or quotes)
+    // false positives (like any kind of brackets or quotes)
     r"[\w@.\-+#$%?!,;~&]|".to_owned() + space_escape
 }
 

--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -14,7 +14,6 @@ use crate::env::current_working_dir;
 
 /// Replaces users home directory from `path` with tilde `~` if the directory
 /// is available, otherwise returns the path unchanged.
-#[inline]
 pub fn fold_home_dir<'a, P>(path: P) -> Cow<'a, Path>
 where
     P: Into<Cow<'a, Path>>,
@@ -187,7 +186,6 @@ where
 ///     assert_eq!(get_truncated_path("").as_path(), Path::new(""));
 /// ```
 ///
-#[inline]
 pub fn get_truncated_path(path: impl AsRef<Path>) -> PathBuf {
     let cwd = current_working_dir();
     let path = path.as_ref();
@@ -209,7 +207,6 @@ pub fn get_truncated_path(path: impl AsRef<Path>) -> PathBuf {
     ret
 }
 
-#[inline]
 fn path_component_regex(windows: bool) -> String {
     // TODO: support backslash path escape on windows (when using git bash for example)
     let space_escape = if windows { r"[\^`]\s" } else { r"[\\]\s" };
@@ -219,12 +216,10 @@ fn path_component_regex(windows: bool) -> String {
 }
 
 /// Regex for delimited environment captures like `${HOME}`.
-#[inline]
 fn braced_env_regex(windows: bool) -> String {
     r"\$\{(?:".to_owned() + &path_component_regex(windows) + r"|[/:=])+\}"
 }
 
-#[inline]
 fn compile_path_regex(
     prefix: &str,
     postfix: &str,
@@ -263,7 +258,6 @@ fn compile_path_regex(
 }
 
 /// If `src` ends with a path then this function returns the part of the slice.
-#[inline]
 pub fn get_path_suffix(src: RopeSlice<'_>, match_single_file: bool) -> Option<RopeSlice<'_>> {
     let regex = if match_single_file {
         static REGEX: Lazy<Regex> = Lazy::new(|| compile_path_regex("", "$", true, cfg!(windows)));
@@ -279,7 +273,6 @@ pub fn get_path_suffix(src: RopeSlice<'_>, match_single_file: bool) -> Option<Ro
 }
 
 /// Returns an iterator of the **byte** ranges in src that contain a path.
-#[inline]
 pub fn find_paths(
     src: RopeSlice<'_>,
     match_single_file: bool,
@@ -295,7 +288,6 @@ pub fn find_paths(
 }
 
 /// Performs substitution of `~` and environment variables, see [`env::expand`](crate::env::expand) and [`expand_tilde`]
-#[inline]
 pub fn expand<T: AsRef<Path> + ?Sized>(path: &T) -> Cow<'_, Path> {
     let path = path.as_ref();
     let path = expand_tilde(path);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -184,7 +184,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: Args) -> Vec<DocumentId> 
     let mut document_ids = vec![];
     for arg in args {
         let doc_id = editor.documents().find_map(|doc| {
-            let arg_path = Some(Path::new(arg.as_ref()));
+            let arg_path = Some(Path::new(arg));
             if doc.path().map(|p| p.as_path()) == arg_path || doc.relative_path() == arg_path {
                 Some(doc.id())
             } else {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1029,10 +1029,10 @@ fn change_current_directory(
         Some("-") => cx
             .editor
             .get_last_cwd()
-            .map(|path| path.to_path_buf())
+            .map(|path| Cow::Owned(path.to_path_buf()))
             .ok_or_else(|| anyhow!("No previous working directory"))?,
-        Some(path) => helix_stdx::path::expand_tilde(Path::new(path)).to_path_buf(),
-        None => home_dir()?,
+        Some(path) => helix_stdx::path::expand_tilde(Path::new(path)),
+        None => Cow::Owned(home_dir()?),
     };
 
     cx.editor.set_cwd(&dir)?;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -637,10 +637,9 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
             editor.switch(*first, Action::Replace);
         }
 
-        let modified_names: Vec<_> = editor
-            .documents()
-            .filter(|doc| doc.is_modified())
-            .map(|doc| (doc.display_name()))
+        let modified_names: Vec<_> = modified_ids
+            .iter()
+            .map(|doc_id| doc!(editor, doc_id).display_name())
             .collect();
 
         bail!(

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1032,10 +1032,11 @@ fn change_current_directory(
 
     cx.editor.last_cwd = helix_stdx::env::set_current_working_dir(dir)?;
 
-    let (_, doc) = current!(cx.editor);
-
-    // Clear the relative path as this will need to be recalculated.
-    doc.relative_path.take();
+    for doc in cx.editor.documents_mut() {
+        // Clear the relative path as this will need to be recalculated
+        // for each document.
+        doc.relative_path.take();
+    }
 
     cx.editor.set_status(format!(
         "Current working directory is now {}",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1032,6 +1032,11 @@ fn change_current_directory(
 
     cx.editor.last_cwd = helix_stdx::env::set_current_working_dir(dir)?;
 
+    let (_, doc) = current!(cx.editor);
+
+    // Clear the relative path as this will need to be recalculated.
+    doc.relative_path.take();
+
     cx.editor.set_status(format!(
         "Current working directory is now {}",
         helix_stdx::env::current_working_dir().display()

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1028,20 +1028,14 @@ fn change_current_directory(
     let dir = match args.next() {
         Some("-") => cx
             .editor
-            .last_cwd
-            .clone()
+            .get_last_cwd()
+            .map(|path| path.to_path_buf())
             .ok_or_else(|| anyhow!("No previous working directory"))?,
         Some(path) => helix_stdx::path::expand_tilde(Path::new(path)).to_path_buf(),
         None => home_dir()?,
     };
 
-    cx.editor.last_cwd = helix_stdx::env::set_current_working_dir(dir)?;
-
-    for doc in cx.editor.documents_mut() {
-        // Clear the relative path as this will need to be recalculated
-        // for each document.
-        doc.relative_path.take();
-    }
+    cx.editor.set_cwd(&dir)?;
 
     cx.editor.set_status(format!(
         "Current working directory is now {}",

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -13,6 +13,7 @@ use helix_core::text_annotations::{InlineAnnotation, Overlay};
 use helix_lsp::util::lsp_pos_to_pos;
 use helix_stdx::faccess::{copy_metadata, readonly};
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
+use once_cell::sync::OnceCell;
 use thiserror;
 
 use ::parking_lot::Mutex;
@@ -148,7 +149,7 @@ pub struct Document {
     pub inlay_hints_oudated: bool,
 
     path: Option<PathBuf>,
-    relative_path: Option<PathBuf>,
+    pub relative_path: OnceCell<Option<PathBuf>>,
     encoding: &'static encoding::Encoding,
     has_bom: bool,
 
@@ -660,7 +661,7 @@ impl Document {
             id: DocumentId::default(),
             active_snippet: None,
             path: None,
-            relative_path: None,
+            relative_path: OnceCell::new(),
             encoding,
             has_bom,
             text,
@@ -1174,10 +1175,9 @@ impl Document {
     pub fn set_path(&mut self, path: Option<&Path>) {
         let path = path.map(helix_stdx::path::canonicalize);
 
-        self.relative_path = path
-            .as_ref()
-            .map(helix_stdx::path::get_relative_path)
-            .map(|rel_path| rel_path.to_path_buf());
+        // `take` to remove any prior relative path that may have existed.
+        // This will get set in `relative_path()`.
+        self.relative_path.take();
 
         // if parent doesn't exist we still want to open the document
         // and error out when document is saved
@@ -1875,7 +1875,14 @@ impl Document {
     }
 
     pub fn relative_path(&self) -> Option<Cow<Path>> {
-        self.relative_path.as_ref().map(|path| path.into())
+        self.relative_path
+            .get_or_init(|| {
+                self.path
+                    .as_ref()
+                    .map(|path| helix_stdx::path::get_relative_path(path).to_path_buf())
+            })
+            .as_ref()
+            .map(|path| path.into())
     }
 
     pub fn display_name(&self) -> Cow<'static, str> {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -149,7 +149,7 @@ pub struct Document {
     pub inlay_hints_oudated: bool,
 
     path: Option<PathBuf>,
-    pub relative_path: OnceCell<Option<PathBuf>>,
+    relative_path: OnceCell<Option<PathBuf>>,
     encoding: &'static encoding::Encoding,
     has_bom: bool,
 
@@ -299,6 +299,14 @@ impl fmt::Debug for DocumentInlayHintsId {
         f.debug_struct("DocumentInlayHintsId")
             .field("lines", &(self.first_line..self.last_line))
             .finish()
+    }
+}
+
+impl Editor {
+    pub(crate) fn clear_doc_relative_paths(&mut self) {
+        for doc in self.documents_mut() {
+            doc.relative_path.take();
+        }
     }
 }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1874,22 +1874,19 @@ impl Document {
         self.view_data_mut(view_id).view_position = new_offset;
     }
 
-    pub fn relative_path(&self) -> Option<Cow<Path>> {
+    pub fn relative_path(&self) -> Option<&Path> {
         self.relative_path
             .get_or_init(|| {
                 self.path
                     .as_ref()
                     .map(|path| helix_stdx::path::get_relative_path(path).to_path_buf())
             })
-            .as_ref()
-            .map(|path| path.into())
+            .as_deref()
     }
 
-    pub fn display_name(&self) -> Cow<'static, str> {
-        self.relative_path().map_or_else(
-            || SCRATCH_BUFFER_NAME.into(),
-            |path| path.to_string_lossy().to_string().into(),
-        )
+    pub fn display_name(&self) -> Cow<'_, str> {
+        self.relative_path()
+            .map_or_else(|| SCRATCH_BUFFER_NAME.into(), |path| path.to_string_lossy())
     }
 
     // transact(Fn) ?

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1079,7 +1079,7 @@ pub struct Editor {
     redraw_timer: Pin<Box<Sleep>>,
     last_motion: Option<Motion>,
     pub last_completion: Option<CompleteAction>,
-    pub last_cwd: Option<PathBuf>,
+    last_cwd: Option<PathBuf>,
 
     pub exit_code: i32,
 
@@ -2208,6 +2208,16 @@ impl Editor {
             doc.ensure_view_init(current_view.id);
             current_view.id
         }
+    }
+
+    pub fn set_cwd(&mut self, path: &Path) -> std::io::Result<()> {
+        self.last_cwd = helix_stdx::env::set_current_working_dir(path)?;
+        self.clear_doc_relative_paths();
+        Ok(())
+    }
+
+    pub fn get_last_cwd(&mut self) -> Option<&Path> {
+        self.last_cwd.as_deref()
     }
 }
 


### PR DESCRIPTION
`helix_stdx::path::get_relative_path` was always performed for the statusline render. This PR now caches the relative path in `Document` instead. 

(Highlighted in purple: `statusline::render`)

Before:
![image](https://github.com/user-attachments/assets/10a47662-a60a-4bed-b969-01f8e09ab824)

After:
![image](https://github.com/user-attachments/assets/8feb34bb-0585-48bf-8045-ea2acb63ed33)

