### PR TITLE
Discard placeholder text for tabstop 0

### DIFF
--- a/helix-core/src/snippets/active.rs
+++ b/helix-core/src/snippets/active.rs
@@ -252,4 +252,21 @@ mod tests {
         snippet.map(edit.changes());
         assert!(!snippet.is_valid(&Selection::point(4)))
     }
+
+    #[test]
+    fn tabstop_zero_with_placeholder() {
+        // The `$0` tabstop should not have placeholder text. When we receive a snippet like this
+        // (from older versions of clangd for example) we should discard the placeholder text.
+        let snippet = Snippet::parse("sizeof(${0:expression-or-type})").unwrap();
+        let mut doc = Rope::from("\n");
+        let (transaction, _, snippet) = snippet.render(
+            &doc,
+            &Selection::point(0),
+            |_| (0, 0),
+            &mut SnippetRenderCtx::test_ctx(),
+        );
+        assert!(transaction.apply(&mut doc));
+        assert_eq!(doc, "sizeof()\n");
+        assert!(ActiveSnippet::new(snippet).is_none());
+    }
 }

--- a/helix-core/src/snippets/elaborate.rs
+++ b/helix-core/src/snippets/elaborate.rs
@@ -178,9 +178,16 @@ impl Snippet {
         &mut self,
         idx: usize,
         parent: Option<TabstopIdx>,
-        default: Vec<parser::SnippetElement>,
+        mut default: Vec<parser::SnippetElement>,
     ) -> TabstopIdx {
         let idx = TabstopIdx::elaborate(idx);
+        if idx == LAST_TABSTOP_IDX && !default.is_empty() {
+            // Older versions of clangd for example may send a snippet like `${0:placeholder}`
+            // which is considered by VSCode to be a misuse of the `$0` tabstop.
+            log::warn!("Discarding placeholder text for the `$0` tabstop ({default:?}). \
+                The `$0` tabstop signifies the final cursor position and should not include placeholder text.");
+            default.clear();
+        }
         let default = self.elaborate(default, Some(idx));
         self.tabstops.push(Tabstop {
             idx,

--- a/helix-core/src/snippets/parser.rs
+++ b/helix-core/src/snippets/parser.rs
@@ -361,7 +361,20 @@ mod test {
                 Text(")".into()),
             ]),
             parse("match(${1:Arg1})")
-        )
+        );
+        // The `$0` tabstop should not have placeholder text. The parser should handle this case
+        // normally and then the placeholder text should be discarded during elaboration.
+        assert_eq!(
+            Ok(vec![
+                Text("sizeof(".into()),
+                Placeholder {
+                    tabstop: 0,
+                    value: vec![Text("expression-or-type".into())],
+                },
+                Text(")".into()),
+            ]),
+            parse("sizeof(${0:expression-or-type})")
+        );
     }
 
     #[test]


### PR DESCRIPTION
This is an alternative approach to https://github.com/helix-editor/helix/pull/12640. Instead of attempting to handle the placeholder text on tabstop `$0` we can simply discard it and log a warning. This should only happen on older versions of `clangd`.

See https://github.com/helix-editor/helix/discussions/12603#discussioncomment-11923324