### PR TITLE
Use the first char in a grapheme for classification

### DIFF
--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -102,6 +102,14 @@ fn long_word_softwrap() {
     );
 }
 
+#[test]
+fn softwrap_multichar_grapheme() {
+    assert_eq!(
+        softwrap_text("xxxx xxxx xxx a\u{0301}bc\n"),
+        "xxxx xxxx xxx \n.ábc \n "
+    )
+}
+
 fn softwrap_text_at_text_width(text: &str) -> String {
     let mut text_fmt = TextFormat::new_test(true);
     text_fmt.soft_wrap_at_text_width = true;

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -64,7 +64,7 @@ impl<'a> Grapheme<'a> {
     }
 
     pub fn is_whitespace(&self) -> bool {
-        !matches!(&self, Grapheme::Other { g } if !g.chars().all(char_is_whitespace))
+        !matches!(&self, Grapheme::Other { g } if !g.chars().next().is_some_and(char_is_whitespace))
     }
 
     // TODO currently word boundaries are used for softwrapping.
@@ -72,7 +72,7 @@ impl<'a> Grapheme<'a> {
     // This could however be improved in the future by considering unicode
     // character classes but
     pub fn is_word_boundary(&self) -> bool {
-        !matches!(&self, Grapheme::Other { g,.. } if g.chars().all(char_is_word))
+        !matches!(&self, Grapheme::Other { g,.. } if g.chars().next().is_some_and(char_is_word))
     }
 }
 


### PR DESCRIPTION
Currently, a grapheme is classified as a "word boundary" if any codepoint in the grapheme is non-alphanumeric. This doesn't work for combining accent characters, like e\u{0301} which renders as é and should usually be considered part of a word for English words like Éclair.

I think the correct behavior here is to only inspect the first code point in the grapheme cluster, based on this recommendation from the Unicode line breaking algorithm: "give each grapheme cluster the line breaking class of its first code point"
https://www.unicode.org/reports/tr14/#Examples

Fixes #12482