### PR TITLE
fix: escape percent character when yanking to search register

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2326,25 +2326,7 @@ fn search_selection_impl(cx: &mut Context, detect_word_boundaries: bool) {
             let prefix = if add_boundary_prefix { "\\b" } else { "" };
             let suffix = if add_boundary_suffix { "\\b" } else { "" };
 
-            let fragment = &selection.fragment(text);
-            let escape_percent = fragment.contains('%');
-
-            let word = regex::escape(fragment);
-
-            let word = if escape_percent {
-                word.chars().fold(String::new(), |mut acc, c| {
-                    if c == '%' {
-                        acc.push('\\');
-                    }
-
-                    acc.push(c);
-
-                    acc
-                })
-            } else {
-                word
-            };
-
+            let word = regex::escape(&selection.fragment(text));
             format!("{}{}{}", prefix, word, suffix)
         })
         .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2326,7 +2326,25 @@ fn search_selection_impl(cx: &mut Context, detect_word_boundaries: bool) {
             let prefix = if add_boundary_prefix { "\\b" } else { "" };
             let suffix = if add_boundary_suffix { "\\b" } else { "" };
 
-            let word = regex::escape(&selection.fragment(text));
+            let fragment = &selection.fragment(text);
+            let escape_percent = fragment.contains('%');
+
+            let word = regex::escape(fragment);
+
+            let word = if escape_percent {
+                word.chars().fold(String::new(), |mut acc, c| {
+                    if c == '%' {
+                        acc.push('\\');
+                    }
+
+                    acc.push(c);
+
+                    acc
+                })
+            } else {
+                word
+            };
+
             format!("{}{}{}", prefix, word, suffix)
         })
         .collect::<HashSet<_>>() // Collect into hashset to deduplicate identical regexes

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1079,9 +1079,14 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     .first_history_completion(ctx.editor)
                     .filter(|_| self.prompt.line().is_empty())
                 {
-                    // The history register is used in global search, we need to escape the '%' character
-                    self.prompt
-                        .set_line(escape_percent(completion.into_owned()), ctx.editor);
+                    // The percent character is used by the query language and needs to be
+                    // escaped with a backslash.
+                    let completion = if completion.contains('%') {
+                        completion.replace('%', "\\%")
+                    } else {
+                        completion.into_owned()
+                    };
+                    self.prompt.set_line(completion, ctx.editor);
 
                     // Inserting from the history register is a paste.
                     self.handle_prompt_change(true);
@@ -1160,19 +1165,3 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
 }
 
 type PickerCallback<T> = Box<dyn Fn(&mut Context, &T, Action)>;
-
-fn escape_percent(query: String) -> String {
-    if query.contains('%') {
-        query.chars().fold(String::new(), |mut acc, c| {
-            if c == '%' {
-                acc.push('\\');
-            }
-
-            acc.push(c);
-
-            acc
-        })
-    } else {
-        query
-    }
-}


### PR DESCRIPTION
When yanking to the search register with `*`, percent signs are used verbatim, which messes with the picker column filter.