### PR TITLE
Update gleam tree-sitter grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2083,7 +2083,7 @@ auto-format = true
 
 [[grammar]]
 name = "gleam"
-source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "426e67087fd62be5f4533581b5916b2cf010fb5b" }
+source = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "6ece453acf8b14568c10f629f8cd25d3dde3794f" }
 
 [[language]]
 name = "quarto"


### PR DESCRIPTION
This adds support for the new `assert` syntax