### PR TITLE
Add '///' to Amber comment-token configuration

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4047,7 +4047,7 @@ source = { git = "https://gitlab.com/spade-lang/tree-sitter-spade", rev = "78bf0
 name = "amber"
 scope = "source.ab"
 file-types = ["ab"]
-comment-token = "//"
+comment-token = ["//", "///"]
 indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]


### PR DESCRIPTION
> ### [:link: Generating Amber Documentation](https://docs.amber-lang.com/0.4.0-alpha/getting_started/usage#generating-amber-documentation)
> 
> The following command extracts comments prefixed with `///` (triple slashes) from a single Amber file, and generates a Markdown file for documentation, by default in the `docs` subdirectory:
> ```sh
> $ amber docs stdlib.ab
> ```
> (https://github.com/amber-lang/amber-docs/blob/dee443f7b67f4b014a4dec307ab0aef6b584e943/docs/0.4.0-alpha/getting_started/usage.md?plain=1#L110-L116)

I missed this at my last PR.