### PR TITLE
chore: bump edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ parking_lot = "0.12"
 
 [workspace.package]
 version = "25.1.1"
-edition = "2021"
+edition = "2024"
 authors = ["Blaž Hrastnik <blaz@mxxn.io>"]
 categories = ["editor"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
-rust-version = "1.82"
+rust-version = "1.85"

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -576,12 +576,18 @@ pub fn goto_treesitter_object(
         let byte_pos = slice.char_to_byte(range.cursor(slice));
 
         let cap_name = |t: TextObject| format!("{}.{}", object_name, t);
+
+        let movement_name = cap_name(TextObject::Movement);
+        let around_name = cap_name(TextObject::Around);
+        let inside_name = cap_name(TextObject::Inside);
+
+        let capture_names = [
+            movement_name.as_str(),
+            around_name.as_str(),
+            inside_name.as_str(),
+        ];
         let nodes = textobject_query?.capture_nodes_any(
-            &[
-                &cap_name(TextObject::Movement),
-                &cap_name(TextObject::Around),
-                &cap_name(TextObject::Inside),
-            ],
+            &capture_names,
             slice_tree,
             slice,
         )?;

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -849,7 +849,8 @@ impl TextObjectQuery {
         node: &Node<'a>,
         slice: RopeSlice<'a>,
     ) -> Option<impl Iterator<Item = CapturedNode<'a>>> {
-        self.capture_nodes_any(&[capture_name], node, slice)
+        let capture_names = [capture_name];
+        self.capture_nodes_any(&capture_names, node, slice)
     }
 
     /// Find the first capture that exists out of all given `capture_names`

--- a/helix-core/src/text_annotations.rs
+++ b/helix-core/src/text_annotations.rs
@@ -256,7 +256,9 @@ impl<T: ?Sized> RawBox<T> {
     /// created by this function may exist at a given time.
     #[allow(clippy::mut_from_ref)]
     unsafe fn get(&self) -> &mut T {
-        &mut *self.0.as_ptr()
+        unsafe {
+            &mut *self.0.as_ptr()
+        }
     }
 }
 impl<T: ?Sized> From<Box<T>> for RawBox<T> {

--- a/helix-event/src/hook.rs
+++ b/helix-event/src/hook.rs
@@ -36,11 +36,13 @@ impl ErasedHook {
             _event: NonNull<Opaque>,
             result: NonNull<Opaque>,
         ) {
-            let hook: NonNull<F> = hook.cast();
-            let result: NonNull<Result<()>> = result.cast();
-            let hook: &F = hook.as_ref();
-            let res = hook();
-            ptr::write(result.as_ptr(), res)
+            unsafe {
+                let hook: NonNull<F> = hook.cast();
+                let result: NonNull<Result<()>> = result.cast();
+                let hook: &F = hook.as_ref();
+                let res = hook();
+                ptr::write(result.as_ptr(), res)
+            }
         }
 
         unsafe {
@@ -57,12 +59,14 @@ impl ErasedHook {
             event: NonNull<Opaque>,
             result: NonNull<Opaque>,
         ) {
-            let hook: NonNull<F> = hook.cast();
-            let mut event: NonNull<E> = event.cast();
-            let result: NonNull<Result<()>> = result.cast();
-            let hook: &F = hook.as_ref();
-            let res = hook(event.as_mut());
-            ptr::write(result.as_ptr(), res)
+            unsafe {
+                let hook: NonNull<F> = hook.cast();
+                let mut event: NonNull<E> = event.cast();
+                let result: NonNull<Result<()>> = result.cast();
+                let hook: &F = hook.as_ref();
+                let res = hook(event.as_mut());
+                ptr::write(result.as_ptr(), res)
+            }
         }
 
         unsafe {

--- a/helix-event/src/lib.rs
+++ b/helix-event/src/lib.rs
@@ -70,7 +70,9 @@ pub fn register_event<E: Event + 'static>() {
 pub unsafe fn register_hook_raw<E: Event>(
     hook: impl Fn(&mut E) -> Result<()> + 'static + Send + Sync,
 ) {
-    registry::with_mut(|registry| registry.register_hook(hook))
+    unsafe {
+        registry::with_mut(|registry| registry.register_hook(hook))
+    }
 }
 
 /// Register a hook solely by event name

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
- **chore: bump**
- **fix: address edition check warnings and errors**

Incomplete: one remaining error I cannot work out how to resolve

```rust
error[E0597]: `capture_names` does not live long enough
   --> helix-core/src/syntax.rs:853:32
    |
848 |         capture_name: &str,
    |                       - let's call the lifetime of this reference `'1`
...
852 |         let capture_names = [capture_name];
    |             ------------- binding `capture_names` declared here
853 |         self.capture_nodes_any(&capture_names, node, slice)
    |         -----------------------^^^^^^^^^^^^^^--------------
    |         |                      |
    |         |                      borrowed value does not live long enough
    |         argument requires that `capture_names` is borrowed for `'1`
854 |     }
    |     - `capture_names` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
error: could not compile `helix-core` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

I tried a few approaches and they didn't work nicely.

It concerns this code:

```rust
#[derive(Debug)]
pub struct TextObjectQuery {
    query: Query,
}

impl TextObjectQuery {
    pub fn new(query: Query) -> Self {
        Self { query }
    }

    /// Run the query on the given node and return sub nodes which match given
    /// capture ("function.inside", "class.around", etc).
    ///
    /// Captures may contain multiple nodes by using quantifiers (+, *, etc),
    /// and support for this is partial and could use improvement.
    ///
    /// ```query
    /// (comment)+ @capture
    ///
    /// ; OR
    /// (
    ///   (comment)*
    ///   .
    ///   (function)
    /// ) @capture
    /// ```
    pub fn capture_nodes<'a>(
        &'a self,
        capture_name: &str,
        node: &Node<'a>,
        slice: RopeSlice<'a>,
    ) -> Option<impl Iterator<Item = CapturedNode<'a>>> {
        let capture_names = [capture_name];
        self.capture_nodes_any(&capture_names, node, slice)
    }

    /// Find the first capture that exists out of all given `capture_names`
    /// and return sub nodes that match this capture.
    pub fn capture_nodes_any<'a>(
        &'a self,
        capture_names: &[&str],
        node: &Node<'a>,
        slice: RopeSlice<'a>,
    ) -> Option<impl Iterator<Item = CapturedNode<'a>>> {
        let capture = capture_names
            .iter()
            .find_map(|cap| self.query.get_capture(cap))?;

        let mut cursor = InactiveQueryCursor::new(0..u32::MAX, TREE_SITTER_MATCH_LIMIT)
            .execute_query(&self.query, node, RopeInput::new(slice));
        let capture_node = iter::from_fn(move || {
            let (mat, _) = cursor.next_matched_node()?;
            Some(mat.nodes_for_capture(capture).cloned().collect())
        })
        .filter_map(move |nodes: Vec<_>| {
            if nodes.len() > 1 {
                Some(CapturedNode::Grouped(nodes))
            } else {
                nodes.into_iter().map(CapturedNode::Single).next()
            }
        });
        Some(capture_node)
    }
}
```