### PR TITLE
fix: Ocaml highlights queries order

### DIFF
--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -37,6 +37,13 @@
 
 [(constructor_name) (tag)] @constructor
 
+; Variables
+;----------
+
+[(value_name) (type_variable)] @variable
+
+(value_pattern) @variable.parameter
+
 ; Functions
 ;----------
 
@@ -74,13 +81,6 @@
 
 (application_expression
   function: (value_path (value_name) @function))
-
-; Variables
-;----------
-
-[(value_name) (type_variable)] @variable
-
-(value_pattern) @variable.parameter
 
 ; Properties
 ;-----------


### PR DESCRIPTION
Since precedence reversing, ocaml functions and applications are highlighted as variables.