### PR TITLE
Fix `goto_file` bug on Windows

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -76,8 +76,7 @@ fn open_external_url_callback(
     let commands = open::commands(url.as_str());
     async {
         for cmd in commands {
-            let mut command = tokio::process::Command::new(cmd.get_program());
-            command.args(cmd.get_args());
+            let mut command: tokio::process::Command = cmd.into();
             if command.output().await.is_ok() {
                 return Ok(job::Callback::Editor(Box::new(|_| {})));
             }


### PR DESCRIPTION
Fixes #13661

Use `From<std::process::Command>` instead of `args`, the latter will result in unexpected behaviors on Windows, just as said in the issue. `raw_arg` is the way to fix it, but `open::commands` has provided us `std::process::Command`s, just use `.into()` to wrap it in tokio's `Command` instead of constructing it by hand.