### PR TITLE
UI: Make code-action popup auto close like other popups

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -807,7 +807,9 @@ pub fn code_action(cx: &mut Context) {
             });
             picker.move_down(); // pre-select the first item
 
-            let popup = Popup::new("code-action", picker).with_scrollbar(false);
+            let popup = Popup::new("code-action", picker)
+                .with_scrollbar(false)
+                .auto_close(true);
 
             compositor.replace_or_push("code-action", popup);
         };


### PR DESCRIPTION
This brings code-actions in line with hover popups. Having the code action menu follow the cursor around feels strange and I am of the opinion it makes sense to close it when moving around.

Closes: #11104