### PR TITLE
Make `goto_word` highlights visible for Adwaita Light (same fix as #12904)

### DIFF
--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -83,6 +83,7 @@ inherits="adwaita-dark"
 "ui.text" = "dark_4"
 "ui.virtual" = "light_1"
 "ui.virtual.ruler" = { bg = "light_5"}
+"ui.virtual.jump-label" = { modifiers = ["reversed"] }
 "ui.menu" = { fg = "dark_4", bg = "light_3" }
 "ui.menu.selected" = { fg = "dark_4", bg = "blue_1" }
 "ui.menu.scroll" = { fg = "dark_6", bg = "light_3" }


### PR DESCRIPTION
I just copied the change from commit 5fac4b610eef700d22e2323bca7b4ca7e841db94 to the Adwaita Light theme.

Before on the left and after on the right.
Screenshot is Ghostty with the Adwaita theme, but GNOME Terminal shows the same before and after.

![image](https://github.com/user-attachments/assets/0f35a329-ee49-4a34-aac2-c9d7dc75b28f)