### PR TITLE
feat: Make the diagnostic picker display the resposible LSP

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -252,6 +252,9 @@ fn diag_picker(
                 .into()
             },
         ),
+        ui::PickerColumn::new("source", |item: &PickerDiagnostic, _| {
+            item.diag.source.clone().unwrap_or("".to_string()).into()
+        }),
         ui::PickerColumn::new("code", |item: &PickerDiagnostic, _| {
             match item.diag.code.as_ref() {
                 Some(NumberOrString::Number(n)) => n.to_string().into(),

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -253,7 +253,7 @@ fn diag_picker(
             },
         ),
         ui::PickerColumn::new("source", |item: &PickerDiagnostic, _| {
-            item.diag.source.clone().unwrap_or("".to_string()).into()
+            item.diag.source.as_deref().unwrap_or("").into()
         }),
         ui::PickerColumn::new("code", |item: &PickerDiagnostic, _| {
             match item.diag.code.as_ref() {
@@ -266,12 +266,12 @@ fn diag_picker(
             item.diag.message.as_str().into()
         }),
     ];
-    let mut primary_column = 2; // message
+    let mut primary_column = 3; // message
 
     if format == DiagnosticsFormat::ShowSourcePath {
         columns.insert(
             // between message code and message
-            2,
+            3,
             ui::PickerColumn::new("path", |item: &PickerDiagnostic, _| {
                 if let Some(path) = item.location.uri.as_path() {
                     path::get_truncated_path(path)


### PR DESCRIPTION
Solves https://github.com/helix-editor/helix/issues/12474 and https://github.com/helix-editor/helix/issues/11452

This should probably be configurable so my current approach is very naive. I just wanted to quickly whip something up for myself.

When programming in Python multiple/many LSP's is the norm and it can be hard to make sense of things. Hence this PR that displays the LSP responsible for a certain diagnostic in the picker.