### PR TITLE
Highlight Ecma escape sequences

### DIFF
--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -235,6 +235,8 @@
   (template_string)
 ] @string
 
+(escape_sequence) @constant.character.escape
+
 (regex) @string.regexp
 (number) @constant.numeric.integer
 


### PR DESCRIPTION
Highlights the Ecma `escape_sequence` node with `constant.character.escape`, which makes escape sequences such as `\n` and `\t` more visible in strings.

| Before | After |
| --- | --- |
| <img width="399" alt="image" src="https://github.com/user-attachments/assets/7070b2a4-bb01-40aa-981a-484aa4d2c413" /> | <img width="394" alt="image" src="https://github.com/user-attachments/assets/9c7fd768-de99-415e-bb11-5e8d3510a43c" /> |