### PR TITLE
feat: highlight rust repetition pattern

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -422,6 +422,7 @@
 )
 
 (token_repetition_pattern [")" "(" "$"] @punctuation.special)
+(token_repetition_pattern "?" @operator)
 
 ; ---
 ; Prelude

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -421,6 +421,8 @@
   (#eq? @special "derive")
 )
 
+(token_repetition_pattern [")" "(" "$"] @punctuation.special)
+
 ; ---
 ; Prelude
 ; ---


### PR DESCRIPTION
Uses `punctuation.special`. I think this scope is fitting here.

## before

![image](https://github.com/user-attachments/assets/e7a8692c-42dd-43f2-8a82-df2c529836f7)


## after

![image](https://github.com/user-attachments/assets/14c7725b-6149-49f5-afbe-2ab0941e8649)

note: Some usages of metavariables aren't highlighted. I thought it was an issue with precedence but that doesn't seem to be the caes. I assume this is a bug in the highlighter? (See `$key`)

![image](https://github.com/user-attachments/assets/1a7f8210-2995-47db-99e8-0319f5ea5368)
