### PR TITLE
Accept more scons as python language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -903,7 +903,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "29f53
 name = "python"
 scope = "source.python"
 injection-regex = "py(thon)?"
-file-types = ["py", "pyi", "py3", "pyw", "ptl", "rpy", "cpy", "ipy", "pyt", { glob = ".python_history" }, { glob = ".pythonstartup" }, { glob = ".pythonrc" }, { glob = "SConstruct" }, { glob = "SConscript" }]
+file-types = ["py", "pyi", "py3", "pyw", "ptl", "rpy", "cpy", "ipy", "pyt", { glob = ".python_history" }, { glob = ".pythonstartup" }, { glob = ".pythonrc" }, { glob = "*SConstruct" }, { glob = "*SConscript" }, { glob = "*sconstruct" }]
 shebangs = ["python", "uv"]
 roots = ["pyproject.toml", "setup.py", "poetry.lock", "pyrightconfig.json"]
 comment-token = "#"


### PR DESCRIPTION
* Change SConstruct, as many times in scons projects you end up with test.SConstruct, gmock.SConstruct, mock.SConstruct
* Change SConscript, as many times in scons projects you end up with test.SConscript, gmock.SConscript, mock.SConscript
* Add sconstruct, as this is epcifically called out in the manual:

> By default, scons searches for a file named SConstruct, Sconstruct, or sconstruct (in that order)
  in the current directory and reads its configuration from the first file found. An alternate file name may be specified via the -f option.