### PR TITLE
Add Amber language server

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -4,7 +4,7 @@
 | adl | ✓ | ✓ | ✓ |  |
 | agda | ✓ |  |  |  |
 | alloy | ✓ |  |  |  |
-| amber | ✓ |  |  |  |
+| amber | ✓ |  |  | `amber-lsp` |
 | astro | ✓ |  |  | `astro-ls` |
 | awk | ✓ | ✓ |  | `awk-language-server` |
 | bash | ✓ | ✓ | ✓ | `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -5,9 +5,10 @@ use-grammars = { except = [ "wren", "gemini" ] }
 
 [language-server]
 
-als = { command = "als" }
-ada-language-server = { command = "ada_language_server" }
 ada-gpr-language-server = {command = "ada_language_server", args = ["--language-gpr"]}
+ada-language-server = { command = "ada_language_server" }
+als = { command = "als" }
+amber-lsp = { command = "amber-lsp" }
 angular = {command = "ngserver", args = ["--stdio", "--tsProbeLocations", ".", "--ngProbeLocations", ".",]}
 asm-lsp = { command = "asm-lsp" }
 awk-language-server = { command = "awk-language-server" }
@@ -4131,6 +4132,7 @@ scope = "source.ab"
 file-types = ["ab"]
 comment-token = ["//", "///"]
 indent = { tab-width = 4, unit = "    " }
+language-servers = ["amber-lsp"]
 
 [[grammar]]
 name = "amber"


### PR DESCRIPTION
Repository: https://github.com/KrosFire/amber-lsp

I think some servers are sorted alphabetically, but most of them are not. Anyway, I've sorted servers around Amber which start with `a`.