### PR TITLE
Fix Ruby highlights

### DIFF
--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -91,6 +91,8 @@
   (instance_variable)
 ] @variable.other.member
 
+(constant) @constructor
+
 ((identifier) @constant.builtin
  (#match? @constant.builtin "^(__FILE__|__LINE__|__ENCODING__)$"))
 
@@ -99,8 +101,6 @@
 
 ((constant) @constant
  (#match? @constant "^[A-Z\\d_]+$"))
-
-(constant) @constructor
 
 (self) @variable.builtin
 (super) @function.builtin

--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -79,11 +79,12 @@
 
 ; Identifiers
 
+((identifier) @function.method
+ (#is-not? local))
+
 [
   (identifier)
 ] @variable
-((identifier) @function.method
- (#is-not? local))
 
 [
   (class_variable)

--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -123,13 +123,13 @@
 
 ; Function calls
 
+(call
+  method: [(identifier) (constant)] @function.method)
+
 ((identifier) @function.builtin
  (#match? @function.builtin "^(attr|attr_accessor|attr_reader|attr_writer|include|prepend|refine|private|protected|public)$"))
 
 "defined?" @function.builtin
-
-(call
-  method: [(identifier) (constant)] @function.method)
 
 ; Keywords
 

--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -39,6 +39,44 @@
   "%i("
 ] @punctuation.bracket
 
+; Literals
+
+[
+  (string)
+  (bare_string)
+  (subshell)
+  (heredoc_body)
+  (heredoc_beginning)
+] @string
+
+[
+  (simple_symbol)
+  (delimited_symbol)
+  (bare_symbol)
+] @string.special.symbol
+
+(pair key: ((_)":" @string.special.symbol) @string.special.symbol)
+
+(regex) @string.regexp
+(escape_sequence) @constant.character.escape
+
+[
+  (integer)
+  (float)
+] @constant.numeric.integer
+
+[
+  (nil)
+  (true)
+  (false)
+] @constant.builtin
+
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(comment) @comment
+
 ; Identifiers
 
 [
@@ -75,6 +113,23 @@
 (method_parameters (identifier) @variable.parameter)
 (block_parameter (identifier) @variable.parameter)
 (block_parameters (identifier) @variable.parameter)
+
+; Function definitions
+
+(alias (identifier) @function.method)
+(setter (identifier) @function.method)
+(method name: [(identifier) (constant)] @function.method)
+(singleton_method name: [(identifier) (constant)] @function.method)
+
+; Function calls
+
+((identifier) @function.builtin
+ (#match? @function.builtin "^(attr|attr_accessor|attr_reader|attr_writer|include|prepend|refine|private|protected|public)$"))
+
+"defined?" @function.builtin
+
+(call
+  method: [(identifier) (constant)] @function.method)
 
 ; Keywords
 
@@ -133,58 +188,3 @@
 
 ((identifier) @keyword.control.exception
  (#match? @keyword.control.exception "^(raise|fail)$"))
-
-; Function calls
-
-((identifier) @function.builtin
- (#match? @function.builtin "^(attr|attr_accessor|attr_reader|attr_writer|include|prepend|refine|private|protected|public)$"))
-
-"defined?" @function.builtin
-
-(call
-  method: [(identifier) (constant)] @function.method)
-
-; Function definitions
-
-(alias (identifier) @function.method)
-(setter (identifier) @function.method)
-(method name: [(identifier) (constant)] @function.method)
-(singleton_method name: [(identifier) (constant)] @function.method)
-
-; Literals
-
-[
-  (string)
-  (bare_string)
-  (subshell)
-  (heredoc_body)
-  (heredoc_beginning)
-] @string
-
-[
-  (simple_symbol)
-  (delimited_symbol)
-  (bare_symbol)
-] @string.special.symbol
-
-(pair key: ((_)":" @string.special.symbol) @string.special.symbol)
-
-(regex) @string.regexp
-(escape_sequence) @constant.character.escape
-
-[
-  (integer)
-  (float)
-] @constant.numeric.integer
-
-[
-  (nil)
-  (true)
-  (false)
-] @constant.builtin
-
-(interpolation
-  "#{" @punctuation.special
-  "}" @punctuation.special) @embedded
-
-(comment) @comment


### PR DESCRIPTION
A few things were no longer highlighted correctly with the highlight precedence changes in #9458:

* Some control keywords (such as `require` or `raise`) were highlighted as regular function calls
* Builtin functions (such as `include` or `attr_accessor`) were highlighted as regular function calls
* Constants were highlighted as constructors
* Local variables were not distinguished from other variables or function calls

I'm not very familiar with the syntax myself, but as the goal of #9458 was to reverse the precedence ordering, my strategy was to rearrange the higher-level groups (Keywords, Function calls, Function definitions, Identifiers, Literals, Operators) so they were fully reversed from what they were in `25.01.1`, then identify any remaining mismatches resulting from conflicts within the groups and flip them.

Left is `25.01.1`, middle is `master` ([dc4761a](https://github.com/helix-editor/helix/commit/dc4761ad3a09a1cc9a3219d75765ff098fb203af)), right is my branch (this isn't particularly useful or functional Ruby code, but it's a decent sample of the expected highlights).

![image](https://github.com/user-attachments/assets/7f02c1e3-901e-4b31-86a7-28f74f6af823)

Note there is one change from `25.01.1` that wasn't expected; a couple things are now highlighted as a local variables, which weren't before:
* `accessible_attribute`, when assigned to `attr_name` in the `SomeClass#splat_method` hash
* `e` from `rescue StandardError => e`

I wasn't able to track that one down on my own (my goal was to set things back exactly as they were in `25.01.1`), but I think this is still a clear improvement.