### PR TITLE
feat: Create, Delete, Copy, Move, Rename files in the new File Explorer

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -14,11 +14,12 @@ mod statusline;
 mod text;
 mod text_decorations;
 
-use crate::compositor::Compositor;
-use crate::filter_picker_entry;
+use crate::compositor::{Compositor, Context};
 use crate::job::{self, Callback};
+use crate::{ctrl, filter_picker_entry};
 pub use completion::Completion;
 pub use editor::EditorView;
+use helix_core::hashmap;
 use helix_stdx::rope;
 use helix_view::theme::Style;
 pub use markdown::Markdown;
@@ -32,6 +33,7 @@ pub use text::Text;
 use helix_view::Editor;
 use tui::text::Span;
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::{error::Error, path::PathBuf};
 
@@ -296,6 +298,11 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
             }
         },
     )];
+
+    let delete_file: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
+        log::error!("1");
+    });
+
     let picker = Picker::new(
         columns,
         0,
@@ -324,7 +331,8 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
             }
         },
     )
-    .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)));
+    .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)))
+    .with_key_handler(hashmap!(ctrl!('x') => delete_file));
 
     Ok(picker)
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -16,7 +16,7 @@ mod text_decorations;
 
 use crate::compositor::{Compositor, Context};
 use crate::job::{self, Callback};
-use crate::{alt, ctrl, filter_picker_entry};
+use crate::{alt, ctrl, declare_key_handlers, filter_picker_entry};
 pub use completion::Completion;
 pub use editor::EditorView;
 use helix_core::hashmap;
@@ -301,17 +301,6 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
         },
     )];
 
-    macro_rules! declare_key_handlers {
-        ($($op:literal $key:expr => |$cx:ident, $path:ident| $handler:block),* $(,)?) => {
-            hashmap!(
-                $(
-                    $key => Box::new(|$cx: &mut Context, $path: &(PathBuf, bool)| $handler)
-                        as Box<dyn Fn(&mut Context, &(PathBuf, bool)) + 'static>
-                ),*
-            )
-        };
-    }
-
     let picker = Picker::new(
         columns,
         0,
@@ -342,16 +331,30 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
     )
     .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)))
     .with_key_handlers(declare_key_handlers! {
-        "Create" alt!('c') => |cx, path| {
+        // TODO: add a way to get user input in the Picker component and then
+        // execute an action based on that. Maybe re-use the existing Prompt component somehow?
+        |cx, path: &(PathBuf, bool)|,
+        // create
+        alt!('c') => {
+            // TODO: ask user for name of file to be created
+            // Fill in with the picker's current directory
             log::error!("create file");
         },
-        "Rename" alt!('r') => |cx, path| {
+        // move
+        alt!('m') => {
+            // TODO: ask the user for new name of file
+            // on enter move the file to the new location
             log::error!("rename file");
         },
-        "Delete" alt!('d') => |cx, path| {
+        // delete
+        alt!('d') => {
+            // TODO: ask user for confirmation, while showing which file
+            // will be deleted
             log::error!("delete file");
         },
-        "Copy" alt!('y') => |cx, path| {
+        // copy
+        alt!('y') => {
+            // TODO: ask the user for new name of file
             log::error!("copy file");
         },
     });

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -16,7 +16,7 @@ mod text_decorations;
 
 use crate::compositor::{Compositor, Context};
 use crate::job::{self, Callback};
-use crate::{ctrl, filter_picker_entry};
+use crate::{alt, ctrl, filter_picker_entry};
 pub use completion::Completion;
 pub use editor::EditorView;
 use helix_core::hashmap;
@@ -299,8 +299,17 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
         },
     )];
 
-    let delete_file: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
-        log::error!("1");
+    let delete: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
+        log::error!("delete file");
+    });
+    let create: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
+        log::error!("create file");
+    });
+    let rename: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
+        log::error!("rename file");
+    });
+    let copy: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
+        log::error!("copy file");
     });
 
     let picker = Picker::new(
@@ -332,7 +341,12 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
         },
     )
     .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)))
