### PR TITLE
feat: add register for absolute path of the current file

### DIFF
--- a/book/src/registers.md
+++ b/book/src/registers.md
@@ -43,7 +43,8 @@ Some registers have special behavior when read from and written to.
 | `_`                | No values are returned | All values are discarded |
 | `#`                | Selection indices (first selection is `1`, second is `2`, etc.) | This register is not writable |
 | `.`                | Contents of the current selections | This register is not writable |
-| `%`                | Name of the current file | This register is not writable |
+| `%`                | Name of the current file, relative to Helix's current working directory | This register is not writable |
+| `=`                | Absolute path to the current file | This register is not writable |
 | `+`                | Reads from the system clipboard | Joins and yanks to the system clipboard |
 | `*`                | Reads from the primary clipboard | Joins and yanks to the primary clipboard |
 


### PR DESCRIPTION
Adds new register `=` that gives the absolute path to the current file

Closes https://github.com/helix-editor/helix/issues/12881