### PR TITLE
add `rockspec` to lua file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1295,7 +1295,7 @@ formatter = { command = "dune", args = ["format-dune-file"] }
 name = "lua"
 injection-regex = "lua"
 scope = "source.lua"
-file-types = ["lua"]
+file-types = ["lua", "rockspec"]
 shebangs = ["lua", "luajit"]
 roots = [".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git"]
 comment-token = "--"


### PR DESCRIPTION
[LuaRocks](https://luarocks.org/) is a common Lua package manager.  The metadata file for a LuaRocks package is a Lua file with a `.rockspec` extension.