### PR TITLE
Prevent soft wrap inside a run of punctuation

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -335,18 +335,15 @@ impl<'t> DocumentFormatter<'t> {
                 .change_position(visual_x, self.text_fmt.tab_width);
             word_width += grapheme.width();
         }
-        if let Some(grapheme) = &mut self.peeked_grapheme {
-            let visual_x = self.visual_pos.col + word_width;
-            grapheme
-                .grapheme
-                .change_position(visual_x, self.text_fmt.tab_width);
-        }
         word_width
     }
 
     fn peek_grapheme(&mut self, col: usize, char_pos: usize) -> Option<&GraphemeWithSource<'t>> {
-        if self.peeked_grapheme.is_none() {
-            self.peeked_grapheme = self.advance_grapheme(col, char_pos);
+        match &mut self.peeked_grapheme {
+            None => self.peeked_grapheme = self.advance_grapheme(col, char_pos),
+            Some(peeked_grapheme) => peeked_grapheme
+                .grapheme
+                .change_position(col, self.text_fmt.tab_width),
         }
         self.peeked_grapheme.as_ref()
     }

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -135,10 +135,6 @@ impl<'a> GraphemeWithSource<'a> {
     fn width(&self) -> usize {
         self.grapheme.width()
     }
-
-    fn is_word_boundary(&self) -> bool {
-        self.grapheme.is_word_boundary()
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +163,10 @@ impl Default for TextFormat {
             soft_wrap_at_text_width: false,
         }
     }
+}
+
+fn wrap_allowed(x: Option<&Grapheme>, y: &Grapheme) -> bool {
+    x.is_some_and(|x| x.is_word_boundary() && (x.is_whitespace() || !y.is_word_boundary()))
 }
 
 #[derive(Debug)]
@@ -351,17 +351,12 @@ impl<'t> DocumentFormatter<'t> {
         self.peeked_grapheme.as_ref()
     }
 
-    fn next_grapheme(&mut self, col: usize, char_pos: usize) -> Option<GraphemeWithSource<'t>> {
-        self.peek_grapheme(col, char_pos);
-        self.peeked_grapheme.take()
-    }
-
     fn advance_to_next_word(&mut self) {
         self.word_buf.clear();
         let mut word_width = 0;
         let mut word_chars = 0;
 
-        if self.exhausted {
+        if self.exhausted && self.peeked_grapheme.is_none() {
             return;
         }
 
@@ -383,7 +378,10 @@ impl<'t> DocumentFormatter<'t> {
                     if self.text_fmt.soft_wrap_at_text_width
                         && self
                             .peek_grapheme(col, char_pos)
-                            .is_some_and(|grapheme| grapheme.is_newline() || grapheme.is_eof()) => {
+                            .is_some_and(|grapheme| grapheme.is_newline() || grapheme.is_eof()) =>
+                {
+                    self.word_buf.push(self.peeked_grapheme.take().unwrap());
+                    return;
                 }
                 Ordering::Equal if word_width > self.text_fmt.max_wrap as usize => return,
                 Ordering::Greater if word_width > self.text_fmt.max_wrap as usize => {
@@ -397,9 +395,22 @@ impl<'t> DocumentFormatter<'t> {
                 Ordering::Less => (),
             }
 
-            let Some(grapheme) = self.next_grapheme(col, char_pos) else {
+            // It would be nice if this could be written as
+            //   let Some(grapheme) = self.peek_grapheme(col, char_pos)
+            // but the borrow checker can't see inside of peek_grapheme and
+            // assumes that the return value borrows mutably from self.
+            let _ = self.peek_grapheme(col, char_pos);
+            let Some(grapheme) = &self.peeked_grapheme else {
                 return;
             };
+            if wrap_allowed(
+                self.word_buf.last().map(|g| &g.grapheme),
+                &grapheme.grapheme,
+            ) {
+                return;
+            }
+
+            let grapheme = self.peeked_grapheme.take().unwrap();
             word_chars += grapheme.doc_chars();
 
             // Track indentation
@@ -409,13 +420,8 @@ impl<'t> DocumentFormatter<'t> {
                 self.indent_level = None;
             }
 
-            let is_word_boundary = grapheme.is_word_boundary();
             word_width += grapheme.width();
             self.word_buf.push(grapheme);
-
-            if is_word_boundary {
-                return;
-            }
         }
     }
 

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -110,6 +110,18 @@ fn softwrap_multichar_grapheme() {
     )
 }
 
+#[test]
+fn softwrap_punctuation() {
+    assert_eq!(
+        softwrap_text("asdfasdfasdfasd ...\n"),
+        "asdfasdfasdfasd \n.... \n "
+    );
+    assert_eq!(
+        softwrap_text("asdfasdfasdf a(bc)\n"),
+        "asdfasdfasdf a(\n.bc) \n "
+    );
+}
+
 fn softwrap_text_at_text_width(text: &str) -> String {
     let mut text_fmt = TextFormat::new_test(true);
     text_fmt.soft_wrap_at_text_width = true;

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -80,6 +80,10 @@ fn softwrap_indentation() {
         softwrap_text("\t\t\tfoo1 foo2 foo3 foo4 foo5 foo6\n"),
         "      foo1 foo2 \n.foo3 foo4 foo5 \n.foo6 \n "
     );
+    assert_eq!(
+        softwrap_text("\t\tfoo1\n\t\tfoo2\n\t\tfoo3\n"),
+        "    foo1 \n    foo2 \n    foo3 \n "
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is a simpler alternative to #12778, based on @pascalkuthe's second idea from [#12471#comment](https://github.com/helix-editor/helix/pull/12471#issuecomment-2629134746)

Fixes #11428