### PR TITLE
feat: `:counter` command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -70,6 +70,7 @@
 | `:toggle-option`, `:toggle` | Toggle a config option at runtime.<br>For example to toggle smart case search, use `:toggle search.smart-case`. |
 | `:get-option`, `:get` | Get the current value of a config option. |
 | `:sort` | Sort ranges in selection. |
+| `:counter` | Inserts indexes from the X (default 1) to count of the selections |
 | `:reflow` | Hard-wrap the current selection of lines to a given width. |
 | `:tree-sitter-subtree`, `:ts-subtree` | Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries. |
 | `:config-reload` | Refresh user config. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -9,7 +9,7 @@ use super::*;
 use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
-use helix_core::line_ending;
+use helix_core::{line_ending, SmartString};
 use helix_stdx::path::home_dir;
 use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
@@ -2148,6 +2148,71 @@ fn sort_impl(cx: &mut compositor::Context, reverse: bool) -> anyhow::Result<()> 
     Ok(())
 }
 
+fn counter(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    counter_impl(
+        cx,
+        args.has_flag("reverse"),
+        args.has_flag("desc"),
+        args.first()
+            .and_then(|start| start.parse::<isize>().ok())
+            .unwrap_or(1),
+    )
+}
+
+fn counter_impl(
+    cx: &mut compositor::Context,
+    reverse: bool,
+    desc: bool,
+    start: isize,
+) -> anyhow::Result<()> {
+    let scrolloff = cx.editor.config().scrolloff;
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+
+    let selection = doc.selection(view.id);
+
+    if selection.len() == 1 {
+        bail!("Sorting requires multiple selections. Hint: split selection first");
+    }
+
+    let mut fragments: Vec<_> = selection
+        .slices(text)
+        .map(|fragment| fragment.chunks().collect())
+        .collect();
+
+    let count_selections = fragments.len() as isize;
+
+    let iter: &mut dyn Iterator<Item = isize> = match (reverse, desc) {
+        (true, true) => &mut (start - count_selections + 1..=start),
+        (true, false) => &mut (start..count_selections + start).rev(),
+        (false, true) => &mut (start - count_selections..=start).rev(),
+        (false, false) => &mut (start..=count_selections + start),
+    };
+
+    fragments.iter_mut().zip(iter).for_each(|(frag, index)| {
+        let index_str = index.to_string();
+        *frag = SmartString::from(index_str);
+    });
+
+    let transaction = Transaction::change(
+        doc.text(),
+        selection
+            .into_iter()
+            .zip(fragments)
+            .map(|(s, fragment)| (s.from(), s.to(), Some(fragment))),
+    );
+
+    doc.apply(&transaction, view.id);
+    doc.append_changes_to_history(view);
+    view.ensure_cursor_in_view(doc, scrolloff);
+
+    Ok(())
+}
+
 fn reflow(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -3360,6 +3425,31 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
                     name: "reverse",
                     alias: Some('r'),
                     doc: "sort ranges in reverse order",
+                    ..Flag::DEFAULT
+                },
+            ],
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "counter",
+        aliases: &[],
+        doc: "Inserts indexes from the X (default 1) to count of the selections",
+        fun: counter,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(1)),
+            flags: &[
+                Flag {
+                    name: "reverse",
+                    alias: Some('r'),
+                    doc: "Counts from X to the beginning",
+                    ..Flag::DEFAULT
+                },
+                Flag {
+                    name: "desc",
+                    alias: Some('d'),
+                    doc: "Counts from the beginning to X in descending order",
                     ..Flag::DEFAULT
                 },
             ],


### PR DESCRIPTION
This command inserts indexes from the start (default 1) to count of the selections

syntax: `:counter [--desc] [--reverse] [start]`

## Examples

`:counter`
![image](https://github.com/user-attachments/assets/23398c5c-3fb2-40a9-bfae-f9695364d783)

`:counter -r`
![image](https://github.com/user-attachments/assets/7dbc32ba-6095-4942-972c-d29ca2b8ae10)

`:counter 5`
![image](https://github.com/user-attachments/assets/50cd0d96-154b-4894-a665-8f795d74d2c5)

`counter -r 5`
![image](https://github.com/user-attachments/assets/f78073c3-24f9-48ec-8c65-83ceb96501ee)

`:counter -d 7`
![image](https://github.com/user-attachments/assets/148b5a05-edc0-4878-85e2-a1ba9ed50a87)

`:counter -r -d 7`
![image](https://github.com/user-attachments/assets/bc7c3726-e9b9-44c8-966e-631c1eaba65d)

## Problems
That is my first PR to helix so i'm not really know how to work with selections and SmartString.
I think that lines are really weird and i need to somebody rewiewed this:
```rust
fragments.iter_mut().zip(iter).for_each(|(frag, index)| {
    let index_str = index.to_string();
    *frag = SmartString::from(index_str);
});
```

Also for example if we have `\n` in selection, it will replace it and we'll get something like this:
![image](https://github.com/user-attachments/assets/51c7dd05-9995-44f5-941d-681edd9fb3ee)
 and the only solution i can imagine is 
```rust
if frag.ends_with('\n') {
    index_str.push('\n');
}
```
But this will add `\n` to selection so this is really bad