### PR TITLE
feat: highlight `:` as a delimiter in Rust

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -113,6 +113,7 @@
   "."
   ";"
   ","
+  ":"
 ] @punctuation.delimiter
 
 [


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/d8e979e5-873e-46bd-a9eb-9e82b9603ec4)


## After

![image](https://github.com/user-attachments/assets/d608e3c1-8450-40f7-9b25-1ebe50f560d4)

## Other languages for comparison

![image](https://github.com/user-attachments/assets/0f3b4de7-38b9-4baa-ae73-98e6a3c20951)
