### PR TITLE
Feat: inlay hint length limit

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -157,6 +157,7 @@ The following statusline elements can be configured:
 | `display-progress-messages` | Display LSP progress messages below statusline[^1]    | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
 | `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |
+| `inlay-hints-length-limit` | Maximum displayed length (non-zero number) of inlay hints | Unset by default  |
 | `display-color-swatches` | Show color swatches next to colors | `true` |
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 | `snippets`      | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1379,7 +1379,9 @@ fn compute_inlay_hints_for_view(
                 // Truncate the hint if too long
                 if let Some(limit) = inlay_hints_length_limit {
                     // Limit on displayed width
-                    use helix_core::unicode::width::{UnicodeWidthChar, UnicodeWidthStr};
+                    use helix_core::unicode::{
+                        segmentation::UnicodeSegmentation, width::UnicodeWidthStr,
+                    };
 
                     let width = label.width();
                     let limit = limit.get().into();
@@ -1387,9 +1389,8 @@ fn compute_inlay_hints_for_view(
                         // It's impossible for LSP to send a string of control chars, so 0 is fine
                         let mut floor_boundary = 0;
                         let mut acc = 0;
-                        for (i, c) in label.char_indices() {
-                            // Control chars are 0-width
-                            acc += c.width().unwrap_or(0);
+                        for (i, grapheme_cluster) in label.grapheme_indices(true) {
+                            acc += grapheme_cluster.width();
 
                             if acc > limit {
                                 floor_boundary = i;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1386,7 +1386,6 @@ fn compute_inlay_hints_for_view(
                     let width = label.width();
                     let limit = limit.get().into();
                     if width > limit {
-                        // It's impossible for LSP to send a string of control chars, so 0 is fine
                         let mut floor_boundary = 0;
                         let mut acc = 0;
                         for (i, grapheme_cluster) in label.grapheme_indices(true) {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1380,7 +1380,7 @@ fn compute_inlay_hints_for_view(
                     // Truncate the hint if too long
                     if let Some(limit) = inlay_hints_length_limit {
                         let limit = limit.into();
-                        if label.len() >= limit {
+                        if label.len() > limit {
                             label.truncate(limit);
                             label.push_str("..");
                         }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -459,6 +459,8 @@ pub struct LspConfig {
     pub display_signature_help_docs: bool,
     /// Display inlay hints
     pub display_inlay_hints: bool,
+    /// Max length of inlay hints, if it's none, there's no limit
+    pub inlay_hints_length_limit: Option<u8>,
     /// Display document color swatches
     pub display_color_swatches: bool,
     /// Whether to enable snippet support
@@ -476,6 +478,7 @@ impl Default for LspConfig {
             auto_signature_help: true,
             display_signature_help_docs: true,
             display_inlay_hints: false,
+            inlay_hints_length_limit: None,
             snippets: true,
             goto_reference_include_declaration: true,
             display_color_swatches: true,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -29,7 +29,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
     io::{self, stdin},
-    num::NonZeroUsize,
+    num::{NonZeroU8, NonZeroUsize},
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -459,8 +459,9 @@ pub struct LspConfig {
     pub display_signature_help_docs: bool,
     /// Display inlay hints
     pub display_inlay_hints: bool,
-    /// Max length of inlay hints, if it's none, there's no limit
-    pub inlay_hints_length_limit: Option<u8>,
+    /// Maximum displayed length of inlay hints (excluding the added trailing `…`).
+    /// If it's `None`, there's no limit
+    pub inlay_hints_length_limit: Option<NonZeroU8>,
     /// Display document color swatches
     pub display_color_swatches: bool,
     /// Whether to enable snippet support


### PR DESCRIPTION
Resolves #13582

What's more, I notice that in `helix-view/src/document.rs` 
![image](https://github.com/user-attachments/assets/e2748f4a-8f68-49cd-84ea-6d9a8c02c836)
here `oudated` might be a spelling error, is it `outdated`(I have not modify it yet)?