### PR TITLE
Make `goto_word` jump-labels easier to distinguish for zed themes

### DIFF
--- a/runtime/themes/zed_onedark.toml
+++ b/runtime/themes/zed_onedark.toml
@@ -57,6 +57,7 @@
 "ui.virtual.whitespace" = { fg = "light-gray" }
 "ui.virtual.ruler" = { bg = "gray" }
 "ui.virtual.inlay-hint" = { fg = "blue-gray", modifiers = ["bold"] }
+"ui.virtual.jump-label" = { fg = "purple", modifiers = ["bold", "italic"] }
 
 "ui.cursor" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }


### PR DESCRIPTION
Themes affected:
- `zed_onedark`
- `zed_onelight` (through theme inheritance)

Resolves #13359

## Before

![image](https://github.com/user-attachments/assets/3347e512-3855-4f0e-b684-04b0fc116b54)

![image](https://github.com/user-attachments/assets/4e377930-d53f-4eb3-8633-0306288f3466)

## After

![image](https://github.com/user-attachments/assets/5d1bed14-3621-417e-b3d2-e9776c7219f5)

![image](https://github.com/user-attachments/assets/bdd1e667-f276-48b2-ba4c-4e568c12bfb3)
