### PR TITLE
fix(highlights/go): defer, go, goto are keywords

### DIFF
--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -114,6 +114,12 @@
 ] @keyword
 
 [
+  "defer"
+  "go"
+  "goto"
+] @keyword.control
+
+[
   "if"  
   "else"
   "switch"
@@ -153,12 +159,6 @@
 [
   "const"
 ] @keyword.storage.modifier
-
-[
-  "defer"
-  "goto"
-  "go"
-] @function.macro
 
 ; Delimiters
 


### PR DESCRIPTION
I don't believe these should be highlighted as `function.macro`:

- They're keywords
- Many themes highlight `function` and `function.macro` the same, which colors `go someFunc()` and `defer someFunc()` uniformly, making the keywords easy to miss
- Other editors give these keyword-ish highlighting as well
