### PR TITLE
feat: add goto_first_selection, goto_last_selection

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -303,5 +303,5 @@
 | `extend_to_word` | Extend to a two-character label | select: `` gw `` |
 | `goto_next_tabstop` | Goto next snippet placeholder |  |
 | `goto_prev_tabstop` | Goto next snippet placeholder |  |
-| `rotate_selection_first` | Make the first selection your primary one |  |
-| `rotate_selection_last` | Make the last selection your primary one |  |
+| `rotate_selections_first` | Make the first selection your primary one |  |
+| `rotate_selections_last` | Make the last selection your primary one |  |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -303,3 +303,5 @@
 | `extend_to_word` | Extend to a two-character label | select: `` gw `` |
 | `goto_next_tabstop` | Goto next snippet placeholder |  |
 | `goto_prev_tabstop` | Goto next snippet placeholder |  |
+| `goto_first_selection` | Make the first selection your primary one |  |
+| `goto_last_selection` | Make the last selection your primary one |  |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -303,5 +303,5 @@
 | `extend_to_word` | Extend to a two-character label | select: `` gw `` |
 | `goto_next_tabstop` | Goto next snippet placeholder |  |
 | `goto_prev_tabstop` | Goto next snippet placeholder |  |
-| `goto_first_selection` | Make the first selection your primary one |  |
-| `goto_last_selection` | Make the last selection your primary one |  |
+| `rotate_selection_first` | Make the first selection your primary one |  |
+| `rotate_selection_last` | Make the last selection your primary one |  |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -601,8 +601,8 @@ impl MappableCommand {
         extend_to_word, "Extend to a two-character label",
         goto_next_tabstop, "Goto next snippet placeholder",
         goto_prev_tabstop, "Goto next snippet placeholder",
-        goto_first_selection, "Make the first selection your primary one",
-        goto_last_selection, "Make the last selection your primary one",
+        rotate_selection_first, "Make the first selection your primary one",
+        rotate_selection_last, "Make the last selection your primary one",
     );
 }
 
@@ -5294,14 +5294,14 @@ fn rotate_selections_backward(cx: &mut Context) {
     rotate_selections(cx, Direction::Backward)
 }
 
-pub fn goto_first_selection(cx: &mut Context) {
+fn rotate_selection_first(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let mut selection = doc.selection(view.id).clone();
     selection.set_primary_index(0);
     doc.set_selection(view.id, selection);
 }
 
-pub fn goto_last_selection(cx: &mut Context) {
+fn rotate_selection_last(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let mut selection = doc.selection(view.id).clone();
     let len = selection.len();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -601,8 +601,8 @@ impl MappableCommand {
         extend_to_word, "Extend to a two-character label",
         goto_next_tabstop, "Goto next snippet placeholder",
         goto_prev_tabstop, "Goto next snippet placeholder",
-        rotate_selection_first, "Make the first selection your primary one",
-        rotate_selection_last, "Make the last selection your primary one",
+        rotate_selections_first, "Make the first selection your primary one",
+        rotate_selections_last, "Make the last selection your primary one",
     );
 }
 
@@ -5294,14 +5294,14 @@ fn rotate_selections_backward(cx: &mut Context) {
     rotate_selections(cx, Direction::Backward)
 }
 
-fn rotate_selection_first(cx: &mut Context) {
+fn rotate_selections_first(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let mut selection = doc.selection(view.id).clone();
     selection.set_primary_index(0);
     doc.set_selection(view.id, selection);
 }
 
-fn rotate_selection_last(cx: &mut Context) {
+fn rotate_selections_last(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let mut selection = doc.selection(view.id).clone();
     let len = selection.len();

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -601,6 +601,8 @@ impl MappableCommand {
         extend_to_word, "Extend to a two-character label",
         goto_next_tabstop, "Goto next snippet placeholder",
         goto_prev_tabstop, "Goto next snippet placeholder",
+        goto_first_selection, "Make the first selection your primary one",
+        goto_last_selection, "Make the last selection your primary one",
     );
 }
 
@@ -5290,6 +5292,21 @@ fn rotate_selections_forward(cx: &mut Context) {
 }
 fn rotate_selections_backward(cx: &mut Context) {
     rotate_selections(cx, Direction::Backward)
+}
+
+pub fn goto_first_selection(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let mut selection = doc.selection(view.id).clone();
+    selection.set_primary_index(0);
+    doc.set_selection(view.id, selection);
+}
+
+pub fn goto_last_selection(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let mut selection = doc.selection(view.id).clone();
+    let len = selection.len();
+    selection.set_primary_index(len - 1);
+    doc.set_selection(view.id, selection);
 }
 
 enum ReorderStrategy {


### PR DESCRIPTION
The usecase is to have made some selections, and then jumping to either the first or the last one, to then "remove all other selections" on. Very helpful for navigation!
