### PR TITLE
Update crossterm, use more terminal features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,25 +237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "filedescriptor",
- "futures-core",
- "libc",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1336,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "helix-crossterm"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8938f95c101672e5084b377daac1f78ed5964c2a75046fc0d29d66cbed975f8c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "filedescriptor",
+ "futures-core",
+ "libc",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "helix-dap"
 version = "25.1.1"
 dependencies = [
@@ -1464,12 +1464,12 @@ dependencies = [
  "arc-swap",
  "chrono",
  "content_inspector",
- "crossterm",
  "fern",
  "futures-util",
  "grep-regex",
  "grep-searcher",
  "helix-core",
+ "helix-crossterm",
  "helix-dap",
  "helix-event",
  "helix-loader",
@@ -1508,8 +1508,8 @@ version = "25.1.1"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm",
  "helix-core",
+ "helix-crossterm",
  "helix-view",
  "log",
  "once_cell",
@@ -1542,9 +1542,9 @@ dependencies = [
  "bitflags",
  "chardetng",
  "clipboard-win",
- "crossterm",
  "futures-util",
  "helix-core",
+ "helix-crossterm",
  "helix-dap",
  "helix-event",
  "helix-loader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ unicode-segmentation = "1.2"
 ropey = { version = "1.6.1", default-features = false, features = ["simd"] }
 foldhash = "0.1"
 parking_lot = "0.12"
+crossterm = { package = "helix-crossterm", version = "0.1.0-beta.1" }
 
 [workspace.package]
 version = "25.1.1"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -55,7 +55,7 @@ once_cell = "1.21"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.28", features = ["event-stream"] }
+crossterm = { workspace = true, features = ["event-stream"] }
 signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
@@ -96,7 +96,7 @@ signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 libc = "0.2.171"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.28", features = ["event-stream", "use-dev-tty", "libc"] }
+crossterm = { workspace = true, features = ["event-stream", "use-dev-tty", "libc"] }
 
 [build-dependencies]
 helix-loader = { path = "../helix-loader" }

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,7 +1,7 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
 use helix_loader::merge_toml_values;
-use helix_view::document::Mode;
+use helix_view::{document::Mode, theme};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -11,7 +11,7 @@ use toml::de::Error as TomlError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: HashMap<Mode, KeyTrie>,
     pub editor: helix_view::editor::Config,
 }
@@ -19,7 +19,7 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigRaw {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: Option<HashMap<Mode, KeyTrie>>,
     pub editor: Option<toml::Value>,
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 
+use arc_swap::access::DynAccess;
 use helix_core::{
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
@@ -29,7 +30,7 @@ use helix_view::{
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
-    Document, Editor, Theme, View,
+    theme, Document, Editor, Theme, View,
 };
 use std::{mem::take, num::NonZeroUsize, path::PathBuf, rc::Rc};
 
@@ -37,6 +38,7 @@ use tui::{buffer::Buffer as Surface, text::Span};
 
 pub struct EditorView {
     pub keymaps: Keymaps,
+    theme_config: Box<dyn DynAccess<Option<theme::Config>>>,
     on_next_key: Option<(OnKeyCallback, OnKeyCallbackKind)>,
     pseudo_pending: Vec<KeyEvent>,
     pub(crate) last_insert: (commands::MappableCommand, Vec<InsertEvent>),
@@ -58,9 +60,13 @@ pub enum InsertEvent {
 }
 
 impl EditorView {
-    pub fn new(keymaps: Keymaps) -> Self {
+    pub fn new(
+        keymaps: Keymaps,
+        theme_config: impl DynAccess<Option<theme::Config>> + 'static,
+    ) -> Self {
         Self {
             keymaps,
+            theme_config: Box::new(theme_config),
             on_next_key: None,
             pseudo_pending: Vec::new(),
             last_insert: (commands::MappableCommand::normal_mode, Vec::new()),
@@ -1533,6 +1539,18 @@ impl Component for EditorView {
                     }
                 }
                 self.terminal_focused = false;
+                EventResult::Consumed(None)
+            }
+            Event::ThemeModeChanged(theme_mode) => {
+                if let Some(theme_config) = self.theme_config.load().as_ref() {
+                    let theme_name = theme_config.choose(Some(*theme_mode));
+                    match context.editor.theme_loader.load(theme_name) {
+                        Ok(theme) => context.editor.set_theme(theme),
+                        Err(err) => {
+                            log::warn!("failed to load theme `{}` - {}", theme_name, err);
+                        }
+                    }
+                }
                 EventResult::Consumed(None)
             }
         }

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -21,7 +21,7 @@ helix-core = { path = "../helix-core" }
 bitflags.workspace = true
 cassowary = "0.3"
 unicode-segmentation.workspace = true
-crossterm = { version = "0.28", optional = true }
+crossterm = { workspace = true, optional = true }
 termini = "1.0"
 once_cell = "1.21"
 log = "~0.4"

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -2,7 +2,10 @@ use std::io;
 
 use crate::{buffer::Cell, terminal::Config};
 
-use helix_view::graphics::{CursorKind, Rect};
+use helix_view::{
+    graphics::{CursorKind, Rect},
+    theme,
+};
 
 #[cfg(feature = "crossterm")]
 mod crossterm;
@@ -27,4 +30,5 @@ pub trait Backend {
     fn clear(&mut self) -> Result<(), io::Error>;
     fn size(&self) -> Result<Rect, io::Error>;
     fn flush(&mut self) -> Result<(), io::Error>;
+    fn get_theme_mode(&self) -> Option<theme::Mode>;
 }

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -164,4 +164,8 @@ impl Backend for TestBackend {
     fn flush(&mut self) -> Result<(), io::Error> {
         Ok(())
     }
+
+    fn get_theme_mode(&self) -> Option<helix_view::theme::Mode> {
+        None
+    }
 }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -26,7 +26,7 @@ helix-vcs = { path = "../helix-vcs" }
 
 bitflags.workspace = true
 anyhow = "1"
-crossterm = { version = "0.28", optional = true }
+crossterm = { workspace = true, optional = true }
 
 tempfile.workspace = true
 

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -5,6 +5,7 @@ use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 
 pub use crate::keyboard::{KeyCode, KeyModifiers, MediaKeyCode, ModifierKeyCode};
+use crate::theme;
 
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 pub enum Event {
@@ -14,6 +15,7 @@ pub enum Event {
     Mouse(MouseEvent),
     Paste(String),
     Resize(u16, u16),
+    ThemeModeChanged(theme::Mode),
     IdleTimeout,
 }
 
@@ -468,6 +470,12 @@ impl From<crossterm::event::Event> for Event {
             crossterm::event::Event::FocusGained => Self::FocusGained,
             crossterm::event::Event::FocusLost => Self::FocusLost,
             crossterm::event::Event::Paste(s) => Self::Paste(s),
+            crossterm::event::Event::ThemeModeChanged(theme_mode) => {
+                Self::ThemeModeChanged(match theme_mode {
+                    crossterm::event::ThemeMode::Light => theme::Mode::Light,
+                    crossterm::event::ThemeMode::Dark => theme::Mode::Dark,
+                })
+            }
         }
     }
 }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -35,6 +35,50 @@ pub static BASE16_DEFAULT_THEME: Lazy<Theme> = Lazy::new(|| Theme {
     ..Theme::from(BASE16_DEFAULT_THEME_DATA.clone())
 });
 
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum Mode {
+    Light,
+    Dark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    light: String,
+    dark: String,
+}
+
+impl Config {
+    pub fn choose(&self, preference: Option<Mode>) -> &str {
+        match preference {
+            Some(Mode::Light) => &self.light,
+            Some(Mode::Dark) | None => &self.dark,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged, deny_unknown_fields)]
+        enum InnerConfig {
+            Constant(String),
+            Adaptive { dark: String, light: String },
+        }
+
+        let inner = InnerConfig::deserialize(deserializer)?;
+
+        let (light, dark) = match inner {
+            InnerConfig::Constant(theme) => (theme.clone(), theme),
+            InnerConfig::Adaptive { light, dark } => (light, dark),
+        };
+
+        Ok(Self { light, dark })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Loader {
     /// Theme directories to search from highest to lowest priority


### PR DESCRIPTION
This is a rollup of a few crossterm related changes. It also switches us to use https://github.com/helix-editor/crossterm instead of upstream crossterm - the idea is to maintain a soft fork where we can experiment with features before sending them upstream.

* This includes https://github.com/helix-editor/helix/pull/12362 (fixes #8899, fixes #13281)
* Handling of terminal emulators that partially support the kitty keyboard protocol is improved (i.e. we turn off the feature if flags we need aren't enabled, fixes #12232)
* Detection of all features (kitty keyboard protocol, synchronized output, theme modes) is done in a single query to the terminal which keeps startup latency low
* Render with synchronized output sequences (fixes #731)