### PR TITLE
Support features of `:open` in `:vsplit` & `:hsplit`

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -258,6 +258,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
     widths: Vec<Constraint>,
 
     callback_fn: PickerCallback<T>,
+    default_action: Action,
 
     pub truncate_start: bool,
     /// Caches paths to documents
@@ -382,6 +383,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             truncate_start: true,
             show_preview: true,
             callback_fn: Box::new(callback_fn),
+            default_action: Action::Replace,
             completion_height: 0,
             widths,
             preview_cache: HashMap::new(),
@@ -437,6 +439,11 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         };
         helix_event::send_blocking(&handler, event);
         self.dynamic_query_handler = Some(handler);
+        self
+    }
+
+    pub fn with_default_action(mut self, action: Action) -> Self {
+        self.default_action = action;
         self
     }
 
@@ -1068,7 +1075,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(Esc) | ctrl!('c') => return close_fn(self),
             alt!(Enter) => {
                 if let Some(option) = self.selection() {
-                    (self.callback_fn)(ctx, option, Action::Replace);
+                    (self.callback_fn)(ctx, option, self.default_action);
                 }
             }
             key!(Enter) => {
@@ -1092,7 +1099,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     self.handle_prompt_change(true);
                 } else {
                     if let Some(option) = self.selection() {
-                        (self.callback_fn)(ctx, option, Action::Replace);
+                        (self.callback_fn)(ctx, option, self.default_action);
                     }
                     if let Some(history_register) = self.prompt.history_register() {
                         if let Err(err) = ctx


### PR DESCRIPTION
`:vsplit` and `:hsplit` lack features that only `:open` supports:

- Cannot create a new split at a specific `file:line:column`
- Passing a directory doesn't trigger a file picker

This unifies the underlying implementation so it's shared between `open/vsplit/hsplit` and all support the same feature set.