### PR TITLE
feat: Improve syntax highlighting support for template languages, such as Tera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 [[package]]
 name = "tree-house"
 version = "0.1.0"
+source = "git+https://github.com/nik-rev/tree-house.git?rev=c5b3f53dbffce5cf8dc42fb5597deddeaa5c9d0a#c5b3f53dbffce5cf8dc42fb5597deddeaa5c9d0a"
 dependencies = [
  "arc-swap",
  "hashbrown 0.15.2",
@@ -2816,6 +2817,7 @@ dependencies = [
 [[package]]
 name = "tree-house-bindings"
 version = "0.1.0"
+source = "git+https://github.com/nik-rev/tree-house.git?rev=c5b3f53dbffce5cf8dc42fb5597deddeaa5c9d0a#c5b3f53dbffce5cf8dc42fb5597deddeaa5c9d0a"
 dependencies = [
  "cc",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,8 +2801,6 @@ checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 [[package]]
 name = "tree-house"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803311306ba3279e87699f7fa16ea18fbcc8889d0ff0c20dc0652317f8b58117"
 dependencies = [
  "arc-swap",
  "hashbrown 0.15.2",
@@ -2818,8 +2816,6 @@ dependencies = [
 [[package]]
 name = "tree-house-bindings"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6894df414648c56f1f5b129830447140ff1017867773694ba882d093aa140"
 dependencies = [
  "cc",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ members = [
   "xtask",
 ]
 
-default-members = [
-  "helix-term"
-]
+default-members = ["helix-term"]
 
 [profile.release]
 lto = "thin"
@@ -37,7 +35,7 @@ package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
 [workspace.dependencies]
-tree-house = { version = "0.1.0", default-features = false }
+tree-house = { git = "https://github.com/nik-rev/tree-house.git", rev = "c5b3f53dbffce5cf8dc42fb5597deddeaa5c9d0a", default-features = false }
 nucleo = "0.5.0"
 slotmap = "1.0.7"
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ members = [
   "xtask",
 ]
 
-default-members = ["helix-term"]
+default-members = [
+  "helix-term"
+]
 
 [profile.release]
 lto = "thin"

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -418,8 +418,13 @@ pub struct Syntax {
 const PARSE_TIMEOUT: Duration = Duration::from_millis(500); // half a second is pretty generous
 
 impl Syntax {
-    pub fn new(source: RopeSlice, language: Language, loader: &Loader) -> Result<Self, Error> {
-        let inner = tree_house::Syntax::new(source, language, PARSE_TIMEOUT, loader)?;
+    pub fn new(
+        source: RopeSlice,
+        language: Language,
+        loader: &Loader,
+        path: Option<std::path::PathBuf>,
+    ) -> Result<Self, Error> {
+        let inner = tree_house::Syntax::new(source, language, PARSE_TIMEOUT, loader, path)?;
         Ok(Self { inner })
     }
 
@@ -966,7 +971,7 @@ mod test {
         let grammar = LOADER.get_config(language).unwrap().grammar;
         let query = Query::new(grammar, query_str, |_, _| Ok(())).unwrap();
         let textobject = TextObjectQuery::new(query);
-        let syntax = Syntax::new(source.slice(..), language, &LOADER).unwrap();
+        let syntax = Syntax::new(source.slice(..), language, &LOADER, None).unwrap();
 
         let root = syntax.tree().root_node();
         let test = |capture, range| {
@@ -1055,7 +1060,7 @@ mod test {
     ) {
         let source = Rope::from_str(source);
         let language = LOADER.language_for_name(language_name).unwrap();
-        let syntax = Syntax::new(source.slice(..), language, &LOADER).unwrap();
+        let syntax = Syntax::new(source.slice(..), language, &LOADER, None).unwrap();
 
         let root = syntax
             .tree()

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -199,7 +199,7 @@ fn test_treesitter_indent(
     let language_config = loader.language(language).config();
     let indent_style = IndentStyle::from_str(&language_config.indent.as_ref().unwrap().unit);
     let text = doc.slice(..);
-    let syntax = Syntax::new(text, language, &loader).unwrap();
+    let syntax = Syntax::new(text, language, &loader, None).unwrap();
     let indent_query = loader.indent_query(language).unwrap();
 
     for i in 0..doc.len_lines() {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -54,7 +54,7 @@ pub fn highlighted_code_block<'a>(
     let ropeslice = RopeSlice::from(text);
     let Some(syntax) = loader
         .language_for_match(RopeSlice::from(language))
-        .and_then(|lang| Syntax::new(ropeslice, lang, loader).ok())
+        .and_then(|lang| Syntax::new(ropeslice, lang, loader, None).ok())
     else {
         return styled_multiline_text(text, code_style);
     };

--- a/helix-term/src/ui/picker/handlers.rs
+++ b/helix-term/src/ui/picker/handlers.rs
@@ -79,7 +79,8 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> AsyncHook
             let text = doc.text().clone();
 
             tokio::task::spawn_blocking(move || {
-                let syntax = match helix_core::Syntax::new(text.slice(..), language, &loader) {
+                let syntax = match helix_core::Syntax::new(text.slice(..), language, &loader, None)
+                {
                     Ok(syntax) => syntax,
                     Err(err) => {
                         log::info!("highlighting picker preview failed: {err}");

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1291,16 +1291,21 @@ impl Document {
     ) {
         self.language = language_config;
         self.syntax = self.language.as_ref().and_then(|config| {
-            Syntax::new(self.text.slice(..), config.language(), loader)
-                .map_err(|err| {
-                    // `NoRootConfig` means that there was an issue loading the language/syntax
-                    // config for the root language of the document. An error must have already
-                    // been logged by `LanguageData::syntax_config`.
-                    if err != syntax::HighlighterError::NoRootConfig {
-                        log::warn!("Error building syntax for '{}': {err}", self.display_name());
-                    }
-                })
-                .ok()
+            Syntax::new(
+                self.text.slice(..),
+                config.language(),
+                loader,
+                self.path().cloned(),
+            )
+            .map_err(|err| {
+                // `NoRootConfig` means that there was an issue loading the language/syntax
+                // config for the root language of the document. An error must have already
+                // been logged by `LanguageData::syntax_config`.
+                if err != syntax::HighlighterError::NoRootConfig {
+                    log::warn!("Error building syntax for '{}': {err}", self.display_name());
+                }
+            })
+            .ok()
         });
     }
 

--- a/runtime/queries/tera/injections.scm
+++ b/runtime/queries/tera/injections.scm
@@ -2,3 +2,7 @@
   (#set! injection.language "yaml")
   (#set! injection.combined)
 )
+
+((content) @injection.content
+  (#set! injection.language "<use-2nd-filename-extension>")
+  (#set! injection.combined))


### PR DESCRIPTION
Template languages like Tera can be used for *any* language at all. They can generate JavaScript, Rust, HTML or Markdown.

That's great! But it makes syntax highlighting for these languages harder than any other. You usually have to make a dedicated grammar for each language combination, like `html-tera`, `css-tera`, `js-tera` etc.

With this PR, it's all in a much better position now! The language injected will be based off the *file name*. That is, if you have a file like `index.html.tera`, it will inject the `html` language. If you have `index.css.tera`, it injects `css`. It simply uses the 2nd extension.

What this means is that, we can basically support all template languages with any possible language that they template *for*.

This PR depends on [*this* PR to tree-house](https://github.com/helix-editor/tree-house/pull/10)

## Before

![image](https://github.com/user-attachments/assets/11ce08f3-ed67-4834-9e16-675cfa2be598)

## After

![image](https://github.com/user-attachments/assets/6a7a02b3-4b17-4447-bf08-2b4052146e6d)
