### PR TITLE
chore(worker): remove unused lifetime on `EventAccumulator`

### DIFF
--- a/helix-vcs/src/diff/worker.rs
+++ b/helix-vcs/src/diff/worker.rs
@@ -94,7 +94,7 @@ struct EventAccumulator {
     render_lock: Option<RenderLock>,
 }
 
-impl<'a> EventAccumulator {
+impl EventAccumulator {
     fn new() -> EventAccumulator {
         EventAccumulator {
             diff_base: None,


### PR DESCRIPTION
In my custom branch I remove the `rust-toolchain.toml` and this is now triggering `clippy`.