### PR TITLE
Use filename completer for all shell commands

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3088,28 +3088,28 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Run shell command, inserting output before each selection.",
         fun: insert_output,
-        signature: CommandSignature::none(),
+        signature: CommandSignature::all(completers::filename)
     },
     TypableCommand {
         name: "append-output",
         aliases: &[],
         doc: "Run shell command, appending output after each selection.",
         fun: append_output,
-        signature: CommandSignature::none(),
+        signature: CommandSignature::all(completers::filename)
     },
     TypableCommand {
         name: "pipe",
         aliases: &[],
         doc: "Pipe each selection to the shell command.",
         fun: pipe,
-        signature: CommandSignature::none(),
+        signature: CommandSignature::all(completers::filename)
     },
     TypableCommand {
         name: "pipe-to",
         aliases: &[],
         doc: "Pipe each selection to the shell command, ignoring output.",
         fun: pipe_to,
-        signature: CommandSignature::none(),
+        signature: CommandSignature::all(completers::filename)
     },
     TypableCommand {
         name: "run-shell-command",


### PR DESCRIPTION
Previously only :sh used the filename completer

I looked at the PRs that introduced the other shell commands (#1972, #2589, #4931), and didn't see any discussion about completers so I think this is just an oversight. It's possible that I missed a shell command I didn't know about so please check for that in the review.
