### PR TITLE
chore(msrv): bump from 1.76 to 1.82

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - cron: "00 01 * * *"
 
 env:
-  MSRV: "1.76"
+  MSRV: "1.82"
   # This key can be changed to bust the cache of tree-sitter grammars.
   GRAMMAR_CACHE_VERSION: ""
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ categories = ["editor"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
-rust-version = "1.76"
+rust-version = "1.82"

--- a/helix-event/src/test.rs
+++ b/helix-event/src/test.rs
@@ -56,6 +56,7 @@ fn smoke_test() {
 }
 
 #[test]
+#[allow(dead_code)]
 fn dynamic() {
     events! {
         Event3 {}

--- a/helix-lsp-types/src/lib.rs
+++ b/helix-lsp-types/src/lib.rs
@@ -2568,8 +2568,8 @@ pub enum Documentation {
 ///
 /// The pair of a language and a value is an equivalent to markdown:
 ///
-/// ```${language}
-/// ${value}
+/// ```language
+/// value
 /// ```
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]

--- a/helix-lsp-types/src/lib.rs
+++ b/helix-lsp-types/src/lib.rs
@@ -2568,9 +2568,9 @@ pub enum Documentation {
 ///
 /// The pair of a language and a value is an equivalent to markdown:
 ///
-/// ```language
-/// value
-/// ```
+/// <pre><code>```${language}
+/// ${value}
+/// ```</code></pre>
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum MarkedString {

--- a/helix-stdx/tests/path.rs
+++ b/helix-stdx/tests/path.rs
@@ -1,10 +1,6 @@
 #![cfg(windows)]
 
-use std::{
-    env::set_current_dir,
-    error::Error,
-    path::{Component, Path, PathBuf},
-};
+use std::{env::set_current_dir, error::Error, path::Component};
 
 use helix_stdx::path;
 use tempfile::Builder;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.82.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
Seems the update to the [policy](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html) page is lagging behind, as looking at the [source](https://searchfox.org/mozilla-release/source/Cargo.toml), the MSRV was indeed already bumped to `1.82` (and its what the policy update says it will be updated to).