### PR TITLE
feat: added comment textobject to toml

### DIFF
--- a/runtime/queries/toml/textobjects.scm
+++ b/runtime/queries/toml/textobjects.scm
@@ -3,3 +3,5 @@
 
 (array
   (_) @entry.around)
+
+(comment)+ @comment.around


### PR DESCRIPTION
This PR adds `comment` text object support to TOML. Being able to select comments with `]c` and `[c` is a big quality of life improvement. 
