### PR TITLE
perf(ropey): enable `simd` feature for `stdx`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "2.0"
 tempfile = "3.15.0"
 bitflags = "2.8"
 unicode-segmentation = "1.2"
+ropey = { version = "1.6.1", default-features = false, features = ["simd"] }
 
 [workspace.package]
 version = "25.1.1"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -20,7 +20,7 @@ helix-stdx = { path = "../helix-stdx" }
 helix-loader = { path = "../helix-loader" }
 helix-parsec = { path = "../helix-parsec" }
 
-ropey = { version = "1.6.1", default-features = false, features = ["simd"] }
+ropey.workspace = true
 smallvec = "1.13"
 smartstring = "1.0.1"
 unicode-segmentation.workspace = true

--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 [dependencies]
 dunce = "1.0"
 etcetera = "0.8"
-ropey = { version = "1.6.1", default-features = false }
+ropey.workspace = true
 which = "7.0"
 regex-cursor = "0.1.4"
 bitflags.workspace = true


### PR DESCRIPTION
Per the `ropey` [docs](https://docs.rs/ropey/latest/ropey/#a-note-about-simd-acceleration):
> Ropey has a `simd` feature flag (enabled by default) that enables explicit SIMD on supported platforms to improve performance.
> 
> There is a bit of a footgun here: if you disable default features to configure line break behavior (as per the section above) then SIMD will also get disabled, and performance will suffer. So be careful to explicitly re-enable the `simd` feature flag (if desired) when doing that.

This also matches `helix-core`.