### PR TITLE
feat: add bidirectional motion repeat with selection support

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -51,7 +51,10 @@
 | `find_prev_char` | Move to previous occurrence of char | normal: `` F `` |
 | `extend_till_prev_char` | Extend till previous occurrence of char | select: `` T `` |
 | `extend_prev_char` | Extend to previous occurrence of char | select: `` F `` |
-| `repeat_last_motion` | Repeat last motion | normal: `` <A-.> ``, select: `` <A-.> `` |
+| `repeat_last_motion` | Repeat last motion | normal: `` <A-.> `` |
+| `repeat_last_motion_reverse` | Repeat last motion in reverse | normal: `` <S-A-.> `` |
+| `extend_repeat_last_motion` | Extend selection by repeating last motion | select: `` <A-.> `` |
+| `extend_repeat_last_motion_reverse` | Extend selection by repeating last motion in reverse | select: `` <S-A-.> `` |
 | `replace` | Replace with new char | normal: `` r ``, select: `` r `` |
 | `switch_case` | Switch (toggle) case | normal: `` ~ ``, select: `` ~ `` |
 | `switch_to_uppercase` | Switch to uppercase | normal: `` <A-`> ``, select: `` <A-`> `` |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -35,33 +35,34 @@ Normal mode is the default mode when you launch helix. You can return to it from
 
 > NOTE: Unlike Vim, `f`, `F`, `t` and `T` are not confined to the current line.
 
