### PR TITLE
fix regression / conflict of Home/End in pickers

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -455,8 +455,8 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | `Tab`, `Down`, `Ctrl-n`      | Next entry                                                 |
 | `PageUp`, `Ctrl-u`           | Page up                                                    |
 | `PageDown`, `Ctrl-d`         | Page down                                                  |
-| `Home`                       | Go to first entry                                          |
-| `End`                        | Go to last entry                                           |
+| `Ctrl-Home`                  | Go to first entry                                          |
+| `Ctrl-End`                   | Go to last entry                                           |
 | `Enter`                      | Open selected                                              |
 | `Alt-Enter`                  | Open selected in the background without closing the picker |
 | `Ctrl-s`                     | Open horizontally                                          |

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1063,10 +1063,10 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(PageUp) | ctrl!('u') => {
                 self.page_up();
             }
-            key!(Home) => {
+            ctrl!(Home) => {
                 self.to_start();
             }
-            key!(End) => {
+            ctrl!(End) => {
                 self.to_end();
             }
             key!(Esc) | ctrl!('c') => return close_fn(self),


### PR DESCRIPTION
Previously, Home/End went to the start/end of the input in a picker. Since recently, Home/End started to go to the first/last item in the results. \
Now the latter is done via *ctrl*+Home/End, and Home/End is back to their unsurprising behavior. \
I updated the part in the documentation about this, as well.
