### PR TITLE
Fix Teal LSP name

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1316,7 +1316,7 @@ file-types = ["tl"]
 comment-tokens = "--"
 block-comment-tokens = { start = "--[[", end = "--]]" }
 roots = [ "tlconfig.lua" ]
-language-servers = [ "teal-lsp" ]
+language-servers = [ "teal-language-server" ]
 
 [[language]]
 name = "svelte"


### PR DESCRIPTION
Congrats on 25.01 release! While testing I noticed that Teal LSP wasn't working.

The reason for this is that the Teal LSP name on `language.toml` it's first defined as `teal-language-server` (as the actual command):

https://github.com/helix-editor/helix/blob/dabfb6ceeae1da57fb93efcd254e917db49655e6/languages.toml#L129

However, the Teal language is later configured as `teal-lsp`:

https://github.com/helix-editor/helix/blob/dabfb6ceeae1da57fb93efcd254e917db49655e6/languages.toml#L1319

The fix is done by using `teal-language-server` instead of `teal-lsp`.