### PR TITLE
mark xsl files as XML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2763,7 +2763,8 @@ file-types = [
   "musicxml",
   "glif",
   "ui",
-  "sublime-snippet"
+  "sublime-snippet",
+  "xsl"
 ]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Another XML file in disguise.

e.g. https://github.com/docbook/xslt10-stylesheets/blob/master/xsl/manpages/docbook.xsl