### PR TITLE
fix(crossterm): When no `terminfo` check if `WezTerm` for undercurl

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -77,7 +77,8 @@ impl Capabilities {
     pub fn from_env_or_default(config: &EditorConfig) -> Self {
         match termini::TermInfo::from_env() {
             Err(_) => Capabilities {
-                has_extended_underlines: config.undercurl,
+                has_extended_underlines: config.undercurl
+                    || matches!(term_program().as_deref(), Some("WezTerm")),
                 ..Capabilities::default()
             },
             Ok(t) => Capabilities {


### PR DESCRIPTION
On `windows` `TermInfo::from_env` (I believe) always fails, so this currently can only be activated by the config option, even if the terminal supports it. We could just leave it at that (and close this PR), or add a list of names of terminals that would support it on platforms like `windows` (which this PR does with `WezTerm`) so that it works out of the box. `true-color` support I beleive is specialized to always return `true` on `windows`, so there is precedent for things like this:

```rust
// helix-term/src/lib.rs
#[cfg(windows)]
fn true_color() -> bool {
    true
}
```