### PR TITLE
Fix: update c++ highlights

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -12,8 +12,6 @@
 (namespace_definition name: (namespace_identifier) @namespace)
 (namespace_identifier) @namespace
 
-(qualified_identifier name: (identifier) @type.enum.variant)
-
 (auto) @type
 "decltype" @type
 
@@ -21,12 +19,29 @@
 (reference_declarator ["&" "&&"] @type.builtin)
 (abstract_reference_declarator ["&" "&&"] @type.builtin)
 
+; -------
 ; Functions
-
-
+; -------
+; Support up to 4 levels of nesting of qualifiers
+; i.e. a::b::c::d::func();
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
+(call_expression
+  function: (qualified_identifier
+    name: (qualified_identifier
+      name: (identifier) @function)))
+(call_expression
+  function: (qualified_identifier
+    name: (qualified_identifier
+      name: (qualified_identifier
+        name: (identifier) @function))))
+(call_expression
+  function: (qualified_identifier
+    name: (qualified_identifier
+      name: (qualified_identifier
+        name: (qualified_identifier
+          name: (identifier) @function)))))
 
 (template_function
   name: (identifier) @function)
@@ -34,25 +49,41 @@
 (template_method
   name: (field_identifier) @function)
 
-; Support up to 3 levels of nesting of qualifiers
-; i.e. a::b::c::func();
+; Support up to 4 levels of nesting of qualifiers
+; i.e. a::b::c::d::func();
 (function_declarator
   declarator: (qualified_identifier
     name: (identifier) @function))
-
 (function_declarator
   declarator: (qualified_identifier
     name: (qualified_identifier
       name: (identifier) @function)))
-
 (function_declarator
   declarator: (qualified_identifier
     name: (qualified_identifier
       name: (qualified_identifier
         name: (identifier) @function))))
+(function_declarator
+  declarator: (qualified_identifier
+    name: (qualified_identifier
+      name: (qualified_identifier
+        name: (qualified_identifier
+          name: (identifier) @function)))))
 
 (function_declarator
   declarator: (field_identifier) @function)
+
+; Constructors
+
+(class_specifier
+  (type_identifier) @type
+  (field_declaration_list
+    (function_definition
+      (function_declarator
+        (identifier) @constructor)))
+        (#eq? @type @constructor)) 
+(destructor_name "~" @constructor
+  (identifier) @constructor)
 
 ; Parameters
 


### PR DESCRIPTION
Referencing [this discussion](https://github.com/helix-editor/helix/discussions/13766).

- Fixes highlighting on namespaced variables
- Fixes highlighting on namespaced functions
- Adds highlighting for constructors and destructors
- Fixes highlighting on nested namespaces

However, making highlighting on namespaced things work makes enum variants be highlighted as variables. Due to how the syntax is parsed, I do not believe there is a solution to have both be highlighted correctly. I believe it is far more common to use namespaced variables and functions (i.e. the entire `std` library or other namespaced libraries), than using enums, so I believe this is the correct option.

Before and after screenshots can be seen in the linked discussion.