### PR TITLE
fix: Rust locals not defined by a function signature

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -14,8 +14,10 @@
 
 ; Definitions
 
-(parameter
-  pattern: (identifier) @local.definition.variable.parameter)
+(function_item
+  (parameters
+    (parameter
+      pattern: (identifier) @local.definition.variable.parameter)))
 
 (closure_parameters (identifier) @local.definition.variable.parameter)
 


### PR DESCRIPTION
Changes `parameter` creating a local definition to only `parameter` that is part of a `function_item`. This removes two cases, `function_signature_item` which is shown in the linked issue and `function_type` which also should not define locals.

Closes: #11172