### PR TITLE
Fix `open_{below, above}` behaviour with multiple cursors

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3474,6 +3474,7 @@ fn open(cx: &mut Context, open: Open) {
     let text = doc.text().slice(..);
     let contents = doc.text();
     let selection = doc.selection(view.id);
+    let mut offs = 0;
 
     let mut ranges = SmallVec::with_capacity(selection.len());
 
@@ -3550,7 +3551,7 @@ fn open(cx: &mut Context, open: Open) {
         let text = text.repeat(count);
 
         // calculate new selection ranges
-        let pos = above_next_line_end_index + above_next_line_end_width;
+        let pos = offs + above_next_line_end_index + above_next_line_end_width;
         let comment_len = continue_comment_token
             .map(|token| token.len() + 1) // `+ 1` for the extra space added
             .unwrap_or_default();
@@ -3562,6 +3563,9 @@ fn open(cx: &mut Context, open: Open) {
                 pos + (i * (1 + indent_len + comment_len)) + indent_len + comment_len,
             ));
         }
+
+        // update the offset for the next range
+        offs += text.chars().count();
 
         (
             above_next_line_end_index,


### PR DESCRIPTION
Fixes https://github.com/helix-editor/helix/issues/12448 and added some tests for them.

TL;DR: I deleted a variable (`offs`) in https://github.com/helix-editor/helix/pull/12215 which I though wouldn't be useful but it was

![hideThePain](https://github.com/user-attachments/assets/d45ce921-4a7f-4016-9c0f-976edc63fbac)

Sorry for this.