### PR TITLE
Add support for Pug language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -180,6 +180,7 @@
 | prolog | ✓ |  | ✓ | `swipl` |
 | protobuf | ✓ | ✓ | ✓ | `buf`, `pb`, `protols` |
 | prql | ✓ |  |  |  |
+| pug | ✓ |  |  |  |
 | purescript | ✓ | ✓ |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | `ruff`, `jedi-language-server`, `pylsp` |
 | qml | ✓ |  | ✓ | `qmlls` |

--- a/languages.toml
+++ b/languages.toml
@@ -4313,3 +4313,14 @@ comment-tokens = "#"
 [[grammar]]
 name = "debian"
 source = { git = "https://gitlab.com/MggMuggins/tree-sitter-debian", rev = "9b3f4b78c45aab8a2f25a5f9e7bbc00995bc3dde" }
+
+[[language]]
+name = "pug"
+scope = "source.pug"
+file-types = ["pug"]
+comment-tokens = ["//", "//-"]
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "pug"
+source = { git = "https://github.com/codepen/tree-sitter-pug", rev = "60a463fd725afd034045496b9018fa4a081469fd" }

--- a/languages.toml
+++ b/languages.toml
@@ -4323,4 +4323,4 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "pug"
-source = { git = "https://github.com/codepen/tree-sitter-pug", rev = "60a463fd725afd034045496b9018fa4a081469fd" }
+source = { git = "https://github.com/zealot128/tree-sitter-pug", rev = "13e9195370172c86a8b88184cc358b23b677cc46" }

--- a/runtime/queries/pug/highlights.scm
+++ b/runtime/queries/pug/highlights.scm
@@ -1,0 +1,111 @@
+(comment) @comment
+
+(
+  doctype
+  (("doctype") @keyword.storage.type)
+  ((doctype_name) @type.enum.variant)
+)
+
+; Tags
+(tag_name) @constant
+(
+  link_tag
+  ("link" @constant)
+)
+(
+  script_tag
+  ("script" @constant)
+)
+(
+  style_tag
+  ("style" @constant)
+)
+
+; Attributes
+(id) @attribute
+(class) @attribute
+(attribute_name) @attribute
+
+(quoted_attribute_value) @string
+
+; Controls
+; NOTE: The grammar currently seems to be missing the "if" conditional
+(
+  case
+  ((keyword) @keyword.control)
+  (
+    when
+    ((keyword) @keyword.control)
+  )
+)
+(
+  each
+  ((keyword) @keyword.control.repeat)
+  ((iteration_variable) @variable)
+  ((keyword) @keyword.operator)
+  (
+    else
+    ((keyword) @keyword.control.conditional)
+  )
+)
+(
+  while
+  ((keyword) @keyword.control.repeat)
+)
+
+; Mixins
+(
+  mixin_definition
+  ((keyword) @keyword.function)
+  ((mixin_name) @function.method)
+)
+(
+  mixin_use
+  (("+") @operator)
+  ((mixin_name) @function.method)
+)
+
+; Includes
+(
+  include
+  ((keyword) @keyword.directive)
+  ((filename) @string.special.path)
+)
+
+; Inheritance
+(
+  extends
+  ((keyword) @keyword.directive)
+  ((filename) @string.special.path)
+)
+(
+  block_definition
+  ((keyword) @keyword.directive)
+  ((block_name) @function.method)
+)
+(
+  block_append
+  ((keyword) @keyword.directive)
+  ((keyword) @keyword.directive)
+  ((block_name) @function.method)
+)
+(
+  block_prepend
+  ((keyword) @keyword.directive)
+  ((keyword) @keyword.directive)
+  ((block_name) @function.method)
+)
+
+; Filters
+(
+  filter
+  (":" @function.macro)
+  ((filter_name) @function.macro)
+  ((content) @special)
+)
+
+; Inline JavaScript
+(
+  unbuffered_code
+  (("-") @operator)
+)

--- a/runtime/queries/pug/highlights.scm
+++ b/runtime/queries/pug/highlights.scm
@@ -6,20 +6,7 @@
   ((doctype_name) @type.enum.variant)
 )
 
-; Tags
 (tag_name) @constant
-(
-  link_tag
-  ("link" @constant)
-)
-(
-  script_tag
-  ("script" @constant)
-)
-(
-  style_tag
-  ("style" @constant)
-)
 
 ; Attributes
 (id) @attribute
@@ -29,7 +16,10 @@
 (quoted_attribute_value) @string
 
 ; Controls
-; NOTE: The grammar currently seems to be missing the "if" conditional
+(
+  conditional
+  ((keyword) @keyword.control.conditional)
+)
 (
   case
   ((keyword) @keyword.control)
@@ -41,12 +31,10 @@
 (
   each
   ((keyword) @keyword.control.repeat)
-  ((iteration_variable) @variable)
-  ((keyword) @keyword.operator)
-  (
-    else
-    ((keyword) @keyword.control.conditional)
-  )
+)
+(
+  else
+  ((keyword) @keyword.control.conditional)
 )
 (
   while
@@ -86,12 +74,10 @@
 (
   block_append
   ((keyword) @keyword.directive)
-  ((keyword) @keyword.directive)
   ((block_name) @function.method)
 )
 (
   block_prepend
-  ((keyword) @keyword.directive)
   ((keyword) @keyword.directive)
   ((block_name) @function.method)
 )
@@ -107,5 +93,5 @@
 ; Inline JavaScript
 (
   unbuffered_code
-  (("-") @operator)
+  (("-") @special)
 )

--- a/runtime/queries/pug/injections.scm
+++ b/runtime/queries/pug/injections.scm
@@ -1,0 +1,3 @@
+((javascript) @injection.content
+  (#set! injection.language "javascript")
+)

--- a/runtime/queries/pug/injections.scm
+++ b/runtime/queries/pug/injections.scm
@@ -1,3 +1,15 @@
 ((javascript) @injection.content
   (#set! injection.language "javascript")
 )
+
+(
+  script_tag
+  ((content_code) @injection.content
+    (#set! injection.language "javascript"))
+)
+
+(
+  style_tag
+  ((content_code) @injection.content
+    (#set! injection.language "css"))
+)

--- a/runtime/queries/pug/injections.scm
+++ b/runtime/queries/pug/injections.scm
@@ -1,15 +1,3 @@
 ((javascript) @injection.content
   (#set! injection.language "javascript")
 )
-
-(
-  script_tag
-  ((content_code) @injection.content
-    (#set! injection.language "javascript"))
-)
-
-(
-  style_tag
-  ((content_code) @injection.content
-    (#set! injection.language "css"))
-)


### PR DESCRIPTION
This adds support for Pug.js (previously known as Jade), a templating language that compiles to HTML.

This is my first time writing tree-sitter queries, so I apologize if the queries look strange in any way.

## To-do

- [x] JavaScript injection in `script` tags
- [x] Support conditionals