### PR TITLE
feat: add zebra-stripe option

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -93,6 +93,10 @@ impl EditorView {
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
 
+        if config.zebra_stripe {
+            decorations.add_decoration(Self::zebra_stripe(view, theme));
+        }
+
         if is_focused && config.cursorline {
             decorations.add_decoration(Self::cursorline(doc, view, theme));
         }
@@ -786,6 +790,20 @@ impl EditorView {
             Rect::new(viewport.right() - width, viewport.y + 1, width, height),
             surface,
         );
+    }
+
+    pub fn zebra_stripe(view: &View, theme: &Theme) -> impl Decoration {
+        let style = theme.get("ui.background.zebra-stripe");
+        let viewport = view.area;
+
+        move |renderer: &mut TextRenderer, pos: LinePos| {
+            if pos.doc_line % 2 == 1 {
+                return;
+            }
+
+            let area = Rect::new(viewport.x, pos.visual_line, viewport.width, 1);
+            renderer.set_style(area, style);
+        }
     }
 
     /// Apply the highlighting on the lines where a cursor is active

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -256,6 +256,8 @@ pub struct Config {
     pub shell: Vec<String>,
     /// Line number mode.
     pub line_number: LineNumber,
+    /// Highlight every other line. Defaults to false.
+    pub zebra_stripe: bool,
     /// Highlight the lines cursors are currently on. Defaults to false.
     pub cursorline: bool,
     /// Highlight the columns cursors are currently on. Defaults to false.
@@ -956,6 +958,7 @@ impl Default for Config {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },
             line_number: LineNumber::Absolute,
+            zebra_stripe: false,
             cursorline: false,
             cursorcolumn: false,
             gutters: GutterConfig::default(),


### PR DESCRIPTION
This PR adds zebra-striping in response to https://github.com/helix-editor/helix/discussions/12655

- [x] display horitonzal highlights for every other line

![image](https://github.com/user-attachments/assets/f77f94de-7135-4321-94b0-367916e3388f)
