### PR TITLE
test: use `pretty_assertions::assert_str_eq` to compare 2 ropes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1570,7 @@ dependencies = [
  "nucleo",
  "once_cell",
  "open",
+ "pretty_assertions",
  "pulldown-cmark",
  "same-file",
  "serde",
@@ -2201,6 +2208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -3190,6 +3207,12 @@ dependencies = [
  "helix-view",
  "toml",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -106,3 +106,4 @@ smallvec = "1.15"
 indoc = "2.0.6"
 tempfile.workspace = true
 same-file = "1.0.1"
+pretty_assertions = "1.4.1"

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -244,7 +244,10 @@ pub async fn test_with_config<T: Into<TestCase>>(
         test_case.clone(),
         &|app| {
             let doc = doc!(app.editor);
-            assert_eq!(&test_case.out_text, doc.text());
+            pretty_assertions::assert_str_eq!(
+                test_case.out_text.to_string(),
+                doc.text().to_string()
+            );
 
             let mut selections: Vec<_> = doc.selections().values().cloned().collect();
             assert_eq!(1, selections.len());


### PR DESCRIPTION
This should make it much easier to debug failing tests

## Before

![Image](https://github.com/user-attachments/assets/6ac91de1-5917-4b63-bfd3-361f5fa05ad8)

## After

![Image](https://github.com/user-attachments/assets/cbfd06e5-fe33-4c49-8025-3fbb733970d3)