### PR TITLE
feat: distinct inline diagnostic theme keys

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -361,9 +361,13 @@ These scopes are used for theming the editor interface:
 | `ui.cursorcolumn.primary`         | The column of the primary cursor ([if cursorcolumn is enabled][editor-section])                |
 | `ui.cursorcolumn.secondary`       | The columns of any other cursors ([if cursorcolumn is enabled][editor-section])                |
 | `warning`                         | Diagnostics warning (gutter)                                                                   |
+| `warning.diagnostic.inline`       | The inline diagnostic for the warning severity                                                 |
 | `error`                           | Diagnostics error (gutter)                                                                     |
+| `error.diagnostic.inline`         | The inline diagnostic for the error severity                                                   |
 | `info`                            | Diagnostics info (gutter)                                                                      |
+| `info.diagnostic.inline`          | The inline diagnostic for the warning severity                                                 |
 | `hint`                            | Diagnostics hint (gutter)                                                                      |
+| `hint.diagnostic.inline`          | The inline diagnostic for the hint severity                                                    |
 | `diagnostic`                      | Diagnostics fallback style (editing area)                                                      |
 | `diagnostic.hint`                 | Diagnostics hint (editing area)                                                                |
 | `diagnostic.info`                 | Diagnostics info (editing area)                                                                |

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -26,10 +26,10 @@ struct Styles {
 impl Styles {
     fn new(theme: &Theme) -> Styles {
         Styles {
-            hint: theme.get("hint"),
-            info: theme.get("info"),
-            warning: theme.get("warning"),
-            error: theme.get("error"),
+            hint: theme.get("hint.diagnostic.inline"),
+            info: theme.get("info.diagnostic.inline"),
+            warning: theme.get("warning.diagnostic.inline"),
+            error: theme.get("error.diagnostic.inline"),
         }
     }
 


### PR DESCRIPTION
# What

Adds more specific theme keys to target the inline diagnostic styles:

- `hint.diagnostic.inline`
- `info.diagnostic.inline`
- `warning.diagnostic.inline`
- `error.diagnostic.inline`

The diagnostic-specific keys are appended to the existing "severity" keys so that it is backwards compatible with all existing themes; they will automatically fallback to use the current styles. Suggestions for alternative theme keys are welcome.

# Why

I'm loving the recent addition of the inline diagnostic feature, however, sometimes I have been finding the `error` messages quite distracting as my helix theme uses quite a lot of red. I'd like to be able to style these so that they are less intrusive and make it easier to read the actual code. 

### Default

```toml
# Theme
"error" = { fg = "red" }
```
![Screenshot 2025-04-10 at 09 20 41](https://github.com/user-attachments/assets/ed64b3f2-ef67-4895-9ebe-fb45a74dd090)

### With modified `error` theme key
While one could simply style the `error` key in the theme, this has the downside of affecting other parts of the UI (such as the gutter icon and the diagnostic picker). For example, I'd like to dim the text of the inline diagnostic but not dim the gutter icon.

```toml
# Theme
"error" = { fg = "red", modifiers = ["italic", "dim"] }
```
![Screenshot 2025-04-10 at 09 24 40](https://github.com/user-attachments/assets/2d1f14ad-8c83-4bb3-8581-a31ce81c8601)



### With proposed changes

With the proposed changes, one can now apply distinct styles to just the inline diagnostics without affecting other parts of the UI and can read the code more easily (note, non-dimmed gutter icon):

```toml
# Theme
"error" = { fg = "red" }
"error.diagnostic.inline" = { fg = "red", modifiers = ["italic", "dim"] }
```

![Screenshot 2025-04-10 at 09 21 08](https://github.com/user-attachments/assets/4ef40e18-f546-4a99-b4d7-de4b335ed013)

# TODO

If this change is deemed acceptable, I will update this PR to:

- [x] include documentation of the new theme keys.
