### PR TITLE
docs: catppuccin themes should not be directly edited here

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -1,3 +1,5 @@
+# NOTE: For contributors looking to change the theme, please submit the change as a PR in https://github.com/catppuccin/helix
+# Do not directly change this theme in the Helix editor repository, as we frequently sync changes from the catppuccin helix theme repo
 # Syntax highlighting
 # -------------------
 "attribute" = "yellow"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -1,5 +1,4 @@
-# NOTE: For contributors looking to change the theme, please submit the change as a PR in https://github.com/catppuccin/helix
-# Do not directly change this theme in the Helix editor repository, as we frequently sync changes from the catppuccin helix theme repo
+# NOTE: For contributors looking to modify the theme, please submit a pull request at https://github.com/catppuccin/helix instead of updating this file. Changes are frequently synchronized from the catppuccin/helix theme repository.
 # Syntax highlighting
 # -------------------
 "attribute" = "yellow"


### PR DESCRIPTION
After https://github.com/helix-editor/helix/pull/12391#issuecomment-2570053460 , looks like it will be better for people to make their changes in the catppuccin repository rather than here. The changes can be synced time to time