### PR TITLE
Show successfully requested code actions after a failed request

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -745,9 +745,12 @@ pub fn code_action(cx: &mut Context) {
 
     cx.jobs.callback(async move {
         let mut actions = Vec::new();
-        // TODO if one code action request errors, all other requests are ignored (even if they're valid)
-        while let Some(mut lsp_items) = futures.try_next().await? {
-            actions.append(&mut lsp_items);
+
+        while let Some(output) = futures.next().await {
+            match output {
+                Ok(mut lsp_items) => actions.append(&mut lsp_items),
+                Err(err) => log::error!("while gathering code actions: {err}"),
+            }
         }
 
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {


### PR DESCRIPTION
When requesting code actions from multiple LSP servers, rather than bailing as soon as an error is encountered, instead log the error and then keep going so that successful requests can be presented to the user.

I encountered this while using `harper-ls` alongside `rust-analyzer` in Rust files, and sometimes harper starts erroring in complex documents, and it was confusing to suddenly no longer have Rust code actions available. 
