### PR TITLE
Remove bg from tokyonight text

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -85,7 +85,7 @@ hint = { fg = "hint" }
 "ui.statusline.normal" = { bg = "blue", fg = "bg", modifiers = ["bold"] }
 "ui.statusline.insert" = { bg = "light-green", fg = "bg", modifiers = ["bold"] }
 "ui.statusline.select" = { bg = "magenta", fg = "bg", modifiers = ["bold"] }
-"ui.text" = { bg = "bg", fg = "fg" }
+"ui.text" = { fg = "fg" }
 "ui.text.focus" = { bg = "bg-focus" }
 "ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
 "ui.text.info" = { bg = "bg-menu", fg = "fg" }


### PR DESCRIPTION
Fixes #13215 

Previous issues: #5961 and pr #6009. I think that since this seems to affect multiple themes, there should be some lint for this (if possible). It probably affects other themes as well, I haven't checked.

Also, I'm not sure if removing the `bg` field from `"ui.text"` would cause problems elsewhere. I essentially copied the change from #6009 into tokyonight.