### PR TITLE
fix: Align `Markdown` styles with tree sitter highlights

### DIFF
--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -152,17 +152,6 @@ impl Markdown {
         }
     }
 
-    /// Hello world.
-    ///
-    /// - One
-    /// - Two
-    /// - Three
-    ///
-    /// 1. One
-    /// 2. Two
-    /// 3. Three
-    fn foo() {}
-
     pub fn parse(&self, theme: Option<&Theme>) -> tui::text::Text<'_> {
         fn push_line<'a>(spans: &mut Vec<Span<'a>>, lines: &mut Vec<Spans<'a>>) {
             let spans = std::mem::take(spans);

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -133,6 +133,8 @@ impl Markdown {
     const TEXT_STYLE: &'static str = "ui.text";
     const BLOCK_STYLE: &'static str = "markup.raw.inline";
     const RULE_STYLE: &'static str = "punctuation.special";
+    const UNNUMBERED_LIST_STYLE: &'static str = "markup.list.unnumbered";
+    const NUMBERED_LIST_STYLE: &'static str = "markup.list.numbered";
     const HEADING_STYLES: [&'static str; 6] = [
         "markup.heading.1",
         "markup.heading.2",
@@ -154,8 +156,11 @@ impl Markdown {
     ///
     /// - One
     /// - Two
-    ///   - Three
-    /// - Four
+    /// - Three
+    ///
+    /// 1. One
+    /// 2. Two
+    /// 3. Three
     fn foo() {}
 
     pub fn parse(&self, theme: Option<&Theme>) -> tui::text::Text<'_> {
@@ -187,6 +192,8 @@ impl Markdown {
         let get_theme = |key: &str| -> Style { theme.map(|t| t.get(key)).unwrap_or_default() };
         let text_style = get_theme(Self::TEXT_STYLE);
         let code_style = get_theme(Self::BLOCK_STYLE);
+        let numbered_list_style = get_theme(Self::NUMBERED_LIST_STYLE);
+        let unnumbered_list_style = get_theme(Self::UNNUMBERED_LIST_STYLE);
         let rule_style = get_theme(Self::RULE_STYLE);
         let heading_styles: Vec<Style> = Self::HEADING_STYLES
             .iter()
@@ -237,10 +244,12 @@ impl Markdown {
                     tags.push(Tag::Item);
 
                     // get the appropriate bullet for the current list
-                    let bullet = list_stack
+                    let (bullet, bullet_style) = list_stack
                         .last()
                         .unwrap_or(&None) // use the '- ' bullet in case the list stack would be empty
-                        .map_or(String::from("- "), |number| format!("{}. ", number));
+                        .map_or((String::from("• "), unnumbered_list_style), |number| {
+                            (format!("{}. ", number), numbered_list_style)
+                        });
 
                     // increment the current list number if there is one
                     if let Some(v) = list_stack.last_mut().unwrap_or(&mut None).as_mut() {
@@ -248,7 +257,7 @@ impl Markdown {
                     }
 
                     let prefix = get_indent(list_stack.len()) + bullet.as_str();
-                    spans.push(Span::from(prefix));
+                    spans.push(Span::styled(prefix, bullet_style));
                 }
                 Event::Start(tag) => {
                     tags.push(tag);

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -132,6 +132,7 @@ pub struct Markdown {
 impl Markdown {
     const TEXT_STYLE: &'static str = "ui.text";
     const BLOCK_STYLE: &'static str = "markup.raw.inline";
+    const RULE_STYLE: &'static str = "punctuation.special";
     const HEADING_STYLES: [&'static str; 6] = [
         "markup.heading.1",
         "markup.heading.2",
@@ -148,6 +149,14 @@ impl Markdown {
             config_loader,
         }
     }
+
+    /// Hello world.
+    ///
+    /// - One
+    /// - Two
+    ///   - Three
+    /// - Four
+    fn foo() {}
 
     pub fn parse(&self, theme: Option<&Theme>) -> tui::text::Text<'_> {
         fn push_line<'a>(spans: &mut Vec<Span<'a>>, lines: &mut Vec<Spans<'a>>) {
@@ -178,6 +187,7 @@ impl Markdown {
         let get_theme = |key: &str| -> Style { theme.map(|t| t.get(key)).unwrap_or_default() };
         let text_style = get_theme(Self::TEXT_STYLE);
         let code_style = get_theme(Self::BLOCK_STYLE);
+        let rule_style = get_theme(Self::RULE_STYLE);
         let heading_styles: Vec<Style> = Self::HEADING_STYLES
             .iter()
             .map(|key| get_theme(key))
@@ -314,7 +324,7 @@ impl Markdown {
                     }
                 }
                 Event::Rule => {
-                    lines.push(Spans::from(Span::styled("---", code_style)));
+                    lines.push(Spans::from(Span::styled("───", rule_style)));
                     lines.push(Spans::default());
                 }
                 // TaskListMarker(bool) true if checked


### PR DESCRIPTION
this PR makes Markdown highlights use the same scopes as what Tree Sitter uses:

- Horizontal rule uses `punctuation.special`
- Numbered lists use `markup.list.numbered`
- Unnumbered lists use `markup.list.unnumbered`

Also, has cosmetic improvements:
- Use `•` for bullet points instead of `-`
- Use `───` for rule instead of `---`

## Before

![image](https://github.com/user-attachments/assets/cdaa0bf0-6a91-4448-868d-10f5107debc5)


## After

![image](https://github.com/user-attachments/assets/9d330765-58f8-40d0-9a90-301480621cd1)