### PR TITLE
feat: Add `search.always_ignore_case` config option

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -117,11 +117,8 @@ pub fn raw_regex_prompt(
                         return;
                     }
 
-                    let case_insensitive = if config.search.smart_case {
-                        !input.chars().any(char::is_uppercase)
-                    } else {
-                        false
-                    };
+                    let case_insensitive = config.search.always_ignore_case
+                        || (config.search.smart_case && !input.chars().any(char::is_uppercase));
 
                     match rope::RegexBuilder::new()
                         .syntax(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -486,6 +486,8 @@ impl Default for LspConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct SearchConfig {
+    /// Always perform case-insensitive searching. Overrides `smart_case` when true. Defaults to false.
+    pub always_ignore_case: bool,
     /// Smart case: Case insensitive searching unless pattern contains upper case characters. Defaults to true.
     pub smart_case: bool,
     /// Whether the search should wrap after depleting the matches. Default to true.
@@ -1036,6 +1038,7 @@ impl Default for SearchConfig {
         Self {
             wrap_around: true,
             smart_case: true,
+            always_ignore_case: false,
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `search.always_ignore_case` configuration option.

When set to true, it forces case-insensitive searching, overriding `search.smart_case`.

By default, this option is `false`, so it does not change the current behavior of Helix.