### PR TITLE
Add option to disable auto completion for commands

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -26,6 +26,7 @@
 |--|--|---------|
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
+| `prompt-completion` | Show prompt completions | `true` |
 | `default-yank-register` | Default register used for yank/paste | `"` |
 | `middle-click-paste` | Middle click paste support | `true` |
 | `scroll-lines` | Number of lines to scroll per scroll wheel step | `3` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -360,6 +360,8 @@ pub struct Config {
     pub end_of_line_diagnostics: DiagnosticFilter,
     // Set to override the default clipboard provider
     pub clipboard_provider: ClipboardProvider,
+    /// Control whether to show prompt completions
+    pub prompt_completion: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -1001,6 +1003,7 @@ impl Default for Config {
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Disable,
             clipboard_provider: ClipboardProvider::default(),
+            prompt_completion: true,
         }
     }
 }


### PR DESCRIPTION
Don't draw the auto completion box that appears
when typing `:` when `prompt-completion = true`.