### PR TITLE
Add goto_column and extend_to_column commands

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -153,8 +153,8 @@
 | `goto_last_change` | Goto last change | normal: `` ]G ``, select: `` ]G `` |
 | `goto_line_start` | Goto line start | normal: `` gh ``, `` <home> ``, select: `` gh ``, insert: `` <home> `` |
 | `goto_line_end` | Goto line end | normal: `` gl ``, `` <end> ``, select: `` gl `` |
-| `goto_column` | Goto column |  |
-| `extend_to_column` | Extend to column |  |
+| `goto_column` | Goto column | normal: `` g\| `` |
+| `extend_to_column` | Extend to column | select: `` g\| `` |
 | `goto_next_buffer` | Goto next buffer | normal: `` gn ``, select: `` gn `` |
 | `goto_previous_buffer` | Goto previous buffer | normal: `` gp ``, select: `` gp `` |
 | `goto_line_end_newline` | Goto newline at line end | insert: `` <end> `` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -153,6 +153,8 @@
 | `goto_last_change` | Goto last change | normal: `` ]G ``, select: `` ]G `` |
 | `goto_line_start` | Goto line start | normal: `` gh ``, `` <home> ``, select: `` gh ``, insert: `` <home> `` |
 | `goto_line_end` | Goto line end | normal: `` gl ``, `` <end> ``, select: `` gl `` |
+| `goto_column` | Goto column |  |
+| `extend_to_column` | Extend to column |  |
 | `goto_next_buffer` | Goto next buffer | normal: `` gn ``, select: `` gn `` |
 | `goto_previous_buffer` | Goto previous buffer | normal: `` gp ``, select: `` gp `` |
 | `goto_line_end_newline` | Goto newline at line end | insert: `` <end> `` |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -213,6 +213,7 @@ Jumps to various locations.
 | Key   | Description                                      | Command                    |
 | ----- | -----------                                      | -------                    |
 | `g`   | Go to line number `<n>` else start of file       | `goto_file_start`          |
+| <code>&#124;</code>  | Go to column number `<n>` else start of line     | `goto_column`              |
 | `e`   | Go to the end of the file                        | `goto_last_line`           |
 | `f`   | Go to files in the selections                    | `goto_file`                |
 | `h`   | Go to the start of the line                      | `goto_line_start`          |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3847,7 +3847,7 @@ fn goto_column_impl(cx: &mut Context, movement: Movement) {
         let line = range.cursor_line(text);
         let line_start = text.line_to_char(line);
         let line_end = line_end_char_index(&text, line);
-        let pos = graphemes::prev_grapheme_boundary(text, line_start + count).min(line_end);
+        let pos = graphemes::nth_next_grapheme_boundary(text, line_start, count - 1).min(line_end);
         range.put_cursor(text, pos, movement == Movement::Extend)
     });
     doc.set_selection(view.id, selection);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -451,6 +451,8 @@ impl MappableCommand {
         goto_last_change, "Goto last change",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
+        goto_column, "Goto column",
+        extend_to_column, "Extend to column",
         goto_next_buffer, "Goto next buffer",
         goto_previous_buffer, "Goto previous buffer",
         goto_line_end_newline, "Goto newline at line end",
@@ -3827,6 +3829,30 @@ fn goto_last_line_impl(cx: &mut Context, movement: Movement) {
 
     push_jump(view, doc);
     doc.set_selection(view.id, selection);
+}
+
+fn goto_column(cx: &mut Context) {
+    goto_column_impl(cx, Movement::Move);
+}
+
+fn extend_to_column(cx: &mut Context) {
+    goto_column_impl(cx, Movement::Extend);
+}
+
+fn goto_column_impl(cx: &mut Context, movement: Movement) {
+    if let Some(count) = cx.count {
+        let (view, doc) = current!(cx.editor);
+        let text = doc.text().slice(..);
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            let line = range.cursor_line(text);
+            let line_start = text.line_to_char(line);
+            let target = line_start + count.get();
+            let line_end = line_end_char_index(&text, line);
+            let pos = graphemes::prev_grapheme_boundary(text, target).min(line_end);
+            range.put_cursor(text, pos, movement == Movement::Extend)
+        });
+        doc.set_selection(view.id, selection);
+    }
 }
 
 fn goto_last_accessed_file(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3840,19 +3840,17 @@ fn extend_to_column(cx: &mut Context) {
 }
 
 fn goto_column_impl(cx: &mut Context, movement: Movement) {
-    if let Some(count) = cx.count {
-        let (view, doc) = current!(cx.editor);
-        let text = doc.text().slice(..);
-        let selection = doc.selection(view.id).clone().transform(|range| {
-            let line = range.cursor_line(text);
-            let line_start = text.line_to_char(line);
-            let target = line_start + count.get();
-            let line_end = line_end_char_index(&text, line);
-            let pos = graphemes::prev_grapheme_boundary(text, target).min(line_end);
-            range.put_cursor(text, pos, movement == Movement::Extend)
-        });
-        doc.set_selection(view.id, selection);
-    }
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let line = range.cursor_line(text);
+        let line_start = text.line_to_char(line);
+        let line_end = line_end_char_index(&text, line);
+        let pos = graphemes::prev_grapheme_boundary(text, line_start + count).min(line_end);
+        range.put_cursor(text, pos, movement == Movement::Extend)
+    });
+    doc.set_selection(view.id, selection);
 }
 
 fn goto_last_accessed_file(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -38,6 +38,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "G" => goto_line,
         "g" => { "Goto"
             "g" => goto_file_start,
+            "|" => goto_column,
             "e" => goto_last_line,
             "f" => goto_file,
             "h" => goto_line_start,
@@ -368,6 +369,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "v" => normal_mode,
         "g" => { "Goto"
             "g" => extend_to_file_start,
+            "|" => extend_to_column,
             "e" => extend_to_last_line,
             "k" => extend_line_up,
             "j" => extend_line_down,


### PR DESCRIPTION
Adds `goto_column` and `goto_line`.
The second commit adds them to the `Goto` menu as `|`, similar to how vim uses `<n>|`.