### PR TITLE
Open languages.toml action

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2214,6 +2214,20 @@ fn open_workspace_config(
     Ok(())
 }
 
+fn open_language_config(
+    cx: &mut compositor::Context,
+    _args: &[Cow<str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .open(&helix_loader::lang_config_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_log(
     cx: &mut compositor::Context,
     _args: &[Cow<str>],
@@ -3069,6 +3083,13 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Open the workspace config.toml file.",
         fun: open_workspace_config,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "language-config-open",
+        aliases: &["lsp-config"],
+        doc: "Open the configuration for language servers",
+        fun: open_language_config,
         signature: CommandSignature::none(),
     },
     TypableCommand {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3086,9 +3086,9 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         signature: CommandSignature::none(),
     },
     TypableCommand {
-        name: "language-config-open",
+        name: "languages-config-open",
         aliases: &["lsp-config"],
-        doc: "Open the configuration for language servers",
+        doc: "Open the languages.toml file.",
         fun: open_language_config,
         signature: CommandSignature::none(),
     },


### PR DESCRIPTION
Make it just as easy to open the languages.toml as it is to open config.toml

currently, I open the languages.toml by using
`:open ~/.config/languages.toml`
while for opening `./config/configuration.toml` there is a shortcut:
`: config-open`
with this merge request we also get
`:language-config-open`