### PR TITLE
Improve %% escaping error message

### DIFF
--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -223,7 +223,11 @@ impl fmt::Display for ParseArgsError<'_> {
                 write!(f, "flag '--{flag}' missing an argument")
             }
             Self::MissingExpansionDelimiter { expansion } => {
-                write!(f, "missing a string delimiter after '%{expansion}'")
+                if expansion.is_empty() {
+                    write!(f, "'%' was not properly escaped. Please use '%%'")
+                } else {
+                    write!(f, "missing a string delimiter after '%{expansion}'")
+                }
             }
             Self::UnknownExpansion { kind } => {
                 write!(f, "unknown expansion '{kind}'")

--- a/helix-term/tests/test/command_line.rs
+++ b/helix-term/tests/test/command_line.rs
@@ -90,3 +90,14 @@ async fn shell_expansion() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn percent_escaping() -> anyhow::Result<()> {
+    test_statusline(
+        r#":sh echo hello 10%"#,
+        "'run-shell-command': '%' was not properly escaped. Please use '%%'",
+        Severity::Error,
+    )
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
https://github.com/helix-editor/helix/issues/12999

This improves the error message if "%" is not escaped as "%%" as in the test.