### PR TITLE
Update golangci-lint command for v2

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -175,7 +175,7 @@ rangeVariableTypes = true
 command = "golangci-lint-langserver"
 
 [language-server.golangci-lint-lsp.config]
-command = ["golangci-lint", "run", "--out-format", "json", "--issues-exit-code=1"]
+command = ["golangci-lint", "run", "--output.json.path=stdout", "--show-stats=false", "--issues-exit-code=1"]
 
 
 [language-server.rust-analyzer]


### PR DESCRIPTION
Hello there 👋 

golangci-lint as made an [update to its v2](https://golangci-lint.run/product/changelog/#v200), which break command line arguments needed to be pass in order to work correctly in helix (or any editor I presume). This PR correct this command. I'm just wondering when it will be a good time to make it default.

PS: That my first PR, I'm sorry if its not up to standard. Its also the first occasion for me to thanks everyone who work on Helix for this great piece of software !