### PR TITLE
feat: Re-open previously closed buffers

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -330,15 +330,13 @@ fn buffer_reopen(
         return Ok(());
     }
 
-    let last_closed_doc_path: Option<PathBuf> = if let Some(last_closed_doc_path) = cx.editor.document_history
+    if let Some(last_closed_doc_path) = cx.editor.document_history
         .iter()
         .filter(|path| cx.editor.document_by_path(path).is_none())
         .last()
+        .cloned()
     {
-        Some(last_closed_doc_path.clone())
-    } else { None };
-    if let Some(path) = last_closed_doc_path {
-        cx.editor.open(&path, Action::Load)?;
+        cx.editor.open(&last_closed_doc_path, Action::Load)?;
     }
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -330,8 +330,7 @@ fn buffer_reopen(
         return Ok(());
     }
 
-    if let Some(last_closed_doc_path) = cx.editor.closed_document_paths.pop()
-    {
+    if let Some(last_closed_doc_path) = cx.editor.closed_document_paths.pop() {
         cx.editor.open(&last_closed_doc_path, Action::Replace)?;
     }
     Ok(())

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -332,8 +332,7 @@ fn buffer_reopen(
 
     if let Some(last_closed_doc_path) = cx.editor.closed_document_paths.pop()
     {
-        let id = cx.editor.open(&last_closed_doc_path, Action::Load)?;
-        cx.editor.switch(id, Action::Load);
+        cx.editor.open(&last_closed_doc_path, Action::Replace)?;
     }
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -330,13 +330,10 @@ fn buffer_reopen(
         return Ok(());
     }
 
-    if let Some(last_closed_doc_path) = cx.editor.document_history
-        .iter()
-        .filter(|path| cx.editor.document_by_path(path).is_none())
-        .last()
-        .cloned()
+    if let Some(last_closed_doc_path) = cx.editor.closed_document_paths.pop()
     {
-        cx.editor.open(&last_closed_doc_path, Action::Load)?;
+        let id = cx.editor.open(&last_closed_doc_path, Action::Load)?;
+        cx.editor.switch(id, Action::Load);
     }
     Ok(())
 }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -321,6 +321,28 @@ fn buffer_previous(
     Ok(())
 }
 
+fn buffer_reopen(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let last_closed_doc_path: Option<PathBuf> = if let Some(last_closed_doc_path) = cx.editor.document_history
+        .iter()
+        .filter(|path| cx.editor.document_by_path(path).is_none())
+        .next()
+    {
+        Some(last_closed_doc_path.clone())
+    } else { None };:
+    if let Some(path) = last_closed_doc_path {
+        cx.editor.open(&path, Action::Load)?;
+    }
+    Ok(())
+}
+
 fn write_impl(cx: &mut compositor::Context, path: Option<&str>, force: bool) -> anyhow::Result<()> {
     let config = cx.editor.config();
     let jobs = &mut cx.jobs;
@@ -2703,6 +2725,17 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             ..Signature::DEFAULT
         },
     },
+    TypableCommand {
+        name: "buffer-reopen",
+        aliases: &["bro"],
+        doc: "Re-open the most previously closed buffer.",
+        fun: buffer_reopen,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },    
     TypableCommand {
         name: "write",
         aliases: &["w"],

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -333,10 +333,10 @@ fn buffer_reopen(
     let last_closed_doc_path: Option<PathBuf> = if let Some(last_closed_doc_path) = cx.editor.document_history
         .iter()
         .filter(|path| cx.editor.document_by_path(path).is_none())
-        .next()
+        .last()
     {
         Some(last_closed_doc_path.clone())
-    } else { None };:
+    } else { None };
     if let Some(path) = last_closed_doc_path {
         cx.editor.open(&path, Action::Load)?;
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2721,7 +2721,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     },
     TypableCommand {
         name: "buffer-reopen",
-        aliases: &["bro"],
+        aliases: &["br", "breopen"],
         doc: "Re-open the most previously closed buffer.",
         fun: buffer_reopen,
         completer: CommandCompleter::none(),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1060,7 +1060,8 @@ pub struct Editor {
     pub tree: Tree,
     pub next_document_id: DocumentId,
     pub documents: BTreeMap<DocumentId, Document>,
-
+    pub document_history: Vec<PathBuf>,
+    
     // We Flatten<> to resolve the inner DocumentSavedEventFuture. For that we need a stream of streams, hence the Once<>.
     // https://stackoverflow.com/a/66875668
     pub saves: HashMap<DocumentId, UnboundedSender<Once<DocumentSavedEventFuture>>>,
@@ -1211,6 +1212,7 @@ impl Editor {
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),
             documents: BTreeMap::new(),
+            document_history: Vec::new(),
             saves: HashMap::new(),
             save_queue: SelectAll::new(),
             write_count: 0,
@@ -1797,6 +1799,7 @@ impl Editor {
 
             let id = self.new_document(doc);
             self.launch_language_servers(id);
+            self.document_history.push(path);
 
             helix_event::dispatch(DocumentDidOpen {
                 editor: self,


### PR DESCRIPTION
Adds a `:buffer-reopen` command that re-opens the most recently closed buffer. This is a feature of many other editors, browsers and other programs which have the concept of "tabs". (The shortcut for most programs is `Ctrl`/`Cmd` + `Shift` + `T`.) 

NOTE:
- It only keeps track of the closed buffers' _filepaths_. I would love to cache each `Document` upon being closed, which keeps track of their scroll position, selections, and other state, but `Document` can't be cloned easily and their ownership is given away at the end of `Editor::close_document()`:
  ```rust
  helix_event::dispatch(DocumentDidClose { editor: self, doc /* <- here */ });
  ```
- There's no maximum closed buffer stack size. Theoretically you could close thousands of buffers and it would save all their paths in memory. Let me know if this is a potential issue.

Please, please leave comments and suggestions. I welcome any and all of them, this is my first time contributing to Helix and I am not expecting this to go in as-is.

---
Here's this functionality in action:

![helix-buffer-reload](https://github.com/user-attachments/assets/fd2b1fa0-0ed8-4a7d-8c20-c691bb378934)