### PR TITLE
Merge formatting options and `config.format` in range format request

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1210,6 +1210,23 @@ impl Client {
             _ => return None,
         };
 
+        // Inject formatting config like above
+        let config_format = self
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.get("format"))
+            .and_then(|fmt| HashMap::<String, lsp::FormattingProperty>::deserialize(fmt).ok());
+
+        let options = if let Some(mut properties) = config_format {
+            properties.extend(options.properties);
+            lsp::FormattingOptions {
+                properties,
+                ..options
+            }
+        } else {
+            options
+        };
+
         let params = lsp::DocumentRangeFormattingParams {
             text_document,
             range,

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -187,7 +187,7 @@ impl Client {
             .and_then(|cfg| cfg.get("format"))
             .and_then(|fmt| HashMap::<String, lsp::FormattingProperty>::deserialize(fmt).ok());
 
-        let options = if let Some(mut properties) = config_format {
+        if let Some(mut properties) = config_format {
             // passed in options take precedence over 'config.format'
             properties.extend(options.properties);
             lsp::FormattingOptions {
@@ -196,9 +196,7 @@ impl Client {
             }
         } else {
             options
-        };
-
-        options
+        }
     }
 
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]


### PR DESCRIPTION
Fix #13710 