### PR TITLE
Changed rust-analyzer configuration to use server-side file watching

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -191,6 +191,8 @@ inlayHints.discriminantHints.enable = "fieldless"
 inlayHints.lifetimeElisionHints.enable = "skip_trivial"
 inlayHints.typeHints.hideClosureInitialization = false
 
+[language-server.rust-analyzer.config.files]
+watcher = "server"
 
 [language-server.typescript-language-server]
 command = "typescript-language-server"


### PR DESCRIPTION
I've changed the configuration for rust-analyzer to use the server-side file watching mechanism instead of the missing client-side.

This means there is no need to use `lsp-restart`  after using `cargo add` or `cargo remove`. Rust-analyzer automatically identifies the added / removed dependencies and provides intellisense and autocompletion. 