### PR TITLE
Print full error chain when failing to load grammar

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -756,7 +756,7 @@ impl LanguageConfiguration {
             let language = get_language(self.grammar.as_deref().unwrap_or(&self.language_id))
                 .map_err(|err| {
                     log::error!(
-                        "Failed to load tree-sitter parser for language {:?}: {}",
+                        "Failed to load tree-sitter parser for language {:?}: {:#}",
                         self.language_id,
                         err
                     )


### PR DESCRIPTION
As per the documentation in `anyhow`: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations to print the full error, one should use `{:#}`. 

This helped me debug an error where a .so file would fail to load for a treesitter grammar by giving more information on the error so I'd figured I'd open a PR so that it might help others.

I didn't write a test because I'm not very familiar with the helix code and test structure but if you'd like one, please give some suggestion on how to implement it and I will 😄 