### PR TITLE
Allow diff gutter symbols configuration

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -381,7 +381,22 @@ These colors are controlled by the theme attributes `diff.plus`, `diff.minus` an
 
 Other diff providers will eventually be supported by a future plugin system.
 
-There are currently no options for this section.
+Options for the diff gutter
+
+| Key               | Description                                             | Default |
+| ---               | ---                                                     | ---     |
+| `added-symbol`    | The symbol used to indicate addition in the gutter      | `▍`     |
+| `deleted-symbol`  | The symbol used to indicate deletion in the gutter      | `▔`     |
+| `modified-symbol` | The symbol used to indicate modification in the gutter  | `▍`     |
+
+Example:
+
+```toml
+[editor.gutters.diff]
+added-symbol = "+"
+deleted-symbol = "-"
+modified-symbol = "~"
+```
 
 #### `[editor.gutters.spacer]` Section
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -89,6 +89,8 @@ pub struct GutterConfig {
     pub layout: Vec<GutterType>,
     /// Options specific to the "line-numbers" gutter
     pub line_numbers: GutterLineNumbersConfig,
+    /// Options specific to the "diff" gutter
+    pub diff: GutterDiffConfig,
 }
 
 impl Default for GutterConfig {
@@ -102,6 +104,7 @@ impl Default for GutterConfig {
                 GutterType::Diff,
             ],
             line_numbers: GutterLineNumbersConfig::default(),
+            diff: GutterDiffConfig::default(),
         }
     }
 }
@@ -169,6 +172,27 @@ pub struct GutterLineNumbersConfig {
 impl Default for GutterLineNumbersConfig {
     fn default() -> Self {
         Self { min_width: 3 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct GutterDiffConfig {
+    /// Symbol to show for added lines (pure insertion)
+    pub added_symbol: String,
+    /// Symbol to show for deleted lines (pure removal)
+    pub deleted_symbol: String,
+    /// Symbol to show for modified lines
+    pub modified_symbol: String,
+}
+
+impl Default for GutterDiffConfig {
+    fn default() -> Self {
+        Self {
+            added_symbol: "▍".to_string(),
+            deleted_symbol: "▔".to_string(),
+            modified_symbol: "▍".to_string(),
+        }
     }
 }
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -708,7 +708,9 @@ mod tests {
     const DEFAULT_GUTTER_OFFSET_ONLY_DIAGNOSTICS: u16 = 3;
 
     use crate::document::Document;
-    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig, GutterType};
+    use crate::editor::{
+        Config, GutterConfig, GutterDiffConfig, GutterLineNumbersConfig, GutterType,
+    };
 
     #[test]
     fn test_text_pos_at_screen_coords() {
@@ -886,6 +888,7 @@ mod tests {
             GutterConfig {
                 layout: vec![GutterType::Diagnostics],
                 line_numbers: GutterLineNumbersConfig::default(),
+                diff: GutterDiffConfig::default(),
             },
         );
         view.area = Rect::new(40, 40, 40, 40);
@@ -916,6 +919,7 @@ mod tests {
             GutterConfig {
                 layout: vec![],
                 line_numbers: GutterLineNumbersConfig::default(),
+                diff: GutterDiffConfig::default(),
             },
         );
         view.area = Rect::new(40, 40, 40, 40);


### PR DESCRIPTION
This PR adds the ability to customize the symbols used to indicate changes in the diff gutter.

Resolves: #6206 