### PR TITLE
Updated lua in `languages.toml` to enable auto-formatting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1350,6 +1350,7 @@ roots = [".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git"]
 comment-token = "--"
 block-comment-tokens = { start = "--[[", end = "--]]" }
 indent = { tab-width = 2, unit = "  " }
+auto-format = true
 language-servers = [ "lua-language-server" ]
 
 [[grammar]]


### PR DESCRIPTION
Fixes a problem people were having in [this discussion](https://github.com/helix-editor/helix/discussions/6651).

[`lua-language-server`](https://github.com/LuaLS/lua-language-server) supports auto-formatting out of the box.