### PR TITLE
feat: Add Clarity language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -21,6 +21,7 @@
 | capnp | ✓ |  | ✓ |  |
 | cel | ✓ |  |  |  |
 | circom | ✓ |  |  | `circom-lsp` |
+| clarity | ✓ |  |  | `clarinet` |
 | clojure | ✓ |  |  | `clojure-lsp` |
 | cmake | ✓ | ✓ | ✓ | `cmake-language-server` |
 | codeql | ✓ | ✓ |  | `codeql` |

--- a/languages.toml
+++ b/languages.toml
@@ -4360,3 +4360,23 @@ file-types = [ { glob = "dunst/dunstrc" } ]
 [[grammar]]
 name = "dunstrc"
 source = { git = "https://github.com/rotmh/tree-sitter-dunstrc", rev = "9cb9d5cc51cf5e2a47bb2a0e2f2e519ff11c1431" }
+
+[language-server.clarinet]
+command = "clarinet"
+args = ["lsp"]
+
+[[language]]
+name = "clarity"
+scope = "source.clar"
+injection-regex = "clarity"
+file-types = ["clar"]
+roots = ["Clarinet.toml"]
+comment-tokens = ";;"
+indent = { tab-width = 2, unit = "  " }
+grammar = "clarity"
+language-servers = [ "clarinet" ]
+
+[[grammar]]
+name = "clarity"
+source = { git = "https://github.com/xlittlerag/tree-sitter-clarity", rev = "7fa54825fdd971a1a676f885384f024fe2b7384a" }
+

--- a/languages.toml
+++ b/languages.toml
@@ -261,6 +261,10 @@ enable = true
 [language-server.vscode-eslint-language-server.config.workingDirectory]
 mode = "location"
 
+[language-server.clarinet]
+command = "clarinet"
+args = ["lsp"]
+
 [[language]]
 name = "rust"
 scope = "source.rust"
@@ -4372,10 +4376,6 @@ injection-regex = "rust-format-args"
 name = "rust-format-args"
 source = { git = "https://github.com/nik-rev/tree-sitter-rustfmt", rev = "2ca0bdd763d0c9dbb1d0bd14aea7544cbe81309c" }
 
-[language-server.clarinet]
-command = "clarinet"
-args = ["lsp"]
-
 [[language]]
 name = "clarity"
 scope = "source.clar"
@@ -4384,7 +4384,6 @@ file-types = ["clar"]
 roots = ["Clarinet.toml"]
 comment-tokens = ";;"
 indent = { tab-width = 2, unit = "  " }
-grammar = "clarity"
 language-servers = [ "clarinet" ]
 
 [[grammar]]

--- a/runtime/queries/clarity/highlights.scm
+++ b/runtime/queries/clarity/highlights.scm
@@ -43,27 +43,13 @@
   ","
 ] @punctuation.delimiter
 
-[
-  "block-height"
-  "burn-block-height"
-  "chain-id"
-  "contract-caller"
-  "is-in_mainnet" ; FIXME
-  "is-in-regtest"
-  "stacks-block-height"
-  "stx-liquid-supply"
-  "tenure-height"
-  "tx-sender"
-  "tx-sponsor?"
-] @keyword
-
 ; Keywords
-[
-  "some"
+(list_lit_token) @keyword
+(some_lit ("some") @keyword)
+(response_lit [
   "ok"
   "err"
-  (list_lit_token)
-] @keyword
+] @keyword)
 
 [
   "+"
@@ -84,11 +70,14 @@
 ; Functions
 (function_signature (identifier) @function)
 (function_signature_for_trait (identifier) @function)
-(basic_native_form operator: (native_identifier) @function.builtin)
-(contract_function_call operator: (identifier) @function.method)
+(contract_function_call operator: (identifier) @function)
 
+(basic_native_form operator: (native_identifier) @function.builtin)
 [
   "let"
+] @function.builtin
+
+[
   "impl-trait"
   "use-trait"
   "define-trait"
@@ -100,7 +89,7 @@
   "define-non-fungible-token"
   "define-constant"
   "define-map"
-] @function.builtin
+] @function.special
 
 ; Variables and parameters
 (function_parameter) @variable.parameter
@@ -109,4 +98,6 @@
 (tuple_lit key: (identifier) @variable)
 (tuple_type key: (identifier) @variable)
 (tuple_type_for_trait key: (identifier) @variable)
+
+(global) @variable.builtin
 

--- a/runtime/queries/clarity/highlights.scm
+++ b/runtime/queries/clarity/highlights.scm
@@ -1,0 +1,112 @@
+; Comments
+(comment) @comment
+
+; Literals
+[
+  (int_lit)
+  (uint_lit)
+] @constant.numeric.integer
+
+[
+  (bool_lit)
+  (none_lit)
+] @constant.builtin
+
+[
+  (ascii_string_lit)
+  (utf8_string_lit)
+] @string
+
+[
+  (buffer_lit)
+  (standard_principal_lit)
+  (contract_principal_lit)
+] @string.special
+
+; Types
+[
+  (native_type)
+  (trait_type)
+] @type
+
+; Punctuation
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "<"
+  ">"
+] @punctuation.bracket
+
+[
+  ","
+] @punctuation.delimiter
+
+[
+  "block-height"
+  "burn-block-height"
+  "chain-id"
+  "contract-caller"
+  "is-in_mainnet" ; FIXME
+  "is-in-regtest"
+  "stacks-block-height"
+  "stx-liquid-supply"
+  "tenure-height"
+  "tx-sender"
+  "tx-sponsor?"
+] @keyword
+
+; Keywords
+[
+  "some"
+  "ok"
+  "err"
+  (list_lit_token)
+] @keyword
+
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "mod"
+  "pow"
+  "<"
+  "<="
+  ">"
+  ">="
+  "and"
+  "or"
+  "xor"
+] @keyword.operator
+
+; Functions
+(function_signature (identifier) @function)
+(function_signature_for_trait (identifier) @function)
+(basic_native_form operator: (native_identifier) @function.builtin)
+(contract_function_call operator: (identifier) @function.method)
+
+[
+  "let"
+  "impl-trait"
+  "use-trait"
+  "define-trait"
+  "define-read-only"
+  "define-private"
+  "define-public"
+  "define-data-var"
+  "define-fungible-token"
+  "define-non-fungible-token"
+  "define-constant"
+  "define-map"
+] @function.builtin
+
+; Variables and parameters
+(function_parameter) @variable.parameter
+(trait_usage trait_alias: (identifier) @type.parameter)
+
+(tuple_lit key: (identifier) @variable)
+(tuple_type key: (identifier) @variable)
+(tuple_type_for_trait key: (identifier) @variable)
+


### PR DESCRIPTION
This PR adds LSP and syntax highlighting support for the Clarity language. Clarity is a decidable, Lisp-like language used for writing smart contracts on the [Stacks blockchain](https://github.com/stacks-network/stacks-core), and is identified by `.clar` file endings