### PR TITLE
Use `@attribute` scope for JSX attributes

### DIFF
--- a/runtime/queries/_jsx/highlights.scm
+++ b/runtime/queries/_jsx/highlights.scm
@@ -25,7 +25,7 @@
 ; Attributes
 ; ----------
 
-(jsx_attribute (property_identifier) @variable.other.member)
+(jsx_attribute (property_identifier) @attribute)
 
 ; Punctuation
 ; -----------


### PR DESCRIPTION
Since JSX attributes are the equivalent of HTML attributes, I see no reason why these shouldn't also use the `@attribute` scope.