### PR TITLE
[Draft] Add simple goto buffer command like Harpoon2 for Helix

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -3,6 +3,9 @@
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
 | `:open`, `:o`, `:edit`, `:e` | Open a file from disk into the current view. |
+| `:jump-to-buffer`, `:j` | Switch to a document buffer using its index in the buffer jumplist. |
+| `:add-buffer-to-jumplist`, `:ab` | Add the current document buffer to the buffer jumplist. |
+| `:remove-buffer-from-jumplist`, `:rb` | Remove the current document buffer from the buffer jumplist. |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3141,6 +3141,7 @@ fn buffer_picker(cx: &mut Context) {
         is_modified: bool,
         is_current: bool,
         focused_at: std::time::Instant,
+        index_in_buffer_jumplist: Option<usize>,
     }
 
     let new_meta = |doc: &Document| BufferMeta {
@@ -3149,6 +3150,11 @@ fn buffer_picker(cx: &mut Context) {
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
         focused_at: doc.focused_at,
+        index_in_buffer_jumplist: cx
+            .editor
+            .buffer_jumplist
+            .iter()
+            .position(|id| id == &doc.id()),
     };
 
     let mut items = cx
@@ -3171,6 +3177,10 @@ fn buffer_picker(cx: &mut Context) {
             if meta.is_current {
                 flags.push('*');
             }
+            if let Some(index) = meta.index_in_buffer_jumplist {
+                flags.push_str(&index.to_string());
+            }
+
             flags.into()
         }),
         PickerColumn::new("path", |meta: &BufferMeta, _| {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1123,6 +1123,9 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+
+    /// Stores a manually curated list of document IDs for navigation.
+    pub buffer_jumplist: Vec<DocumentId>,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1245,6 +1248,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            buffer_jumplist: Vec::new(),
         }
     }
 
@@ -1823,6 +1827,9 @@ impl Editor {
 
         // This will also disallow any follow-up writes
         self.saves.remove(&doc_id);
+
+        // Removes the document from the buffer jumplist when closed.
+        self.buffer_jumplist.retain(|doc| *doc != doc_id);
 
         enum Action {
             Close(ViewId),


### PR DESCRIPTION
Add a `goto` buffer feature to Helix, inspired by [Harpoon2](https://github.com/ThePrimeagen/harpoon/tree/harpoon2) for Neovim. It lets you quickly jump between open buffers with a `typed` command.

The PR is still rough around the edges. I'd appreciate your early feedback. No tests or docs yet - I’ll add those if y’all like the idea. This patch already works for my needs, but I’m down to polish it if the community is into it. My goal was a minimal MVP patch with maximum reuse.

The changes include adding the buffer `jumplist` functionality, commands for interacting with the `jumplist`, and updates to the user interface to display `jumplist` indices.

### Buffer Jumplist Functionality

* Add a `buffer_jumplist` field to the `Editor` struct to store a manually curated list of document IDs for navigation.

### Commands for Jumplist Interaction

* Introduce three new commands:
  - `jump-to-buffer`: Switches to a document buffer using its index in the `jumplist`.
  - `add-buffer-to-jumplist`: Adds the current document buffer to the `jumplist`. 
  - `remove-buffer-from-jumplist`: Removes the current document buffer from the `jumplist`.

### UI changes
<img width="1532" alt="image" src="https://github.com/user-attachments/assets/0f76e593-32c1-485b-8fac-c1430db85381" />

* Update the `buffer_picker` function to display the index of each buffer in the `jumplist` as part of the flags column. This helps me identify and navigate to buffers in the `jumplist` more easily. I know this isn't an ideal user experience, but it's good enough for a draft PR and initial feedback. I'm planning to add a new column or even an entirely new picker for the buffer `jumplist`.

### Example usage 

Feel free to configure the keybindings however it suits you:
```toml
q.a=":ab"
q.d=":rb"
q.0=":j 0"
q.1=":j 1"
q.2=":j 2"
q.3=":j 3"
q.4=":j 4"
```
<img width="687" alt="image" src="https://github.com/user-attachments/assets/a9fd36dd-f75d-4b0b-aa76-9c17a0bb134b" />
