### PR TITLE
feat(multi-client): Split the Editor data structure to support multip…

### DIFF
--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -17,12 +17,13 @@ pub enum EventResult {
 
 use crate::job::Jobs;
 use crate::ui::picker;
-use helix_view::Editor;
+use helix_view::{ClientId, Editor};
 
 pub use helix_view::input::Event;
 
 pub struct Context<'a> {
     pub editor: &'a mut Editor,
+    pub client_id: ClientId,
     pub scroll: Option<usize>,
     pub jobs: &'a mut Jobs,
 }
@@ -53,7 +54,12 @@ pub trait Component: Any + AnyComponent {
     fn render(&mut self, area: Rect, frame: &mut Surface, ctx: &mut Context);
 
     /// Get cursor position and cursor kind.
-    fn cursor(&self, _area: Rect, _ctx: &Editor) -> (Option<Position>, CursorKind) {
+    fn cursor(
+        &self,
+        _area: Rect,
+        _ctx: &Editor,
+        _client_id: ClientId,
+    ) -> (Option<Position>, CursorKind) {
         (None, CursorKind::Hidden)
     }
 
@@ -182,9 +188,14 @@ impl Compositor {
         }
     }
 
-    pub fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
+    pub fn cursor(
+        &self,
+        area: Rect,
+        editor: &Editor,
+        client_id: ClientId,
+    ) -> (Option<Position>, CursorKind) {
         for layer in self.layers.iter().rev() {
-            if let (Some(pos), kind) = layer.cursor(area, editor) {
+            if let (Some(pos), kind) = layer.cursor(area, editor, client_id) {
                 return (Some(pos), kind);
             }
         }

--- a/helix-term/src/handlers/document_colors.rs
+++ b/helix-term/src/handlers/document_colors.rs
@@ -33,7 +33,7 @@ impl helix_event::AsyncHook for DocumentColorsHandler {
     fn finish_debounce(&mut self) {
         let docs = std::mem::take(&mut self.docs);
 
-        job::dispatch_blocking(move |editor, _compositor| {
+        job::dispatch_blocking(move |editor| {
             for doc in docs {
                 request_document_colors(editor, doc);
             }
@@ -92,7 +92,7 @@ fn request_document_colors(editor: &mut Editor, doc_id: DocumentId) {
                 None => return,
             }
         }
-        job::dispatch(move |editor, _| attach_document_colors(editor, doc_id, all_colors)).await;
+        job::dispatch(move |editor| attach_document_colors(editor, doc_id, all_colors)).await;
     });
 }
 

--- a/helix-term/src/handlers/snippet.rs
+++ b/helix-term/src/handlers/snippet.rs
@@ -22,7 +22,7 @@ pub(super) fn register_hooks(_handlers: &Handlers) {
     });
     register_hook!(move |event: &mut DocumentFocusLost<'_>| {
         let editor = &mut event.editor;
-        doc_mut!(editor).active_snippet = None;
+        doc_mut!(editor, event.client).active_snippet = None;
         Ok(())
     });
 }

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -1,5 +1,6 @@
 use helix_core::Position;
 use helix_view::{
+    ClientId,
     graphics::{CursorKind, Rect},
     Editor,
 };
@@ -65,9 +66,14 @@ impl<T: Component + 'static> Component for Overlay<T> {
         self.content.handle_event(event, ctx)
     }
 
-    fn cursor(&self, area: Rect, ctx: &Editor) -> (Option<Position>, CursorKind) {
+    fn cursor(
+        &self,
+        area: Rect,
+        ctx: &Editor,
+        client_id: ClientId,
+    ) -> (Option<Position>, CursorKind) {
         let dimensions = (self.calc_child_size)(area);
-        self.content.cursor(dimensions, ctx)
+        self.content.cursor(dimensions, ctx, client_id)
     }
 
     fn id(&self) -> Option<&'static str> {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -10,6 +10,7 @@ use tui::{
 
 use helix_core::Position;
 use helix_view::{
+    ClientId,
     graphics::{Margin, Rect},
     input::{MouseEvent, MouseEventKind},
     Editor,
@@ -119,12 +120,12 @@ impl<T: Component> Popup<T> {
         &mut self.contents
     }
 
-    pub fn area(&mut self, viewport: Rect, editor: &Editor) -> Rect {
-        self.render_info(viewport, editor).area
+    pub fn area(&mut self, viewport: Rect, editor: &Editor, client_id: ClientId) -> Rect {
+        self.render_info(viewport, editor, client_id).area
     }
 
-    fn render_info(&mut self, viewport: Rect, editor: &Editor) -> RenderInfo {
-        let mut position = editor.cursor().0.unwrap_or_default();
+    fn render_info(&mut self, viewport: Rect, editor: &Editor, client_id: ClientId) -> RenderInfo {
+        let mut position = editor.cursor(client_id).0.unwrap_or_default();
         if let Some(old_position) = self
             .position
             .filter(|old_position| old_position.row == position.row)
@@ -306,7 +307,7 @@ impl<T: Component> Component for Popup<T> {
             child_height,
             render_borders,
             is_menu,
-        } = self.render_info(viewport, cx.editor);
+        } = self.render_info(viewport, cx.editor, cx.client_id);
         self.area = area;
 
         // clear area

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -11,11 +11,13 @@ use helix_view::{
 use crate::ui::ProgressSpinners;
 
 use helix_view::editor::StatusLineElement as StatusLineElementID;
+use helix_view::ClientId;
 use tui::buffer::Buffer as Surface;
 use tui::text::{Span, Spans};
 
 pub struct RenderContext<'a> {
     pub editor: &'a Editor,
+    pub client_id: ClientId,
     pub doc: &'a Document,
     pub view: &'a View,
     pub focused: bool,
@@ -26,6 +28,7 @@ pub struct RenderContext<'a> {
 impl<'a> RenderContext<'a> {
     pub fn new(
         editor: &'a Editor,
+        client_id: ClientId,
         doc: &'a Document,
         view: &'a View,
         focused: bool,
@@ -33,6 +36,7 @@ impl<'a> RenderContext<'a> {
     ) -> Self {
         RenderContext {
             editor,
+            client_id,
             doc,
             view,
             focused,
@@ -178,7 +182,7 @@ where
         format!(
             " {} ",
             if visible {
-                match context.editor.mode() {
+                match client!(context.editor, context.client_id).mode {
                     Mode::Insert => &modenames.insert,
                     Mode::Select => &modenames.select,
                     Mode::Normal => &modenames.normal,
@@ -189,7 +193,7 @@ where
             }
         ),
         if visible && config.color_modes {
-            match context.editor.mode() {
+            match client!(context.editor, context.client_id).mode {
                 Mode::Insert => Some(context.editor.theme.get("ui.statusline.insert")),
                 Mode::Select => Some(context.editor.theme.get("ui.statusline.select")),
                 Mode::Normal => Some(context.editor.theme.get("ui.statusline.normal")),
@@ -569,7 +573,7 @@ fn render_register<F>(context: &mut RenderContext, write: F)
 where
     F: Fn(&mut RenderContext, String, Option<Style>) + Copy,
 {
-    if let Some(reg) = context.editor.selected_register {
+    if let Some(reg) = client!(context.editor, context.client_id).selected_register {
         write(context, format!(" reg={} ", reg), None)
     }
 }

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -223,14 +223,14 @@ async fn test_write_fail_mod_flag() -> anyhow::Result<()> {
             (
                 None,
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert!(!doc.is_modified());
                 }),
             ),
             (
                 Some("ihello<esc>"),
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert!(doc.is_modified());
                 }),
             ),
@@ -239,7 +239,7 @@ async fn test_write_fail_mod_flag() -> anyhow::Result<()> {
                 Some(&|app| {
                     assert_eq!(&Severity::Error, app.editor.get_status().unwrap().1);
 
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert!(doc.is_modified());
                 }),
             ),
@@ -335,7 +335,7 @@ async fn test_write_new_path() -> anyhow::Result<()> {
             (
                 Some("ii can eat glass, it will not hurt me<ret><esc>:w<ret>"),
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert!(!app.editor.is_err());
                     assert_eq!(&path::normalize(file1.path()), doc.path().unwrap());
                 }),
@@ -343,7 +343,7 @@ async fn test_write_new_path() -> anyhow::Result<()> {
             (
                 Some(&format!(":w {}<ret>", file2.path().to_string_lossy())),
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert!(!app.editor.is_err());
                     assert_eq!(&path::normalize(file2.path()), doc.path().unwrap());
                     assert!(app.editor.document_by_path(file1.path()).is_none());
@@ -377,7 +377,7 @@ async fn test_write_fail_new_path() -> anyhow::Result<()> {
             (
                 None,
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert_ne!(
                         Some(&Severity::Error),
                         app.editor.get_status().map(|status| status.1)
@@ -388,7 +388,7 @@ async fn test_write_fail_new_path() -> anyhow::Result<()> {
             (
                 Some(&format!(":w {}<ret>", file.path().to_string_lossy())),
                 Some(&|app| {
-                    let doc = doc!(app.editor);
+                    let doc = doc!(app.editor, app.client_id);
                     assert_eq!(
                         Some(&Severity::Error),
                         app.editor.get_status().map(|status| status.1)

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -118,7 +118,7 @@ pub async fn test_key_sequences(
     let num_inputs = inputs.len();
 
     for (i, (in_keys, test_fn)) in inputs.into_iter().enumerate() {
-        let (view, doc) = current_ref!(app.editor);
+        let (_client, view, doc) = current_ref!(app.editor, app.client_id);
         let state = test::plain(doc.text().slice(..), doc.selection(view.id));
 
         log::debug!("executing test with document state:\n\n-----\n\n{}", state);
@@ -134,7 +134,7 @@ pub async fn test_key_sequences(
         let app_exited = !app.event_loop_until_idle(&mut rx_stream).await;
 
         if !app_exited {
-            let (view, doc) = current_ref!(app.editor);
+            let (_client, view, doc) = current_ref!(app.editor, app.client_id);
             let state = test::plain(doc.text().slice(..), doc.selection(view.id));
 
             log::debug!(
@@ -196,7 +196,7 @@ pub async fn test_key_sequence_with_input_text<T: Into<TestCase>>(
         None => Application::new(Args::default(), test_config(), test_syntax_loader(None))?,
     };
 
-    let (view, doc) = helix_view::current!(app.editor);
+    let (_client, view, doc) = helix_view::current!(app.editor, app.client_id);
     let sel = doc.selection(view.id).clone();
 
     // replace the initial text with the input text
@@ -243,7 +243,7 @@ pub async fn test_with_config<T: Into<TestCase>>(
         Some(app),
         test_case.clone(),
         &|app| {
-            let doc = doc!(app.editor);
+            let doc = doc!(app.editor, app.client_id);
             assert_eq!(&test_case.out_text, doc.text());
 
             let mut selections: Vec<_> = doc.selections().values().cloned().collect();
@@ -383,7 +383,7 @@ impl AppBuilder {
         let mut app = Application::new(self.args, self.config, self.syn_loader)?;
 
         if let Some((text, selection)) = self.input {
-            let (view, doc) = helix_view::current!(app.editor);
+            let (_client, view, doc) = helix_view::current!(app.editor, app.client_id);
             let sel = doc.selection(view.id).clone();
             let trans = Transaction::change_by_selection(doc.text(), &sel, |_| {
                 (0, doc.text().len_chars(), Some((text.clone()).into()))

--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -419,7 +419,7 @@ async fn cursor_position_newly_opened_file() -> anyhow::Result<()> {
             .with_file(file.path(), None)
             .build()?;
 
-        let (view, doc) = helix_view::current!(app.editor);
+        let (_client, view, doc) = helix_view::current!(app.editor, app.client_id);
         let sel = doc.selection(view.id).clone();
         assert_eq!(expected_sel, sel);
 

--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -47,14 +47,14 @@ async fn test_split_write_quit_all() -> anyhow::Result<()> {
                     assert_eq!("hello3", doc3.text().to_string());
 
                     helpers::assert_status_not_error(&app.editor);
-                    assert_eq!(3, app.editor.tree.views().count());
+                    assert_eq!(3, app.editor.views.iter().count());
                 }),
             ),
             (
                 Some(":wqa<ret>"),
                 Some(&|app| {
                     helpers::assert_status_not_error(&app.editor);
-                    assert_eq!(0, app.editor.tree.views().count());
+                    assert_eq!(0, app.editor.views.iter().count());
                 }),
             ),
         ],
@@ -82,7 +82,7 @@ async fn test_split_write_quit_same_file() -> anyhow::Result<()> {
             (
                 Some("O<esc>ihello<esc>:sp<ret>ogoodbye<esc>"),
                 Some(&|app| {
-                    assert_eq!(2, app.editor.tree.views().count());
+                    assert_eq!(2, app.editor.views.iter().count());
                     helpers::assert_status_not_error(&app.editor);
 
                     let mut docs: Vec<_> = app.editor.documents().collect();
@@ -102,7 +102,7 @@ async fn test_split_write_quit_same_file() -> anyhow::Result<()> {
                 Some(":wq<ret>"),
                 Some(&|app| {
                     helpers::assert_status_not_error(&app.editor);
-                    assert_eq!(1, app.editor.tree.views().count());
+                    assert_eq!(1, app.editor.views.iter().count());
 
                     let mut docs: Vec<_> = app.editor.documents().collect();
                     assert_eq!(1, docs.len());

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -44,6 +44,7 @@ use helix_core::{
 };
 
 use crate::{
+    ClientId,
     editor::Config,
     events::{DocumentDidChange, SelectionDidChange},
     expansion,
@@ -782,9 +783,10 @@ impl Document {
     pub fn auto_format(
         &self,
         editor: &Editor,
+        client_id: ClientId,
     ) -> Option<BoxFuture<'static, Result<Transaction, FormatterError>>> {
         if self.language_config()?.auto_format {
-            self.format(editor)
+            self.format(editor, client_id)
         } else {
             None
         }
@@ -797,6 +799,7 @@ impl Document {
     pub fn format(
         &self,
         editor: &Editor,
+        client_id: ClientId,
     ) -> Option<BoxFuture<'static, Result<Transaction, FormatterError>>> {
         if let Some((fmt_cmd, fmt_args)) = self
             .language_config()
@@ -824,7 +827,7 @@ impl Document {
 
             let args = match fmt_args
                 .iter()
-                .map(|content| expansion::expand(editor, Token::expand(content)))
+                .map(|content| expansion::expand(editor, client_id, Token::expand(content)))
                 .collect::<Result<Vec<_>, _>>()
             {
                 Ok(args) => args,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -2,7 +2,7 @@ use helix_core::{ChangeSet, Rope};
 use helix_event::events;
 use helix_lsp::LanguageServerId;
 
-use crate::{Document, DocumentId, Editor, ViewId};
+use crate::{ClientId, Document, DocumentId, Editor, ViewId};
 
 events! {
     DocumentDidOpen<'a> {
@@ -23,7 +23,7 @@ events! {
     SelectionDidChange<'a> { doc: &'a mut Document, view: ViewId }
     DiagnosticsDidChange<'a> { editor: &'a mut Editor, doc: DocumentId }
     // called **after** a document loses focus (but not when its closed)
-    DocumentFocusLost<'a> { editor: &'a mut Editor, doc: DocumentId }
+    DocumentFocusLost<'a> { editor: &'a mut Editor, client: ClientId, doc: DocumentId }
 
     LanguageServerInitialized<'a> {
         editor: &'a mut Editor,

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -4,6 +4,7 @@ use helix_core::command_line::{ExpansionKind, Token, TokenKind, Tokenizer};
 
 use anyhow::{anyhow, bail, Result};
 
+use crate::ClientId;
 use crate::Editor;
 
 /// Variables that can be expanded in the command mode (`:`) via the expansion syntax.
@@ -67,7 +68,7 @@ impl Variable {
 ///
 /// Note that the lifetime of the expanded variable is only bound to the input token and not the
 /// `Editor`. See `expand_variable` below for more discussion of lifetimes.
-pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
+pub fn expand<'a>(editor: &Editor, client_id: ClientId, token: Token<'a>) -> Result<Cow<'a, str>> {
     // Note: see the `TokenKind` documentation for more details on how each branch should expand.
     match token.kind {
         TokenKind::Unquoted | TokenKind::Quoted(_) => Ok(token.content),
@@ -75,7 +76,7 @@ pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
             let var = Variable::from_name(&token.content)
                 .ok_or_else(|| anyhow!("unknown variable '{}'", token.content))?;
 
-            expand_variable(editor, var)
+            expand_variable(editor, client_id, var)
         }
         TokenKind::Expansion(ExpansionKind::Unicode) => {
             if let Some(ch) = u32::from_str_radix(token.content.as_ref(), 16)
@@ -90,8 +91,10 @@ pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
                 ))
             }
         }
-        TokenKind::Expand => expand_inner(editor, token.content),
-        TokenKind::Expansion(ExpansionKind::Shell) => expand_shell(editor, token.content),
+        TokenKind::Expand => expand_inner(editor, client_id, token.content),
+        TokenKind::Expansion(ExpansionKind::Shell) => {
+            expand_shell(editor, client_id, token.content)
+        }
         // Note: see the docs for this variant.
         TokenKind::ExpansionKind => unreachable!(
             "expansion name tokens cannot be emitted when command line validation is enabled"
@@ -100,11 +103,15 @@ pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
 }
 
 /// Expand a shell command.
-pub fn expand_shell<'a>(editor: &Editor, content: Cow<'a, str>) -> Result<Cow<'a, str>> {
+pub fn expand_shell<'a>(
+    editor: &Editor,
+    client_id: ClientId,
+    content: Cow<'a, str>,
+) -> Result<Cow<'a, str>> {
     use std::process::{Command, Stdio};
 
     // Recursively expand the expansion's content before executing the shell command.
-    let content = expand_inner(editor, content)?;
+    let content = expand_inner(editor, client_id, content)?;
 
     let config = editor.config();
     let shell = &config.shell;
@@ -148,7 +155,11 @@ pub fn expand_shell<'a>(editor: &Editor, content: Cow<'a, str>) -> Result<Cow<'a
 }
 
 /// Expand a token's contents recursively.
-fn expand_inner<'a>(editor: &Editor, content: Cow<'a, str>) -> Result<Cow<'a, str>> {
+fn expand_inner<'a>(
+    editor: &Editor,
+    client_id: ClientId,
+    content: Cow<'a, str>,
+) -> Result<Cow<'a, str>> {
     let mut escaped = String::new();
     let mut start = 0;
 
@@ -170,7 +181,7 @@ fn expand_inner<'a>(editor: &Editor, content: Cow<'a, str>) -> Result<Cow<'a, st
                 .unwrap()
                 .map_err(|err| anyhow!("{err}"))?;
             // expand it (this is the recursive part),
-            let expanded = expand(editor, token)?;
+            let expanded = expand(editor, client_id, token)?;
             escaped.push_str(expanded.as_ref());
             // and move forward to the end of the expansion.
             start = idx + tokenizer.pos();
@@ -191,8 +202,12 @@ fn expand_inner<'a>(editor: &Editor, content: Cow<'a, str>) -> Result<Cow<'a, st
 // function to return then, instead, would normally be a `String`. We can return some statically
 // known strings like the scratch buffer name or line ending strings though, so this function
 // returns a `Cow<'static, str>` instead.
-fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, str>> {
-    let (view, doc) = current_ref!(editor);
+fn expand_variable(
+    editor: &Editor,
+    client_id: ClientId,
+    variable: Variable,
+) -> Result<Cow<'static, str>> {
+    let (_client, view, doc) = current_ref!(editor, client_id);
     let text = doc.text().slice(..);
 
     match variable {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -5,7 +5,7 @@ use helix_core::syntax::LanguageServerFeature;
 use crate::{
     editor::GutterType,
     graphics::{Style, UnderlineStyle},
-    Document, Editor, Theme, View,
+    ClientId, Document, Editor, Theme, View,
 };
 
 fn count_digits(n: usize) -> usize {
@@ -20,6 +20,7 @@ impl GutterType {
     pub fn style<'doc>(
         self,
         editor: &'doc Editor,
+        client_id: ClientId,
         doc: &'doc Document,
         view: &View,
         theme: &Theme,
@@ -29,7 +30,9 @@ impl GutterType {
             GutterType::Diagnostics => {
                 diagnostics_or_breakpoints(editor, doc, view, theme, is_focused)
             }
-            GutterType::LineNumbers => line_numbers(editor, doc, view, theme, is_focused),
+            GutterType::LineNumbers => {
+                line_numbers(editor, client_id, doc, view, theme, is_focused)
+            }
             GutterType::Spacer => padding(editor, doc, view, theme, is_focused),
             GutterType::Diff => diff(editor, doc, view, theme, is_focused),
         }
@@ -141,6 +144,7 @@ pub fn diff<'doc>(
 
 pub fn line_numbers<'doc>(
     editor: &'doc Editor,
+    client_id: ClientId,
     doc: &'doc Document,
     view: &View,
     theme: &Theme,
@@ -163,7 +167,7 @@ pub fn line_numbers<'doc>(
         .char_to_line(doc.selection(view.id).primary().cursor(text));
 
     let line_number = editor.config().line_number;
-    let mode = editor.mode;
+    let mode = client!(editor, client_id).mode;
 
     Box::new(
         move |line: usize, selected: bool, first_visual_line: bool, out: &mut String| {

--- a/helix-view/src/handlers.rs
+++ b/helix-view/src/handlers.rs
@@ -3,7 +3,7 @@ use helix_event::send_blocking;
 use tokio::sync::mpsc::Sender;
 
 use crate::handlers::lsp::SignatureHelpInvoked;
-use crate::{DocumentId, Editor, ViewId};
+use crate::{ClientId, DocumentId, Editor, ViewId};
 
 pub mod completion;
 pub mod dap;
@@ -26,9 +26,16 @@ pub struct Handlers {
 
 impl Handlers {
     /// Manually trigger completion (c-x)
-    pub fn trigger_completions(&self, trigger_pos: usize, doc: DocumentId, view: ViewId) {
+    pub fn trigger_completions(
+        &self,
+        trigger_pos: usize,
+        client: ClientId,
+        doc: DocumentId,
+        view: ViewId,
+    ) {
         self.completions.event(CompletionEvent::ManualTrigger {
             cursor: trigger_pos,
+            client,
             doc,
             view,
         });

--- a/helix-view/src/handlers/completion.rs
+++ b/helix-view/src/handlers/completion.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use helix_core::completion::CompletionProvider;
 use helix_event::{send_blocking, TaskController};
 
-use crate::{document::SavePoint, DocumentId, ViewId};
+use crate::{document::SavePoint, ClientId, DocumentId, ViewId};
 
 use tokio::sync::mpsc::Sender;
 
@@ -41,6 +41,7 @@ pub enum CompletionEvent {
     /// Auto completion was triggered by typing a word char
     AutoTrigger {
         cursor: usize,
+        client: ClientId,
         doc: DocumentId,
         view: ViewId,
     },
@@ -48,12 +49,14 @@ pub enum CompletionEvent {
     /// specified by the LSP
     TriggerChar {
         cursor: usize,
+        client: ClientId,
         doc: DocumentId,
         view: ViewId,
     },
     /// A completion was manually requested (c-x)
     ManualTrigger {
         cursor: usize,
+        client: ClientId,
         doc: DocumentId,
         view: ViewId,
     },

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -40,6 +40,7 @@ impl std::fmt::Display for DocumentId {
 
 slotmap::new_key_type! {
     pub struct ViewId;
+    pub struct ClientId;
 }
 
 pub enum Align {
@@ -74,7 +75,7 @@ pub fn align_view(doc: &mut Document, view: &View, align: Align) {
 }
 
 pub use document::Document;
-pub use editor::Editor;
+pub use editor::{Editor, EditorClient};
 use helix_core::char_idx_at_visual_offset;
 pub use theme::Theme;
 pub use view::View;

--- a/helix-view/src/macros.rs
+++ b/helix-view/src/macros.rs
@@ -11,20 +11,23 @@
 /// Returns `(&mut View, &mut Document)`
 #[macro_export]
 macro_rules! current {
-    ($editor:expr) => {{
-        let view = $crate::view_mut!($editor);
+    ($editor:expr, $client_id:expr) => {{
+        let client = $crate::client_mut!($editor, $client_id);
+        let view = $editor.views.get_mut(client.tree.focus);
         let id = view.doc;
-        let doc = $crate::doc_mut!($editor, &id);
-        (view, doc)
+        let doc = $crate::doc_with_id_mut!($editor, &id);
+        (client, view, doc)
     }};
 }
 
 #[macro_export]
 macro_rules! current_ref {
-    ($editor:expr) => {{
-        let view = $editor.tree.get($editor.tree.focus);
-        let doc = &$editor.documents[&view.doc];
-        (view, doc)
+    ($editor:expr, $client_id:expr) => {{
+        let client = $crate::client!($editor, $client_id);
+        let view = $editor.views.get(client.tree.focus);
+        let id = view.doc;
+        let doc = $crate::doc_with_id!($editor, &id);
+        (client, view, doc)
     }};
 }
 
@@ -32,11 +35,29 @@ macro_rules! current_ref {
 /// Returns `&mut Document`
 #[macro_export]
 macro_rules! doc_mut {
+    ($editor:expr, $client_id:expr) => {{
+        $crate::current!($editor, $client_id).2
+    }};
+}
+
+#[macro_export]
+macro_rules! doc_with_id_mut {
     ($editor:expr, $id:expr) => {{
         $editor.documents.get_mut($id).unwrap()
     }};
-    ($editor:expr) => {{
-        $crate::current!($editor).1
+}
+
+#[macro_export]
+macro_rules! client {
+    ($editor:expr, $id:expr) => {{
+        &$editor.clients[$id]
+    }};
+}
+
+#[macro_export]
+macro_rules! client_mut {
+    ($editor:expr, $id:expr) => {{
+        $editor.clients.get_mut($id).unwrap()
     }};
 }
 
@@ -44,11 +65,8 @@ macro_rules! doc_mut {
 /// Returns `&mut View`
 #[macro_export]
 macro_rules! view_mut {
-    ($editor:expr, $id:expr) => {{
-        $editor.tree.get_mut($id)
-    }};
-    ($editor:expr) => {{
-        $editor.tree.get_mut($editor.tree.focus)
+    ($editor:expr, $view_id:expr) => {{
+        $editor.views.get_mut($view_id)
     }};
 }
 
@@ -56,20 +74,41 @@ macro_rules! view_mut {
 /// Returns `&View`
 #[macro_export]
 macro_rules! view {
-    ($editor:expr, $id:expr) => {{
-        $editor.tree.get($id)
+    ($editor:expr, $view_id:expr) => {{
+        $editor.views.get($view_id)
     }};
-    ($editor:expr) => {{
-        $editor.tree.get($editor.tree.focus)
+}
+
+/// Get the current view mutably.
+/// Returns `&mut View`
+#[macro_export]
+macro_rules! client_view_mut {
+    ($editor:expr, $client_id:expr) => {{
+        let client = $crate::client_mut!($editor, $client_id);
+        $editor.views.get_mut(client.tree.focus)
+    }};
+}
+
+/// Get the current view immutably
+/// Returns `&View`
+#[macro_export]
+macro_rules! client_view {
+    ($editor:expr, $client_id:expr) => {{
+        let client = &mut $crate::client!($editor, $client_id);
+        $editor.views.get(client.tree.focus)
     }};
 }
 
 #[macro_export]
 macro_rules! doc {
+    ($editor:expr, $client_id:expr) => {{
+        $crate::current_ref!($editor, $client_id).2
+    }};
+}
+
+#[macro_export]
+macro_rules! doc_with_id {
     ($editor:expr, $id:expr) => {{
         &$editor.documents[$id]
-    }};
-    ($editor:expr) => {{
-        $crate::current_ref!($editor).1
     }};
 }


### PR DESCRIPTION
…le clients

This commit is the first step towards allowing the editor to support multiple clients, where a "client" can be thought of as a window displaying the editor UI. This change may support the following use cases:

- Client-server architecture with multiple terminal windows displaying the UI with shared buffers (#312). This will be the initial use case.
- Helix mode for other editors.
- Multiple windows for a GUI.

With this change, the Editor owns multiple EditorClients, with each EditorClient holding the data for a particular client, such as its views and state related to user input, such as the mode and repeat count. Clients are referenced using a ClientId which is used as a key for per-client data.

For the time being, the Application class only creates one client, but in a followup change (which is still work-in-progress and is available at [1]) the Application will be modified to implement the client-server support.

Apologies for the size of this change, I couldn't see a good way to split it up due to the many interdependencies. Probably the easiest way to review it is to download it locally and use `git show -w --color-words`.

Note that only a minimum amount of per-client state has been moved to the EditorClient; for example, the state for the status bar is still shared. The remaining state will be moved in followup changes.

[1] https://github.com/pcc/helix/tree/client-server-rebase