### PR TITLE
build(Cargo): add panic=abort to `profile.opt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
+panic = "abort"
 strip = true
 opt-level = 3
 


### PR DESCRIPTION
I ran this cmd
```sh
grep -ri unwind h*
```
To see if any part of the code-base uses `catch_unwind` or relies on `unwind`ing behavior. However, dependencies may rely on `unwind`, but I'm not aware of which ones