### PR TITLE
feat: language support for mail files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -134,6 +134,7 @@
 | log | ✓ |  |  |  |
 | lpf | ✓ |  |  |  |
 | lua | ✓ | ✓ | ✓ | `lua-language-server` |
+| mail | ✓ | ✓ |  |  |
 | make | ✓ |  | ✓ |  |
 | markdoc | ✓ |  |  | `markdoc-ls` |
 | markdown | ✓ |  |  | `marksman`, `markdown-oxide` |

--- a/languages.toml
+++ b/languages.toml
@@ -1671,6 +1671,16 @@ name = "tablegen"
 source = { git = "https://github.com/Flakebi/tree-sitter-tablegen", rev = "3e9c4822ab5cdcccf4f8aa9dcd42117f736d51d9" }
 
 [[language]]
+name = "mail"
+scope = "text.mail"
+file-types = ["eml"]
+injection-regex = "mail|eml|email"
+
+[[grammar]]
+name = "mail"
+source = { git = "https://github.com/ficcdaf/tree-sitter-mail", rev = "8e60f38efbae1cc5f22833ae13c5500dd0f3b12f" }
+
+[[language]]
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"

--- a/runtime/queries/mail/highlights.scm
+++ b/runtime/queries/mail/highlights.scm
@@ -1,4 +1,3 @@
-(ERROR) @diagnostic.error
 ; header fields
 [
   (header_field_email)

--- a/runtime/queries/mail/highlights.scm
+++ b/runtime/queries/mail/highlights.scm
@@ -1,0 +1,29 @@
+(ERROR) @diagnostic.error
+; header fields
+[
+  (header_field_email)
+  (header_field_subject)
+  (header_field)
+] @keyword
+
+; delimited punctuation
+(header_separator) @punctuation.delimiter
+(email_delimiter) @punctuation.delimiter
+
+; email subject contents
+(header_subject
+  (subject) @markup.bold)
+; extra metadata headers
+(header_other
+  (header_unstructured) @comment)
+
+; Addressee Name (Firstname, Lastname, etc.)
+(atom) @variable
+
+; Email Address
+(email) @string
+
+; Quoted Reply
+(quote_marker) @punctuation.special
+(quote_contents) @markup.quote
+

--- a/runtime/queries/mail/textobjects.scm
+++ b/runtime/queries/mail/textobjects.scm
@@ -1,0 +1,13 @@
+(atom_block
+  (atom) @entry.inside) @entry.around
+
+(email_address) @entry.around
+(header_other
+  (header_unstructured) @entry.around)
+
+(quoted_block)+ @comment.around
+
+(body_block)+ @function.around
+
+(header_subject
+  (subject) @function.around)


### PR DESCRIPTION
This PR adds `mail` language support to Helix. It includes a tree-sitter grammar, highlight queries, and textobject queries. I've updated the documentation and tested it extensively. 