### PR TITLE
Added configurable toggle to always show encoding

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -405,8 +405,9 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     let enc = context.doc.encoding();
+    let config = context.editor.config();
 
-    if enc != encoding::UTF_8 {
+    if config.encoding_always_show || enc != encoding::UTF_8 {
         write(context, format!(" {} ", enc.name()).into());
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -318,6 +318,8 @@ pub struct Config {
     pub file_picker: FilePickerConfig,
     /// Configuration of the statusline elements
     pub statusline: StatusLineConfig,
+    /// Toggle encoding to always show
+    pub encoding_always_show: bool,
     /// Shape for cursor in each mode
     pub cursor_shape: CursorShapeConfig,
     /// Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
@@ -996,6 +998,7 @@ impl Default for Config {
             auto_info: true,
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),
+            encoding_always_show: false,
             cursor_shape: CursorShapeConfig::default(),
             true_color: false,
             undercurl: false,


### PR DESCRIPTION
This is a simple change - to add a boolean to toggle encoding always on or default off when the file is UTF-8.
See https://github.com/helix-editor/helix/issues/13706
Compare to https://github.com/helix-editor/helix/pull/13708