### PR TITLE
Add Tera templating language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -215,6 +215,7 @@
 | tcl | ✓ |  | ✓ |  |
 | teal | ✓ |  |  | `teal-language-server` |
 | templ | ✓ |  |  | `templ` |
+| tera | ✓ |  |  |  |
 | textproto | ✓ | ✓ | ✓ |  |
 | tfvars | ✓ |  | ✓ | `terraform-ls` |
 | thrift | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4110,3 +4110,19 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "ghostty"
 source = { git = "https://github.com/bezhermoso/tree-sitter-ghostty" , rev = "8438a93b44367e962b2ea3a3b6511885bebd196a" }
+
+[[language]]
+name = "tera"
+scope = "source.tera"
+file-types = ["tera"]
+block-comment-tokens = [
+  { start = "{#", end = "#}" },
+  { start = "{#-", end = "-#}" },
+  { start = "{#", end = "-#}" },
+  { start = "{#-", end = "#}" },
+]
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "tera"
+source = { git = "https://github.com/uncenter/tree-sitter-tera", rev = "e8d679a29c03e64656463a892a30da626e19ed8e" }

--- a/runtime/queries/tera/highlights.scm
+++ b/runtime/queries/tera/highlights.scm
@@ -1,0 +1,225 @@
+; Syntax highlighting scopes for Helix: https://docs.helix-editor.com/themes.html.
+
+(import_statement
+  scope: (identifier) @namespace)
+
+; Namespaces
+
+(filter_expression
+  filter: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ; Filters - https://keats.github.io/tera/docs/#built-in-filters
+    "lower"
+    "upper"
+    "wordcount"
+    "capitalize"
+    "replace"
+    "addslashes"
+    "slugify"
+    "title"
+    "trim"
+    "trim_start"
+    "trim_end"
+    "trim_start_matches"
+    "trim_end_matches"
+    "truncate"
+    "linebreaksbr"
+    "spaceless"
+    "indent"
+    "striptags"
+    "first"
+    "last"
+    "nth"
+    "join"
+    "length"
+    "reverse"
+    "sort"
+    "unique"
+    "slice"
+    "group_by"
+    "filter"
+    "map"
+    "concat"
+    "urlencode"
+    "urlencode_strict"
+    "abs"
+    "pluralize"
+    "round"
+    "filesizeformat"
+    "date"
+    "escape"
+    "escape_xml"
+    "safe"
+    "get"
+    "split"
+    "int"
+    "float"
+    "json_encode"
+    "as_str"
+    "default"))
+
+(filter_expression
+  filter: (identifier) @function.method)
+
+(test_expression
+  test: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ; Tests - https://keats.github.io/tera/docs/#built-in-tests
+    "defined"
+    "undefined"
+    "odd"
+    "even"
+    "string"
+    "number"
+    "divisibleby"
+    "iterable"
+    "object"
+    "starting_with"
+    "ending_with"
+    "containing"
+    "matching"))
+
+(test_expression
+  test: (identifier) @function)
+
+(call_expression
+  name: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ; Functions - https://keats.github.io/tera/docs/#built-in-functions
+    "range"
+    "now"
+    "throw"
+    "get_random"
+    "get_env"))
+
+(call_expression
+  scope: (identifier)? @namespace
+  name: (identifier) @function)
+
+(macro_statement
+  name: (identifier) @function
+  (parameter_list
+    parameter: (identifier) @variable.parameter
+    (optional_parameter
+      name: (identifier) @variable.parameter)))
+
+; Functions
+
+[
+  "set"
+  "set_global"
+  "filter"
+  "endfilter"
+  "block"
+  "endblock"
+  "macro"
+  "endmacro"
+  "raw"
+  "endraw"
+  "as"
+] @keyword
+
+[
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "in"
+  "and"
+  "or"
+  "not"
+  "is"
+] @keyword.operator
+
+[
+  "include"
+  "import"
+  "extends"
+] @keyword.control.import
+
+[
+  "for"
+  "endfor"
+] @keyword.control.repeat
+
+[
+  "if"
+  "elif"
+  "else"
+  "endif"
+] @keyword.control.conditional
+
+; Keywords
+;-----------
+
+(comment_tag) @comment
+
+; Tags
+;-----------
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{%"
+  "%}"
+  "-%}"
+  "{%-"
+  "}}"
+  "{{"
+  "-}}"
+  "{{-"
+  "::"
+] @punctuation.bracket
+
+[
+  "*"
+  "/"
+  "%"
+  "|"
+  "+"
+  "-"
+  "~"
+  "="
+  "=="
+  "!="
+  "<"
+  ">"
+  "<="
+  ">="
+] @operator
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+; Tokens
+;-----------
+
+(number) @constant.numeric
+
+(bool) @constant.builtin
+
+(string) @string
+
+; Literals
+;-----------
+
+(member_expression
+  property: (identifier)? @variable.other.member)
+
+; Properties
+;-----------
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin
+    "loop"
+    "__tera_context"))
+
+(identifier) @variable
+
+; Variables
+;----------

