### PR TITLE
fix: indentation with spaces aligned on columns

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4225,14 +4225,23 @@ pub mod insert {
 
     fn insert_tab_impl(cx: &mut Context, count: usize) {
         let (view, doc) = current!(cx.editor);
-        // TODO: round out to nearest indentation level (for example a line with 3 spaces should
-        // indent by one to reach 4 spaces).
 
-        let indent = Tendril::from(doc.indent_style.as_str().repeat(count));
-        let transaction = Transaction::insert(
+        let transaction = Transaction::change(
             doc.text(),
-            &doc.selection(view.id).clone().cursors(doc.text().slice(..)),
-            indent,
+            doc.selection(view.id).ranges().iter().map(|range| {
+                let cursor = range.cursor(doc.text().slice(..));
+                let indent = if let IndentStyle::Spaces(indent_width) = doc.indent_style {
+                    let line = range.cursor_line(doc.text().slice(..));
+                    let line_start = doc.text().line_to_char(line);
+                    let offset = (cursor - line_start) % indent_width as usize;
+
+                    Tendril::from(doc.indent_style.as_str().repeat(count)).split_off(offset)
+                } else {
+                    Tendril::from(doc.indent_style.as_str().repeat(count))
+                };
+
+                (cursor, cursor, Some(indent))
+            }),
         );
         doc.apply(&transaction, view.id);
     }
@@ -4964,7 +4973,16 @@ fn indent(cx: &mut Context) {
                 return None;
             }
             let pos = doc.text().line_to_char(line);
-            Some((pos, pos, Some(indent.clone())))
+
+            let indent = if let IndentStyle::Spaces(indent_width) = doc.indent_style {
+                let line = doc.text().line(line);
+                let offset = line.first_non_whitespace_char().unwrap_or(0) % indent_width as usize;
+                indent.clone().split_off(offset)
+            } else {
+                indent.clone()
+            };
+
+            Some((pos, pos, Some(indent)))
         }),
     );
     doc.apply(&transaction, view.id);

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -437,7 +437,7 @@ async fn test_smart_tab_move_parent_node_end() -> anyhow::Result<()> {
                     let result = if true {
                             #[|\"yes\"\n]#
                     } else {
-                        \"no    #(|\"\n)#
+                        \"no #(|\"\n)#
                     }
                 }
             "},


### PR DESCRIPTION
When pressing tab in insert mode, or indenting with `>` in normal mode, adjusts the number of spaces to align on columns. This fixes #13498.

[Capture vidéo du 2025-06-23 19-14-49.webm](https://github.com/user-attachments/assets/d8cf3aca-a808-4db1-9993-637cdac4d55d)
