### PR TITLE
just: bump grammar support to handle more kind of shebang injections

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3234,7 +3234,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "8eddc55e3235d9d87f11b75130857800ec7ba765" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "8d03cfdd7ab89ff76d935827de1b93450fa0ec0a" }
 
 [[language]]
 name = "gn"


### PR DESCRIPTION
<img width="442" alt="Screenshot 2025-02-08 at 17 59 41" src="https://github.com/user-attachments/assets/cd3c4a83-3813-487e-8473-5bd2ba01a1d2" />

Asked for in poliorcetics/tree-sitter-just#3