### PR TITLE
Navigate previous searches in global search

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -463,6 +463,8 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | `Ctrl-v`                     | Open vertically                                            |
 | `Ctrl-t`                     | Toggle preview                                             |
 | `Escape`, `Ctrl-c`           | Close picker                                               |
+| `Alt-p`                      | Previous search entry                                      |
+| `Alt-n`,                     | Next search entry                                          |
 
 ## Prompt
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1069,6 +1069,24 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(End) => {
                 self.to_end();
             }
+            alt!('p') => {
+                if let Some(register) = self.prompt.history_register() {
+                    self.prompt.change_history(
+                        ctx,
+                        register,
+                        ui::prompt::CompletionDirection::Backward,
+                    );
+                }
+            }
+            alt!('n') => {
+                if let Some(register) = self.prompt.history_register() {
+                    self.prompt.change_history(
+                        ctx,
+                        register,
+                        ui::prompt::CompletionDirection::Forward,
+                    );
+                }
+            }
             key!(Esc) | ctrl!('c') => return close_fn(self),
             alt!(Enter) => {
                 if let Some(option) = self.selection() {


### PR DESCRIPTION
### Motivation

Currently the user has an ability to go only to the previous search (`C-Enter`) with no way of going further backwards in the search history.

### Summary

Added bindings for the search history navigation. The bindings are only a suggestion that makes sense to me, since you can navigate history in the command mode by using `C-p` and `C-n` then it would be consistent to do `C-p` and `C-n` in the search picker but as those are already taken by picker results navigation `Alt-p` and `Alt-n` make sense, as even though the modifier key changes the intent of the binding remains the same.