### PR TITLE
Set an active snippet for `${0:placeholder}`

### DIFF
--- a/helix-core/src/snippets/parser.rs
+++ b/helix-core/src/snippets/parser.rs
@@ -361,7 +361,18 @@ mod test {
                 Text(")".into()),
             ]),
             parse("match(${1:Arg1})")
-        )
+        );
+        assert_eq!(
+            Ok(vec![
+                Text("sizeof(".into()),
+                Placeholder {
+                    tabstop: 0,
+                    value: vec![Text("expression-or-type".into())],
+                },
+                Text(")".into()),
+            ]),
+            parse("sizeof(${0:expression-or-type})")
+        );
     }
 
     #[test]


### PR DESCRIPTION
An older version of clangd (v14) sends a snippet `sizeof(${0:expression-or-type})` which is a bit odd - `$0` is usually not accompanied by placeholder text since it's meant only to signal the final cursor position.

`ActiveSnippet::new` previously returned `None` for a snippet like this but that prevented later edits from removing the placeholder automatically. `ActiveSnippet::new` should instead only return `None` when no interactivity is needed for the snippet (i.e. no tabbing between tabstops, no replacing placeholders). This change updates the condition that we use to return `None` to check that the snippet only has a `$0` tabstop with no placeholder.

Fixes https://github.com/helix-editor/helix/discussions/12603