### PR TITLE
Improve `dark_plus` theme: Change `special`, `ui.text.directory` and `ui.virtual.wrap`

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -24,7 +24,7 @@
 "operator"                  = "text"
 "punctuation"               = "text"
 "punctuation.delimiter"     = "text"
-"special"                   = "text"
+"special"                   = "light_blue"
 "string"                    = "orange"
 "string.regexp"             = "gold"
 "tag"                       = "blue2"
@@ -72,9 +72,10 @@
 "ui.bufferline.background"   = { bg = "background" }
 "ui.text"                    = { fg = "text" }
 "ui.text.focus"              = { fg = "white" }
-"ui.text.directory"          = { fg = "blue3" }
+"ui.text.directory"          = { fg = "blue2" }
 "ui.text.inactive"           = { fg = "dark_gray" }
 "ui.virtual.whitespace"      = { fg = "#3e3e3d" }
+"ui.virtual.wrap"            = { fg = "#3e3e3d" }
 "ui.virtual.ruler"           = { bg = "borders" }
 "ui.virtual.indent-guide"    = { fg = "dark_gray4" }
 "ui.virtual.inlay-hint"      = { fg = "dark_gray5"}


### PR DESCRIPTION
I made some important changes that I hope can get merged before the upcoming patch release :)

1. Color the fuzzy searcher, before there was no color and it was a bad user experience:

![image](https://github.com/user-attachments/assets/0e131c4b-34bb-4574-bfef-8bad29aba69f)

I based the choice on the official VS Code theme using the closest available color in the `dark_plus` theme:

![image](https://github.com/user-attachments/assets/98f91887-3f82-4e9b-ae39-9639487d4b99)

I took into account that `special` is also used as syntax and checked the change worked there too.

2. Changed the `ui.text.directory` slightly to a more VS Codish blue vibe:

### OLD
![image](https://github.com/user-attachments/assets/b6667450-3bd1-4f77-97a8-64f6e8e932ba)

### NEW
![image](https://github.com/user-attachments/assets/fff0298c-2597-4e9c-9ed2-41c04b5255a0)

3. Made `ui.virtual.wrap` the same color as white-space, before it was white and horrible, leaping out when it is meant to be in the background.

### OLD

![image](https://github.com/user-attachments/assets/99f808e7-be5c-44e0-81cc-9dca32352d5a)

### NEW

![image](https://github.com/user-attachments/assets/a159ecbb-5a27-4053-b02e-3e6b80c5b643)
