### PR TITLE
feat: Add support for the Ink programming language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -101,6 +101,7 @@
 | idris |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |
 | ini | ✓ |  |  |  |
+| ink | ✓ |  |  |  |
 | inko | ✓ | ✓ | ✓ |  |
 | janet | ✓ |  |  |  |
 | java | ✓ | ✓ | ✓ | `jdtls` |

--- a/languages.toml
+++ b/languages.toml
@@ -4139,3 +4139,19 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "fga"
 source = { git = "https://github.com/matoous/tree-sitter-fga", rev = "5005e8dd976e1f67beb3d23204580eb6f8b4c965" }
+
+[[language]]
+name = "ink"
+scope = "source.ink"
+file-types = ["ink"]
+injection-regex = "ink"
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/"}
+indent = { tab-width = 4, unit = "\t" }
+soft-wrap = { enable = true }
+grammar = "ink"
+
+[[grammar]]
+name = "ink"
+source = { git = "https://github.com/rhizoome/tree-sitter-ink", rev = "8486e9b1627b0bc6b2deb9ee8102277a7c1281ac" }
+

--- a/runtime/queries/ink/highlights.scm
+++ b/runtime/queries/ink/highlights.scm
@@ -1,0 +1,53 @@
+; tags and labels
+(label) @label
+(tag (identifier) @commment)
+(tag) @comment
+
+; values
+(identifier) @function
+(string) @string
+(boolean) @constant
+(number) @constant.numeric
+
+; headers
+(knot_header) @keyword
+(stitch_header) @keyword
+(function_header) @keyword
+
+; marks (ink)
+(option_mark) @keyword.directive
+(gather_mark) @type.builtin
+(glue) @type.builtin
+
+; calls
+(divert_or_thread) @function
+
+; operators
+(assignment) @operator
+
+; special marks/operators (ink)
+(arrow) @special
+(double_arrow) @special
+(back_arrow) @constant
+(dot) @special
+(mark_start) @special
+(mark_end) @special
+(hide_start) @special
+(hide_end) @special
+
+; declarations
+(var_line) @attribute
+(const_line) @constant
+(list_line) @type
+
+; comments
+(line_comment) @comment
+(block_comment) @comment
+
+; unparsed code
+(inline_block) @keyword
+(condition_block) @keyword
+(code_text) @keyword
+
+; support injection
+(program) @ui.text


### PR DESCRIPTION
Add support for [ink by inkle](http://github.com/inkle/ink). I have currently implemented basic syntax highlighting.

- Since ink is a language for interactive fiction we use soft-wrap. The inky IDE also uses soft-wrap. This is what users expect.
- Since ink is more a markup language and language constructs (knot, stitch, weave, gather, glue) are very different to traditional programming languages, I look the highlighting-types in highlights.scm that give a good visual impression
- This uses my [tree-sitter-ink](https://github.com/rhizoome/tree-sitter-ink) parser, to my knowledge there is no other tree-sitter parser for ink
- I made this because inky does not properly support unicode and I took special care to support it well

<img src="/rhizoome/tree-sitter-ink/raw/main/assets/demo.png" alt="Ink Demo" width="326">