### PR TITLE
feat: Improve look of Global Search Picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2438,7 +2438,7 @@ fn global_search(cx: &mut Context) {
 
             Cell::from(Spans::from(vec![
                 Span::styled(directories, config.directory_style),
-                Span::raw(filename.to_string()),
+                Span::raw(filename),
                 Span::styled(":", config.colon_style),
                 Span::styled((item.line_num + 1).to_string(), config.number_style),
             ]))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2425,19 +2425,19 @@ fn global_search(cx: &mut Context) {
         PickerColumn::new("path", |item: &FileResult, config: &GlobalSearchConfig| {
             let path = helix_stdx::path::get_relative_path(&item.path);
 
-            let mut components = path.components().map(|a| a.as_os_str().to_string_lossy());
+            let directories = path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| p.to_string_lossy().to_string() + "/")
+                .unwrap_or_default();
 
-            let filename = components.next_back().unwrap_or_default();
-
-            let mut directories = String::new();
-
-            for segment in components {
-                directories.push_str(&segment);
-                directories.push(std::path::MAIN_SEPARATOR)
-            }
+            let filename = path
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
 
             Cell::from(Spans::from(vec![
-                Span::styled(directories.to_string(), config.directory_style),
+                Span::styled(directories, config.directory_style),
                 Span::raw(filename.to_string()),
                 Span::styled(":", config.colon_style),
                 Span::styled((item.line_num + 1).to_string(), config.number_style),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2428,7 +2428,7 @@ fn global_search(cx: &mut Context) {
             let directories = path
                 .parent()
                 .filter(|p| !p.as_os_str().is_empty())
-                .map(|p| p.to_string_lossy().to_string() + "/")
+                .map(|p| format!("{}{}", p.display(), std::path::MAIN_SEPARATOR))
                 .unwrap_or_default();
 
             let filename = path

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -11,7 +11,10 @@ use helix_stdx::{
 };
 use helix_vcs::{FileChange, Hunk};
 pub use lsp::*;
-use tui::text::Span;
+use tui::{
+    text::{Span, Spans},
+    widgets::Cell,
+};
 pub use typed::*;
 
 use helix_core::{
@@ -2404,18 +2407,41 @@ fn global_search(cx: &mut Context) {
     struct GlobalSearchConfig {
         smart_case: bool,
         file_picker_config: helix_view::editor::FilePickerConfig,
+        directory_style: Style,
+        number_style: Style,
+        colon_style: Style,
     }
 
     let config = cx.editor.config();
     let config = GlobalSearchConfig {
         smart_case: config.search.smart_case,
         file_picker_config: config.file_picker.clone(),
+        directory_style: cx.editor.theme.get("ui.text.directory"),
+        number_style: cx.editor.theme.get("constant.numeric"),
+        colon_style: cx.editor.theme.get("punctuation"),
     };
 
     let columns = [
-        PickerColumn::new("path", |item: &FileResult, _| {
+        PickerColumn::new("path", |item: &FileResult, config: &GlobalSearchConfig| {
             let path = helix_stdx::path::get_relative_path(&item.path);
-            format!("{}:{}", path.to_string_lossy(), item.line_num + 1).into()
+
+            let mut components = path.components().map(|a| a.as_os_str().to_string_lossy());
+
+            let filename = components.next_back().unwrap_or_default();
+
+            let mut directories = String::new();
+
+            for segment in components {
+                directories.push_str(&segment);
+                directories.push(std::path::MAIN_SEPARATOR)
+            }
+
+            Cell::from(Spans::from(vec![
+                Span::styled(directories.to_string(), config.directory_style),
+                Span::raw(filename.to_string()),
+                Span::styled(":", config.colon_style),
+                Span::styled((item.line_num + 1).to_string(), config.number_style),
+            ]))
         }),
         PickerColumn::hidden("contents"),
     ];

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2417,7 +2417,7 @@ fn global_search(cx: &mut Context) {
         smart_case: config.search.smart_case,
         file_picker_config: config.file_picker.clone(),
         directory_style: cx.editor.theme.get("ui.text.directory"),
-        number_style: cx.editor.theme.get("constant.numeric"),
+        number_style: cx.editor.theme.get("constant.numeric.integer"),
         colon_style: cx.editor.theme.get("punctuation"),
     };
 
@@ -2431,10 +2431,11 @@ fn global_search(cx: &mut Context) {
                 .map(|p| format!("{}{}", p.display(), std::path::MAIN_SEPARATOR))
                 .unwrap_or_default();
 
-            let filename = path
+            let filename = item
+                .path
                 .file_name()
-                .map(|f| f.to_string_lossy().to_string())
-                .unwrap_or_default();
+                .expect("global search paths are normalized (can't end in `..`)")
+                .to_string_lossy();
 
             Cell::from(Spans::from(vec![
                 Span::styled(directories, config.directory_style),


### PR DESCRIPTION
This PR:
- Styles directory segments with `ui.text.directory` for consistency with the rest of the editor (as well as readability: it is easier now to tell the filename of each entry apart from its path)
- Applies `constant.numeric` to the line number and `:` to the colon. This also has the advantage that it's easier to tell apart a filename ending with a colon / number from the actual line number


![before-after-color-grep-picker](https://github.com/user-attachments/assets/9c0bfd49-e10d-491a-a5b4-47f207319ac2)

