### PR TITLE
feat: allow customizing diff gutter characters

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -381,7 +381,18 @@ These colors are controlled by the theme attributes `diff.plus`, `diff.minus` an
 
 Other diff providers will eventually be supported by a future plugin system.
 
-There are currently no options for this section.
+| Key | Description | Default |
+|-----|-------------|---------|
+| `characters` | Literal characters to use when rendering the diff gutter. Sub-keys may be any of `added`, `deleted`, or `modified` | See example below |
+
+Example:
+
+```toml
+[editor.gutters.diff.characters]
+added = '▏' # some characters that work well: '▍', '▏', '▎'
+deleted = '▁'
+modified = '▏'
+```
 
 #### `[editor.gutters.spacer]` Section
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -92,6 +92,8 @@ pub struct GutterConfig {
     pub layout: Vec<GutterType>,
     /// Options specific to the "line-numbers" gutter
     pub line_numbers: GutterLineNumbersConfig,
+    /// Options specific to the "diff" gutter
+    pub diff: GutterDiffConfig,
 }
 
 impl Default for GutterConfig {
@@ -105,6 +107,7 @@ impl Default for GutterConfig {
                 GutterType::Diff,
             ],
             line_numbers: GutterLineNumbersConfig::default(),
+            diff: GutterDiffConfig::default(),
         }
     }
 }
@@ -172,6 +175,36 @@ pub struct GutterLineNumbersConfig {
 impl Default for GutterLineNumbersConfig {
     fn default() -> Self {
         Self { min_width: 3 }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct GutterDiffConfig {
+    pub characters: DiffCharacters
+}
+
+impl Default for GutterDiffConfig {
+    fn default() -> Self {
+        Self { characters: DiffCharacters::default() }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DiffCharacters {
+    pub added: char,
+    pub deleted: char,
+    pub modified: char,
+}
+
+impl Default for DiffCharacters {
+    fn default() -> Self {
+        Self {
+            added: '▍',
+            deleted: '▔',
+            modified: '▍',
+        }
     }
 }
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -88,7 +88,7 @@ pub fn diagnostic<'doc>(
 }
 
 pub fn diff<'doc>(
-    _editor: &'doc Editor,
+    editor: &'doc Editor,
     doc: &'doc Document,
     _view: &View,
     theme: &Theme,
@@ -97,6 +97,12 @@ pub fn diff<'doc>(
     let added = theme.get("diff.plus.gutter");
     let deleted = theme.get("diff.minus.gutter");
     let modified = theme.get("diff.delta.gutter");
+
+    let diff_chars = editor.config().gutters.diff.characters;
+    let added_icon = diff_chars.added;
+    let deleted_icon = diff_chars.deleted;
+    let modified_icon = diff_chars.modified;
+
     if let Some(diff_handle) = doc.diff_handle() {
         let hunks = diff_handle.load();
         let mut hunk_i = 0;
@@ -120,14 +126,14 @@ pub fn diff<'doc>(
                 }
 
                 let (icon, style) = if hunk.is_pure_insertion() {
-                    ("▍", added)
+                    (added_icon, added)
                 } else if hunk.is_pure_removal() {
                     if !first_visual_line {
                         return None;
                     }
-                    ("▔", deleted)
+                    (deleted_icon, deleted)
                 } else {
-                    ("▍", modified)
+                    (modified_icon, modified)
                 };
 
                 write!(out, "{}", icon).unwrap();
@@ -330,7 +336,7 @@ mod tests {
 
     use super::*;
     use crate::document::Document;
-    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig};
+    use crate::editor::{Config, GutterConfig, GutterDiffConfig, GutterLineNumbersConfig};
     use crate::graphics::Rect;
     use crate::DocumentId;
     use arc_swap::ArcSwap;
@@ -381,6 +387,7 @@ mod tests {
         let gutters = GutterConfig {
             layout: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             line_numbers: GutterLineNumbersConfig { min_width: 10 },
+            diff: GutterDiffConfig::default(),
         };
 
         let mut view = View::new(DocumentId::default(), gutters);
@@ -404,6 +411,7 @@ mod tests {
         let gutters = GutterConfig {
             layout: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             line_numbers: GutterLineNumbersConfig { min_width: 1 },
+            diff: GutterDiffConfig::default(),
         };
 
         let mut view = View::new(DocumentId::default(), gutters);


### PR DESCRIPTION
Allows customizing what characters are used for the `diff` part of the gutter.

## Configuration changes

Adds `characters` table to the `editor.gutters.diff` with the `added`, `deleted`, and `modified` keys.

```toml
[editor.gutters.diff.characters]
added = '▏' # some characters that work well: '▍', '▏', '▎'
deleted = '▁'
modified = '▏'
```