### PR TITLE
Scroll window functionality, no default keybinding

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -362,6 +362,8 @@ impl MappableCommand {
         page_cursor_down, "Move page and cursor down",
         page_cursor_half_up, "Move page and cursor half up",
         page_cursor_half_down, "Move page and cursor half down",
+        scroll_window_down, "Scroll window down",
+        scroll_window_up, "Scroll window up",
         select_all, "Select whole document",
         select_regex, "Select all regex matches inside selections",
         split_selection, "Split selections on regex matches",
@@ -1961,6 +1963,14 @@ fn page_cursor_half_down(cx: &mut Context) {
     let view = view!(cx.editor);
     let offset = view.inner_height() / 2;
     scroll(cx, offset, Direction::Forward, true);
+}
+
+fn scroll_window_down(cx: &mut Context) {
+    scroll(cx, cx.count(), Direction::Backward, false);
+}
+
+fn scroll_window_up(cx: &mut Context) {
+    scroll(cx, cx.count(), Direction::Forward, false);
 }
 
 #[allow(deprecated)]

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -187,6 +187,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "C-f" | "pagedown" => page_down,
         "C-u" => page_cursor_half_up,
         "C-d" => page_cursor_half_down,
+        // vi/vim/neovim bindings
+        // "C-e" = "scroll_window_up"
+        // "C-y" = "scroll_window_down"
 
         "C-w" => { "Window"
             "C-w" | "w" => rotate_view,


### PR DESCRIPTION
Add ability to scroll window without moving the cursor.

Users can add to their keymaps, or the default vi keymap can be used by uncommenting default.rs