### PR TITLE
fix: trim whitespace up to the last selection on insert_newline

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4206,6 +4206,7 @@ pub mod insert {
             None
         };
 
+        let mut last_pos = 0;
         let mut transaction = Transaction::change_by_selection(contents, selection, |range| {
             // Tracks the number of trailing whitespace characters deleted by this selection.
             let mut chars_deleted = 0;
@@ -4227,7 +4228,8 @@ pub mod insert {
             let (from, to, local_offs) = if let Some(idx) =
                 text.slice(line_start..pos).last_non_whitespace_char()
             {
-                let first_trailing_whitespace_char = (line_start + idx + 1).min(pos);
+                let first_trailing_whitespace_char = (line_start + idx + 1).clamp(last_pos, pos);
+                last_pos = pos;
                 let line = text.line(current_line);
 
                 let indent = match line.first_non_whitespace_char() {

--- a/helix-term/tests/test/commands/insert.rs
+++ b/helix-term/tests/test/commands/insert.rs
@@ -173,6 +173,18 @@ async fn insert_newline_trim_trailing_whitespace() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn insert_newline_trim_whitespace_to_previous_selection() -> anyhow::Result<()> {
+    test((
+        indoc! {"\"#[a|]# #(a|)# #(a|)#\""},
+        "c<ret>",
+        indoc! {"\"\n#[\n|]##(\n|)##(\"|)#"},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn insert_newline_continue_line_comment() -> anyhow::Result<()> {
     // `insert_newline` continues a single line comment
     test((


### PR DESCRIPTION
Fixes the panic mentioned in https://github.com/helix-editor/helix/issues/12662 and adds a similar integration test.

My understanding is that multiple selections on one line try to trim to the beginning of the line which are overlapping ranges and cause the panic. Instead this changes it so that each selection is only trimmed up to the previous one (if any).

Closes #12662