### PR TITLE
Use separate glyphs for hint/info/warning/error diagnostic indicators

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -20,6 +20,17 @@ impl Default for Severity {
     }
 }
 
+impl Severity {
+    pub const fn indicator(&self) -> &'static str {
+        match self {
+            Self::Hint => "○",
+            Self::Info => "●",
+            Self::Warning => "▲",
+            Self::Error => "■",
+        }
+    }
+}
+
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
 pub enum NumberOrString {
     Number(i32),

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -237,24 +237,36 @@ where
     for sev in &context.editor.config().statusline.diagnostics {
         match sev {
             Severity::Hint if hints > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("hint")));
+                write(
+                    context,
+                    Span::styled(Severity::Hint.indicator(), context.editor.theme.get("hint")),
+                );
                 write(context, format!(" {} ", hints).into());
             }
             Severity::Info if info > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("info")));
+                write(
+                    context,
+                    Span::styled(Severity::Info.indicator(), context.editor.theme.get("info")),
+                );
                 write(context, format!(" {} ", info).into());
             }
             Severity::Warning if warnings > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get("warning")),
+                    Span::styled(
+                        Severity::Warning.indicator(),
+                        context.editor.theme.get("warning"),
+                    ),
                 );
                 write(context, format!(" {} ", warnings).into());
             }
             Severity::Error if errors > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get("error")),
+                    Span::styled(
+                        Severity::Error.indicator(),
+                        context.editor.theme.get("error"),
+                    ),
                 );
                 write(context, format!(" {} ", errors).into());
             }
@@ -304,24 +316,36 @@ where
     for sev in sevs_to_show {
         match sev {
             Severity::Hint if hints > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("hint")));
+                write(
+                    context,
+                    Span::styled(Severity::Hint.indicator(), context.editor.theme.get("hint")),
+                );
                 write(context, format!(" {} ", hints).into());
             }
             Severity::Info if info > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("info")));
+                write(
+                    context,
+                    Span::styled(Severity::Info.indicator(), context.editor.theme.get("info")),
+                );
                 write(context, format!(" {} ", info).into());
             }
             Severity::Warning if warnings > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get("warning")),
+                    Span::styled(
+                        Severity::Warning.indicator(),
+                        context.editor.theme.get("warning"),
+                    ),
                 );
                 write(context, format!(" {} ", warnings).into());
             }
             Severity::Error if errors > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get("error")),
+                    Span::styled(
+                        Severity::Error.indicator(),
+                        context.editor.theme.get("error"),
+                    ),
                 );
                 write(context, format!(" {} ", errors).into());
             }

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -75,12 +75,13 @@ pub fn diagnostic<'doc>(
                         })
                 });
             diagnostics_on_line.max_by_key(|d| d.severity).map(|d| {
-                write!(out, "●").ok();
-                match d.severity {
-                    Some(Severity::Error) => error,
-                    Some(Severity::Warning) | None => warning,
-                    Some(Severity::Info) => info,
-                    Some(Severity::Hint) => hint,
+                let severity = d.severity();
+                out.push_str(severity.indicator());
+                match severity {
+                    Severity::Error => error,
+                    Severity::Warning => warning,
+                    Severity::Info => info,
+                    Severity::Hint => hint,
                 }
             })
         },


### PR DESCRIPTION
Currently all diagnostics use '●' as an indicator. This can be hard to distinguish at a glance, especially if you are colorblind and/or the theme doesn't distinguish much between `warning` and `error` styles for example. We should split these out into separate simple shapes so each severity is easy to recognize.

Also see the discussion in https://github.com/helix-editor/helix/pull/12060.

The current set of glyphs here is:

* hint `○`
* info `●`
* warning `▲`
* error `■`

I'm not super attached to this choice but I've been using it for a while and it seems easy to read.