### PR TITLE
fix: Rust now correctly highlights doc comments as @comment.block.documentation

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -106,12 +106,17 @@
   (string_literal)
   (raw_string_literal)
 ] @string
-(outer_doc_comment_marker "/" @comment)
-(inner_doc_comment_marker "!" @comment)
+
 [
   (line_comment)
   (block_comment)
 ] @comment
+(line_comment
+  (outer_doc_comment_marker "/" @comment.block.documentation)
+  (doc_comment)) @comment.block.documentation
+(line_comment
+  (inner_doc_comment_marker "!" @comment.block.documentation)
+  (doc_comment)) @comment.block.documentation
 
 ; ---
 ; Extraneous


### PR DESCRIPTION
Closes #13658.

This change makes `/// Example` and `//! Example` all match as `@comment.block.documentation`.
Previously, these cases would all match as `@comment`.