### PR TITLE
fix: re-ordered and updated python highlights

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -1,8 +1,16 @@
+; -------
+; Punctuation
+; -------
+
 ["," "." ":" ";" (ellipsis)] @punctuation.delimiter
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 (interpolation
   "{" @punctuation.special
-  "}" @punctuation.special) @embedded
+  "}" @punctuation.special)
+
+; -------
+; Operators
+; -------
 
 [
   "-"
@@ -43,148 +51,20 @@
   "@="
 ] @operator
 
-[
-  "as"
-  "assert"
-  "await"
-  "from"
-  "pass"
-
-  "with"
-] @keyword.control
-
-[
-  "if"
-  "elif"
-  "else"
-  "match"
-  "case"
-] @keyword.control.conditional
-
-[
-  "while"
-  "for"
-  "break"
-  "continue"
-] @keyword.control.repeat
-
-[
-  "return"
-  "yield"
-] @keyword.control.return
-(yield "from" @keyword.control.return)
-
-[
-  "raise"
-  "try"
-  "except"
-  "finally"
-] @keyword.control.except
-(raise_statement "from" @keyword.control.except)
-"import" @keyword.control.import
-
-(for_statement "in" @keyword.control)
-(for_in_clause "in" @keyword.control)
-
-[
-  "async"
-  "class"
-  "exec"
-  "global"
-  "nonlocal"
-  "print"
-  "type"
-] @keyword
-[
-  "and"
-  "or"
-  "not in"
-  "in"
-  "not"
-  "del"
-  "is not"
-  "is"
-] @keyword.operator
-
-; Literals
-(none) @constant.builtin
-[
-  (true)
-  (false)
-] @constant.builtin.boolean
-
-(integer) @constant.numeric.integer
-(float) @constant.numeric.float
-(comment) @comment
-(string) @string
-(escape_sequence) @constant.character.escape
-
+; -------
 ; Variables
+; -------
 
 (identifier) @variable
 
+; - Member
 (attribute attribute: (identifier) @variable.other.member)
 
