### PR TITLE
:buffer-nth command

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -33,6 +33,7 @@
 | `:quit-all!`, `:qa!` | Force close all views ignoring unsaved changes. |
 | `:cquit`, `:cq` | Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2). |
 | `:cquit!`, `:cq!` | Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2). |
+| `:buffer-nth`, `:bi` | Switch to the nth buffer, out of those you have open. |
 | `:theme` | Change the editor theme (show current theme if no name specified). |
 | `:yank-join` | Yank joined selections. A separator can be provided as first argument. Default value is newline. |
 | `:clipboard-yank` | Yank main selection into system clipboard. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -377,6 +377,24 @@ fn buffer_previous(
     Ok(())
 }
 
+fn buffer_nth(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+    let n: usize = args[0]
+        .parse()
+        .context("provided argument is not an integer")?;
+    ensure!(n != 0);
+    let (id, _) = if args.has_flag("reverse") {
+        cx.editor.documents.iter().nth_back(n - 1)
+    } else {
+        cx.editor.documents.iter().nth(n - 1)
+    }
+    .ok_or_else(|| anyhow!("buffer {n} is out of range"))?;
+    cx.editor.switch(*id, helix_view::editor::Action::Replace);
+    Ok(())
+}
+
 fn write_impl(
     cx: &mut compositor::Context,
     path: Option<&str>,
@@ -3373,6 +3391,25 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(1)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "buffer-nth",
+        aliases: &["bi"],
+        doc: "Switch to the nth buffer, out of those you have open.",
+        fun: buffer_nth,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (1, None),
+            flags: &[
+                Flag {
+                    name: "reverse",
+                    alias: Some('r'),
+                    doc: "count buffers from the end",
+                    ..Flag::DEFAULT
+                },
+            ],
             ..Signature::DEFAULT
         },
     },


### PR DESCRIPTION
Say I have 5 buffers open currently. \
My usecase is to have hotkeys where <kbd>ctrl+1</kbd> goes to the first one, <kbd>ctrl+2</kbd> goes to the second one, … <kbd>ctrl+0</kbd> goes to the last one. Kinda like in a browser! \
This will aid a more buffer-closey approach, along with the `:buffer-next` & `:buffer-previous` commands, as due to helix not having live buffer reloading, closing buffers aggressively is a good idea.

My first thought was to have the user simply provide a negative number to count from the end, but that results in them having to `-- -1`. `-r 1` is slightly nicer.
