### PR TITLE
build(grammar): remove `-fPIC` flag from windows build

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -497,7 +497,7 @@ fn build_tree_sitter_library(
             .arg(format!("/out:{}", library_path.to_str().unwrap()));
     } else {
         #[cfg(not(windows))]
-        let command = command.arg("-fPIC");
+        command.arg("-fPIC");
 
         command
             .arg("-shared")
@@ -521,7 +521,7 @@ fn build_tree_sitter_library(
                     library_path.with_file_name(format!("{}_scanner.o", &grammar.grammar_id));
 
                 #[cfg(not(windows))]
-                let cpp_command = cpp_command.arg("-fPIC");
+                cpp_command.arg("-fPIC");
 
                 cpp_command
                     .arg("-fno-exceptions")

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -496,9 +496,11 @@ fn build_tree_sitter_library(
             .arg("/link")
             .arg(format!("/out:{}", library_path.to_str().unwrap()));
     } else {
+        #[cfg(not(windows))]
+        let command = command.arg("-fPIC");
+
         command
             .arg("-shared")
-            .arg("-fPIC")
             .arg("-fno-exceptions")
             .arg("-I")
             .arg(header_path)
@@ -517,8 +519,11 @@ fn build_tree_sitter_library(
                 cpp_command.args(compiler.args());
                 let object_file =
                     library_path.with_file_name(format!("{}_scanner.o", &grammar.grammar_id));
+
+                #[cfg(not(windows))]
+                let cpp_command = cpp_command.arg("-fPIC");
+
                 cpp_command
-                    .arg("-fPIC")
                     .arg("-fno-exceptions")
                     .arg("-I")
                     .arg(header_path)


### PR DESCRIPTION
Even though there is a check for `is_like_msvc`, when setting the `CXX`  environment variable to `clang++`, this will miss that check and try to use `-fPIC`, which is an invalid flag for the target.