### PR TITLE
feat: add ConsoleOnly to desktop entry categories

### DIFF
--- a/contrib/Helix.desktop
+++ b/contrib/Helix.desktop
@@ -86,6 +86,6 @@ Keywords[ru]=текст;текстовый редактор;
 Keywords[sr]=Текст;едитор;
 Keywords[tr]=Metin;düzenleyici;
 Icon=helix
-Categories=Utility;TextEditor;
+Categories=Utility;TextEditor;ConsoleOnly
 StartupNotify=false
 MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;


### PR DESCRIPTION
I was grouping apps based on categories and noticed that desktop entry file is missing ConsoleOnly in categories. So I have just added that.

Thanks!