### PR TITLE
Add highlighting for lua methods

### DIFF
--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -189,6 +189,9 @@
     name: (identifier) @function
     value: (function_definition)))
 
+;; Property
+(dot_index_expression field: (identifier) @variable.other.member)
+
 (function_call
   name: [
     (identifier) @function.call
@@ -216,9 +219,3 @@
 ; A bit of a tricky one, this will only match field names
 (field . (identifier) @variable.other.member (_))
 (hash_bang_line) @comment
-
-;; Property
-(dot_index_expression field: (identifier) @variable.other.member)
-
-;; Method
-(function_call name: (dot_index_expression field: (identifier) @function.call))

--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -219,3 +219,6 @@
 
 ;; Property
 (dot_index_expression field: (identifier) @variable.other.member)
+
+;; Method
+(function_call name: (dot_index_expression field: (identifier) @function.call))


### PR DESCRIPTION
### Description 

This PR adds proper syntax highlighting for function calls that use dot notation (methods) in Lua files. Previously, when using a function call like object.method(), the method name was highlighted as a property (variable.other.member) rather than as a function call.

Before:
<img width="661" alt="Bildschirmfoto 2025-04-24 um 20 38 58" src="https://github.com/user-attachments/assets/3ce6e6bc-b03a-4960-bf6f-21cfc36f74b2" />

After:
<img width="661" alt="Bildschirmfoto 2025-04-24 um 20 39 15" src="https://github.com/user-attachments/assets/4b65ba08-0657-463e-b6a3-5a37beae0ce5" />
