### PR TITLE
feat!: Collapse all yank-join commands into a single `:yank-join` with flags

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -32,11 +32,9 @@
 | `:cquit`, `:cq` | Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2). |
 | `:cquit!`, `:cq!` | Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2). |
 | `:theme` | Change the editor theme (show current theme if no name specified). |
-| `:yank-join` | Yank joined selections. A separator can be provided as first argument. Default value is newline. |
+| `:yank-join`, `:yj` | Yank the selections joined with a separator |
 | `:clipboard-yank` | Yank main selection into system clipboard. |
-| `:clipboard-yank-join` | Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline. |
 | `:primary-clipboard-yank` | Yank main selection into system primary clipboard. |
-| `:primary-clipboard-yank-join` | Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline. |
 | `:clipboard-paste-after` | Paste system clipboard after selections. |
 | `:clipboard-paste-before` | Paste system clipboard before selections. |
 | `:clipboard-paste-replace` | Replace selections with content of system clipboard. |

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -5,6 +5,7 @@ use super::*;
 mod insert;
 mod movement;
 mod write;
+mod yank_join;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn search_selection_detect_word_boundaries_at_eof() -> anyhow::Result<()> {

--- a/helix-term/tests/test/commands/yank_join.rs
+++ b/helix-term/tests/test/commands/yank_join.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_flags() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+                #[o|]#ne
+                #(t|)#wo
+                three"
+        },
+        ":yank-join<ret>p",
+        indoc! {"\
+                o#[o
+                t|]#ne
+                t#(o
+                t|)#wo
+                three"
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn separator_flag() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+                #[o|]#ne
+                #(t|)#wo
+                three"
+        },
+        ":yank-join --separator x<ret>p",
+        indoc! {"\
+                o#[oxt|]#ne
+                t#(oxt|)#wo
+                three"
+        },
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn register_flag() -> anyhow::Result<()> {
+    test((
+        indoc! {"\
+                #[o|]#ne
+                #(t|)#wo
+                three"
+        },
+        // 1. Yank the two selections into register `x`
+        // 2. Move cursor down + right
+        // 3. Yank two other selections into the default register
+        // 4. Move cursor back up + left, to the original position
+        // 5. Pasting from register `x` will paste as if actions 2, 3 and 4 never occured
+        ":yank-join --register x<ret>jl:yank-join<ret>kh\"xp",
+        indoc! {"\
+                o#[o
+                t|]#ne
+                t#(o
+                t|)#wo
+                three"
+        },
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Instead of 3 similar commands, we now have 1 command `:yank-join`:

```
┌────────────────────────────────────────────────────────────────────────────────────────┐
│ Yank the selections joined with a separator                                            │
│ Aliases: yj                                                                            │
│ Flags:                                                                                 │
│   --separator/-s <arg>  Separator to between joined selections [default: newline]      │
│   --register/-r <arg>   Yank into this register                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
:yank-join
```

Additionally:

- Added alias `yj` for `yank-join`
- Added tests for each flag + without

Breaking changes:
- Removed `:clipboard-yank-join`, use `yank-join --register +` instead
- Removed `:primary-clipboard-yank-join`, use `yank-join --register *` instead