### PR TITLE
fix(keymap): point to proper `MappableCommand` instead of `Command`

### DIFF
--- a/helix-term/src/keymap/macros.rs
+++ b/helix-term/src/keymap/macros.rs
@@ -90,7 +90,7 @@ macro_rules! keymap {
     };
 
     (@trie [$($cmd:ident),* $(,)?]) => {
-        $crate::keymap::KeyTrie::Sequence(vec![$($crate::commands::Command::$cmd),*])
+        $crate::keymap::KeyTrie::Sequence(vec![$($crate::commands::MappableCommand::$cmd),*])
     };
 
     (


### PR DESCRIPTION
`KeyTrie::Sequence` takes a `Vec<MappableCommand>`, not any `Command`.

```rust
pub enum KeyTrie {
    MappableCommand(MappableCommand),
    Sequence(Vec<MappableCommand>),
    Node(KeyTrieNode),
}
```