### PR TITLE
feat(highlights): add missing highlight for `hurl` from version 6.0.0

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3467,7 +3467,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "hurl"
-source = { git = "https://github.com/pfeiferj/tree-sitter-hurl", rev = "cd1a0ada92cc73dd0f4d7eedc162be4ded758591" }
+source = { git = "https://github.com/pfeiferj/tree-sitter-hurl", rev = "1124058cd192e80d80914652a5850a5b1887cc10" }
 
 [[language]]
 name = "markdoc"

--- a/runtime/queries/hurl/highlights.scm
+++ b/runtime/queries/hurl/highlights.scm
@@ -1,7 +1,10 @@
 [
   "[QueryStringParams]"
+  "[Query]"
   "[FormParams]"
+  "[Form]"
   "[MultipartFormData]"
+  "[Multipart]"
   "[Cookies]"
   "[Captures]"
   "[Asserts]"
@@ -116,6 +119,9 @@
   "isBoolean"
   "isString"
   "isCollection"
+  "isNumber"
+  "isIsoDate"
+  "isEmpty"
 ] @keyword.operator
 
 (integer) @constant.numeric.integer


### PR DESCRIPTION
Version 6.0.0 of [hurl](https://hurl.dev/blog/2024/12/04/announcing-hurl-6.0.0.html) added some new operators and 3 shorthand alias names for section names. This PR adds highlighting support for them.