### PR TITLE
Stack picker and preview vertically if too narrow

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1226,7 +1226,7 @@ impl<T: 'static + Send + Sync, D> Picker<T, D> {
             && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
             && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
         let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
-        return (render_preview, stack_vertically);
+        (render_preview, stack_vertically)
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1046,12 +1046,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         // |         |
         // +---------+
 
-        let render_preview = self.show_preview
-            && self.file_fn.is_some()
-            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
-            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
-        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
-
+        let (render_preview, stack_vertically) = self.get_picker_layout(area);
         let picker_area = if render_preview {
             if stack_vertically {
                 area.with_height(area.height / 3)
@@ -1198,21 +1193,15 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         // calculate the inner area inside the box
         let inner = block.inner(area);
 
-        // prompt area
-        let render_preview = self.show_preview
-            && self.file_fn.is_some()
-            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
-            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
-        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
-
+        let (render_preview, stack_vertically) = self.get_picker_layout(area);
         let picker_width = if render_preview && !stack_vertically {
             area.width / 2
         } else {
             area.width
         };
-        let area = inner.clip_left(1).with_height(1).with_width(picker_width);
+        let prompt_area = inner.clip_left(1).with_height(1).with_width(picker_width);
 
-        self.prompt.cursor(area, editor)
+        self.prompt.cursor(prompt_area, editor)
     }
 
     fn required_size(&mut self, (width, height): (u16, u16)) -> Option<(u16, u16)> {
@@ -1228,6 +1217,16 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
     fn drop(&mut self) {
         // ensure we cancel any ongoing background threads streaming into the picker
         self.version.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+}
+impl<T: 'static + Send + Sync, D> Picker<T, D> {
+    fn get_picker_layout(&self, area: Rect) -> (bool, bool) {
+        let render_preview = self.show_preview
+            && self.file_fn.is_some()
+            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
+            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
+        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
+        return (render_preview, stack_vertically);
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1022,6 +1022,15 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             );
         }
     }
+
+    fn get_layout(&self, area: Rect) -> (bool, bool) {
+        let render_preview = self.show_preview
+            && self.file_fn.is_some()
+            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
+            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
+        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
+        (render_preview, stack_vertically)
+    }
 }
 
 impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I, D> {
@@ -1046,7 +1055,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         // |         |
         // +---------+
 
-        let (render_preview, stack_vertically) = self.get_picker_layout(area);
+        let (render_preview, stack_vertically) = self.get_layout(area);
         let picker_area = if render_preview {
             if stack_vertically {
                 area.with_height(area.height / 3)
@@ -1193,7 +1202,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         // calculate the inner area inside the box
         let inner = block.inner(area);
 
-        let (render_preview, stack_vertically) = self.get_picker_layout(area);
+        let (render_preview, stack_vertically) = self.get_layout(area);
         let picker_width = if render_preview && !stack_vertically {
             area.width / 2
         } else {
@@ -1217,16 +1226,6 @@ impl<T: 'static + Send + Sync, D> Drop for Picker<T, D> {
     fn drop(&mut self) {
         // ensure we cancel any ongoing background threads streaming into the picker
         self.version.fetch_add(1, atomic::Ordering::Relaxed);
-    }
-}
-impl<T: 'static + Send + Sync, D> Picker<T, D> {
-    fn get_picker_layout(&self, area: Rect) -> (bool, bool) {
-        let render_preview = self.show_preview
-            && self.file_fn.is_some()
-            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
-            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
-        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
-        (render_preview, stack_vertically)
     }
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -56,7 +56,9 @@ use self::handlers::{DynamicQueryChange, DynamicQueryHandler, PreviewHighlightHa
 
 pub const ID: &str = "picker";
 
+/// Narrowest preview width before switching to a stack layout instead of side-by-side
 pub const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
+/// Shortest preview height before preview is hidden entirely
 pub const MIN_AREA_HEIGHT_FOR_PREVIEW: u16 = 24;
 /// Biggest file size to preview in bytes
 pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
@@ -1024,11 +1026,11 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     }
 
     fn get_layout(&self, area: Rect) -> (bool, bool) {
+        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
         let render_preview = self.show_preview
             && self.file_fn.is_some()
-            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
-            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
-        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
+            && ((stack_vertically && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW * 3 / 2)
+                || (!stack_vertically && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW));
         (render_preview, stack_vertically)
     }
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -57,6 +57,7 @@ use self::handlers::{DynamicQueryChange, DynamicQueryHandler, PreviewHighlightHa
 pub const ID: &str = "picker";
 
 pub const MIN_AREA_WIDTH_FOR_PREVIEW: u16 = 72;
+pub const MIN_AREA_HEIGHT_FOR_PREVIEW: u16 = 24;
 /// Biggest file size to preview in bytes
 pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
 
@@ -1025,27 +1026,50 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
 impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I, D> {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
+        // default render
         // +---------+ +---------+
         // |prompt   | |preview  |
         // +---------+ |         |
         // |picker   | |         |
         // |         | |         |
         // +---------+ +---------+
+        //
+        // stack vertically
+        // +---------+
+        // |prompt   |
+        // +---------+
+        // |picker   |
+        // |         |
+        // +---------+
+        // |preview  |
+        // |         |
+        // |         |
+        // +---------+
 
-        let render_preview =
-            self.show_preview && self.file_fn.is_some() && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
+        let render_preview = self.show_preview
+            && self.file_fn.is_some()
+            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
+            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
+        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
 
-        let picker_width = if render_preview {
-            area.width / 2
+        let picker_area = if render_preview {
+            if stack_vertically {
+                area.with_height(area.height / 3)
+            } else {
+                area.with_width(area.width / 2)
+            }
         } else {
-            area.width
+            area
         };
 
-        let picker_area = area.with_width(picker_width);
         self.render_picker(picker_area, surface, cx);
 
         if render_preview {
-            let preview_area = area.clip_left(picker_width);
+            let preview_area = if stack_vertically {
+                area.clip_top(picker_area.height)
+            } else {
+                area.clip_left(picker_area.width)
+            };
             self.render_preview(preview_area, surface, cx);
         }
     }
@@ -1175,10 +1199,13 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         let inner = block.inner(area);
 
         // prompt area
-        let render_preview =
-            self.show_preview && self.file_fn.is_some() && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
+        let render_preview = self.show_preview
+            && self.file_fn.is_some()
+            && area.width >= MIN_AREA_WIDTH_FOR_PREVIEW
+            && area.height >= MIN_AREA_HEIGHT_FOR_PREVIEW;
+        let stack_vertically = area.width / 2 < MIN_AREA_WIDTH_FOR_PREVIEW;
 
-        let picker_width = if render_preview {
+        let picker_width = if render_preview && !stack_vertically {
             area.width / 2
         } else {
             area.width


### PR DESCRIPTION
I couldn't get #7783 to work well for me so I rewrote it.

@pascalkuthe if you're still interested now that #9647 has landed.

I tried @archseer's [suggestion](https://github.com/helix-editor/helix/pull/7783#issuecomment-2273713481) but in practice, I didn't like it for shorter terminals that you would still want a vertical picker for because they were also narrow.

Looks like this:
<img width="1007" height="1390" alt="file picker open with preview shown stacked below it" src="https://github.com/user-attachments/assets/6c818024-e745-43c6-b728-d25da12543df" />


At `MIN_AREA_HEIGHT_FOR_PREVIEW`, eight entries are shown:
<img width="1007" height="651" alt="file picker open with eight search results before a preview with height 24" src="https://github.com/user-attachments/assets/65040505-9b93-4367-8422-07b985f9f22a" />

