### PR TITLE
queries(scheme): consider the first argument of λ to be a variable as well

### DIFF
--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -46,7 +46,7 @@
  .
  (list
    (symbol) @variable)
- (#eq? @_f "lambda"))
+ (#any-of? @_f "lambda" "λ"))
 
 (list
  .


### PR DESCRIPTION
in a few scheme dialects `λ` and `lambda` behave the same, but the tree-sitter highlight to highlight the first argument of `lambda` as a variable instead of a `function` was only added for the `lambda` keyword. this also adds that for `λ`.

before:
![image](https://github.com/user-attachments/assets/857e95b7-d82c-4726-b314-8b36259af2d2)
![image](https://github.com/user-attachments/assets/b969209b-c181-43c5-a986-cce5bf3d7d08)

after:
![image](https://github.com/user-attachments/assets/b0c7a024-c808-40a8-960e-f3ac2bdec3cb)

(note: i am using a custom version of the solarized light theme where variables are blue and functions are violet)
(note: the "after" image was taken with the tree-house branch, as it didn't work otherwise)