### PR TITLE
Add fish-lsp and ghostty + hgrc file types

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -56,7 +56,7 @@
 | erlang | ✓ | ✓ |  | `erlang_ls`, `elp` |
 | esdl | ✓ |  |  |  |
 | fidl | ✓ |  |  |  |
-| fish | ✓ | ✓ | ✓ |  |
+| fish | ✓ | ✓ | ✓ | `fish-lsp` |
 | forth | ✓ |  |  | `forth-lsp` |
 | fortran | ✓ |  | ✓ | `fortls` |
 | fsharp | ✓ |  |  | `fsautocomplete` |

--- a/languages.toml
+++ b/languages.toml
@@ -2823,6 +2823,8 @@ file-types = [
   "network",
   { glob = ".editorconfig" },
   { glob = ".npmrc" },
+  { glob = "ghostty/config" },
+  { glob = "hgrc" },
   { glob = "npmrc" },
   { glob = "rclone.conf" },
   "properties",
@@ -2835,7 +2837,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "ini"
-source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "4d247fb876b4ae6b347687de4a179511bf67fcbc" }
+source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "1b0498a89a1a4c0a3705846699f0b0bad887dd04" }
 
 [[language]]
 name = "inko"

--- a/languages.toml
+++ b/languages.toml
@@ -37,6 +37,7 @@ elm-language-server = { command = "elm-language-server" }
 elp = { command = "elp", args = ["server"] }
 elvish = { command = "elvish", args = ["-lsp"] }
 erlang-ls = { command = "erlang_ls" }
+fish-lsp = { command = "fish-lsp", args = ["start"], environment = { fish_lsp_show_client_popups = "false" } }
 forc = { command = "forc", args = ["lsp"] }
 forth-lsp = { command = "forth-lsp" }
 fortls = { command = "fortls", args = ["--lowercase_intrinsics"] }
@@ -388,13 +389,14 @@ injection-regex = "fish"
 file-types = ["fish"]
 shebangs = ["fish"]
 comment-token = "#"
+language-servers = ["fish-lsp"]
 indent = { tab-width = 4, unit = "    " }
 auto-format = true
 formatter = { command = "fish_indent" }
 
 [[grammar]]
 name = "fish"
-source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "84436cf24c2b3176bfbb220922a0fdbd0141e406" }
+source = { git = "https://github.com/ram02z/tree-sitter-fish", rev = "a78aef9abc395c600c38a037ac779afc7e3cc9e0" }
 
 [[language]]
 name = "mint"

--- a/runtime/queries/fish/highlights.scm
+++ b/runtime/queries/fish/highlights.scm
@@ -4,14 +4,13 @@
  "&&"
  "||"
  "|"
+ "&|"
+ "2>|"
  "&"
- "="
- "!="
  ".."
  "!"
  (direction)
  (stream_redirect)
- (test_option)
 ] @operator
 
 [
@@ -39,12 +38,12 @@
  "case"
 ] @keyword.control.conditional)
 
-(else_clause 
+(else_clause
 [
  "else"
 ] @keyword.control.conditional)
 
-(else_if_clause 
+(else_if_clause
 [
  "else"
  "if"
@@ -96,6 +95,14 @@
 ;; Commands
 
 (command
+  name: (word) @function.builtin (#match? @function.builtin "^test$")
+  argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+
+(command
+  name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
+  argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+
+(command
   argument: [
              (word) @variable.parameter (#match? @variable.parameter "^-")
             ]
@@ -109,8 +116,6 @@
   ]
 )
 
-(test_command "test" @function.builtin)
-
 ; non-builtin command names
 (command name: (word) @function)
 
@@ -121,7 +126,7 @@
 (function_definition
   name: [
         (word) (concatenation)
-        ] 
+        ]
 @function)
 
 (function_definition
@@ -146,7 +151,6 @@
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float
 (comment) @comment
-(test_option) @string
 
 ((word) @constant.builtin.boolean
 (#match? @constant.builtin.boolean "^(true|false)$"))


### PR DESCRIPTION
* Add [fish-lsp](https://github.com/ndonfris/fish-lsp) as the default language server for fish (disabling popups as helix doesn't yet support them: https://github.com/helix-editor/helix/issues/4699)
* Add [`~/.config/ghostty/config`](https://ghostty.org/docs/config) and [`hgrc`](https://www.mercurial-scm.org/doc/hgrc.5.html) as INI  files
* Bump to latest https://github.com/ram02z/tree-sitter-fish/commit/a78aef9abc395c600c38a037ac779afc7e3cc9e0 and https://github.com/justinmk/tree-sitter-ini/commit/1b0498a89a1a4c0a3705846699f0b0bad887dd04