### PR TITLE
Add LilyPond to languages.toml

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -131,6 +131,7 @@
 | ldif | ✓ |  |  |  |
 | lean | ✓ |  |  | `lean` |
 | ledger | ✓ |  |  |  |
+| lilypond | ✓ | ✓ | ✓ |  |
 | llvm | ✓ | ✓ | ✓ |  |
 | llvm-mir | ✓ | ✓ | ✓ |  |
 | llvm-mir-yaml | ✓ |  | ✓ |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1180,6 +1180,21 @@ name = "bibtex"
 source = { git = "https://github.com/latex-lsp/tree-sitter-bibtex", rev = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34" }
 
 [[language]]
+name = "lilypond"
+scope = "source.lilypond"
+injection-regex = "lilypond"
+file-types = ["ly"]
+roots = []
+comment-token = "%"
+indent = { tab-width = 4, unit = "    " }
+formatter = { command = "ly", args = ["reformat"] }
+auto-format = true
+
+[[grammar]]
+name = "lilypond"
+source = { git = "https://github.com/nwhetsell/tree-sitter-lilypond", rev = "6b0f470b2e5acbfc4d1d64ba89b396adecf06ea4" }
+
+[[language]]
 name = "lean"
 scope = "source.lean"
 injection-regex = "lean"

--- a/languages.toml
+++ b/languages.toml
@@ -1192,7 +1192,7 @@ auto-format = true
 
 [[grammar]]
 name = "lilypond"
-source = { git = "https://github.com/nwhetsell/tree-sitter-lilypond", rev = "6b0f470b2e5acbfc4d1d64ba89b396adecf06ea4" }
+source = { git = "https://github.com/nwhetsell/tree-sitter-lilypond", rev = "6b0f470b2e5acbfc4d1d64ba89b396adecf06ea4", subpath = "lilypond" }
 
 [[language]]
 name = "lean"


### PR DESCRIPTION
This PR adds support for [LilyPond](https://lilypond.org/). Basically
- `ly reformat` as formatter; and
- [nwhetsell/tree-sitter-lilypond](https://github.com/nwhetsell/tree-sitter-lilypond) for the grammar