### PR TITLE
docs: fix typo in usage.md

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -25,7 +25,7 @@ Inspired by [Kakoune](http://kakoune.org/), Helix follows the `selection → act
 
 ## Multiple selections
 
-Also inspired by Kakoune, multiple selections are a core mode of interaction in Helix. For example, the standard way of replacing multiple instance of a word is to first select all instances (so there is one selection per instance) and then use the change action (`c`) to edit them all at the same time.
+Also inspired by Kakoune, multiple selections are a core mode of interaction in Helix. For example, the standard way of replacing multiple instances of a word is to first select all instances (so there is one selection per instance) and then use the change action (`c`) to edit them all at the same time.
 
 ## Motions
 


### PR DESCRIPTION
I remembered that the updated usage page from #11485 would be moving to the stable site with the next release, so I gave it a skim and found a typo!