### PR TITLE
feat: added just formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3289,8 +3289,8 @@ injection-regex = "just"
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 language-servers = ["just-lsp"]
-# auto-format = true
-# formatter = { command = "just", args = ["--dump"] } # Please see: https://github.com/helix-editor/helix/issues/9703
+auto-format = true
+formatter = { command = "just-formatter" } # See https://github.com/eli-yip/just-formatter
 
 [[grammar]]
 name = "just"


### PR DESCRIPTION
This PR adds [just-formatter](https://github.com/eli-yip/just-formatter) as the default formatter for justfiles. Previous approaches were not cross-platform, but @eli-yip wrote a Rust wrapper that can be easily installed with `cargo` and works very well. Please see the discussion at #13287 for more information. 