### PR TITLE
fix: check and print remaining language servers

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -224,8 +224,7 @@ pub fn languages_all() -> std::io::Result<()> {
 
         for cmd in cmds {
             write!(stdout, "{}", fit(""))?;
-            check_binary(Some(cmd));
-            writeln!(stdout)?;
+            writeln!(stdout, "{}", check_binary(Some(cmd)))?;
         }
     }
 


### PR DESCRIPTION
This is a small regression fix introduced by #12355.
fixes #12403