### PR TITLE
feat: Double click selects word, Triple click selects line

### DIFF
--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -11,7 +11,12 @@ use crate::syntax::LanguageConfiguration;
 use crate::Range;
 use crate::{surround, Syntax};
 
-fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, long: bool) -> usize {
+pub fn find_word_boundary(
+    slice: RopeSlice,
+    mut pos: usize,
+    direction: Direction,
+    long: bool,
+) -> usize {
     use CharCategory::{Eol, Whitespace};
 
     let iter = match direction {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1174,27 +1174,16 @@ impl EditorView {
                 let editor = &mut cxt.editor;
 
                 if let Some((pos, view_id)) = pos_and_view(editor, row, column, true) {
-                    let click_type = editor.mouse_clicks.register_click(pos);
-
-                    let message;
                     let prev_view_id = view!(editor).id;
                     let doc = doc_mut!(editor, &view!(editor, view_id).doc);
 
-                    match click_type {
-                        MouseClick::Triple => {
-                            message = format!("triple click: {:?}, {}", editor.mouse_clicks, pos);
-                        }
-                        MouseClick::Double => {
-                            message = format!("double click: {:?}, {}", editor.mouse_clicks, pos);
-                        }
+                    match editor.mouse_clicks.register_click(pos) {
+                        MouseClick::Triple => {}
+                        MouseClick::Double => {}
                         MouseClick::Single => {
                             if modifiers == KeyModifiers::ALT {
                                 let selection = doc.selection(view_id).clone();
                                 doc.set_selection(view_id, selection.push(Range::point(pos)));
-                                message = format!(
-                                    "(alt) single click: {:?}, {}",
-                                    editor.mouse_clicks, pos
-                                );
                             } else if editor.mode == Mode::Select {
                                 // Discards non-primary selections for consistent UX with normal mode
                                 let primary = doc.selection(view_id).primary().put_cursor(
@@ -1202,20 +1191,12 @@ impl EditorView {
                                     pos,
                                     true,
                                 );
-                                message = format!(
-                                    "(select) single click: {:?}, {}",
-                                    editor.mouse_clicks, pos
-                                );
-
                                 editor.mouse_down_range = Some(primary);
                                 doc.set_selection(
                                     view_id,
                                     Selection::single(primary.anchor, primary.head),
                                 );
                             } else {
-                                message =
-                                    format!("single click: {:?}, {}", editor.mouse_clicks, pos);
-
                                 doc.set_selection(view_id, Selection::point(pos));
                             }
                         }
@@ -1227,8 +1208,6 @@ impl EditorView {
 
                     editor.focus(view_id);
                     editor.ensure_cursor_in_view(view_id);
-
-                    editor.set_status(message);
 
                     return EventResult::Consumed(None);
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -46,6 +46,50 @@ pub struct EditorView {
     terminal_focused: bool,
 }
 
+/// Tracks the character positions where the mouse was last clicked
+///
+/// If we double click, select that word
+/// If we triple click, select full line
+struct MouseClicks {
+    clicks: [Option<usize>; 2],
+    count: usize,
+}
+
+impl MouseClicks {
+    fn new() -> Self {
+        Self {
+            clicks: [None, None],
+            count: 0,
+        }
+    }
+
+    fn register_click(&mut self, char_idx: usize) {
+        match self.count {
+            0 => {
+                self.clicks[0] = Some(char_idx);
+                self.count = 1;
+            }
+            1 => {
+                self.clicks[1] = Some(char_idx);
+                self.count = 2;
+            }
+            2 => {
+                self.clicks[0] = self.clicks[1];
+                self.clicks[1] = Some(char_idx);
+            }
+            _ => unreachable!("Mouse click count should never exceed 2"),
+        }
+    }
+
+    fn has_double_click(&mut self) -> Option<usize> {
+        self.clicks[0].filter(|first_click| Some(first_click) != self.clicks[1].as_ref())
+    }
+
+    fn has_single_click(&mut self) -> Option<usize> {
+        self.clicks[1]
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum InsertEvent {
     Key(KeyEvent),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -105,6 +105,7 @@ impl MouseClicks {
         }
     }
 
+    /// Registers a click for a certain character, and returns the type of this click
     pub fn register_click(&mut self, char_idx: usize) -> MouseClick {
         let click_type = if self.is_triple_click(char_idx) {
             MouseClick::Triple

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -8,7 +8,7 @@ use crate::{
     graphics::{CursorKind, Rect},
     handlers::Handlers,
     info::Info,
-    input::KeyEvent,
+    input::{KeyEvent, MouseClicks},
     register::Registers,
     theme::{self, Theme},
     tree::{self, Tree},
@@ -79,68 +79,6 @@ where
             .try_into()
             .map_err(|_| serde::ser::Error::custom("duration value overflowed u64"))?,
     )
-}
-
-/// Tracks the character positions where the mouse was last clicked
-///
-/// If we double click, select that word
-/// If we triple click, select full line
-#[derive(Debug)]
-pub struct MouseClicks {
-    clicks: [Option<usize>; 2],
-    count: usize,
-}
-
-pub enum MouseClick {
-    Single,
-    Double,
-    Triple,
-}
-
-impl MouseClicks {
-    fn new() -> Self {
-        Self {
-            clicks: [None, None],
-            count: 0,
-        }
-    }
-
-    /// Registers a click for a certain character, and returns the type of this click
-    pub fn register_click(&mut self, char_idx: usize) -> MouseClick {
-        let click_type = if self.is_triple_click(char_idx) {
-            MouseClick::Triple
-        } else if self.is_double_click(char_idx) {
-            MouseClick::Double
-        } else {
-            MouseClick::Single
-        };
-
-        match self.count {
-            0 => {
-                self.clicks[0] = Some(char_idx);
-                self.count = 1;
-            }
-            1 => {
-                self.clicks[1] = Some(char_idx);
-                self.count = 2;
-            }
-            2 => {
-                self.clicks[0] = self.clicks[1];
-                self.clicks[1] = Some(char_idx);
-            }
-            _ => unreachable!("Mouse click count will never exceed 2"),
-        };
-
-        click_type
-    }
-
-    fn is_triple_click(&mut self, pos: usize) -> bool {
-        Some(pos) == self.clicks[0] && Some(pos) == self.clicks[1]
-    }
-
-    fn is_double_click(&mut self, pos: usize) -> bool {
-        Some(pos) == self.clicks[1] && Some(pos) != self.clicks[0]
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -91,6 +91,12 @@ pub struct MouseClicks {
     count: usize,
 }
 
+pub enum MouseClick {
+    Single,
+    Double,
+    Triple,
+}
+
 impl MouseClicks {
     fn new() -> Self {
         Self {
@@ -99,7 +105,15 @@ impl MouseClicks {
         }
     }
 
-    pub fn register_click(&mut self, char_idx: usize) {
+    pub fn register_click(&mut self, char_idx: usize) -> MouseClick {
+        let click_type = if self.is_triple_click(char_idx) {
+            MouseClick::Triple
+        } else if self.is_double_click(char_idx) {
+            MouseClick::Double
+        } else {
+            MouseClick::Single
+        };
+
         match self.count {
             0 => {
                 self.clicks[0] = Some(char_idx);
@@ -113,15 +127,17 @@ impl MouseClicks {
                 self.clicks[0] = self.clicks[1];
                 self.clicks[1] = Some(char_idx);
             }
-            _ => unreachable!("Mouse click count should never exceed 2"),
-        }
+            _ => unreachable!("Mouse click count will never exceed 2"),
+        };
+
+        click_type
     }
 
-    pub fn is_triple_click(&mut self, pos: usize) -> bool {
+    fn is_triple_click(&mut self, pos: usize) -> bool {
         Some(pos) == self.clicks[0] && Some(pos) == self.clicks[1]
     }
 
-    pub fn is_double_click(&mut self, pos: usize) -> bool {
+    fn is_double_click(&mut self, pos: usize) -> bool {
         Some(pos) == self.clicks[1] && Some(pos) != self.clicks[0]
     }
 }


### PR DESCRIPTION
this PR improves mouse support by implementing 2 functionalities common in other text editors:
- Double-clicking selects the word
- Triple-clicking selects the full line

It is desirable to implement this in the editor as it provides cross-terminal support as well as, allowing functionality that terminal emulators won't be able to provide: such selecting the entire line in the document.

Would close https://github.com/helix-editor/helix/issues/12500