### PR TITLE
Update tree-sitter-v

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2406,7 +2406,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "v"
-source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "12ed90d735051ad961c54c4f0ec126354db4f966"}
+source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "59a8889d84a293d7c0366d14c8dbb0eec24fe889"}
 
 [[language]]
 name = "verilog"

--- a/languages.toml
+++ b/languages.toml
@@ -2406,7 +2406,7 @@ indent = { tab-width = 4, unit = "\t" }
 
 [[grammar]]
 name = "v"
-source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "e14fdf6e661b10edccc744102e4ccf0b187aa8ad"}
+source = {git = "https://github.com/vlang/v-analyzer", subpath = "tree_sitter_v", rev = "12ed90d735051ad961c54c4f0ec126354db4f966"}
 
 [[language]]
 name = "verilog"

--- a/runtime/queries/v/highlights.scm
+++ b/runtime/queries/v/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+[(line_comment) (block_comment)] @comment
 
 (module_clause
  (identifier) @namespace)
@@ -84,9 +84,9 @@
 ] @string
 
 (string_interpolation
- (braced_interpolation_opening) @punctuation.bracket
- (interpolated_expression) @embedded
- (braced_interpolation_closing) @punctuation.bracket)
+ (interpolation_opening) @punctuation.bracket
+ (interpolation_expression) @embedded
+ (interpolation_closing) @punctuation.bracket)
 
 (attribute) @attribute
 

--- a/runtime/queries/v/injections.scm
+++ b/runtime/queries/v/injections.scm
@@ -1,4 +1,4 @@
-((comment) @injection.content
+([(line_comment) (block_comment)] @injection.content
  (#set! injection.language "comment"))
 
 ((sql_expression) @injection.content

--- a/runtime/queries/v/textobjects.scm
+++ b/runtime/queries/v/textobjects.scm
@@ -22,6 +22,6 @@
 (struct_field_declaration
   ((_) @parameter.inside) @parameter.around)
 
-(comment) @comment.inside
-(comment)+ @comment.around
+[(line_comment) (block_comment)] @comment.inside
+[(line_comment)+ (block_comment)+] @comment.around
 


### PR DESCRIPTION
Updates the V language grammar from the v-analyzer project to a version that fixes the string literal highlighting bug, ticket #12885

This has been tested as best as I can, which is visually. It's a later commit (6 mos) ahead in the v-analyzer project, and it's appears to address the problem. The commit on the v-analyzer project immediately after this one _entirely_ breaks V highlighting in Helix, so that there's no highlighting at all.

I bisected backwards from HEAD until I found a version that addressed the string literal issue. I also [filed a ticket](https://github.com/vlang/v-analyzer/issues/161) about the tree sitter on the v-analyzer project. It seems that crowd mostly uses VSCode and don't seem to see any issues with the tree-sitter over there, so there's something Helix is doing differently with the grammar. In any case, this commit is both newer, addresses the string literal issue, and doesn't appear to introduce any new ones as far as I can tell.