### PR TITLE
feat: add option tto ignore binary files

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -195,6 +195,7 @@ All git related options are only enabled in a git repository.
 | Key | Description | Default |
 |--|--|---------|
 |`hidden` | Enables ignoring hidden files | `true`
+|`binary` | Enables ignoring binary files | `false`
 |`follow-symlinks` | Follow symlinks instead of ignoring them | `true`
 |`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | `true`
 |`parents` | Enables reading ignore files from parent directories | `true`

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2552,7 +2552,7 @@ fn global_search(cx: &mut Context) {
                 .git_exclude(config.file_picker_config.git_exclude)
                 .max_depth(config.file_picker_config.max_depth)
                 .filter_entry(move |entry| {
-                    filter_picker_entry(entry, &absolute_root, dedup_symlinks)
+                    filter_picker_entry(entry, &absolute_root, dedup_symlinks, false)
                 })
                 .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
                 .add_custom_ignore_filename(".helix/ignore")

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -205,8 +205,8 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
     let now = Instant::now();
 
     let dedup_symlinks = config.file_picker.deduplicate_links;
+    let ignore_binaries = config.file_picker.binary_files;
     let absolute_root = root.canonicalize().unwrap_or_else(|_| root.clone());
-
     let mut walk_builder = WalkBuilder::new(&root);
     walk_builder
         .hidden(config.file_picker.hidden)
@@ -218,7 +218,9 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         .git_exclude(config.file_picker.git_exclude)
         .sort_by_file_name(|name1, name2| name1.cmp(name2))
         .max_depth(config.file_picker.max_depth)
-        .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks));
+        .filter_entry(move |entry| {
+            filter_picker_entry(entry, &absolute_root, dedup_symlinks, ignore_binaries)
+        });
 
     walk_builder.add_custom_ignore_filename(helix_loader::config_dir().join("ignore"));
     walk_builder.add_custom_ignore_filename(".helix/ignore");

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -746,7 +746,7 @@ async fn test_hardlink_write() -> anyhow::Result<()> {
 async fn edit_file_with_content(file_content: &[u8]) -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
 
-    file.as_file_mut().write_all(&file_content)?;
+    file.as_file_mut().write_all(file_content)?;
 
     helpers::test_key_sequence(
         &mut helpers::AppBuilder::new()

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -425,7 +425,7 @@ pub fn reload_file(file: &mut NamedTempFile) -> anyhow::Result<()> {
     let f = std::fs::OpenOptions::new()
         .write(true)
         .read(true)
-        .open(&path)?;
+        .open(path)?;
     *file.as_file_mut() = f;
     Ok(())
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -182,6 +182,9 @@ pub struct FilePickerConfig {
     /// Enables ignoring hidden files.
     /// Whether to hide hidden files in file picker and global search results. Defaults to true.
     pub hidden: bool,
+    /// Enables ignoring binary files.
+    /// Whether to hide binary files in file picker. Defaults to false.
+    pub binary_files: bool,
     /// Enables following symlinks.
     /// Whether to follow symbolic links in file picker and file or directory completions. Defaults to true.
     pub follow_symlinks: bool,
@@ -218,6 +221,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            binary_files: false,
         }
     }
 }


### PR DESCRIPTION
This pr adds an option to ignore binary files. Not all binary fiels are .gitignored (for example image files for readme) so you have to manually add their formats to helix ignore. I think it would be simpler to just add an option to ignore all binaries. It is false by default because I don't know, maybe someone ues helix for binary files
