### PR TITLE
Highlight $ template literals as shell commands

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -10,6 +10,18 @@
   arguments: (template_string) @injection.content
   (#any-of? @injection.language "html" "css" "json" "sql" "js" "ts" "bash"))
 
+; Parse the contents of $ template literals as shell commands
+
+(call_expression
+  function: [
+    (identifier) @_template_function_name
+    (member_expression
+      property: (property_identifier) @_template_function_name)
+  ]
+  arguments: (template_string) @injection.content
+ (#eq? @_template_function_name "$")
+ (#set! injection.language "bash"))
+
 ; Parse the contents of gql template literals
 
 ((call_expression


### PR DESCRIPTION
See https://github.com/helix-editor/helix/pull/12217#issuecomment-2572394677. Supports highlighting `$` template literals as shell commands, as commonly done in [execa](https://github.com/sindresorhus/execa), [zx](https://github.com/google/zx), and [bun](https://bun.sh/docs/runtime/shell).

| Before | After |
| --- | --- |
| ![CleanShot 2025-02-01 at 18 54 36](https://github.com/user-attachments/assets/2564a9f1-4455-4857-b90b-2eaf1b5e533d) | ![CleanShot 2025-02-01 at 18 54 29](https://github.com/user-attachments/assets/0e40cd33-4e5b-42ec-8fbe-576376cb873e) |
