### PR TITLE
queries: inject all lines in a newline escaped RUN instruction as bash

### DIFF
--- a/runtime/queries/dockerfile/injections.scm
+++ b/runtime/queries/dockerfile/injections.scm
@@ -1,6 +1,7 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
-([(shell_command) (shell_fragment)] @injection.content
- (#set! injection.language "bash"))
+((shell_command (shell_fragment) @injection.content)
+ (#set! injection.language "bash")
+ (#set! injection.combined))
 


### PR DESCRIPTION
The previous query would only inject the last line.

**Before**

![image](https://github.com/user-attachments/assets/04fb61dc-017c-41e4-a4bc-c56d79642bdd)


**After**

![image](https://github.com/user-attachments/assets/ab803ba6-a8e7-4a21-9abb-0c413fa1883c)
