### PR TITLE
typst: add symbols query

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -220,7 +220,7 @@
 | twig | ✓ |  |  |  |  |
 | typescript | ✓ | ✓ | ✓ |  | `typescript-language-server` |
 | typespec | ✓ | ✓ | ✓ |  | `tsp-server` |
-| typst | ✓ |  |  |  | `tinymist`, `typst-lsp` |
+| typst | ✓ |  |  | ✓ | `tinymist`, `typst-lsp` |
 | ungrammar | ✓ |  |  |  |  |
 | unison | ✓ | ✓ | ✓ |  |  |
 | uxntal | ✓ |  |  |  |  |

--- a/runtime/queries/typst/symbols.scm
+++ b/runtime/queries/typst/symbols.scm
@@ -1,0 +1,6 @@
+; should be a heading
+(heading (text) @definition.class)
+
+; should be a label/reference/tag
+(heading (label) @definition.function )
+(content (label) @definition.function)


### PR DESCRIPTION
I added symbols for typst (alternative to latex). IMO there should be symbols for markup, in this case `heading` and `link/tag/reference`.