### PR TITLE
feat: move directories while updating buffer paths (supercharged `:move`)

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -84,7 +84,7 @@
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:redraw` | Clear and re-render the whole UI |
-| `:move`, `:mv` | Move the current buffer and its corresponding file to a different path |
+| `:move`, `:mv` | Move files, updating any affected open buffers. A single argument moves the current buffer's file, multiple arguments move multiple source files to a target (same as the Unix `mv` command) |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |
 | `:echo` | Prints the given arguments to the statusline. |


### PR DESCRIPTION
`:move` is nice, but it doesn't let you move a directory and automatically update the buffer paths for any files inside of it that are opened in the editor. Currently this is rather cumbersome, you need to `:sh mv foo bar`, close all affected buffers, then reopen them again at their new paths.

This PR proposes a couple of **backwards-compatible** changes:

1. `Editor::move_path` now handles updating the paths for all affected buffers when it moves a directory.
2. `:move` takes 1 to n arguments. If a single argument is given, the argument is the destination path and the buffer path is the source (this is the existing behavior, which continues to work as before). If multiple arguments are given, `:move` behaves like the Unix `mv` command: `:move foo bar` moves `foo` to `bar`, `:move foo bar baz` moves `foo` and `bar` into `baz`.
3. `:move foo bar` knows to move `foo` to `bar/foo` if `bar` is an existing directory. Again this mirrors the behavior of Unix `mv` and should be more intuitive.

I think this is a natural extension to the existing behavior and has worked very well for me during testing so far. Any suggestions or feedback is appreciated :)