### PR TITLE
fix `regex` and `sql` injections in runtime/queries/rust/injections.scm

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -25,8 +25,16 @@
  (#set! injection.language "slint")
  (#set! injection.include-children))
 
-((macro_invocation
-  (token_tree) @injection.content)
+(macro_invocation
+  macro:
+    [
+      (identifier)
+      (scoped_identifier
+        path: (identifier) @_path (#not-eq? @_path "sqlx"))
+      (scoped_identifier
+        name: (identifier) @_name (#not-match? @_name "^query((_scalar|_as)(_unchecked)?)?$"))
+    ]
+  (token_tree) @injection.content
  (#set! injection.language "rust")
  (#set! injection.include-children))
 
@@ -57,7 +65,10 @@
   (token_tree
     ; Only the first argument is SQL
     .
-    [(string_literal) (raw_string_literal)] @injection.content
+    [
+      (string_literal (string_content) @injection.content)
+      (raw_string_literal (string_content)  @injection.content)
+    ]
   )
   (#set! injection.language "sql"))
 
@@ -72,6 +83,9 @@
     ; Allow anything as the first argument in case the user has lower case type
     ; names for some reason
     (_)
-    [(string_literal) (raw_string_literal)] @injection.content
+    [
+      (string_literal (string_content) @injection.content)
+      (raw_string_literal (string_content) @injection.content)
+    ]
   )
   (#set! injection.language "sql"))

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -37,16 +37,16 @@
 
 (call_expression
   function: (scoped_identifier
-    path: (identifier) @_regex (#eq? @_regex "Regex")
+    path: (identifier) @_regex (#any-of? @_regex "Regex" "RegexBuilder")
     name: (identifier) @_new (#eq? @_new "new"))
-  arguments: (arguments (raw_string_literal) @injection.content)
+  arguments: (arguments (raw_string_literal (string_content) @injection.content))
   (#set! injection.language "regex"))
 
 (call_expression
   function: (scoped_identifier
-    path: (scoped_identifier (identifier) @_regex (#eq? @_regex "Regex") .)
+    path: (scoped_identifier (identifier) @_regex (#any-of? @_regex "Regex" "RegexBuilder") .)
     name: (identifier) @_new (#eq? @_new "new"))
-  arguments: (arguments (raw_string_literal) @injection.content)
+  arguments: (arguments (raw_string_literal (string_content) @injection.content))
   (#set! injection.language "regex"))
 
 ; Highlight SQL in `sqlx::query!()`, `sqlx::query_scalar!()`, and `sqlx::query_scalar_unchecked!()`


### PR DESCRIPTION
this fixes the rust injections for `regex` and `sql` by injecting the language into the `(string_content)` instead of the outer `(raw_string_literal)`/`(string_literal)`

additionally for the `sql` injections another issue was that they were being overriden by the default "rust" injections into the `(token_tree)` of all `(macro_invocations)`, so this now filters out those specific macros.

i also wanted to add an injection for the `json!` macro, but i couldn't figure out a way to strip the leading and trailing paranthesis in the `json!({})` call to make the content actually valid json, similar to https://github.com/nvim-treesitter/nvim-treesitter/pull/7715, but (as far as i can tell) helix does not support the `(#offset! )` directive and i couldn't figure out a way to achieve this with the `(#strip! )` directive.

before:

![image](https://github.com/user-attachments/assets/732ad2ea-b923-413a-9e22-787723e5fd30)

after:

![image](https://github.com/user-attachments/assets/11d6c041-041f-4fb6-b72d-1788b2539125)