### PR TITLE
helix-view: expand primary selection line range in shell commands

### DIFF
--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -49,6 +49,8 @@ The following variables are supported:
 | `line_ending` | A string containing the line ending of the currently focused document. For example on Unix systems this is usually a line-feed character (`\n`) but on Windows systems this may be a carriage-return plus a line-feed (`\r\n`). The line ending kind of the currently focused document can be inspected with the `:line-ending` command. |
 | `language` | A string containing the language name of the currently focused document.|
 | `selection` | A string containing the contents of the primary selection of the currently focused document. |
+| `selection_line_start` | The line number of the start of the primary selection in the currently focused document, starting at 1. |
+| `selection_line_end` | The line number of the end of the primary selection in the currently focused document, starting at 1. |
 
 Aside from editor variables, the following expansions may be used:
 

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -37,6 +37,10 @@ pub enum Variable {
     Language,
     // Primary selection
     Selection,
+    // The one-indexed line number of the start of the primary selection in the currently focused document.
+    SelectionLineStart,
+    // The one-indexed line number of the end of the primary selection in the currently focused document.
+    SelectionLineEnd,
 }
 
 impl Variable {
@@ -47,6 +51,8 @@ impl Variable {
         Self::LineEnding,
         Self::Language,
         Self::Selection,
+        Self::SelectionLineStart,
+        Self::SelectionLineEnd,
     ];
 
     pub const fn as_str(&self) -> &'static str {
@@ -57,6 +63,8 @@ impl Variable {
             Self::LineEnding => "line_ending",
             Self::Language => "language",
             Self::Selection => "selection",
+            Self::SelectionLineStart => "selection_line_start",
+            Self::SelectionLineEnd => "selection_line_end",
         }
     }
 
@@ -68,6 +76,8 @@ impl Variable {
             "line_ending" => Some(Self::LineEnding),
             "language" => Some(Self::Language),
             "selection" => Some(Self::Selection),
+            "selection_line_start" => Some(Self::SelectionLineStart),
+            "selection_line_end" => Some(Self::SelectionLineEnd),
             _ => None,
         }
     }
@@ -232,5 +242,13 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
         Variable::Selection => Ok(Cow::Owned(
             doc.selection(view.id).primary().fragment(text).to_string(),
         )),
+        Variable::SelectionLineStart => {
+            let start_line = doc.selection(view.id).primary().line_range(text).0;
+            Ok(Cow::Owned((start_line + 1).to_string()))
+        }
+        Variable::SelectionLineEnd => {
+            let end_line = doc.selection(view.id).primary().line_range(text).1;
+            Ok(Cow::Owned((end_line + 1).to_string()))
+        }
     }
 }


### PR DESCRIPTION
When calling commands with `:sh` and friends, it wasn't previously possible to access the start and end line numbers for the primary selection. Expand `selection_line_start` and `selection_line_end` at the command line.

Replaces #13839