### PR TITLE
ellipsis for inlay-hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "once_cell",
  "open",
  "pulldown-cmark",
+ "regex",
  "same-file",
  "serde",
  "serde_json",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -90,6 +90,7 @@ serde = { version = "1.0", features = ["derive"] }
 # ripgrep for global search
 grep-regex = "0.1.13"
 grep-searcher = "0.1.14"
+regex = "1.10.2"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1408,8 +1408,16 @@ fn compute_inlay_hints_for_view(
                 if let Some(true) = hint.padding_left {
                     padding_before_inlay_hints.push(InlineAnnotation::new(char_idx, " "));
                 }
+                let re = regex::Regex::new(r"<.+>").unwrap();
 
-                inlay_hints_vec.push(InlineAnnotation::new(char_idx, label));
+                inlay_hints_vec.push(InlineAnnotation::new(
+                    char_idx,
+                    if label.len() >= 20 {
+                        re.replace(&label, "<...>").into_owned()
+                    } else {
+                        label
+                    },
+                ));
 
                 if let Some(true) = hint.padding_right {
                     padding_after_inlay_hints.push(InlineAnnotation::new(char_idx, " "));


### PR DESCRIPTION
Auto inferred types can be long in some cases, especially type parameters with paradigms, which will make the inlay hint very distracting to code readers, this PR will collapse the display for inlay hints longer than 20 characters

before:
<img width="1081" alt="41C2B188-3E71-4B5D-A7A1-772D6966090E-8615-000002743F44169B" src="https://github.com/user-attachments/assets/5ce2ae87-b13c-4f17-8414-f195de08e950" />

after:
![IMG_3224](https://github.com/user-attachments/assets/501dbc8b-7803-493f-abb9-f73140dcd0d5)
