### PR TITLE
Warn against overwriting directories

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -928,9 +928,14 @@ impl Document {
                 }
             }
 
-            // Protect against overwriting changes made externally
             if !force {
                 if let Ok(metadata) = fs::metadata(&path).await {
+                    // Protect against overwriting entire directories
+                    // if `path` doesn't end with a directory separator.
+                    if metadata.is_dir() {
+                        bail!("path points to a directory, use :w! to overwrite that directory and its contents");
+                    }
+                    // Protect against overwriting changes made externally
                     if let Ok(mtime) = metadata.modified() {
                         if last_saved_time < mtime {
                             bail!("file modified by an external process, use :w! to overwrite");


### PR DESCRIPTION
Warn against overwriting directories if the destination path doesn't end with a directory separator.

* Create a directory `test-dir` and a `test-file.txt` inside (so we end with `test-dir/test-file.txt`)
* Open Helix in the current directory
* Use `:n` to create a new buffer and add some content to it
* Use `:w test-dir` to save the new buffer (note the directory name is used without the trailing slash)
* Observe that now the buffer was correctly saved to `test-dir` as a file
* However the directory itself was not lost, but renamed with a temporary/backup name (something like `test-dirp4F0MM.bck/`).

While not a critical data loss bug (the backup-rename of the original directory happens every time) it would be nice to prevent this situation in the first place, very much like we warn against external modifications by checking modification time.
