### PR TITLE
feat: `--execute` flag which runs the passed keymap before launch

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -21,7 +21,7 @@ _hx() {
 
     case "$2" in
     -*)
-        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -x --execute -c --config --log" -- """$2""")
+        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -e --execute -c --config --log" -- """$2""")
         return 0
         ;;
     *)

--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -21,7 +21,7 @@ _hx() {
 
     case "$2" in
     -*)
-        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")
+        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -x --execute -c --config --log" -- """$2""")
         return 0
         ;;
     *)

--- a/contrib/completion/hx.elv
+++ b/contrib/completion/hx.elv
@@ -50,6 +50,8 @@ set edit:completion:arg-completer[hx] = {|@args|
   $candidate "--grammar" "(Fetch or build the tree-sitter grammars)"
   $candidate "--vsplit" "(Splits all given files vertically)"
   $candidate "--hsplit" "(Splits all given files horizontally)"
+  $candidate "-x" "(Executes the given command on startup)"
+  $candidate "--execute" "(Executes the given command on startup)"
   $candidate "--config" "(Specifies a file to use for configuration)"
   $candidate "--log" "(Specifies a file to write log data into)"
 }

--- a/contrib/completion/hx.elv
+++ b/contrib/completion/hx.elv
@@ -50,7 +50,7 @@ set edit:completion:arg-completer[hx] = {|@args|
   $candidate "--grammar" "(Fetch or build the tree-sitter grammars)"
   $candidate "--vsplit" "(Splits all given files vertically)"
   $candidate "--hsplit" "(Splits all given files horizontally)"
-  $candidate "-x" "(Executes the given command on startup)"
+  $candidate "-e" "(Executes the given command on startup)"
   $candidate "--execute" "(Executes the given command on startup)"
   $candidate "--config" "(Specifies a file to use for configuration)"
   $candidate "--log" "(Specifies a file to write log data into)"

--- a/contrib/completion/hx.fish
+++ b/contrib/completion/hx.fish
@@ -12,6 +12,7 @@ complete -c hx -l hsplit -d "Splits all given files horizontally"
 complete -c hx -s c -l config -r -d "Specifies a file to use for config"
 complete -c hx -l log -r -d "Specifies a file to use for logging"
 complete -c hx -s w -l working-dir -d "Specify initial working directory" -xa "(__fish_complete_directories)"
+complete -c hx -s e -l execute -d "Executes the given command on startup"
 
 function __hx_langs_ops
     hx --health languages | tail -n '+2' | string replace -fr '^(\S+) .*' '$1'

--- a/contrib/completion/hx.nu
+++ b/contrib/completion/hx.nu
@@ -24,7 +24,7 @@ export extern hx [
     --version(-V),                              # Prints version information
     --vsplit,                                   # Splits all given files vertically into different windows
     --hsplit,                                   # Splits all given files horizontally into different windows
-    --execute(-x),                              # Executes the given command on startup
+    --execute(-e),                              # Executes the given command on startup
     --working-dir(-w): glob,                    # Specify an initial working directory
     ...files: glob,                             # Sets the input file to use, position can also be specified via file[:row[:col]]
 ]

--- a/contrib/completion/hx.nu
+++ b/contrib/completion/hx.nu
@@ -24,6 +24,7 @@ export extern hx [
     --version(-V),                              # Prints version information
     --vsplit,                                   # Splits all given files vertically into different windows
     --hsplit,                                   # Splits all given files horizontally into different windows
+    --execute(-x),                              # Executes the given command on startup
     --working-dir(-w): glob,                    # Specify an initial working directory
     ...files: glob,                             # Sets the input file to use, position can also be specified via file[:row[:col]]
 ]

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -18,6 +18,8 @@ _hx() {
 		"--hsplit[Splits all given files horizontally]" \
 		"-c[Specifies a file to use for configuration]" \
 		"--config[Specifies a file to use for configuration]" \
+		"-x[Executes the given command on startup]" \
+		"--execute[Executes the given command on startup]" \
 		"-w[Specify initial working directory]" \
 		"--working-dir[Specify initial working directory]" \
 		"--log[Specifies a file to use for logging]" \

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -18,7 +18,7 @@ _hx() {
 		"--hsplit[Splits all given files horizontally]" \
 		"-c[Specifies a file to use for configuration]" \
 		"--config[Specifies a file to use for configuration]" \
-		"-x[Executes the given command on startup]" \
+		"-e[Executes the given command on startup]" \
 		"--execute[Executes the given command on startup]" \
 		"-w[Specify initial working directory]" \
 		"--working-dir[Specify initial working directory]" \

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -76,13 +76,10 @@ impl Args {
                     Some(path) => args.log_file = Some(path.into()),
                     None => anyhow::bail!("--log must specify a path to write"),
                 },
-                "-e" | "--execute" => {
-                    if let Some(command) = argv.next().as_deref() {
-                        args.execute = helix_view::input::parse_macro(command)?;
-                    } else {
-                        anyhow::bail!("--execute receives a command to execute")
-                    }
-                }
+                "-e" | "--execute" => match argv.next().as_deref() {
+                    Some(command) => args.execute = helix_view::input::parse_macro(command)?,
+                    None => anyhow::bail!("--execute receives a command to execute"),
+                },
                 "-w" | "--working-dir" => match argv.next().as_deref() {
                     Some(path) => {
                         args.working_directory = if Path::new(path).is_dir() {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -76,7 +76,7 @@ impl Args {
                     Some(path) => args.log_file = Some(path.into()),
                     None => anyhow::bail!("--log must specify a path to write"),
                 },
-                "-x" | "--execute" => {
+                "-e" | "--execute" => {
                     if let Some(command) = argv.next().as_deref() {
                         args.execute = helix_view::input::parse_macro(command)?;
                     } else {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -19,6 +19,8 @@ pub struct Args {
     pub config_file: Option<PathBuf>,
     pub files: IndexMap<PathBuf, Vec<Position>>,
     pub working_directory: Option<PathBuf>,
+    /// The macro to execute on startup
+    pub execute: Vec<helix_view::input::KeyEvent>,
 }
 
 impl Args {
@@ -74,6 +76,13 @@ impl Args {
                     Some(path) => args.log_file = Some(path.into()),
                     None => anyhow::bail!("--log must specify a path to write"),
                 },
+                "-x" | "--execute" => {
+                    if let Some(command) = argv.next().as_deref() {
+                        args.execute = helix_view::input::parse_macro(command)?;
+                    } else {
+                        anyhow::bail!("--execute receives a command to execute")
+                    }
+                }
                 "-w" | "--working-dir" => match argv.next().as_deref() {
                     Some(path) => {
                         args.working_directory = if Path::new(path).is_dir() {

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -76,7 +76,7 @@ FLAGS:
     --hsplit                       Splits all given files horizontally into different windows
     -w, --working-dir <path>       Specify an initial working directory
     +N                             Open the first given file at line number N
-    -x, --execute <command>        Executes the given command on startup
+    -e, --execute <command>        Executes the given command on startup
 ",
             env!("CARGO_PKG_NAME"),
             VERSION_AND_GIT_HASH,


### PR DESCRIPTION
Adds a new flag `-e`/`--execute` which gets passed a command to execute before launching helix.

**Why**: Currently, when passing a directory to Helix like `hx ..` it will open a file finder `<space>f`.

What if instead of that, you want to open it with a file explorer `<space>e`? This PR allows you to do this by using `hx .. --execute "<esc><space>e"` which will open the file explorer instead

It allows for more versatility as well: you'll be able to start helix with whatever sequence of commands you want