### PR TITLE
chore: enable clippy lint `if_not_else` and fix occurences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ package.helix-core.opt-level = 2
 package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
+[workspace.lints.clippy]
+if_not_else = "warn"
+
 [workspace.dependencies]
 tree-sitter = { version = "0.22" }
 nucleo = "0.5.0"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -11,6 +11,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 unicode-lines = ["ropey/unicode_lines"]
 integration = []

--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -103,12 +103,12 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
     for line in to_change {
         let pos = text.line_to_char(line) + min;
 
-        if !commented {
-            // comment line
-            changes.push((pos, pos, Some(comment.clone())));
-        } else {
+        if commented {
             // uncomment line
             changes.push((pos, pos + token.len() + margin, None));
+        } else {
+            // comment line
+            changes.push((pos, pos, Some(comment.clone())));
         }
     }
 
@@ -190,16 +190,7 @@ pub fn find_block_comments(
                 }
             }
 
-            if !line_commented {
-                comment_changes.push(CommentChange::Uncommented {
-                    range: *range,
-                    start_pos,
-                    end_pos,
-                    start_token: default_tokens.start.clone(),
-                    end_token: default_tokens.end.clone(),
-                });
-                commented = false;
-            } else {
+            if line_commented {
                 comment_changes.push(CommentChange::Commented {
                     range: *range,
                     start_pos,
@@ -210,6 +201,15 @@ pub fn find_block_comments(
                     start_token: start_token.to_string(),
                     end_token: end_token.to_string(),
                 });
+            } else {
+                comment_changes.push(CommentChange::Uncommented {
+                    range: *range,
+                    start_pos,
+                    end_pos,
+                    start_token: default_tokens.start.clone(),
+                    end_token: default_tokens.end.clone(),
+                });
+                commented = false;
             }
             only_whitespace = false;
         } else {

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -365,7 +365,7 @@ where
     F: Fn(char) -> bool,
 {
     let mut chars = slice.chars_at(pos).enumerate();
-    chars.find_map(|(i, c)| if !fun(c) { Some(pos + i) } else { None })
+    chars.find_map(|(i, c)| if fun(c) { None } else { Some(pos + i) })
 }
 
 #[inline]
@@ -379,10 +379,10 @@ where
     let mut chars_starting_from_next = slice.chars_at(pos);
     let mut backwards = iter::from_fn(|| chars_starting_from_next.prev()).enumerate();
     backwards.find_map(|(i, c)| {
-        if !fun(c) {
-            Some(pos.saturating_sub(i))
-        } else {
+        if fun(c) {
             None
+        } else {
+            Some(pos.saturating_sub(i))
         }
     })
 }

--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -85,10 +85,10 @@ fn select_children<'n>(
         .map(|child| Range::from_node(child, text, range.direction()))
         .collect::<Vec<_>>();
 
-    if !children.is_empty() {
-        children
-    } else {
+    if children.is_empty() {
         vec![range]
+    } else {
+        children
     }
 }
 

--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 helix-stdx = { path = "../helix-stdx" }

--- a/helix-event/Cargo.toml
+++ b/helix-event/Cargo.toml
@@ -11,6 +11,9 @@ homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 foldhash.workspace = true
 hashbrown = "0.15"

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -10,6 +10,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "hx-loader"
 path = "src/main.rs"

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -278,7 +278,9 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<FetchStatus> {
         }
 
         // ensure the revision matches the configured revision
-        if get_revision(&grammar_dir).as_ref() != Some(&revision) {
+        if get_revision(&grammar_dir).as_ref() == Some(&revision) {
+            Ok(FetchStatus::GitUpToDate)
+        } else {
             // Fetch the exact revision from the remote.
             // Supported by server-side git since v2.5.0 (July 2015),
             // enabled by default on major git hosts.
@@ -289,8 +291,6 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<FetchStatus> {
             git(&grammar_dir, ["checkout", &revision])?;
 
             Ok(FetchStatus::GitUpdated { revision })
-        } else {
-            Ok(FetchStatus::GitUpToDate)
         }
     } else {
         Ok(FetchStatus::NonGit)

--- a/helix-lsp-types/Cargo.toml
+++ b/helix-lsp-types/Cargo.toml
@@ -20,6 +20,9 @@ keywords = ["language", "server", "lsp", "vscode", "lsif"]
 
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 bitflags.workspace = true
 serde = { version = "1.0.219", features = ["derive"] }

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 helix-stdx = { path = "../helix-stdx" }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -107,10 +107,10 @@ pub mod util {
             })
             .collect();
 
-        let tags = if !new_tags.is_empty() {
-            Some(new_tags)
-        } else {
+        let tags = if new_tags.is_empty() {
             None
+        } else {
+            Some(new_tags)
         };
 
         lsp::Diagnostic {
@@ -421,10 +421,10 @@ pub mod util {
             doc,
             edits.into_iter().map(|edit| {
                 // simplify "" into None for cleaner changesets
-                let replacement = if !edit.new_text.is_empty() {
-                    Some(edit.new_text.into())
-                } else {
+                let replacement = if edit.new_text.is_empty() {
                     None
+                } else {
+                    Some(edit.new_text.into())
                 };
 
                 let start =

--- a/helix-parsec/Cargo.toml
+++ b/helix-parsec/Cargo.toml
@@ -11,4 +11,7 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -11,6 +11,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 dunce = "1.0"
 etcetera = "0.10"

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -110,15 +110,15 @@ fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>)
             continue;
         }
         let var = &bytes[captures.get_group(1).unwrap().range()];
-        let default = if pattern_id != 5 {
+        let default = if pattern_id == 5 {
+            &[]
+        } else {
             let Some(bracket_pos) = find_brace_end(&bytes[range.end..]) else {
                 break;
             };
             let default = &bytes[range.end..range.end + bracket_pos];
             range.end += bracket_pos + 1;
             default
-        } else {
-            &[]
         };
         // safety: this is a codepoint aligned substring of an osstr (always valid)
         let var = unsafe { OsStr::from_encoded_bytes_unchecked(var) };

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.deb]
 # generate a .deb in target/debian/ with the command: cargo deb --no-build
 name = "helix"

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -381,10 +381,10 @@ fn trim_trailing_whitespace(doc: &mut Document, view_id: ViewId) {
             // Char before the line ending character(s), or the final char in the text if there
             // is no line-ending on this line:
             let line_end = pos - line_end_len_chars;
-            if first_trailing_whitespace != line_end {
-                Some((first_trailing_whitespace, line_end))
-            } else {
+            if first_trailing_whitespace == line_end {
                 None
+            } else {
+                Some((first_trailing_whitespace, line_end))
             }
         }),
     );

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -250,10 +250,10 @@ pub fn show_signature_help(
                 .active_signature()
                 .min(signatures.len() - 1);
 
-            if old_lsp_sig != lsp_signature {
-                lsp_signature.unwrap_or(old_sig)
-            } else {
+            if old_lsp_sig == lsp_signature {
                 old_sig
+            } else {
+                lsp_signature.unwrap_or(old_sig)
             }
         })
         .unwrap_or(lsp_signature.unwrap_or_default());

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -11,6 +11,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["crossterm"]
 

--- a/helix-vcs/Cargo.toml
+++ b/helix-vcs/Cargo.toml
@@ -10,6 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -10,6 +10,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 term = ["crossterm"]

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -177,13 +177,13 @@ mod external {
                 name: &'static str,
                 provider: &'static CommandProvider,
             ) -> Cow<'a, str> {
-                if provider.yank.command != provider.paste.command {
+                if provider.yank.command == provider.paste.command {
+                    Cow::Owned(format!("{} ({})", name, provider.yank.command))
+                } else {
                     Cow::Owned(format!(
                         "{} ({}+{})",
                         name, provider.yank.command, provider.paste.command
                     ))
-                } else {
-                    Cow::Owned(format!("{} ({})", name, provider.yank.command))
                 }
             }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
`if_not_else` lints to replace conditions of the form
```rs
if !cond { a } else { b }
```
with
```rs
if cond { b } else { a } 
```

it is harder to read negated conditions as you have to mentally invert them