### PR TITLE
feat: add ! alias for sh and | for pipe

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3442,7 +3442,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "pipe",
-        aliases: &[],
+        aliases: &["|"],
         doc: "Pipe each selection to the shell command.",
         fun: pipe,
         completer: SHELL_COMPLETER,
@@ -3458,7 +3458,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "run-shell-command",
-        aliases: &["sh"],
+        aliases: &["sh", "!"],
         doc: "Run a shell command",
         fun: run_shell_command,
         completer: SHELL_COMPLETER,


### PR DESCRIPTION
I've added two aliases:

1. `!` for `sh` (or `run-shell-command`)
2. `|` for `pipe`

*I've had these aliases patched into my own build for a while now, I think it's time everyone can enjoy them.*