### PR TITLE
Treat punctuation as part of a word for softwrap.

### DIFF
--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -102,6 +102,18 @@ fn long_word_softwrap() {
     );
 }
 
+#[test]
+fn softwrap_punctuation() {
+    assert_eq!(
+        softwrap_text("asdfasdfasdfasd ...\n"),
+        "asdfasdfasdfasd \n.... \n "
+    );
+    assert_eq!(
+        softwrap_text("asdfasdfasdfas X.Y\n"),
+        "asdfasdfasdfas \n.X.Y \n "
+    );
+}
+
 fn softwrap_text_at_text_width(text: &str) -> String {
     let mut text_fmt = TextFormat::new_test(true);
     text_fmt.soft_wrap_at_text_width = true;

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::ptr::NonNull;
 use std::{slice, str};
 
-use crate::chars::{char_is_whitespace, char_is_word};
+use crate::chars;
 use crate::LineEnding;
 
 #[inline]
@@ -64,7 +64,7 @@ impl<'a> Grapheme<'a> {
     }
 
     pub fn is_whitespace(&self) -> bool {
-        !matches!(&self, Grapheme::Other { g } if !g.chars().all(char_is_whitespace))
+        !matches!(&self, Grapheme::Other { g } if !g.chars().all(chars::char_is_whitespace))
     }
 
     // TODO currently word boundaries are used for softwrapping.
@@ -72,7 +72,7 @@ impl<'a> Grapheme<'a> {
     // This could however be improved in the future by considering unicode
     // character classes but
     pub fn is_word_boundary(&self) -> bool {
-        !matches!(&self, Grapheme::Other { g,.. } if g.chars().all(char_is_word))
+        !matches!(&self, Grapheme::Other { g,.. } if g.chars().all(|c| chars::char_is_word(c) || chars::char_is_punctuation(c)))
     }
 }
 


### PR DESCRIPTION
In addition to the examples in the tests, wrapping at punctuation tends to break URLs across lines which makes them more difficult to copy-paste. For code, the result is more subjective, so I will show a few examples here

Before:
![before1](https://github.com/user-attachments/assets/90156e83-2e6e-4b62-adae-14811862001b)

After:
![after1](https://github.com/user-attachments/assets/0d4fb1d4-a590-4ca8-830a-6836cbac19e8)

Before:
![before2](https://github.com/user-attachments/assets/42b3b934-6739-4a15-b337-a2a65a007845)

After:
![after2](https://github.com/user-attachments/assets/2d4e3e6a-7f2c-4dfc-92ae-c4f8077afddd)

Fixes #11428