### PR TITLE
Improve jump label colors for `github_light` theme

### DIFF
--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -62,6 +62,7 @@ label = "scale.red.5"
 "ui.text.directory" = { fg = "scale.blue.4" }
 "ui.virtual" = { fg = "scale.gray.2" }
 "ui.virtual.ruler" = { bg = "canvas.subtle" }
+"ui.virtual.jump-label" = { modifiers = ["reversed"] }
 
 "ui.selection" = { bg = "scale.blue.0" }
 "ui.selection.primary" = { bg = "scale.blue.1" }


### PR DESCRIPTION
Improve jump label colors as per issue (#12904)

The "reversed" modifier seems to provide a better visibility.

The screenshot below demonstrates the before-and-after result of this fix.

Kindly approve these changes and accept the pull request as this theme is very important to many users.

Yours faithfully
~oxcrow

![helix-fix-1](https://github.com/user-attachments/assets/545dc02f-fa0f-43b1-b391-811c40caf20c)