### PR TITLE
feat: Picker titles

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2527,6 +2527,7 @@ fn global_search(cx: &mut Context) {
     cx.editor.registers.last_search_register = reg;
 
     let picker = Picker::new(
+        Some("Global Search"),
         columns,
         1, // contents
         [],
@@ -3037,9 +3038,16 @@ fn buffer_picker(cx: &mut Context) {
                 .into()
         }),
     ];
-    let picker = Picker::new(columns, 2, items, (), |cx, meta, action| {
-        cx.editor.switch(meta.id, action);
-    })
+    let picker = Picker::new(
+        Some("Buffers"),
+        columns,
+        2,
+        items,
+        (),
+        |cx, meta, action| {
+            cx.editor.switch(meta.id, action);
+        },
+    )
     .with_preview(|editor, meta| {
         let doc = &editor.documents.get(&meta.id)?;
         let &view_id = doc.selections().keys().next()?;
@@ -3116,6 +3124,7 @@ fn jumplist_picker(cx: &mut Context) {
     ];
 
     let picker = Picker::new(
+        Some("Jump List"),
         columns,
         1, // path
         cx.editor.tree.views().flat_map(|(view, _)| {
@@ -3198,6 +3207,7 @@ fn changed_file_picker(cx: &mut Context) {
     ];
 
     let picker = Picker::new(
+        Some("Changed Files"),
         columns,
         1, // path
         [],
@@ -3288,32 +3298,39 @@ pub fn command_palette(cx: &mut Context) {
                 ui::PickerColumn::new("doc", |item: &MappableCommand, _| item.doc().into()),
             ];
 
-            let picker = Picker::new(columns, 0, commands, keymap, move |cx, command, _action| {
-                let mut ctx = Context {
-                    register,
-                    count,
-                    editor: cx.editor,
-                    callback: Vec::new(),
-                    on_next_key_callback: None,
-                    jobs: cx.jobs,
-                };
-                let focus = view!(ctx.editor).id;
+            let picker = Picker::new(
+                Some("Commands"),
+                columns,
+                0,
+                commands,
+                keymap,
+                move |cx, command, _action| {
+                    let mut ctx = Context {
+                        register,
+                        count,
+                        editor: cx.editor,
+                        callback: Vec::new(),
+                        on_next_key_callback: None,
+                        jobs: cx.jobs,
+                    };
+                    let focus = view!(ctx.editor).id;
 
-                command.execute(&mut ctx);
+                    command.execute(&mut ctx);
 
-                if ctx.editor.tree.contains(focus) {
-                    let config = ctx.editor.config();
-                    let mode = ctx.editor.mode();
-                    let view = view_mut!(ctx.editor, focus);
-                    let doc = doc_mut!(ctx.editor, &view.doc);
+                    if ctx.editor.tree.contains(focus) {
+                        let config = ctx.editor.config();
+                        let mode = ctx.editor.mode();
+                        let view = view_mut!(ctx.editor, focus);
+                        let doc = doc_mut!(ctx.editor, &view.doc);
 
-                    view.ensure_cursor_in_view(doc, config.scrolloff);
+                        view.ensure_cursor_in_view(doc, config.scrolloff);
 
-                    if mode != Mode::Insert {
-                        doc.append_changes_to_history(view);
+                        if mode != Mode::Insert {
+                            doc.append_changes_to_history(view);
+                        }
                     }
-                }
-            });
+                },
+            );
             compositor.push(Box::new(overlaid(picker)));
         },
     ));

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -52,6 +52,7 @@ fn thread_picker(
                 }),
             ];
             let picker = Picker::new(
+                None,
                 columns,
                 0,
                 threads,
@@ -257,6 +258,7 @@ pub fn dap_launch(cx: &mut Context) {
     )];
 
     cx.push_layer(Box::new(overlaid(Picker::new(
+        None,
         columns,
         0,
         templates,
@@ -731,7 +733,7 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
     let columns = [ui::PickerColumn::new("frame", |item: &StackFrame, _| {
         item.name.as_str().into() // TODO: include thread_states in the label
     })];
-    let picker = Picker::new(columns, 0, frames, (), move |cx, frame, _action| {
+    let picker = Picker::new(None, columns, 0, frames, (), move |cx, frame, _action| {
         let debugger = debugger!(cx.editor);
         // TODO: this should be simpler to find
         let pos = debugger.stack_frames[&thread_id]

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -281,6 +281,7 @@ fn diag_picker(
     }
 
     Picker::new(
+        Some("Diagnostics"),
         columns,
         primary_column,
         flat_diag,
@@ -405,6 +406,7 @@ pub fn symbol_picker(cx: &mut Context) {
             ];
 
             let picker = Picker::new(
+                Some("Document Symbols"),
                 columns,
                 1, // name column
                 symbols,
@@ -516,6 +518,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     ];
 
     let picker = Picker::new(
+        Some("Workspace Symbols"),
         columns,
         1, // name column
         [],
@@ -854,6 +857,7 @@ impl Display for ApplyEditErrorKind {
 
 /// Precondition: `locations` should be non-empty.
 fn goto_impl(
+    title: &str,
     editor: &mut Editor,
     compositor: &mut Compositor,
     locations: Vec<Location>,
@@ -880,9 +884,16 @@ fn goto_impl(
                 },
             )];
 
-            let picker = Picker::new(columns, 0, locations, cwdir, move |cx, location, action| {
-                jump_to_location(cx.editor, location, offset_encoding, action)
-            })
+            let picker = Picker::new(
+                Some(title),
+                columns,
+                0,
+                locations,
+                cwdir,
+                move |cx, location, action| {
+                    jump_to_location(cx.editor, location, offset_encoding, action)
+                },
+            )
             .with_preview(move |_editor, location| location_to_file_location(location));
             compositor.push(Box::new(overlaid(picker)));
         }
@@ -928,7 +939,13 @@ where
             if items.is_empty() {
                 editor.set_error("No definition found.");
             } else {
-                goto_impl(editor, compositor, items, offset_encoding);
+                goto_impl(
+                    "Goto Implementation",
+                    editor,
+                    compositor,
+                    items,
+                    offset_encoding,
+                );
             }
         },
     );
@@ -996,7 +1013,7 @@ pub fn goto_reference(cx: &mut Context) {
             if items.is_empty() {
                 editor.set_error("No references found.");
             } else {
-                goto_impl(editor, compositor, items, offset_encoding);
+                goto_impl("Goto Reference", editor, compositor, items, offset_encoding);
             }
         },
     );

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1342,6 +1342,7 @@ fn lsp_workspace_command(
                         },
                     )];
                     let picker = ui::Picker::new(
+                        Some("Workspace Symbols"),
                         columns,
                         0,
                         commands,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -240,16 +240,23 @@ pub fn file_picker(root: PathBuf, config: &helix_view::editor::Config) -> FilePi
                 .into()
         },
     )];
-    let picker = Picker::new(columns, 0, [], root, move |cx, path: &PathBuf, action| {
-        if let Err(e) = cx.editor.open(path, action) {
-            let err = if let Some(err) = e.source() {
-                format!("{}", err)
-            } else {
-                format!("unable to open \"{}\"", path.display())
-            };
-            cx.editor.set_error(err);
-        }
-    })
+    let picker = Picker::new(
+        Some("Files"),
+        columns,
+        0,
+        [],
+        root,
+        move |cx, path: &PathBuf, action| {
+            if let Err(e) = cx.editor.open(path, action) {
+                let err = if let Some(err) = e.source() {
+                    format!("{}", err)
+                } else {
+                    format!("unable to open \"{}\"", path.display())
+                };
+                cx.editor.set_error(err);
+            }
+        },
+    )
     .with_preview(|_editor, path| Some((path.as_path().into(), None)));
     let injector = picker.injector();
     let timeout = std::time::Instant::now() + std::time::Duration::from_millis(30);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -259,6 +259,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
     /// An event handler for syntax highlighting the currently previewed file.
     preview_highlight_handler: Sender<Arc<Path>>,
     dynamic_query_handler: Option<Sender<DynamicQueryChange>>,
+    title: Option<String>,
 }
 
 impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
@@ -287,6 +288,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     pub fn new<C, O, F>(
+        title: Option<&str>,
         columns: C,
         primary_column: usize,
         options: O,
@@ -312,6 +314,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             inject_nucleo_item(&injector, &columns, item, &editor_data);
         }
         Self::with(
+            title,
             matcher,
             columns,
             primary_column,
@@ -322,12 +325,14 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     pub fn with_stream(
+        title: Option<&str>,
         matcher: Nucleo<T>,
         primary_column: usize,
         injector: Injector<T, D>,
         callback_fn: impl Fn(&mut Context, &T, Action) + 'static,
     ) -> Self {
         Self::with(
+            title,
             matcher,
             injector.columns,
             primary_column,
@@ -338,6 +343,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     fn with(
+        title: Option<&str>,
         matcher: Nucleo<T>,
         columns: Arc<[Column<T, D>]>,
         default_column: usize,
@@ -380,6 +386,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             file_fn: None,
             preview_highlight_handler: PreviewHighlightHandler::<T, D>::default().spawn(),
             dynamic_query_handler: None,
+            title: title.map(|title| title.into()),
         }
     }
 
@@ -640,12 +647,14 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let background = cx.editor.theme.get("ui.background");
         surface.clear_with(area, background);
 
-        const BLOCK: Block<'_> = Block::bordered();
+        let block: Block<'_> = self.title.as_ref().map_or(Block::bordered(), |title| {
+            Block::bordered().title(title.to_string())
+        });
 
         // calculate the inner area inside the box
-        let inner = BLOCK.inner(area);
+        let inner = block.inner(area);
 
-        BLOCK.render(area, surface);
+        block.render(area, surface);
 
         // -- Render the input bar:
 
@@ -934,7 +943,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
 impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I, D> {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        // +---------+ +---------+
+        // +--title--+ +---------+
         // |prompt   | |preview  |
         // +---------+ |         |
         // |picker   | |         |


### PR DESCRIPTION
Pickers now have titles. This improves user experience

It also gives us flexibility, for when we want to add additional contextual information into the picker. For instance, https://github.com/helix-editor/helix/pull/11285 would benefit from displaying the current directory of the file picker.

![image](https://github.com/user-attachments/assets/00cf2c65-49cf-4d32-a62b-3d68e71592e2)

|picker type|title|
|-------------|--------|
| thread_picker | -|
| dap_launch | -|
| dap_switch_stack_frame | -|
| diag_picker | Diagnostics |
| symbol_picker | Document Symbols |
| lsp_workspace_command | Workspace Symbols| 
| workspace_symbol_picker | Workspace Symbols |
| goto_reference | Goto Reference |
| goto_single_impl | Goto Implementation |
| file_picker | Files |
| command_palette | Commands |
| changed_file_picker | Changed Files |
| jumplist_picker | Jump List |
| buffer_picker | Buffers |
| global_search | Global Search |

Closes https://github.com/helix-editor/helix/pull/12204