### PR TITLE
Do not record keys pressed by macros while recording a macro

### DIFF
--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -137,9 +137,12 @@ impl Compositor {
     }
 
     pub fn handle_event(&mut self, event: &Event, cx: &mut Context) -> bool {
-        // If it is a key event and a macro is being recorded, push the key event to the recording.
+        // If it is a key event, a macro is being recorded, and a macro isn't being replayed,
+        // push the key event to the recording.
         if let (Event::Key(key), Some((_, keys))) = (event, &mut cx.editor.macro_recording) {
-            keys.push(*key);
+            if cx.editor.macro_replaying.is_empty() {
+                keys.push(*key);
+            }
         }
 
         let mut callbacks = Vec::new();


### PR DESCRIPTION
Fixes #12697 by not recording key presses of macros replayed while recording a macro. This results in the macro in the `@` register in the issue's reproduction example being `"aqi<space>world<esc>` instead of `"aqihello<esc>i<space>world<esc>`.