### PR TITLE
feat: add csv language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -30,6 +30,7 @@
 | cpp | ✓ | ✓ | ✓ | `clangd` |
 | crystal | ✓ | ✓ |  | `crystalline` |
 | css | ✓ |  | ✓ | `vscode-css-language-server` |
+| csv | ✓ |  |  |  |
 | cue | ✓ |  |  | `cuelsp` |
 | cylc | ✓ | ✓ | ✓ |  |
 | d | ✓ | ✓ | ✓ | `serve-d` |

--- a/languages.toml
+++ b/languages.toml
@@ -4074,3 +4074,14 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "gren"
 source = { git = "https://github.com/MaeBrooks/tree-sitter-gren", rev = "76554f4f2339f5a24eed19c58f2079b51c694152" }
+
+[[language]]
+name = "csv"
+scope = "text.csv"
+injection-regex = "csv"
+file-types = ["csv"]
+roots = []
+
+[[grammar]]
+name = "csv"
+source = { git = "https://github.com/arnau/tree-sitter-csv", rev = "4a42cdc393df37db9f3d71cf4c95b0b33bcebb09" }

--- a/runtime/queries/csv/highlights.scm
+++ b/runtime/queries/csv/highlights.scm
@@ -1,0 +1,19 @@
+; Literals
+(boolean) @constant.builtin.boolean
+[
+  (integer)
+  (float)
+  (hex)
+] @constant.numeric
+[
+  (null)
+  (na)
+] @constant.builtin
+
+(string) @string
+
+(escape_sequence) @constant.character.escape
+
+; Punctuation
+(delimiter) @punctuation.delimiter
+(quote) @punctuation.bracket


### PR DESCRIPTION
This pull request adds syntax highlighting for CSV files, using this grammar: https://github.com/arnau/tree-sitter-csv. There's no comment, indents, locals, or textobjects configurations since these things aren't relevant to CSVs. The `highlights.scm` file was copied directly from the upstream grammar repo. I tested things and it appears that no reordering is necessary, since all of the different highlightable things seem to be non-overlapping.

Here's a screenshot with the gruvbox theme:

![2025-01-26T11:25:02,455609759-05:00](https://github.com/user-attachments/assets/80c6aaab-b15b-4e6d-af60-dd920aec865a)