### PR TITLE
LSP: when picking lsp_root use nearest root marker

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -971,11 +971,12 @@ pub fn find_lsp_workspace(
 
     let mut top_marker = None;
     for ancestor in file.ancestors() {
-        if root_markers
-            .iter()
-            .any(|marker| ancestor.join(marker).exists())
+        if top_marker.is_none()
+            && root_markers
+                .iter()
+                .any(|marker| ancestor.join(marker).exists())
         {
-            top_marker = Some(ancestor);
+            top_marker.replace(ancestor);
         }
 
         if root_dirs


### PR DESCRIPTION
Given some project tree:
```
workspace
`- Cargo.toml
 - sub-project
   ` Cargo.toml
   ` main.rs
```
If we try to open `main.rs` lsp root detected would be the whole workspace, but I think the whole point of having root markers is to be able to find nearest project to the file, not the furthest 