### PR TITLE
Highlight HTML entities

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -935,7 +935,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "html"
-source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "29f53d8f4f2335e61bf6418ab8958dac3282077a" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "cbb91a0ff3621245e890d1c50cc811bffb77a26b" }
 
 [[language]]
 name = "python"

--- a/runtime/queries/astro/highlights.scm
+++ b/runtime/queries/astro/highlights.scm
@@ -1,3 +1,48 @@
-; inherits: html
+(tag_name) @tag
+(erroneous_end_tag_name) @error
+(doctype) @constant
+(attribute_name) @attribute
+(comment) @comment
+
+((attribute
+  (attribute_name) @attribute
+  (quoted_attribute_value (attribute_value) @markup.link.url))
+ (#any-of? @attribute "href" "src"))
+
+((element
+  (start_tag
+    (tag_name) @tag)
+  (text) @markup.link.label)
+  (#eq? @tag "a"))
+
+(attribute [(attribute_value) (quoted_attribute_value)] @string)
+
+((element
+  (start_tag
+    (tag_name) @tag)
+  (text) @markup.bold)
+  (#any-of? @tag "strong" "b"))
+
+((element
+  (start_tag
+    (tag_name) @tag)
+  (text) @markup.italic)
+  (#any-of? @tag "em" "i"))
+
+((element
+  (start_tag
+    (tag_name) @tag)
+  (text) @markup.strikethrough)
+  (#any-of? @tag "s" "del"))
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+  "<!"
+] @punctuation.bracket
+
+"=" @punctuation.delimiter
 
 ["---"] @punctuation.delimiter

--- a/runtime/queries/html/highlights.scm
+++ b/runtime/queries/html/highlights.scm
@@ -2,6 +2,7 @@
 (erroneous_end_tag_name) @error
 (doctype) @constant
 (attribute_name) @attribute
+(entity) @string.special.symbol
 (comment) @comment
 
 ((attribute


### PR DESCRIPTION
Updates the tree-sitter-html repository from where it was - 2022 commit? - to the latest commit (5 months ago). This is required to support the `entity` node that has been added, which is captured here with the `string.special.symbol` capture/scope.

| Before | After |
| --- | --- |
| ![CleanShot 2025-06-12 at 16 24 08](https://github.com/user-attachments/assets/e28ea442-6ab6-4d24-9b9c-2011063cd048) | ![CleanShot 2025-06-12 at 16 24 37](https://github.com/user-attachments/assets/a6bc93a1-2ca6-4eda-a213-c5f3e3f48ac8) |