### PR TITLE
languages: detect `~/.gem/credentials` as yaml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1424,6 +1424,7 @@ file-types = [
   { glob = ".clangd" },
   { glob = ".clang-format" },
   { glob = ".clang-tidy" },
+  { glob = ".gem/credentials" },
   "sublime-syntax"
 ]
 comment-token = "#"


### PR DESCRIPTION
This file stores client credentials for [RubyGems.org](https://rubygems.org/), the package management framework for Ruby.
I have not found any official docs describing the format, but going through the [code](https://github.com/rubygems/rubygems/blob/89f7f5f760fa24dda7f21fee7c93f0a69780cd21/lib/rubygems/config_file.rb#L365-L385) one can see that it is expected to be parsed as yaml.