### PR TITLE
docs(guides/textobject): list `parameter.around` capture

### DIFF
--- a/book/src/guides/textobject.md
+++ b/book/src/guides/textobject.md
@@ -23,6 +23,7 @@ The following [captures][tree-sitter-captures] are recognized:
 | `test.inside`      |
 | `test.around`      |
 | `parameter.inside` |
+| `parameter.around` |
 | `comment.inside`   |
 | `comment.around`   |
 | `entry.inside`     |


### PR DESCRIPTION
Seems like this is/has been supported, e.g. https://github.com/helix-editor/helix/pull/2543?