### PR TITLE
Fix: .editorconfig is now reloaded on `:config-reload`

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -401,6 +401,8 @@ impl Application {
             // Re-parse any open documents with the new language config.
             let lang_loader = self.editor.syn_loader.load();
             for document in self.editor.documents.values_mut() {
+                // Re-detect .editorconfig
+                document.detect_editor_config();
                 document.detect_language(&lang_loader);
                 let diagnostics = Editor::doc_diagnostics(
                     &self.editor.language_servers,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1172,7 +1172,7 @@ impl Document {
         }
     }
 
-    pub(crate) fn detect_editor_config(&mut self) {
+    pub fn detect_editor_config(&mut self) {
         if self.config.load().editor_config {
             if let Some(path) = self.path.as_ref() {
                 self.editor_config = EditorConfig::find(path);


### PR DESCRIPTION
Closes  #13268

I documented the list of files updated on `:config-reload` and added `.editorconfig` to the list of files reloaded since it is now a part of the configuration of the editor.

Any feedback is appreciated.