### PR TITLE
fix(highlights/ungrammar): improve UX

### DIFF
--- a/runtime/queries/ungrammar/highlights.scm
+++ b/runtime/queries/ungrammar/highlights.scm
@@ -1,6 +1,12 @@
 (line_comment) @comment
 
-(identifier) @variable
+(identifier) @function
+
+(labeled_rule
+  (identifier) @type)
+
+(node_rule
+  (identifier) @variable.parameter)
 
 (token) @string
 


### PR DESCRIPTION
Improve UX of highlighting `ungrammar` grammar by assuming each Rule as a `function`, Labeled as a `type`, and Node as a `parameter`. This is better than just all white.

- Before:
![image](https://github.com/user-attachments/assets/a71928dc-bbbe-40e8-b2f8-68b90a2915ed)

- After:
![image](https://github.com/user-attachments/assets/b2cf2ed1-c5ef-4b3f-96f8-4a278370012f)
