### PR TITLE
feat: `Alt-Enter` inserts newline without continuing comment

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -112,8 +112,10 @@
 | `last_picker` | Open last picker | normal: `` <space>' ``, select: `` <space>' `` |
 | `insert_at_line_start` | Insert at start of line | normal: `` I ``, select: `` I `` |
 | `insert_at_line_end` | Insert at end of line | normal: `` A ``, select: `` A `` |
-| `open_below` | Open new line below selection | normal: `` o ``, select: `` o `` |
-| `open_above` | Open new line above selection | normal: `` O ``, select: `` O `` |
+| `open_below` | Open new line below selection | normal: `` go ``, select: `` go `` |
+| `open_above` | Open new line above selection | normal: `` gO ``, select: `` gO `` |
+| `open_below_continue_comment` | Open new line below selection and continue comment | normal: `` o ``, select: `` o `` |
+| `open_above_continue_comment` | Open new line above selection and continue comment | normal: `` O ``, select: `` O `` |
 | `normal_mode` | Enter normal mode | normal: `` <esc> ``, select: `` v ``, insert: `` <esc> `` |
 | `select_mode` | Enter selection extend mode | normal: `` v `` |
 | `exit_select_mode` | Exit selection mode | select: `` <esc> `` |
@@ -159,7 +161,8 @@
 | `signature_help` | Show signature help |  |
 | `smart_tab` | Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command. | insert: `` <tab> `` |
 | `insert_tab` | Insert tab char | insert: `` <S-tab> `` |
-| `insert_newline` | Insert newline char | insert: `` <C-j> ``, `` <ret> `` |
+| `insert_newline` | Insert newline char | insert: `` <A-ret> `` |
+| `insert_newline_continue_comment` | Insert newline char and continue comment | insert: `` <C-j> ``, `` <ret> `` |
 | `delete_char_backward` | Delete previous char | insert: `` <C-h> ``, `` <backspace> ``, `` <S-backspace> `` |
 | `delete_char_forward` | Delete next char | insert: `` <C-d> ``, `` <del> `` |
 | `delete_word_backward` | Delete previous word | insert: `` <C-w> ``, `` <A-backspace> `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -457,6 +457,7 @@ impl MappableCommand {
         smart_tab, "Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.",
         insert_tab, "Insert tab char",
         insert_newline, "Insert newline char",
+        insert_newline_continue_comment, "Insert newline char and continue comment",
         delete_char_backward, "Delete previous char",
         delete_char_forward, "Delete next char",
         delete_word_backward, "Delete previous word",
@@ -3974,7 +3975,7 @@ pub mod insert {
         doc.apply(&transaction, view.id);
     }
 
-    pub fn insert_newline(cx: &mut Context) {
+    pub fn insert_newline_impl(cx: &mut Context, continue_comment: bool) {
         let (view, doc) = current_ref!(cx.editor);
         let text = doc.text().slice(..);
 
@@ -4000,7 +4001,8 @@ pub mod insert {
 
             let mut new_text = String::new();
 
-            let continue_comment_token = if doc.config.load().continue_comments {
+            let continue_comment_token = if doc.config.load().continue_comments && continue_comment
+            {
                 doc.language_config()
                     .and_then(|config| config.comment_tokens.as_ref())
                     .and_then(|tokens| comment::get_comment_token(text, tokens, current_line))
@@ -4108,6 +4110,14 @@ pub mod insert {
 
         let (view, doc) = current!(cx.editor);
         doc.apply(&transaction, view.id);
+    }
+
+    pub fn insert_newline_continue_comment(cx: &mut Context) {
+        insert_newline_impl(cx, true)
+    }
+
+    pub fn insert_newline(cx: &mut Context) {
+        insert_newline_impl(cx, false)
     }
 
     pub fn delete_char_backward(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -59,6 +59,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" => move_line_down,
             "." => goto_last_modification,
             "w" => goto_word,
+            "o" => open_below,
+            "O" => open_above,
         },
         ":" => command_mode,
 
@@ -67,9 +69,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "a" => append_mode,
         "A" => insert_at_line_end,
         "o" => open_below_continue_comment,
-        "A-o" => open_below,
         "O" => open_above_continue_comment,
-        "A-O" => open_above,
 
         "d" => delete_selection,
         "A-d" => delete_selection_noyank,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -383,7 +383,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "C-k" => kill_to_line_end,
         "C-h" | "backspace" | "S-backspace" => delete_char_backward,
         "C-d" | "del" => delete_char_forward,
-        "C-j" | "ret" => insert_newline,
+        "C-j" | "ret" => insert_newline_continue_comment,
+        "A-ret" => insert_newline,
         "tab" => smart_tab,
         "S-tab" => insert_tab,
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -66,8 +66,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "I" => insert_at_line_start,
         "a" => append_mode,
         "A" => insert_at_line_end,
-        "o" => open_below,
-        "O" => open_above,
+        "o" => open_below_continue_comment,
+        "A-o" => open_below,
+        "O" => open_above_continue_comment,
+        "A-O" => open_above,
 
         "d" => delete_selection,
         "A-d" => delete_selection_noyank,


### PR DESCRIPTION
The comment functionality is really useful, but often times I just want to make a newline without continuing the current comment. And without needing to disable the feature entirely, just for 1 newline

This PR:
- Renames `insert_newline` to `insert_newline_continue_comment`
- Adds `insert_newline`, which does not continue the comment
- Binds `Alt-Enter` to `insert_newline` and `Enter` to `insert_newline_continue_comment`

Also added these, but feel free to reject them:
- Renames `open_below` and `open_above` to `open_below_continue_comment` and `open_above_continue_comment`
- Adds `open_below` and `open_above` which add a newline below and above, but do not continue the comment
- Binds `go` to `open_below` and `o` to `open_below_continue_comment`
- Binds `gO` to `open_above` and `O` to `open_above_continue_comment`

Related to https://github.com/helix-editor/helix/issues/12423

---

Note: Chose `A-ret` instead of `S-ret` because the latter seems to not be supported by Helix. I tested with Kitty and Wezterm