### PR TITLE
docs: another injection query example

### DIFF
--- a/book/src/guides/injection.md
+++ b/book/src/guides/injection.md
@@ -4,10 +4,15 @@ Writing language injection queries allows one to highlight a specific node as a 
 In addition to the [standard][upstream-docs] language injection options used by tree-sitter, there
 are a few Helix specific extensions that allow for more control.
 
-And example of a simple query that would highlight all strings as bash in Nix:
+An example of a simple query that would highlight all strings as bash in Nix:
 ```scm
 ((string_expression (string_fragment) @injection.content)
   (#set! injection.language "bash"))
+```
+Another example is this query, which highlights links in comments and keywords like "TODO", by reusing the dedicated "comment" language:
+```
+((comment) @injection.content
+  (#set! injection.language "comment"))
 ```
 
 ## Capture Types


### PR DESCRIPTION
Took me a bit to figure out why all the languages support highlighting inside comments, although it's never in the actual highlight queries. So I thought, maybe worth documenting.