### PR TITLE
add more quote types to markdown autopairs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1740,6 +1740,17 @@ language-servers = [ "marksman", "markdown-oxide" ]
 indent = { tab-width = 2, unit = "  " }
 block-comment-tokens = { start = "<!--", end = "-->" }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+"'" = "'"
+'`' = '`'
+'‘' = '’'
+'«' = '»'
+'“' = '”'
+
 [[grammar]]
 name = "markdown"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "62516e8c78380e3b51d5b55727995d2c511436d8", subpath = "tree-sitter-markdown" }


### PR DESCRIPTION
I believe this is quite a nice default, as various fancy quotes like “” ‘’ «» will appear in markdown more than anywhere. \
Inserting a fancy quote and seeing it get autoclosed will spark the thought of “omg that's so nice!” — adding them manually might simply be something most people won't think to do / won't care enough to do, while appreciating it as a default. \
I was actually thinking to add those special quotes to *all* languages, but that's a lot more controversial; would love to hear thoughts about this.
