### PR TITLE
remove unnecessary allocations in switch_case

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -64,6 +64,7 @@ use crate::{
 
 use crate::job::{self, Jobs};
 use std::{
+    char::{ToLowercase, ToUppercase},
     cmp::Ordering,
     collections::{HashMap, HashSet},
     error::Error,
@@ -1724,17 +1725,48 @@ where
     exit_select_mode(cx);
 }
 
+enum CaseSwitcher {
+    ToUppercase(ToUppercase),
+    ToLowercase(ToLowercase),
+    Nothing(Option<char>),
+}
+
+impl Iterator for CaseSwitcher {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            CaseSwitcher::ToUppercase(upper) => upper.next(),
+            CaseSwitcher::ToLowercase(lower) => lower.next(),
+            CaseSwitcher::Nothing(nothing) => nothing.take(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            CaseSwitcher::ToUppercase(upper) => upper.size_hint(),
+            CaseSwitcher::ToLowercase(lower) => lower.size_hint(),
+            CaseSwitcher::Nothing(nothing) => {
+                let n = usize::from(nothing.is_some());
+                (n, Some(n))
+            }
+        }
+    }
+}
+
+impl ExactSizeIterator for CaseSwitcher {}
+
 fn switch_case(cx: &mut Context) {
     switch_case_impl(cx, |string| {
         string
             .chars()
             .flat_map(|ch| {
                 if ch.is_lowercase() {
-                    ch.to_uppercase().collect()
+                    CaseSwitcher::ToUppercase(ch.to_uppercase())
                 } else if ch.is_uppercase() {
-                    ch.to_lowercase().collect()
+                    CaseSwitcher::ToLowercase(ch.to_lowercase())
                 } else {
-                    vec![ch]
+                    CaseSwitcher::Nothing(Some(ch))
                 }
             })
             .collect()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1726,9 +1726,9 @@ where
 }
 
 enum CaseSwitcher {
-    ToUppercase(ToUppercase),
-    ToLowercase(ToLowercase),
-    Nothing(Option<char>),
+    Upper(ToUppercase),
+    Lower(ToLowercase),
+    Keep(Option<char>),
 }
 
 impl Iterator for CaseSwitcher {
@@ -1736,18 +1736,18 @@ impl Iterator for CaseSwitcher {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            CaseSwitcher::ToUppercase(upper) => upper.next(),
-            CaseSwitcher::ToLowercase(lower) => lower.next(),
-            CaseSwitcher::Nothing(nothing) => nothing.take(),
+            CaseSwitcher::Upper(upper) => upper.next(),
+            CaseSwitcher::Lower(lower) => lower.next(),
+            CaseSwitcher::Keep(ch) => ch.take(),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
-            CaseSwitcher::ToUppercase(upper) => upper.size_hint(),
-            CaseSwitcher::ToLowercase(lower) => lower.size_hint(),
-            CaseSwitcher::Nothing(nothing) => {
-                let n = usize::from(nothing.is_some());
+            CaseSwitcher::Upper(upper) => upper.size_hint(),
+            CaseSwitcher::Lower(lower) => lower.size_hint(),
+            CaseSwitcher::Keep(ch) => {
+                let n = if ch.is_some() { 1 } else { 0 };
                 (n, Some(n))
             }
         }
@@ -1762,11 +1762,11 @@ fn switch_case(cx: &mut Context) {
             .chars()
             .flat_map(|ch| {
                 if ch.is_lowercase() {
-                    CaseSwitcher::ToUppercase(ch.to_uppercase())
+                    CaseSwitcher::Upper(ch.to_uppercase())
                 } else if ch.is_uppercase() {
-                    CaseSwitcher::ToLowercase(ch.to_lowercase())
+                    CaseSwitcher::Lower(ch.to_lowercase())
                 } else {
-                    CaseSwitcher::Nothing(Some(ch))
+                    CaseSwitcher::Keep(Some(ch))
                 }
             })
             .collect()


### PR DESCRIPTION
previously it would allocate a Vec for every single char it would try to switch_case for, even when the case did not actually change, which is not necessary.