### PR TITLE
Follow-up to #12831, fix the git hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
   runCommand,
   installShellFiles,
   git,
+  gitRev ? null,
   ...
 }: let
   fs = lib.fileset;
@@ -34,9 +35,6 @@
     ln -s ${grammars} $out/grammars
   '';
 in
-  # Currently rustPlatform.buildRustPackage doesn't have the finalAttrs pattern
-  # hooked up. To get around this while having good customization, mkDerivation is
-  # used instead.
   rustPlatform.buildRustPackage (self: {
     cargoLock = {
       lockFile = ./Cargo.lock;
@@ -63,7 +61,7 @@ in
     HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
 
     # So Helix knows what rev it is.
-    HELIX_NIX_BUILD_REV = self.rev or self.dirtyRev or null;
+    HELIX_NIX_BUILD_REV = gitRev;
 
     doCheck = false;
     strictDeps = true;

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
     flake-utils,
     rust-overlay,
     ...
-  }:
+  }: let
+    gitRev = self.rev or self.dirtyRev or null;
+  in
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;
@@ -31,13 +33,20 @@
       };
     in {
       packages = rec {
-        helix = pkgs.callPackage ./default.nix {};
+        helix = pkgs.callPackage ./default.nix {inherit gitRev;};
 
-        # The default Helix build. Uses the latest stable Rust toolchain, and unstable
-        # nixpkgs.
-        #
-        # This can be overridden though to add Cargo Features, flags, and different toolchains with
-        # packages.${system}.default.override { ... };
+        /**
+        The default Helix build. Uses the latest stable Rust toolchain, and unstable
+        nixpkgs.
+        
+        The build inputs can be overriden with the following:
+         
+        packages.${system}.default.override { rustPlatform = newPlatform; };
+         
+        Overriding a derivation attribute can be done as well:
+        
+        packages.${system}.default.overrideAttrs { buildType = "debug"; };
+        */ 
         default = helix;
       };
 
@@ -71,7 +80,7 @@
     })
     // {
       overlays.default = final: prev: {
-        helix = final.callPackage ./default.nix {};
+        helix = final.callPackage ./default.nix {inherit gitRev;};
       };
     };
 


### PR DESCRIPTION
The git hash is not added properly. When I copy and pasted to a new file it referenced `self`, but this new `self` is the derivation so there is no `rev` or `dirtyRev` attrs, leading to it always being null. This fixes that. 

I also expanded the comment about overriding.