### PR TITLE
Properly prevent `crossterm` features being used when `feature = "term"` not enabled in `helix-view`

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -122,10 +122,11 @@ mod external {
                 Self::Tmux
             } else if binary_exists("pbcopy") && binary_exists("pbpaste") {
                 Self::Pasteboard
-            } else if cfg!(feature = "term") {
-                Self::Termcode
             } else {
-                Self::None
+                #[cfg(feature = "term")]
+                return Self::Termcode;
+                #[cfg(not(feature = "term"))]
+                return Self::None;
             }
         }
 

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -342,6 +342,7 @@ impl FromStr for UnderlineStyle {
     }
 }
 
+#[cfg(feature = "term")]
 impl From<UnderlineStyle> for crossterm::style::Attribute {
     fn from(style: UnderlineStyle) -> Self {
         match style {


### PR DESCRIPTION
Previously failed to compile when `features = []`