### PR TITLE
Update base16_transparent.toml

### DIFF
--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -8,7 +8,7 @@
 "ui.menu" = { fg = "white" }
 "ui.menu.selected" = { modifiers = ["reversed"] }
 "ui.menu.scroll" = { fg = "light-gray" }
-"ui.linenr" = { fg = "light-gray" }
+"ui.linenr" = { fg = "dim" }
 "ui.linenr.selected" = { fg = "white",  modifiers = ["bold"] }
 "ui.popup" = { fg = "white" }
 "ui.window" = { fg = "gray" }


### PR DESCRIPTION
Change `ui.linenr` to "dim" so the color can be inherithed from a higher scope (eg. the ghostty theme)

Before | After
-------|------
<img width="451" alt="before-bug" src="https://github.com/user-attachments/assets/d8135a99-6b64-4d9b-bba3-a716e69c7b0a" /> | <img width="450" alt="after-fix" src="https://github.com/user-attachments/assets/a7e168e9-f9a3-40c2-8dbc-ebb9a23ca863" />
