### PR TITLE
Added missing CSS highlight Tree Sitter Scopes

### DIFF
--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -52,6 +52,9 @@
  (from)
  (important)
  (to)
+ (keyword_query)
+ (keyframes_name)
+ (unit)
 ] @keyword
 
 [


### PR DESCRIPTION
I saw that some highlighting was missing in my CSS files. 
I added the missing scopes (or nodes? idk how to call them) but I don't know what proper color for them would be, so please, advice me regarding the changes to make.

For now, for demonstration purposes, I added them as keywords.

Before:
![image](https://github.com/user-attachments/assets/c419005c-0419-4983-bf8c-23f03714ca5f)
![image](https://github.com/user-attachments/assets/3903ef7f-4cae-4904-852a-9a022feca016)
![image](https://github.com/user-attachments/assets/4bec346b-5368-4b53-851c-b671a3f7bbe1)

After:
![image](https://github.com/user-attachments/assets/dec8922f-ec19-40f3-991e-4827afcc920a)
![image](https://github.com/user-attachments/assets/00f0f44d-4b76-40b6-9356-0cc76fe92b57)
![image](https://github.com/user-attachments/assets/8d494823-d419-4753-b5c5-4a5fdb7bae3c)

Also, right now we have these queries
```
[
 "and"
 "not"
 "only"
 "or"
] @keyword.operator
```
Which incorrectly capture things inside `::part()` selector, inside of which can be any label (used to access elements inside Shadow-DOM). But as I understood it requires some changes to the C parser, and I have never written C or Parser/lexer so I cannot fix it... I will just notify whoever can fix it 

![image](https://github.com/user-attachments/assets/e77115cd-ecdb-42f6-add3-bb36ec07b7e6)

And one more question, is there any way to copy/dump the tree-sitter tree, similar to #12208? That would be great for analysis or bug fixes or learning.
