### PR TITLE
Save/Load Editor Splits

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -63,6 +63,8 @@
 | `:vsplit-new`, `:vnew` | Open a scratch buffer in a vertical split. |
 | `:hsplit`, `:hs`, `:sp` | Open the file in a horizontal split. |
 | `:hsplit-new`, `:hnew` | Open a scratch buffer in a horizontal split. |
+| `:save-splits` | Save the current split with the name specified as argument or a default name is none provided. |
+| `:load-splits` | Loads the specified split or the default one if not name is provided. |
 | `:tutor` | Open the tutorial. |
 | `:goto`, `:g` | Goto line number. |
 | `:set-language`, `:lang` | Set the language of current buffer (show current language if no value specified). |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2585,6 +2585,36 @@ const SHELL_COMPLETER: CommandCompleter = CommandCompleter::positional(&[
     completers::repeating_filenames,
 ]);
 
+fn save_splits(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(args.len() <= 1, ":save-splits takes at most one argument");
+
+    cx.editor.save_split(match args.len() {
+        0 => "".to_string(),
+        _ => args.first().unwrap().to_string(),
+    });
+
+    Ok(())
+}
+
+fn load_splits(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    ensure!(args.len() <= 1, ":load-splits takes at most one argument");
+
+    cx.editor.load_split(match args.len() {
+        0 => "".to_string(),
+        _ => args.first().unwrap().to_string(),
+    })?;
+
+    Ok(())
+}
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "quit",
@@ -3280,6 +3310,28 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "save-splits",
+        aliases: &[],
+        doc: "Save the current split with the name specified as argument or a default name is none provided.",
+        fun: save_splits,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, None),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "load-splits",
+        aliases: &[],
+        doc: "Loads the specified split or the default one if not name is provided.",
+        fun: load_splits,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, None),
             ..Signature::DEFAULT
         },
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3329,7 +3329,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Loads the specified split or the default one if not name is provided.",
         fun: load_splits,
-        completer: CommandCompleter::none(),
+        completer: CommandCompleter::all(completers::splits),
         signature: Signature {
             positionals: (0, None),
             ..Signature::DEFAULT

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -738,4 +738,17 @@ pub mod completers {
 
         completions
     }
+
+    pub fn splits(editor: &Editor, input: &str) -> Vec<Completion> {
+        let iter = editor
+            .split_info
+            .keys()
+            .filter(|k| !k.is_empty())
+            .map(|k| k.to_string());
+
+        fuzzy_match(input, iter, false)
+            .into_iter()
+            .map(|(name, _)| ((0..), name.into()))
+            .collect()
+    }
 }


### PR DESCRIPTION
Add commands save-splits and load-splits. More details of each command:
- `save-splits`: It saves the current splits with a default name. A string can be used as split name and that name is later used for recalling in the `load-splits`. A split can be overwritten by simply saving the split with the same name. Example: `:save-splits a` will save the current split as `a`.
- `load-splits`: Close the current splits and open the named splits. If an argument is used, it tries to open the named splits. Example: `:load-splits a` will load the split previously saved with `:save-splits a`.

This is useful by itself but it is the stepping stone for other very useful features like:
1. Persistent splits.
2. Undo/Redo splits.