-    .with_key_handler(hashmap!(ctrl!('x') => delete_file));
+    .with_key_handler(HashMap::from([
+        (alt!('c'), create),
+        (alt!('d'), delete),
+        (alt!('y'), copy),
+        (alt!('r'), rename),
+    ]));
 
     Ok(picker)
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -302,11 +302,11 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
     )];
 
     macro_rules! declare_key_handlers {
-        ($($op:literal $key:expr => $handler:expr),*) => {
+        ($($op:literal $key:expr => |$cx:ident, $path:ident| $handler:block),* $(,)?) => {
             hashmap!(
                 $(
-                    $key => Box::new($handler)
-                        as Box<dyn Fn(&mut Context) + 'static>
+                    $key => Box::new(|$cx: &mut Context, $path: &(PathBuf, bool)| $handler)
+                        as Box<dyn Fn(&mut Context, &(PathBuf, bool)) + 'static>
                 ),*
             )
         };
@@ -342,18 +342,18 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
     )
     .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)))
     .with_key_handlers(declare_key_handlers! {
-        "Create" alt!('c') => |cx: &mut Context| {
+        "Create" alt!('c') => |cx, path| {
             log::error!("create file");
         },
-        "Delete" alt!('d') => |cx: &mut Context| {
+        "Rename" alt!('r') => |cx, path| {
+            log::error!("rename file");
+        },
+        "Delete" alt!('d') => |cx, path| {
             log::error!("delete file");
         },
-        "Copy" alt!('y') => |cx: &mut Context| {
+        "Copy" alt!('y') => |cx, path| {
             log::error!("copy file");
         },
-        "Rename" alt!('r') => |cx: &mut Context| {
-            log::error!("rename file");
-        }
     });
 
     Ok(picker)

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -37,6 +37,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::{error::Error, path::PathBuf};
 
+use self::picker::PickerKeyHandler;
+
 struct Utf8PathBuf {
     path: String,
     is_dir: bool,
@@ -299,18 +301,16 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
         },
     )];
 
-    let delete: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
-        log::error!("delete file");
-    });
-    let create: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
-        log::error!("create file");
-    });
-    let rename: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
-        log::error!("rename file");
-    });
-    let copy: Box<dyn Fn(&mut Context) + 'static> = Box::new(|cx: &mut Context| {
-        log::error!("copy file");
-    });
+    macro_rules! declare_key_handlers {
+        ($($op:literal $key:expr => $handler:expr),*) => {
+            hashmap!(
+                $(
+                    $key => Box::new($handler)
+                        as Box<dyn Fn(&mut Context) + 'static>
+                ),*
+            )
+        };
+    }
 
     let picker = Picker::new(
         columns,
@@ -341,12 +341,20 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
         },
     )
     .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)))
-    .with_key_handler(HashMap::from([
-        (alt!('c'), create),
-        (alt!('d'), delete),
-        (alt!('y'), copy),
-        (alt!('r'), rename),
-    ]));
+    .with_key_handlers(declare_key_handlers! {
+        "Create" alt!('c') => |cx: &mut Context| {
+            log::error!("create file");
+        },
+        "Delete" alt!('d') => |cx: &mut Context| {
+            log::error!("delete file");
+        },
+        "Copy" alt!('y') => |cx: &mut Context| {
+            log::error!("copy file");
+        },
+        "Rename" alt!('r') => |cx: &mut Context| {
+            log::error!("rename file");
+        }
+    });
 
     Ok(picker)
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -395,7 +395,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         }
     }
 
-    pub fn with_key_handler(mut self, handlers: PickerKeyHandler) -> Self {
+    pub fn with_key_handlers(mut self, handlers: PickerKeyHandler) -> Self {
         self.custom_key_handlers = handlers;
         self
     }
@@ -1179,4 +1179,4 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
 }
 
 type PickerCallback<T> = Box<dyn Fn(&mut Context, &T, Action)>;
-type PickerKeyHandler = HashMap<KeyEvent, Box<dyn Fn(&mut Context)>>;
+pub type PickerKeyHandler = HashMap<KeyEvent, Box<dyn Fn(&mut Context) + 'static>>;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1182,3 +1182,16 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
 
 type PickerCallback<T> = Box<dyn Fn(&mut Context, &T, Action)>;
 pub type PickerKeyHandler<T> = HashMap<KeyEvent, Box<dyn Fn(&mut Context, &T) + 'static>>;
+
+/// Convenience macro to add custom keybindings per picker
+#[macro_export]
+macro_rules! declare_key_handlers {
+        (|$cx:ident, $item:ident : $t:ty|, $($key:expr => $handler:block),* $(,)?) => {
+            hashmap!(
+                $(
+                    $key => Box::new(|$cx: &mut Context, $item: $t| $handler)
+                        as Box<dyn Fn(&mut Context, $t) + 'static>
+                ),*
+            )
+        };
+    }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -259,7 +259,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
     widths: Vec<Constraint>,
 
     callback_fn: PickerCallback<T>,
