### PR TITLE
Detect and warn when document is modified externally (#1125)

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -623,6 +623,9 @@ impl Application {
                     self.render().await;
                 }
             }
+            EditorEvent::ExternalModification(_) => {
+                self.render().await;
+            }
             EditorEvent::Redraw => {
                 self.render().await;
             }

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -6,6 +6,7 @@ use helix_event::AsyncHook;
 use crate::config::Config;
 use crate::events;
 use crate::handlers::auto_save::AutoSaveHandler;
+use crate::handlers::check_modification::CheckModificationHandler;
 use crate::handlers::completion::CompletionHandler;
 use crate::handlers::signature_help::SignatureHelpHandler;
 
@@ -13,6 +14,7 @@ pub use completion::trigger_auto_completion;
 pub use helix_view::handlers::Handlers;
 
 mod auto_save;
+mod check_modification;
 pub mod completion;
 mod diagnostics;
 mod signature_help;
@@ -24,16 +26,19 @@ pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
     let completions = CompletionHandler::new(config).spawn();
     let signature_hints = SignatureHelpHandler::new().spawn();
     let auto_save = AutoSaveHandler::new().spawn();
+    let check_modification = CheckModificationHandler::new().spawn();
 
     let handlers = Handlers {
         completions,
         signature_hints,
         auto_save,
+        check_modification,
     };
 
     completion::register_hooks(&handlers);
     signature_help::register_hooks(&handlers);
     auto_save::register_hooks(&handlers);
+    check_modification::register_hooks(&handlers);
     diagnostics::register_hooks(&handlers);
     snippet::register_hooks(&handlers);
     handlers

--- a/helix-term/src/handlers/check_modification.rs
+++ b/helix-term/src/handlers/check_modification.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashSet,
-    sync::{
-        Arc,
-        Mutex,
-    },
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -11,14 +8,13 @@ use anyhow::Ok;
 
 use helix_event::{register_hook, send_blocking};
 use helix_view::{
-    DocumentId,
     events::DocumentDidChange,
     handlers::{CheckModificationEvent, Handlers},
+    DocumentId,
 };
 use tokio::time::Instant;
 
 use crate::job;
-
 
 /// CheckModificationHandler reacts to user changes in the editor by checking if there
 /// has been an external change on the filesystem for the same file since the last save.
