### PR TITLE
Add ability to configure atomic saving

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -53,7 +53,7 @@
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
-| `atomic-save` | Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
+| `atomic-save` | Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
 | `trim-final-newlines` | Whether to automatically remove line-endings after the final one on write | `false` |
 | `trim-trailing-whitespace` | Whether to automatically remove whitespace preceding line endings on write | `false` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -53,7 +53,7 @@
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
-| `atomic-save` | Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
+| `atomic-save` | Whether to use atomic operations to write documents to disk. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
 | `trim-final-newlines` | Whether to automatically remove line-endings after the final one on write | `false` |
 | `trim-trailing-whitespace` | Whether to automatically remove whitespace preceding line endings on write | `false` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -53,6 +53,7 @@
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
+| `atomic-save` | Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
 | `trim-final-newlines` | Whether to automatically remove line-endings after the final one on write | `false` |
 | `trim-trailing-whitespace` | Whether to automatically remove whitespace preceding line endings on write | `false` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -53,7 +53,7 @@
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
-| `atomic-save` | Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
+| `atomic-save` | Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs. | `true` |
 | `trim-final-newlines` | Whether to automatically remove line-endings after the final one on write | `false` |
 | `trim-trailing-whitespace` | Whether to automatically remove whitespace preceding line endings on write | `false` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |

--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -34,7 +34,6 @@ pub struct EditorConfig {
     // pub spelling_language: Option<SpellingLanguage>,
     pub trim_trailing_whitespace: Option<bool>,
     pub insert_final_newline: Option<bool>,
-    pub atomic_save: Option<bool>,
     pub max_line_length: Option<NonZeroU16>,
 }
 
@@ -160,13 +159,6 @@ impl EditorConfig {
                 "false" => Some(false),
                 _ => None,
             });
-        let atomic_save = pairs
-            .get("atomic_save")
-            .and_then(|value| match value.as_ref() {
-                "true" => Some(true),
-                "false" => Some(false),
-                _ => None,
-            });
         // This option is not in the spec but is supported by some editors.
         // <https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length>
         let max_line_length = pairs
@@ -180,7 +172,6 @@ impl EditorConfig {
             encoding,
             trim_trailing_whitespace,
             insert_final_newline,
-            atomic_save,
             max_line_length,
         }
     }
