### PR TITLE
Clean up Nix Flake & make it easier to customize

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,36 +34,20 @@ in
   # Currently rustPlatform.buildRustPackage doesn't have the finalAttrs pattern
   # hooked up. To get around this while having good customization, mkDerivation is
   # used instead.
-  stdenv.mkDerivation (self: {
+  rustPlatform.buildRustPackage (self: {
     # START: Reevaluate the below attrs when
     # https://github.com/NixOS/nixpkgs/pull/354999
     # or
     # https://github.com/NixOS/nixpkgs/pull/194475
     # Are merged.
-
-    # TODO: Probably change to cargoLock
-    cargoDeps = rustPlatform.importCargoLock {
-      lockFile = ./Cargo.lock;
-    };
+    cargoLock.lockFile = ./Cargo.lock;
 
     nativeBuildInputs = [
-      rustPlatform.rust.rustc # TODO: Remove
-      rustPlatform.rust.cargo # TODO: Remove
       pkgs.installShellFiles
       pkgs.git
     ];
 
-    # TODO: Remove entire attr
-    buildInputs = with rustPlatform; [
-      cargoSetupHook
-      cargoBuildHook
-      cargoInstallHook
-    ];
-
-    # Use Helix's opt profile for the build.
-    # TODO: s/cargoBuildType/buildType
-    cargoBuildType = "release";
-    # END: Funny attrs to reevaluate
+    buildType = "release";
 
     name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;
     src = fs.toSource {

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,96 @@
-# Flake's default package for non-flake-enabled nix instances
-let
-  compat = builtins.fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/b4a34015c698c7793d592d66adbab377907a2be8.tar.gz";
-    sha256 = "sha256:1qc703yg0babixi6wshn5wm2kgl5y1drcswgszh4xxzbrwkk9sv7";
-  };
+{
+  pkgs,
+  rustPlatform,
+  stdenv,
+  ...
+}: let
+  fs = pkgs.lib.fileset;
+
+  src = fs.difference (fs.gitTracked ./.) (fs.unions [
+    ./.envrc
+    ./rustfmt.toml
+    ./screenshot.png
+    ./book
+    ./docs
+    ./flake.lock
+    (fs.fileFilter (file: pkgs.lib.strings.hasInfix ".git" file.name) ./.)
+    (fs.fileFilter (file: file.hasExt "svg") ./.)
+    (fs.fileFilter (file: file.hasExt "md") ./.)
+    (fs.fileFilter (file: file.hasExt "nix") ./.)
+  ]);
+
+  # Next we actually need to build the grammars and the runtime directory
+  # that they reside in. It is built by calling the derivation in the
+  # grammars.nix file, then taking the runtime directory in the git repo
+  # and hooking symlinks up to it.
+  grammars = pkgs.callPackage ./grammars.nix {};
+  runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+    mkdir -p $out
+    ln -s ${./runtime}/* $out
+    rm -r $out/grammars
+    ln -s ${grammars} $out/grammars
+  '';
 in
-  (import compat {src = ./.;}).defaultNix
+  # Currently rustPlatform.buildRustPackage doesn't have the finalAttrs pattern
+  # hooked up. To get around this while having good customization, mkDerivation is
+  # used instead.
+  stdenv.mkDerivation (self: {
+    # START: Reevaluate the below attrs when
+    # https://github.com/NixOS/nixpkgs/pull/354999
+    # or
+    # https://github.com/NixOS/nixpkgs/pull/194475
+    # Are merged.
+
+    # TODO: Probably change to cargoLock
+    cargoDeps = rustPlatform.importCargoLock {
+      lockFile = ./Cargo.lock;
+    };
+
+    nativeBuildInputs = [
+      rustPlatform.rust.rustc # TODO: Remove
+      rustPlatform.rust.cargo # TODO: Remove
+      pkgs.installShellFiles
+      pkgs.git
+    ];
+
+    # TODO: Remove entire attr
+    buildInputs = with rustPlatform; [
+      cargoSetupHook
+      cargoBuildHook
+      cargoInstallHook
+    ];
+
+    # Use Helix's opt profile for the build.
+    # TODO: s/cargoBuildType/buildType
+    cargoBuildType = "release";
+    # END: Funny attrs to reevaluate
+
+    name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;
+    src = fs.toSource {
+      root = ./.;
+      fileset = src;
+    };
+
+    # Helix attempts to reach out to the network and get the grammars. Nix doesn't allow this.
+    HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+
+    # So Helix knows what rev it is.
+    HELIX_NIX_BUILD_REV = self.rev or self.dirtyRev or null;
+
+    doCheck = false;
+    strictDeps = true;
+
+    # Sets the Helix runtimedir to the grammars
+    env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
+
+    # Get all the application stuff in the output directory.
+    postInstall = ''
+      mkdir -p $out/lib
+      installShellCompletion ${./contrib/completion}/hx.{bash,fish,zsh}
+      mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
+      cp ${./contrib/Helix.desktop} $out/share/applications
+      cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps
+    '';
+
+    meta.mainProgram = "hx";
+  })

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,15 @@
 {
   pkgs,
+  lib,
   rustPlatform,
   stdenv,
+  callPackage,
+  runCommand,
+  installShellFiles,
+  git,
   ...
 }: let
-  fs = pkgs.lib.fileset;
+  fs = lib.fileset;
 
   src = fs.difference (fs.gitTracked ./.) (fs.unions [
     ./.envrc
@@ -13,7 +18,7 @@
     ./book
     ./docs
     ./flake.lock
-    (fs.fileFilter (file: pkgs.lib.strings.hasInfix ".git" file.name) ./.)
+    (fs.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.)
     (fs.fileFilter (file: file.hasExt "svg") ./.)
     (fs.fileFilter (file: file.hasExt "md") ./.)
     (fs.fileFilter (file: file.hasExt "nix") ./.)
@@ -23,8 +28,8 @@
   # that they reside in. It is built by calling the derivation in the
   # grammars.nix file, then taking the runtime directory in the git repo
   # and hooking symlinks up to it.
-  grammars = pkgs.callPackage ./grammars.nix {};
-  runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+  grammars = callPackage ./grammars.nix {};
+  runtimeDir = runCommand "helix-runtime" {} ''
     mkdir -p $out
     ln -s ${./runtime}/* $out
     rm -r $out/grammars
@@ -35,16 +40,11 @@ in
   # hooked up. To get around this while having good customization, mkDerivation is
   # used instead.
   rustPlatform.buildRustPackage (self: {
-    # START: Reevaluate the below attrs when
-    # https://github.com/NixOS/nixpkgs/pull/354999
-    # or
-    # https://github.com/NixOS/nixpkgs/pull/194475
-    # Are merged.
     cargoLock.lockFile = ./Cargo.lock;
 
     nativeBuildInputs = [
-      pkgs.installShellFiles
-      pkgs.git
+      installShellFiles
+      git
     ];
 
     buildType = "release";

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,6 @@
 {
-  pkgs,
   lib,
   rustPlatform,
-  stdenv,
   callPackage,
   runCommand,
   installShellFiles,

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1737563566,
-        "narHash": "sha256-GLJvkOG29XCynQm8XWPyykMRqIhxKcBARVu7Ydrz02M=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "849376434956794ebc7a6b487d31aace395392ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -51,7 +36,6 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737599167,
-        "narHash": "sha256-S2rHCrQWCDVp63XxL/AQbGr1g5M8Zx14C7Jooa4oM8o=",
+        "lastModified": 1740623427,
+        "narHash": "sha256-3SdPQrZoa4odlScFDUHd4CUPQ/R1gtH4Mq9u8CBiK8M=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "38374302ae9edf819eac666d1f276d62c712dd06",
+        "rev": "d342e8b5fd88421ff982f383c853f0fc78a847ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,7 @@
     flake-utils,
     rust-overlay,
     ...
-  }: let
-  in
+  }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
         rustc = msrvToolchain;
       };
     in {
-      packages = {
+      packages = rec {
         # Make MSRV Helix
         helix = pkgs.callPackage mkHelix {rustPlatform = msrvPlatform;};
 
@@ -117,7 +117,7 @@
         # default nixpkgs, which is the one in the Flake.lock of Helix.
         #
         # This can be overridden though to add Cargo Features, flags, and different toolchains.
-        default = self.packages.${system}.helix;
+        default = helix;
       };
 
       checks.helix = self.outputs.packages.${system}.helix.overrideAttrs {

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
         (fs.fileFilter (file: file.hasExt "md") ./.)
         (fs.fileFilter (file: file.hasExt "nix") ./.)
       ]);
-      
+
       # Next we actually need to build the grammars and the runtime directory
       # that they reside in. It is built by calling the derivation in the
       # grammars.nix file, then taking the runtime directory in the git repo
@@ -128,7 +128,7 @@
       };
     in {
       packages = rec {
-        helix = pkgs.callPackage mkHelix { };
+        helix = pkgs.callPackage mkHelix {};
 
         # The default Helix build. Uses the latest stable Rust toolchain, and unstable
         # nixpkgs.
@@ -149,12 +149,16 @@
       in
         pkgs.mkShell
         {
-          inputsFrom = builtins.attrValues self.checks.${system};
           nativeBuildInputs = with pkgs;
-            [lld_13 cargo-flamegraph rust-analyzer]
-            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) pkgs.cargo-tarpaulin)
-            ++ (lib.optional stdenv.isLinux pkgs.lldb)
-            ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreFoundation);
+            [
+              lld_13
+              cargo-flamegraph
+              rust-bin.nightly.latest.rust-analyzer
+              msrvToolchain
+            ]
+            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
+            ++ (lib.optional stdenv.isLinux lldb)
+            ++ (lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation);
           shellHook = ''
             export HELIX_RUNTIME="$PWD/runtime"
             export RUST_BACKTRACE="1"

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
       # Overrides to use Nightly toolchain
       #
       #   pkgs = import nixpkgs {
-      #     inherit syste;
+      #     inherit system;
       #     overlays = [ (import rust-overlay) ]
       #   };
       #   craneLib = crane.mkLib pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -69,18 +69,21 @@
       # This allows for an overridable helix build.
       #
       build_helix = pkgs.lib.makeOverridable ({
-        pkgs,
-        craneLib,
-        runtimeDir,
+        pkgs ? pkgs,
+        craneLib ? craneLibMSRV,
+        runtimeDir ? runtimeDir,
         cargoExtraArgs ? "",
       }:
         craneLib.buildPackage (commonArgs
           // rec {
-            inherit cargoArtifacts cargoExtraArgs;
+            inherit cargoExtraArgs;
             nativeBuildInputs = [
               pkgs.installShellFiles
               pkgs.git
             ];
+
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+            
             env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
 
             postInstall = ''
@@ -97,10 +100,7 @@
           }));
     in {
       packages = {
-        helix = build_helix {
-          inherit pkgs runtimeDir;
-          craneLib = craneLibMSRV;
-        };
+        helix = build_helix { };
 
         # The default Helix build. Uses the default MSRV Rust toolchain, and the
         # default nixpkgs, which is the one in the Flake.lock of Helix.

--- a/flake.nix
+++ b/flake.nix
@@ -27,12 +27,12 @@
 
       src = fs.difference (fs.gitTracked ./.) (fs.unions [
         ./.envrc
-        ./.gitignore
         ./rustfmt.toml
         ./screenshot.png
         ./book
         ./docs
         ./flake.lock
+        (fs.fileFilter (file: pkgs.lib.strings.hasInfix ".git" file.name) ./.)
         (fs.fileFilter (file: file.hasExt "svg") ./.)
         (fs.fileFilter (file: file.hasExt "md") ./.)
         (fs.fileFilter (file: file.hasExt "nix") ./.)

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
       # grammars.nix file, then taking the runtime directory in the git repo
       # and hooking symlinks up to it.
       grammars = pkgs.callPackage ./grammars.nix {};
-      runtimeDir = pkgs.runCommand "helix-runtime" {} ''
+      runtime = pkgs.runCommand "helix-runtime" {} ''
         mkdir -p $out
         ln -s ${./runtime}/* $out
         rm -r $out/grammars
@@ -69,21 +69,21 @@
       # This allows for an overridable helix build.
       #
       build_helix = pkgs.lib.makeOverridable ({
-        pkgs ? pkgs,
+        npkgs ? pkgs,
         craneLib ? craneLibMSRV,
-        runtimeDir ? runtimeDir,
+        runtimeDir ? runtime,
         cargoExtraArgs ? "",
       }:
         craneLib.buildPackage (commonArgs
           // rec {
             inherit cargoExtraArgs;
             nativeBuildInputs = [
-              pkgs.installShellFiles
-              pkgs.git
+              npkgs.installShellFiles
+              npkgs.git
             ];
 
             cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-            
+
             env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
 
             postInstall = ''
@@ -100,7 +100,7 @@
           }));
     in {
       packages = {
-        helix = build_helix { };
+        helix = build_helix {};
 
         # The default Helix build. Uses the default MSRV Rust toolchain, and the
         # default nixpkgs, which is the one in the Flake.lock of Helix.

--- a/flake.nix
+++ b/flake.nix
@@ -134,11 +134,11 @@
         # nixpkgs.
         #
         # This can be overridden though to add Cargo Features, flags, and different toolchains with
-        # packages.${system}.default.overrideAttrs { ... };
+        # packages.${system}.default.override { ... };
         default = helix;
       };
 
-      checks.helix = self.outputs.packages.${system}.helix.overrideAttrs {
+      checks.helix = self.outputs.packages.${system}.helix.override {
         cargoBuildType = "debug";
         rustPlatform = msrvPlatform;
       };
@@ -149,12 +149,12 @@
       in
         pkgs.mkShell
         {
+          inputsFrom = [self.checks.${system}.helix];
           nativeBuildInputs = with pkgs;
             [
               lld_13
               cargo-flamegraph
               rust-bin.nightly.latest.rust-analyzer
-              msrvToolchain
             ]
             ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
             ++ (lib.optional stdenv.isLinux lldb)

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
       # hooked up. To get around this while having good customization, mkDerivation is
       # used instead.
       stdenv.mkDerivation (self: {
-        # START: Reelvalute the below attrs when
+        # START: Reevaluate the below attrs when
         # https://github.com/NixOS/nixpkgs/pull/354999
         # or
         # https://github.com/NixOS/nixpkgs/pull/194475
@@ -93,9 +93,7 @@
           cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps
         '';
 
-        meta = {
-          mainProgram = "hx";
-        };
+        meta.mainProgram = "hx";
       });
   in
     flake-utils.lib.eachDefaultSystem (system: let
@@ -122,10 +120,8 @@
         default = self.packages.${system}.helix;
       };
 
-      checks = {
-        helix = self.outputs.packages.${system}.helix.overrideAttrs {
-          cargoBuildType = "debug";
-        };
+      checks.helix = self.outputs.packages.${system}.helix.overrideAttrs {
+        cargoBuildType = "debug";
       };
 
       formatter = pkgs.alejandra;
@@ -150,10 +146,8 @@
         };
     })
     // {
-      overlays = {
-        default = final: prev: {
-          helix = final.callPackage mkHelix {};
-        };
+      overlays.default = final: prev: {
+        helix = final.callPackage mkHelix {};
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,9 @@
         ./book
         ./docs
         ./flake.lock
-        (fs.maybeMissing ./.github)
-        (fs.maybeMissing ./.ignore)
-        (fs.fileFilter (file: file.hasExt ".svg") ./.)
-        (fs.fileFilter (file: file.hasExt ".md") ./.)
-        (fs.fileFilter (file: file.hasExt ".nix") ./.)
+        (fs.fileFilter (file: file.hasExt "svg") ./.)
+        (fs.fileFilter (file: file.hasExt "md") ./.)
+        (fs.fileFilter (file: file.hasExt "nix") ./.)
       ]);
       
       # Next we actually need to build the grammars and the runtime directory

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
 
         # Use Helix's opt profile for the build.
         # TODO: s/cargoBuildType/buildType
-        cargoBuildType = "opt";
+        cargoBuildType = "release";
         # END: Funny attrs to reevaluate
 
         name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;

--- a/flake.nix
+++ b/flake.nix
@@ -17,102 +17,6 @@
     rust-overlay,
     ...
   }: let
-    mkHelix = {
-      pkgs,
-      rustPlatform,
-      stdenv,
-      ...
-    }: let
-      fs = pkgs.lib.fileset;
-
-      src = fs.difference (fs.gitTracked ./.) (fs.unions [
-        ./.envrc
-        ./rustfmt.toml
-        ./screenshot.png
-        ./book
-        ./docs
-        ./flake.lock
-        (fs.fileFilter (file: pkgs.lib.strings.hasInfix ".git" file.name) ./.)
-        (fs.fileFilter (file: file.hasExt "svg") ./.)
-        (fs.fileFilter (file: file.hasExt "md") ./.)
-        (fs.fileFilter (file: file.hasExt "nix") ./.)
-      ]);
-
-      # Next we actually need to build the grammars and the runtime directory
-      # that they reside in. It is built by calling the derivation in the
-      # grammars.nix file, then taking the runtime directory in the git repo
-      # and hooking symlinks up to it.
-      grammars = pkgs.callPackage ./grammars.nix {};
-      runtimeDir = pkgs.runCommand "helix-runtime" {} ''
-        mkdir -p $out
-        ln -s ${./runtime}/* $out
-        rm -r $out/grammars
-        ln -s ${grammars} $out/grammars
-      '';
-    in
-      # Currently rustPlatform.buildRustPackage doesn't have the finalAttrs pattern
-      # hooked up. To get around this while having good customization, mkDerivation is
-      # used instead.
-      stdenv.mkDerivation (self: {
-        # START: Reevaluate the below attrs when
-        # https://github.com/NixOS/nixpkgs/pull/354999
-        # or
-        # https://github.com/NixOS/nixpkgs/pull/194475
-        # Are merged.
-
-        # TODO: Probably change to cargoLock
-        cargoDeps = rustPlatform.importCargoLock {
-          lockFile = ./Cargo.lock;
-        };
-
-        nativeBuildInputs = [
-          rustPlatform.rust.rustc # TODO: Remove
-          rustPlatform.rust.cargo # TODO: Remove
-          pkgs.installShellFiles
-          pkgs.git
-        ];
-
-        # TODO: Remove entire attr
-        buildInputs = with rustPlatform; [
-          cargoSetupHook
-          cargoBuildHook
-          cargoInstallHook
-        ];
-
-        # Use Helix's opt profile for the build.
-        # TODO: s/cargoBuildType/buildType
-        cargoBuildType = "release";
-        # END: Funny attrs to reevaluate
-
-        name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;
-        src = fs.toSource {
-          root = ./.;
-          fileset = src;
-        };
-
-        # Helix attempts to reach out to the network and get the grammars. Nix doesn't allow this.
-        HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-
-        # So Helix knows what rev it is.
-        HELIX_NIX_BUILD_REV = self.rev or self.dirtyRev or null;
-
-        doCheck = false;
-        strictDeps = true;
-
-        # Sets the Helix runtimedir to the grammars
-        env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
-
-        # Get all the application stuff in the output directory.
-        postInstall = ''
-          mkdir -p $out/lib
-          installShellCompletion ${./contrib/completion}/hx.{bash,fish,zsh}
-          mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
-          cp ${./contrib/Helix.desktop} $out/share/applications
-          cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps
-        '';
-
-        meta.mainProgram = "hx";
-      });
   in
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
@@ -128,7 +32,7 @@
       };
     in {
       packages = rec {
-        helix = pkgs.callPackage mkHelix {};
+        helix = pkgs.callPackage ./default.nix {};
 
         # The default Helix build. Uses the latest stable Rust toolchain, and unstable
         # nixpkgs.
@@ -168,7 +72,7 @@
     })
     // {
       overlays.default = final: prev: {
-        helix = final.callPackage mkHelix {};
+        helix = final.callPackage ./default.nix {};
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
       };
 
       checks.helix = self.outputs.packages.${system}.helix.override {
-        cargoBuildType = "debug";
+        buildType = "debug";
         rustPlatform = msrvPlatform;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -88,10 +88,10 @@
 
             postInstall = ''
               mkdir -p $out/lib
-              installShellCompletion contrib/completion/hx.{bash,fish,zsh}
+              installShellCompletion ${./contrib/completion}/hx.{bash,fish,zsh}
               mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
-              cp contrib/Helix.desktop $out/share/applications
-              cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
+              cp ${./contrib/Helix.desktop} $out/share/applications
+              cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps
             '';
 
             meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -130,21 +130,20 @@
       };
     in {
       packages = rec {
-        # Make MSRV Helix
-        helix = pkgs.callPackage mkHelix {rustPlatform = msrvPlatform;};
+        helix = pkgs.callPackage mkHelix { };
 
-        # The default Helix build. Uses the default MSRV Rust toolchain, and the
-        # default nixpkgs, which is the one in the Flake.lock of Helix.
+        # The default Helix build. Uses the latest stable Rust toolchain, and unstable
+        # nixpkgs.
         #
-        # This can be overridden though to add Cargo Features, flags, and different toolchains.
+        # This can be overridden though to add Cargo Features, flags, and different toolchains with
+        # packages.${system}.default.overrideAttrs { ... };
         default = helix;
       };
 
       checks.helix = self.outputs.packages.${system}.helix.overrideAttrs {
         cargoBuildType = "debug";
+        rustPlatform = msrvPlatform;
       };
-
-      formatter = pkgs.alejandra;
 
       # Devshell behavior is preserved.
       devShells.default = let

--- a/grammars.nix
+++ b/grammars.nix
@@ -32,10 +32,10 @@
   # If `use-grammars.except` is set, use all other grammars.
   # Otherwise use all grammars.
   useGrammar = grammar:
-    if languagesConfig?use-grammars.only then
-      builtins.elem grammar.name languagesConfig.use-grammars.only
-    else if languagesConfig?use-grammars.except then
-      !(builtins.elem grammar.name languagesConfig.use-grammars.except)
+    if languagesConfig ? use-grammars.only
+    then builtins.elem grammar.name languagesConfig.use-grammars.only
+    else if languagesConfig ? use-grammars.except
+    then !(builtins.elem grammar.name languagesConfig.use-grammars.except)
     else true;
   grammarsToUse = builtins.filter useGrammar languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
@@ -66,10 +66,10 @@
       version = grammar.source.rev;
 
       src = source;
-      sourceRoot = if builtins.hasAttr "subpath" grammar.source then
-        "source/${grammar.source.subpath}"
-      else
-        "source";
+      sourceRoot =
+        if builtins.hasAttr "subpath" grammar.source
+        then "source/${grammar.source.subpath}"
+        else "source";
 
       dontConfigure = true;
 
@@ -116,15 +116,19 @@
       '';
     };
   grammarsToBuild = builtins.filter includeGrammarIf gitGrammars;
-  builtGrammars = builtins.map (grammar: {
-    inherit (grammar) name;
-    value = buildGrammar grammar;
-  }) grammarsToBuild;
+  builtGrammars =
+    builtins.map (grammar: {
+      inherit (grammar) name;
+      value = buildGrammar grammar;
+    })
+    grammarsToBuild;
   extensibleGrammars =
     lib.makeExtensible (self: builtins.listToAttrs builtGrammars);
-  overlaidGrammars = lib.pipe extensibleGrammars
+  overlaidGrammars =
+    lib.pipe extensibleGrammars
     (builtins.map (overlay: grammar: grammar.extend overlay) grammarOverlays);
-  grammarLinks = lib.mapAttrsToList
+  grammarLinks =
+    lib.mapAttrsToList
     (name: artifact: "ln -s ${artifact}/${name}.so $out/${name}.so")
     (lib.filterAttrs (n: v: lib.isDerivation v) overlaidGrammars);
 in


### PR DESCRIPTION
Hello. It has been a while since #11528. I am better at Nix, so I decided to take a crack at cleaning the flake up. 

My main issues with it is that it was not setup to be very customizable. Also the Cachix cache is nearly useless since it is compiled with `target-cpu=native`, so the cache will nearly always be missed. So I refactored it and added some comments.

1. ~~I am unconvinced it needs all the source filtering.~~
2. By default everything uses the MSRV compiler as that is a safe default.
3. Cleaned up a few vestigial things that my guess is were left from earlier revisions

I did preserve the behavior that the devshell will compile with `target-cpu=native` and other flags. But now the Cachix cache is actually possible to hit.

You can see an example of it in use in my NixOS config here: https://github.com/RossSmyth/nixos/blob/338fce6a5b7c3c5fe9c1790929bae40ce1494006/home-manager/helix.nix#L10-L29

The main issue is that the previous weird setup may be relied one by some people. So this will break them.

Commits can be squashed when merged.