### PR TITLE
contrib(completions/nushell): switch from deprecated `filter` to `where`

### DIFF
--- a/contrib/completion/hx.nu
+++ b/contrib/completion/hx.nu
@@ -5,7 +5,7 @@
 #       The help message won't be overridden though, so it will still be present here
 
 def health_categories [] {
-    let languages = ^hx --health languages | detect columns | get Language | filter { $in != null }
+    let languages = ^hx --health languages | detect columns | get Language | where { $in != null }
     let completions = [ "all", "clipboard", "languages" ] | append $languages
     return $completions
 }


### PR DESCRIPTION
Relevant release notes: https://www.nushell.sh/blog/2025-06-10-nushell_0_105_0.html#one-where-to-rule-them-all-toc

We may want to wait a little before merging to ensure people have time to update, but I don't think it's a big deal if we merge now either.