--- a/runtime/queries/tera/highlights.scm
+++ b/runtime/queries/tera/highlights.scm
@@ -1,9 +1,169 @@
-; Namespaces
+; Variables
+;----------
 
-(import_statement
-  scope: (identifier) @namespace)
+(identifier) @variable
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin
+    "loop"
+    "__tera_context"))
+
+; Properties
+;-----------
+
+(member_expression
+  property: (identifier)? @variable.other.member)
+
+; Literals
+;-----------
+
+(string) @string
+
+(bool) @constant.builtin
+
+(number) @constant.numeric
+
+; Tokens
+;-----------
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "*"
+  "/"
+  "%"
+  "|"
+  "+"
+  "-"
+  "~"
+  "="
+  "=="
+  "!="
+  "<"
+  ">"
+  "<="
+  ">="
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{%"
+  "%}"
+  "-%}"
+  "{%-"
+  "}}"
+  "{{"
+  "-}}"
+  "{{-"
+  "::"
+] @punctuation.bracket
+
+; Tags
+;-----------
+
+(comment_tag) @comment
+
+; Keywords
+;-----------
+
+[
+  "if"
+  "elif"
+  "else"
+  "endif"
+] @keyword.control.conditional
+
+[
+  "for"
+  "endfor"
+] @keyword.control.repeat
+
+[
+  "include"
+  "import"
+  "extends"
+] @keyword.control.import
+
+[
+  "in"
+  "and"
+  "or"
+  "not"
+  "is"
+] @keyword.operator
+
+[
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "set"
+  "set_global"
+  "filter"
+  "endfilter"
+  "block"
+  "endblock"
+  "macro"
+  "endmacro"
+  "raw"
+  "endraw"
+  "as"
+] @keyword
 
 ; Functions
+;-----------
+
+(macro_statement
+  name: (identifier) @function
+  (parameter_list
+    parameter: (identifier) @variable.parameter
+    (optional_parameter
+      name: (identifier) @variable.parameter)))
+
+(call_expression
+  scope: (identifier)? @namespace
+  name: (identifier) @function)
+
+(call_expression
+  name: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ; Functions - https://keats.github.io/tera/docs/#built-in-functions
+    "range"
+    "now"
+    "throw"
+    "get_random"
+    "get_env"))
+
+(test_expression
+  test: (identifier) @function)
+
+(test_expression
+  test: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ; Tests - https://keats.github.io/tera/docs/#built-in-tests
+    "defined"
+    "undefined"
+    "odd"
+    "even"
+    "string"
+    "number"
+    "divisibleby"
+    "iterable"
+    "object"
+    "starting_with"
+    "ending_with"
+    "containing"
+    "matching"))
+
+(filter_expression
+  filter: (identifier) @function.method)
 
 (filter_expression
   filter: (identifier) @function.builtin
@@ -58,161 +218,8 @@
     "as_str"
     "default"))
 
-(filter_expression
-  filter: (identifier) @function.method)
+; Namespaces
+;-----------
 
