### PR TITLE
Fix Bash completion space regression

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -9,23 +9,23 @@ _hx() {
 
     case "$prev" in
     -g | --grammar)
-        COMPREPLY=($(compgen -W 'fetch build' -- "$cur"))
+        mapfile -t COMPREPLY < <(compgen -W 'fetch build' -- "$cur")
         return 0
         ;;
     --health)
         languages=$(hx --health | tail -n '+7' | awk '{print $1}' | sed 's/\x1b\[[0-9;]*m//g')
-        COMPREPLY=($(compgen -W """$languages""" -- "$cur"))
+        mapfile -t COMPREPLY < <(compgen -W """$languages""" -- "$cur")
         return 0
         ;;
     esac
 
     case "$2" in
     -*)
-        COMPREPLY=($(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2"""))
+        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")
         return 0
         ;;
     *)
-        COMPREPLY=($(compgen -fd -- """$2"""))
+        mapfile -t COMPREPLY < <(compgen -fd -- """$2""")
         return 0
         ;;
     esac


### PR DESCRIPTION
Once fixed in #9708, PR #11246 accidentally introduces a regression that breaks bash completion with space in filename (The `IFS=$'\n'` is removed).

Instead of setting `IFS`, this PR uses an alternative `mapfile` approach, as suggested by ShellCheck [SC2207](https://www.shellcheck.net/wiki/SC2207).