### PR TITLE
feat(kdl): add `kdlfmt` as formatter for kdl

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2706,6 +2706,7 @@ file-types = ["kdl"]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 injection-regex = "kdl"
+formatter = { command = "kdlfmt", args = ["format", "-"] }
 
 [[grammar]]
 name = "kdl"


### PR DESCRIPTION
This PR configures [kdlfmt](https://github.com/hougesen/kdlfmt), which can easily be installed with `cargo install`, as the default formatter for `kdl` files.
