### PR TITLE
feat: add a tree-sitter grammar and highlights for dunst's config

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -46,6 +46,7 @@
 | dot | ✓ |  |  | `dot-language-server` |
 | dtd | ✓ |  |  |  |
 | dune | ✓ |  |  |  |
+| dunstrc | ✓ |  |  |  |
 | earthfile | ✓ | ✓ | ✓ | `earthlyls` |
 | edoc | ✓ |  |  |  |
 | eex | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4313,3 +4313,14 @@ comment-tokens = "#"
 [[grammar]]
 name = "debian"
 source = { git = "https://gitlab.com/MggMuggins/tree-sitter-debian", rev = "9b3f4b78c45aab8a2f25a5f9e7bbc00995bc3dde" }
+
+[[language]]
+name = "dunstrc"
+scope = "source.dunstrc"
+comment-tokens = ["#", ";"]
+file-types = [ { glob = "dunst/dunstrc" } ]
+grammar = "dunstrc"
+
+[[grammar]]
+name = "dunstrc"
+source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "b2d193553603c41762418d67827883492c9119a3" }

--- a/languages.toml
+++ b/languages.toml
@@ -4323,4 +4323,4 @@ grammar = "dunstrc"
 
 [[grammar]]
 name = "dunstrc"
-source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "b2d193553603c41762418d67827883492c9119a3" }
+source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "f40e8b5b46ff43164fc32ef1debf6e23a3bfba24" }

--- a/languages.toml
+++ b/languages.toml
@@ -4323,4 +4323,4 @@ grammar = "dunstrc"
 
 [[grammar]]
 name = "dunstrc"
-source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "928af88be0dc91d5f1dc716c550d0f54200608b0" }
+source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "d0a2753634873428008f5b5ae77e75055f904992" }

--- a/languages.toml
+++ b/languages.toml
@@ -4345,7 +4345,6 @@ name = "dunstrc"
 scope = "source.dunstrc"
 comment-tokens = ["#", ";"]
 file-types = [ { glob = "dunst/dunstrc" } ]
-grammar = "dunstrc"
 
 [[grammar]]
 name = "dunstrc"

--- a/languages.toml
+++ b/languages.toml
@@ -4323,4 +4323,4 @@ grammar = "dunstrc"
 
 [[grammar]]
 name = "dunstrc"
-source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "f40e8b5b46ff43164fc32ef1debf6e23a3bfba24" }
+source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "928af88be0dc91d5f1dc716c550d0f54200608b0" }

--- a/languages.toml
+++ b/languages.toml
@@ -4323,4 +4323,4 @@ grammar = "dunstrc"
 
 [[grammar]]
 name = "dunstrc"
-source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "d0a2753634873428008f5b5ae77e75055f904992" }
+source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "9cb9d5cc51cf5e2a47bb2a0e2f2e519ff11c1431" }

--- a/runtime/queries/dunstrc/highlights.scm
+++ b/runtime/queries/dunstrc/highlights.scm
@@ -1,0 +1,14 @@
+(assign
+  (key) @attribute)
+
+(comment) @comment.line
+
+[
+  "["
+  "]"
+] @punctuation.bracket
+
+"=" @operator
+
+(section
+  (name) @namespace)

--- a/runtime/queries/dunstrc/highlights.scm
+++ b/runtime/queries/dunstrc/highlights.scm
@@ -1,10 +1,6 @@
 (assign
   (key) @attribute)
 
-(assign
-  (value
-    (quoted) @string))
-
 (comment) @comment.line
 
 [

--- a/runtime/queries/dunstrc/highlights.scm
+++ b/runtime/queries/dunstrc/highlights.scm
@@ -1,6 +1,10 @@
 (assign
   (key) @attribute)
 
+(assign
+  (value
+    (quoted) @string))
+
 (comment) @comment.line
 
 [


### PR DESCRIPTION
Helix currently has an `ini` grammar defined in the `languages.toml`, but `dunstrc`'s `ini` flavor is different than that grammar.

`dunst` differs by:

- allowing comments at end of lines [^1]
- allows using quotation marks to mark values that can contain comment indicators [^2]
- ignoring any content after the closing `]` in a section [^3]

Example of the syntax highlighting in Helix using this PR:

![image](https://github.com/user-attachments/assets/ad2e97c1-09db-435a-b4e7-0b1496914c8d)

[^1]: https://github.com/dunst-project/dunst/blob/d0f89761/src/ini.c#L137-L139
[^2]: https://github.com/dunst-project/dunst/blob/d0f89761/src/ini.c#L125-L135
      a common use case for this is RGB colors (e.g., `"#FFAACC"`)
[^3]: https://github.com/dunst-project/dunst/blob/d0f89761/src/ini.c#L102-L108