### PR TITLE
feat: add basic Slang support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -200,6 +200,7 @@
 | scala | ✓ | ✓ | ✓ | `metals` |
 | scheme | ✓ |  | ✓ |  |
 | scss | ✓ |  |  | `vscode-css-language-server` |
+| slang | ✓ | ✓ | ✓ | `slangd` |
 | slint | ✓ | ✓ | ✓ | `slint-lsp` |
 | smali | ✓ |  | ✓ |  |
 | smithy | ✓ |  |  | `cs` |

--- a/languages.toml
+++ b/languages.toml
@@ -104,6 +104,7 @@ robotframework_ls = { command = "robotframework_ls" }
 ruff = { command = "ruff", args = ["server"] }
 ruby-lsp = { command = "ruby-lsp" }
 serve-d = { command = "serve-d" }
+slangd = { command = "slangd" }
 slint-lsp = { command = "slint-lsp", args = [] }
 solargraph = { command = "solargraph", args = ["stdio"] }
 solc = { command = "solc", args = ["--lsp"] }
@@ -2576,6 +2577,20 @@ formatter = { command = "cue", args = ["fmt", "-"] }
 [[grammar]]
 name = "cue"
 source = { git = "https://github.com/eonpatapon/tree-sitter-cue", rev = "8a5f273bfa281c66354da562f2307c2d394b6c81" }
+
+[[language]]
+name = "slang"
+scope = "source.lang"
+injection-regex = "slang"
+file-types = ["slang"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+language-servers = [ "slangd" ]
+indent = { tab-width = 4, unit = "  " }
+
+[[grammar]]
+name = "slang"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-slang", rev = "327b1b821c255867a4fb724c8eee48887e3d014b" }
 
 [[language]]
 name = "slint"

--- a/runtime/queries/slang/highlights.scm
+++ b/runtime/queries/slang/highlights.scm
@@ -16,16 +16,12 @@
 (optional_parameter_declaration
   declarator: (_) @variable.parameter)
 
-;(field_expression) @variable.parameter ;; How to highlight this?
-((field_expression
-  (field_identifier) @function.method) @_parent
-  (#has-parent? @_parent template_method function_declarator))
-
 (field_declaration
   (field_identifier) @variable.other.member)
 
 (field_initializer
-  (field_identifier) @property)
+  (field_identifier) @variable.other.member
+
 
 (function_declarator
   declarator: (field_identifier) @function.method)
@@ -373,4 +369,4 @@
 ] @keyword.control.import
 
 (property_declaration
-  (identifier) @property)
+  (identifier) @variable.other.member)

--- a/runtime/queries/slang/highlights.scm
+++ b/runtime/queries/slang/highlights.scm
@@ -20,8 +20,7 @@
   (field_identifier) @variable.other.member)
 
 (field_initializer
-  (field_identifier) @variable.other.member
-
+  (field_identifier) @variable.other.member)
 
 (function_declarator
   declarator: (field_identifier) @function.method)

--- a/runtime/queries/slang/highlights.scm
+++ b/runtime/queries/slang/highlights.scm
@@ -1,8 +1,8 @@
 ; inherits: c
 
 ; cpp
-((identifier) @variable.member
-  (#match? @variable.member "^m_.*$"))
+((identifier) @variable.other.member
+  (#match? @variable.other.member "^m_.*$"))
 
 (parameter_declaration
   declarator: (reference_declarator) @variable.parameter)
@@ -22,7 +22,7 @@
   (#has-parent? @_parent template_method function_declarator))
 
 (field_declaration
-  (field_identifier) @variable.member)
+  (field_identifier) @variable.other.member)
 
 (field_initializer
   (field_identifier) @property)
@@ -31,12 +31,12 @@
   declarator: (field_identifier) @function.method)
 
 (concept_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (alias_declaration
-  name: (type_identifier) @type.definition)
+  name: (type_identifier) @type)
 
-(namespace_identifier) @module
+(namespace_identifier) @namespace
 
 ((namespace_identifier) @type
   (#match? @type "^[%u]"))
@@ -54,7 +54,7 @@
   [
     (qualified_identifier)
     (identifier)
-  ] @module)
+  ] @namespace)
 
 (destructor_name
   (identifier) @function.method)
@@ -75,13 +75,6 @@
       (qualified_identifier
         (identifier) @function))))
 
