### PR TITLE
feat: Selecting around `"` while cursor is on `"` will no longer error

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use crate::{
     graphemes::next_grapheme_boundary,
     match_brackets::{
-        find_matching_bracket, find_matching_bracket_fuzzy, get_pair, is_close_bracket,
+        self, find_matching_bracket, find_matching_bracket_fuzzy, get_pair, is_close_bracket,
         is_open_bracket,
     },
     movement::Direction,
@@ -162,6 +162,7 @@ pub fn find_nth_pairs_pos(
     ch: char,
     range: Range,
     n: usize,
+    syntax: Option<&Syntax>,
 ) -> Result<(usize, usize)> {
     if text.len_chars() < 2 {
         return Err(Error::PairNotFound);
@@ -175,6 +176,26 @@ pub fn find_nth_pairs_pos(
 
     let (open, close) = if open == close {
         if Some(open) == text.get_char(pos) {
+            // In this case, the Cursor is directly on the match char. There is still hope to find a matching char.
+
+            if let Some(final_attempt) = syntax
+                .map_or_else(
+                    || match_brackets::find_matching_bracket_plaintext(text.slice(..), pos),
+                    |syntax| {
+                        match_brackets::find_matching_bracket_fuzzy(syntax, text.slice(..), pos)
+                    },
+                )
+                .map(|matching_pair_pos| {
+                    if matching_pair_pos > pos {
+                        (pos, matching_pair_pos)
+                    } else {
+                        (matching_pair_pos, pos)
+                    }
+                })
+            {
+                return Ok(final_attempt);
+            };
+
             // Cursor is directly on match char. We return no match
             // because there's no way to know which side of the char
             // we should be searching on.
@@ -298,7 +319,7 @@ pub fn get_surround_pos(
     for &range in selection {
         let (open_pos, close_pos) = {
             let range_raw = match ch {
-                Some(ch) => find_nth_pairs_pos(text, ch, range, skip)?,
+                Some(ch) => find_nth_pairs_pos(text, ch, range, skip, syntax)?,
                 None => find_nth_closest_pairs_pos(syntax, text, range, skip)?,
             };
             let range = Range::new(range_raw.0, range_raw.1);
@@ -392,7 +413,7 @@ mod test {
 
         assert_eq!(2, expectations.len());
         assert_eq!(
-            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 1)
+            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 1, None)
                 .expect("find should succeed"),
             (expectations[0], expectations[1])
         )
@@ -409,7 +430,7 @@ mod test {
 
         assert_eq!(2, expectations.len());
         assert_eq!(
-            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 2)
+            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 2, None)
                 .expect("find should succeed"),
             (expectations[0], expectations[1])
         )
@@ -425,7 +446,7 @@ mod test {
             );
 
         assert_eq!(
-            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 1),
+            find_nth_pairs_pos(doc.slice(..), '\'', selection.primary(), 1, None),
             Err(Error::CursorOnAmbiguousPair)
         )
     }

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -228,7 +228,7 @@ fn textobject_pair_surround_impl(
     count: usize,
 ) -> Range {
     let pair_pos = match ch {
-        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count),
+        Some(ch) => surround::find_nth_pairs_pos(slice, ch, range, count, syntax),
         None => surround::find_nth_closest_pairs_pos(syntax, slice, range, count),
     };
     pair_pos

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5627,73 +5627,16 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 let (view, doc) = current!(editor);
                 let text = doc.text().slice(..);
 
-                let textobject_treesitter = |obj_name: &str, range: Range| -> Range {
-                    let (lang_config, syntax) = match doc.language_config().zip(doc.syntax()) {
-                        Some(t) => t,
-                        None => return range,
-                    };
-                    textobject::textobject_treesitter(
+                let selection = doc.selection(view.id).clone().transform(|range| match ch {
+                    ch if !ch.is_ascii_alphanumeric() => textobject::textobject_pair_surround(
+                        doc.syntax(),
                         text,
                         range,
                         objtype,
-                        obj_name,
-                        syntax.tree().root_node(),
-                        lang_config,
+                        ch,
                         count,
-                    )
-                };
-
-                if ch == 'g' && doc.diff_handle().is_none() {
-                    editor.set_status("Diff is not available in current buffer");
-                    return;
-                }
-
-                let textobject_change = |range: Range| -> Range {
-                    let diff_handle = doc.diff_handle().unwrap();
-                    let diff = diff_handle.load();
-                    let line = range.cursor_line(text);
-                    let hunk_idx = if let Some(hunk_idx) = diff.hunk_at(line as u32, false) {
-                        hunk_idx
-                    } else {
-                        return range;
-                    };
-                    let hunk = diff.nth_hunk(hunk_idx).after;
-
-                    let start = text.line_to_char(hunk.start as usize);
-                    let end = text.line_to_char(hunk.end as usize);
-                    Range::new(start, end).with_direction(range.direction())
-                };
-
-                let selection = doc.selection(view.id).clone().transform(|range| {
-                    match ch {
-                        'w' => textobject::textobject_word(text, range, objtype, count, false),
-                        'W' => textobject::textobject_word(text, range, objtype, count, true),
-                        't' => textobject_treesitter("class", range),
-                        'f' => textobject_treesitter("function", range),
-                        'a' => textobject_treesitter("parameter", range),
-                        'c' => textobject_treesitter("comment", range),
-                        'T' => textobject_treesitter("test", range),
-                        'e' => textobject_treesitter("entry", range),
-                        'p' => textobject::textobject_paragraph(text, range, objtype, count),
-                        'm' => textobject::textobject_pair_surround_closest(
-                            doc.syntax(),
-                            text,
-                            range,
-                            objtype,
-                            count,
-                        ),
-                        'g' => textobject_change(range),
-                        // TODO: cancel new ranges if inconsistent surround matches across lines
-                        ch if !ch.is_ascii_alphanumeric() => textobject::textobject_pair_surround(
-                            doc.syntax(),
-                            text,
-                            range,
-                            objtype,
-                            ch,
-                            count,
-                        ),
-                        _ => range,
-                    }
+                    ),
+                    _ => range,
                 });
                 doc.set_selection(view.id, selection);
             };


### PR DESCRIPTION
Previously, if you had a file like this:

```
"ui.text" "example"
```

Having cursor on the 2nd `"` will give an error: `Cursor on ambiguous pair`

With this PR, it won't error anymore and it will highlight the entire `"ui.text"` correctly