### PR TITLE
feat: print helpful suggestion when using `:{,r}sort` incorrectly

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2087,8 +2087,7 @@ fn sort_impl(
     let selection = doc.selection(view.id);
 
     if selection.len() == 1 {
-        cx.editor.set_warning("Sorting requires multiple selections. Hint: split selection first");
-        return Ok(());
+        bail!("Sorting requires multiple selections. Hint: split selection first");
     }
 
     let mut fragments: Vec<_> = selection

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2087,12 +2087,7 @@ fn sort_impl(
     let selection = doc.selection(view.id);
 
     if selection.len() == 1 {
-        let (start, end) = selection.line_ranges(text).nth(0).unwrap();
-        let single_selection_spans_multiple_lines = start != end;
-        if single_selection_spans_multiple_lines {
-            cx.editor.set_warning("Sorting a single selection does nothing. Hint: use `split_selection_on_newline` mapped to <A-s> first, and then sort");
-        }
-
+        cx.editor.set_warning("Sorting requires multiple selections. Hint: split selection first");
         return Ok(());
     }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2086,6 +2086,16 @@ fn sort_impl(
 
     let selection = doc.selection(view.id);
 
+    if selection.len() == 1 {
+        let (start, end) = selection.line_ranges(text).nth(0).unwrap();
+        let single_selection_spans_multiple_lines = start != end;
+        if single_selection_spans_multiple_lines {
+            cx.editor.set_warning("Sorting a single selection does nothing. Hint: use `split_selection_on_newline` mapped to <A-s> first, and then sort");
+        }
+
+        return Ok(());
+    }
+
     let mut fragments: Vec<_> = selection
         .slices(text)
         .map(|fragment| fragment.chunks().collect())


### PR DESCRIPTION
I often forget that `:{,r}sort` only does something with multiple selections, and not 1. This commit will print a helpful suggestion to the user when `:{,r}sort` is called with one selection that spans more than 1 line, to first do `split_selection_on_newline`.