### PR TITLE
add language server for wat

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -236,7 +236,7 @@
 | vhs | ✓ |  |  |  |
 | vue | ✓ |  |  | `vue-language-server` |
 | wast | ✓ |  |  |  |
-| wat | ✓ |  |  |  |
+| wat | ✓ |  |  | `wat_server` |
 | webc | ✓ |  |  |  |
 | wgsl | ✓ |  |  | `wgsl_analyzer` |
 | wit | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -128,6 +128,7 @@ pkgbuild-language-server = { command = "pkgbuild-language-server" }
 helm_ls = { command = "helm_ls", args = ["serve"] }
 ember-language-server = { command = "ember-language-server", args = ["--stdio"] }
 teal-language-server = { command = "teal-language-server" }
+wasm-language-tools = { command = "wat_server" }
 
 [language-server.ansible-language-server]
 command = "ansible-language-server"
@@ -2613,6 +2614,7 @@ scope = "source.wat"
 comment-token = ";;"
 block-comment-tokens = { start = "(;", end = ";)" }
 file-types = ["wat"]
+language-servers = ["wasm-language-tools"]
 
 [[grammar]]
 name = "wat"
@@ -3958,12 +3960,12 @@ block-comment-tokens = [
 language-servers = [ "spade-language-server" ]
 indent = { tab-width = 4, unit = "    " }
 
-[language.auto-pairs] 
-'(' = ')' 
-'{' = '}' 
-'[' = ']' 
-'"' = '"' 
-'<' = '>' 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'<' = '>'
 
 [[grammar]]
 name = "spade"
@@ -4027,7 +4029,7 @@ file-types = [
   { glob = "sites-available/*.conf" },
   { glob = "sites-enabled/*.conf" },
   { glob = "nginx.conf" },
-  { glob = "conf.d/*.conf" } 
+  { glob = "conf.d/*.conf" }
 ]
 roots = ["nginx.conf"]
 comment-token = "#"

--- a/languages.toml
+++ b/languages.toml
@@ -3960,12 +3960,12 @@ block-comment-tokens = [
 language-servers = [ "spade-language-server" ]
 indent = { tab-width = 4, unit = "    " }
 
-[language.auto-pairs]
-'(' = ')'
-'{' = '}'
-'[' = ']'
-'"' = '"'
-'<' = '>'
+[language.auto-pairs] 
+'(' = ')' 
+'{' = '}' 
+'[' = ']' 
+'"' = '"' 
+'<' = '>' 
 
 [[grammar]]
 name = "spade"
@@ -4029,7 +4029,7 @@ file-types = [
   { glob = "sites-available/*.conf" },
   { glob = "sites-enabled/*.conf" },
   { glob = "nginx.conf" },
-  { glob = "conf.d/*.conf" }
+  { glob = "conf.d/*.conf" } 
 ]
 roots = ["nginx.conf"]
 comment-token = "#"


### PR DESCRIPTION
This PR adds [wasm-language-tools](https://github.com/g-plane/wasm-language-tools) as language server for WebAssembly Text Format (wat).