### PR TITLE
Update `tree-sitter-rust`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -296,7 +296,7 @@ args = { attachCommands = [ "platform select remote-gdb-server", "platform conne
 
 [[grammar]]
 name = "rust"
-source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "9c84af007b0f144954adb26b3f336495cbb320a7" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "1f63b33efee17e833e0ea29266dd3d713e27e321" }
 
 [[language]]
 name = "sway"

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -174,8 +174,7 @@
 
 (for_expression
   "for" @keyword.control.repeat)
-((identifier) @keyword.control
-  (#match? @keyword.control "^yield$"))
+(gen_block "gen" @keyword.control)
 
 "in" @keyword.control
 
@@ -196,6 +195,7 @@
   "continue"
   "return"
   "await"
+  "yield"
 ] @keyword.control.return
 
 "use" @keyword.control.import

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -204,6 +204,10 @@
 
 (type_cast_expression "as" @keyword.operator)
 
+((generic_type
+    type: (type_identifier) @keyword)
+ (#eq? @keyword "use"))
+
 [
   (crate)
   (super)
@@ -241,6 +245,7 @@
 [
   "static"
   "const"
+  "raw"
   "ref"
   "move"
   "dyn"


### PR DESCRIPTION
The catalyst for this was that I was updating my code to use the `raw` references added in Rust version 1.82 and saw they weren't being highlighted properly.

This bumps `tree-sitter-rust` to the master branch, which is just one (seemingly bugfix) commit ahead of their 0.23.2 release.