### PR TITLE
feat: trim paths to cwd if possible on file open

### DIFF
--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -297,6 +297,20 @@ pub fn expand<T: AsRef<Path> + ?Sized>(path: &T) -> Cow<'_, Path> {
     }
 }
 
+/// trims absolute path if there is an overlap or returns the given path
+pub fn trim_absolute_to_cwd(path: impl AsRef<Path>, cwd: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    let cwd = cwd.as_ref();
+
+    if path.is_absolute() {
+        if let Ok(stripped) = path.strip_prefix(cwd) {
+            return stripped.to_path_buf();
+        }
+    }
+
+    path.to_path_buf()
+}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/helix-stdx/src/path.rs
+++ b/helix-stdx/src/path.rs
@@ -297,8 +297,9 @@ pub fn expand<T: AsRef<Path> + ?Sized>(path: &T) -> Cow<'_, Path> {
     }
 }
 
-/// trims absolute path if there is an overlap or returns the given path
-pub fn trim_absolute_to_cwd(path: impl AsRef<Path>, cwd: impl AsRef<Path>) -> PathBuf {
+/// Attempts to trim the path to the current working directory if possible, otherwise return the
+/// original path
+pub fn attempt_truncate_to_cwd(path: impl AsRef<Path>, cwd: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
     let cwd = cwd.as_ref();
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1742,14 +1742,8 @@ impl Editor {
     // ??? possible use for integration tests
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
-        let path = if path.is_absolute() {
-            match &self.last_cwd {
-                None => path,
-                Some(cwd) => helix_stdx::path::trim_absolute_to_cwd(path, cwd),
-            }
-        } else {
-            path
-        };
+        let path =
+            helix_stdx::path::attempt_truncate_to_cwd(path, helix_stdx::env::current_working_dir());
         let id = self.document_id_by_path(&path);
 
         let id = if let Some(id) = id {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1742,6 +1742,14 @@ impl Editor {
     // ??? possible use for integration tests
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
+        let path = if path.is_absolute() {
+            match &self.last_cwd {
+                None => path,
+                Some(cwd) => helix_stdx::path::trim_absolute_to_cwd(path, cwd),
+            }
+        } else {
+            path
+        };
         let id = self.document_id_by_path(&path);
 
         let id = if let Some(id) = id {


### PR DESCRIPTION
This is my first contribution to helix.

I haven't been able to fully repro this, but the code I've written makes sense. If the LSP gives back a path that's an absolute path helix may attempt to open a buffer using that path, rather than coalescing with the existing buffer opened using a relative path.

Closes this issue #12807 