### PR TITLE
Fix: File picker no longer ignores git-ignore configuration

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -473,7 +473,7 @@ pub mod completers {
     }
 
     pub fn filename(editor: &Editor, input: &str) -> Vec<Completion> {
-        filename_with_git_ignore(editor, input, true)
+        filename_with_git_ignore(editor, input, editor.config().file_picker.git_ignore)
     }
 
     pub fn filename_with_git_ignore(


### PR DESCRIPTION
Fixes #13348 