### PR TITLE
verilog: add highlighting for the "var" keyword

### DIFF
--- a/runtime/queries/verilog/highlights.scm
+++ b/runtime/queries/verilog/highlights.scm
@@ -150,6 +150,9 @@
 (port_identifier
  (simple_identifier) @variable)
 
+(variable_port_header ("var") @type.builtin)
+(data_declaration ("var") @type.builtin)
+(tf_port_item1 ("var") @type.builtin)
 [
   (net_type)
   (integer_vector_type)


### PR DESCRIPTION
The keyword is semantically similar to the "wire" keyword, covered by the `(net_type)` production. However, the grammar does not have a named production for the "var" keyword.

Instead of using a catch-all `"var"` in the same query, this adds three queries to cover the legal uses of the "var" keyword. Example:

```verilog
module example_m(
  input var abc  // <-- variable_port_header
);
  var something; // <-- data_declaration
endmodule

function example_f(
  input var def  // <-- tf_port_item1
);
endfunction
```