@@ -314,7 +305,6 @@ mod test {
 
         [docs/**.txt]
         insert_final_newline = true
-        atomic_save = true
         "#;
 
         assert_eq!(
@@ -336,7 +326,6 @@ mod test {
             EditorConfig {
                 indent_style: Some(IndentStyle::Spaces(4)),
                 insert_final_newline: Some(true),
-                atomic_save: Some(true),
                 ..Default::default()
             }
         );

--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -314,7 +314,7 @@ mod test {
 
         [docs/**.txt]
         insert_final_newline = true
-        atomic_write = true
+        atomic_save = true
         "#;
 
         assert_eq!(

--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -34,6 +34,7 @@ pub struct EditorConfig {
     // pub spelling_language: Option<SpellingLanguage>,
     pub trim_trailing_whitespace: Option<bool>,
     pub insert_final_newline: Option<bool>,
+    pub atomic_save: Option<bool>,
     pub max_line_length: Option<NonZeroU16>,
 }
 
@@ -159,6 +160,13 @@ impl EditorConfig {
                 "false" => Some(false),
                 _ => None,
             });
+        let atomic_save = pairs
+            .get("atomic_save")
+            .and_then(|value| match value.as_ref() {
+                "true" => Some(true),
+                "false" => Some(false),
+                _ => None,
+            });
         // This option is not in the spec but is supported by some editors.
         // <https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length>
         let max_line_length = pairs
@@ -172,6 +180,7 @@ impl EditorConfig {
             encoding,
             trim_trailing_whitespace,
             insert_final_newline,
+            atomic_save,
             max_line_length,
         }
     }
@@ -305,6 +314,7 @@ mod test {
 
         [docs/**.txt]
         insert_final_newline = true
+        atomic_write = true
         "#;
 
         assert_eq!(
@@ -326,6 +336,7 @@ mod test {
             EditorConfig {
                 indent_style: Some(IndentStyle::Spaces(4)),
                 insert_final_newline: Some(true),
+                atomic_save: Some(true),
                 ..Default::default()
             }
         );

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1915,7 +1915,7 @@ impl Document {
             .unwrap_or_else(|| self.config.load().insert_final_newline)
     }
 
-    /// Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs.
+    /// Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs.
     pub fn atomic_save(&self) -> bool {
         self.config.load().atomic_save
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -980,7 +980,7 @@ impl Document {
         // mark changes up to now as saved
         let current_rev = self.get_current_revision();
         let doc_id = self.id();
-        let atomic_write = self.atomic_save();
+        let atomic_save = self.atomic_save();
 
         let encoding_with_bom_info = (self.encoding, self.has_bom);
         let last_saved_time = self.last_saved_time;
@@ -1030,7 +1030,7 @@ impl Document {
 
             // Assume it is a hardlink to prevent data loss if the metadata cant be read (e.g. on certain Windows configurations)
             let is_hardlink = helix_stdx::faccess::hardlink_count(&write_path).unwrap_or(2) > 1;
-            let backup = if path.exists() && atomic_write {
+            let backup = if path.exists() && atomic_save {
                 let path_ = write_path.clone();
                 // hacks: we use tempfile to handle the complex task of creating
                 // non clobbered temporary path for us we don't want

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1915,7 +1915,7 @@ impl Document {
             .unwrap_or_else(|| self.config.load().insert_final_newline)
     }
 
-    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs.
+    /// Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs.
     pub fn atomic_save(&self) -> bool {
         self.editor_config
             .atomic_save

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1915,7 +1915,7 @@ impl Document {
             .unwrap_or_else(|| self.config.load().insert_final_newline)
     }
 
-    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss when saving, but may confuse some file watching/hot reloading programs.
+    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs.
     pub fn atomic_save(&self) -> bool {
         self.editor_config
             .atomic_save

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1917,9 +1917,7 @@ impl Document {
 
     /// Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs.
     pub fn atomic_save(&self) -> bool {
-        self.editor_config
-            .atomic_save
-            .unwrap_or_else(|| self.config.load().atomic_save)
+        self.config.load().atomic_save
     }
 
     /// Whether the document should trim whitespace preceding line endings on save.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -980,7 +980,7 @@ impl Document {
         // mark changes up to now as saved
         let current_rev = self.get_current_revision();
         let doc_id = self.id();
-        let atomic_save = self.atomic_save();
+        let atomic_save = self.config.load().atomic_save;
 
         let encoding_with_bom_info = (self.encoding, self.has_bom);
         let last_saved_time = self.last_saved_time;
@@ -1913,11 +1913,6 @@ impl Document {
         self.editor_config
             .insert_final_newline
             .unwrap_or_else(|| self.config.load().insert_final_newline)
-    }
-
-    /// Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs.
-    pub fn atomic_save(&self) -> bool {
-        self.config.load().atomic_save
     }
 
     /// Whether the document should trim whitespace preceding line endings on save.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -346,7 +346,7 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
-    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
+    /// Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
     pub atomic_save: bool,
     /// Whether to automatically remove all trailing line-endings after the final one on write.
     /// Defaults to `false`.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -346,6 +346,8 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
+    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss when saving, but may confuse some file watching/hot reloading programs. Defaults to `true`
+    pub atomic_save: bool,
     /// Whether to automatically remove all trailing line-endings after the final one on write.
     /// Defaults to `false`.
     pub trim_final_newlines: bool,
@@ -1017,6 +1019,7 @@ impl Default for Config {
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,
+            atomic_save: true,
             trim_final_newlines: false,
             trim_trailing_whitespace: false,
             smart_tab: Some(SmartTabConfig::default()),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -346,7 +346,9 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
-    /// Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
+    /// Whether to use atomic operations to write documents to disk.
+    /// This prevents data loss if the editor is interrupted while writing the file, but may
+    /// confuse some file watching/hot reloading programs. Defaults to `true`.
     pub atomic_save: bool,
     /// Whether to automatically remove all trailing line-endings after the final one on write.
     /// Defaults to `false`.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -346,7 +346,7 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
-    /// Whether the document should write it's contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
+    /// Whether the document should write its contents to a backup file, then rename that backup to the target file when saving. This prevents data loss if the editor is interrupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
     pub atomic_save: bool,
     /// Whether to automatically remove all trailing line-endings after the final one on write.
     /// Defaults to `false`.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -346,7 +346,7 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
-    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss when saving, but may confuse some file watching/hot reloading programs. Defaults to `true`
+    /// Whether the document should write it's contents to a backup file, then rename the backup to the target file when saving. This prevents data loss if the editor is interupted while writing the file, but may confuse some file watching/hot reloading programs. Defaults to `true`
     pub atomic_save: bool,
     /// Whether to automatically remove all trailing line-endings after the final one on write.
     /// Defaults to `false`.


### PR DESCRIPTION
For some file watching/hot reloading programs, the way that Helix writes files can confuse them and cause them to throw errors or corrupt their caches. One such program is the `parcel` bundler

https://parceljs.org/features/development/#known-issues-with-file-watching

They explicitly document that if your editor saves files using an "atomic save" or "safe write" or "backup copy" strategy, that it should be disabled. Helix currently does not allow you to disable this functionality, and adding this configuration option makes it so that that is possible. 