### PR TITLE
language support: CodeQL

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -23,7 +23,7 @@
 | circom | ✓ |  |  | `circom-lsp` |
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
-| codeql | ✓ | ✓ |  |  |
+| codeql | ✓ | ✓ |  | `codeql` |
 | comment | ✓ |  |  |  |
 | common-lisp | ✓ |  | ✓ | `cl-lsp` |
 | cpon | ✓ |  | ✓ |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -23,6 +23,7 @@
 | circom | ✓ |  |  | `circom-lsp` |
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
+| codeql | ✓ | ✓ |  |  |
 | comment | ✓ |  |  |  |
 | common-lisp | ✓ |  | ✓ | `cl-lsp` |
 | cpon | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -21,6 +21,7 @@ cl-lsp = { command = "cl-lsp", args = [ "stdio" ] }
 clangd = { command = "clangd" }
 clojure-lsp = { command = "clojure-lsp" }
 cmake-language-server = { command = "cmake-language-server" }
+codeql = { command = "codeql", args = ["execute", "language-server", "--check-errors=ON_CHANGE"] }
 crystalline = { command = "crystalline", args = ["--stdio"] }
 cs = { command = "cs", args = ["launch", "--contrib", "smithy-language-server", "--", "0"] }
 csharp-ls = { command = "csharp-ls" }
@@ -4043,6 +4044,7 @@ block-comment-tokens = { start = "/*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 injection-regex = "codeql"
 grammar = "ql"
+language-servers = ["codeql"]
 
 [[grammar]]
 name = "ql"

--- a/languages.toml
+++ b/languages.toml
@@ -4033,3 +4033,17 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "nginx"
 source = { git = "https://gitlab.com/joncoole/tree-sitter-nginx", rev = "b4b61db443602b69410ab469c122c01b1e685aa0" }
+
+[[language]]
+name = "codeql"
+scope = "source.ql"
+file-types = ["ql", "qll"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 2, unit = "  " }
+injection-regex = "codeql"
+grammar = "ql"
+
+[[grammar]]
+name = "ql"
+source = { git = "https://github.com/tree-sitter/tree-sitter-ql", rev = "1fd627a4e8bff8c24c11987474bd33112bead857" }

--- a/runtime/queries/codeql/highlights.scm
+++ b/runtime/queries/codeql/highlights.scm
@@ -1,0 +1,104 @@
+[
+  "and"
+  "any"
+  "as"
+  "asc"
+  "avg"
+  "by"
+  "class"
+  "concat"
+  "count"
+  "desc"
+  "else"
+  "exists"
+  "extends"
+  "forall"
+  "forex"
+  "from"
+  "if"
+  "implements"
+  "implies"
+  "import"
+  "in"
+  "instanceof"
+  "max"
+  "min"
+  "module"
+  "newtype"
+  "not"
+  "or"
+  "order"
+  "rank"
+  "select"
+  "strictconcat"
+  "strictcount"
+  "strictsum"
+  "sum"
+  "then"
+  "where"
+
+  (false)
+  (predicate)
+  (result)
+  (specialId)
+  (super)
+  (this)
+  (true)
+] @keyword
+
+[
+  "boolean"
+  "float"
+  "int"
+  "date"
+  "string"
+] @type.builtin
+
+(annotName) @attribute
+
+[
+  "<"
+  "<="
+  "="
+  ">"
+  ">="
+  "-"
+  "!="
+  "/"
+  "*"
+  "%"
+  "+"
+  "::"
+] @operator
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  "|"
+] @punctuation.delimiter
+
+(className) @type
+
+(varName) @variable
+
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+(string) @string
+
+(aritylessPredicateExpr (literalId) @function)
+(predicateName) @function
+
+[
+  (line_comment)
+  (block_comment)
+  (qldoc)
+] @comment

--- a/runtime/queries/codeql/textobjects.scm
+++ b/runtime/queries/codeql/textobjects.scm
@@ -1,0 +1,16 @@
+(qldoc) @comment.around
+(block_comment) @comment.around
+(line_comment) @comment.inside
+(line_comment)+ @comment.around
+
+(classlessPredicate
+  ((varDecl) @parameter.inside . ","?) @parameter.around
+  (body "{" (_)* @function.inside "}")) @function.around
+(memberPredicate
+  ((varDecl) @parameter.inside . ","?) @parameter.around
+  (body "{" (_)* @function.inside "}")) @function.around
+
+(dataclass
+  ("{" (_)* @class.inside "}")?) @class.around
+(datatype) @class.around
+(datatypeBranch) @class.around


### PR DESCRIPTION
adds [CodeQL](https://codeql.github.com/) support for highlighting, text objects, and LSP!

the treesitter grammer defines the language as just `ql` (thus exporting the function `tree_sitter_ql` in the dylib) but I've never heard it referred by just that, it's always "CodeQL", so I stuck with "codeql" for all user facing names for this language.

For code fences in markdown, github supports this language as `codeql` or `ql`, but again, I don't think anyone refers to this language as just `ql`, so I left the injection-regex as `codeql`.

For the language server, it works as defined, but minimally. Formatting works, goto definition, etc. But to be actually useful, users will probably need to override the args to add `--search-path=P` where P is a path to their local checkout of the [standard queries](https://github.com/github/codeql). It would be nice to have an lsp option for appending args to the default like this:

```toml
# ideally:
[language-servers.codeql]
extraArgs = ["--search-path=P"] # just the appended args

# current users need to respecify default args:
[language-servers.codeql]
args = ["execute", "language-server", "--check-errors=ON_CHANGE", "--search-path=P"]
```