### PR TITLE
Improve auto completion for shell commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6315,7 +6315,7 @@ fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBeha
         cx,
         prompt,
         Some('|'),
-        ui::completers::filename,
+        ui::completers::shell,
         move |cx, input: &str, event: PromptEvent| {
             if event != PromptEvent::Validate {
                 return;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -68,6 +68,13 @@ impl CommandCompleter {
             var_args: completer,
         }
     }
+
+    const fn hybrid(completers: &'static [Completer], fallback: Completer) -> Self {
+        Self {
+            positional_args: completers,
+            var_args: fallback,
+        }
+    }
 }
 
 fn quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -68,13 +68,6 @@ impl CommandCompleter {
             var_args: completer,
         }
     }
-
-    const fn hybrid(completers: &'static [Completer], fallback: Completer) -> Self {
-        Self {
-            positional_args: completers,
-            var_args: fallback,
-        }
-    }
 }
 
 fn quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
@@ -2565,6 +2558,9 @@ fn noop(_cx: &mut compositor::Context, _args: Args, _event: PromptEvent) -> anyh
     Ok(())
 }
 
+// TODO: SHELL_SIGNATURE should specify var args for arguments, so that just completers::filename can be used,
+// but Signature does not yet allow for var args.
+
 /// This command handles all of its input as-is with no quoting or flags.
 const SHELL_SIGNATURE: Signature = Signature {
     positionals: (1, Some(2)),
@@ -2573,10 +2569,10 @@ const SHELL_SIGNATURE: Signature = Signature {
 };
 
 const SHELL_COMPLETER: CommandCompleter = CommandCompleter::positional(&[
-    // Command name (TODO: consider a command completer - Kakoune has prior art)
-    completers::none,
+    // Command name
+    completers::program,
     // Shell argument(s)
-    completers::filename,
+    completers::repeating_filenames,
 ]);
 
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -682,9 +682,11 @@ pub mod completers {
     pub fn program(_editor: &Editor, input: &str) -> Vec<Completion> {
         static PROGRAMS_IN_PATH: Lazy<Vec<String>> = Lazy::new(|| {
             // Go through the entire PATH and read all files into a vec.
-            let mut vec = std::env::var("PATH")
-                .unwrap_or("".to_owned())
-                .split(":")
+            let Some(path) = std::env::var_os("PATH") else {
+                return Vec::new();
+            };
+
+            let mut vec = std::env::split_paths(&path)
                 .flat_map(|s| {
                     std::fs::read_dir(s)
                         .map_or_else(|_| vec![], |res| res.into_iter().collect::<Vec<_>>())

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -371,7 +371,7 @@ fn directory_content(path: &Path) -> Result<Vec<(PathBuf, bool)>, std::io::Error
 pub mod completers {
     use super::Utf8PathBuf;
     use crate::ui::prompt::Completion;
-    use helix_core::command_line::{self, Token, Tokenizer};
+    use helix_core::command_line::{self, Tokenizer};
     use helix_core::fuzzy::fuzzy_match;
     use helix_core::syntax::LanguageServerFeature;
     use helix_view::document::SCRATCH_BUFFER_NAME;
@@ -379,6 +379,7 @@ pub mod completers {
     use helix_view::{editor::Config, Editor};
     use once_cell::sync::Lazy;
     use std::borrow::Cow;
+    use std::collections::BTreeSet;
     use tui::text::Span;
 
     pub type Completer = fn(&Editor, &str) -> Vec<Completion>;
@@ -680,27 +681,24 @@ pub mod completers {
     }
 
     pub fn program(_editor: &Editor, input: &str) -> Vec<Completion> {
-        static PROGRAMS_IN_PATH: Lazy<Vec<String>> = Lazy::new(|| {
-            // Go through the entire PATH and read all files into a vec.
+        static PROGRAMS_IN_PATH: Lazy<BTreeSet<String>> = Lazy::new(|| {
+            // Go through the entire PATH and read all files into a set.
             let Some(path) = std::env::var_os("PATH") else {
-                return Vec::new();
+                return Default::default();
             };
 
-            let mut vec = std::env::split_paths(&path)
-                .flat_map(|s| {
-                    std::fs::read_dir(s)
-                        .map_or_else(|_| vec![], |res| res.into_iter().collect::<Vec<_>>())
+            std::env::split_paths(&path)
+                .filter_map(|path| std::fs::read_dir(path).ok())
+                .flatten()
+                .filter_map(|res| {
+                    let entry = res.ok()?;
+                    if entry.metadata().ok()?.is_file() {
+                        entry.file_name().into_string().ok()
+                    } else {
+                        None
+                    }
                 })
-                .filter_map(|it| it.ok())
-                .map(|f| f.path())
-                .filter(|p| !p.is_dir())
-                .filter_map(|p| p.file_name().and_then(|s| s.to_str().map(|s| s.to_owned())))
-                .collect::<Vec<_>>();
-
-            // Paths can share programs like /bin and /usr/bin sometimes contain the same.
-            vec.dedup();
-
-            vec
+                .collect()
         });
 
         fuzzy_match(input, PROGRAMS_IN_PATH.iter(), false)
@@ -709,22 +707,15 @@ pub mod completers {
             .collect()
     }
 
-    fn get_last_argument(input: &str) -> Option<Token> {
-        let tokenizer = Tokenizer::new(input, false);
-        let last = tokenizer.last()?;
-
-        Some(last.unwrap())
-    }
-
     /// This expects input to be a raw string of arguments, because this is what Signature's raw_after does.
     pub fn repeating_filenames(editor: &Editor, input: &str) -> Vec<Completion> {
-        let Some(token) = get_last_argument(input) else {
-            return Vec::new();
+        let token = match Tokenizer::new(input, false).last() {
+            Some(token) => token.unwrap(),
+            None => return filename(editor, input),
         };
 
         let offset = token.content_start;
 
-        // Theoretically one could now parse bash completion scripts, but filename should suffice for now.
         let mut completions = filename(editor, &input[offset..]);
         for completion in completions.iter_mut() {
             completion.0.start += offset;
@@ -733,20 +724,16 @@ pub mod completers {
     }
 
     pub fn shell(editor: &Editor, input: &str) -> Vec<Completion> {
-        let (_, _, complete_command) = command_line::split(input);
+        let (command, args, complete_command) = command_line::split(input);
 
         if complete_command {
-            return program(editor, input);
+            return program(editor, command);
         }
 
-        let Some(token) = get_last_argument(input) else {
-            return Vec::new();
-        };
-
-        let mut completions = repeating_filenames(editor, &token.content);
-
+        let mut completions = repeating_filenames(editor, args);
         for completion in completions.iter_mut() {
-            completion.0.start += token.content_start;
+            // + 1 for separator between `command` and `args`
+            completion.0.start += command.len() + 1;
         }
 
         completions


### PR DESCRIPTION
This makes the very first argument of shell commands (like run-shell-command or pipe) auto complete programs instead of files.

This works relatively well for the commands themselves, however for the shell prompts (so the action pipe or pipe-to) this is pretty hard to do, because there the completions functions get the full line as input. This makes it impossible to figure out what argument you are editing, since you are missing the cursor position. (For command mode, this is handled by the command mode prompt itself, so the input for completion functions is just the argument which the user is editing right now.

Thinking about it, the pipe action might be able to be replaced using a macro that effectively does "@:pipe ", since the shell actions duplicate the commands from command mode.

For now, I handle this by basically completing the first argument to be a program and the rest are just seen as one big file. The previous behavior was to just see the entire prompt as a single big file, so I think this is sane.


https://github.com/user-attachments/assets/0fa7e3bc-702d-43bd-a5a3-417675c78f00

