### PR TITLE
feat: Inject arbitrary language into Rust strings if they are preceded by a comment

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -421,6 +421,7 @@
   (#eq? @special "derive")
 )
 
+(token_repetition_pattern) @punctuation.delimiter
 (token_repetition_pattern [")" "(" "$"] @punctuation.special)
 (token_repetition_pattern "?" @operator)
 

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -7,7 +7,10 @@
 
 (
   ([(block_comment) (line_comment)] @injection.language) .
-  (string_literal (string_content) @injection.content)
+  [
+    (string_literal (string_content) @injection.content)
+    (raw_string_literal (string_content) @injection.content)
+  ]
   (#set! injection.combined)
 )
 
@@ -119,10 +122,10 @@
           name: (_) @_macro_name)
         (identifier) @_macro_name
       ]
-    (token_tree
-      . (string_literal
-        (string_content) @injection.content
-      )
+    (token_tree . [
+        (string_literal (string_content) @injection.content)
+        (raw_string_literal (string_content) @injection.content)
+      ]
     )
   )
   (#any-of? @_macro_name
@@ -162,9 +165,10 @@
       ]
     (token_tree
       . (_)
-      . (string_literal
-          (string_content) @injection.content
-      )
+      . [
+        (string_literal (string_content) @injection.content)
+        (raw_string_literal (string_content) @injection.content)
+      ]
     )
   )
   (#any-of? @_macro_name
@@ -191,9 +195,10 @@
     (token_tree
       . (_)
       . (_)
-      . (string_literal
-          (string_content) @injection.content
-      )
+      . [
+        (string_literal (string_content) @injection.content)
+        (raw_string_literal (string_content) @injection.content)
+      ]
     )
   )
   (#any-of? @_macro_name

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -5,6 +5,12 @@
  (#set! injection.language "markdown-rustdoc")
  (#set! injection.combined))
 
+(
+  ([(block_comment) (line_comment)] @injection.language) .
+  (string_literal (string_content) @injection.content)
+  (#set! injection.combined)
+)
+
 ((macro_invocation
   (token_tree) @injection.content)
  (#set! injection.language "rust")


### PR DESCRIPTION
This PR lets you write a comment directly preceding a string literal, and whatever is in the comment gets injected into the string literal

![image](https://github.com/user-attachments/assets/568ecb6a-c20e-4edc-9bdc-5b7eadc46d74)

Nix has this feature, so I think Rust can have it too!
It won't have a high false negative rate because the comment must be *directly* before the string literal. if the comment is e.g. on the previous line, it won': inject:

![image](https://github.com/user-attachments/assets/870d8cc2-adb4-4a3e-b676-8c9f2302a6e6)

## Some other smaller fixes

- Delimiters in macro repetition patterns: `),*`, `)|+`, `)anything*` are now correctly highlighted as `@punctuation.delimiter`

### before

![image](https://github.com/user-attachments/assets/91b07ba0-47c2-44bf-b9b2-c7107b924959)

### after

![image](https://github.com/user-attachments/assets/7f43cb22-0e7f-443f-b868-b379b8350d6b)

- `rust_format_args` language is injected into raw strings now 

![image](https://github.com/user-attachments/assets/06288926-d27f-4964-9969-8eb4f685b27d)


