### PR TITLE
feat(lsp): add container name as a column in the symbol pickers

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::{BTreeMap, HashSet},
     fmt::Display,
@@ -407,6 +408,9 @@ pub fn symbol_picker(cx: &mut Context) {
                 ui::PickerColumn::new("name", |item: &SymbolInformationItem, _| {
                     item.symbol.name.as_str().into()
                 }),
+                ui::PickerColumn::new("container", |item: &SymbolInformationItem, _| {
+                    Cow::from(item.symbol.container_name.clone().unwrap_or_default()).into()
+                }),
             ];
 
             let picker = Picker::new(
@@ -508,6 +512,9 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
             item.symbol.name.as_str().into()
         })
         .without_filtering(),
+        ui::PickerColumn::new("container", |item: &SymbolInformationItem, _| {
+            Cow::from(item.symbol.container_name.clone().unwrap_or_default()).into()
+        }),
         ui::PickerColumn::new("path", |item: &SymbolInformationItem, _| {
             if let Some(path) = item.location.uri.as_path() {
                 path::get_relative_path(path)

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -32,7 +32,6 @@ use crate::{
 };
 
 use std::{
-    borrow::Cow,
     cmp::Ordering,
     collections::{BTreeMap, HashSet},
     fmt::Display,
@@ -409,7 +408,11 @@ pub fn symbol_picker(cx: &mut Context) {
                     item.symbol.name.as_str().into()
                 }),
                 ui::PickerColumn::new("container", |item: &SymbolInformationItem, _| {
-                    Cow::from(item.symbol.container_name.clone().unwrap_or_default()).into()
+                    item.symbol
+                        .container_name
+                        .as_deref()
+                        .unwrap_or_default()
+                        .into()
                 }),
             ];
 
@@ -513,7 +516,11 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
         })
         .without_filtering(),
         ui::PickerColumn::new("container", |item: &SymbolInformationItem, _| {
-            Cow::from(item.symbol.container_name.clone().unwrap_or_default()).into()
+            item.symbol
+                .container_name
+                .as_deref()
+                .unwrap_or_default()
+                .into()
         }),
         ui::PickerColumn::new("path", |item: &SymbolInformationItem, _| {
             if let Some(path) = item.location.uri.as_path() {


### PR DESCRIPTION
This (experiment) adds the container name of a symbol to the picker as well. The intention is to be able to navigate to various implementations of a method for example, if there's multiple classes in the same file.

Note: I have no clue what I'm doing, so consider this more as an "enhanced feature request". It seems to work just fine for me though, so any feedback is appreciated.

I've also thought about joining the container and name together into one column, but that's difficult if you're trying to respect language specific symbol separators (`::` in C++, `.` in JS, Python etc, ...) so I've figured I'd rather have a separate column.

Maybe even better would be to have the column selection configurable, as it may not make sense for some languages, and may take away quite a bit of room in others.

Here's a screenshot of how it looks now. Note that without the "container" column, it's really hard (even with the preview) to figure out which class the to-be-selected field belongs to.
![image](https://github.com/user-attachments/assets/adcd7cee-3ca0-4021-8b92-d2f0e4fbe29d)
