### PR TITLE
Improve markdown heading highlights

### DIFF
--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -2,12 +2,12 @@
 (setext_heading (paragraph) @markup.heading.1 (setext_h1_underline) @markup.heading.marker)
 (setext_heading (paragraph) @markup.heading.2 (setext_h2_underline) @markup.heading.marker)
 
-(atx_heading (atx_h1_marker) @markup.heading.marker (inline) @markup.heading.1)
-(atx_heading (atx_h2_marker) @markup.heading.marker (inline) @markup.heading.2)
-(atx_heading (atx_h3_marker) @markup.heading.marker (inline) @markup.heading.3)
-(atx_heading (atx_h4_marker) @markup.heading.marker (inline) @markup.heading.4)
-(atx_heading (atx_h5_marker) @markup.heading.marker (inline) @markup.heading.5)
-(atx_heading (atx_h6_marker) @markup.heading.marker (inline) @markup.heading.6)
+(atx_heading (atx_h1_marker) @markup.heading.marker) @markup.heading.1
+(atx_heading (atx_h2_marker) @markup.heading.marker) @markup.heading.2
+(atx_heading (atx_h3_marker) @markup.heading.marker) @markup.heading.3
+(atx_heading (atx_h4_marker) @markup.heading.marker) @markup.heading.4
+(atx_heading (atx_h5_marker) @markup.heading.marker) @markup.heading.5
+(atx_heading (atx_h6_marker) @markup.heading.marker) @markup.heading.6
 
 [
   (indented_code_block)


### PR DESCRIPTION
This PR changes the markdown highlights to apply the `@markup.heading.<n>` (e.g. `@markup.heading.3`) captures to the entire heading - not just the text content, specifically including the marker (`##` part of `## ABC`). I have tested this and can confirm that if the `markup.heading.marker` key is set in the theme configuration, that applies to the headers. If it isn't set, the `@markup.heading.<n>` capture styles apply.