### PR TITLE
sonokai: fix constant.builtin highlights

### DIFF
--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -6,7 +6,9 @@
 # License: MIT License
 
 "type" = "blue"
+"boolean" = "purple"
 "constant" = "fg"
+"constant.builtin" = "purple"
 "constant.numeric" = "purple"
 "constant.character.escape" = "orange"
 "string" = "yellow"

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -6,7 +6,6 @@
 # License: MIT License
 
 "type" = "blue"
-"boolean" = "purple"
 "constant" = "fg"
 "constant.builtin" = "purple"
 "constant.numeric" = "purple"


### PR DESCRIPTION
properly sets them to purple (based on the original's vim `colors`)

Before:
![image](https://github.com/user-attachments/assets/7a50beab-d857-497e-8c9e-67ace1563755)

After:
![image](https://github.com/user-attachments/assets/8cffcfe8-f078-4f21-877a-3d08f43e7785)
