### PR TITLE
Change OCaml highlighting and add `type.structure` and `type.interface` highlights

### DIFF
--- a/runtime/queries/ocaml/highlights.scm
+++ b/runtime/queries/ocaml/highlights.scm
@@ -23,7 +23,8 @@
 ; Modules
 ;--------
 
-[(module_name) (module_type_name)] @namespace
+[(module_name)] @type.structure
+[(module_type_name)] @type.interface
 
 ; Types
 ;------
@@ -33,7 +34,7 @@
   (#match? @type.builtin "^(int|char|bytes|string|float|bool|unit|exn|array|list|option|int32|int64|nativeint|format6|lazy_t)$")
 )
 
-[(class_name) (class_type_name) (type_constructor)] @type
+[(class_name) (class_type_name) (type_constructor)] @type.structure
 
 [(constructor_name) (tag)] @constructor
 
@@ -44,43 +45,44 @@
 
 (value_pattern) @variable.parameter
 
+(type_variable) @type.parameter
+
 ; Functions
 ;----------
 
 (let_binding
-  pattern: (value_name) @function
+  pattern: (value_name) @variable
   (parameter))
 
 (let_binding
-  pattern: (value_name) @function
+  pattern: (value_name) @variable
   body: [(fun_expression) (function_expression)])
 
-(value_specification (value_name) @function)
+(value_specification (value_name) @variable)
 
-(external (value_name) @function)
+(external (value_name) @variable)
 
 (method_name) @function.method
 
 ; Application
 ;------------
 
-(
-  (value_name) @function.builtin
-  (#match? @function.builtin "^(raise(_notrace)?|failwith|invalid_arg)$")
-)
-
 (infix_expression
-  left: (value_path (value_name) @function)
+  left: (value_path (value_name) @variable)
   operator: (concat_operator) @operator
   (#eq? @operator "@@"))
 
 (infix_expression
   operator: (rel_operator) @operator
-  right: (value_path (value_name) @function)
+  right: (value_path (value_name) @variable)
   (#eq? @operator "|>"))
 
 (application_expression
-  function: (value_path (value_name) @function))
+  function: (value_path (value_name) @variable))
+
+((value_name) @function.builtin
+  (#match? @function.builtin "^(raise(_notrace)?|failwith|invalid_arg)$")
+)
 
 ; Properties
 ;-----------


### PR DESCRIPTION
About a month ago, #13293 fixed an apparent bug which was causing OCaml functions to be highlighted the same color as variables. However, I think that it actually looked better that way, since the difference between functions and variables is kind of blurred in OCaml. I originally tried to simply make that change in my work-in-progress custom theme, but it would also change the color of functions in Rust and there's no way to satisfy both. This might be a controversial change, so if anyone disagrees, maybe we could create a `function.variable` or `variable.function` highlight to accomodate both options.

Also, I created a new highlight called `type.structure` and applied it to OCaml's modules (previously colored as `namespace`). This highlight should be assigned to all structs and classes in various languages. I was a bit surprised that no such highlight exists and I think it might be useful. I also added a `type.interface` highlight intended for example for Rust's `trait`, Java's `interface` or OCaml's `module type`, though I'm not sure whether anyone would ever need to highlight them differently, but it doesn't hurt to add it I guess.