### PR TITLE
Replace current file when loading in background from picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1014,7 +1014,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(Esc) | ctrl!('c') => return close_fn(self),
             alt!(Enter) => {
                 if let Some(option) = self.selection() {
-                    (self.callback_fn)(ctx, option, Action::Load);
+                    (self.callback_fn)(ctx, option, Action::Replace);
                 }
             }
             key!(Enter) => {


### PR DESCRIPTION
#4435 added an Alt-Enter keybinding to the file picker that loads the selected file in the background, allowing the user to open multiple files without closing the picker. I assumed the binding wasn't working at all and opened #12413, where I learned that the binding *was* working – it just loads the selected file in the background. Another user there described the same issue, which indicates that I'm not the only one who finds the existing behavior confusing.

Accordingly, this PR changes the behavior of the binding so that the selected file replaces the current file, which provides immediate feedback to the user. I personally find this behavior more intuitive (it's what I originally expected to happen, which is why I assumed the binding wasn't working), and I can't come up with a reason to keep the existing behavior, but either way, I do believe there should be *some* form of feedback to prevent confusion. (I'm not a Rust developer, so any other solution is probably beyond my abilities.)