### PR TITLE
warn when configured theme is unusable for color reasons

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -115,7 +115,17 @@ impl Application {
                         e
                     })
                     .ok()
-                    .filter(|theme| (true_color || theme.is_16_color()))
+                    .filter(|theme| {
+                        let colors_ok = true_color || theme.is_16_color();
+                        if !colors_ok {
+                            log::warn!(
+                                "loaded theme `{}` but cannot use it because true color \
+                                support is not enabled",
+                                theme.name()
+                            );
+                        }
+                        colors_ok
+                    })
             })
             .unwrap_or_else(|| theme_loader.default_theme(true_color));
 
@@ -433,7 +443,17 @@ impl Application {
                         e
                     })
                     .ok()
-                    .filter(|theme| (true_color || theme.is_16_color()))
+                    .filter(|theme| {
+                        let colors_ok = true_color || theme.is_16_color();
+                        if !colors_ok {
+                            log::warn!(
+                                "loaded theme `{}` but cannot use it because true color \
+                                support is not enabled",
+                                theme.name()
+                            );
+                        }
+                        colors_ok
+                    })
             })
             .unwrap_or_else(|| self.editor.theme_loader.default_theme(true_color));
 


### PR DESCRIPTION
if `config.toml` either does not have `editor.true-color` or sets it to false, many (most?) themes stop being usable. when loading such a theme, Helix falls back to the default theme, but didn't mention this anywhere - even in `~/.cache/helix/helix.log` when run with `-v`.

if this occurs when reloading a theme at runtime with `:theme`, there's a fairly helpful error about

> `theme requires true color support`

seems worth logging about this if it happens during startup too.

i didn't see an obvious place to include a test about this, but this log shows up in my `~/.cache/helix/helix.log` in the cases i was very confused about this afternoon, and is no longer logged when i set `true-color = true` :)