### PR TITLE
feat: correct Swift highlights

### DIFF
--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -4,7 +4,7 @@
   ["\\(" ")"] @punctuation.special)
 
 ["." ";" ":" "," ] @punctuation.delimiter
-["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+["(" ")" "[" "]" "{" "}" "<" ">"] @punctuation.bracket
 
 ; Identifiers
 (attribute) @variable
@@ -136,7 +136,7 @@
 ["\"" "\"\"\""] @string
 
 ; Lambda literals
-(lambda_literal "in" @keyword.operator)
+(lambda_literal "in" @keyword.operator) @variable.parameter
 
 ; Basic literals
 [
@@ -147,7 +147,7 @@
 (integer_literal) @constant.numeric.integer
 (real_literal) @constant.numeric.float
 (boolean_literal) @constant.builtin.boolean
-"nil" @variable.builtin
+"nil" @constant.builtin
 
 "?" @type
 (type_annotation "!" @type)

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -92,6 +92,9 @@
    (#match? @type "^[A-Z]"))
 (call_expression (simple_identifier) @keyword (#eq? @keyword "defer")) ; defer { ... }
 
+(navigation_suffix
+  (simple_identifier) @variable.other.member)
+
 (try_operator) @operator
 (try_operator ["try" @keyword])
 
@@ -161,6 +164,7 @@
   "?"
   "+"
   "-"
+  "\\"
   "*"
   "/"
   "%"

--- a/runtime/queries/swift/highlights.scm
+++ b/runtime/queries/swift/highlights.scm
@@ -24,6 +24,7 @@
 ] @keyword
 
 (function_declaration (simple_identifier) @function.method)
+(protocol_function_declaration (simple_identifier) @function.method)
 (init_declaration ["init" @constructor])
 (deinit_declaration ["deinit" @constructor])
 
@@ -136,7 +137,7 @@
 ["\"" "\"\"\""] @string
 
 ; Lambda literals
-(lambda_literal "in" @keyword.operator) @variable.parameter
+(lambda_literal "in" @keyword.operator)
 
 ; Basic literals
 [

--- a/runtime/queries/swift/injections.scm
+++ b/runtime/queries/swift/injections.scm
@@ -4,3 +4,7 @@
 
 ((regex_literal) @injection.content
  (#set! injection.language "regex"))
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#set! injection.include-children))


### PR DESCRIPTION
- Adds injections for the `comment` language
- Correct highlight of the `nil` value. Same highlight as `null` in javascript, java and others
- Recognize `<` and `>` as punctuation, used in generics (same color as the syntax used in other languages)
- `protocol` function methods are recognized
- When accessing object properties, like `hello.world`, the `world` is properly recognized as being a member
- Recognize the `\` as an operator