-; Imports
-
-(dotted_name
-  (identifier)* @namespace)
-
-(aliased_import
-  alias: (identifier) @namespace)
-
-; Function calls
-
-[
-  "def"
-  "lambda"
-] @keyword.function
-
-(call
-  function: (attribute attribute: (identifier) @function.method))
-
-(call
-  function: (identifier) @function)
-
-(call
-  function: (attribute attribute: (identifier) @constructor)
- (#match? @constructor "^[A-Z]"))
-(call
-  function: (identifier) @constructor
- (#match? @constructor "^[A-Z]"))
-
-; Builtin functions
-
-((call
-  function: (identifier) @function.builtin)
- (#match?
-   @function.builtin
-   "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
-
-; Function definitions
-
-(function_definition
-  name: (identifier) @function)
-
-(function_definition
-  name: (identifier) @constructor
- (#match? @constructor "^(__new__|__init__)$"))
-
-; Decorators
-
-(decorator) @function
-(decorator (identifier) @function)
-(decorator (attribute attribute: (identifier) @function))
-(decorator (call
-  function: (attribute attribute: (identifier) @function)))
-
-; Parameters
-
+; - Parameter
 (parameters (identifier) @variable.parameter)
 (parameters (typed_parameter (identifier) @variable.parameter))
 (parameters (default_parameter name: (identifier) @variable.parameter))
 (parameters (typed_default_parameter name: (identifier) @variable.parameter))
-
 (parameters
   (list_splat_pattern ; *args
     (identifier) @variable.parameter))
@@ -195,27 +75,111 @@
 (lambda_parameters
   (identifier) @variable.parameter)
 
-; Builtins, constants, etc.
-
+; - Builtin
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^(self|cls)$"))
+ (#any-of? @variable.builtin "self" "cls"))
 
-((identifier) @type.builtin
-  (#match? @type.builtin
-    "^(BaseException|Exception|ArithmeticError|BufferError|LookupError|AssertionError|AttributeError|EOFError|FloatingPointError|GeneratorExit|ImportError|ModuleNotFoundError|IndexError|KeyError|KeyboardInterrupt|MemoryError|NameError|NotImplementedError|OSError|OverflowError|RecursionError|ReferenceError|RuntimeError|StopIteration|StopAsyncIteration|SyntaxError|IndentationError|TabError|SystemError|SystemExit|TypeError|UnboundLocalError|UnicodeError|UnicodeEncodeError|UnicodeDecodeError|UnicodeTranslateError|ValueError|ZeroDivisionError|EnvironmentError|IOError|WindowsError|BlockingIOError|ChildProcessError|ConnectionError|BrokenPipeError|ConnectionAbortedError|ConnectionRefusedError|ConnectionResetError|FileExistsError|FileNotFoundError|InterruptedError|IsADirectoryError|NotADirectoryError|PermissionError|ProcessLookupError|TimeoutError|Warning|UserWarning|DeprecationWarning|PendingDeprecationWarning|SyntaxWarning|RuntimeWarning|FutureWarning|ImportWarning|UnicodeWarning|BytesWarning|ResourceWarning)$"))
+; -------
+; Keywords
+; -------
 
-((identifier) @type
- (#match? @type "^[A-Z]"))
+[
+  "async"
+  "class"
+  "exec"
+  "global"
+  "nonlocal"
+  "print"
+  "type"
+] @keyword
 
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+; Operators
+[
+  "and"
+  "or"
+  "not in"
+  "in" ; Has to be before loop keywords because "in" is overloaded
+  "not"
+  "del"
+  "is not"
+  "is"
+] @keyword.operator
 
+; Control
+[
+  "as"
+  "assert"
+  "await"
+  "from"
+  "pass"
+
+  "with"
+] @keyword.control
+
+; Conditionals
+[
+  "if"
+  "elif"
+  "else"
+  "match"
+  "case"
+] @keyword.control.conditional
+
+; Exceptions
+[
+  "raise"
+  "try"
+  "except"
+  "finally"
+] @keyword.control.except
+(raise_statement "from" @keyword.control.except)
+
+; Functions
+[
+  "def"
+  "lambda"
+] @keyword.function
+
+; Import
+"import" @keyword.control.import
+
+; Loops
+[
+  "while"
+  "for"
+  "break"
+  "continue"
+] @keyword.control.repeat
+
+(for_statement "in" @keyword.control.repeat)
+(for_in_clause "in" @keyword.control.repeat)
+
+; Return
+[
+  "return"
+  "yield"
+] @keyword.control.return
+(yield "from" @keyword.control.return)
+
+; -------
+; Imports
+; -------
+ 
+(dotted_name
+  (identifier)* @namespace)
+
+(aliased_import
+  alias: (identifier) @namespace)
+
+; - Builtins
+(none) @constant.builtin ; Has to be before types
+
+; -------
 ; Types
-
-((identifier) @type.builtin
- (#match?
-   @type.builtin
-   "^(bool|bytes|dict|float|frozenset|int|list|set|str|tuple)$"))
+; -------
+ 
+((identifier) @type 
+ (#match? @type "^[A-Z]")) ; Has to be before constructor due to this being a more general match 
 
 ; In type hints make everything types to catch non-conforming identifiers
 ; (e.g., datetime.datetime) and None
@@ -227,5 +191,115 @@
       (_ [(identifier) (none)]? @type
         (_ [(identifier) (none)]? @type)))))
 
+; Classes
 (class_definition name: (identifier) @type)
 (class_definition superclasses: (argument_list (identifier) @type))
+
+; -------
+; Functions
+; -------
+
+(function_definition
+  name: (identifier) @function)
+
+(call
+  function: (identifier) @function)
+
+; Decorators
+(decorator) @function
+(decorator (identifier) @function)
+(decorator (attribute attribute: (identifier) @function))
+(decorator (call
+  function: (attribute attribute: (identifier) @function)))
+
+; Methods
+(call
+  function: (attribute attribute: (identifier) @function.method))
+
+; Builtin functions
+((call
+  function: (identifier) @function.builtin)
+ (#any-of?
+   @function.builtin
+   "abs" "all" "any" "ascii" "bin" "breakpoint" "bytearray" "callable" "chr"
+   "classmethod" "compile" "complex" "delattr" "dir" "divmod" "enumerate"
+   "eval" "exec" "filter" "format" "getattr" "globals" "hasattr" "hash" "help"
+   "hex" "id" "input" "isinstance" "issubclass" "iter" "len" "locals" "map"
+   "max" "memoryview" "min" "next" "object" "oct" "open" "ord" "pow" "print"
+   "property" "range" "repr" "reversed" "round" "setattr" "slice" "sorted"
+   "staticmethod" "sum" "super" "type" "vars" "zip" "__import__"))
+
+; Constructors
+(call
+  function: (attribute attribute: (identifier) @constructor)
+  (#any-of?
+    @constructor
+    "__new__" "__init__"))
+
+((call
+  function: (identifier) @constructor)
+ (#any-of?
+   @constructor
+   "__new__" "__init__"))
+
+(function_definition
+  name: (identifier) @constructor
+ (#any-of? @constructor "__new__" "__init__"))
+
+(call
+  function: (attribute attribute: (identifier) @constructor)
+ (#match? @constructor "^[A-Z]"))
+(call
+  function: (identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+; Builtin types
+((identifier) @type.builtin ; Has to be after functions due to broad matching
+ (#any-of?
+   @type.builtin
+   "bool" "bytes" "dict" "float" "frozenset" "int" "list" "set" "str" "tuple"))
+
+; Builtin error types
+((identifier) @type.builtin ; Has to be after constructors due to broad matching of constructor
+  (#any-of? @type.builtin
+    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError"
+    "AssertionError" "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit"
+    "ImportError" "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt"
+    "MemoryError" "NameError" "NotImplementedError" "OSError" "OverflowError"
+    "RecursionError" "ReferenceError" "RuntimeError" "StopIteration" "StopAsyncIteration"
+    "SyntaxError" "IndentationError" "TabError" "SystemError" "SystemExit" "TypeError"
+    "UnboundLocalError" "UnicodeError" "UnicodeEncodeError" "UnicodeDecodeError"
+    "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
+    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
+    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError"
+    "ConnectionResetError" "FileExistsError" "FileNotFoundError" "InterruptedError"
+    "IsADirectoryError" "NotADirectoryError" "PermissionError" "ProcessLookupError"
+    "TimeoutError" "Warning" "UserWarning" "DeprecationWarning" "PendingDeprecationWarning"
+    "SyntaxWarning" "RuntimeWarning" "FutureWarning" "ImportWarning" "UnicodeWarning"
+    "BytesWarning" "ResourceWarning"))
+
+; -------
+; Constants
+; -------
+
+((identifier) @constant
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+
+(escape_sequence) @constant.character.escape
+
+[
+  (true)
+  (false)
+] @constant.builtin.boolean
+
+
+; - Numbers
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+; -------
+; Other literals
+; -------
+ 
+(comment) @comment
+(string) @string


### PR DESCRIPTION
Some highlights were overwriting each other in a way that seemed accidental (i.e. more general matches overwriting specific ones). I reordered the highlights and attempted to group them by category except when necessary for correct matching order.

I also switched whole-word `match` predicates to `any-of`.

Before/After:
`for`, `in`, `break`, and `continue` should all be `keyword.control.repeat`, `in` is `keyword.operator`.
![image](https://github.com/user-attachments/assets/175b0c08-a3e7-415d-b467-bd692cd63bf1)
<img width="255" alt="Screenshot 2025-06-08 at 1 54 20 PM" src="https://github.com/user-attachments/assets/56585dd3-1d98-44db-b174-07fb2cb3f876" />

`.__init__()`, `.__new__()`, `Init()`, `Gee()`, `__init__`, and `__new__` should all be `constructor`, but `.__init__()` and `.__new__()` are `function.method` and `Init()` and `Gee()` are `type`.
<img width="187" alt="Screenshot 2025-06-08 at 1 51 38 PM" src="https://github.com/user-attachments/assets/6f972009-fdf0-494f-960a-0bdb45823df8" />
<img width="183" alt="Screenshot 2025-06-08 at 1 55 43 PM" src="https://github.com/user-attachments/assets/464d6705-e4be-45d8-b4aa-87194f5184d8" />

All should be `type.builtin` but above `bool`, all are `type`.
<img width="274" alt="Screenshot 2025-06-08 at 1 53 08 PM" src="https://github.com/user-attachments/assets/3ebe7de3-b3c2-44d8-98e5-97c1d303081f" />
<img width="272" alt="Screenshot 2025-06-08 at 1 56 42 PM" src="https://github.com/user-attachments/assets/aeab522c-a8b1-4c5c-b95b-c361e7762aec" />
