### PR TITLE
docs(view::editor): comments explaining why actions-loop is 2-pass

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1820,17 +1820,29 @@ impl Editor {
         // This will also disallow any follow-up writes
         self.saves.remove(&doc_id);
 
+        // ad-hoc
         enum Action {
             Close(ViewId),
             ReplaceDoc(ViewId, DocumentId),
         }
 
+        // `Box<[Action]>` is more efficient,
+        // but it doesn't directly `impl IntoIterator`
+        // until 1.80.
+        // See: https://doc.rust-lang.org/std/boxed/struct.Box.html#impl-IntoIterator-for-Box%3C%5BI%5D,+A%3E
+        // TODO: when MSRV >= 1.80
         let actions: Vec<Action> = self
             .tree
             .views_mut()
+            // Because of RPITIT, `FilterMap` iterator borrows from `self`,
+            // even though the result is owned.
+            // See: https://users.rust-lang.org/t/fully-owned-iterator-causing-lifetime-problems/107677/4
             .filter_map(|(view, _focus)| {
                 view.remove_document(&doc_id);
 
+                // to avoid potential bugs when mutating what's being iterated,
+                // and to satisfy borrowck,
+                // we generate a sequence of `Action`s to be executed in the next pass.
                 if view.doc == doc_id {
                     // something was previously open in the view, switch to previous doc
                     if let Some(prev_doc) = view.docs_access_history.pop() {
@@ -1843,6 +1855,8 @@ impl Editor {
                     None
                 }
             })
+            // this erases ref info from the type-system,
+            // at the cost of potential alloc
             .collect();
 
         for action in actions {


### PR DESCRIPTION
I've tried 2 or 3 different refactors to merge the loops into one, mostly to avoid `collect` allocations. I've documented why the code has stayed as it is, to prevent people from wasting time (like me :smiling_face_with_tear:). Also to make the code less confusing to newbies.

I assume that there are `>=2` places in the code-base that may need the same comments, but I don't have time to find them