### PR TITLE
feat: allow multiple language servers for a hover event

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1039,7 +1039,7 @@ pub fn hover(cx: &mut Context) {
 
     cx.callback(
         join(futures),
-        move |editor, compositor, response: Vec<Option<(String, lsp::Hover)>>| {
+        move |editor, compositor, response: Vec<(String, Option<lsp::Hover>)>| {
             fn marked_string_to_markdown(contents: lsp::MarkedString) -> String {
                 match contents {
                     lsp::MarkedString::String(contents) => contents,
@@ -1055,7 +1055,7 @@ pub fn hover(cx: &mut Context) {
 
             let contents = response
                 .into_iter()
-                .flatten()
+                .filter_map(|(name, hover)| hover.map(|hover| (name, hover)))
                 .map(|(name, hover)| {
                     let content = match hover.contents {
                         lsp::HoverContents::Scalar(contents) => marked_string_to_markdown(contents),


### PR DESCRIPTION
This is a draft for previewing hover responses from multiple language server. For example, with two language servers (`taplo` and `harper-ls`), this will be presented on hover:

```
taplo

This is the rust edition, valid options are...

---

harper-ls

Did you mean to spell `didnt` this way?
```

Instead of this (what is currently shown):

```
This is the rust edition, valid options are...
```

Currently, helix will choose the first language server that supports `hover`, and only work with it. 

I wanted this feature, as I was working with multiple language servers, that both provide hover. Also, I saw a TODO in the hover function that suggests that this is something we want:

https://github.com/helix-editor/helix/blob/aac0ce5fd13df7f275b6523da58dec1ec054a8c8/helix-term/src/commands/lsp.rs#L1014

This is my first PR, so please point my attention if I missed something.