### PR TITLE
docs: Fix broken link

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -67,7 +67,7 @@ These configuration keys are available:
 | `language-servers`    | The Language Servers used for this language. See below for more information in the section [Configuring Language Servers for a language](#configuring-language-servers-for-a-language)   |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
-| `soft-wrap` | [editor.softwrap](./configuration.md#editorsoft-wrap-section)
+| `soft-wrap`           | [editor.softwrap](./editor.md#editorsoft-wrap-section)
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set, defaults to `editor.text-width`   |
 | `path-completion`     | Overrides the `editor.path-completion` config key for the language. |
 | `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. |


### PR DESCRIPTION
The link was probably broken by
a959c0ef9be59e63617c8e95d1ac59889d45a8b5