### PR TITLE
chore(jjdescription): bump rev to latest

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3428,7 +3428,7 @@ text-width = 72
 
 [[grammar]]
 name = "jjdescription"
-source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "d09205b52b5a0165b588a793e366c1116468d86f" }
+source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "1613b8c85b6ead48464d73668f39910dcbb41911" }
 
 [[language]]
 name = "jq"

--- a/runtime/queries/jjdescription/highlights.scm
+++ b/runtime/queries/jjdescription/highlights.scm
@@ -4,5 +4,7 @@
 (change type: "A" @diff.plus)
 (change type: "D" @diff.minus)
 (change type: "M" @diff.delta)
+(change type: "C" @diff.plus)
+(change type: "R" @diff.delta)
 
 (comment) @comment


### PR DESCRIPTION
Trying it out more in my workflow and noticed that some of the symbols weren't highlighted.