### PR TITLE
feat(lsp): sort diagnostic picker by severity

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -231,6 +231,13 @@ fn diag_picker(
         }
     }
 
+    flat_diag.sort_by(|a, b| {
+        a.diag
+            .severity
+            .unwrap_or(lsp::DiagnosticSeverity::HINT)
+            .cmp(&b.diag.severity.unwrap_or(lsp::DiagnosticSeverity::HINT))
+    });
+
     let styles = DiagnosticStyles {
         hint: cx.editor.theme.get("hint"),
         info: cx.editor.theme.get("info"),


### PR DESCRIPTION
This was brought up again in https://github.com/helix-editor/helix/issues/3543 and I think that while the search options to narrow a scope down is very nice, I find myself searching for errors as the most common case, which requires to always have a `%s E` search. This works, but one issue is that the `SPACE+'`, for example, doesnt update with new info after changing things. And the picker doesnt persist the queries, requiring a retype of the same thing many times as issues are addressed.

Sorting by default optimizes this flow. And the search options still provide a way to narrow from there. While I think this should be the default, there was mention of configuration, but most cases need a search, which bypasses any specific search order anyways (I think it uses a different search sort mechanism (nucleos?)).