### PR TITLE
Improve `onedarker` theme contrast `cursorline`/`selection`

### DIFF
--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -83,6 +83,7 @@
 "ui.bufferline.background" = { bg = "light-black" }
 
 "ui.text" = { fg = "white" }
+"ui.text.directory" = { fg = "blue" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 
 "ui.help" = { fg = "white", bg = "gray" }

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -65,9 +65,9 @@
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.match" = { fg = "blue", modifiers = ["underlined"]}
 
-"ui.selection" = { bg = "light-gray" }
+"ui.selection" = { bg = "black", modifiers = ["reversed"] }
 "ui.selection.primary" = { bg = "gray" }
-"ui.cursorline.primary" = { bg = "light-black" }
+"ui.cursorline.primary" = { bg = "dark-black" }
 
 "ui.linenr" = { fg = "linenr" }
 "ui.linenr.selected" = { fg = "white" }
@@ -105,6 +105,7 @@ gold = "#D19A66"
 cyan = "#46A6B2"
 white = "#ABB2BF"
 black = "#16181A"
+dark-black = "#12100E"
 light-black = "#2C323C"
 gray = "#252D30"
 faint-gray = "#ABB2BF"


### PR DESCRIPTION
Previously `ui.cursorline.primary`
(`light-black`)/`ui.selection.primary` (`gray`) and `ui.selection` (`light-gray`)/`comment` (`light-gray`) had little or no contrast. `ui.cursorline.primary` is changed to a new darker color, `dark-black` and `ui.selection` is set to use `reversed`.

After playing with the example solution in #12579 I decided to go with one that keeps the gray hue for selections and only requires adding one new color to the palette. The change also supports 256-color mode.

24-bit color:
![image](https://github.com/user-attachments/assets/245fa63b-ccca-4ba5-85a2-51f130aae8c2)

256-color:
![image](https://github.com/user-attachments/assets/88f11451-2ff0-4379-ba3a-98e2797f381d)