### PR TITLE
Added: missing highlighting to `queries/_typescript`

### DIFF
--- a/runtime/queries/_typescript/highlights.scm
+++ b/runtime/queries/_typescript/highlights.scm
@@ -64,6 +64,10 @@
   (array_pattern
     (identifier) @variable.parameter))
 
+(public_field_definition) @punctuation.special
+(this_type) @variable.builtin
+(type_predicate) @keyword.operator
+
 ; Punctuation
 ; -----------
 
@@ -82,6 +86,7 @@
 [
   "abstract"
   "declare"
+  "module"
   "export"
   "infer"
   "implements"
@@ -127,9 +132,16 @@
     ">"
   ] @punctuation.bracket)
 
+(omitting_type_annotation) @punctuation.special
+(opting_type_annotation) @punctuation.special
+
 ; Literals
 ; --------
 
 [
   (template_literal_type)
 ] @string
+
+(import_require_clause
+  (identifier) "="
+  ("require") @keyword)

--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -74,16 +74,12 @@
 [
   "async"
   "debugger"
-  "delete"
   "extends"
   "from"
   "get"
   "new"
   "set"
   "target"
-  "typeof"
-  "instanceof"
-  "void"
   "with"
 ] @keyword
 
@@ -91,6 +87,10 @@
   "of"
   "as"
   "in"
+  "delete"
+  "typeof"
+  "instanceof"
+  "void"
 ] @keyword.operator
 
 [


### PR DESCRIPTION
Before:
<img src="https://github.com/user-attachments/assets/62dd093c-1161-40d4-b260-708363648893" width="500">

After:
<img src="https://github.com/user-attachments/assets/49ebe157-aad8-4a51-9941-e7b61bd940aa" width="500">


This one, I couldn't highlight (bug in parser?)
![image](https://github.com/user-attachments/assets/a0ee9b68-1504-4ecf-8e0d-7c0481399745)

Please, advise me if anything needs adjustments.

---

And in `queries/ecma` - I was wondering, why `delete`, `typeof`, `instanceof`, and `void` are in `@keyword` category, shouldn't they be in `@keyword.operator`?
<img src="https://github.com/user-attachments/assets/5efa735d-9b1d-4100-ab8e-ac325280a0df" width="200">