@@ -76,7 +72,7 @@ pub(super) fn register_hooks(handlers: &Handlers) {
         send_blocking(
             &tx,
             CheckModificationEvent {
-                doc_id: event.doc.id()
+                doc_id: event.doc.id(),
             },
         );
         Ok(())

--- a/helix-term/src/handlers/check_modification.rs
+++ b/helix-term/src/handlers/check_modification.rs
@@ -34,7 +34,7 @@ impl CheckModificationHandler {
 
 // Strike a balance between spamming stat syscalls and informing the user relatively soon
 // after they start making changes that there's a conflict.
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
+const DEBOUNCE_INTERVAL: Duration = Duration::from_millis(500);
 
 impl helix_event::AsyncHook for CheckModificationHandler {
     type Event = CheckModificationEvent;

--- a/helix-term/src/handlers/check_modification.rs
+++ b/helix-term/src/handlers/check_modification.rs
@@ -1,0 +1,84 @@
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        Mutex,
+    },
+    time::Duration,
+};
+
+use anyhow::Ok;
+
+use helix_event::{register_hook, send_blocking};
+use helix_view::{
+    DocumentId,
+    events::DocumentDidChange,
+    handlers::{CheckModificationEvent, Handlers},
+};
+use tokio::time::Instant;
+
+use crate::job;
+
+
+/// CheckModificationHandler reacts to user changes in the editor by checking if there
+/// has been an external change on the filesystem for the same file since the last save.
+#[derive(Debug)]
+pub(super) struct CheckModificationHandler {
+    /// Documents that should be polled.
+    docs: Arc<Mutex<HashSet<DocumentId>>>,
+}
+
+impl CheckModificationHandler {
+    pub fn new() -> CheckModificationHandler {
+        CheckModificationHandler {
+            docs: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+// Strike a balance between spamming stat syscalls and informing the user relatively soon
+// after they start making changes that there's a conflict.
+const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
+
+impl helix_event::AsyncHook for CheckModificationHandler {
+    type Event = CheckModificationEvent;
+
+    fn handle_event(
+        &mut self,
+        event: Self::Event,
+        existing_debounce: Option<tokio::time::Instant>,
+    ) -> Option<Instant> {
+        {
+            let mu = self.docs.clone();
+            let mut docs = mu.lock().unwrap();
+            docs.insert(event.doc_id);
+        }
+        existing_debounce.or_else(|| Some(Instant::now() + DEBOUNCE_INTERVAL))
+    }
+
+    fn finish_debounce(&mut self) {
+        let docs = {
+            let mu = self.docs.clone();
+            let mut docs = mu.lock().unwrap();
+            docs.drain().collect::<Vec<DocumentId>>()
+        };
+        job::dispatch_blocking(move |editor, _| {
+            for doc_id in docs {
+                editor.check_external_modification(doc_id);
+            }
+        });
+    }
+}
+
+pub(super) fn register_hooks(handlers: &Handlers) {
+    let tx = handlers.check_modification.clone();
+    register_hook!(move |event: &mut DocumentDidChange<'_>| {
+        send_blocking(
+            &tx,
+            CheckModificationEvent {
+                doc_id: event.doc.id()
+            },
+        );
+        Ok(())
+    });
+}

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -458,7 +458,8 @@ where
         (true, false) => "[+]",
         (false, true) => "[-]",
         (false, false) => "   ",
-    }.to_string();
+    }
+    .to_string();
     write(context, title, None);
 }
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -451,13 +451,14 @@ fn render_file_modification_indicator<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    let title = (if context.doc.is_modified() {
-        "[+]"
-    } else {
-        "   "
-    })
-    .to_string();
-
+    let is_modified = context.doc.is_modified();
+    let externally_modified = context.doc.externally_modified;
+    let title = match (is_modified, externally_modified) {
+        (true, true) => "[!]",
+        (true, false) => "[+]",
+        (false, true) => "[-]",
+        (false, false) => "   ",
+    }.to_string();
     write(context, title, None);
 }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -187,7 +187,7 @@ pub struct Document {
     pub(crate) modified_since_accessed: bool,
     // Whether the file was modified by another process after it was last opened or saved.
     // Just a heuristic, and may be stale.
-    pub(crate) externally_modified: bool,
+    pub externally_modified: bool,
 
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) language_servers: HashMap<LanguageServerName, Arc<Client>>,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -180,11 +180,14 @@ pub struct Document {
 
     // Last time we wrote to the file. This will carry the time the file was last opened if there
     // were no saves.
-    last_saved_time: SystemTime,
+    pub(crate) last_saved_time: SystemTime,
 
     last_saved_revision: usize,
     version: i32, // should be usize?
     pub(crate) modified_since_accessed: bool,
+    // Whether the file was modified by another process after it was last opened or saved.
+    // Just a heuristic, and may be stale.
+    pub(crate) externally_modified: bool,
 
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) language_servers: HashMap<LanguageServerName, Arc<Client>>,
@@ -287,6 +290,7 @@ impl fmt::Debug for Document {
             .field("last_saved_revision", &self.last_saved_revision)
             .field("version", &self.version)
             .field("modified_since_accessed", &self.modified_since_accessed)
+            .field("externally_modified", &self.externally_modified)
             .field("diagnostics", &self.diagnostics)
             // .field("language_server", &self.language_server)
             .finish()
@@ -691,6 +695,7 @@ impl Document {
             last_saved_time: SystemTime::now(),
             last_saved_revision: 0,
             modified_since_accessed: false,
+            externally_modified: false,
             language_servers: HashMap::new(),
             diff_handle: None,
             config,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1105,7 +1105,7 @@ pub struct Editor {
 
     external_modification_events: (
         UnboundedSender<ExternalModificationEvent>,
-        UnboundedReceiver<ExternalModificationEvent>
+        UnboundedReceiver<ExternalModificationEvent>,
     ),
 }
 
@@ -1483,7 +1483,10 @@ impl Editor {
             // to edit.  The most likely problem is lacking read ACLs, in which case we
             // can't reload anyway.
             let _ = was_modified.await.map(|was_modified| {
-                tx.send(ExternalModificationEvent { doc_id, was_modified })
+                tx.send(ExternalModificationEvent {
+                    doc_id,
+                    was_modified,
+                })
             });
         });
     }
@@ -2296,8 +2299,10 @@ fn try_restore_indent(doc: &mut Document, view: &mut View) {
     }
 }
 
