### PR TITLE
Rework soft wrap to allow split priorities.

### DIFF
--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -110,6 +110,18 @@ fn softwrap_multichar_grapheme() {
     )
 }
 
+#[test]
+fn softwrap_punctuation() {
+    assert_eq!(
+        softwrap_text("asdfasdfasdfasd ...\n"),
+        "asdfasdfasdfasd \n.... \n "
+    );
+    assert_eq!(
+        softwrap_text("asdfasdfasdf a(bc)\n"),
+        "asdfasdfasdf a(\n.bc) \n "
+    );
+}
+
 fn softwrap_text_at_text_width(text: &str) -> String {
     let mut text_fmt = TextFormat::new_test(true);
     text_fmt.soft_wrap_at_text_width = true;


### PR DESCRIPTION
The new algorithm works by buffering the last maxwrap graphemes. When it needs to split a line, it looks for the best split within this buffer.

What I like most about this strategy is that the split_priority function can be easily overridden in the future, for example it could use the unicode line breaking algorithm to decide on possible splits, and the rest of the implementation could stay exactly the same.

Fixes #11428