### PR TITLE
Basic language support for Fennel.  Might even work.

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -57,6 +57,7 @@
 | erb | ✓ |  |  |  |
 | erlang | ✓ | ✓ |  | `erlang_ls`, `elp` |
 | esdl | ✓ |  |  |  |
+| fennel | ✓ |  |  | `fennel-ls` |
 | fga | ✓ | ✓ | ✓ |  |
 | fidl | ✓ |  |  |  |
 | fish | ✓ | ✓ | ✓ | `fish-lsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -409,8 +409,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "fennel"
-source.git = "https://github.com/alexmozaidze/tree-sitter-fennel"
-source.rev = "ea4a536bca8997e30b22709f210f44f97e75bf7d"
+source = { git = "https://github.com/alexmozaidze/tree-sitter-fennel", rev = "ea4a536bca8997e30b22709f210f44f97e75bf7d" }
 
 [[language]]
 name = "fish"

--- a/languages.toml
+++ b/languages.toml
@@ -400,7 +400,7 @@ source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "02a
 [[language]]
 name = "fennel"
 scope = "source.fennel"
-file-types = ["fnl"]
+file-types = ["fnl", "fnlm"]
 shebangs = ["fennel"]
 comment-token = ";"
 language-servers = ["fennel-ls"]

--- a/languages.toml
+++ b/languages.toml
@@ -39,6 +39,7 @@ elm-language-server = { command = "elm-language-server" }
 elp = { command = "elp", args = ["server"] }
 elvish = { command = "elvish", args = ["-lsp"] }
 erlang-ls = { command = "erlang_ls" }
+fennel-ls = { command = "fennel-ls" }
 fish-lsp = { command = "fish-lsp", args = ["start"], environment = { fish_lsp_show_client_popups = "false" } }
 forc = { command = "forc", args = ["lsp"] }
 forth-lsp = { command = "forth-lsp" }
@@ -395,6 +396,21 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "elixir"
 source = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "02a6f7fd4be28dd94ee4dd2ca19cb777053ea74e" }
+
+[[language]]
+name = "fennel"
+scope = "source.fennel"
+file-types = ["fnl"]
+shebangs = ["fennel"]
+comment-token = ";"
+language-servers = ["fennel-ls"]
+formatter = { command = "fnlfmt", args = ["-"]}
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "fennel"
+source.git = "https://github.com/alexmozaidze/tree-sitter-fennel"
+source.rev = "ea4a536bca8997e30b22709f210f44f97e75bf7d"
 
 [[language]]
 name = "fish"

--- a/languages.toml
+++ b/languages.toml
@@ -409,7 +409,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "fennel"
-source = { git = "https://github.com/alexmozaidze/tree-sitter-fennel", rev = "ea4a536bca8997e30b22709f210f44f97e75bf7d" }
+source = { git = "https://github.com/alexmozaidze/tree-sitter-fennel", rev = "cfbfa478dc2dbef267ee94ae4323d9c886f45e94" }
 
 [[language]]
 name = "fish"

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -88,11 +88,11 @@
 
 ; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
 ([
-  (symbol) @module.builtin
+  (symbol) @variable.builtin
   (multi_symbol
-    base: (symbol_fragment) @module.builtin)
+    base: (symbol_fragment) @variable.builtin)
 ]
-  (#any-of? @module.builtin
+  (#any-of? @variable.builtin
     "vim" "_G" "_ENV" "debug" "io" "jit" "math" "os" "package" "string" "table" "utf8"))
 
 ([

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -1,7 +1,7 @@
 ; Most primitive nodes
 (shebang) @keyword.directive
 
-(comment) @comment @spell
+(comment) @comment
 
 (fn_form
   name: [

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -1,0 +1,196 @@
+; Most primitive nodes
+(shebang) @keyword.directive
+
+(comment) @comment @spell
+
+(fn_form
+  name: [
+    (symbol) @function
+    (multi_symbol
+      member: (symbol_fragment) @function .)
+  ])
+
+(lambda_form
+  name: [
+    (symbol) @function
+    (multi_symbol
+      member: (symbol_fragment) @function .)
+  ])
+
+((symbol) @operator
+  (#any-of? @operator
+    ; arithmetic
+    "+" "-" "*" "/" "//" "%" "^"
+    ; comparison
+    ">" "<" ">=" "<=" "=" "~="
+    ; other
+    "#" "." "?." ".."))
+
+((symbol) @keyword.operator
+  (#any-of? @keyword.operator
+    ; comparison
+    "not="
+    ; boolean
+    "and" "or" "not"
+    ; bitwise
+    "lshift" "rshift" "band" "bor" "bxor" "bnot"
+    ; other
+    "length"))
+
+(case_guard
+  call: (_) @keyword.conditional)
+
+(case_guard_or_special
+  call: (_) @keyword.conditional)
+
+(case_catch
+  call: (symbol) @keyword)
+
+(import_macros_form
+  imports: (table_binding
+    (table_binding_pair
+      value: (symbol_binding) @function.macro)))
+
+
+((symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
+
+((symbol) @keyword.repeat
+  (#any-of? @keyword.repeat "for" "each" "while"))
+
+((symbol) @keyword.conditional
+  (#any-of? @keyword.conditional "if" "when" "match" "case" "match-try" "case-try"))
+
+((symbol) @keyword
+  (#any-of? @keyword
+    "global" "local" "let" "set" "var" "comment" "do" "doc" "eval-compiler" "lua" "macros" "unquote"
+    "quote" "tset" "values" "tail!"))
+
+((symbol) @keyword.import
+  (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
+
+((symbol) @function.macro
+  (#any-of? @function.macro
+    "collect" "icollect" "fcollect" "accumulate" "faccumulate" "->" "->>" "-?>" "-?>>" "?." "doto"
+    "macro" "macrodebug" "partial" "pick-args" "pick-values" "with-open"))
+
+((symbol) @variable.builtin
+  (#eq? @variable.builtin "..."))
+
+((symbol) @constant.builtin
+  (#eq? @constant.builtin "_VERSION"))
+
+((symbol) @function.builtin
+  (#any-of? @function.builtin
+    "assert" "collectgarbage" "dofile" "error" "getmetatable" "ipairs" "load" "loadfile" "next"
+    "pairs" "pcall" "print" "rawequal" "rawget" "rawlen" "rawset" "require" "select" "setmetatable"
+    "tonumber" "tostring" "type" "warn" "xpcall" "module" "setfenv" "loadstring" "unpack"))
+
+; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
+([
+  (symbol) @module.builtin
+  (multi_symbol
+    base: (symbol_fragment) @module.builtin)
+]
+  (#any-of? @module.builtin
+    "vim" "_G" "_ENV" "debug" "io" "jit" "math" "os" "package" "string" "table" "utf8"))
+
+([
+  (symbol) @variable.builtin
+  (multi_symbol
+    .
+    (symbol_fragment) @variable.builtin)
+]
+  (#eq? @variable.builtin "arg"))
+(symbol_option) @keyword.directive
+
+(escape_sequence) @string.escape
+
+(multi_symbol
+  "." @punctuation.delimiter
+  member: (symbol_fragment) @variable.member)
+
+(list
+  call: (symbol) @function.call)
+
+(list
+  call: (multi_symbol
+    member: (symbol_fragment) @function.call .))
+
+(multi_symbol_method
+  ":" @punctuation.delimiter
+  method: (symbol_fragment) @function.method.call)
+
+(quasi_quote_reader_macro
+  macro: _ @punctuation.special)
+
+(quote_reader_macro
+  macro: _ @punctuation.special)
+
+(unquote_reader_macro
+  macro: _ @punctuation.special)
+
+[ ":" ":until" "&" "&as" "?" ] @punctuation.special
+(vararg) @punctuation.special
+
+(hashfn_reader_macro
+  macro: _ @keyword.function)
+
+(docstring) @string.documentation
+
+; NOTE: The macro name is highlighted as @variable because it
+; gives a nicer contrast instead of everything being the same
+; color. Rust queries use this workaround too for `macro_rules!`.
+(macro_form
+  name: [
+    (symbol) @variable
+    (multi_symbol
+      member: (symbol_fragment) @variable .)
+  ])
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+(sequence_arguments
+  (symbol_binding) @variable.parameter)
+
+(sequence_arguments
+  (rest_binding
+    rhs: (symbol_binding) @variable.parameter))
+
+((symbol) @variable.parameter
+  (#any-of? @variable.parameter "$" "$..."))
+
+((symbol) @variable.parameter
+  (#any-of? @variable.parameter "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"))
+
+[
+  (nil)
+  (nil_binding)
+] @constant.builtin
+
+[
+  (boolean)
+  (boolean_binding)
+] @boolean
+
+[
+  (number)
+  (number_binding)
+] @number
+
+[
+  (string)
+  (string_binding)
+] @string
+
+[
+  (symbol)
+  (symbol_binding)
+] @variable

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -38,10 +38,10 @@
     "length"))
 
 (case_guard
-  call: (_) @keyword.conditional)
+  call: (_) @keyword.control.conditional)
 
 (case_guard_or_special
-  call: (_) @keyword.conditional)
+  call: (_) @keyword.control.conditional)
 
 (case_catch
   call: (symbol) @keyword)
@@ -55,19 +55,19 @@
 ((symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
 
-((symbol) @keyword.repeat
-  (#any-of? @keyword.repeat "for" "each" "while"))
+((symbol) @keyword.control.repeat
+  (#any-of? @keyword.control.repeat "for" "each" "while"))
 
-((symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "if" "when" "match" "case" "match-try" "case-try"))
+((symbol) @keyword.control.conditional
+  (#any-of? @keyword.control.conditional "if" "when" "match" "case" "match-try" "case-try"))
 
 ((symbol) @keyword
   (#any-of? @keyword
     "global" "local" "let" "set" "var" "comment" "do" "doc" "eval-compiler" "lua" "macros" "unquote"
     "quote" "tset" "values" "tail!"))
 
-((symbol) @keyword.import
-  (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
+((symbol) @keyword.control.import
+  (#any-of? @keyword.control.import "require" "require-macros" "import-macros" "include"))
 
 ((symbol) @function.macro
   (#any-of? @function.macro
@@ -104,22 +104,22 @@
   (#eq? @variable.builtin "arg"))
 (symbol_option) @keyword.directive
 
-(escape_sequence) @string.escape
+(escape_sequence) @constant.character.escape
 
 (multi_symbol
   "." @punctuation.delimiter
-  member: (symbol_fragment) @variable.member)
+  member: (symbol_fragment) @variable.other.member)
 
 (list
-  call: (symbol) @function.call)
+  call: (symbol) @function)
 
 (list
   call: (multi_symbol
-    member: (symbol_fragment) @function.call .))
+    member: (symbol_fragment) @function .))
 
 (multi_symbol_method
   ":" @punctuation.delimiter
-  method: (symbol_fragment) @function.method.call)
+  method: (symbol_fragment) @function.method)
 
 (quasi_quote_reader_macro
   macro: _ @punctuation.special)
@@ -136,7 +136,7 @@
 (hashfn_reader_macro
   macro: _ @keyword.function)
 
-(docstring) @string.documentation
+(docstring) @comment.block.documentation
 
 ; NOTE: The macro name is highlighted as @variable because it
 ; gives a nicer contrast instead of everything being the same
@@ -178,12 +178,12 @@
 [
   (boolean)
   (boolean_binding)
-] @boolean
+] @constant.builtin.boolean
 
 [
   (number)
   (number_binding)
-] @number
+] @constant.numeric
 
 [
   (string)

--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -130,9 +130,6 @@
 (unquote_reader_macro
   macro: _ @punctuation.special)
 
-[ ":" ":until" "&" "&as" "?" ] @punctuation.special
-(vararg) @punctuation.special
-
 (hashfn_reader_macro
   macro: _ @keyword.function)
 


### PR DESCRIPTION
Closes https://github.com/helix-editor/helix/issues/3846 .  After pondering it (for two years) it seems obvious that having a single grammar that tries to cover multiple Lisps is silly.

There are two different tree-sitter parsers for Fennel mentioned in that issue:

 * https://github.com/travonted/tree-sitter-fennel
 * https://github.com/alexmozaidze/tree-sitter-fennel

This PR has mostly-arbitrarily chosen the second one.  There's also several different `highlights.scm` options, I've mostly chosen the most recent one but tried to incorporate bits and pieces from the others where I could find them.