### PR TITLE
fix: Use correct condition to determine if buffer is shown in another…

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1630,7 +1630,7 @@ impl Editor {
                     && !self
                         .tree
                         .traverse()
-                        .any(|(_, v)| v.doc == doc.id && v.id != view.id);
+                        .all(|(_, v)| v.doc == doc.id || v.id != view.id);
 
                 let (view, doc) = current!(self);
                 let view_id = view.id;


### PR DESCRIPTION
… split

The current condition is checking for whether there exists a split that is not displaying the buffer, but the intent was to check whether all other splits are not displaying it. Fix it.