### PR TITLE
`tree-house`: Inject `rust` language into documentation comments when the language is not specified

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -138,6 +138,7 @@
 | make | ✓ |  | ✓ |  |
 | markdoc | ✓ |  |  | `markdoc-ls` |
 | markdown | ✓ |  |  | `marksman`, `markdown-oxide` |
+| markdown-rustdoc | ✓ |  |  |  |
 | markdown.inline | ✓ |  |  |  |
 | matlab | ✓ | ✓ | ✓ |  |
 | mermaid | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1705,6 +1705,17 @@ name = "markdown"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "62516e8c78380e3b51d5b55727995d2c511436d8", subpath = "tree-sitter-markdown" }
 
 [[language]]
+name = "markdown-rustdoc"
+scope = "source.markdown-rustdoc"
+grammar = "markdown"
+injection-regex = "markdown-rustdoc"
+file-types = []
+roots = []
+language-servers = []
+indent = { tab-width = 2, unit = "  " }
+block-comment-tokens = { start = "<!--", end = "-->" }
+
+[[language]]
 name = "markdown.inline"
 scope = "source.markdown.inline"
 injection-regex = "markdown\\.inline"

--- a/languages.toml
+++ b/languages.toml
@@ -1710,8 +1710,6 @@ scope = "source.markdown-rustdoc"
 grammar = "markdown"
 injection-regex = "markdown-rustdoc"
 file-types = []
-roots = []
-language-servers = []
 indent = { tab-width = 2, unit = "  " }
 block-comment-tokens = { start = "<!--", end = "-->" }
 

--- a/runtime/queries/markdown-rustdoc/highlights.scm
+++ b/runtime/queries/markdown-rustdoc/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: markdown

--- a/runtime/queries/markdown-rustdoc/injections.scm
+++ b/runtime/queries/markdown-rustdoc/injections.scm
@@ -8,13 +8,6 @@
   (#set! injection.language "rust")
   (#set! injection.include-unnamed-children))
 
-; cargo-script uses an embedded virtual Cargo manifest
-(fenced_code_block
-  (info_string
-    (language) @_language)
-  (code_fence_content) @injection.content
-(#eq? @_language "cargo") (#set! injection.language "toml") (#set! injection.include-unnamed-children))
-
 (fenced_code_block
   (info_string
     (language) @injection.language)

--- a/runtime/queries/markdown-rustdoc/injections.scm
+++ b/runtime/queries/markdown-rustdoc/injections.scm
@@ -1,0 +1,15 @@
+; inherits: markdown
+
+; In Rust, it is common to have documentation code blocks not specify the
+; language, and it is assumed to be Rust if it is not specified.
+
+(fenced_code_block
+  (code_fence_content) @injection.content
+  (#set! injection.language "rust")
+  (#set! injection.include-unnamed-children))
+
+(fenced_code_block
+  (info_string
+    (language) @injection.language)
+  (code_fence_content) @injection.content (#set! injection.include-unnamed-children))
+  

--- a/runtime/queries/markdown-rustdoc/injections.scm
+++ b/runtime/queries/markdown-rustdoc/injections.scm
@@ -8,6 +8,13 @@
   (#set! injection.language "rust")
   (#set! injection.include-unnamed-children))
 
+; cargo-script uses an embedded virtual Cargo manifest
+(fenced_code_block
+  (info_string
+    (language) @_language)
+  (code_fence_content) @injection.content
+(#eq? @_language "cargo") (#set! injection.language "toml") (#set! injection.include-unnamed-children))
+
 (fenced_code_block
   (info_string
     (language) @injection.language)

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -2,7 +2,7 @@
  (#set! injection.language "comment"))
 
 ((doc_comment) @injection.content
- (#set! injection.language "markdown")
+ (#set! injection.language "markdown-rustdoc")
  (#set! injection.combined))
 
 ((macro_invocation


### PR DESCRIPTION
This PR is described in https://github.com/helix-editor/helix/pull/12972#issuecomment-2725719482