### PR TITLE
perf(syntax): short-circuit if name matches `language_id`

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1008,9 +1008,9 @@ impl Loader {
     /// function will perform a regex match on the given string to find the closest language match.
     pub fn language_config_for_name(&self, slice: RopeSlice) -> Option<Arc<LanguageConfiguration>> {
         // PERF: If the name matches up with the id, then this saves the need to do expensive regex.
-        let shortcircut = self.language_config_for_language_id(slice);
-        if shortcircut.is_some() {
-            return shortcircut;
+        let shortcircuit = self.language_config_for_language_id(slice);
+        if shortcircuit.is_some() {
+            return shortcircuit;
         }
 
         // If the name did not match up with a known id, then match on injection regex.

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -994,16 +994,27 @@ impl Loader {
             .cloned()
     }
 
-    pub fn language_config_for_language_id(&self, id: &str) -> Option<Arc<LanguageConfiguration>> {
+    pub fn language_config_for_language_id(
+        &self,
+        id: impl PartialEq<String>,
+    ) -> Option<Arc<LanguageConfiguration>> {
         self.language_configs
             .iter()
-            .find(|config| config.language_id == id)
+            .find(|config| id.eq(&config.language_id))
             .cloned()
     }
 
-    /// Unlike language_config_for_language_id, which only returns Some for an exact id, this
+    /// Unlike `language_config_for_language_id`, which only returns Some for an exact id, this
     /// function will perform a regex match on the given string to find the closest language match.
     pub fn language_config_for_name(&self, slice: RopeSlice) -> Option<Arc<LanguageConfiguration>> {
+        // PERF: If the name matches up with the id, then this saves the need to do expensive regex.
+        let shortcircut = self.language_config_for_language_id(slice);
+        if shortcircut.is_some() {
+            return shortcircut;
+        }
+
+        // If the name did not match up with a known id, then match on injection regex.
+
         let mut best_match_length = 0;
         let mut best_match_position = None;
         for (i, configuration) in self.language_configs.iter().enumerate() {
@@ -1026,7 +1037,7 @@ impl Loader {
         capture: &InjectionLanguageMarker,
     ) -> Option<Arc<LanguageConfiguration>> {
         match capture {
-            InjectionLanguageMarker::LanguageId(id) => self.language_config_for_language_id(id),
+            InjectionLanguageMarker::LanguageId(id) => self.language_config_for_language_id(*id),
             InjectionLanguageMarker::Name(name) => self.language_config_for_name(*name),
             InjectionLanguageMarker::Filename(file) => {
                 let path_str: Cow<str> = (*file).into();


### PR DESCRIPTION
Previously, there would always be a `Regex::find` that would take place, even if the name perfectly matches an id(`name` in the `language.toml`). This PR introduces a short-circuit opportunity, to check if the name matches the id, as regex is much more expensive and shouldn't be done unless as a fallback, especially when the most often case appears to be an exact match.

The workload here was to go into `helix-term::commands::typed.rs`, and at the start of the file, enter insert mode, and hold enter to insert newlines until it reaches line ~1000. This is artificial, but it shows the point well. In just this operation, it accounted for 16% of samples. After, 0.5%.

Before:
![image](https://github.com/user-attachments/assets/15f922d0-d75e-467c-b324-a6aca9f2f065)

After:
![image](https://github.com/user-attachments/assets/49eae70a-30f0-4a62-90bf-13d16c0a1a87)
