### PR TITLE
feat(term): add `shell_pipe_into_buffer` command.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -587,6 +587,7 @@ impl MappableCommand {
         dap_disable_exceptions, "Disable exception breakpoints",
         shell_pipe, "Pipe selections through shell command",
         shell_pipe_to, "Pipe selections into shell command ignoring output",
+        shell_pipe_into_buffer, "Pipe selections into shell command and output in new buffer",
         shell_insert_output, "Insert shell command output before selections",
         shell_append_output, "Append shell command output after selections",
         shell_keep_pipe, "Filter selections with shell predicate",
@@ -6148,6 +6149,7 @@ enum ShellBehavior {
     Ignore,
     Insert,
     Append,
+    OpenBuffer,
 }
 
 fn shell_pipe(cx: &mut Context) {
@@ -6164,6 +6166,10 @@ fn shell_insert_output(cx: &mut Context) {
 
 fn shell_append_output(cx: &mut Context) {
     shell_prompt(cx, "append-output:".into(), ShellBehavior::Append);
+}
+
+fn shell_pipe_into_buffer(cx: &mut Context) {
+    shell_prompt(cx, "open-buffer:".into(), ShellBehavior::OpenBuffer);
 }
 
 fn shell_keep_pipe(cx: &mut Context) {
@@ -6285,7 +6291,7 @@ async fn shell_impl_async(
 fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
         ShellBehavior::Replace | ShellBehavior::Ignore => true,
-        ShellBehavior::Insert | ShellBehavior::Append => false,
+        ShellBehavior::Insert | ShellBehavior::Append | ShellBehavior::OpenBuffer => false,
     };
 
     let config = cx.editor.config();
@@ -6331,6 +6337,7 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
             ShellBehavior::Replace => (range.from(), range.to(), range.len()),
             ShellBehavior::Insert => (range.from(), range.from(), 0),
             ShellBehavior::Append => (range.to(), range.to(), 0),
+            ShellBehavior::OpenBuffer => (0, 0, 0),
             _ => (range.from(), range.from(), 0),
         };
 
@@ -6351,16 +6358,23 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
         changes.push((from, to, Some(output)));
     }
 
-    if behavior != &ShellBehavior::Ignore {
+    if behavior != &ShellBehavior::Ignore && behavior != &ShellBehavior::OpenBuffer {
         let transaction = Transaction::change(doc.text(), changes.into_iter())
             .with_selection(Selection::new(ranges, selection.primary_index()));
         doc.apply(&transaction, view.id);
         doc.append_changes_to_history(view);
-    }
 
-    // after replace cursor may be out of bounds, do this to
-    // make sure cursor is in view and update scroll as well
-    view.ensure_cursor_in_view(doc, config.scrolloff);
+        // after replace cursor may be out of bounds, do this to
+        // make sure cursor is in view and update scroll as well
+        view.ensure_cursor_in_view(doc, config.scrolloff);
+    } else if behavior == &ShellBehavior::OpenBuffer {
+        cx.editor.new_file(Action::Replace);
+        let (view, doc) = current!(cx.editor);
+
+        let transaction = Transaction::change(doc.text(), changes.into_iter());
+        doc.apply(&transaction, view.id);
+        doc.append_changes_to_history(view);
+    }
 }
 
 fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBehavior) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6169,7 +6169,7 @@ fn shell_append_output(cx: &mut Context) {
 }
 
 fn shell_pipe_into_buffer(cx: &mut Context) {
-    shell_prompt(cx, "open-buffer:".into(), ShellBehavior::OpenBuffer);
+    shell_prompt(cx, "pipe-into-buffer:".into(), ShellBehavior::OpenBuffer);
 }
 
 fn shell_keep_pipe(cx: &mut Context) {
@@ -6290,8 +6290,8 @@ async fn shell_impl_async(
 
 fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
-        ShellBehavior::Replace | ShellBehavior::Ignore => true,
-        ShellBehavior::Insert | ShellBehavior::Append | ShellBehavior::OpenBuffer => false,
+        ShellBehavior::Replace | ShellBehavior::Ignore | ShellBehavior::OpenBuffer => true,
+        ShellBehavior::Insert | ShellBehavior::Append => false,
     };
 
     let config = cx.editor.config();


### PR DESCRIPTION
`shell_pipe_into_buffer` run a shell command which receive the selection as input like `shell_pipe` do, and open a new buffer to display its output. Following is a usage which cooperate with `smartcat`.

![helix1](https://github.com/user-attachments/assets/c278af9d-a380-417f-a2bc-3fee45842ba8)

(This feature should be implemented in the `universal REPL` (#2806) too, imo.)