### PR TITLE
Add support for a workspace runtime directory

### DIFF
--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -10,7 +10,7 @@ documentation][tree-sitter-queries].
 Query files should be placed in `runtime/queries/{language}/textobjects.scm`
 when contributing to Helix. Note that to test the query files locally you should put
 them under your local runtime directory (`~/.config/helix/runtime` on Linux
-for example).
+for example) or the workspace runtime directory (`$PWD/.helix/runtime`).
 
 The following [captures][tree-sitter-captures] are recognized:
 


### PR DESCRIPTION
closes #12821

In the documentation, there isn't much reference to these directories, other than that `hx --health` displays them. The new workspace directory is correctly included there.