### PR TITLE
bump: tree-sitter-cpp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -626,7 +626,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "cpp"
-source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "670404d7c689be1c868a46f919ba2a3912f2b7ef" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "56455f4245baf4ea4e0881c5169de69d7edd5ae7" }
 
 [[language]]
 name = "crystal"

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -3,7 +3,7 @@
 ; Constants
 
 (this) @variable.builtin
-(nullptr) @constant.builtin
+(null) @constant.builtin
 
 ; Types
 


### PR DESCRIPTION
Recently fixed how C++23's lambdas were sometimes failing to highlight with tree-sitter (link to the issue https://github.com/tree-sitter/tree-sitter-cpp/issues/315). Bump to bring this feature into helix o/