### PR TITLE
chore: updated c, c++ highlights. Fixed python mistake

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -14,8 +14,6 @@
 ] @keyword.storage.type
 
 [
-  "extern"
-  "register"
   (type_qualifier)
   (storage_class_specifier)
 ] @keyword.storage.modifier
@@ -55,8 +53,11 @@
   (preproc_directive)
 ] @keyword.directive
 
-(pointer_declarator "*" @type.builtin)
-(abstract_pointer_declarator "*" @type.builtin)
+"..." @punctuation
+
+["," "." ":" "::" ";" "->"] @punctuation.delimiter
+
+["(" ")" "[" "]" "{" "}" "[[" "]]"] @punctuation.bracket
 
 [
   "+"
@@ -95,13 +96,11 @@
   "?"
 ] @operator
 
-(conditional_expression ":" @operator)
+(conditional_expression ":" @operator) ; After punctuation
 
-"..." @punctuation
+(pointer_declarator "*" @type.builtin) ; After Operators
+(abstract_pointer_declarator "*" @type.builtin)
 
-["," "." ":" ";" "->" "::"] @punctuation.delimiter
-
-["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 [(true) (false)] @constant.builtin.boolean
 

--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -23,11 +23,6 @@
 
 ; Functions
 
-; These casts are parsed as function calls, but are not.
-((identifier) @keyword (#eq? @keyword "static_cast"))
-((identifier) @keyword (#eq? @keyword "dynamic_cast"))
-((identifier) @keyword (#eq? @keyword "reinterpret_cast"))
-((identifier) @keyword (#eq? @keyword "const_cast"))
 
 (call_expression
   function: (qualified_identifier
@@ -39,6 +34,8 @@
 (template_method
   name: (field_identifier) @function)
 
+; Support up to 3 levels of nesting of qualifiers
+; i.e. a::b::c::func();
 (function_declarator
   declarator: (qualified_identifier
     name: (identifier) @function))
@@ -47,6 +44,12 @@
   declarator: (qualified_identifier
     name: (qualified_identifier
       name: (identifier) @function)))
+
+(function_declarator
+  declarator: (qualified_identifier
+    name: (qualified_identifier
+      name: (qualified_identifier
+        name: (identifier) @function))))
 
 (function_declarator
   declarator: (field_identifier) @function)
@@ -71,6 +74,13 @@
   "[]"
   "()"
 ] @operator
+
+
+; These casts are parsed as function calls, but are not.
+((identifier) @keyword (#eq? @keyword "static_cast"))
+((identifier) @keyword (#eq? @keyword "dynamic_cast"))
+((identifier) @keyword (#eq? @keyword "reinterpret_cast"))
+((identifier) @keyword (#eq? @keyword "const_cast"))
 
 [
   "co_await"

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -131,8 +131,8 @@
   "try"
   "except"
   "finally"
-] @keyword.control.except
-(raise_statement "from" @keyword.control.except)
+] @keyword.control.exception
+(raise_statement "from" @keyword.control.exception)
 
 ; Functions
 [


### PR DESCRIPTION
### C
- Ternary operator `:` gets highlighted as `operator` instead of `punctuation.delimiter`
- `*` that are part of types are highlighted as such (i.e. `char *s`)
- `[[` and `]]` are now `punctuation.delimiter` instead of nothing (used in attributes)
  
### C++
- All of the above
- `cast` keywords are highlighted as such instead of as functions (i.e. `static_cast<int>(a)`)

### Python
- Fixed my earlier mistake of labeling exception keywords as `keyword.control.except` instead of `keyword.control.exception`