### PR TITLE
highlights/go: fix locals clashing with variable.other.member

### DIFF
--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -7,16 +7,13 @@
 
 (package_identifier) @namespace
 
-(parameter_declaration (identifier) @variable.parameter)
-(variadic_parameter_declaration (identifier) @variable.parameter)
-
 (const_spec
   name: (identifier) @constant)
 
 (type_spec 
   name: (type_identifier) @constructor)
 
-(keyed_element (literal_element (identifier) @variable.other.member))
+(keyed_element . (literal_element (identifier) @variable.other.member))
 (field_declaration
   name: (field_identifier) @variable.other.member)
 

--- a/runtime/queries/go/locals.scm
+++ b/runtime/queries/go/locals.scm
@@ -8,10 +8,6 @@
 
 ; Definitions
 
-(type_parameter_list
-  (parameter_declaration
-    name: (identifier) @local.definition.variable.parameter))
-
 (parameter_declaration (identifier) @local.definition.variable.parameter)
 (variadic_parameter_declaration (identifier) @local.definition.variable.parameter)
 
@@ -22,5 +18,7 @@
 ; References
 
 (identifier) @local.reference
-(field_identifier) @local.reference
-(type_identifier) @local.reference
+
+; Field names in struct literals are identifier rather than field_identifier,
+; these cannot be locals.
+(keyed_element . (literal_element (identifier) @variable.other.member))


### PR DESCRIPTION
Look at below Rust snippet and note the highlighting of struct fields and function parameters:

![image](https://github.com/user-attachments/assets/4d7cb2e3-9042-4c08-a015-baa7d49fe918)

Now look at the quasi-equivalent code in Go, note that function parameter and struct field highlighting spill into places they shouldn't:

![image](https://github.com/user-attachments/assets/a1158ebe-ba3e-4c28-a5bc-bce8bd3122a5)

With this PR, we get the same (correct) highlighting in Go, just as shown in the Rust example:

![image](https://github.com/user-attachments/assets/238a715c-c86e-4049-92a3-3c61a35be853)
