### PR TITLE
More glob to detect gitattributes file

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1899,7 +1899,7 @@ source = { git = "https://github.com/the-mikedavis/tree-sitter-git-config", rev 
 [[language]]
 name = "git-attributes"
 scope = "source.gitattributes"
-file-types = [{ glob = ".gitattributes" }]
+file-types = [{ glob = ".gitattributes" }, { glob = ".config/git/attributes" }]
 injection-regex = "git-attributes"
 comment-token = "#"
 grammar = "gitattributes"


### PR DESCRIPTION
Per https://git-scm.com/docs/gitattributes, the new "global scope" location for this file is *~/.config/git/attributes*.