-| Key                   | Description                                        | Command                     |
-| -----                 | -----------                                        | -------                     |
-| `h`, `Left`           | Move left                                          | `move_char_left`            |
-| `j`, `Down`           | Move down                                          | `move_visual_line_down`     |
-| `k`, `Up`             | Move up                                            | `move_visual_line_up`       |
-| `l`, `Right`          | Move right                                         | `move_char_right`           |
-| `w`                   | Move next word start                               | `move_next_word_start`      |
-| `b`                   | Move previous word start                           | `move_prev_word_start`      |
-| `e`                   | Move next word end                                 | `move_next_word_end`        |
-| `W`                   | Move next WORD start                               | `move_next_long_word_start` |
-| `B`                   | Move previous WORD start                           | `move_prev_long_word_start` |
-| `E`                   | Move next WORD end                                 | `move_next_long_word_end`   |
-| `t`                   | Find 'till next char                               | `find_till_char`            |
-| `f`                   | Find next char                                     | `find_next_char`            |
-| `T`                   | Find 'till previous char                           | `till_prev_char`            |
-| `F`                   | Find previous char                                 | `find_prev_char`            |
-| `G`                   | Go to line number `<n>`                            | `goto_line`                 |
-| `Alt-.`               | Repeat last motion (`f`, `t`, `m`, `[` or `]`)     | `repeat_last_motion`        |
-| `Home`                | Move to the start of the line                      | `goto_line_start`           |
-| `End`                 | Move to the end of the line                        | `goto_line_end`             |
-| `Ctrl-b`, `PageUp`    | Move page up                                       | `page_up`                   |
-| `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                 |
-| `Ctrl-u`              | Move cursor and page half page up                  | `page_cursor_half_up`       |
-| `Ctrl-d`              | Move cursor and page half page down                | `page_cursor_half_down`     |
-| `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`              |
-| `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`             |
-| `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`            |
+| Key                   | Description                                        | Command                      |
+| -----                 | -----------                                        | -------                      |
+| `h`, `Left`           | Move left                                          | `move_char_left`             |
+| `j`, `Down`           | Move down                                          | `move_visual_line_down`      |
+| `k`, `Up`             | Move up                                            | `move_visual_line_up`        |
+| `l`, `Right`          | Move right                                         | `move_char_right`            |
+| `w`                   | Move next word start                               | `move_next_word_start`       |
+| `b`                   | Move previous word start                           | `move_prev_word_start`       |
+| `e`                   | Move next word end                                 | `move_next_word_end`         |
+| `W`                   | Move next WORD start                               | `move_next_long_word_start`  |
+| `B`                   | Move previous WORD start                           | `move_prev_long_word_start`  |
+| `E`                   | Move next WORD end                                 | `move_next_long_word_end`    |
+| `t`                   | Find 'till next char                               | `find_till_char`             |
+| `f`                   | Find next char                                     | `find_next_char`             |
+| `T`                   | Find 'till previous char                           | `till_prev_char`             |
+| `F`                   | Find previous char                                 | `find_prev_char`             |
+| `G`                   | Go to line number `<n>`                            | `goto_line`                  |
+| `Alt-.`               | Repeat last motion (`f`, `t`, `m`, `[` or `]`)     | `repeat_last_motion`         |
+| `Alt-S-.`             | Reverse repeat last motion                         | `repeat_last_motion_reverse` |
+| `Home`                | Move to the start of the line                      | `goto_line_start`            |
+| `End`                 | Move to the end of the line                        | `goto_line_end`              |
+| `Ctrl-b`, `PageUp`    | Move page up                                       | `page_up`                    |
+| `Ctrl-f`, `PageDown`  | Move page down                                     | `page_down`                  |
+| `Ctrl-u`              | Move cursor and page half page up                  | `page_cursor_half_up`        |
+| `Ctrl-d`              | Move cursor and page half page down                | `page_cursor_half_down`      |
+| `Ctrl-i`              | Jump forward on the jumplist                       | `jump_forward`               |
+| `Ctrl-o`              | Jump backward on the jumplist                      | `jump_backward`              |
+| `Ctrl-s`              | Save the current selection to the jumplist         | `save_selection`             |
 
 ### Changes
 

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -25,6 +25,15 @@ pub enum Direction {
     Backward,
 }
 
+impl Direction {
+    pub fn reverse(self) -> Self {
+        match self {
+            Direction::Forward => Direction::Backward,
+            Direction::Backward => Direction::Forward,
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Movement {
     Extend,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5298,12 +5298,19 @@ fn shrink_selection(cx: &mut Context) {
     cx.editor.apply_motion(motion);
 }
 
-fn select_sibling_impl<F>(cx: &mut Context, sibling_fn: F)
-where
-    F: Fn(&helix_core::Syntax, RopeSlice, Selection) -> Selection + 'static,
-{
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
+fn select_sibling_impl(cx: &mut Context, direction: Direction) {
+    let motion = move |editor: &mut Editor, mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
+
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
+
+        let sibling_fn = match direction {
+            Direction::Forward => object::select_next_sibling,
+            Direction::Backward => object::select_prev_sibling,
+        };
 
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
@@ -5316,26 +5323,31 @@ where
 }
 
 fn select_next_sibling(cx: &mut Context) {
-    select_sibling_impl(cx, object::select_next_sibling)
+    select_sibling_impl(cx, Direction::Forward)
 }
 
 fn select_prev_sibling(cx: &mut Context) {
-    select_sibling_impl(cx, object::select_prev_sibling)
+    select_sibling_impl(cx, Direction::Backward)
 }
 
-fn move_node_bound_impl(cx: &mut Context, dir: Direction, movement: Movement) {
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
+fn move_node_bound_impl(cx: &mut Context, direction: Direction, movement: Movement) {
+    let motion = move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
             let current_selection = doc.selection(view.id);
 
+            let movement = move_override.unwrap_or(movement);
             let selection = movement::move_parent_node_end(
                 syntax,
                 text,
                 current_selection.clone(),
-                dir,
+                direction,
                 movement,
             );
 
@@ -5683,8 +5695,14 @@ fn scroll_down(cx: &mut Context) {
 
 fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direction) {
     let count = cx.count();
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
+    let motion = move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
+
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
+
         if let Some((lang_config, syntax)) = doc.language_config().zip(doc.syntax()) {
             let text = doc.text().slice(..);
             let root = syntax.tree().root_node();
@@ -5700,16 +5718,22 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
                     count,
                 );
 
-                if editor.mode == Mode::Select {
-                    let head = if new_range.head < range.anchor {
-                        new_range.anchor
-                    } else {
-                        new_range.head
-                    };
-
-                    Range::new(range.anchor, head)
+                let movement = move_override.unwrap_or(if editor.mode == Mode::Select {
+                    Movement::Extend
                 } else {
-                    new_range.with_direction(direction)
+                    Movement::Move
+                });
+                match movement {
+                    Movement::Extend => {
+                        let head = if new_range.head < range.anchor {
+                            new_range.anchor
+                        } else {
+                            new_range.head
+                        };
+
+                        Range::new(range.anchor, head)
+                    }
+                    Movement::Move => new_range.with_direction(direction),
                 }
             });
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -29,7 +29,7 @@ use helix_core::{
     movement::{self, move_vertically_visual, Direction},
     object, pos_at_coords,
     regex::{self, Regex},
-    search::{self, CharMatcher},
+    search::{self},
     selection, shellwords, surround,
     syntax::{BlockCommentToken, LanguageServerFeature},
     text_annotations::{Overlay, TextAnnotations},
@@ -40,7 +40,7 @@ use helix_core::{
 };
 use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
-    editor::Action,
+    editor::{Action, MotionMode},
     info::Info,
     input::KeyEvent,
     keyboard::KeyCode,
@@ -345,6 +345,9 @@ impl MappableCommand {
         extend_till_prev_char, "Extend till previous occurrence of char",
         extend_prev_char, "Extend to previous occurrence of char",
         repeat_last_motion, "Repeat last motion",
+        repeat_last_motion_reverse, "Repeat last motion in reverse",
+        extend_repeat_last_motion, "Extend selection by repeating last motion",
+        extend_repeat_last_motion_reverse, "Extend selection by repeating last motion in reverse",
         replace, "Replace with new char",
         switch_case, "Switch (toggle) case",
         switch_to_uppercase, "Switch to uppercase",
@@ -1221,35 +1224,42 @@ fn move_next_sub_word_end(cx: &mut Context) {
     move_word_impl(cx, movement::move_next_sub_word_end)
 }
 
-fn goto_para_impl<F>(cx: &mut Context, move_fn: F)
-where
-    F: Fn(RopeSlice, Range, usize, Movement) -> Range + 'static,
-{
+fn goto_para_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count();
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
         let text = doc.text().slice(..);
-        let behavior = if editor.mode == Mode::Select {
+
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
+        let move_fn = match direction {
+            Direction::Forward => movement::move_next_paragraph,
+            Direction::Backward => movement::move_prev_paragraph,
+        };
+
+        let movement = move_override.unwrap_or(if editor.mode == Mode::Select {
             Movement::Extend
         } else {
             Movement::Move
-        };
+        });
 
         let selection = doc
             .selection(view.id)
             .clone()
-            .transform(|range| move_fn(text, range, count, behavior));
+            .transform(|range| move_fn(text, range, count, movement));
         doc.set_selection(view.id, selection);
     };
     cx.editor.apply_motion(motion)
 }
 
 fn goto_prev_paragraph(cx: &mut Context) {
-    goto_para_impl(cx, movement::move_prev_paragraph)
+    goto_para_impl(cx, Direction::Backward)
 }
 
 fn goto_next_paragraph(cx: &mut Context) {
-    goto_para_impl(cx, movement::move_next_paragraph)
+    goto_para_impl(cx, Direction::Forward)
 }
 
 fn goto_file_start(cx: &mut Context) {
@@ -1461,56 +1471,67 @@ fn find_char_line_ending(
     count: usize,
     direction: Direction,
     inclusive: bool,
-    extend: bool,
+    movement: Movement,
 ) {
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
+    let motion = move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
+        let (view, doc) = current!(editor);
+        let text = doc.text().slice(..);
 
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        let cursor = range.cursor(text);
-        let cursor_line = range.cursor_line(text);
-
-        // Finding the line where we're going to find <ret>. Depends mostly on
-        // `count`, but also takes into account edge cases where we're already at the end
-        // of a line or the beginning of a line
-        let find_on_line = match direction {
-            Direction::Forward => {
-                let on_edge = line_end_char_index(&text, cursor_line) == cursor;
-                let line = cursor_line + count - 1 + (on_edge as usize);
-                if line >= text.len_lines() - 1 {
-                    return range;
-                } else {
-                    line
-                }
-            }
-            Direction::Backward => {
-                let on_edge = text.line_to_char(cursor_line) == cursor && !inclusive;
-                let line = cursor_line as isize - (count as isize - 1 + on_edge as isize);
-                if line <= 0 {
-                    return range;
-                } else {
-                    line as usize
-                }
-            }
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
         };
 
-        let pos = match (direction, inclusive) {
-            (Direction::Forward, true) => line_end_char_index(&text, find_on_line),
-            (Direction::Forward, false) => line_end_char_index(&text, find_on_line) - 1,
-            (Direction::Backward, true) => line_end_char_index(&text, find_on_line - 1),
-            (Direction::Backward, false) => text.line_to_char(find_on_line),
-        };
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            let cursor = range.cursor(text);
+            let cursor_line = range.cursor_line(text);
 
-        if extend {
-            range.put_cursor(text, pos, true)
-        } else {
-            Range::point(range.cursor(text)).put_cursor(text, pos, true)
-        }
-    });
-    doc.set_selection(view.id, selection);
+            // Finding the line where we're going to find <ret>. Depends mostly on
+            // `count`, but also takes into account edge cases where we're already at the end
+            // of a line or the beginning of a line
+            let find_on_line = match direction {
+                Direction::Forward => {
+                    let on_edge = if inclusive {
+                        line_end_char_index(&text, cursor_line) == cursor
+                    } else {
+                        line_end_char_index(&text, cursor_line) - 1 == cursor
+                    };
+                    let line = cursor_line + count - 1 + (on_edge as usize);
+                    if line >= text.len_lines() - 1 {
+                        return range;
+                    } else {
+                        line
+                    }
+                }
+                Direction::Backward => {
+                    let on_edge = text.line_to_char(cursor_line) == cursor && !inclusive;
+                    let line = cursor_line as isize - (count as isize - 1 + on_edge as isize);
+                    if line <= 0 {
+                        return range;
+                    } else {
+                        line as usize
+                    }
+                }
+            };
+
+            let pos = match (direction, inclusive) {
+                (Direction::Forward, true) => line_end_char_index(&text, find_on_line),
+                (Direction::Forward, false) => line_end_char_index(&text, find_on_line) - 1,
+                (Direction::Backward, true) => line_end_char_index(&text, find_on_line - 1),
+                (Direction::Backward, false) => text.line_to_char(find_on_line),
+            };
+
+            match move_override.unwrap_or(movement) {
+                Movement::Extend => range.put_cursor(text, pos, true),
+                Movement::Move => Range::point(range.cursor(text)).put_cursor(text, pos, true),
+            }
+        });
+        doc.set_selection(view.id, selection);
+    };
+    cx.editor.apply_motion(motion);
 }
 
-fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, extend: bool) {
+fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, movement: Movement) {
     // TODO: count is reset to 1 before next key so we move it into the closure here.
     // Would be nice to carry over.
     let count = cx.count();
@@ -1524,7 +1545,7 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, extend: bo
                 code: KeyCode::Enter,
                 ..
             } => {
-                find_char_line_ending(cx, count, direction, inclusive, extend);
+                find_char_line_ending(cx, count, direction, inclusive, movement);
                 return;
             }
 
@@ -1538,56 +1559,45 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool, extend: bo
             } => ch,
             _ => return,
         };
-        let motion = move |editor: &mut Editor| {
-            match direction {
-                Direction::Forward => {
-                    find_char_impl(editor, &find_next_char_impl, inclusive, extend, ch, count)
-                }
-                Direction::Backward => {
-                    find_char_impl(editor, &find_prev_char_impl, inclusive, extend, ch, count)
-                }
+        let motion =
+            move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
+                let (view, doc) = current!(editor);
+                let text = doc.text().slice(..);
+
+                let direction = match mode {
+                    MotionMode::Normal => direction,
+                    MotionMode::Reverse => direction.reverse(),
+                };
+
+                let selection = doc.selection(view.id).clone().transform(|range| {
+                    // TODO: use `Range::cursor()` here instead.  However, that works in terms of
+                    // graphemes, whereas this function doesn't yet.  So we're doing the same logic
+                    // here, but just in terms of chars instead.
+                    let search_start_pos = if range.anchor < range.head {
+                        range.head - 1
+                    } else {
+                        range.head
+                    };
+
+                    let search_fn = match direction {
+                        Direction::Forward => find_next_char_impl,
+                        Direction::Backward => find_prev_char_impl,
+                    };
+
+                    search_fn(text, ch, search_start_pos, count, inclusive).map_or(range, |pos| {
+                        match move_override.unwrap_or(movement) {
+                            Movement::Extend => range.put_cursor(text, pos, true),
+                            Movement::Move => {
+                                Range::point(range.cursor(text)).put_cursor(text, pos, true)
+                            }
+                        }
+                    })
+                });
+                doc.set_selection(view.id, selection);
             };
-        };
 
         cx.editor.apply_motion(motion);
     })
-}
-
-//
-
-#[inline]
-fn find_char_impl<F, M: CharMatcher + Clone + Copy>(
-    editor: &mut Editor,
-    search_fn: &F,
-    inclusive: bool,
-    extend: bool,
-    char_matcher: M,
-    count: usize,
-) where
-    F: Fn(RopeSlice, M, usize, usize, bool) -> Option<usize> + 'static,
-{
-    let (view, doc) = current!(editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        // TODO: use `Range::cursor()` here instead.  However, that works in terms of
-        // graphemes, whereas this function doesn't yet.  So we're doing the same logic
-        // here, but just in terms of chars instead.
-        let search_start_pos = if range.anchor < range.head {
-            range.head - 1
-        } else {
-            range.head
-        };
-
-        search_fn(text, char_matcher, search_start_pos, count, inclusive).map_or(range, |pos| {
-            if extend {
-                range.put_cursor(text, pos, true)
-            } else {
-                Range::point(range.cursor(text)).put_cursor(text, pos, true)
-            }
-        })
-    });
-    doc.set_selection(view.id, selection);
 }
 
 fn find_next_char_impl(
@@ -1628,39 +1638,51 @@ fn find_prev_char_impl(
 }
 
 fn find_till_char(cx: &mut Context) {
-    find_char(cx, Direction::Forward, false, false);
+    find_char(cx, Direction::Forward, false, Movement::Move);
 }
 
 fn find_next_char(cx: &mut Context) {
-    find_char(cx, Direction::Forward, true, false)
+    find_char(cx, Direction::Forward, true, Movement::Move)
 }
 
 fn extend_till_char(cx: &mut Context) {
-    find_char(cx, Direction::Forward, false, true)
+    find_char(cx, Direction::Forward, false, Movement::Extend)
 }
 
 fn extend_next_char(cx: &mut Context) {
-    find_char(cx, Direction::Forward, true, true)
+    find_char(cx, Direction::Forward, true, Movement::Extend)
 }
 
 fn till_prev_char(cx: &mut Context) {
-    find_char(cx, Direction::Backward, false, false)
+    find_char(cx, Direction::Backward, false, Movement::Move)
 }
 
 fn find_prev_char(cx: &mut Context) {
-    find_char(cx, Direction::Backward, true, false)
+    find_char(cx, Direction::Backward, true, Movement::Move)
 }
 
 fn extend_till_prev_char(cx: &mut Context) {
-    find_char(cx, Direction::Backward, false, true)
+    find_char(cx, Direction::Backward, false, Movement::Extend)
 }
 
 fn extend_prev_char(cx: &mut Context) {
-    find_char(cx, Direction::Backward, true, true)
+    find_char(cx, Direction::Backward, true, Movement::Extend)
 }
 
 fn repeat_last_motion(cx: &mut Context) {
     cx.editor.repeat_last_motion(cx.count())
+}
+
+fn repeat_last_motion_reverse(cx: &mut Context) {
+    cx.editor.repeat_last_motion_reverse(cx.count())
+}
+
+fn extend_repeat_last_motion(cx: &mut Context) {
+    cx.editor.extend_repeat_last_motion(cx.count())
+}
+
+fn extend_repeat_last_motion_reverse(cx: &mut Context) {
+    cx.editor.extend_repeat_last_motion_reverse(cx.count())
 }
 
 fn replace(cx: &mut Context) {
@@ -3825,7 +3847,7 @@ fn goto_last_diag(cx: &mut Context) {
 }
 
 fn goto_next_diag(cx: &mut Context) {
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
         let cursor_pos = doc
@@ -3851,7 +3873,7 @@ fn goto_next_diag(cx: &mut Context) {
 }
 
 fn goto_prev_diag(cx: &mut Context) {
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
         let cursor_pos = doc
@@ -3916,7 +3938,7 @@ fn goto_prev_change(cx: &mut Context) {
 
 fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count() as u32 - 1;
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
         let doc_text = doc.text().slice(..);
         let diff_handle = if let Some(diff_handle) = doc.diff_handle() {
@@ -5226,7 +5248,7 @@ fn reverse_selection_contents(cx: &mut Context) {
 // tree sitter node selection
 
 fn expand_selection(cx: &mut Context) {
-    let motion = |editor: &mut Editor| {
+    let motion = |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
         if let Some(syntax) = doc.syntax() {
@@ -5248,7 +5270,7 @@ fn expand_selection(cx: &mut Context) {
 }
 
 fn shrink_selection(cx: &mut Context) {
-    let motion = |editor: &mut Editor| {
+    let motion = |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
         let current_selection = doc.selection(view.id);
         // try to restore previous selection
@@ -5275,7 +5297,7 @@ fn select_sibling_impl<F>(cx: &mut Context, sibling_fn: F)
 where
     F: Fn(&helix_core::Syntax, RopeSlice, Selection) -> Selection + 'static,
 {
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
         if let Some(syntax) = doc.syntax() {
@@ -5297,7 +5319,7 @@ fn select_prev_sibling(cx: &mut Context) {
 }
 
 fn move_node_bound_impl(cx: &mut Context, dir: Direction, movement: Movement) {
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
 
         if let Some(syntax) = doc.syntax() {
@@ -5350,7 +5372,7 @@ where
 }
 
 fn select_all_siblings(cx: &mut Context) {
-    let motion = |editor: &mut Editor| {
+    let motion = |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         select_all_impl(editor, object::select_all_siblings);
     };
 
@@ -5358,7 +5380,7 @@ fn select_all_siblings(cx: &mut Context) {
 }
 
 fn select_all_children(cx: &mut Context) {
-    let motion = |editor: &mut Editor| {
+    let motion = |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         select_all_impl(editor, object::select_all_children);
     };
 
@@ -5656,7 +5678,7 @@ fn scroll_down(cx: &mut Context) {
 
 fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direction) {
     let count = cx.count();
-    let motion = move |editor: &mut Editor| {
+    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
         if let Some((lang_config, syntax)) = doc.language_config().zip(doc.syntax()) {
             let text = doc.text().slice(..);
@@ -5756,7 +5778,9 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     cx.on_next_key(move |cx, event| {
         cx.editor.autoinfo = None;
         if let Some(ch) = event.char() {
-            let textobject = move |editor: &mut Editor| {
+            let textobject = move |editor: &mut Editor,
+                                   _mode: MotionMode,
+                                   _move_override: Option<Movement>| {
                 let (view, doc) = current!(editor);
                 let text = doc.text().slice(..);
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3930,8 +3930,14 @@ fn goto_prev_change(cx: &mut Context) {
 
 fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count() as u32 - 1;
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
+    let motion = move |editor: &mut Editor, mode: MotionMode, move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
+
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
+
         let doc_text = doc.text().slice(..);
         let diff_handle = if let Some(diff_handle) = doc.diff_handle() {
             diff_handle
@@ -3957,16 +3963,23 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
             };
             let hunk = diff.nth_hunk(hunk_idx);
             let new_range = hunk_range(hunk, doc_text);
-            if editor.mode == Mode::Select {
-                let head = if new_range.head < range.anchor {
-                    new_range.anchor
-                } else {
-                    new_range.head
-                };
 
-                Range::new(range.anchor, head)
+            let movement = move_override.unwrap_or(if editor.mode == Mode::Select {
+                Movement::Extend
             } else {
-                new_range.with_direction(direction)
+                Movement::Move
+            });
+            match movement {
+                Movement::Extend => {
+                    let head = if new_range.head < range.anchor {
+                        new_range.anchor
+                    } else {
+                        new_range.head
+                    };
+
+                    Range::new(range.anchor, head)
+                }
+                Movement::Move => new_range.with_direction(direction),
             }
         });
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3847,52 +3847,44 @@ fn goto_last_diag(cx: &mut Context) {
 }
 
 fn goto_next_diag(cx: &mut Context) {
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
-        let (view, doc) = current!(editor);
-
-        let cursor_pos = doc
-            .selection(view.id)
-            .primary()
-            .cursor(doc.text().slice(..));
-
-        let diag = doc
-            .diagnostics()
-            .iter()
-            .find(|diag| diag.range.start > cursor_pos);
-
-        let selection = match diag {
-            Some(diag) => Selection::single(diag.range.start, diag.range.end),
-            None => return,
-        };
-        doc.set_selection(view.id, selection);
-        view.diagnostics_handler
-            .immediately_show_diagnostic(doc, view.id);
-    };
-
-    cx.editor.apply_motion(motion);
+    goto_diag_impl(cx, Direction::Forward)
 }
 
 fn goto_prev_diag(cx: &mut Context) {
-    let motion = move |editor: &mut Editor, _mode: MotionMode, _move_override: Option<Movement>| {
+    goto_diag_impl(cx, Direction::Backward)
+}
+
+fn goto_diag_impl(cx: &mut Context, direction: Direction) {
+    let motion = move |editor: &mut Editor, mode: MotionMode, _move_override: Option<Movement>| {
         let (view, doc) = current!(editor);
+
+        let direction = match mode {
+            MotionMode::Normal => direction,
+            MotionMode::Reverse => direction.reverse(),
+        };
 
         let cursor_pos = doc
             .selection(view.id)
             .primary()
             .cursor(doc.text().slice(..));
 
-        let diag = doc
-            .diagnostics()
-            .iter()
-            .rev()
-            .find(|diag| diag.range.start < cursor_pos);
+        let diagnostics = doc.diagnostics();
+        let diag = match direction {
+            Direction::Forward => diagnostics.iter().find(|d| d.range.start > cursor_pos),
+            Direction::Backward => diagnostics
+                .iter()
+                .rev()
+                .find(|d| d.range.start < cursor_pos),
+        };
 
         let selection = match diag {
-            // NOTE: the selection is reversed because we're jumping to the
-            // previous diagnostic.
-            Some(diag) => Selection::single(diag.range.end, diag.range.start),
+            Some(diag) => match direction {
+                Direction::Forward => Selection::single(diag.range.start, diag.range.end),
+                Direction::Backward => Selection::single(diag.range.end, diag.range.start),
+            },
             None => return,
         };
+
         doc.set_selection(view.id, selection);
         view.diagnostics_handler
             .immediately_show_diagnostic(doc, view.id);

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -18,6 +18,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "r" => replace,
         "R" => replace_with_yanked,
         "A-." =>  repeat_last_motion,
+        "A-S-." =>  repeat_last_motion_reverse,
 
         "~" => switch_case,
         "`" => switch_to_lowercase,
