### PR TITLE
feat: add `harper-ls` LSP configuration 

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -47,6 +47,7 @@ fsharp-ls = { command = "fsautocomplete", config = { AutomaticWorkspaceInit = tr
 gleam = { command = "gleam", args = ["lsp"] }
 glsl_analyzer = { command = "glsl_analyzer" }
 graphql-language-service = { command = "graphql-lsp", args = ["server", "-m", "stream"] }
+harper-ls = { command = "harper-ls", args = ["--stdio"] }
 haskell-language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
 hyprls = { command = "hyprls" }
 idris2-lsp = { command = "idris2-lsp" }


### PR DESCRIPTION
## What?

This PR adds the `harper-ls` LSP configuration. It doesn't add it to any language by default, but now to use Harper, users just need to install it to their path and add it to the `language-servers` array for the language they want.

_Note:_ I edited this PR description to reflect the changes discussed in the conversation below. The PR is now ready for review.