### PR TITLE
fix: selection highlight in completion with onedark (#13338)

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -86,7 +86,7 @@
 "ui.bufferline.background" = { bg = "light-black" }
 
 "ui.text" = { fg = "white" }
-"ui.text.directory" = { fg = "blue" }
+"ui.text.directory" = { fg = "red" }
 "ui.text.focus" = { fg = "white", bg = "light-black", modifiers = ["bold"] }
 
 "ui.help" = { fg = "white", bg = "gray" }


### PR DESCRIPTION
This PR fixes #13338 by switching the background color of the selected completion item. The problem was introduced by f07c1c1b29ad. 

Here are the results:
![image](https://github.com/user-attachments/assets/94fa0366-6461-43db-9777-1c0bf9382139)
My issue is that it reduces the contrast when selecting the completion of a command:
![image](https://github.com/user-attachments/assets/714a7376-2ba6-4536-8568-1217cf55e028)




