### PR TITLE
feat: add tmTheme as XML filetype

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2782,6 +2782,7 @@ file-types = [
   "rng",
   "shproj",
   "tld",
+  { glob = "*.tm[Tt]heme" },
   "tmx",
   "vbproj.user",
   "vcxproj",


### PR DESCRIPTION
This PR makes `.tmTheme` files recognized as the `xml` filetype. Note that `.tmtheme` and `.tmTheme` are both valid.
