### PR TITLE
flake: drop flake-utils dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,6 @@
   installShellFiles,
   git,
   gitRev ? null,
-  ...
 }: let
   fs = lib.fileset;
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1740560979,
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -58,21 +39,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,77 +12,90 @@
   outputs = {
     self,
     nixpkgs,
-    flake-utils,
     rust-overlay,
     ...
   }: let
+    inherit (nixpkgs) lib;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    eachSystem = lib.genAttrs systems;
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        localSystem.system = system;
+        overlays = [(import rust-overlay) self.overlays.helix];
+      });
     gitRev = self.rev or self.dirtyRev or null;
-  in
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [(import rust-overlay)];
-      };
+  in {
+    packages = eachSystem (system: {
+      inherit (pkgsFor.${system}) helix;
+      /*
+      The default Helix build. Uses the latest stable Rust toolchain, and unstable
+      nixpkgs.
 
-      # Get Helix's MSRV toolchain to build with by default.
-      msrvToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-      msrvPlatform = pkgs.makeRustPlatform {
-        cargo = msrvToolchain;
-        rustc = msrvToolchain;
-      };
-    in {
-      packages = rec {
-        helix = pkgs.callPackage ./default.nix {inherit gitRev;};
+      The build inputs can be overriden with the following:
 
-        /**
-        The default Helix build. Uses the latest stable Rust toolchain, and unstable
-        nixpkgs.
-        
-        The build inputs can be overriden with the following:
-         
-        packages.${system}.default.override { rustPlatform = newPlatform; };
-         
-        Overriding a derivation attribute can be done as well:
-        
-        packages.${system}.default.overrideAttrs { buildType = "debug"; };
-        */ 
-        default = helix;
-      };
+      packages.${system}.default.override { rustPlatform = newPlatform; };
 
-      checks.helix = self.outputs.packages.${system}.helix.override {
-        buildType = "debug";
-        rustPlatform = msrvPlatform;
-      };
+      Overriding a derivation attribute can be done as well:
 
-      # Devshell behavior is preserved.
-      devShells.default = let
-        commonRustFlagsEnv = "-C link-arg=-fuse-ld=lld -C target-cpu=native --cfg tokio_unstable";
-        platformRustFlagsEnv = pkgs.lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
-      in
-        pkgs.mkShell
-        {
-          inputsFrom = [self.checks.${system}.helix];
-          nativeBuildInputs = with pkgs;
-            [
-              lld
-              cargo-flamegraph
-              rust-bin.nightly.latest.rust-analyzer
-            ]
-            ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
-            ++ (lib.optional stdenv.isLinux lldb)
-            ++ (lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation);
-          shellHook = ''
-            export RUST_BACKTRACE="1"
-            export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"
-          '';
+      packages.${system}.default.overrideAttrs { buildType = "debug"; };
+      */
+      default = self.packages.${system}.helix;
+    });
+    checks =
+      lib.mapAttrs (system: pkgs: let
+        # Get Helix's MSRV toolchain to build with by default.
+        msrvToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        msrvPlatform = pkgs.makeRustPlatform {
+          cargo = msrvToolchain;
+          rustc = msrvToolchain;
         };
-    })
-    // {
-      overlays.default = final: prev: {
+      in {
+        helix = self.packages.${system}.helix.override {
+          buildType = "debug";
+          rustPlatform = msrvPlatform;
+        };
+      })
+      pkgsFor;
+
+    # Devshell behavior is preserved.
+    devShells =
+      lib.mapAttrs (system: pkgs: {
+        default = let
+          commonRustFlagsEnv = "-C link-arg=-fuse-ld=lld -C target-cpu=native --cfg tokio_unstable";
+          platformRustFlagsEnv = lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
+        in
+          pkgs.mkShell {
+            inputsFrom = [self.checks.${system}.helix];
+            nativeBuildInputs = with pkgs;
+              [
+                lld
+                cargo-flamegraph
+                rust-bin.nightly.latest.rust-analyzer
+              ]
+              ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
+              ++ (lib.optional stdenv.isLinux lldb)
+              ++ (lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation);
+            shellHook = ''
+              export RUST_BACKTRACE="1"
+              export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"
+            '';
+          };
+      })
+      pkgsFor;
+
+    overlays = {
+      helix = final: prev: {
         helix = final.callPackage ./default.nix {inherit gitRev;};
       };
-    };
 
+      default = self.overlays.helix;
+    };
+  };
   nixConfig = {
     extra-substituters = ["https://helix.cachix.org"];
     extra-trusted-public-keys = ["helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs="];

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,6 @@
         };
       in {
         helix = self.packages.${system}.helix.override {
-          buildType = "debug";
           rustPlatform = msrvPlatform;
         };
       })


### PR DESCRIPTION
Remove the dependency on flake-utils, which simplifies the flake by removing abstraction. 
Add nix-systems to enable local overriding of the systems.