### PR TITLE
Allow `:theme` to show current theme

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2926,7 +2926,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         fun: theme,
         completer: CommandCompleter::positional(&[completers::theme]),
         signature: Signature {
-            positionals: (1, Some(1)),
+            positionals: (0, Some(1)),
             ..Signature::DEFAULT
         },
     },


### PR DESCRIPTION
Updates the signature for the command to take 0 arguments. This probably regressed during 0efa8207d86d39f9bdd54e72117ae9c8817e2cc6.