### PR TITLE
Add WESL language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -248,6 +248,7 @@
 | wat | ✓ |  |  | `wat_server` |
 | webc | ✓ |  |  |  |
 | werk | ✓ |  |  |  |
+| wesl | ✓ | ✓ |  |  |
 | wgsl | ✓ |  |  | `wgsl-analyzer` |
 | wit | ✓ |  | ✓ |  |
 | wren | ✓ | ✓ | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1621,6 +1621,18 @@ name = "comment"
 source = { git = "https://github.com/stsewd/tree-sitter-comment", rev = "aefcc2813392eb6ffe509aa0fc8b4e9b57413ee1" }
 
 [[language]]
+name = "wesl"
+scope = "source.wesl"
+file-types = ["wesl"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "wesl"
+source = { git = "https://github.com/wgsl-tooling-wg/tree-sitter-wesl", rev = "94ee6122680ef8ce2173853ca7c99f7aaeeda8ce" }
+
+[[language]]
 name = "wgsl"
 scope = "source.wgsl"
 file-types = ["wgsl"]

--- a/runtime/queries/wesl/highlights.scm
+++ b/runtime/queries/wesl/highlights.scm
@@ -1,0 +1,168 @@
+; reserved: must not be used in source code. https://www.w3.org/TR/WGSL/#reserved-words
+
+; ((identifier) @special
+;   (#any-of? @special
+;   "NULL" "Self" "abstract" "active" "alignas" "alignof" "as" "asm"
+; "asm_fragment" "async" "attribute" "auto" "await" "become" "binding_array"
+; "cast" "catch" "class" "co_await" "co_return" "co_yield" "coherent"
+; "column_major" "common" "compile" "compile_fragment" "concept" "const_cast"
+; "consteval" "constexpr" "constinit" "crate" "debugger" "decltype" "delete"
+; "demote" "demote_to_helper" "do" "dynamic_cast" "enum" "explicit" "export"
+; "extends" "extern" "external" "fallthrough" "filter" "final" "finally" "friend"
+; "from" "fxgroup" "get" "goto" "groupshared" "highp" "impl" "implements" "import"
+; "inline" "instanceof" "interface" "layout" "lowp" "macro" "macro_rules" "match"
+; "mediump" "meta" "mod" "module" "move" "mut" "mutable" "namespace" "new"
+; "nil" "noexcept" "noinline" "nointerpolation" "non_coherent" "noncoherent"
+; "noperspective" "null" "nullptr" "of" "operator" "package" "packoffset"
+; "partition" "pass" "patch" "pixelfragment" "precise" "precision" "premerge"
+; "priv" "protected" "pub" "public" "readonly" "ref" "regardless" "register"
+; "reinterpret_cast" "require" "resource" "restrict" "self" "set" "shared"
+; "sizeof" "smooth" "snorm" "static" "static_assert" "static_cast" "std"
+; "subroutine" "super" "target" "template" "this" "thread_local" "throw" "trait"
+; "try" "type" "typedef" "typeid" "typename" "typeof" "union" "unless" "unorm"
+; "unsafe" "unsized" "use" "using" "varying" "virtual" "volatile" "wgsl" "where"
+; "with" "writeonly" "yield"))
+
+; comments
+
+(line_comment) @comment.line
+(block_comment) @comment.block
+
+; imports (WESL extension)
+
+(import_item (identifier) @type
+  (#match? @type "^[A-Z]"))
+
+(import_item (identifier) @constant
+  (#match? @constant "^[A-Z0-9_]+$"))
+
+(import_item (identifier) @namespace)
+
+(import_path (identifier) @namespace)
+
+(ident_path (identifier) @namespace)
+
+; types
+
+((identifier) @constant
+  (#match? @constant "^[A-Z0-9_]+$"))
+
+((identifier) @type
+  (#match? @type "^[A-Z]"))
+
+(type_specifier
+    (identifier) @type)
+
+; functions
+
+(function_decl 
+  (function_header
+    (identifier) @function))
+
+(call_expression
+  (identifier) @function)
+
+; templates
+
+(template_list) @punctuation
+
+(variable_decl ; this is var<storage> et.al
+  (template_list
+    (identifier) @keyword.storage.modifier))
+
+(type_specifier
+  (template_list
+    (identifier) @type))
+
+(template_list
+  (template_list
+    (identifier) @type))
+
+; attributes
+
+(attribute
+  (identifier) @attribute) @attribute
+
+(attribute
+  (identifier) @attr-name
+  (argument_list
+    (identifier) @variable.builtin)
+  (#eq? @attr-name "builtin"))
+
+; variables, names
+
+(param
+  (identifier) @variable.parameter)
+(variable_decl
+  (identifier) @variable)
+(const_assert_statement) @variable
+
+(struct_decl
+  (identifier) @type)
+
+(struct_member
+  name: (_) @variable.other.member)
+
+(named_component_expression
+  component: (_) @variable.other.member)
+
+(identifier) @variable
+
+; literals
+
+(bool_literal) @constant.builtin.boolean
+(int_literal) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+
+
+; keywords
+
+[
+  "if"
+  "else"
+  "loop"
+  "for"
+  "while"
+  "switch"
+  "case"
+  "default"
+  "break"
+  "continue"
+  "return"
+  "discard"
+] @keyword.control
+
+[ ; WESL import extension
+  "import"
+  "as"
+] @keyword.control.import
+
+[
+  "var"
+  "let"
+  "const"
+  "fn"
+  "struct"
+  "alias"
+  "virtual" ; Bevy / naga_oil extension
+  "override" ; Bevy / naga_oil extension
+] @keyword
+
+; expressions
+
+[
+  "-" "!" "~" "*" "&" ; unary
+  "^" "|" "/" "%" "+" (shift_left) (shift_right) ; binary
+  (less_than) (greater_than) (less_than_equal) (greater_than_equal) "==" "!=" ; relational
+  "+=" "-=" "*=" "/=" "%=" "|=" "^=" "++" "--" "=" ; assign
+  "->" ; return
+] @operator
+
+; punctuation
+
+[ "(" ")" "[" "]" "{" "}" ] @punctuation.bracket
+[ "," "." ":" ";" ] @punctuation.delimiter
+
+; preprocessor
+
+[ (preproc_directive) "#import" ] @keyword.directive

--- a/runtime/queries/wesl/highlights.scm
+++ b/runtime/queries/wesl/highlights.scm
@@ -120,29 +120,37 @@
 [
   "if"
   "else"
+] @keyword.control.conditional
+[
   "loop"
   "for"
   "while"
+  "break"
+  "continue"
+] @keyword.control.repeat
+[
+  "return"
+] @keyword.control.return
+[
   "switch"
   "case"
   "default"
-  "break"
-  "continue"
-  "return"
   "discard"
 ] @keyword.control
-
 [ ; WESL import extension
   "import"
   "as"
 ] @keyword.control.import
-
+[
+  "fn"
+] @keyword.function
 [
   "var"
   "let"
   "const"
-  "fn"
   "struct"
+] @keyword.storage.type
+[
   "alias"
   "virtual" ; Bevy / naga_oil extension
   "override" ; Bevy / naga_oil extension

--- a/runtime/queries/wesl/injections.scm
+++ b/runtime/queries/wesl/injections.scm
@@ -1,0 +1,2 @@
+([(line_comment) (block_comment)] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/wesl/locals.scm
+++ b/runtime/queries/wesl/locals.scm
@@ -1,0 +1,18 @@
+; Scopes
+
+[
+  (global_decl)
+  (switch_body)
+  (compound_statement)
+] @local.scope
+
+; Definitions
+
+(param
+  (identifier) @local.definition)
+
+; References
+
+(identifier) @local.reference
+; (type_specifier) @local.reference
+

--- a/runtime/queries/wesl/textobjects.scm
+++ b/runtime/queries/wesl/textobjects.scm
@@ -1,0 +1,23 @@
+(function_decl
+  body: (_) @function.inside) @function.around
+
+(struct_decl
+  body: (_) @class.inside) @class.around
+
+(param_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(argument_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(template_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment.inside
+  
+(line_comment)+ @comment.around
+
+(block_comment) @comment.around


### PR DESCRIPTION
Adds [WESL](https://wesl-lang.dev) as a supported language following the instructions [here](https://docs.helix-editor.com/guides/adding_languages.html). The queries are copied from [here](https://github.com/wgsl-tooling-wg/tree-sitter-wesl/tree/94ee6122680ef8ce2173853ca7c99f7aaeeda8ce/queries).