### PR TITLE
feat: give formatters access to filename

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -66,7 +66,7 @@ These configuration keys are available:
 | `indent`              | The indent to use. Has sub keys `unit` (the text inserted into the document when indenting; usually set to N spaces or `"\t"` for tabs) and `tab-width` (the number of spaces rendered for a tab) |
 | `language-servers`    | The Language Servers used for this language. See below for more information in the section [Configuring Language Servers for a language](#configuring-language-servers-for-a-language)   |
 | `grammar`             | The tree-sitter grammar to use (defaults to the value of `name`) |
-| `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
+| `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout. The filename of the current buffer can be passed as argument by using the `%{buffer_name}` expansion variable. See below for more information in the [Configuring the formatter command](#configuring-the-formatter-command) |
 | `soft-wrap`           | [editor.softwrap](./editor.md#editorsoft-wrap-section)
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set, defaults to `editor.text-width`   |
 | `rulers`              | Overrides the `editor.rulers` config key for the language. |
@@ -101,6 +101,16 @@ with the following priorities:
 2. Extension: if there are no glob matches, any `file-types` string that matches
    the file extension of a given file wins. In the example above, the `"toml"`
    config matches files like `Cargo.toml` or `languages.toml`.
+
+### Configuring the formatter command
+
+[Command line expansions](./command-line.md#expansions) are supported in the arguments
+of the formatter command. In particular, the `%{buffer_name}` variable can be passed as
+argument to the formatter:
+
+```toml
+formatter = { command = "mylang-formatter" , args = ["--stdin", "--stdin-filename %{buffer_name}"] }
+```
 
 ## Language Server configuration
 

--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -357,13 +357,22 @@ pub struct Token<'a> {
     pub is_terminated: bool,
 }
 
-impl Token<'_> {
+impl<'a> Token<'a> {
     pub fn empty_at(content_start: usize) -> Self {
         Self {
             kind: TokenKind::Unquoted,
             content_start,
             content: Cow::Borrowed(""),
             is_terminated: false,
+        }
+    }
+
+    pub fn expand(content: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            kind: TokenKind::Expand,
+            content_start: 0,
+            content: content.into(),
+            is_terminated: true,
         }
     }
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -324,22 +324,20 @@ fn buffer_previous(
 fn write_impl(cx: &mut compositor::Context, path: Option<&str>, force: bool) -> anyhow::Result<()> {
     let config = cx.editor.config();
     let jobs = &mut cx.jobs;
-    {
-        let (view, doc) = current!(cx.editor);
+    let (view, doc) = current!(cx.editor);
 
-        if doc.trim_trailing_whitespace() {
-            trim_trailing_whitespace(doc, view.id);
-        }
-        if config.trim_final_newlines {
-            trim_final_newlines(doc, view.id);
-        }
-        if doc.insert_final_newline() {
-            insert_final_newline(doc, view.id);
-        }
-
-        // Save an undo checkpoint for any outstanding changes.
-        doc.append_changes_to_history(view);
+    if doc.trim_trailing_whitespace() {
+        trim_trailing_whitespace(doc, view.id);
     }
+    if config.trim_final_newlines {
+        trim_final_newlines(doc, view.id);
+    }
+    if doc.insert_final_newline() {
+        insert_final_newline(doc, view.id);
+    }
+
+    // Save an undo checkpoint for any outstanding changes.
+    doc.append_changes_to_history(view);
 
     let (view, doc) = current_ref!(cx.editor);
     let fmt = if config.auto_format {
@@ -738,26 +736,24 @@ pub fn write_all_impl(
         .collect();
 
     for (doc_id, target_view) in saves {
-        {
-            let doc = doc_mut!(cx.editor, &doc_id);
-            let view = view_mut!(cx.editor, target_view);
+        let doc = doc_mut!(cx.editor, &doc_id);
+        let view = view_mut!(cx.editor, target_view);
 
-            if doc.trim_trailing_whitespace() {
-                trim_trailing_whitespace(doc, target_view);
-            }
-            if config.trim_final_newlines {
-                trim_final_newlines(doc, target_view);
-            }
-            if doc.insert_final_newline() {
-                insert_final_newline(doc, target_view);
-            }
-
-            // Save an undo checkpoint for any outstanding changes.
-            doc.append_changes_to_history(view);
+        if doc.trim_trailing_whitespace() {
+            trim_trailing_whitespace(doc, target_view);
+        }
+        if config.trim_final_newlines {
+            trim_final_newlines(doc, target_view);
+        }
+        if doc.insert_final_newline() {
+            insert_final_newline(doc, target_view);
         }
 
-        let doc = doc!(cx.editor, &doc_id);
+        // Save an undo checkpoint for any outstanding changes.
+        doc.append_changes_to_history(view);
+
         let fmt = if options.auto_format && config.auto_format {
+            let doc = doc!(cx.editor, &doc_id);
             doc.auto_format(cx.editor).map(|fmt| {
                 let callback = make_format_callback(
                     doc_id,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -814,8 +814,22 @@ impl Document {
                 process.current_dir(doc_dir);
             }
 
+            let filename_in_args = fmt_args.iter().any(|arg| arg.contains("{}"));
+            let fmt_args = filename_in_args
+                .then_some(self.path().map(|path| {
+                    let path = path.to_string_lossy();
+                    Cow::Owned(
+                        fmt_args
+                            .iter()
+                            .map(|arg| arg.replace("{}", &path))
+                            .collect(),
+                    )
+                }))
+                .flatten()
+                .unwrap_or(Cow::Borrowed(fmt_args));
+
             process
-                .args(fmt_args)
+                .args(fmt_args.as_ref())
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());


### PR DESCRIPTION
Partially solves #3596 

This implementation is a bit different from #5626 in that here the contents of the buffer is still passed to the formatter via stdin and not read from disk. This implementation allows to use the filename of the current buffer with formatters that accept arguments like `--stdin-filepath` or `--stdin-filename` ([prettier](https://prettier.io/docs/options#file-path), [stylua](https://github.com/JohnnyMorganz/StyLua?tab=readme-ov-file#filtering-when-using-stdin), [ruff](https://docs.astral.sh/ruff/formatter/), [black](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#stdin-filename), [eslint](https://eslint.org/docs/latest/use/command-line-interface#--stdin-filename) and [clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)).

It's working, but I do have a couple of questions:
- In this implementation, a fair amount of code was stolen from `helix-view/src/expansion.rs` to parse and expand the `%{buffer_name}` variable correctly. I did that instead of calling a function from the `expansion` module because I was thinking maybe we only want to allow `%{buffer_name}` in format commands, instead of the whole set of possible variables?
- If we do want to allow the full set of possible expansions, then I think we probably want to make `expand_inner` pub, since it does just what we need here. I was able to make that work as well, it just required to pass a reference to the editor to the format method because `expand_inner` takes one, and this in turn required a few tweaks to make the borrow checker happy, but that wasn't too difficult. If that sounds like what we want to do I can push the commit I have.

Note also that I have been testing this patch "manually", I haven't tried to implement actual Rust tests, but I'm definitely willing to do so if I get confirmation that my choices make sense.

I think to fully close #3596 we would technically also need to allow formatter commands to work with the file on disk instead of stdin/stdout, but I don't know if that's something we want to implement, as I think this will require an additional setting. It seems to me like it would be hard to "guess" from the command and the args if the formatter command is expected to read from stdin or from disk.