### PR TITLE
feat(lang:r): Add roxygen header comment token

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2009,7 +2009,7 @@ scope = "source.r"
 injection-regex = "(r|R)"
 file-types = ["r", "R", { glob = ".Rprofile" }, { glob = "Rprofile.site" }, { glob = ".RHistory" }]
 shebangs = ["r", "R"]
-comment-token = "#"
+comment-tokens = ["#", "#'"]
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "r" ]
 


### PR DESCRIPTION
Adds another comment token for a very common documentation header style used in the R language, see example from [`dplyr::mutate()`](https://github.com/tidyverse/dplyr/blob/fb25640fa1eb74746a7a74a06090045106e5d20f/R/mutate.R#L1-L7)