### PR TITLE
Support `.git-blame-ignore-revs`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1899,7 +1899,7 @@ source = { git = "https://github.com/mtoohey31/tree-sitter-gitattributes", rev =
 [[language]]
 name = "git-ignore"
 scope = "source.gitignore"
-file-types = [{ glob = ".gitignore_global" }, { glob = "git/ignore" }, { glob = ".ignore" }, { glob = "CODEOWNERS" }, { glob = ".config/helix/ignore" }, { glob = ".helix/ignore" }, { glob = ".*ignore" }]
+file-types = [{ glob = ".gitignore_global" }, { glob = "git/ignore" }, { glob = ".ignore" }, { glob = "CODEOWNERS" }, { glob = ".config/helix/ignore" }, { glob = ".helix/ignore" }, { glob = ".*ignore" }, { glob = ".git-blame-ignore-revs" }]
 injection-regex = "git-ignore"
 comment-token = "#"
 grammar = "gitignore"


### PR DESCRIPTION
The blame ignore format is used by git to ignore certain commits in the blame view. This is especially useful for formatting commits that clutter the blame with changes that don't affect behavior (and are likely automated).

While Git itself has not decided on a standard filename last time I checked, [GitHub has somewhat standardized the filename `.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view).

Kind of in the spirit of https://github.com/helix-editor/helix/pull/8220#issuecomment-1712572064, the blame ignore file format is close enough to the gitignore format that it should be suitable for syntax highlighting.

Example format:

```git-revision-list
# some comment
0815b52e0959e21ec792ea41d508a050b552f850
```