### PR TITLE
fix(commands): fix an off-by-one in `toggle_option`

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1861,7 +1861,7 @@ fn toggle_option(
                 args.clone()
                     .skip_while(|e| *e != value)
                     .nth(1)
-                    .unwrap_or_else(|| args.nth(1).unwrap())
+                    .unwrap_or_else(|| args.next().unwrap())
                     .to_string(),
             )
         }
@@ -1878,7 +1878,7 @@ fn toggle_option(
                 args.clone()
                     .skip_while(|e| *e != value)
                     .nth(1)
-                    .unwrap_or_else(|| args.nth(1).unwrap())
+                    .unwrap_or_else(|| args.next().unwrap())
                     .parse()?,
             )
         }


### PR DESCRIPTION
With the off-by-one, it would work only if the first option was not the same something as what the option was currently set. Now, it properly toggles. 

![toggle_off_by_one_fix](https://github.com/user-attachments/assets/7e19c7c7-74a6-4609-a757-1040bc6c9ade)

There is still an existing issue that this way of toggling really only toggles for two options, but more are supposed to be accepted. I would argue though that is actually what "toggle" is supposed to be, not a "cycle".

