### PR TITLE
build(grammar): remove explicit opt out of optimizations for MSVC

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -451,7 +451,6 @@ fn build_tree_sitter_library(
         command
             .args(["/nologo", "/LD", "/I"])
             .arg(header_path)
-            .arg("/Od")
             .arg("/utf-8")
             .arg("/std:c11");
         if let Some(scanner_path) = scanner_path.as_ref() {
@@ -469,7 +468,6 @@ fn build_tree_sitter_library(
                 cpp_command
                     .args(["/nologo", "/LD", "/I"])
                     .arg(header_path)
-                    .arg("/Od")
                     .arg("/utf-8")
                     .arg("/std:c++14")
                     .arg(format!("/Fo{}", object_file.display()))


### PR DESCRIPTION
`cc` should pick correct defaults when `debug` or `release`.

This was discussed at https://github.com/helix-editor/helix/discussions/13345#discussioncomment-12847728