### PR TITLE
feat: differentiate buffers with same name by progressively adding prior path components

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,12 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc};
+use std::{
+    mem::take,
+    num::NonZeroUsize,
+    path::{PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
+    rc::Rc,
+};
 
 use tui::{buffer::Buffer as Surface, text::Span};
 
@@ -610,7 +615,6 @@ impl EditorView {
 
     /// Render bufferline at the top
     pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) {
-        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         surface.clear_with(
             viewport,
             editor
@@ -633,13 +637,7 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = doc
-                .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let fname = Self::make_document_name(doc, editor);
 
             let style = if current_doc == doc.id() {
                 bufferline_active
@@ -658,6 +656,63 @@ impl EditorView {
             if x >= surface.area.right() {
                 break;
             }
+        }
+    }
+
+    fn make_document_name(doc: &Document, editor: &Editor) -> String {
+        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
+
+        let paths: Vec<String> = editor
+            .documents()
+            .map(|d| {
+                d.path()
+                    .unwrap_or(&scratch)
+                    .to_str()
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect();
+
+        let components: Vec<Vec<String>> = paths
+            .iter()
+            .map(|p| p.split(MAIN_SEPARATOR).map(String::from).collect())
+            .collect();
+
+        let doc_path = doc
+            .path()
+            .unwrap_or(&scratch)
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+
+        let doc_index = paths.iter().position(|p| p == &doc_path).unwrap();
+        let doc_components_len = components[doc_index].len();
+
+        let mut k = 1;
+
+        loop {
+            let start = doc_components_len.saturating_sub(k);
+            let curr_doc: Vec<&str> = components[doc_index][start..]
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+
+            let count = components
+                .iter()
+                .enumerate()
+                .filter(|&(index, _)| index != doc_index)
+                .filter(|&(_, parts)| {
+                    let len = parts.len();
+                    let start = len.saturating_sub(k);
+                    parts[start..] == curr_doc
+                })
+                .count();
+
+            if count == 0 {
+                return curr_doc.join(MAIN_SEPARATOR_STR);
+            }
+
+            k += 1;
         }
     }
 


### PR DESCRIPTION
### The Problem

In lots projects its not uncommon to have multiple files with the same name, if you have multiple of them open as separate buffers this can make navigating through them somewhat difficult. This problem gets especially bad with some web frameworks utilizing "file based routers" as for instance in the case of SvelteKit every single page is called "+page.svelte" and the directory name is the thing that actually helps you differentiate them:

![image](https://github.com/user-attachments/assets/d7a14cb9-8880-4b21-9527-3b71fb990e76)

### Solution

One fairly simple way to solve this is by progressively prefixing the buffer name with parts of the path to make it unique, which is what this PR proposes

See the following showing the same setup as before:

![image](https://github.com/user-attachments/assets/1b73e2c6-32d4-4c27-866e-32257e44a490)

Or an example from helix:

![image](https://github.com/user-attachments/assets/27c2e358-4263-42d4-88e6-e91b931d5c91)
