### PR TITLE
fix: highlight `floor` in `|> float.floor` as function in Gleam

### DIFF
--- a/runtime/queries/gleam/highlights.scm
+++ b/runtime/queries/gleam/highlights.scm
@@ -40,6 +40,7 @@
 ((function_call
    function: (identifier) @function)
  (#is-not? local))
+; highlights `a` in `|> a` as function
 ((binary_expression
    operator: "|>"
    right: (identifier) @function)
@@ -186,3 +187,10 @@
 ; affects e.g. `replace` in `string.replace("+", "-")`
 ; without this, it would be highlighted as a field instead of function
 (function_call (field_access (label) @function))
+
+; highlights `floor` in `|> float.floor` as function
+(binary_expression
+  left: (_) "|>"
+  right: (field_access
+    record: (identifier) "."
+    field: (label) @function))


### PR DESCRIPTION
For example in this code:

```gleam
pub fn debug(term: anything) -> anything {
  term
  |> string.inspect
  |> do_debug_println

  term
}
```

`inspect` in `string.inspect` would be a field access, but we know it must be a function if it's the subject of a pipe