-(test_expression
-  test: (identifier) @function.builtin
-  (#any-of? @function.builtin
-    ; Tests - https://keats.github.io/tera/docs/#built-in-tests
-    "defined"
-    "undefined"
-    "odd"
-    "even"
-    "string"
-    "number"
-    "divisibleby"
-    "iterable"
-    "object"
-    "starting_with"
-    "ending_with"
-    "containing"
-    "matching"))
-
-(test_expression
-  test: (identifier) @function)
-
-(call_expression
-  name: (identifier) @function.builtin
-  (#any-of? @function.builtin
-    ; Functions - https://keats.github.io/tera/docs/#built-in-functions
-    "range"
-    "now"
-    "throw"
-    "get_random"
-    "get_env"))
-
-(call_expression
-  scope: (identifier)? @namespace
-  name: (identifier) @function)
-
-(macro_statement
-  name: (identifier) @function
-  (parameter_list
-    parameter: (identifier) @variable.parameter
-    (optional_parameter
-      name: (identifier) @variable.parameter)))
-
-; Keywords
-
-[
-  "set"
-  "set_global"
-  "filter"
-  "endfilter"
-  "block"
-  "endblock"
-  "macro"
-  "endmacro"
-  "raw"
-  "endraw"
-  "as"
-] @keyword
-
-[
-  "break"
-  "continue"
-] @keyword.control.return
-
-[
-  "in"
-  "and"
-  "or"
-  "not"
-  "is"
-] @keyword.operator
-
-[
-  "include"
-  "import"
-  "extends"
-] @keyword.control.import
-
-[
-  "for"
-  "endfor"
-] @keyword.control.repeat
-
-[
-  "if"
-  "elif"
-  "else"
-  "endif"
-] @keyword.control.conditional
-
-; Tags
-
-(comment_tag) @comment
-
-; Tokens
-
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{%"
-  "%}"
-  "-%}"
-  "{%-"
-  "}}"
-  "{{"
-  "-}}"
-  "{{-"
-  "::"
-] @punctuation.bracket
-
-[
-  "*"
-  "/"
-  "%"
-  "|"
-  "+"
-  "-"
-  "~"
-  "="
-  "=="
-  "!="
-  "<"
-  ">"
-  "<="
-  ">="
-] @operator
-
-[
-  "."
-  ","
-] @punctuation.delimiter
-
-
-; Literals
-
-(number) @constant.numeric
-
-(bool) @constant.builtin
-
-(string) @string
-
-; Properties
-
-(member_expression
-  property: (identifier)? @variable.other.member)
-
-; Variables
-
-((identifier) @variable.builtin
-  (#any-of? @variable.builtin
-    "loop"
-    "__tera_context"))
-
-(identifier) @variable
+(import_statement
+  scope: (identifier) @namespace)

--- a/runtime/queries/tera/highlights.scm
+++ b/runtime/queries/tera/highlights.scm
@@ -1,9 +1,9 @@
-; Syntax highlighting scopes for Helix: https://docs.helix-editor.com/themes.html.
+; Namespaces
 
 (import_statement
   scope: (identifier) @namespace)
 
-; Namespaces
+; Functions
 
 (filter_expression
   filter: (identifier) @function.builtin
@@ -103,7 +103,7 @@
     (optional_parameter
       name: (identifier) @variable.parameter)))
 
-; Functions
+; Keywords
 
 [
   "set"
@@ -150,13 +150,11 @@
   "endif"
 ] @keyword.control.conditional
 
-; Keywords
-;-----------
+; Tags
 
 (comment_tag) @comment
 
-; Tags
-;-----------
+; Tokens
 
 [
   "("
@@ -196,8 +194,8 @@
   ","
 ] @punctuation.delimiter
 
-; Tokens
-;-----------
+
+; Literals
 
 (number) @constant.numeric
 
@@ -205,14 +203,12 @@
 
 (string) @string
 
-; Literals
-;-----------
+; Properties
 
 (member_expression
   property: (identifier)? @variable.other.member)
 
-; Properties
-;-----------
+; Variables
 
 ((identifier) @variable.builtin
   (#any-of? @variable.builtin
@@ -220,6 +216,3 @@
     "__tera_context"))
 
 (identifier) @variable
-
-; Variables
-;----------

--- a/runtime/queries/tera/injections.scm
+++ b/runtime/queries/tera/injections.scm
@@ -1,0 +1,4 @@
+(frontmatter (content) @injection.content
+  (#set! injection.language "yaml")
+  (#set! injection.combined)
+)

--- a/runtime/queries/tera/locals.scm
+++ b/runtime/queries/tera/locals.scm
@@ -1,0 +1,7 @@
+(identifier) @local.reference
+(assignment_expression
+   left: (identifier) @local.definition)
+(macro_statement
+  (parameter_list
+    (identifier) @local.definition))
+(macro_statement) @local.scope


### PR DESCRIPTION
Adds support for the [Tera](https://keats.github.io/tera/) templating language, using my grammar https://github.com/uncenter/tree-sitter-tera. This only highlights the template tag logic and not the content around the template tags, but I plan to do that in the future by adding multiple `tera-` languages if I am allowed to do so - see https://github.com/uncenter/zed-tera/tree/main/languages for what I mean.

Closes https://github.com/helix-editor/helix/issues/6277.