### PR TITLE
Add Djot support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -38,6 +38,7 @@
 | devicetree | ✓ |  |  |  |
 | dhall | ✓ | ✓ |  | `dhall-lsp-server` |
 | diff | ✓ |  |  |  |
+| djot | ✓ |  |  |  |
 | docker-compose | ✓ | ✓ | ✓ | `docker-compose-langserver`, `yaml-language-server` |
 | dockerfile | ✓ | ✓ |  | `docker-langserver` |
 | dot | ✓ |  |  | `dot-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -1666,6 +1666,18 @@ name = "markdown_inline"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "62516e8c78380e3b51d5b55727995d2c511436d8", subpath = "tree-sitter-markdown-inline" }
 
 [[language]]
+name = "djot"
+scope = "source.djot"
+injection-regex = "dj|djot"
+file-types = ["dj", "djot"]
+indent = { tab-width = 2, unit = "  " }
+block-comment-tokens = { start = "{%", end = "%}" }
+
+[[grammar]]
+name = "djot"
+source = { git = "https://github.com/treeman/tree-sitter-djot", rev = "886601b67d1f4690173a4925c214343c30704d32" }
+
+[[language]]
 name = "dart"
 scope = "source.dart"
 file-types = ["dart"]

--- a/languages.toml
+++ b/languages.toml
@@ -1675,7 +1675,7 @@ block-comment-tokens = { start = "{%", end = "%}" }
 
 [[grammar]]
 name = "djot"
-source = { git = "https://github.com/treeman/tree-sitter-djot", rev = "886601b67d1f4690173a4925c214343c30704d32" }
+source = { git = "https://github.com/treeman/tree-sitter-djot", rev = "67e6e23ba7be81a4373e0f49e21207bdc32d12a5" }
 
 [[language]]
 name = "dart"

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -1,0 +1,311 @@
+[
+  (footnote_marker_begin)
+  (footnote_marker_end)
+] @punctuation.bracket
+
+(footnote_reference (reference_label) @markup.link.label)
+
+(footnote (reference_label) @markup.link.label)
+
+[
+  (autolink)
+  (inline_link_destination)
+  (link_destination)
+] @markup.link.url
+
+(link_reference_definition (link_label) @markup.link.label)
+
+(link_reference_definition
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(image_description
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(image_description) @label
+
+(inline_image
+  [
+    "!["
+    "]"
+  ] @punctuation.bracket)
+
+(collapsed_reference_image
+  [
+    "!["
+    "]"
+  ] @punctuation.bracket)
+
+(collapsed_reference_image "[]" @punctuation.bracket)
+
+(full_reference_image
+  [
+    "!["
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(full_reference_image (link_label) @markup.link.label)
+
+(inline_link (link_text) @markup.link.text)
+
+(collapsed_reference_link (link_text) @markup.link.text)
+
+(full_reference_link
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(collapsed_reference_link "[]" @punctuation.bracket)
+
+(full_reference_link (link_label) @markup.link.label)
+
+(full_reference_link (link_text) @markup.link.text)
+
+(link_reference_definition ":" @punctuation.delimiter)
+
+(inline_link_destination
+  [
+    "("
+    ")"
+  ] @punctuation.bracket)
+
+(autolink
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(link_text
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(key_value (value) @string)
+
+(key_value (key) @attribute)
+
+(key_value "=" @operator)
+
+; NOTE: Not perfectly semantically accurate, but a fair approximation.
+(identifier) @string.special.symbol
+
+[
+  (class)
+  (class_name)
+] @type
+
+(block_attribute
+  [
+    "{"
+    "}"
+  ] @punctuation.bracket)
+
+(inline_attribute
+  [
+    "{"
+    "}"
+  ] @punctuation.bracket)
+
+(span
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(comment
+  [
+    "{"
+    "}"
+    "%"
+  ] @comment.block)
+
+; INFO: djot only has block-scoped comments.
+(comment) @comment.block
+
+(raw_inline) @markup.raw
+
+(verbatim) @markup.raw
+
+(math) @markup.raw
+
+([
+  (emphasis_begin)
+  (emphasis_end)
+  (strong_begin)
+  (strong_end)
+  (verbatim_marker_begin)
+  (verbatim_marker_end)
+  (math_marker)
+  (math_marker_begin)
+  (math_marker_end)
+  (raw_inline_attribute)
+  (raw_inline_marker_begin)
+  (raw_inline_marker_end)
+] @punctuation.bracket)
+
+(subscript
+  [
+    "~"
+    "{~"
+    "~}"
+  ] @punctuation.bracket)
+
+(superscript
+  [
+    "^"
+    "{^"
+    "^}"
+  ] @punctuation.bracket)
+
+(delete
+  [
+    "{-"
+    "-}"
+  ] @punctuation.bracket)
+
+(insert
+  [
+    "{+"
+    "+}"
+  ] @punctuation.bracket)
+
+; NOTE: We need to target tokens specifically because `{=` etc can exist as fallback symbols in
+; regular text, which we don't want to highlight or conceal.
+(highlighted
+  [
+    "{="
+    "=}"
+  ] @punctuation.bracket)
+
+; TEMP: Scope not available, with no appropriate alternative.
+(subscript) @markup.subscript
+
+; TEMP: Scope not available, with no appropriate alternative.
+(superscript) @markup.superscript
+
+; TEMP: Scope not available, with no appropriate alternative.
+(highlighted) @markup.highlighted
+
+; TEMP: Scope not available, with no appropriate alternative.
+(insert) @markup.insert
+
+(delete) @markup.strikethrough
+
+; INFO: This applies to emojis.
+(symbol) @string.special.symbol
+
+(strong) @markup.bold
+
+(emphasis) @markup.italic
+
+(backslash_escape) @constant.character.escape
+
+(hard_line_break) @constant.character.escape
+
+((quotation_marks) @constant.character.escape
+  (#any-of? @constant.character.escape "\\\"" "\\'"))
+
+; NOTE: Opting for this over the @punctuation.bracket used for things like
+; {-delete-} to emphasise the semantic significance of specified opening/closing
+; quotation marks.
+(quotation_marks) @markup.quote
+
+; INFO: `term` only matches on definition list items -- other list items won't be highlighted.
+(list_item (term) @type)
+
+[
+  (ellipsis)
+  (en_dash)
+  (em_dash)
+] @punctuation.special
+
+(checked 
+  [
+   "x"
+   "X"
+  ] @constant.builtin.boolean) @markup.list.checked
+
+(list_marker_task (checked)) @markup.list.checked
+
+(list_marker_task (unchecked)) @markup.list.unchecked
+
+[
+  (list_marker_decimal_period)
+  (list_marker_decimal_paren)
+  (list_marker_decimal_parens)
+  (list_marker_lower_alpha_period)
+  (list_marker_lower_alpha_paren)
+  (list_marker_lower_alpha_parens)
+  (list_marker_upper_alpha_period)
+  (list_marker_upper_alpha_paren)
+  (list_marker_upper_alpha_parens)
+  (list_marker_lower_roman_period)
+  (list_marker_lower_roman_paren)
+  (list_marker_lower_roman_parens)
+  (list_marker_upper_roman_period)
+  (list_marker_upper_roman_paren)
+  (list_marker_upper_roman_parens)
+] @markup.list.numbered
+
+[
+  (list_marker_dash)
+  (list_marker_plus)
+  (list_marker_star)
+  (list_marker_definition)
+] @markup.list.unnumbered
+
+(table_caption) @label
+
+(table_caption (marker) @punctuation.special)
+
+(table_separator) @punctuation.special
+
+(table_row "|" @punctuation.special)
+
+(table_header "|" @punctuation.special)
+
+(table_header) @markup.heading
+
+(block_quote) @markup.quote
+
+(block_quote_marker) @markup.quote
+
+(language_marker) @punctuation.delimiter
+
+(inline_attribute _ @attribute)
+
+(language) @type.enum.variant
+
+[
+  (code_block_marker_begin)
+  (code_block_marker_end)
+  (raw_block_marker_begin)
+  (raw_block_marker_end)
+] @punctuation.bracket
+
+[
+  (code_block)
+  (raw_block)
+] @markup.raw.block
+
+[
+  (div_marker_begin)
+  (div_marker_end)
+] @tag
+
+(thematic_break) @special
+
+(heading1 (marker) @markup.heading.marker) @markup.heading.1
+(heading2 (marker) @markup.heading.marker) @markup.heading.2
+(heading3 (marker) @markup.heading.marker) @markup.heading.3
+(heading4 (marker) @markup.heading.marker) @markup.heading.4
+(heading5 (marker) @markup.heading.marker) @markup.heading.5
+(heading6 (marker) @markup.heading.marker) @markup.heading.6

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -135,9 +135,9 @@
 
 (highlighted) @markup.bold
 
-(superscript) @string.special
+(superscript) @string.special.superscript
 
-(subscript) @string.special
+(subscript) @string.special.subscript
 
 [
   (emphasis_begin)

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -131,17 +131,13 @@
 
 (delete) @markup.strikethrough
 
-; TEMP: Scope not available, with no appropriate alternative.
-(insert) @markup.insert
+(insert) @markup.italic
 
-; TEMP: Scope not available, with no appropriate alternative.
-(highlighted) @markup.highlighted
+(highlighted) @markup.bold
 
-; TEMP: Scope not available, with no appropriate alternative.
-(superscript) @markup.superscript
+(superscript) @string.special
 
-; TEMP: Scope not available, with no appropriate alternative.
-(subscript) @markup.subscript
+(subscript) @string.special
 
 [
   (emphasis_begin)

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -219,7 +219,7 @@
 (quotation_marks) @markup.quote
 
 ; INFO: `term` only matches on definition list items -- other list items won't be highlighted.
-(list_item (term) @type)
+(list_item (term) @constructor)
 
 [
   (ellipsis)

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -1,123 +1,147 @@
+(heading) @markup.heading
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.1
+  (#eq? @markup.heading.marker "# "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.2
+  (#eq? @markup.heading.marker "## "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.3
+  (#eq? @markup.heading.marker "### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.4
+  (#eq? @markup.heading.marker "##### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.5
+  (#eq? @markup.heading.marker "###### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.6
+  (#eq? @markup.heading.marker "####### "))
+
+(thematic_break) @special
+
 [
-  (footnote_marker_begin)
-  (footnote_marker_end)
+  (div_marker_begin)
+  (div_marker_end)
+] @tag
+
+[
+  (code_block)
+  (raw_block)
+  (frontmatter)
+] @markup.raw.block
+
+[
+  (code_block_marker_begin)
+  (code_block_marker_end)
+  (raw_block_marker_begin)
+  (raw_block_marker_end)
 ] @punctuation.bracket
 
-(footnote_reference (reference_label) @markup.link.label)
+(language) @type.enum.variant
 
-(footnote (reference_label) @markup.link.label)
+(inline_attribute _ @attribute)
 
-[
-  (autolink)
-  (inline_link_destination)
-  (link_destination)
-] @markup.link.url
-
-(inline_link_destination
-  [
-    "("
-    ")"
-  ] @punctuation.bracket)
-
-(link_reference_definition (link_label) @markup.link.label)
-
-(link_reference_definition
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
-
-(image_description) @label
-
-(image_description
-  [
-    "!["
-    "]"
-  ] @punctuation.bracket)
-
-(collapsed_reference_image "[]" @punctuation.bracket)
-
-(full_reference_image
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
-
-(full_reference_image (link_label) @markup.link.label)
-
-(inline_link (link_text) @markup.link.text)
-
-(collapsed_reference_link (link_text) @markup.link.text)
-
-(full_reference_link
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
-
-(collapsed_reference_link "[]" @punctuation.bracket)
-
-(full_reference_link (link_label) @markup.link.label)
-
-(full_reference_link (link_text) @markup.link.text)
-
-(link_reference_definition ":" @punctuation.delimiter)
-
-(inline_link (inline_link_destination) @markup.link.url)
-
-(autolink
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
-
-(link_text
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
-
-(key_value (value) @string)
-
-(key_value (key) @attribute)
-
-(key_value "=" @operator)
-
-; NOTE: Not perfectly semantically accurate, but a fair approximation.
-(identifier) @string.special.symbol
+(language_marker) @punctuation.delimiter
 
 [
-  (class)
-  (class_name)
-] @type
+  (block_quote)
+  (block_quote_marker)
+] @markup.quote
 
-(block_attribute
+(table_header) @markup.heading
+
+(table_header "|" @punctuation.special)
+
+(table_row "|" @punctuation.special)
+
+(table_separator) @punctuation.special
+
+(table_caption (marker) @punctuation.special)
+
+(table_caption) @label
+
+[
+  (list_marker_dash)
+  (list_marker_plus)
+  (list_marker_star)
+  (list_marker_definition)
+] @markup.list.unnumbered
+
+[
+  (list_marker_decimal_period)
+  (list_marker_decimal_paren)
+  (list_marker_decimal_parens)
+  (list_marker_lower_alpha_period)
+  (list_marker_lower_alpha_paren)
+  (list_marker_lower_alpha_parens)
+  (list_marker_upper_alpha_period)
+  (list_marker_upper_alpha_paren)
+  (list_marker_upper_alpha_parens)
+  (list_marker_lower_roman_period)
+  (list_marker_lower_roman_paren)
+  (list_marker_lower_roman_parens)
+  (list_marker_upper_roman_period)
+  (list_marker_upper_roman_paren)
+  (list_marker_upper_roman_parens)
+] @markup.list.numbered
+
+(list_marker_task
+  (unchecked)) @markup.list.unchecked
+
+(list_marker_task
+  (checked)) @markup.list.checked
+
+(checked
   [
-    "{"
-    "}"
-  ] @punctuation.bracket)
+    "x"
+    "X"
+  ] @constant.builtin.boolean) @markup.list.checked
 
-(inline_attribute
-  [
-    "{"
-    "}"
-  ] @punctuation.bracket)
+[
+  (ellipsis)
+  (en_dash)
+  (em_dash)
+  (quotation_marks)
+] @punctuation.special
 
-(span
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
+(list_item (term) @constructor)
 
-(inline_comment) @comment.line
+(quotation_marks) @markup.quote
 
-(comment) @comment.block
+((quotation_marks) @constant.character.escape
+  (#any-of? @constant.character.escape "\\\"" "\\'"))
 
-(verbatim) @markup.raw
+[
+  (hard_line_break)
+  (backslash_escape)
+] @constant.character.escape
 
-(raw_inline) @markup.raw
+(emphasis) @markup.italic
 
-(math) @markup.raw
+(strong) @markup.bold
+
+(symbol) @string.special.symbol
+
+(delete) @markup.strikethrough
+
+; TEMP: Scope not available, with no appropriate alternative.
+(insert) @markup.insert
+
+; TEMP: Scope not available, with no appropriate alternative.
+(highlighted) @markup.highlighted
+
+; TEMP: Scope not available, with no appropriate alternative.
+(superscript) @markup.superscript
+
+; TEMP: Scope not available, with no appropriate alternative.
+(subscript) @markup.subscript
 
 [
   (emphasis_begin)
@@ -144,147 +168,123 @@
   (raw_inline_marker_end)
 ] @punctuation.bracket
 
-; TEMP: Scope not available, with no appropriate alternative.
-(subscript) @markup.subscript
+(math) @markup.raw
 
-; TEMP: Scope not available, with no appropriate alternative.
-(superscript) @markup.superscript
+(verbatim) @markup.raw
 
-; TEMP: Scope not available, with no appropriate alternative.
-(highlighted) @markup.highlighted
+(raw_inline) @markup.raw
 
-; TEMP: Scope not available, with no appropriate alternative.
-(insert) @markup.insert
+(comment) @comment.block
 
-(delete) @markup.strikethrough
+(inline_comment) @comment.line
 
-(symbol) @string.special.symbol
-
-(strong) @markup.bold
-
-(emphasis) @markup.italic
-
-[
-  (hard_line_break)
-  (backslash_escape)
-] @constant.character.escape
-
-((quotation_marks) @constant.character.escape
-  (#any-of? @constant.character.escape "\\\"" "\\'"))
-
-(quotation_marks) @markup.quote
-
-(list_item (term) @constructor)
-
-[
-  (ellipsis)
-  (en_dash)
-  (em_dash)
-  (quotation_marks)
-] @punctuation.special
-
-(checked
+(span
   [
-    "x"
-    "X"
-  ] @constant.builtin.boolean) @markup.list.checked
+    "["
+    "]"
+  ] @punctuation.bracket)
 
-(list_marker_task
-  (checked)) @markup.list.checked
+(inline_attribute
+  [
+    "{"
+    "}"
+  ] @punctuation.bracket)
 
-(list_marker_task
-  (unchecked)) @markup.list.unchecked
-
-[
-  (list_marker_decimal_period)
-  (list_marker_decimal_paren)
-  (list_marker_decimal_parens)
-  (list_marker_lower_alpha_period)
-  (list_marker_lower_alpha_paren)
-  (list_marker_lower_alpha_parens)
-  (list_marker_upper_alpha_period)
-  (list_marker_upper_alpha_paren)
-  (list_marker_upper_alpha_parens)
-  (list_marker_lower_roman_period)
-  (list_marker_lower_roman_paren)
-  (list_marker_lower_roman_parens)
-  (list_marker_upper_roman_period)
-  (list_marker_upper_roman_paren)
-  (list_marker_upper_roman_parens)
-] @markup.list.numbered
+(block_attribute
+  [
+    "{"
+    "}"
+  ] @punctuation.bracket)
 
 [
-  (list_marker_dash)
-  (list_marker_plus)
-  (list_marker_star)
-  (list_marker_definition)
-] @markup.list.unnumbered
+  (class)
+  (class_name)
+] @type
 
-(table_caption) @label
+; NOTE: Not perfectly semantically accurate, but a fair approximation.
+(identifier) @string.special.symbol
 
-(table_caption (marker) @punctuation.special)
+(key_value "=" @operator)
 
-(table_separator) @punctuation.special
+(key_value (key) @attribute)
 
-(table_row "|" @punctuation.special)
+(key_value (value) @string)
 
-(table_header "|" @punctuation.special)
+(link_text
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
 
-(table_header) @markup.heading
+(autolink
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(inline_link (inline_link_destination) @markup.link.url)
+
+(link_reference_definition ":" @punctuation.delimiter)
+
+(full_reference_link (link_text) @markup.link.text)
+
+(full_reference_link (link_label) @markup.link.label)
+
+(collapsed_reference_link "[]" @punctuation.bracket)
+
+(full_reference_link
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(collapsed_reference_link (link_text) @markup.link.text)
+
+(inline_link (link_text) @markup.link.text)
+
+(full_reference_image (link_label) @markup.link.label)
+
+(full_reference_image
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(collapsed_reference_image "[]" @punctuation.bracket)
+
+(image_description
+  [
+    "!["
+    "]"
+  ] @punctuation.bracket)
+
+(image_description) @label
+
+(link_reference_definition
+  [
+    "["
+    "]"
+  ] @punctuation.bracket)
+
+(link_reference_definition (link_label) @markup.link.label)
+
+(inline_link_destination
+  [
+    "("
+    ")"
+  ] @punctuation.bracket)
 
 [
-  (block_quote)
-  (block_quote_marker)
-] @markup.quote
+  (autolink)
+  (inline_link_destination)
+  (link_destination)
+] @markup.link.url
 
-(language_marker) @punctuation.delimiter
+(footnote (reference_label) @markup.link.label)
 
-(inline_attribute _ @attribute)
-
-(language) @type.enum.variant
+(footnote_reference (reference_label) @markup.link.label)
 
 [
-  (code_block_marker_begin)
-  (code_block_marker_end)
-  (raw_block_marker_begin)
-  (raw_block_marker_end)
+  (footnote_marker_begin)
+  (footnote_marker_end)
 ] @punctuation.bracket
-
-[
-  (code_block)
-  (raw_block)
-  (frontmatter)
-] @markup.raw.block
-
-[
-  (div_marker_begin)
-  (div_marker_end)
-] @tag
-
-(thematic_break) @special
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.1
-  (#eq? @markup.heading.marker "# "))
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.2
-  (#eq? @markup.heading.marker "## "))
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.3
-  (#eq? @markup.heading.marker "### "))
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.4
-  (#eq? @markup.heading.marker "##### "))
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.5
-  (#eq? @markup.heading.marker "###### "))
-
-((heading
-  (marker) @markup.heading.marker) @markup.heading.6
-  (#eq? @markup.heading.marker "####### "))
-
-(heading) @markup.heading

--- a/runtime/queries/djot/highlights.scm
+++ b/runtime/queries/djot/highlights.scm
@@ -13,6 +13,12 @@
   (link_destination)
 ] @markup.link.url
 
+(inline_link_destination
+  [
+    "("
+    ")"
+  ] @punctuation.bracket)
+
 (link_reference_definition (link_label) @markup.link.label)
 
 (link_reference_definition
@@ -21,21 +27,9 @@
     "]"
   ] @punctuation.bracket)
 
-(image_description
-  [
-    "["
-    "]"
-  ] @punctuation.bracket)
-
 (image_description) @label
 
-(inline_image
-  [
-    "!["
-    "]"
-  ] @punctuation.bracket)
-
-(collapsed_reference_image
+(image_description
   [
     "!["
     "]"
@@ -45,7 +39,6 @@
 
 (full_reference_image
   [
-    "!["
     "["
     "]"
   ] @punctuation.bracket)
@@ -70,11 +63,7 @@
 
 (link_reference_definition ":" @punctuation.delimiter)
 
-(inline_link_destination
-  [
-    "("
-    ")"
-  ] @punctuation.bracket)
+(inline_link (inline_link_destination) @markup.link.url)
 
 (autolink
   [
@@ -120,27 +109,31 @@
     "]"
   ] @punctuation.bracket)
 
-(comment
-  [
-    "{"
-    "}"
-    "%"
-  ] @comment.block)
+(inline_comment) @comment.line
 
-; INFO: djot only has block-scoped comments.
 (comment) @comment.block
-
-(raw_inline) @markup.raw
 
 (verbatim) @markup.raw
 
+(raw_inline) @markup.raw
+
 (math) @markup.raw
 
-([
+[
   (emphasis_begin)
   (emphasis_end)
   (strong_begin)
   (strong_end)
+  (superscript_begin)
+  (superscript_end)
+  (subscript_begin)
+  (subscript_end)
+  (highlighted_begin)
+  (highlighted_end)
+  (insert_begin)
+  (insert_end)
+  (delete_begin)
+  (delete_end)
   (verbatim_marker_begin)
   (verbatim_marker_end)
   (math_marker)
@@ -149,41 +142,7 @@
   (raw_inline_attribute)
   (raw_inline_marker_begin)
   (raw_inline_marker_end)
-] @punctuation.bracket)
-
-(subscript
-  [
-    "~"
-    "{~"
-    "~}"
-  ] @punctuation.bracket)
-
-(superscript
-  [
-    "^"
-    "{^"
-    "^}"
-  ] @punctuation.bracket)
-
-(delete
-  [
-    "{-"
-    "-}"
-  ] @punctuation.bracket)
-
-(insert
-  [
-    "{+"
-    "+}"
-  ] @punctuation.bracket)
-
-; NOTE: We need to target tokens specifically because `{=` etc can exist as fallback symbols in
-; regular text, which we don't want to highlight or conceal.
-(highlighted
-  [
-    "{="
-    "=}"
-  ] @punctuation.bracket)
+] @punctuation.bracket
 
 ; TEMP: Scope not available, with no appropriate alternative.
 (subscript) @markup.subscript
@@ -199,43 +158,42 @@
 
 (delete) @markup.strikethrough
 
-; INFO: This applies to emojis.
 (symbol) @string.special.symbol
 
 (strong) @markup.bold
 
 (emphasis) @markup.italic
 
-(backslash_escape) @constant.character.escape
-
-(hard_line_break) @constant.character.escape
+[
+  (hard_line_break)
+  (backslash_escape)
+] @constant.character.escape
 
 ((quotation_marks) @constant.character.escape
   (#any-of? @constant.character.escape "\\\"" "\\'"))
 
-; NOTE: Opting for this over the @punctuation.bracket used for things like
-; {-delete-} to emphasise the semantic significance of specified opening/closing
-; quotation marks.
 (quotation_marks) @markup.quote
 
-; INFO: `term` only matches on definition list items -- other list items won't be highlighted.
 (list_item (term) @constructor)
 
 [
   (ellipsis)
   (en_dash)
   (em_dash)
+  (quotation_marks)
 ] @punctuation.special
 
-(checked 
+(checked
   [
-   "x"
-   "X"
+    "x"
+    "X"
   ] @constant.builtin.boolean) @markup.list.checked
 
-(list_marker_task (checked)) @markup.list.checked
+(list_marker_task
+  (checked)) @markup.list.checked
 
-(list_marker_task (unchecked)) @markup.list.unchecked
+(list_marker_task
+  (unchecked)) @markup.list.unchecked
 
 [
   (list_marker_decimal_period)
@@ -274,9 +232,10 @@
 
 (table_header) @markup.heading
 
-(block_quote) @markup.quote
-
-(block_quote_marker) @markup.quote
+[
+  (block_quote)
+  (block_quote_marker)
+] @markup.quote
 
 (language_marker) @punctuation.delimiter
 
@@ -294,6 +253,7 @@
 [
   (code_block)
   (raw_block)
+  (frontmatter)
 ] @markup.raw.block
 
 [
@@ -303,9 +263,28 @@
 
 (thematic_break) @special
 
-(heading1 (marker) @markup.heading.marker) @markup.heading.1
-(heading2 (marker) @markup.heading.marker) @markup.heading.2
-(heading3 (marker) @markup.heading.marker) @markup.heading.3
-(heading4 (marker) @markup.heading.marker) @markup.heading.4
-(heading5 (marker) @markup.heading.marker) @markup.heading.5
-(heading6 (marker) @markup.heading.marker) @markup.heading.6
+((heading
+  (marker) @markup.heading.marker) @markup.heading.1
+  (#eq? @markup.heading.marker "# "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.2
+  (#eq? @markup.heading.marker "## "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.3
+  (#eq? @markup.heading.marker "### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.4
+  (#eq? @markup.heading.marker "##### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.5
+  (#eq? @markup.heading.marker "###### "))
+
+((heading
+  (marker) @markup.heading.marker) @markup.heading.6
+  (#eq? @markup.heading.marker "####### "))
+
+(heading) @markup.heading

--- a/runtime/queries/djot/injections.scm
+++ b/runtime/queries/djot/injections.scm
@@ -1,0 +1,16 @@
+((content) @injection.content
+ (#set! injection.language "comment"))
+
+(code_block
+  (language) @injection.language
+  (code) @injection.content (#set! injection.include-unnamed-children))
+
+(raw_block
+  (raw_block_info
+    (language) @injection.language)
+  (content) @injection.content (#set! injection.include-unnamed-children))
+
+(raw_inline
+  (content) @injection.content
+  (raw_inline_attribute
+    (language) @injection.language) (#set! injection.include-unnamed-children))

--- a/runtime/queries/djot/injections.scm
+++ b/runtime/queries/djot/injections.scm
@@ -1,5 +1,8 @@
-((content) @injection.content
+(comment (content) @injection.content
  (#set! injection.language "comment"))
+
+(math (content) @injection.content
+  (#set! injection.language "latex") (#set! injection.include-unnamed-children))
 
 (code_block
   (language) @injection.language
@@ -11,6 +14,6 @@
   (content) @injection.content (#set! injection.include-unnamed-children))
 
 (raw_inline
-  (content) @injection.content
+  (content) @injection.content (#set! injection.include-unnamed-children)
   (raw_inline_attribute
-    (language) @injection.language) (#set! injection.include-unnamed-children))
+    (language) @injection.language))

--- a/runtime/queries/djot/injections.scm
+++ b/runtime/queries/djot/injections.scm
@@ -1,5 +1,5 @@
 (comment (content) @injection.content
- (#set! injection.language "comment"))
+  (#set! injection.language "comment"))
 
 (math (content) @injection.content
   (#set! injection.language "latex") (#set! injection.include-unnamed-children))


### PR DESCRIPTION
This change adds support for the Djot markup language. The grammar used is [tree-sitter-djot](https://github.com/treeman/tree-sitter-djot) and the highlights & injections have been adapted for Helix's scopes.

There are 4 highlight queries with TEMP comments above them as they are semantically significant but I don't feel they have appropriate existing scopes.

In preparation for #9458 I will be maintaining a version with inverse precedence.

Closes #12264
Closes treeman/tree-sitter-djot#10