-async fn check_external_modification(path: Option<PathBuf>, last_saved_time: SystemTime)
-    -> anyhow::Result<bool> {
+async fn check_external_modification(
+    path: Option<PathBuf>,
+    last_saved_time: SystemTime,
+) -> anyhow::Result<bool> {
     if let Some(path) = path {
         let metadata = tokio::fs::metadata(&path).await?;
         let mtime = metadata.modified()?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -33,6 +33,7 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
+    time::SystemTime,
 };
 
 use tokio::{
@@ -1101,6 +1102,16 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+
+    external_modification_events: (
+        UnboundedSender<ExternalModificationEvent>,
+        UnboundedReceiver<ExternalModificationEvent>
+    ),
+}
+
+struct ExternalModificationEvent {
+    doc_id: DocumentId,
+    was_modified: bool,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1177,6 +1188,7 @@ impl Editor {
         let language_servers = helix_lsp::Registry::new(syn_loader.clone());
         let conf = config.load();
         let auto_pairs = (&conf.auto_pairs).into();
+        let external_modification_events = tokio::sync::mpsc::unbounded_channel();
 
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;
@@ -1223,6 +1235,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            external_modification_events,
         }
     }
 
@@ -1451,6 +1464,28 @@ impl Editor {
         doc.language_servers.clear();
         doc.set_path(Some(path));
         self.refresh_doc_language(doc_id)
+    }
+
+    pub fn check_external_modification(&mut self, doc_id: DocumentId) {
+        //let path = self.document(doc_id).map(|
+        let (path, last_saved_time) = {
+            let Some(doc) = self.document(doc_id) else {
+                // It's okay if the document is gone - we expect to be called async.
+                return;
+            };
+            (doc.path().cloned(), doc.last_saved_time)
+        };
+        let tx = self.external_modification_events.0.clone();
+
+        let was_modified = check_external_modification(path, last_saved_time);
+        tokio::spawn(async move {
+            // Drop the error for now since we'll try again the next time the user tries
+            // to edit.  The most likely problem is lacking read ACLs, in which case we
+            // can't reload anyway.
+            let _ = was_modified.await.map(|was_modified| {
+                tx.send(ExternalModificationEvent { doc_id, was_modified })
+            });
+        });
     }
 
     pub fn refresh_doc_language(&mut self, doc_id: DocumentId) {
@@ -2107,6 +2142,11 @@ impl Editor {
                 Some(event) = self.debugger_events.next() => {
                     return EditorEvent::DebuggerEvent(event)
                 }
+                Some(event) = self.external_modification_events.1.recv() => {
+                    if let Some(doc) = self.document_mut(event.doc_id) {
+                        doc.externally_modified = event.was_modified;
+                    }
+                }
 
                 _ = helix_event::redraw_requested() => {
                     if  !self.needs_redraw{
@@ -2253,6 +2293,18 @@ fn try_restore_indent(doc: &mut Document, view: &mut View) {
                 (line_start_pos, pos, None)
             });
         doc.apply(&transaction, view.id);
+    }
+}
+
+async fn check_external_modification(path: Option<PathBuf>, last_saved_time: SystemTime)
+    -> anyhow::Result<bool> {
+    if let Some(path) = path {
+        let metadata = tokio::fs::metadata(&path).await?;
+        let mtime = metadata.modified()?;
+        Ok(last_saved_time < mtime)
+    } else {
+        // No path means there can't be an external modification.
+        Ok(false)
     }
 }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1109,7 +1109,8 @@ pub struct Editor {
     ),
 }
 
-struct ExternalModificationEvent {
+#[derive(Debug)]
+pub struct ExternalModificationEvent {
     doc_id: DocumentId,
     was_modified: bool,
 }
@@ -1122,6 +1123,7 @@ pub enum EditorEvent {
     ConfigEvent(ConfigEvent),
     LanguageServerMessage((LanguageServerId, Call)),
     DebuggerEvent(dap::Payload),
+    ExternalModification(ExternalModificationEvent),
     IdleTimer,
     Redraw,
 }
@@ -2149,6 +2151,7 @@ impl Editor {
                     if let Some(doc) = self.document_mut(event.doc_id) {
                         doc.externally_modified = event.was_modified;
                     }
+                    return EditorEvent::ExternalModification(event)
                 }
 
                 _ = helix_event::redraw_requested() => {

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -14,11 +14,19 @@ pub enum AutoSaveEvent {
     LeftInsertMode,
 }
 
+/// Indicates that the file corresponding to a particular document should be checked for
+/// external modifications.
+#[derive(Debug)]
+pub struct CheckModificationEvent {
+    pub doc_id: DocumentId
+}
+
 pub struct Handlers {
     // only public because most of the actual implementation is in helix-term right now :/
     pub completions: Sender<lsp::CompletionEvent>,
     pub signature_hints: Sender<lsp::SignatureHelpEvent>,
     pub auto_save: Sender<AutoSaveEvent>,
+    pub check_modification: Sender<CheckModificationEvent>,
 }
 
 impl Handlers {

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -18,7 +18,7 @@ pub enum AutoSaveEvent {
 /// external modifications.
 #[derive(Debug)]
 pub struct CheckModificationEvent {
-    pub doc_id: DocumentId
+    pub doc_id: DocumentId,
 }
 
 pub struct Handlers {


### PR DESCRIPTION
A pragmatic solution to #1125.

Whenever a document is changed within helix, check the mtime from the file system to see if it is different than the last-known save time.  If it is:

* Use `+`, `-` or `!` respectively to indicate whether there is an internal modification, external modification, or both (a conflict).
* Show a message in the editor status advising the user to write or reload in the case of a conflict.

Reloading is not forced on the user; just encouraged.

This PR does not do any fancy registration for push notifications ala inotify/fsevent, nor is it suitable for keeping LSPs in sync.  But it does solve the problem of warning users before they invest time into making edits that will either clobber or need to be manually merged with other changes later.

The heuristic it uses (using the file system mtime) isn't perfect, but it matches the existing logic that `:write` applies today to detect conflicts.