### PR TITLE
Marks revival

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -4,8 +4,8 @@
 //! All positioning is done via `char` offsets into the buffer.
 use crate::{
     graphemes::{
-        ensure_grapheme_boundary_next, ensure_grapheme_boundary_prev, next_grapheme_boundary,
-        prev_grapheme_boundary,
+        ensure_grapheme_boundary_next, ensure_grapheme_boundary_prev, grapheme_width,
+        next_grapheme_boundary, prev_grapheme_boundary,
     },
     line_ending::get_line_ending,
     movement::Direction,
@@ -243,6 +243,37 @@ impl Range {
         }
     }
 
+    /// Returns a range that encompasses the intersection of the input ranges.
+    ///
+    /// If the input ranges overlap, the intersection is the area covered by
+    /// both input ranges. Otherwise, the intersection is the area between the
+    /// input ranges.
+    ///
+    /// The range is [Direction::Backward] if both input ranges are
+    /// [Direction::Backward], [Direction::Forward] otherwise.
+    #[must_use]
+    pub fn intersect(&self, other: Self) -> Self {
+        let sel = if self.anchor > self.head && other.anchor > other.head {
+            Range {
+                anchor: self.anchor.min(other.anchor),
+                head: self.head.max(other.head),
+                old_visual_position: None,
+            }
+        } else {
+            Range {
+                anchor: self.from().max(other.from()),
+                head: self.to().min(other.to()),
+                old_visual_position: None,
+            }
+        };
+
+        if !self.overlaps(&other) {
+            return sel.flip();
+        }
+
+        sel
+    }
+
     // groupAt
 
     /// Returns the text inside this range given the text of the whole buffer.
@@ -389,6 +420,15 @@ impl Range {
     /// direction.
     pub fn into_byte_range(&self, text: RopeSlice) -> (usize, usize) {
         (text.char_to_byte(self.from()), text.char_to_byte(self.to()))
+    }
+
+    /// Gets the display-width of the range in columns.
+    #[must_use]
+    pub fn width(&self, text: RopeSlice) -> usize {
+        let graphemes = text.slice(self.from()..self.to()).graphemes();
+        graphemes
+            .map(|slice| grapheme_width(&Cow::from(slice)))
+            .sum()
     }
 }
 
@@ -584,6 +624,18 @@ impl Selection {
             .unwrap();
 
         self
+    }
+
+    /// Creates a new selection including ranges from `self` and `other`. The
+    /// primary selection index is inherited from `self`.
+    ///
+    /// `self` and `other` are assumed to be normalized. The produced selection
+    /// is normalized.
+    pub fn append(self, other: Selection) -> Self {
+        let mut ranges = self.ranges.clone();
+        ranges.extend(other.ranges.clone());
+
+        Selection::new(ranges, self.primary_index)
     }
 
     /// Replaces ranges with one spanning from first to last range.

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -144,6 +144,29 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "*" => search_selection_detect_word_boundaries,
         "A-*" => search_selection,
 
+        "^" => { "Selections"
+            "s" => save_selection_to_register,
+            "S" => restore_selection,
+            "c" => { "Combine selection from register"
+                "a" => append_selection_from_register,
+                "u" => union_selection_from_register,
+                "i" => intersect_selection_from_register,
+                "lt" => select_leftmost_cursor_selection_from_register,
+                "gt" => select_rightmost_cursor_selection_from_register,
+                "minus" => select_shortest_selection_from_register,
+                "+" => select_longest_selection_from_register,
+            },
+            "C" => { "Combine selection to register"
+                "a" => append_selection_to_register,
+                "u" => union_selection_to_register,
+                "i" => intersect_selection_to_register,
+                "lt" => select_leftmost_cursor_selection_to_register,
+                "gt" => select_rightmost_cursor_selection_to_register,
+                "minus" => select_shortest_selection_to_register,
+                "+" => select_longest_selection_to_register,
+            },
+        },
+
         "u" => undo,
         "U" => redo,
         "A-u" => earlier,


### PR DESCRIPTION
This pull request acts as a continuation of #3720 

Questions/notes:
---
- Currently the marks are only associated with the special register "^", which when read yields the marks contents. Should they be written to/read from registers? Should they be stored in a jump list fashion?
- It's not clear what should happen if you combine `Selection`s with multiple `Selection`s when the results overlap. Currently this PR combines them in a pair-wise fashion, but I wrongly believe that combining them in a windowed fashion in order may be a better solution. What should the behavior be?


The following is the description taken from #3720 
---
Marks are a way of recording selections/ranges in a way that can be used later. It's like the ability to store jumplist entry in a registers plus commands to combine selections to/from registers. This PR implements [kakoune's marks commands](https://github.com/mawww/kakoune/blob/master/doc/pages/keys.asciidoc#marks) and also adds a function that joins the ranges of a given selection together.

I would like to explore basing LSP snippets on marks so I'll keep this as a draft for now.
[...]
Closes https://github.com/helix-editor/helix/issues/703