### PR TITLE
refactor(statusline): reverse error and warning diagnostic order

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -240,15 +240,6 @@ where
             counts
         });
 
-    if warnings > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
-    }
-
     if errors > 0 {
         write(
             context,
@@ -256,6 +247,15 @@ where
             Some(context.editor.theme.get("error")),
         );
         write(context, format!(" {} ", errors), None);
+    }
+
+    if warnings > 0 {
+        write(
+            context,
+            "●".to_string(),
+            Some(context.editor.theme.get("warning")),
+        );
+        write(context, format!(" {} ", warnings), None);
     }
 }
 
@@ -282,15 +282,6 @@ where
         write(context, " W ".into(), None);
     }
 
-    if warnings > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
-    }
-
     if errors > 0 {
         write(
             context,
@@ -298,6 +289,15 @@ where
             Some(context.editor.theme.get("error")),
         );
         write(context, format!(" {} ", errors), None);
+    }
+
+    if warnings > 0 {
+        write(
+            context,
+            "●".to_string(),
+            Some(context.editor.theme.get("warning")),
+        );
+        write(context, format!(" {} ", warnings), None);
     }
 }
 


### PR DESCRIPTION
This is something I do in my own branch, but thought I would upstream it. Im not sure about others, but this just clicks better for my brain.

![image](https://github.com/user-attachments/assets/4e0694e2-2626-46b3-a8a6-a76c125e1296)
