### PR TITLE
Recognize `.envrc` and `.envrc.*` files as bash

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1021,6 +1021,8 @@ file-types = [
   { glob = ".bash_logout" },
   { glob = ".bash_profile" },
   { glob = ".bashrc" },
+  { glob = ".envrc" },
+  { glob = ".envrc.*" },
   { glob = ".profile" },
   { glob = ".zshenv" },
   { glob = ".zlogin" },
@@ -2799,7 +2801,7 @@ source = { git = "https://github.com/hh9527/tree-sitter-wit", rev = "c917790ab9a
 [[language]]
 name = "env"
 scope = "source.env"
-file-types = [{ glob = ".env" }, { glob = ".env.*" }, { glob = ".envrc" }, { glob = ".envrc.*" }]
+file-types = [{ glob = ".env" }, { glob = ".env.*" }]
 injection-regex = "env"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
[direnv](https://direnv.net/)'s `.envrc` files are always executed as bash scripts, so automatically recognizing them as bash ensures that the correct language server, formatter, etc are are used when editing them.

Note:  I was a little curious whether this would be an unsafe change because there's another non-direnv tool that also uses files called `.envrc` (or `.envrc.*`, which I have never encountered).  Some quick internet searching only seems to turn up direnv-related results, so I'm hoping this is reasonably safe.
