### PR TITLE
fix: add comment token for svelte files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1334,6 +1334,8 @@ scope = "source.svelte"
 injection-regex = "svelte"
 file-types = ["svelte"]
 indent = { tab-width = 2, unit = "  " }
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "svelteserver" ]
 
 [[grammar]]


### PR DESCRIPTION
there was a PR which changed the default comment token from `//` to `#`. Since svelte didn't have a token set, its comment token was changed to `#` 