### PR TITLE
add a knob to configure tree sitter timeout

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -31,6 +31,14 @@ There are three possible locations for a `languages.toml` file:
    `.helix` folder. Its settings will be merged with the language configuration
    in the configuration directory and the built-in configuration.
 
+## Top level configuration
+
+These top level configuration keys are available:
+
+| Key              | Description                                                                |
+| ---              | -----------                                                                |
+| `syntax-timeout` | How long to allow tree-sitter to parse a file. Default is 500 milliseconds |
+
 ## Language configuration
 
 Each language is configured by adding a `[[language]]` section to a


### PR DESCRIPTION
- adds `syntax-timeout` to languages configuration (not tied to any specific language)
- preserves existing half-second timeout
- doing this because I have some very large KDL files I work with that take a bit longer than half a second to parse