### PR TITLE
add `sld` to Scheme file type extensions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2380,7 +2380,7 @@ source = { git = "https://github.com/metio/tree-sitter-ssh-client-config", rev =
 name = "scheme"
 scope = "source.scheme"
 injection-regex = "scheme"
-file-types = ["ss", "scm"]
+file-types = ["ss", "scm", "sld"]
 shebangs = ["scheme", "guile", "chicken"]
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
You will see this extension used for source files that solely consist of an R7RS library declaration (where the `sld` file can then include the corresponding `scm` file).

You can check this part of the chibi scheme source for an example of this kind of organization: https://github.com/ashinn/chibi-scheme/tree/master/lib/chibi