### PR TITLE
feat(ini): bumped grammar version to include support for global parameters

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2904,7 +2904,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "ini"
-source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "1b0498a89a1a4c0a3705846699f0b0bad887dd04" }
+source = { git = "https://github.com/justinmk/tree-sitter-ini", rev = "32b31863f222bf22eb43b07d4e9be8017e36fb31" }
 
 [[language]]
 name = "inko"


### PR DESCRIPTION
The `ini` tree-sitter parser was just updated to fix an issue where global parameters were preventing the entire file from being highlighted properly. This PR bumps the version that `languages.toml` points to for the grammar to include this fix. Please see the issue below for more details.

https://github.com/justinmk/tree-sitter-ini/issues/14
