### PR TITLE
added crystal formatter in languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -648,7 +648,7 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 grammar = "ruby"
 language-servers = [ "crystalline" ]
-formatter = { command = "crystal", args = ["crystal", "tool", "format" "-"] }
+formatter = { command = "crystal", args = ["crystal", "tool", "format", "-"] }
 
 [[language]]
 name = "c-sharp"

--- a/languages.toml
+++ b/languages.toml
@@ -648,6 +648,7 @@ comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 grammar = "ruby"
 language-servers = [ "crystalline" ]
+formatter = { command = "crystal", args = ["crystal", "tool", "format" "-"] }
 
 [[language]]
 name = "c-sharp"


### PR DESCRIPTION
hi, the formatter is built in the crystal compiler so i think it doesn't costs anything to add it into the default helix config.

see https://crystal-lang.org/reference/1.16/man/crystal/index.html#crystal-tool-format

There is no mention of "-" in the docs, but it is used to use stdin
command:
 ```bash
crystal tool format  --help
```
Output:
```
Usage: crystal tool format [options] [- | file or directory ...]

Formats Crystal code in place.

If a file or directory is omitted,
Crystal source files beneath the working directory are formatted.

To format STDIN to STDOUT, use '-' in place of any path arguments.

Options:
    --check                          Checks that formatting code produces no changes
    -i <path>, --include <path>      Include path
    -e <path>, --exclude <path>      Exclude path (default: lib)
    -h, --help                       Show this message
    --no-color                       Disable colored output
    --show-backtrace                 Show backtrace on a bug (used only for debugging)
```