### PR TITLE
chore(solidity): update to newest grammar and fix queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1948,7 +1948,7 @@ language-servers = [ "solc" ]
 
 [[grammar]]
 name = "solidity"
-source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "08338dcee32603383fcef08f36321900bb7a354b" }
+source = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "f7f5251a3f5b1d04f0799b3571b12918af177fc8" }
 
 [[language]]
 name = "gleam"

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -137,6 +137,7 @@
  "storage"
  "calldata"
  "constant"
+ (immutable)
 ] @keyword.storage.modifier
 
 [

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -68,7 +68,7 @@
 
 ; Invocations
 (emit_statement name: (_) @type)
-(revert_statement error: (_) @type)
+(revert_statement error: (expression (identifier) @type))
 (modifier_invocation . (_) @function)
 
 (call_expression . (_(member_expression property: (_) @function.method)))

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -138,6 +138,7 @@
  "calldata"
  "constant"
  (immutable)
+ "transient"
 ] @keyword.storage.modifier
 
 [

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -2,10 +2,8 @@
 (pragma_directive) @keyword.directive
 (solidity_version_comparison_operator _ @keyword.directive)
 
-
 ; Literals
 ; --------
-
 [
  (string)
  (hex_string_literal)
@@ -27,10 +25,8 @@
 
 (comment) @comment
 
-
 ; Definitions and references
 ; -----------
-
 (type_name) @type
 
 [
@@ -38,7 +34,8 @@
   (number_unit)
 ] @type.builtin
 
-(user_defined_type (identifier) @type)
+(user_defined_type (_) @type)
+(user_defined_type_definition name: (identifier) @type)
 (type_alias (identifier) @type)
 
 ; Color payable in payable address conversion as type and not as keyword
@@ -47,24 +44,15 @@
 (type_name "(" @punctuation.bracket "=>" @punctuation.delimiter ")" @punctuation.bracket)
 
 ; Definitions
-(struct_declaration
-  name: (identifier) @type)
-(enum_declaration
-  name: (identifier) @type)
-(contract_declaration
-  name: (identifier) @type)
-(library_declaration
-  name: (identifier) @type)
-(interface_declaration
-  name: (identifier) @type)
-(event_definition
-  name: (identifier) @type)
-
-(function_definition
-  name:  (identifier) @function)
-
-(modifier_definition
-  name:  (identifier) @function)
+(struct_declaration name: (identifier) @type)
+(enum_declaration name: (identifier) @type)
+(contract_declaration name: (identifier) @type)
+(library_declaration name: (identifier) @type)
+(interface_declaration name: (identifier) @type)
+(event_definition name: (identifier) @type)
+(error_declaration name: (identifier) @type)
+(function_definition name: (identifier) @function)
+(modifier_definition name: (identifier) @function)
 (yul_evm_builtin) @function.builtin
 
 ; Use constructor coloring for special functions
@@ -75,14 +63,16 @@
 
 (struct_member name: (identifier) @variable.other.member)
 (enum_value) @constant
+; SCREAMING_SNAKE_CASE identifier are constants
+((identifier) @constant (#match? @constant "^[A-Z][A-Z_]+$"))
 
 ; Invocations
-(emit_statement . (identifier) @type)
-(revert_statement error: (identifier) @type)
-(modifier_invocation (identifier) @function)
+(emit_statement name: (_) @type)
+(revert_statement error: (_) @type)
+(modifier_invocation . (_) @function)
 
-(call_expression . (member_expression property: (identifier) @function.method))
-(call_expression . (identifier) @function)
+(call_expression . (_(member_expression property: (_) @function.method)))
+(call_expression . (expression (identifier) @function))
 
 ; Function parameters
 (call_struct_argument name: (identifier) @field)
@@ -90,14 +80,19 @@
 (parameter name: (identifier) @variable.parameter)
 
 ; Yul functions
-(yul_function_call function: (yul_identifier) @function)
-(yul_function_definition . (yul_identifier) @function (yul_identifier) @variable.parameter)
-
+(yul_function_call function: (_) @function)
+(yul_function_definition
+  ("function" (yul_identifier) @function "(" (
+      (yul_identifier) @variable.parameter ("," (yul_identifier) @variable.parameter)*
+    )
+  )
+)
 
 ; Structs and members
 (member_expression property: (identifier) @variable.other.member)
-(struct_expression type: ((identifier) @type .))
+(struct_expression type: ((expression(identifier)) @type .))
 (struct_field_assignment name: (identifier) @variable.other.member)
+
 
 ; Tokens
 ; -------
@@ -113,9 +108,9 @@
  "struct"
  "enum"
  "event"
+ "type"
  "assembly"
  "emit"
-
  "public"
  "internal"
  "private"
@@ -123,7 +118,6 @@
  "pure"
  "view"
  "payable"
-
  "modifier"
  "var"
  "let"
@@ -137,8 +131,8 @@
  "storage"
  "calldata"
  "constant"
- (immutable)
  "transient"
+ (immutable)
 ] @keyword.storage.modifier
 
 [
@@ -177,7 +171,6 @@
 (event_parameter "indexed" @keyword)
 
 ; Punctuation
-
 [
   "("
   ")"
@@ -187,7 +180,6 @@
   "}"
 ] @punctuation.bracket
 
-
 [
   "."
   ","
@@ -196,14 +188,11 @@
   "=>"
 ] @punctuation.delimiter
 
-
 ; Operators
-
 [
   "&&"
   "||"
   ">>"
-  ">>>"
   "<<"
   "&"
   "^"
@@ -218,15 +207,12 @@
   "<="
   "=="
   "!="
-  "!=="
   ">="
   ">"
   "!"
   "~"
   "-"
   "+"
-  "delete"
-  "new"
   "++"
   "--"
   "+="
@@ -246,10 +232,9 @@
   "new"
 ] @keyword.operator
 
-; TODO: move to top when order swapped
 ; identifiers
 ; -----------
-((identifier) @variable.builtin
- (#match? @variable.builtin "^(this|msg|block|tx)$"))
+((identifier) @variable.builtin (#match? @variable.builtin "^(this|msg|block|tx)$"))
 (identifier) @variable
 (yul_identifier) @variable
+

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -67,7 +67,7 @@
 ((identifier) @constant (#match? @constant "^[A-Z][A-Z_]+$"))
 
 ; Invocations
-(emit_statement name: (_) @type)
+(emit_statement name: (expression (identifier) @type))
 (revert_statement error: (expression (identifier) @type))
 (modifier_invocation . (_) @function)
 

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -234,7 +234,7 @@
 
 ; identifiers
 ; -----------
-((identifier) @variable.builtin (#match? @variable.builtin "^(this|msg|block|tx)$"))
+((identifier) @variable.builtin (#any-of? @variable.builtin "this" "msg" "block" "tx"))
 (identifier) @variable
 (yul_identifier) @variable
 

--- a/runtime/queries/solidity/highlights.scm
+++ b/runtime/queries/solidity/highlights.scm
@@ -90,7 +90,7 @@
 
 ; Structs and members
 (member_expression property: (identifier) @variable.other.member)
-(struct_expression type: ((expression(identifier)) @type .))
+(struct_expression type: ((expression (identifier)) @type .))
 (struct_field_assignment name: (identifier) @variable.other.member)
 
 

--- a/runtime/queries/solidity/locals.scm
+++ b/runtime/queries/solidity/locals.scm
@@ -1,9 +1,9 @@
 (function_definition) @local.scope
+(constructor_definition) @local.scope
 (block_statement) @local.scope
 
 (function_definition (parameter name: (identifier) @local.definition))
-
-; still have to support tuple assignments
-(assignment_expression left: (identifier) @local.definition)
+(constructor_definition (parameter name: (identifier) @local.definition))
+(variable_declaration name: (identifier) @local.definition)
 
 (identifier) @local.reference

--- a/runtime/queries/solidity/textobjects.scm
+++ b/runtime/queries/solidity/textobjects.scm
@@ -17,7 +17,7 @@
   ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (return_type_definition 
-  ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
+  ((parameter) @entry.inside . ","? @entry.around) @entry.around)
 
 (modifier_definition 
   ((parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
@@ -29,13 +29,13 @@
   ((error_parameter) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (call_argument
-  ((call_struct_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
+  ((call_struct_argument) @entry.inside . ","? @entry.around) @entry.around)
 
 (call_expression
   ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
 
 (variable_declaration_tuple
-  ((variable_declaration) @parameter.inside . ","? @parameter.around) @parameter.around)
+  ((variable_declaration) @entry.inside . ","? @entry.around) @entry.around)
 
 (emit_statement
   ((call_argument) @parameter.inside . ","? @parameter.around) @parameter.around)
@@ -52,3 +52,4 @@
 (comment) @comment.inside
 
 (comment)+ @comment.around
+


### PR DESCRIPTION
This PR updates the solidity grammar to the latest version and fixes the queries to work with it.

At the same time, a few improvements were made:
- user-defined types are colored like types also in their definition statement
- identifiers that are SCREAMING_SNAKE_CASE are colored as constants
- add missing keywords: `type`, `transient`, `immutable`
- fixed modifier invocation query
- fix locals query for variable declaration and add constructor scope
- change some textobject queries to use `entry` instead of `parameter` where it makes sense