### PR TITLE
feat: add buffer-close-right and buffer-close-left commands

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -9,6 +9,10 @@
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Force close all buffers but the currently focused one. |
 | `:buffer-close-all`, `:bca`, `:bcloseall` | Close all buffers without quitting. |
 | `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Force close all buffers ignoring unsaved changes without quitting. |
+| `:buffer-close-right`, `:bcr`, `:bcloseright` | Close all to the right buffers without quitting. |
+| `:buffer-close-right!`, `:bcr!`, `:bcloseright!` | Force close all buffers to the right ignoring unsaved changes without quitting. |
+| `:buffer-close-left`, `:bcl`, `:bcloseleft` | Close all to the left buffers without quitting. |
+| `:buffer-close-left!`, `:bcl!`, `:bcloseleft!` | Force close all buffers to the left ignoring unsaved changes without quitting. |
 | `:buffer-next`, `:bn`, `:bnext` | Goto next buffer. |
 | `:buffer-previous`, `:bp`, `:bprev` | Goto previous buffer. |
 | `:write`, `:w` | Write changes to disk. Accepts an optional path (:write some/path.txt) |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -295,6 +295,77 @@ fn force_buffer_close_all(
     buffer_close_by_ids_impl(cx, &document_ids, true)
 }
 
+fn buffer_gather_right_impl(editor: &mut Editor) -> Vec<DocumentId> {
+    let current_document = &doc!(editor).id();
+    editor
+        .documents()
+        .map(|doc| doc.id())
+        .skip_while(|doc| doc != current_document)
+        .skip(1)
+        .collect()
+}
+
+fn buffer_close_right(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_right_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
+fn force_buffer_close_right(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_right_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, true)
+}
+
+fn buffer_gather_left_impl(editor: &mut Editor) -> Vec<DocumentId> {
+    let current_document = &doc!(editor).id();
+    editor
+        .documents()
+        .map(|doc| doc.id())
+        .take_while(|doc| doc != current_document)
+        .collect()
+}
+
+fn buffer_close_left(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_left_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
+fn force_buffer_close_left(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_left_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, true)
+}
+
 fn buffer_next(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2607,6 +2678,50 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["bca!", "bcloseall!"],
         doc: "Force close all buffers ignoring unsaved changes without quitting.",
         fun: force_buffer_close_all,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "buffer-close-right",
+        aliases: &["bcr", "bcloseright"],
+        doc: "Close all to the right buffers without quitting.",
+        fun: buffer_close_right,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "buffer-close-right!",
+        aliases: &["bcr!", "bcloseright!"],
+        doc: "Force close all buffers to the right ignoring unsaved changes without quitting.",
+        fun: force_buffer_close_right,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "buffer-close-left",
+        aliases: &["bcl", "bcloseleft"],
+        doc: "Close all to the left buffers without quitting.",
+        fun: buffer_close_left,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "buffer-close-left!",
+        aliases: &["bcl!", "bcloseleft!"],
+        doc: "Force close all buffers to the left ignoring unsaved changes without quitting.",
+        fun: force_buffer_close_left,
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),


### PR DESCRIPTION
Adds the ability to close buffers left and right of the current one. I find myself very often to close multiple buffers at once but buffer-close-other and buffer-close-all often tend to close too much so I'm often closing buffers one by one which can be a bit cumbersome at task. Editors like VS Code (and others) usually have a "Close tabs to the right/left" option when you right click a tab and since switching I wanted to have this in Helix too.