### PR TITLE
feat: add basic Quarto support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -182,6 +182,7 @@
 | purescript | ✓ | ✓ |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | `ruff`, `jedi-language-server`, `pylsp` |
 | qml | ✓ |  | ✓ | `qmlls` |
+| quarto | ✓ |  | ✓ |  |
 | quint | ✓ |  |  | `quint-language-server` |
 | r | ✓ |  |  | `R` |
 | racket | ✓ |  | ✓ | `racket` |

--- a/languages.toml
+++ b/languages.toml
@@ -2048,6 +2048,16 @@ name = "gleam"
 source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "426e67087fd62be5f4533581b5916b2cf010fb5b" }
 
 [[language]]
+name = "quarto"
+scope = "source.qmd"
+language-id = "qmd"
+injection-regex = "qmd"
+file-types = ["qmd"]
+indent = { tab-width = 2, unit = "  " }
+grammar = "markdown"
+block-comment-tokens = { start = "<!--", end = "-->" }
+
+[[language]]
 name = "ron"
 scope = "source.ron"
 injection-regex = "ron"

--- a/runtime/queries/quarto/highlights.scm
+++ b/runtime/queries/quarto/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: markdown

--- a/runtime/queries/quarto/indents.scm
+++ b/runtime/queries/quarto/indents.scm
@@ -1,0 +1,1 @@
+; inherits: markdown

--- a/runtime/queries/quarto/injections.scm
+++ b/runtime/queries/quarto/injections.scm
@@ -1,0 +1,1 @@
+; inherits: markdown


### PR DESCRIPTION
I saw #9389 and took a swing at following the instructions to add support. I gave it a test and it seems to work, but very new to helix so not sure what I may have missed.

At the moment there is no language server, though one is planned, so it also occurred to me that maybe adding `.qmd` to `markdown` is the more straightforward approach.