### PR TITLE
Help Linguist identify Tree-sitter queries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 *.md       text diff=markdown
 
 book/theme/highlight.js linguist-vendored
+runtime/queries/**/*.scm linguist-language=Tree-sitter-Query
 Cargo.lock text


### PR DESCRIPTION
I noticed that linguist was identifying some queries as Scheme and others as Tree-sitter Queries.

My fork's stats might not have updated yet, but I confirmed the expected results by running github-linguist locally.