### PR TITLE
Fixed a Helix crash on launch when the install directory cannot be canonicalized (the ol' `.unwrap_or`)

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -69,7 +69,7 @@ fn prioritize_runtime_dirs() -> Vec<PathBuf> {
     // canonicalize the path in case the executable is symlinked
     let exe_rt_dir = std::env::current_exe()
         .ok()
-        .and_then(|path| std::fs::canonicalize(path).ok())
+        .and_then(|path| Some(std::fs::canonicalize(&path).unwrap_or(path)))
         .and_then(|path| path.parent().map(|path| path.to_path_buf().join(RT_DIR)))
         .unwrap();
     rt_dirs.push(exe_rt_dir);


### PR DESCRIPTION
I admittedly have a weird situation in that I installed Helix on a RAM disk (RAM being treated as a mounted filesystem)
Regardless, Helix crashes immediately on startup because of this canonicalization of the path which fails in my situation.

Let me know if I should write this differently, I've never contributed before so don't know what's up. There are several other file system related `.unwrap()`s in this same function which returns "A list of runtime directories from highest to lowest priority" that might also want to be examined or some error handling added (even just something like a `.expect()`).