### PR TITLE
feat: allow moving nonexistent file

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1433,7 +1433,11 @@ impl Editor {
                 log::error!("failed to apply workspace edit: {err:?}")
             }
         }
-        fs::rename(old_path, &new_path)?;
+
+        if old_path.exists() {
+            fs::rename(old_path, &new_path)?;
+        }
+
         if let Some(doc) = self.document_by_path(old_path) {
             self.set_doc_path(doc.id(), &new_path);
         }


### PR DESCRIPTION
Currently moving nonexistent files fails with no such file or directory. A simple condition to only move when the file exists resolves this issue. This could be useful when you :open a new file but decide on a different name before writing it
