### PR TITLE
recognize `mimeapps.list` as INI

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2963,6 +2963,7 @@ file-types = [
   "service",
   "automount",
   "desktop",
+  { glob = "mimeapps.list" },
   "device",
   "mount",
   "nspawn",


### PR DESCRIPTION
On Free-Desktop/XDG compliant systems, the file-path `~/.config/mimeapps.list` is used to set default handler apps and associations (`xdg-mime`). In addition to the user-specific one, there's also a system-wide equivalent, but I couldn't find info about its standard path