### PR TITLE
feat: 2-character "find next / prev pair" commands similar to `f` and `F`

### DIFF
--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -44,6 +44,35 @@ pub fn find_nth_next<M: CharMatcher>(
     Some(pos - 1)
 }
 
+pub fn find_nth_next_pair<M: CharMatcher>(
+    text: RopeSlice,
+    char_matcher: M,
+    char_matcher_2: M,
+    mut pos: usize,
+    n: usize,
+) -> Option<usize> {
+    if pos >= text.len_chars() || n == 0 {
+        return None;
+    }
+
+    let mut chars = text.chars_at(pos).peekable();
+
+    for _ in 0..n {
+        loop {
+            let c = chars.next()?;
+            let c2 = chars.peek()?;
+
+            pos += 1;
+
+            if char_matcher.char_match(c) && char_matcher_2.char_match(*c2) {
+                break;
+            }
+        }
+    }
+
+    Some(pos - 1)
+}
+
 pub fn find_nth_prev(text: RopeSlice, ch: char, mut pos: usize, n: usize) -> Option<usize> {
     if pos == 0 || n == 0 {
         return None;
@@ -65,3 +94,34 @@ pub fn find_nth_prev(text: RopeSlice, ch: char, mut pos: usize, n: usize) -> Opt
 
     Some(pos)
 }
+
+
+pub fn find_nth_prev_pair<M: CharMatcher>(
+    text: RopeSlice,
+    char_matcher: M,
+    char_matcher_2: M,
+    mut pos: usize,
+    n: usize,
+) -> Option<usize> {
+    if pos >= text.len_chars() || n == 0 {
+        return None;
+    }
+
+    let mut chars = text.chars_at(pos).reversed().peekable();
+
+    for _ in 0..n {
+        loop {
+            let c = chars.next()?;
+            let c2 = chars.peek()?;
+
+            pos -= 1;
+
+            if char_matcher.char_match(c) && char_matcher_2.char_match(*c2) {
+                break;
+            }
+        }
+    }
+
+    Some(pos - 1)
+}
+

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -11,6 +11,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "k" | "up" => move_visual_line_up,
         "l" | "right" => move_char_right,
 
+        "L" => find_next_pair,
+        "H" => find_prev_pair,
+        
         "t" => find_till_char,
         "f" => find_next_char,
         "T" => till_prev_char,


### PR DESCRIPTION
2 new commands:
- `find_next_pair`: Ask for 2 chars. Create selection at the next occurence of these 2 chars (accepts count). Bound to `L`
- `find_prev_pair`: Ask for 2 chars. Create selection at the previous occurence of these 2 chars (accepts count). Bound to `H`

## Why

More granular control is desired when moving selections. This makes it easier to perform a range of text selections / transformation with fewer keystrokes and less overhead (see linked issue for more examples)

> [!NOTE]
> Draft at the moment. Only `find_next_pair` works at the moment., lots of copy-pasting in the code. Will refactor tomorrow!

Closes https://github.com/helix-editor/helix/issues/12878
