### PR TITLE
set working dir of the lsp command to workspace root

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -201,6 +201,7 @@ impl Client {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .current_dir(&root_path)
             // make sure the process is reaped on drop
             .kill_on_drop(true)
             .spawn();


### PR DESCRIPTION
Currently, when helix invokes the command to start the LSP client, it does not configure the process's working directory, so it just runs in the shell's working directory.

For most cases, this works out fine because the LS itself is initialized with the workspace root when it starts up, and it manages the directory structure of the project on its own.

However, there are cases where the invocation of the LS itself can depend on the working directory of the invoking process. For example, say we have a Python project and you want to configure Helix to run pylsp via a tool like [`uv`](https://docs.astral.sh/uv/guides/scripts/) so that it uses a project's configured version of the LS in its dev dependencies, you could configure `pylsp` like so:

```toml
[language-server.pylsp]
command = "uv"
args = [
  "run",
  "--with", "python-lsp-server",
  "--with", "pylsp-mypy",

  "pylsp",
  "-vvv",
]
```

But `uv` will first attempt to use the project's configured virtualenv, if it has one. If the working directory of helix is above the actual project root, `uv` cannot find the project, and therefore makes a new one just for the invocation of `pylsp`. This leads to problems, because `mypy` needs to be in the same virtualenv as the project; otherwise, it does not find any of your dependencies during type checking. Even though pylsp itself is configured with the workspace root during initialization, it just invokes the `mypy` executable that's on the path, which will not be in the project's virtualenv unless `uv` can find the project root.

By setting the working directory of the `uv` executable to the workspace root, it correctly identifies the project root and starts in the project's virtualenv. And additionally, if any other python source files are opened that belong to a different project altogether, that instance of `pylsp` will also get started in the correct virtualenv.
