### PR TITLE
fix(tutor): recommend `e` instead of `w` for selecting word

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -316,7 +316,7 @@
  Insert mode, so it is a very common shorthand for di.
 
  1. Move the cursor to the line marked '-->' below.
- 2. Move to the start of an incorrect word and type w to
+ 2. Move to the start of an incorrect word and type e to
     select it.
  3. Type c to delete the word and enter Insert mode.
  4. Type the correct word.


### PR DESCRIPTION
# Single-character fix in Helix tutor

I was doing the tutorial to learn Helix, and found a section where it's more sensible to use `e` than the recommended `w`.

## Problem

You are supposed to learn the change command, and apply it to the following sentence:
Assuming cursor is at |

*This sentence has incorrect words |behind it.*

If you use `wc`, then you will get:
This sentence has incorrect words |it.

while `ec` will give you
This sentence has incorrect words | it.

Which enables you to drop removing and adding a space for no reason.
The tutorial currently recommends users to use `w`.

```text
1. Move the cursor to the line marked '-->' below.
 2. Move to the start of an incorrect word and type w to
    select it.
 3. Type c to delete the word and enter Insert mode.
 4. Type the correct word.
 5. Repeat until the line matches the line below it.
```


## Fix

Recommend *go to start of incorrect word and press `e`* (not w).