### PR TITLE
feat(commands): add `language` variable expansion

### DIFF
--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -47,6 +47,7 @@ The following variables are supported:
 | `cursor_column` | The column number of the primary cursor in the currently focused document, starting at 1. This is counted as the number of grapheme clusters from the start of the line rather than bytes or codepoints. |
 | `buffer_name` | The relative path of the currently focused document. `[scratch]` is expanded instead for scratch buffers. |
 | `line_ending` | A string containing the line ending of the currently focused document. For example on Unix systems this is usually a line-feed character (`\n`) but on Windows systems this may be a carriage-return plus a line-feed (`\r\n`). The line ending kind of the currently focused document can be inspected with the `:line-ending` command. |
+| `language` | A string containing the language name of the currently focused document.|
 
 Aside from editor variables, the following expansions may be used:
 

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -33,6 +33,8 @@ pub enum Variable {
     BufferName,
     /// A string containing the line-ending of the currently focused document.
     LineEnding,
+    // The name of current buffers language as set in `languages.toml`
+    Language,
 }
 
 impl Variable {
@@ -41,6 +43,7 @@ impl Variable {
         Self::CursorColumn,
         Self::BufferName,
         Self::LineEnding,
+        Self::Language,
     ];
 
     pub const fn as_str(&self) -> &'static str {
@@ -49,6 +52,7 @@ impl Variable {
             Self::CursorColumn => "cursor_column",
             Self::BufferName => "buffer_name",
             Self::LineEnding => "line_ending",
+            Self::Language => "language",
         }
     }
 
@@ -58,6 +62,7 @@ impl Variable {
             "cursor_column" => Some(Self::CursorColumn),
             "buffer_name" => Some(Self::BufferName),
             "line_ending" => Some(Self::LineEnding),
+            "language" => Some(Self::Language),
             _ => None,
         }
     }
@@ -215,5 +220,8 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             }
         }
         Variable::LineEnding => Ok(Cow::Borrowed(doc.line_ending.as_str())),
+        Variable::Language => Ok(Cow::Owned(
+            doc.language_name().unwrap_or("text").to_string(),
+        )),
     }
 }

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -220,8 +220,9 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             }
         }
         Variable::LineEnding => Ok(Cow::Borrowed(doc.line_ending.as_str())),
-        Variable::Language => Ok(Cow::Owned(
-            doc.language_name().unwrap_or("text").to_string(),
-        )),
+        Variable::Language => Ok(match doc.language_name() {
+            Some(lang) => Cow::Owned(lang.to_owned()),
+            None => Cow::Borrowed("text"),
+        }),
     }
 }


### PR DESCRIPTION
This is needed so that, for example, there could be conditional logic around the type of file. For example, run `cargo test` when its `rust` and `go test` when its `go`.

Rough example:
```
:noop %sh{ test ${language}  }
```

```nushell
def --env test [lang: string] {
	match $lang {
		"rust" => (cargo test)
		"go" => (go test)
	}
}
```