### PR TITLE
feat: specify custom lang server(s) for `:lsp-stop` and `:lsp-restart`

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -52,7 +52,7 @@
 | `:reload-all`, `:rla` | Discard changes and reload all documents from the source files. |
 | `:update`, `:u` | Write changes only if the file has been modified. |
 | `:lsp-workspace-command` | Open workspace command picker |
-| `:lsp-restart` | Restarts the language servers used by the current doc |
+| `:lsp-restart` | Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied |
 | `:lsp-stop` | Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied |
 | `:tree-sitter-scopes` | Display tree sitter scopes, primarily for theming and development. |
 | `:tree-sitter-highlight-name` | Display name of tree-sitter highlight scope under the cursor. |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -53,7 +53,7 @@
 | `:update`, `:u` | Write changes only if the file has been modified. |
 | `:lsp-workspace-command` | Open workspace command picker |
 | `:lsp-restart` | Restarts the language servers used by the current doc |
-| `:lsp-stop` | Stops the language servers that are used by the current doc |
+| `:lsp-stop` | Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied |
 | `:tree-sitter-scopes` | Display tree sitter scopes, primarily for theming and development. |
 | `:tree-sitter-highlight-name` | Display name of tree-sitter highlight scope under the cursor. |
 | `:debug-start`, `:dbg` | Start a debug session from a given template with given parameters. |

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -659,31 +659,6 @@ impl Registry {
         Some(Ok(client))
     }
 
-    /// If this method is called, all documents that have a reference to language servers used by the language config have to refresh their language servers,
-    /// as it could be that language servers of these documents were stopped by this method.
-    /// See helix_view::editor::Editor::refresh_language_servers
-    pub fn restart_all_servers(
-        &mut self,
-        language_config: &LanguageConfiguration,
-        doc_path: Option<&std::path::PathBuf>,
-        root_dirs: &[PathBuf],
-        enable_snippets: bool,
-    ) -> Result<Vec<Arc<Client>>> {
-        language_config
-            .language_servers
-            .iter()
-            .filter_map(|server| {
-                self.restart_server(
-                    &server.name,
-                    language_config,
-                    doc_path,
-                    root_dirs,
-                    enable_snippets,
-                )
-            })
-            .collect()
-    }
-
     pub fn stop(&mut self, name: &str) {
         if let Some(clients) = self.inner_by_name.get_mut(name) {
             // Drain the clients vec so that the entry in `inner_by_name` remains

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -618,7 +618,7 @@ impl Registry {
         Ok(self.inner[id].clone())
     }
 
-    /// If this method is called, all documents that have a reference to language server have to refresh their language servers,
+    /// If this method is called, all documents that have a reference to the language server have to refresh their language servers,
     /// See helix_view::editor::Editor::refresh_language_servers
     pub fn restart_server(
         &mut self,

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2924,9 +2924,9 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "lsp-stop",
         aliases: &[],
-        doc: "Stops the language servers that are used by the current doc",
+        doc: "Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied",
         fun: lsp_stop,
-        signature: CommandSignature::none(),
+        signature: CommandSignature::all(completers::language_servers),
     },
     TypableCommand {
         name: "tree-sitter-scopes",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1546,8 +1546,6 @@ fn lsp_stop(
             .map(|m| m.to_string())
             .partition(|ls| ls_shutdown_names.contains(ls));
 
-        log::error!("{valid:?}, {invalid:?}");
-
         if !invalid.is_empty() {
             let s = if invalid.len() == 1 { "" } else { "s" };
             bail!("Unknown language server{s}: {}", invalid.join(", "));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1519,13 +1519,16 @@ fn lsp_restart(
     let ls_restart_names = valid_lang_servers(doc, args)?;
 
     for server in ls_restart_names.iter() {
-        cx.editor.language_servers.restart_server(
-            server,
-            config,
-            doc.path(),
-            &editor_config.workspace_lsp_roots,
-            editor_config.lsp.snippets,
-        );
+        cx.editor
+            .language_servers
+            .restart_server(
+                server,
+                config,
+                doc.path(),
+                &editor_config.workspace_lsp_roots,
+                editor_config.lsp.snippets,
+            )
+            .transpose()?;
     }
 
     // This collect is needed because refresh_language_server would need to re-borrow editor.

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1526,7 +1526,7 @@ fn lsp_restart(
 
 fn lsp_stop(
     cx: &mut compositor::Context,
-    _args: &[Cow<str>],
+    args: &[Cow<str>],
     event: PromptEvent,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
@@ -1535,8 +1535,15 @@ fn lsp_stop(
 
     let ls_shutdown_names = doc!(cx.editor)
         .language_servers()
-        .map(|ls| ls.name().to_string())
-        .collect::<Vec<_>>();
+        .map(|ls| ls.name().to_string());
+
+    let ls_shutdown_names: Vec<_> = if args.is_empty() {
+        ls_shutdown_names.collect()
+    } else {
+        ls_shutdown_names
+            .filter(|ls| args.contains(&Cow::Borrowed(ls)))
+            .collect()
+    };
 
     for ls_name in &ls_shutdown_names {
         cx.editor.language_servers.stop(ls_name);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -339,6 +339,17 @@ pub mod completers {
         }
     }
 
+    pub fn language_servers(editor: &Editor, input: &str) -> Vec<Completion> {
+        let language_servers = doc!(editor)
+            .language_servers()
+            .map(|ls| ls.name().to_string());
+
+        fuzzy_match(input, language_servers, false)
+            .into_iter()
+            .map(|(name, _)| ((0..), Span::raw(name)))
+            .collect()
+    }
+
     pub fn setting(_editor: &Editor, input: &str) -> Vec<Completion> {
         static KEYS: Lazy<Vec<String>> = Lazy::new(|| {
             let mut keys = Vec::new();

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -340,13 +340,11 @@ pub mod completers {
     }
 
     pub fn language_servers(editor: &Editor, input: &str) -> Vec<Completion> {
-        let language_servers = doc!(editor)
-            .language_servers()
-            .map(|ls| ls.name().to_string());
+        let language_servers = doc!(editor).language_servers().map(|ls| ls.name());
 
         fuzzy_match(input, language_servers, false)
             .into_iter()
-            .map(|(name, _)| ((0..), Span::raw(name)))
+            .map(|(name, _)| ((0..), Span::raw(name.to_string())))
             .collect()
     }
 


### PR DESCRIPTION
also comes with completion for language servers:

![image](https://github.com/user-attachments/assets/4af14403-b2c8-4fc2-9981-9e969ee3a31e)

Closes https://github.com/helix-editor/helix/issues/12569