### PR TITLE
fix(lints): clippy 1.86

### DIFF
--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -65,7 +65,7 @@ pub fn print(s: &str) -> (String, Selection) {
         let head_at_beg = iter.next_if_eq(&"|").is_some();
         let last_grapheme = |s: &str| {
             UnicodeSegmentation::graphemes(s, true)
-                .last()
+                .next_back()
                 .map(String::from)
         };
 

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -39,7 +39,7 @@ fn workspace_for_uri(uri: lsp::Url) -> WorkspaceFolder {
     lsp::WorkspaceFolder {
         name: uri
             .path_segments()
-            .and_then(|segments| segments.last())
+            .and_then(|mut segments| segments.next_back())
             .map(|basename| basename.to_string())
             .unwrap_or_default(),
         uri,

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -732,7 +732,7 @@ impl Component for Prompt {
     fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
         let area = area
             .clip_left(self.prompt.len() as u16)
-            .clip_right(if self.prompt.len() > 0 { 0 } else { 2 });
+            .clip_right(if self.prompt.is_empty() { 2 } else { 0 });
 
         let anchor = self.anchor.min(self.line.len().saturating_sub(1));
         let mut col = area.left() as usize

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -854,7 +854,7 @@ impl Document {
                 } else if !output.stderr.is_empty() {
                     log::debug!(
                         "Formatter printed to stderr: {}",
-                        String::from_utf8_lossy(&output.stderr).to_string()
+                        String::from_utf8_lossy(&output.stderr)
                     );
                 }
 

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -145,7 +145,8 @@ impl Registers {
     }
 
     pub fn last<'a>(&'a self, name: char, editor: &'a Editor) -> Option<Cow<'a, str>> {
-        self.read(name, editor).and_then(|values| values.last())
+        self.read(name, editor)
+            .and_then(|mut values| values.next_back())
     }
 
     pub fn iter_preview(&self) -> impl Iterator<Item = (char, &str)> {


### PR DESCRIPTION
In particular, for the [`next_back`](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last) change:
> `Iterator::last` is implemented by consuming the iterator, which is unnecessary if the iterator is a `DoubleEndedIterator`. Since Rust traits do not allow specialization, `Iterator::last` cannot be optimized for `DoubleEndedIterator`.