### PR TITLE
fix: unable to detect Color completion item hex code for some LSPs

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -93,7 +93,7 @@ impl menu::Item for CompletionItem {
                             }) => value,
                         };
                         // LSPs which send Color completion items include a 6 digit hex code at the end for the color. The extra 1 digit is for the '#'
-                        text.get(text.len() - 7..)
+                        text.get(text.len().checked_sub(7)?..)
                     })
                     .and_then(Color::from_hex)
                     .map_or("color".into(), |color| {

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -92,6 +92,7 @@ impl menu::Item for CompletionItem {
                                 value, ..
                             }) => value,
                         };
+                        // LSPs which send Color completion items include a 6 digit hex code at the end for the color. The extra 1 digit is for the '#'
                         text.get(text.len() - 7..)
                     })
                     .and_then(Color::from_hex)

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -92,7 +92,8 @@ impl menu::Item for CompletionItem {
                                 value, ..
                             }) => value,
                         };
-                        // LSPs which send Color completion items include a 6 digit hex code at the end for the color. The extra 1 digit is for the '#'
+                        // Language servers which send Color completion items tend to include a 6
+                        // digit hex code at the end for the color. The extra 1 digit is for the '#'
                         text.get(text.len().checked_sub(7)?..)
                     })
                     .and_then(Color::from_hex)

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -92,8 +92,9 @@ impl menu::Item for CompletionItem {
                                 value, ..
                             }) => value,
                         };
-                        Color::from_hex(text)
+                        text.get(text.len() - 7..)
                     })
+                    .and_then(Color::from_hex)
                     .map_or("color".into(), |color| {
                         Spans::from(vec![
                             Span::raw("color "),


### PR DESCRIPTION
In https://github.com/helix-editor/helix/pull/12299#issuecomment-2585354083 it was discovered that some LSPs also send additional documentation per LSP color, other than the color's hex code

Since our current approach is to check if the *entire* documentation matches a hex code, this meant the hex code can't be detected

With this PR, we now check against the end of the documentation, which means all LSPs which currently work will continue to work, but LSPs that send extra documentation per-color (like Dart LSP) will work as well.