### PR TITLE
rust-analyzer default config: exclude 'target' directory

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -188,6 +188,7 @@ inlayHints.closureReturnTypeHints.enable = "with_block"
 inlayHints.discriminantHints.enable = "fieldless"
 inlayHints.lifetimeElisionHints.enable = "skip_trivial"
 inlayHints.typeHints.hideClosureInitialization = false
+files.excludeDirs = [ "target" ]
 
 
 [language-server.typescript-language-server]


### PR DESCRIPTION
Otherwise rust-analyzer might index generated (OUT_DIR) code twice, resulting in erractic behavior.

This settings is also used by other lsp client configurations, like astronvim.

Fixes #13123