### PR TITLE
feat: provide context around the language config (merged TOML) on load error

### DIFF
--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -44,7 +44,7 @@ log = "0.4"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.8"
+toml = { version = "0.8", features = ["parse"] }
 
 imara-diff = "0.1.8"
 

--- a/helix-core/src/config.rs
+++ b/helix-core/src/config.rs
@@ -1,4 +1,5 @@
 use crate::syntax::{config::Configuration, Loader, LoaderError};
+use serde::de::Error;
 
 /// Language configuration based on built-in languages.toml.
 pub fn default_lang_config() -> Configuration {
@@ -36,10 +37,76 @@ pub fn user_lang_config() -> Result<Configuration, toml::de::Error> {
 
 /// Language configuration loader based on user configured languages.toml.
 pub fn user_lang_loader() -> Result<Loader, LanguageLoaderError> {
-    let config: Configuration = helix_loader::config::user_lang_config()
-        .map_err(LanguageLoaderError::DeserializeError)?
-        .try_into()
+    let toml_value = helix_loader::config::user_lang_config()
         .map_err(LanguageLoaderError::DeserializeError)?;
 
+    // Convert to string so we can get span information on parse errors
+    let toml_string = toml::to_string(&toml_value)
+        .map_err(|e| {
+            eprintln!("Failed to serialize TOML value: {}", e);
+            LanguageLoaderError::DeserializeError(toml::de::Error::custom("Failed to serialize TOML"))
+        })?;
+
+    let config: Configuration = toml::from_str(&toml_string)
+        .map_err(|e| {
+            // Now we have span information
+            if let Some(span) = e.span() {
+                let (line, col) = byte_pos_to_line_col(&toml_string, span.start);
+                eprintln!("Error at line {}, column {}: {}", line, col, e);
+                show_error_context(&toml_string, span);
+            }
+            LanguageLoaderError::DeserializeError(e)
+        })?;
+
     Loader::new(config).map_err(LanguageLoaderError::LoaderError)
+}
+
+fn byte_pos_to_line_col(source: &str, pos: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+
+    for (i, ch) in source.char_indices() {
+        if i >= pos {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+
+    (line, col)
+}
+
+fn show_error_context(content: &str, span: std::ops::Range<usize>) {
+   let (line_num, _) = byte_pos_to_line_col(content, span.start);
+   let lines: Vec<&str> = content.lines().collect();
+
+   eprintln!("Context around error:");
+   // If the error line starts with [[, it's a section header - start from that line
+   // Otherwise, show the 3 preceding lines for context
+   let start_line = if line_num <= lines.len() && lines[line_num-1].trim().starts_with("[[") {
+       line_num
+   } else {
+       line_num.saturating_sub(3).max(1)
+   };
+
+   // Find the end of this section (next [[...]] or reasonable limit)
+   let mut end_line = line_num + 50; // reasonable limit
+   for i in (line_num + 1)..=lines.len().min(line_num + 50) {
+       if i <= lines.len() && lines[i-1].trim().starts_with("[[") {
+           end_line = i - 1;
+           break;
+       }
+   }
+   end_line = end_line.min(lines.len());
+
+   for i in start_line..=end_line {
+       let marker = if i == line_num { ">>> " } else { "    " };
+       if i > 0 && i <= lines.len() {
+           eprintln!("  {}{:4}: {}", marker, i, lines[i-1]);
+       }
+   }
 }


### PR DESCRIPTION
I noticed while working with Helix recently (noted in #11666) that if I produced a bad configuration, it was hard to tell what I'd done wrong.

This is made doubly hard as the true source of the bug is a **merged** TOML (the default language config and the user's language config). The user's config may have many languages in, but if a language fails to parse into a `Configuration` (serde-derived struct) then the entire block will be given as the error source, so you would just see for example:

```rust
duplicate field `comment-tokens` in key "language"
```

I added a second step where, in the case of an error, this merged TOML value is retrieved, then converted to a string (thus allowing an error from parsing it to have a span, i.e. to know which byte and thus which line it occurred at, and thus to track down which language section it was in).

I then added a simple "go to the end of the section" and put a sensible limit of no more than 50 lines of context (for the example of the Rust language section it was 20 lines, and you need to read at least 8 lines to see the `name = "rust` line, as it's alphabetised when merging by the looks of it).

The resulting diagnostic would be very helpful when in a tricky situtation. In the case shown here, you'd be able to see that the error was misleading: the duplicate field is actually due to an alias. With only the `language` line though you could be really stumped trying to figure this one out.

```rust
Error at line 5872, column 1: TOML parse error at line 5872, column 1
     |
5872 | [[language]]
     | ^^^^^^^^^^^^
duplicate field `comment-tokens`

Context around error:
  >>> 5872: [[language]]
      5873: auto-format = true
      5874: comment-token = "//"
      5875: comment-tokens = ["//", "///", "//!"]
      5876: file-types = ["rs"]
      5877: injection-regex = "rs|rust"
      5878: language-servers = ["rust-analyzer"]
      5879: name = "rust"
      5880: persistent-diagnostic-sources = ["rustc", "clippy"]
      5881: roots = ["Cargo.toml", "Cargo.lock"]
      5882: scope = "source.rust"
      5883: shebangs = ["rust-script", "cargo"]
      5884: 
      5885: [language.auto-pairs]
      5886: '"' = '"'
      5887: "(" = ")"
      5888: "[" = "]"
      5889: "`" = "`"
      5890: "{" = "}"
      5891: 
Failed to parse language config: TOML parse error at line 5872, column 1
     |
5872 | [[language]]
     | ^^^^^^^^^^^^
duplicate field `comment-tokens`

Press <ENTER> to continue with default language config
```