### PR TITLE
Cyan Theme : fix popup not having any background

### DIFF
--- a/runtime/themes/cyan_light.toml
+++ b/runtime/themes/cyan_light.toml
@@ -93,7 +93,7 @@
 "ui.statusline.insert" = { fg = "shade00", bg = "green" }
 "ui.statusline.select" = { fg = "shade00", bg = "purple" }
 
-"ui.popup" = { fg = "shade04", bg = "shade00" }
+"ui.popup" = { fg = "shade04", bg = "shade01_lighter" }
 "ui.window" = { fg = "shade04", bg = "shade00" }
 "ui.help" = { fg = "shade06", bg = "shade00" }
 "ui.text" = "shade05"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/191f0409-c88e-4b9a-98c3-2ab710e3cc0e)

to

![image](https://github.com/user-attachments/assets/6ed34fad-1c6f-429b-bf94-06ef7cbe1deb)