-((qualified_identifier
-  (qualified_identifier
-    (qualified_identifier
-      (qualified_identifier
-        (identifier) @function)))) @_parent
-  (#has-ancestor? @_parent function_declarator))
-
 (function_declarator
   (template_function
     (identifier) @function))
@@ -95,56 +88,41 @@
 
 (call_expression
   (qualified_identifier
-    (identifier) @function.call))
+    (identifier) @function))
 
 
 (call_expression
   (qualified_identifier
     (qualified_identifier
-      (identifier) @function.call)))
+      (identifier) @function)))
 
 (call_expression
   (qualified_identifier
     (qualified_identifier
       (qualified_identifier
-        (identifier) @function.call))))
-
-((qualified_identifier
-  (qualified_identifier
-    (qualified_identifier
-      (qualified_identifier
-        (identifier) @function.call)))) @_parent
-  (#has-ancestor? @_parent call_expression))
+        (identifier) @function))))
 
 (call_expression
   (template_function
-    (identifier) @function.call))
+    (identifier) @function))
 
 (call_expression
   (qualified_identifier
     (template_function
-      (identifier) @function.call)))
+      (identifier) @function)))
 
 (call_expression
   (qualified_identifier
     (qualified_identifier
       (template_function
-        (identifier) @function.call))))
+        (identifier) @function))))
 
 (call_expression
   (qualified_identifier
     (qualified_identifier
       (qualified_identifier
         (template_function
-          (identifier) @function.call)))))
-
-((qualified_identifier
-  (qualified_identifier
-    (qualified_identifier
-      (qualified_identifier
-        (template_function
-          (identifier) @function.call))))) @_parent
-  (#has-ancestor? @_parent call_expression))
+          (identifier) @function)))))
 
 ; methods
 (function_declarator
@@ -153,7 +131,7 @@
 
 (call_expression
   (field_expression
-    (field_identifier) @function.method.call))
+    (field_identifier) @function.method))
 
 ; constructors
 ((function_declarator
@@ -187,9 +165,9 @@
 (null
   "nullptr" @constant.builtin)
 
-(true) @boolean
+(true) @constant.builtin.boolean
 
-(false) @boolean
+(false) @constant.builtin.boolean
 
 ; Literals
 (raw_string_literal) @string
@@ -200,7 +178,7 @@
   "catch"
   "noexcept"
   "throw"
-] @keyword.exception
+] @keyword.control.exception
 
 [
   "decltype"
@@ -218,13 +196,13 @@
   "template"
   "typename"
   "concept"
-] @keyword.type
+] @keyword.storage.type
 
 [
   "co_await"
   "co_yield"
   "co_return"
-] @keyword.coroutine
+] @keyword
 
 [
   "public"
@@ -232,7 +210,7 @@
   "protected"
   "final"
   "virtual"
-] @keyword.modifier
+] @keyword.storage.modifier
 
 [
   "new"
@@ -293,7 +271,7 @@
   "triangleadj"
   "lineadj"
   "triangle"
-] @keyword.modifier
+] @keyword
 
 ((identifier) @variable.builtin
   (#match? @variable.builtin "^SV_"))
@@ -327,9 +305,9 @@
   "set"
 ] @function.builtin
 
-(call_expression) @function.call
+(call_expression) @function
 
-(call_expression (identifier)) @function.call
+(call_expression (identifier)) @function
 
 ((call_expression
   function: (identifier) @function.builtin)
@@ -392,7 +370,7 @@
 [
   "__exported"
   "import"
-] @keyword.import
+] @keyword.control.import
 
 (property_declaration
   (identifier) @property)

--- a/runtime/queries/slang/highlights.scm
+++ b/runtime/queries/slang/highlights.scm
@@ -1,0 +1,398 @@
+; inherits: c
+
+; cpp
+((identifier) @variable.member
+  (#match? @variable.member "^m_.*$"))
+
+(parameter_declaration
+  declarator: (reference_declarator) @variable.parameter)
+
+; function(Foo ...foo)
+(variadic_parameter_declaration
+  declarator: (variadic_declarator
+    (_) @variable.parameter))
+
+; int foo = 0
+(optional_parameter_declaration
+  declarator: (_) @variable.parameter)
+
+;(field_expression) @variable.parameter ;; How to highlight this?
+((field_expression
+  (field_identifier) @function.method) @_parent
+  (#has-parent? @_parent template_method function_declarator))
+
+(field_declaration
+  (field_identifier) @variable.member)
+
+(field_initializer
+  (field_identifier) @property)
+
+(function_declarator
+  declarator: (field_identifier) @function.method)
+
+(concept_definition
+  name: (identifier) @type.definition)
+
+(alias_declaration
+  name: (type_identifier) @type.definition)
+
+(namespace_identifier) @module
+
+((namespace_identifier) @type
+  (#match? @type "^[%u]"))
+
+(case_statement
+  value: (qualified_identifier
+    (identifier) @constant))
+
+(using_declaration
+  .
+  "using"
+  .
+  "namespace"
+  .
+  [
+    (qualified_identifier)
+    (identifier)
+  ] @module)
+
+(destructor_name
+  (identifier) @function.method)
+
+; functions
+(function_declarator
+  (qualified_identifier
+    (identifier) @function))
+
+(function_declarator
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function)))
+
+(function_declarator
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function))))
+
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function)))) @_parent
+  (#has-ancestor? @_parent function_declarator))
+
+(function_declarator
+  (template_function
+    (identifier) @function))
+
+(operator_name) @function
+
+"operator" @function
+
+"static_assert" @function.builtin
+
+
+(call_expression
+  (qualified_identifier
+    (identifier) @function.call))
+
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function.call)))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call))))
+
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call)))) @_parent
+  (#has-ancestor? @_parent call_expression))
+
+(call_expression
+  (template_function
+    (identifier) @function.call))
+
+(call_expression
+  (qualified_identifier
+    (template_function
+      (identifier) @function.call)))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (template_function
+        (identifier) @function.call))))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (template_function
+          (identifier) @function.call)))))
+
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (template_function
+          (identifier) @function.call))))) @_parent
+  (#has-ancestor? @_parent call_expression))
+
+; methods
+(function_declarator
+  (template_method
+    (field_identifier) @function.method))
+
+(call_expression
+  (field_expression
+    (field_identifier) @function.method.call))
+
+; constructors
+((function_declarator
+  (qualified_identifier
+    (identifier) @constructor))
+  (#match? @constructor "^%u"))
+
+((call_expression
+  function: (identifier) @constructor)
+  (#match? @constructor "^%u"))
+
+((call_expression
+  function: (qualified_identifier
+    name: (identifier) @constructor))
+  (#match? @constructor "^%u"))
+
+((call_expression
+  function: (field_expression
+    field: (field_identifier) @constructor))
+  (#match? @constructor "^%u"))
+
+; constructing a type in an initializer list: Constructor ():  **SuperType (1)**
+((field_initializer
+  (field_identifier) @constructor
+  (argument_list))
+  (#match? @constructor "^%u"))
+
+; Constants
+(this) @variable.builtin
+
+(null
+  "nullptr" @constant.builtin)
+
+(true) @boolean
+
+(false) @boolean
+
+; Literals
+(raw_string_literal) @string
+
+; Keywords
+[
+  "try"
+  "catch"
+  "noexcept"
+  "throw"
+] @keyword.exception
+
+[
+  "decltype"
+  "explicit"
+  "friend"
+  "override"
+  "using"
+  "requires"
+  "constexpr"
+] @keyword
+
+[
+  "class"
+  "namespace"
+  "template"
+  "typename"
+  "concept"
+] @keyword.type
+
+[
+  "co_await"
+  "co_yield"
+  "co_return"
+] @keyword.coroutine
+
+[
+  "public"
+  "private"
+  "protected"
+  "final"
+  "virtual"
+] @keyword.modifier
+
+[
+  "new"
+  "delete"
+  "xor"
+  "bitand"
+  "bitor"
+  "compl"
+  "not"
+  "xor_eq"
+  "and_eq"
+  "or_eq"
+  "not_eq"
+  "and"
+  "or"
+] @keyword.operator
+
+"<=>" @operator
+
+"::" @punctuation.delimiter
+
+(template_argument_list
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(template_parameter_list
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(literal_suffix) @operator
+
+; hlsl
+[
+  "in"
+  "out"
+  "inout"
+  "uniform"
+  "shared"
+  "groupshared"
+  "discard"
+  "cbuffer"
+  "row_major"
+  "column_major"
+  "globallycoherent"
+  "centroid"
+  "noperspective"
+  "nointerpolation"
+  "sample"
+  "linear"
+  "snorm"
+  "unorm"
+  "point"
+  "line"
+  "triangleadj"
+  "lineadj"
+  "triangle"
+] @keyword.modifier
+
+((identifier) @variable.builtin
+  (#match? @variable.builtin "^SV_"))
+; ((identifier) @variable)
+
+(hlsl_attribute) @attribute
+
+(hlsl_attribute
+  [
+    "["
+    "]"
+  ] @attribute)
+
+"This" @type.builtin
+
+[
+  "interface"
+  "extension"
+  "property"
+  "associatedtype"
+  "where"
+	"var"
+	"let"
+] @keyword
+
+"__init" @constructor
+
+[
+  "__subscript"
+  "get"
+  "set"
+] @function.builtin
+
+(call_expression) @function.call
+
+(call_expression (identifier)) @function.call
+
+((call_expression
+  function: (identifier) @function.builtin)
+  (#any-of? @function.builtin
+		"frac" "abs" "acos" "acosh" "asin" "asinh" "atan" "atanh" "cos" "cosh" "exp" "exp2" "floor" "log" "log10" "log2" "round" "rsqrt" "sin" "sincos" "sinh" "sqrt" "tan" "tanh" "trunc"
+		"AllMemoryBarrier" "AllMemoryBarrierWithGroupSync" "DeviceMemoryBarrier" "DeviceMemoryBarrierWithGroupSync" "GroupMemoryBarrier" "GroupMemoryBarrierWithGroupSync"
+		"abort" "clip" "errorf" "printf"
+		"all" "any" "countbits" "faceforward" "firstbithigh" "firstbitlow" "isfinite" "isinf" "isnan" "max" "min" "noise" "pow" "reversebits" "sign"
+		"asdouble" "asfloat" "asint" "asuint" "D3DCOLORtoUBYTE4" "f16tof32" "f32tof16"
+		"ceil" "clamp" "degrees" "fma" "fmod" "frac" "frexp" "ldexp" "lerp" "mad" "modf" "radiants" "saturate" "smoothstep" "step"
+		"cross" "determinant" "distance" "dot" "dst" "length" "lit" "msad4" "mul" "normalize" "rcp" "reflect" "refract" "transpose"
+		"ddx" "ddx_coarse" "ddx_fine" "ddy" "ddy_coarse" "ddy_fine" "fwidth"
+		"EvaluateAttributeAtCentroid" "EvaluateAttributeAtSample" "EvaluateAttributeSnapped"
+		"GetRenderTargetSampleCount" "GetRenderTargetSamplePosition"
+		"InterlockedAdd" "InterlockedAnd" "InterlockedCompareExchange" "InterlockedCompareStore" "InterlockedExchange" "InterlockedMax" "InterlockedMin" "InterlockedOr" "InterlockedXor"
+		"InterlockedCompareStoreFloatBitwise" "InterlockedCompareExchangeFloatBitwise"
+		"Process2DQuadTessFactorsAvg" "Process2DQuadTessFactorsMax" "Process2DQuadTessFactorsMin" "ProcessIsolineTessFactors"
+		"ProcessQuadTessFactorsAvg" "ProcessQuadTessFactorsMax" "ProcessQuadTessFactorsMin" "ProcessTriTessFactorsAvg" "ProcessTriTessFactorsMax" "ProcessTriTessFactorsMin"
+		"tex1D" "tex1Dbias" "tex1Dgrad" "tex1Dlod" "tex1Dproj"
+		"tex2D" "tex2Dbias" "tex2Dgrad" "tex2Dlod" "tex2Dproj"
+		"tex3D" "tex3Dbias" "tex3Dgrad" "tex3Dlod" "tex3Dproj"
+		"texCUBE" "texCUBEbias" "texCUBEgrad" "texCUBElod" "texCUBEproj"
+		"WaveIsFirstLane" "WaveGetLaneCount" "WaveGetLaneIndex"
+		"IsHelperLane"
+		"WaveActiveAnyTrue" "WaveActiveAllTrue" "WaveActiveBallot"
+		"WaveReadLaneFirst" "WaveReadLaneAt"
+		"WaveActiveAllEqual" "WaveActiveAllEqualBool" "WaveActiveCountBits"
+		"WaveActiveSum" "WaveActiveProduct" "WaveActiveBitAnd" "WaveActiveBitOr" "WaveActiveBitXor" "WaveActiveMin" "WaveActiveMax"
+		"WavePrefixCountBits" "WavePrefixProduct" "WavePrefixSum"
+		"QuadReadAcrossX" "QuadReadAcrossY" "QuadReadAcrossDiagonal" "QuadReadLaneAt"
+		"QuadAny" "QuadAll"
+		"WaveMatch" "WaveMultiPrefixSum" "WaveMultiPrefixProduct" "WaveMultiPrefixCountBits" "WaveMultiPrefixAnd" "WaveMultiPrefixOr" "WaveMultiPrefixXor"
+		"NonUniformResourceIndex"
+		"DispatchMesh" "SetMeshOutputCounts"
+		"dot4add_u8packed" "dot4add_i8packed" "dot2add"
+		"RestartStrip"
+		"CalculateLevelOfDetail" "CalculateLevelOfDetailUnclamped" "Gather" "GetDimensions" "GetSamplePosition" "Load" "Sample" "SampleBias" "SampleCmp" "SampleCmpLevelZero" "SampleGrad" "SampleLevel" "GatherRaw" "SampleCmpLevel"
+		"SampleCmpBias" "SampleCmpGrad"
+		"WriteSamplerFeedback" "WriteSamplerFeedbackBias" "WriteSamplerFeedbackGrad" "WriteSamplerFeedbackLevel"
+		"Append" "Consume" "DecrementCounter" "IncrementCounter"
+		"Load2" "Load3" "Load4" "Store" "Store2" "Store3" "Store4"
+		"GatherRed" "GatherGreen" "GatherBlue" "GatherAlpha" "GatherCmp" "GatherCmpRed" "GatherCmpGreen" "GatherCmpBlue" "GatherCmpAlpha"
+	))
+
+(interface_requirements
+  (identifier) @type)
+
+(binary_expression
+  [
+    "is"
+    "as"
+  ]
+  right: (identifier) @type)
+
+[
+  "as"
+  "is"
+] @keyword.operator
+
+[
+  "__exported"
+  "import"
+] @keyword.import
+
+(property_declaration
+  (identifier) @property)

--- a/runtime/queries/slang/indents.scm
+++ b/runtime/queries/slang/indents.scm
@@ -1,0 +1,6 @@
+; inherits: hlsl
+
+[
+  (interface_specifier)
+  (extension_specifier)
+] @indent.begin

--- a/runtime/queries/slang/indents.scm
+++ b/runtime/queries/slang/indents.scm
@@ -3,4 +3,4 @@
 [
   (interface_specifier)
   (extension_specifier)
-] @indent.begin
+] @indent

--- a/runtime/queries/slang/injections.scm
+++ b/runtime/queries/slang/injections.scm
@@ -1,0 +1,5 @@
+((preproc_arg) @injection.content
+  (#set! injection.language "slang"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/slang/textobjects.scm
+++ b/runtime/queries/slang/textobjects.scm
@@ -1,0 +1,30 @@
+(function_definition
+  body: (_) @function.inside) @function.around
+
+(struct_specifier
+  body: (_) @class.inside) @class.around
+
+(interface_specifier
+  body: (_) @class.inside) @class.around
+
+(enum_specifier
+  body: (_) @class.inside) @class.around
+
+(union_specifier
+  body: (_) @class.inside) @class.around
+
+(parameter_list 
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(argument_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+(enumerator
+  (_) @entry.inside) @entry.around
+
+(initializer_list
+  (_) @entry.around)


### PR DESCRIPTION
Related issue: #13343

I was unable to find any tree-sitter grammars with queries and do not have the familiarity with the language to write my own.

LSP support works so hopefully this is still helpful for Slang users.

If lack of queries is too large an issue, feel free to reject.

Thank you!