### PR TITLE
Updated python/locals.scm to label `self` and `cls` as `variable.buitin`

### DIFF
--- a/runtime/queries/python/locals.scm
+++ b/runtime/queries/python/locals.scm
@@ -28,7 +28,7 @@
     (identifier) @local.definition.variable.parameter))
 (parameters
   (identifier) @local.definition.variable.builtin
-  (#match? @local.definition.variable.builtin "^(self|cls)$")) ; label self/cls as builtin
+  (#any-of? @local.definition.variable.builtin "self" "cls")) ; label self/cls as builtin
     
 (lambda_parameters
   (identifier) @local.definition.variable.parameter)

--- a/runtime/queries/python/locals.scm
+++ b/runtime/queries/python/locals.scm
@@ -26,6 +26,9 @@
 (parameters
   (dictionary_splat_pattern ; **kwargs
     (identifier) @local.definition.variable.parameter))
+(parameters
+  (identifier) @local.definition.variable.builtin
+  (#match? @local.definition.variable.builtin "^(self|cls)$")) ; label self/cls as builtin
     
 (lambda_parameters
   (identifier) @local.definition.variable.parameter)


### PR DESCRIPTION
Got hit during the wide updating of locals.scm everywhere. Closes #13548 