### PR TITLE
 Update mint lsp command args 

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -68,7 +68,7 @@ markdown-oxide = { command = "markdown-oxide" }
 marksman = { command = "marksman", args = ["server"] }
 metals = { command = "metals", config = { "isHttpEnabled" = true, metals = { inlayHints = { typeParameters = {enable = true} , hintsInPatternMatch = {enable = true} }  } } }
 mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
-mint = { command = "mint", args = ["ls"] }
+mint = { command = "mint", args = ["tool" "ls"] }
 mojo-lsp = { command = "magic", args = ["run", "mojo-lsp-server"] }
 nil = { command = "nil" }
 nimlangserver = { command = "nimlangserver" }

--- a/languages.toml
+++ b/languages.toml
@@ -68,7 +68,7 @@ markdown-oxide = { command = "markdown-oxide" }
 marksman = { command = "marksman", args = ["server"] }
 metals = { command = "metals", config = { "isHttpEnabled" = true, metals = { inlayHints = { typeParameters = {enable = true} , hintsInPatternMatch = {enable = true} }  } } }
 mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
-mint = { command = "mint", args = ["tool" "ls"] }
+mint = { command = "mint", args = ["tool", "ls"] }
 mojo-lsp = { command = "magic", args = ["run", "mojo-lsp-server"] }
 nil = { command = "nil" }
 nimlangserver = { command = "nimlangserver" }


### PR DESCRIPTION
Hi,

The Mint language now keeps the lsp server under the `tool` subcommand.

This PR updates the mint lsp command args to reflect this change.

https://mint-lang.com/guides/cli/tool-ls