### PR TITLE
Add pipe append and inline pipe append

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2281,6 +2281,14 @@ fn pipe_to(
     pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
 
+fn pipe_append(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::PipeAppend) 
+}
+
+fn pipe_inline_append(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::PipeInlineAppend)
+}
+
 fn pipe(cx: &mut compositor::Context, args: &[Cow<str>], event: PromptEvent) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Replace)
 }
@@ -3095,6 +3103,20 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Run shell command, appending output after each selection.",
         fun: append_output,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "pipe-inline-append", 
+        aliases: &[],
+        doc: "Pipe selection to shell command and append the output inline after cursor position",
+        fun: pipe_inline_append,
+        signature: CommandSignature::none(),
+    },
+    TypableCommand {
+        name: "pipe-append", 
+        aliases: &[],
+        doc: "Pipe selection to shell command and append the output after the selection",
+        fun: pipe_append,
         signature: CommandSignature::none(),
     },
     TypableCommand {


### PR DESCRIPTION
This PR introduces two new commands:

`pipe-append`
Takes selected text and pipes it to a shell command.
Appends the shell command's output on a new line immediately after the selected text.

`pipe-inline-append`
Works similarly but inserts the shell command's output directly at the cursor position, rather than on a new line.

Intent of this is to add flexibility in using shell commands for text completion and insertion.
For example using shell commands to complete code/text.
`:pipe-append aichat Given the current context, suggest next line. Output only text, no explanations:`
`:pipe-append-inline aichat Given the current context, finish this line. Output only text, no explanations:`


Adding keybindings for completion
```
[keys.normal]
"tab" = ":pipe-append aichat \"Given the current context, suggest next line. Output only text, no explanations:\""

[keys.normal]
"tab" = ":pipe-append aichat \"Given the current context, suggest next line. Output only text, no explanations:\""
```