### PR TITLE
feat(highlights): add more built-in functions for `ecma`, `rust` and `haskell`

### DIFF
--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -16,8 +16,31 @@
  (#match? @variable.builtin "^(arguments|module|console|window|document)$")
  (#is-not? local))
 
-((identifier) @function.builtin
- (#eq? @function.builtin "require")
+(call_expression
+ (identifier) @function.builtin
+ (#any-of? @function.builtin
+  "eval"
+  "fetch"
+  "isFinite"
+  "isNaN"
+  "parseFloat"
+  "parseInt"
+  "decodeURI"
+  "decodeURIComponent"
+  "encodeURI"
+  "encodeURIComponent"
+  "require"
+  "alert"
+  "prompt"
+  "btoa"
+  "atob"
+  "confirm"
+  "structuredClone"
+  "setTimeout"
+  "clearTimeout"
+  "setInterval"
+  "clearInterval"
+  "queueMicrotask")
  (#is-not? local))
 
 ; Function and method definitions

--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -7,6 +7,45 @@
 (char) @constant.character
 (string) @string
 
+(exp_apply
+ (exp_name
+  (variable) @function.builtin
+   (#any-of? @function.builtin
+    "fst"
+    "snd"
+    "const"
+    "id"
+    "flip"
+    "curry"
+    "uncurry"
+    "not"
+    "elem"
+    "map"
+    "filter"
+    "foldl"
+    "foldr"
+    "head"
+    "tail"
+    "last"
+    "init"
+    "length"
+    "null"
+    "reverse"
+    "zip"
+    "unzip"
+    "take"
+    "drop"
+    "splitAt"
+    "cycle"
+    "replicate"
+    "repeat"
+    "iterate"
+    "scanl"
+    "scanr")
+  )
+)
+
+
 (con_unit) @constant.builtin ; unit, as in ()
 
 (comment) @comment

--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -11,37 +11,247 @@
  (exp_name
   (variable) @function.builtin
    (#any-of? @function.builtin
+    ; built in functions from the Haskell prelude (https://hackage.haskell.org/package/base-4.21.0.0/docs/Prelude.html)
+    ; basic data types
+    "not"
+    "maybe"
+    "either"
+
+    ; tuples
     "fst"
     "snd"
-    "const"
-    "id"
-    "flip"
     "curry"
     "uncurry"
-    "not"
+
+    ; Ord
+    "compare"
+    "min"
+    "max"
+
+    ; Enum
+    "succ"
+    "pred"
+    "toEnum"
+    "fromEnum"
+    "enumFrom"
+    "enumFromThen"
+    "enumFromThenTo"
+
+    ; Num
+    "negate"
+    "abs"
+    "signum"
+    "fromInteger"
+
+    ; Real
+    "toRational"
+
+    ; Integral
+    "quot"
+    "rem"
+    "div"
+    "mod"
+    "quotRem"
+    "divMod"
+    "toInteger"
+
+    ; Fractional
+    "recip"
+    "fromRational"
+
+    ; Floating
+    "exp"
+    "log"
+    "sqrt"
+    "logBase"
+    "sin"
+    "cos"
+    "tan"
+    "asin"
+    "acos"
+    "atan"
+    "sinh"
+    "cosh"
+    "tanh"
+    "asinh"
+    "acosh"
+    "atanh"
+
+    ; RealFrac
+    "properFraction"
+    "truncate"
+    "round"
+    "ceiling"
+    "floor"
+
+    ; RealFloat
+    "floatRadix"
+    "floatDigits"
+    "floatRange"
+    "decodeFloat"
+    "encodeFloat"
+    "exponent"
+    "significand"
+    "scaleFloat"
+    "isNaN"
+    "isInfinite"
+    "isDenormalized"
+    "isNegativeZero"
+    "isIEEE"
+    "atan2"
+
+    ; Numeric functions
+    "subtract"
+    "even"
+    "odd"
+    "gcd"
+    "lcm"
+    "fromIntegral"
+    "realToFrac"
+
+    ; Monoid
+    "mempty"
+    "mconcat"
+    "mappend"
+
+    ; Functor
+    "fmap"
+
+    ; Applicative
+    "liftA2"
+    "pure"
+    
+    ; Monad
+    "return"
+
+    ; MonadFail
+    "fail"
+    "mapM_"
+    "sequence_"
+
+    ; Foldable
+    "foldMap"
+    "foldr"
+    "foldl"
+    "foldl'"
+    "foldr1"
+    "foldl1"
     "elem"
+    "maximum"
+    "minimum"
+    "sum"
+    "product"
+
+    ; Traversable
+    "traverse"
+    "sequenceA"
+    "mapM"
+    "sequence"
+
+    ; miscellaneous
+    "id"
+    "const"
+    "flip"
+    "until"
+    "asTypeOf"
+    "error"
+    "errorWithoutStackTrace"
+    "undefined"
+
+    ; List
     "map"
     "filter"
-    "foldl"
-    "foldr"
     "head"
-    "tail"
     "last"
+    "tail"
     "init"
-    "length"
     "null"
+    "length"
     "reverse"
-    "zip"
-    "unzip"
+
+    ; Foldable
+    "and"
+    "or"
+    "any"
+    "all"
+    "concat"
+    "concatMap"
+
+    ; Building lists
+    "scanl"
+    "scanl1"
+    "scanr"
+    "scanr1"
+
+    ; Infinite lists
+    "iterate"
+    "repeat"
+    "replicate"
+    "cycle"
+
+    ; Sublists
     "take"
     "drop"
+    "takeWhile"
+    "dropWhile"
+    "span"
+    "break"
     "splitAt"
-    "cycle"
-    "replicate"
-    "repeat"
-    "iterate"
-    "scanl"
-    "scanr")
+
+    ; Searching lists
+    "notElem"
+    "lookup"
+
+    ; zipping and unzipping
+    "zip"
+    "zip3"
+    "zipWith"
+    "zipWith3"
+    "unzip"
+    "unzip3"
+
+    ; String
+    "lines"
+    "words"
+    "unlines"
+    "unwords"
+
+    ; Converting to String
+    "show"
+    "showList"
+    "shows"
+    "showChar"
+    "showString"
+    "showParen"
+
+    ; Converting from String
+    "readsPrec"
+    "readList"
+    "reads"
+    "readParen"
+    "read"
+    "lex"
+
+    ; Input and output
+    "putChar"
+    "putStr"
+    "putStrLn"
+    "print"
+    "getChar"
+    "getLine"
+    "getContents"
+    "interact"
+
+    ; Files 
+    "readFile"
+    "writeFile"
+    "appendFile"
+    "readIO"
+    "readLn"
+
+    ; Exception handling
+    "ioError"
+    "userError")
   )
 )
 

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -63,6 +63,14 @@
  (#any-of? @type.enum.variant.builtin "Some" "None" "Ok" "Err"))
 
 
+(call_expression
+  (identifier) @function.builtin
+  (#any-of? @function.builtin
+    "drop"
+    "size_of"
+    "size_of_val"
+    "align_of"
+    "align_of_val"))
 
 ((type_identifier) @type.builtin
  (#any-of?


### PR DESCRIPTION
- [Includes all `Prelude` functions for Rust](https://doc.rust-lang.org/std/prelude/index.html)
- [Includes all `Prelude` functions for Haskell](https://hackage.haskell.org/package/base-4.21.0.0/docs/Prelude.html)
- Includes global functions for JavaScript
