### PR TITLE
Add paste_all_selections_before paste_all_selections_after to replicate kakoune <a-p> <a-P>.

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -86,6 +86,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `y`         | Yank selection                                                       | `yank`                    |
 | `p`         | Paste after selection                                                | `paste_after`             |
 | `P`         | Paste before selection                                               | `paste_before`            |
+| `Alt-p`     | Paste all after selection                                            | `paste_after_all`
+| `Alt-P`     | Paste all before selection                                           | `paste_before_all`
 | `"` `<reg>` | Select a register to yank to or paste from                           | `select_register`         |
 | `>`         | Indent selection                                                     | `indent`                  |
 | `<`         | Unindent selection                                                   | `unindent`                |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4681,10 +4681,7 @@ fn paste_impl(
 
     // Precompute the combined tendril value if we will be doing a PasteType::All
     let combined_tendril_value = match paste_type {
-        PasteType::All => Some(values.iter().fold(Tendril::default(), |mut acc, v| {
-            acc = acc + v;
-            acc
-        })),
+        PasteType::All => Some(values.iter().collect::<Tendril>()),
         PasteType::Default => None,
     };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4739,7 +4739,16 @@ fn paste_impl(
     });
 
     if mode == Mode::Normal {
-        transaction = transaction.with_selection(Selection::new(ranges, selection.primary_index()));
+        transaction = transaction.with_selection(Selection::new(
+            ranges,
+            match paste_type {
+                PasteType::All => {
+                    // Last selection pasted for the previous primary selection
+                    (selection.primary_index() * values.len()) + (values.len() - 1)
+                }
+                PasteType::Default => selection.primary_index(),
+            },
+        ));
     }
 
     doc.apply(&transaction, view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -488,8 +488,8 @@ impl MappableCommand {
         replace_with_yanked, "Replace with yanked text",
         replace_selections_with_clipboard, "Replace selections by clipboard content",
         replace_selections_with_primary_clipboard, "Replace selections by primary clipboard",
-        paste_after_all, "Paste all after selection",
-        paste_before_all, "Paste all before selection",
+        paste_all_selections_after, "Paste all after selection",
+        paste_all_selections_before, "Paste all before selection",
         paste_after, "Paste after selection",
         paste_before, "Paste before selection",
         paste_clipboard_after, "Paste clipboard after selections",
@@ -4870,23 +4870,25 @@ fn paste(editor: &mut Editor, register: char, pos: Paste, count: usize, paste_ty
     paste_impl(&values, doc, view, pos, count, editor.mode, paste_type);
 }
 
-fn paste_after_all(cx: &mut Context) {
+fn paste_all_selections_after(cx: &mut Context) {
     paste(
-        cx,
+        cx.editor,
         cx.register
             .unwrap_or(cx.editor.config().default_yank_register),
         Paste::After,
+        cx.count(),
         PasteType::All,
     );
     exit_select_mode(cx);
 }
 
-fn paste_before_all(cx: &mut Context) {
+fn paste_all_selections_before(cx: &mut Context) {
     paste(
-        cx,
+        cx.editor,
         cx.register
             .unwrap_or(cx.editor.config().default_yank_register),
         Paste::Before,
+        cx.count(),
         PasteType::All,
     );
     exit_select_mode(cx);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1039,7 +1039,7 @@ fn paste_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::After, 1);
+    paste(cx.editor, '+', Paste::After, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1052,7 +1052,7 @@ fn paste_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::Before, 1);
+    paste(cx.editor, '+', Paste::Before, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1065,7 +1065,7 @@ fn paste_primary_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::After, 1);
+    paste(cx.editor, '*', Paste::After, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1078,7 +1078,7 @@ fn paste_primary_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::Before, 1);
+    paste(cx.editor, '*', Paste::Before, 1, PasteType::Default);
     Ok(())
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -152,8 +152,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "y" => yank,
         // yank_all
         "p" => paste_after,
-        // paste_all
+        // TODO: This is a terrible mapping, but "A-p" coincides with "select_prev_sibling"
+        "C-p" => paste_after_all,
         "P" => paste_before,
+        "A-P" => paste_before_all,
 
         "Q" => record_macro,
         "q" => replay_macro,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -153,9 +153,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         // yank_all
         "p" => paste_after,
         // TODO: This is a terrible mapping, but "A-p" coincides with "select_prev_sibling"
-        "C-p" => paste_after_all,
+        "C-p" => paste_all_selections_after,
         "P" => paste_before,
-        "A-P" => paste_before_all,
+        "A-P" => paste_all_selections_before,
 
         "Q" => record_macro,
         "q" => replay_macro,

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -4,6 +4,7 @@ use super::*;
 
 mod insert;
 mod movement;
+mod paste_all_selections;
 mod write;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/helix-term/tests/test/commands/paste_all_selections.rs
+++ b/helix-term/tests/test/commands/paste_all_selections.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+use helix_core::hashmap;
+use helix_term::keymap;
+use helix_view::document::Mode;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paste_all_selections() -> anyhow::Result<()> {
+    let mut config = Config::default();
+    config.keys.insert(
+        Mode::Normal,
+        keymap!({"Normal Mode"
+            "A-P" => paste_all_selections_before,
+            "A-p" => paste_all_selections_after,
+        }),
+    );
+
+    // Test paste_all_selections_before
+    // Selection direction matches paste target selections.
+    test_with_config(
+        AppBuilder::new().with_config(config.clone()),
+        (
+            indoc! {"\
+            #(|one)#_cat
+            #(|two)#_dog
+            #[|three]#_cow
+            "},
+            "y<A-P>",
+            indoc! {"\
+            #(|one)##(|two)##(|three)#one_cat
+            #(|one)##(|two)##(|three)#two_dog
+            #(|one)##(|two)##[|three]#three_cow
+            "},
+        ),
+    )
+    .await?;
+
+    // Test paste_all_selections_after
+    // Primary selection is last selection pasted for previous primary.
+    test_with_config(
+        AppBuilder::new().with_config(config.clone()),
+        (
+            indoc! {"\
+            #(one|)#_cat
+            #[two|]#_dog
+            #(three|)#_cow
+            "},
+            "y<A-p>",
+            indoc! {"\
+            one#(one|)##(two|)##(three|)#_cat
+            two#(one|)##(two|)##[three|]#_dog
+            three#(one|)##(two|)##(three|)#_cow
+            "},
+        ),
+    )
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This is building on top of https://github.com/helix-editor/helix/pull/4694 with the following changes:
* Rebased to current head
* Choose a more meaningful primary index selection.
  * Note that this behaviour diverges from kakoune: in kakoune the resulting primary selection is always just the last selection added at the last input selection. This implementation will choose the last selection added at the current primary selection.
* Added integration test

This is an alternative to https://github.com/helix-editor/helix/pull/13600 Imo this is better because:
* it preserves separate selections
* it is a more atomic operation, not mixing in logically separate behavior (inserting newlines)
* This can be used as a building block to achieve the same outcomes as https://github.com/helix-editor/helix/pull/13600 but the reverse is not true.