### PR TITLE
feat(themes): add `ui.text.directory` to gruber-darker

### DIFF
--- a/runtime/themes/gruber-darker.toml
+++ b/runtime/themes/gruber-darker.toml
@@ -54,6 +54,7 @@
 "ui.window" = { fg = "bg1" }
 "ui.help" = { bg = "bg1", fg = "fg0" }
 "ui.text" = { fg = "fg0" }
+"ui.text.directory" = { fg = "niagara0", modifiers = ["bold"] }
 "ui.text.focus" = { bg = "bg5", modifiers = ["bold"] }
 "ui.selection" = { bg = "bg2" }
 "ui.selection.primary" = { bg = "bg5" }


### PR DESCRIPTION
This matches the highlights used for directories in the "upstream" Emacs theme, e.g. here: https://github.com/rexim/gruber-darker-theme/blob/2e9f99c41fe8ef0557e9ea0f3b94ef50c68b5557/gruber-darker-theme.el#L143

<img width="362" alt="image" src="https://github.com/user-attachments/assets/e74acfae-fb84-4742-afab-0bf8756562f9" />
