### PR TITLE
feat: allow rendering a string for rulers

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -47,6 +47,7 @@
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
+| `rulers-string` | A string displayed on ruler columns | ` ` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,7 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-use std::{mem::take, num::NonZeroUsize, ops, path::PathBuf, rc::Rc};
+use std::{fmt::Debug, mem::take, num::NonZeroUsize, ops, path::PathBuf, rc::Rc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
 
@@ -237,6 +237,7 @@ impl EditorView {
         let ruler_theme = theme
             .try_get("ui.virtual.ruler")
             .unwrap_or_else(|| Style::default().bg(Color::Red));
+        let ruler_string = &editor.config().rulers_string;
 
         let rulers = doc
             .language_config()
@@ -252,7 +253,11 @@ impl EditorView {
             .filter_map(|ruler| ruler.checked_sub(1 + view_offset.horizontal_offset as u16))
             .filter(|ruler| ruler < &viewport.width)
             .map(|ruler| viewport.clip_left(ruler).with_width(1))
-            .for_each(|area| surface.set_style(area, ruler_theme))
+            .for_each(|area| {
+                for y in area.y..area.height {
+                    surface.set_string(area.x, y, ruler_string, ruler_theme);
+                }
+            })
     }
 
     fn viewport_byte_range(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -331,6 +331,8 @@ pub struct Config {
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
     pub rulers: Vec<u16>,
+    /// A string displayed on the ruler column.
+    pub rulers_string: String,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
@@ -1007,6 +1009,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
+            rulers_string: " ".to_owned(),
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),


### PR DESCRIPTION
This is basically what https://github.com/xiyaowong/virtcolumn.nvim does.

Setting 
```toml
[editor]
rulers-string = "▏"
```
and modifying a theme with
```toml
"ui.virtual.ruler" = { fg = "#bbbbbb" }
```
results in rulers like these:
![image](https://github.com/user-attachments/assets/7ce2ed4a-39c8-489b-8cd7-96422ee5821f)

This is a very naive approach and I'm honestly surprised it "just works" - would it make sense to provide a method on `Buffer` to fill an area with a string to avoid the loop?

Another question is whether setting this from themes makes more sense - though I'm not sure how I would go about it.