### PR TITLE
feat(config): add `[workspace-]diagnostics` fields to statusline

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -104,6 +104,8 @@ separator = "│"
 mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
+diagnostics = ["warning", "error"]
+workspace-diagnostics = ["warning", "error"]
 ```
 The `[editor.statusline]` key takes the following sub-keys:
 
@@ -116,6 +118,8 @@ The `[editor.statusline]` key takes the following sub-keys:
 | `mode.normal` | The text shown in the `mode` element for normal mode | `"NOR"` |
 | `mode.insert` | The text shown in the `mode` element for insert mode | `"INS"` |
 | `mode.select` | The text shown in the `mode` element for select mode | `"SEL"` |
+| `diagnostics` | A list of severities which are displayed for the current buffer | `["warning", "error"]` |
+| `workspace-diagnostics` | A list of severities which are displayed for the workspace | `["warning", "error"]` |
 
 The following statusline elements can be configured:
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -226,36 +226,58 @@ fn render_diagnostics<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    let (warnings, errors) = context
-        .doc
-        .diagnostics()
-        .iter()
-        .fold((0, 0), |mut counts, diag| {
-            use helix_core::diagnostic::Severity;
-            match diag.severity {
-                Some(Severity::Warning) => counts.0 += 1,
-                Some(Severity::Error) | None => counts.1 += 1,
-                _ => {}
+    use helix_core::diagnostic::Severity;
+    let (hints, info, warnings, errors) =
+        context
+            .doc
+            .diagnostics()
+            .iter()
+            .fold((0, 0, 0, 0), |mut counts, diag| {
+                match diag.severity {
+                    Some(Severity::Hint) | None => counts.0 += 1,
+                    Some(Severity::Info) => counts.1 += 1,
+                    Some(Severity::Warning) => counts.2 += 1,
+                    Some(Severity::Error) => counts.3 += 1,
+                }
+                counts
+            });
+
+    for sev in &context.editor.config().statusline.diagnostics {
+        match sev {
+            Severity::Hint if hints > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("hint")),
+                );
+                write(context, format!(" {} ", hints), None);
             }
-            counts
-        });
-
-    if warnings > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
-    }
-
-    if errors > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+            Severity::Info if info > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("info")),
+                );
+                write(context, format!(" {} ", info), None);
+            }
+            Severity::Warning if warnings > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("warning")),
+                );
+                write(context, format!(" {} ", warnings), None);
+            }
+            Severity::Error if errors > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("error")),
+                );
+                write(context, format!(" {} ", errors), None);
+            }
+            _ => {}
+        }
     }
 }
 
@@ -263,41 +285,61 @@ fn render_workspace_diagnostics<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    let (warnings, errors) =
-        context
-            .editor
-            .diagnostics
-            .values()
-            .flatten()
-            .fold((0, 0), |mut counts, (diag, _)| {
-                match diag.severity {
-                    Some(DiagnosticSeverity::WARNING) => counts.0 += 1,
-                    Some(DiagnosticSeverity::ERROR) | None => counts.1 += 1,
-                    _ => {}
-                }
-                counts
-            });
+    use helix_core::diagnostic::Severity;
+    let (hints, info, warnings, errors) = context.editor.diagnostics.values().flatten().fold(
+        (0, 0, 0, 0),
+        |mut counts, (diag, _)| {
+            match diag.severity {
+                Some(DiagnosticSeverity::HINT) | None => counts.0 += 1,
+                Some(DiagnosticSeverity::INFORMATION) => counts.1 += 1,
+                Some(DiagnosticSeverity::WARNING) => counts.2 += 1,
+                Some(DiagnosticSeverity::ERROR) => counts.3 += 1,
+                _ => {}
+            }
+            counts
+        },
+    );
 
-    if warnings > 0 || errors > 0 {
+    if hints > 0 || info > 0 || warnings > 0 || errors > 0 {
         write(context, " W ".into(), None);
     }
 
-    if warnings > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("warning")),
-        );
-        write(context, format!(" {} ", warnings), None);
-    }
-
-    if errors > 0 {
-        write(
-            context,
-            "●".to_string(),
-            Some(context.editor.theme.get("error")),
-        );
-        write(context, format!(" {} ", errors), None);
+    for sev in &context.editor.config().statusline.w_diagnostics {
+        match sev {
+            Severity::Hint if hints > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("hint")),
+                );
+                write(context, format!(" {} ", hints), None);
+            }
+            Severity::Info if info > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("info")),
+                );
+                write(context, format!(" {} ", info), None);
+            }
+            Severity::Warning if warnings > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("warning")),
+                );
+                write(context, format!(" {} ", warnings), None);
+            }
+            Severity::Error if errors > 0 => {
+                write(
+                    context,
+                    "●".to_string(),
+                    Some(context.editor.theme.get("error")),
+                );
+                write(context, format!(" {} ", errors), None);
+            }
+            _ => {}
+        }
     }
 }
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -304,7 +304,7 @@ where
         write(context, " W ".into(), None);
     }
 
-    for sev in &context.editor.config().statusline.w_diagnostics {
+    for sev in &context.editor.config().statusline.workspace_diagnostics {
         match sev {
             Severity::Hint if hints > 0 => {
                 write(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -497,6 +497,8 @@ pub struct StatusLineConfig {
     pub right: Vec<StatusLineElement>,
     pub separator: String,
     pub mode: ModeConfig,
+    pub diagnostics: Vec<Severity>,
+    pub w_diagnostics: Vec<Severity>,
 }
 
 impl Default for StatusLineConfig {
@@ -521,6 +523,8 @@ impl Default for StatusLineConfig {
             ],
             separator: String::from("│"),
             mode: ModeConfig::default(),
+            diagnostics: vec![Severity::Warning, Severity::Error],
+            w_diagnostics: vec![Severity::Warning, Severity::Error],
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -498,7 +498,7 @@ pub struct StatusLineConfig {
     pub separator: String,
     pub mode: ModeConfig,
     pub diagnostics: Vec<Severity>,
-    pub w_diagnostics: Vec<Severity>,
+    pub workspace_diagnostics: Vec<Severity>,
 }
 
 impl Default for StatusLineConfig {
@@ -524,7 +524,7 @@ impl Default for StatusLineConfig {
             separator: String::from("│"),
             mode: ModeConfig::default(),
             diagnostics: vec![Severity::Warning, Severity::Error],
-            w_diagnostics: vec![Severity::Warning, Severity::Error],
+            workspace_diagnostics: vec![Severity::Warning, Severity::Error],
         }
     }
 }


### PR DESCRIPTION
Adds `diagnostics` and `workspace-diagnostics` fields to the statusline editor config. This allows you to define a list of severities that will then be rendered in the order of definition:

```toml
[editor.statusline]
diagnostics = ["error", "hint", "warning"]
workspace-diagnostics = ["warning", "hint", "error"]
```

![image](https://github.com/user-attachments/assets/78aa466e-9542-4956-a8fd-2abcdd382ef6)

This defaults to:
```toml
[editor.statusline]
diagnostics = ["warning", "error"]
workspace-diagnostics = ["warning", "error"]
```
the current `master` behavior.

Subsumes:  #13256 and #13257