### PR TITLE
fix: adjust spelling of simlink->symlink

### DIFF
--- a/helix-stdx/tests/path.rs
+++ b/helix-stdx/tests/path.rs
@@ -100,7 +100,7 @@ fn test_normalize_path() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         path::normalize(&path),
         expected,
-        "input {:?} and \"..\" should not erase the simlink that goes ahead",
+        "input {:?} and \"..\" should not erase the symlink that goes ahead",
         &path
     );
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -126,7 +126,7 @@ pub struct SavePoint {
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocumentOpenError {
-    #[error("path must be a regular file, simlink, or directory")]
+    #[error("path must be a regular file, symlink, or directory")]
     IrregularFile,
     #[error(transparent)]
     IoError(#[from] io::Error),


### PR DESCRIPTION
pretty straightforward, the title says it all, just a simple spelling issue.