### PR TITLE
feat: add yamlfmt as default yaml formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1396,6 +1396,8 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "yaml-language-server", "ansible-language-server" ]
 injection-regex = "yml|yaml"
+formatter = { command = "yamlfmt", args = ['-'] }
+auto-format = true
 
 [[grammar]]
 name = "yaml"


### PR DESCRIPTION
This PR adds [yamlfmt](https://github.com/google/yamlfmt) as the default configured formatter for `yaml` files. It also enables `auto-format` for consistency with what's already set for `json` and `jsonc`.