### PR TITLE
docs(building-from-source): suggest optimized install cmd as alternative

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -40,10 +40,11 @@ RUSTFLAGS="-C target-feature=-crt-static"
    ```
    ```sh
    # Optimized
-   cargo +stable install \
+   cargo install \
       --profile opt \
       --config 'build.rustflags="-C target-cpu=native"' \
-      --path helix-term
+      --path helix-term \
+      --locked
    ```
 
    Either command will create the `hx` executable and construct the tree-sitter

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -35,10 +35,18 @@ RUSTFLAGS="-C target-feature=-crt-static"
 2. Compile from source:
 
    ```sh
+   # Reproducible
    cargo install --path helix-term --locked
    ```
+   ```sh
+   # Optimized
+   cargo +stable install \
+      --profile opt \
+      --config 'build.rustflags="-C target-cpu=native"' \
+      --path helix-term
+   ```
 
-   This command will create the `hx` executable and construct the tree-sitter
+   Either command will create the `hx` executable and construct the tree-sitter
    grammars in the local `runtime` folder.
 
 > 💡 If you do not want to fetch or build grammars, set an environment variable `HELIX_DISABLE_AUTO_GRAMMAR_BUILD`
@@ -182,7 +190,7 @@ cargo deb -- --locked
 ```
 
 > 💡 This locks you into the `--release` profile. But you can also build helix in any way you like.
-> As long as you leave a `target/release/hx` file, it will get packaged with `cargo deb --no-build` 
+> As long as you leave a `target/release/hx` file, it will get packaged with `cargo deb --no-build`
 
 > 💡 Don't worry about the following:
 > ```


### PR DESCRIPTION
For users who don't need/want reproducible builds, and to [set a sensible-default that would be a breaking-change for Cargo](https://github.com/rust-lang/cargo/issues/4150)