### PR TITLE
chore: Point OpenSCAD grammar to official repo

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2412,7 +2412,7 @@ indent = { tab-width = 2, unit = "\t" }
 
 [[grammar]]
 name = "openscad"
-source = { git = "https://github.com/openscad/tree-sitter-openscad", rev = "654280c0ea7beaa81c402f199a13f25379535f89" }
+source = { git = "https://github.com/openscad/tree-sitter-openscad", rev = "acc196e969a169cadd8b7f8d9f81ff2d30e3e253" }
 
 [[language]]
 name = "prisma"

--- a/languages.toml
+++ b/languages.toml
@@ -2412,7 +2412,7 @@ indent = { tab-width = 2, unit = "\t" }
 
 [[grammar]]
 name = "openscad"
-source = { git = "https://github.com/bollian/tree-sitter-openscad", rev = "5c3ce93df0ac1da7197cf6ae125aade26d6b8972" }
+source = { git = "https://github.com/openscad/tree-sitter-openscad", rev = "654280c0ea7beaa81c402f199a13f25379535f89" }
 
 [[language]]
 name = "prisma"
@@ -4030,12 +4030,12 @@ block-comment-tokens = [
 language-servers = [ "spade-language-server" ]
 indent = { tab-width = 4, unit = "    " }
 
-[language.auto-pairs] 
-'(' = ')' 
-'{' = '}' 
-'[' = ']' 
-'"' = '"' 
-'<' = '>' 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'<' = '>'
 
 [[grammar]]
 name = "spade"
@@ -4099,7 +4099,7 @@ file-types = [
   { glob = "sites-available/*.conf" },
   { glob = "sites-enabled/*.conf" },
   { glob = "nginx.conf" },
-  { glob = "conf.d/*.conf" } 
+  { glob = "conf.d/*.conf" }
 ]
 roots = ["nginx.conf"]
 comment-token = "#"

--- a/runtime/queries/openscad/highlights.scm
+++ b/runtime/queries/openscad/highlights.scm
@@ -1,40 +1,68 @@
-(number) @constant.numeric
-(string) @string
-(boolean) @constant.builtin.boolean
-(include_path) @string.special.path
-
+; Includes
 (identifier) @variable
 
-(parameters_declaration (identifier) @variable.parameter)
-(function_declaration name: (identifier) @function)
+"include" @keyword.import
 
-(function_call function: (identifier) @function)
-(module_call name: (identifier) @function)
+(include_path) @string.special.path
 
+; Functions
+
+(function_item
+  (identifier) @function
+)
+(function_item
+  parameters: (parameters (parameter (assignment value: (_) @constant)))
+)
+(function_call name: (identifier) @function.call)
+(function_call
+  arguments: (arguments (assignment name: _ @variable.parameter))
+)
+; for the puroposes of distintion since modules are "coloured" impure functions, we will treat them as methods
+(module_item (identifier) @function.method)
+(module_item
+  parameters: (parameters (parameter (assignment value: (_) @constant)))
+)
+(module_call name: (identifier) @function.method.call)
+(module_call
+  arguments: (arguments (assignment name: _ @variable.parameter))
+)
+
+; assertion statements/expression arguments behave similar to function calls
+(assert_expression
+  arguments: (arguments (assignment name: _ @variable.parameter))
+)
+(assert_statement
+  arguments: (arguments (assignment name: _ @variable.parameter))
+)
+
+(echo_expression
+  arguments: (arguments (assignment name: _ @variable.parameter))
+)
+(echo_expression "echo" @function.builtin)
+
+; Variables
+(parameter
+  [_ @variable.parameter (assignment name: _ @variable.parameter)]
+)
 (special_variable) @variable.builtin
+(undef) @constant.builtin
 
+; Types/Properties/
+(dot_index_expression index: (_) @variable.member)
+
+; Keywords
 [
+  "module"
   "function"
   "let"
   "assign"
+  "use"
+  "each"
+  (assert_statement "assert")
+  (assert_expression "assert")
 ] @keyword
 
-[
-  "for"
-  "each"
-  "intersection_for"
-] @keyword.control.repeat
-
-[
-  "if"
-] @keyword.control.conditional
-
-[
-  "module"
-  "use"
-  "include"
-] @keyword.control.import
-
+; Operators
 [
   "||"
   "&&"
@@ -50,15 +78,87 @@
   "/"
   "%"
   "^"
-  "?"
   "!"
   ":"
+  "="
 ] @operator
 
+; Builtin modules
+(module_call
+  name: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    "circle"
+    "color"
+    "cube"
+    "cylinder"
+    "difference"
+    "hull"
+    "intersection"
+    "linear_extrude"
+    "minkowski"
+    "mirror"
+    "multmatrix"
+    "offset"
+    "polygon"
+    "polyhedron"
+    "projection"
+    "resize"
+    "rotate"
+    "rotate_extrude"
+    "scale"
+    "sphere"
+    "square"
+    "surface"
+    "text"
+    "translate"
+    "union"
+    "echo"
+  )
+)
+(
+  (identifier) @identifier
+  (#eq? @identifier "PI")
+) @constant.builtin
+
+; Conditionals
+[
+  "if"
+  "else"
+] @keyword.conditional
+(ternary_expression
+  ["?" ":"] @keyword.conditional.ternary
+)
+
+; Repeats
+[
+  "for"
+  "intersection_for"
+] @keyword.repeat
+
+; Literals
+(integer) @number
+(float) @number.float
+(string) @string
+(escape_sequence) @string.escape
+(boolean) @boolean
+
+; Misc
+(modifier
+  [
+    "*"
+    "!"
+    "#"
+    "%"
+  ] @keyword.modifier
+)
+["{" "}"] @punctuation.bracket
+["(" ")"] @punctuation.bracket
+["[" "]"] @punctuation.bracket
 [
   ";"
   ","
   "."
 ] @punctuation.delimiter
 
-(comment) @comment
+; Comments
+[(line_comment) (block_comment)] @comment @spell

--- a/runtime/queries/openscad/highlights.scm
+++ b/runtime/queries/openscad/highlights.scm
@@ -1,7 +1,7 @@
 ; Includes
 (identifier) @variable
 
-"include" @keyword.import
+"include" @keyword.control.import
 
 (include_path) @string.special.path
 
@@ -13,7 +13,7 @@
 (function_item
   parameters: (parameters (parameter (assignment value: (_) @constant)))
 )
-(function_call name: (identifier) @function.call)
+(function_call name: (identifier) @function)
 (function_call
   arguments: (arguments (assignment name: _ @variable.parameter))
 )
@@ -22,7 +22,7 @@
 (module_item
   parameters: (parameters (parameter (assignment value: (_) @constant)))
 )
-(module_call name: (identifier) @function.method.call)
+(module_call name: (identifier) @function.method)
 (module_call
   arguments: (arguments (assignment name: _ @variable.parameter))
 )
@@ -48,7 +48,7 @@
 (undef) @constant.builtin
 
 ; Types/Properties/
-(dot_index_expression index: (_) @variable.member)
+(dot_index_expression index: (_) @variable.other.member)
 
 ; Keywords
 [
@@ -124,23 +124,23 @@
 [
   "if"
   "else"
-] @keyword.conditional
+] @keyword.control.conditional
 (ternary_expression
-  ["?" ":"] @keyword.conditional.ternary
+  ["?" ":"] @keyword.control.conditional
 )
 
 ; Repeats
 [
   "for"
   "intersection_for"
-] @keyword.repeat
+] @keyword.control.repeat
 
 ; Literals
-(integer) @number
-(float) @number.float
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
 (string) @string
-(escape_sequence) @string.escape
-(boolean) @boolean
+(escape_sequence) @constant.character.escape
+(boolean) @constant.builtin.boolean
 
 ; Misc
 (modifier
@@ -149,7 +149,7 @@
     "!"
     "#"
     "%"
-  ] @keyword.modifier
+  ] @keyword.storage.modifier
 )
 ["{" "}"] @punctuation.bracket
 ["(" ")"] @punctuation.bracket
@@ -161,4 +161,4 @@
 ] @punctuation.delimiter
 
 ; Comments
-[(line_comment) (block_comment)] @comment @spell
+[(line_comment) (block_comment)] @comment


### PR DESCRIPTION
# Use official grammar repo for OpenSCAD

References https://github.com/Leathong/openscad-LSP/issues/35

## Description

tree-sitter-openscad has moved to the https://github.com/openscad org where the NPM package, crate, and python lib are pushed from. This PR updates the grammar location for openscad to point to https://github.com/openscad/tree-sitter-openscad/
