### PR TITLE
languages.toml: Change wgsl_analyzer to wgsl-analyzer

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -246,7 +246,7 @@
 | wast | ✓ |  |  |  |
 | wat | ✓ |  |  | `wat_server` |
 | webc | ✓ |  |  |  |
-| wgsl | ✓ |  |  | `wgsl_analyzer` |
+| wgsl | ✓ |  |  | `wgsl-analyzer` |
 | wit | ✓ |  | ✓ |  |
 | wren | ✓ | ✓ | ✓ |  |
 | xit | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -125,7 +125,7 @@ vscode-css-language-server = { command = "vscode-css-language-server", args = ["
 vscode-html-language-server = { command = "vscode-html-language-server", args = ["--stdio"], config = { provideFormatter = true } }
 vscode-json-language-server = { command = "vscode-json-language-server", args = ["--stdio"], config = { provideFormatter = true, json = { validate = { enable = true } } } }
 vuels = { command = "vue-language-server", args = ["--stdio"], config = { typescript = { tsdk = "node_modules/typescript/lib/" } } }
-wgsl_analyzer = { command = "wgsl_analyzer" }
+wgsl-analyzer = { command = "wgsl-analyzer" }
 yaml-language-server = { command = "yaml-language-server", args = ["--stdio"] }
 yls = { command = "yls", args = ["-vv"] }
 zls = { command = "zls" }
@@ -1626,7 +1626,7 @@ scope = "source.wgsl"
 file-types = ["wgsl"]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "wgsl_analyzer" ]
+language-servers = [ "wgsl-analyzer" ]
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]


### PR DESCRIPTION
The binary name was changed in wgsl-analyzer commit [4c56b1435d30cd45d8aee52297bbf68ed5bb3beb](https://github.com/wgsl-analyzer/wgsl-analyzer/commit/4c56b1435d30cd45d8aee52297bbf68ed5bb3beb) and released in [0.9.7](https://github.com/wgsl-analyzer/wgsl-analyzer/releases/tag/v0.9.7).

I updated my [AUR packages](https://aur.archlinux.org/packages/wgsl-analyzer) to use the new executable name. Please let me know if there are problems with this change!