@@ -360,6 +361,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "f" => extend_next_char,
         "T" => extend_till_prev_char,
         "F" => extend_prev_char,
+        "A-." =>  extend_repeat_last_motion,
+        "A-S-." =>  extend_repeat_last_motion_reverse,
 
         "home" => extend_to_line_start,
         "end" => extend_to_line_end,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -45,6 +45,7 @@ use anyhow::{anyhow, bail, Error};
 pub use helix_core::diagnostic::Severity;
 use helix_core::{
     auto_pairs::AutoPairs,
+    movement::Movement,
     syntax::{self, AutoPairConfig, IndentationHeuristic, LanguageServerFeature, SoftWrap},
     Change, LineEnding, Position, Range, Selection, Uri, NATIVE_LINE_ENDING,
 };
@@ -1103,7 +1104,13 @@ pub struct Editor {
     pub cursor_cache: CursorCache,
 }
 
-pub type Motion = Box<dyn Fn(&mut Editor)>;
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum MotionMode {
+    Normal,
+    Reverse,
+}
+
+pub type Motion = Box<dyn Fn(&mut Editor, MotionMode, Option<Movement>)>;
 
 #[derive(Debug)]
 pub enum EditorEvent {
@@ -1236,19 +1243,44 @@ impl Editor {
             || self.config().popup_border == PopupBorderConfig::Menu
     }
 
-    pub fn apply_motion<F: Fn(&mut Self) + 'static>(&mut self, motion: F) {
-        motion(self);
+    pub fn apply_motion<F>(&mut self, motion: F)
+    where
+        F: Fn(&mut Self, MotionMode, Option<Movement>) + 'static,
+    {
+        motion(self, MotionMode::Normal, None);
         self.last_motion = Some(Box::new(motion));
     }
 
     pub fn repeat_last_motion(&mut self, count: usize) {
+        self.repeat_last_motion_impl(count, MotionMode::Normal, Some(Movement::Move));
+    }
+
+    pub fn repeat_last_motion_reverse(&mut self, count: usize) {
+        self.repeat_last_motion_impl(count, MotionMode::Reverse, Some(Movement::Move));
+    }
+
+    pub fn extend_repeat_last_motion(&mut self, count: usize) {
+        self.repeat_last_motion_impl(count, MotionMode::Normal, Some(Movement::Extend));
+    }
+
+    pub fn extend_repeat_last_motion_reverse(&mut self, count: usize) {
+        self.repeat_last_motion_impl(count, MotionMode::Reverse, Some(Movement::Extend));
+    }
+
+    fn repeat_last_motion_impl(
+        &mut self,
+        count: usize,
+        mode: MotionMode,
+        movement_override: Option<Movement>,
+    ) {
         if let Some(motion) = self.last_motion.take() {
             for _ in 0..count {
-                motion(self);
+                motion(self, mode, movement_override);
             }
             self.last_motion = Some(motion);
         }
     }
+
     /// Current editing mode for the [`Editor`].
     pub fn mode(&self) -> Mode {
         self.mode

--- a/runtime/tutor
+++ b/runtime/tutor
@@ -707,7 +707,8 @@
 =================================================================
 
  Type . to repeat the last insert command.
- Press Alt-. to repeat the last f / t selection.
+ Press Alt-. to repeat the last motion (e.g. f / t selection)
+ and Alt-S-. to reverse repeat the last motion.
 
  1. Move the cursor to the line marked '-->' below.
  2. Make a change, insertion or appendage and repeat it with . .


### PR DESCRIPTION
Closes #12877
Fixes #8761

Related discussion: https://github.com/helix-editor/helix/discussions/8495

This continues @Aqaao's initial work [here](https://github.com/helix-editor/helix/issues/12092#issuecomment-2660711956).
Taking into consideration @the-mikedavis's [comment here](https://github.com/helix-editor/helix/issues/8761#issuecomment-1803145453).

- Add reverse motion repeat (Alt-Shift-.) to complement existing repeat (Alt-.)

  I'm completely open to suggestions for an alternative key binding. I
  personally use a heavily modified keymap to support Colemak-DHm. I'm planning
  to bind this to `'` / `"` (select register `&`) in my config.

- New commands:
  - `repeat_last_motion_reverse`
  - `extend_repeat_last_motion`
  - `extend_repeat_last_motion_reverse`

- Add extend variants for both forward/reverse motion repeat

  Why add extend variants of `repeat_last_motion`? This is motivated by
  @pascalkuthe's
  [comment](https://github.com/helix-editor/helix/issues/8761#issuecomment-1802795771):

  >This is the only consistent behaviour because select mode is not supposed to
  >be special. Instead it should just be a keymap like window mode/space
  >mode/goto mode,... You can already bind extend_next_char in normal mode and
  >it would be strange if that would extend the selection (similarly it would be
  >strange if you biud find_next_char in visual mode and itwould be similarly
  >strange if reperating that would extend the selection.

  The extend variants override the last `movement` (i.e Move / Extend) to always extend.

- Update documentation and tutor

- Note this also fixes some issue I run into when using find / till on `<ret>`
  Basically, it works as expected now. I haven't searched through existing
  issues to see if any can be closed yet.

## Possible improvements

I haven't looked into adding tests.

## Short demos

find / till `.` either starting in normal or select mode and switching:

https://github.com/user-attachments/assets/6f8f209f-5eb4-4ce8-8598-1e89ec2a2c4f

repeat motion and reverse repeat on next paragraph:

https://github.com/user-attachments/assets/7bc19f4d-034b-4f07-9374-ab9130f17be9

repeat motion and reverse on next function:

https://github.com/user-attachments/assets/d653206d-03ef-4930-a10b-089f0b9233a1

