### PR TITLE
Accept a language's file extension as the argument to `:set-language`

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -959,16 +959,14 @@ impl Loader {
     pub fn language_config_for_file_name(&self, path: &Path) -> Option<Arc<LanguageConfiguration>> {
         // Find all the language configurations that match this file name
         // or a suffix of the file name.
-        let configuration_id = self
-            .language_config_ids_glob_matcher
+        self.language_config_ids_glob_matcher
             .language_id_for_path(path)
+            .and_then(|&id| self.language_configs.get(id).cloned())
             .or_else(|| {
                 path.extension()
                     .and_then(|extension| extension.to_str())
-                    .and_then(|extension| self.language_config_ids_by_extension.get(extension))
-            });
-
-        configuration_id.and_then(|&id| self.language_configs.get(id).cloned())
+                    .and_then(|extension| self.language_config_for_extension(extension))
+            })
 
         // TODO: content_regex handling conflict resolution
     }
@@ -1000,8 +998,17 @@ impl Loader {
     ) -> Option<Arc<LanguageConfiguration>> {
         self.language_configs
             .iter()
-            .find(|config| id.eq(&config.language_id))
+            .find(|config| id == config.language_id)
             .cloned()
+    }
+
+    pub fn language_config_for_extension(
+        &self,
+        extension: &str,
+    ) -> Option<Arc<LanguageConfiguration>> {
+        self.language_config_ids_by_extension
+            .get(extension)
+            .and_then(|&id| self.language_configs.get(id).cloned())
     }
 
     /// Unlike `language_config_for_language_id`, which only returns Some for an exact id, this

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2084,7 +2084,7 @@ fn language(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
     if &args[0] == DEFAULT_LANGUAGE_NAME {
         doc.set_language(None, None)
     } else {
-        doc.set_language_by_language_id(&args[0], cx.editor.syn_loader.clone())?;
+        doc.set_language_by_human_name(&args[0], cx.editor.syn_loader.clone())?;
     }
     doc.detect_indent_and_line_ending();
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1225,15 +1225,18 @@ impl Document {
 
     /// Set the programming language for the file if you know the language but don't have the
     /// [`syntax::LanguageConfiguration`] for it.
-    pub fn set_language_by_language_id(
+    pub fn set_language_by_human_name(
         &mut self,
-        language_id: &str,
+        name: &str,
         config_loader: Arc<ArcSwap<syntax::Loader>>,
     ) -> anyhow::Result<()> {
-        let language_config = (*config_loader)
-            .load()
-            .language_config_for_language_id(language_id)
-            .ok_or_else(|| anyhow!("invalid language id: {}", language_id))?;
+        let language_config = {
+            let config = (*config_loader).load();
+            config
+                .language_config_for_language_id(name)
+                .or_else(|| config.language_config_for_extension(name))
+                .ok_or_else(|| anyhow!("unknown language: {}", name))?
+        };
         self.set_language(Some(language_config), Some(config_loader));
         Ok(())
     }


### PR DESCRIPTION
Pretty small feature. Merely comes out of the fact I found myself intuitively attempting to execute `:lang js` etc. and being disappointed that the shorthand wasn't accepted.
