### PR TITLE
Stop picker before looping

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -452,8 +452,10 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | -----                        | -------------                                              |
 | `Shift-Tab`, `Up`, `Ctrl-p`  | Previous entry                                             |
 | `Tab`, `Down`, `Ctrl-n`      | Next entry                                                 |
-| `PageUp`, `Ctrl-u`           | Page up                                                    |
-| `PageDown`, `Ctrl-d`         | Page down                                                  |
+| `PageUp`, `Ctrl-b`           | Page up                                                    |
+| `PageDown`, `Ctrl-f`         | Page down                                                  |
+| `Ctrl-u`                     | Half page up                                               |
+| `Ctrl-d`                     | Half page down                                             |
 | `Home`                       | Go to first entry                                          |
 | `End`                        | Go to last entry                                           |
 | `Enter`                      | Open selected                                              |

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -440,24 +440,46 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             return;
         }
 
+        let last = len - 1;
         match direction {
+            // Leave the cursor at the edge before and after looping
             Direction::Forward => {
-                self.cursor = self.cursor.saturating_add(amount) % len;
+                if self.cursor == last {
+                    self.cursor = 0
+                } else if self.cursor.saturating_add(amount) > last {
+                    self.cursor = last;
+                } else {
+                    self.cursor = self.cursor.saturating_add(amount);
+                }
             }
             Direction::Backward => {
-                self.cursor = self.cursor.saturating_add(len).saturating_sub(amount) % len;
+                if self.cursor == 0 {
+                    self.cursor = last
+                } else {
+                    self.cursor = self.cursor.saturating_sub(amount);
+                }
             }
         }
     }
 
-    /// Move the cursor down by exactly one page. After the last page comes the first page.
+    /// Move the cursor up by exactly one page. After the first page comes the last page.
     pub fn page_up(&mut self) {
         self.move_by(self.completion_height as u32, Direction::Backward);
     }
 
-    /// Move the cursor up by exactly one page. After the first page comes the last page.
+    /// Move the cursor down by exactly one page. After the last page comes the first page.
     pub fn page_down(&mut self) {
         self.move_by(self.completion_height as u32, Direction::Forward);
+    }
+
+    /// Move the cursor up by half a page.
+    pub fn half_page_up(&mut self) {
+        self.move_by(self.completion_height as u32 / 2, Direction::Backward);
+    }
+
+    /// Move the cursor down by half a page.
+    pub fn half_page_down(&mut self) {
+        self.move_by(self.completion_height as u32 / 2, Direction::Forward);
     }
 
     /// Move the cursor to the first entry
@@ -999,11 +1021,17 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(Tab) | key!(Down) | ctrl!('n') => {
                 self.move_by(1, Direction::Forward);
             }
-            key!(PageDown) | ctrl!('d') => {
+            key!(PageDown) | ctrl!('f') => {
                 self.page_down();
             }
-            key!(PageUp) | ctrl!('u') => {
+            key!(PageUp) | ctrl!('b') => {
                 self.page_up();
+            }
+            ctrl!('d') => {
+                self.half_page_down();
+            }
+            ctrl!('u') => {
+                self.half_page_up();
             }
             key!(Home) => {
                 self.to_start();


### PR DESCRIPTION
PgDown / PgUp - Not being at the edge after looping is confusing. Especially on single-page lists the jumps seam random.

Also aligned the PgDown / Half-PgDown shortcuts with the ones used in the editor.

Overall more intuitive picker experience.