-    custom_key_handlers: PickerKeyHandler,
+    custom_key_handlers: PickerKeyHandler<T>,
 
     pub truncate_start: bool,
     /// Caches paths to documents
@@ -395,7 +395,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         }
     }
 
-    pub fn with_key_handlers(mut self, handlers: PickerKeyHandler) -> Self {
+    pub fn with_key_handlers(mut self, handlers: PickerKeyHandler<T>) -> Self {
         self.custom_key_handlers = handlers;
         self
     }
@@ -518,8 +518,10 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     fn custom_event_handler(&mut self, event: &KeyEvent, cx: &mut Context) -> EventResult {
-        if let Some(callback) = self.custom_key_handlers.get(event) {
-            callback(cx);
+        if let (Some(callback), Some(selected)) =
+            (self.custom_key_handlers.get(event), self.selection())
+        {
+            callback(cx, selected);
             EventResult::Consumed(None)
         } else {
             EventResult::Ignored(None)
@@ -1179,4 +1181,4 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
 }
 
 type PickerCallback<T> = Box<dyn Fn(&mut Context, &T, Action)>;
-pub type PickerKeyHandler = HashMap<KeyEvent, Box<dyn Fn(&mut Context) + 'static>>;
+pub type PickerKeyHandler<T> = HashMap<KeyEvent, Box<dyn Fn(&mut Context, &T) + 'static>>;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -47,6 +47,7 @@ use helix_core::{
 use helix_view::{
     editor::Action,
     graphics::{CursorKind, Margin, Modifier, Rect},
+    input::KeyEvent,
     theme::Style,
     view::ViewPosition,
     Document, DocumentId, Editor,
@@ -258,6 +259,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
     widths: Vec<Constraint>,
 
     callback_fn: PickerCallback<T>,
+    custom_key_handlers: PickerKeyHandler,
 
     pub truncate_start: bool,
     /// Caches paths to documents
@@ -385,11 +387,17 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             completion_height: 0,
             widths,
             preview_cache: HashMap::new(),
+            custom_key_handlers: HashMap::new(),
             read_buffer: Vec::with_capacity(1024),
             file_fn: None,
             preview_highlight_handler: PreviewHighlightHandler::<T, D>::default().spawn(),
             dynamic_query_handler: None,
         }
+    }
+
+    pub fn with_key_handler(mut self, handlers: PickerKeyHandler) -> Self {
+        self.custom_key_handlers = handlers;
+        self
     }
 
     pub fn injector(&self) -> Injector<T, D> {
@@ -507,6 +515,15 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
     pub fn toggle_preview(&mut self) {
         self.show_preview = !self.show_preview;
+    }
+
+    fn custom_event_handler(&mut self, event: &KeyEvent, cx: &mut Context) -> EventResult {
+        if let Some(callback) = self.custom_key_handlers.get(event) {
+            callback(cx);
+            EventResult::Consumed(None)
+        } else {
+            EventResult::Ignored(None)
+        }
     }
 
     fn prompt_handle_event(&mut self, event: &Event, cx: &mut Context) -> EventResult {
@@ -1113,8 +1130,13 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             ctrl!('t') => {
                 self.toggle_preview();
             }
-            _ => {
-                self.prompt_handle_event(event, ctx);
+            key_event => {
+                if !matches!(
+                    self.custom_event_handler(&key_event, ctx),
+                    EventResult::Consumed(_)
+                ) {
+                    self.prompt_handle_event(event, ctx);
+                };
             }
         }
 
@@ -1157,3 +1179,4 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
 }
 
 type PickerCallback<T> = Box<dyn Fn(&mut Context, &T, Action)>;
+type PickerKeyHandler = HashMap<KeyEvent, Box<dyn Fn(&mut Context)>>;


### PR DESCRIPTION
The recently added File Explorer (https://github.com/helix-editor/helix/pull/11285) is awesome, but it's missing a couple of features which I'd classify as nice-to-have (you can already delete / move / create etc files in Helix, but it's more ergonomic to be able to do that right from the picker instead of having to close it, type the command in cmd mode (`:`) and then going back to the picker)

Currently WIP. Progress:
- [x] Introduce new API that allows passing custom key handlers when creating new Pickers. This'll also be nice for the plugin ecosystem
- [ ] Ability to spawn a 2nd `Prompt` on top of the file picker.
- [ ] Implement the 4 aforementioned functions

## Keymapping

|keybinding|action|
|<kbd>A-c</kbd>|Create|
|<kbd>A-m</kbd>|Move|
|<kbd>A-d</kbd>|Delete|
|<kbd>A-y</kbd>|Copy|