### PR TITLE
Debian control file syntax highlighting

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -36,6 +36,7 @@
 | d | ✓ | ✓ | ✓ | `serve-d` |
 | dart | ✓ | ✓ | ✓ | `dart` |
 | dbml | ✓ |  |  |  |
+| debian | ✓ |  |  |  |
 | devicetree | ✓ |  |  |  |
 | dhall | ✓ | ✓ |  | `dhall-lsp-server` |
 | diff | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4255,3 +4255,18 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "werk"
 source = { git = "https://github.com/little-bonsai/tree-sitter-werk", rev = "92b0f7fe98465c4c435794a58e961306193d1c1e" }
+
+[[language]]
+name = "debian"
+scope = "text.debian"
+file-types = [
+  "dsc",
+  "changes",
+  { glob = "debian/**/control" },
+  { glob = "etc/apt/sources.list.d/*.sources"}
+]
+comment-tokens = "#"
+
+[[grammar]]
+name = "debian"
+source = { git = "https://gitlab.com/MggMuggins/tree-sitter-debian", rev = "9b3f4b78c45aab8a2f25a5f9e7bbc00995bc3dde" }

--- a/runtime/queries/debian/highlights.scm
+++ b/runtime/queries/debian/highlights.scm
@@ -1,0 +1,2 @@
+(comment) @comment
+(field_name) @tag


### PR DESCRIPTION
Thanks for Helix! Would love colors for Debian metadata as I'm reading them often.

File format described at https://www.debian.org/doc/debian-policy/ch-controlfields.html

The grammar is pretty basic at the moment but I'm hoping to add specific AST nodes for things like version specifiers at some point.