### PR TITLE
Add the full (rust) compiler error picker preview

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -29,7 +29,7 @@ use helix_view::{
 use crate::{
     compositor::{self, Compositor},
     job::Callback,
-    ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
+    ui::{self, overlay::overlaid, picker::PathOrId, FileLocation, Picker, Popup, PromptEvent},
 };
 
 use std::{cmp::Ordering, collections::HashSet, fmt::Display, future::Future, path::Path};
@@ -295,7 +295,27 @@ fn diag_picker(
                 .immediately_show_diagnostic(doc, view.id);
         },
     )
-    .with_preview(move |_editor, diag| location_to_file_location(&diag.location))
+    .with_preview(move |_editor, diag| {
+        // let a: Option<(PathOrId, Option<(usize, usize)>)> =
+        // location_to_file_location(&diag.location);
+        // let document = Document::default(editor.config.clone(), editor.syn_loader.clone());
+        // editor.document_by_path(path)
+        match diag.diag.data {
+            Some(ref data) => Some((
+                PathOrId::Document(
+                    data.as_object()
+                        .unwrap()
+                        .get("rendered")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                ),
+                Some((0, 0)),
+            )),
+            None => location_to_file_location(&diag.location),
+        }
+    })
     .truncate_start(false)
 }
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -42,7 +42,7 @@ use std::{
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::{
     char_idx_at_visual_offset, fuzzy::MATCHER, movement::Direction,
-    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position,
+    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position, Rope,
 };
 use helix_view::{
     editor::Action,
@@ -64,6 +64,7 @@ pub const MAX_FILE_SIZE_FOR_PREVIEW: u64 = 10 * 1024 * 1024;
 pub enum PathOrId<'a> {
     Id(DocumentId),
     Path(&'a Path),
+    Document(String),
 }
 
 impl<'a> From<&'a Path> for PathOrId<'a> {
@@ -575,6 +576,21 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let (path_or_id, range) = (self.file_fn.as_ref()?)(editor, current)?;
 
         match path_or_id {
+            PathOrId::Document(s) => {
+                let rope = Rope::from_str(&s);
+                let document =
+                    Document::from(rope, None, editor.config.clone(), editor.syn_loader.clone());
+                let _ = self.preview_cache.insert(
+                    Path::new("/tmp/.helix_error").into(),
+                    CachedPreview::Document(Box::new(document)),
+                );
+                let preview = Preview::Cached(
+                    self.preview_cache
+                        .get(Path::new("/tmp/.helix_error"))
+                        .unwrap(),
+                );
+                Some((preview, range))
+            }
             PathOrId::Path(path) => {
                 if let Some(doc) = editor.document_by_path(path) {
                     return Some((Preview::EditorDocument(doc), range));


### PR DESCRIPTION
This pull requests adds the preview of the full compiler error.

When displaying the errors from the LSP, at least in the case of Rust, it is sometimes useful to see the full compiler error. This pull request modifies the Diagnostics Picker's preview to display the actual compiler error (if available) instead of the file preview. 

For now, the error is displayed without coloring. If this feature is something that is wanted in helix, I can implement coloring too.

I tested this PR only in the context of Rust, but I assume other LSPs might do the same.

<img width="1217" alt="Screenshot 2025-05-19 at 15 17 07" src="https://github.com/user-attachments/assets/b44960d0-bb19-415f-bb8f-ca48f61e3b7d" />
