### PR TITLE
Fix  typo in ada queries

### DIFF
--- a/runtime/queries/ada/highlights.scm
+++ b/runtime/queries/ada/highlights.scm
@@ -75,7 +75,7 @@
    "parallel"
    "reverse"
    "some"
-] @kewyord.control.repeat
+] @keyword.control.repeat
 [
    "return"
 ] @keyword.control.return
@@ -113,7 +113,6 @@
 
 (loop_statement "end" @keyword.control.repeat)
 (if_statement "end" @keyword.control.conditional)
-(loop_parameter_specification "in" @keyword.control.repeat)
 (loop_parameter_specification "in" @keyword.control.repeat)
 (iterator_specification ["in" "of"] @keyword.control.repeat)
 (range_attribute_designator "range" @keyword.control.repeat)


### PR DESCRIPTION
Accidentally found a typo in capture group for `queries/ada`, and removed a duplicate query