### PR TITLE
queries: inject nix into `lib.literalExression` string contents

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -256,3 +256,17 @@
 
 ((indented_string_expression (string_fragment) @injection.shebang @injection.content)
   (#set! injection.combined))
+
+; string contents of lib.literalExpression is nix code
+((apply_expression
+    function: [
+      (select_expression) ; `lib.literalExpression`
+      (variable_expression) ; `literalExpression` this is the case when the symbol is brougth into scope e.g. `let inherit (lib) literalExpression; in`
+    ] @_func
+    argument: [
+      (indented_string_expression (string_fragment) @injection.content)  ; lib.literalExpression ''...''
+      (string_expression (string_fragment) @injection.content) ; lib.literalExpression "..."
+    ])
+  (#any-of? @_func "lib.literalExpression" "literalExpression")
+  (#set! injection.language "nix")
+  (#set! injection.combined))


### PR DESCRIPTION
I was looking through some nix code in [home-manager](https://github.com/nix-community/home-manager) and thought that the examples set with `lib.literalExpression ''...''` were hard to parse without it being highlighted as nix code. This PR adds an injection query to set the string argument for `lib.literalExpression` to be nix code.

IMO it makes it easier to tell the structure of the examples, but at the same time it makes it harder to quickly tell if these expressions are evaluated as code, or just as a string. 🤷

If there is no support for this, then maybe it can serve as an example in the docs for how to write a somewhat complex tree-sitter query.

**Before**

![image](https://github.com/user-attachments/assets/5d240692-c938-4f59-86cc-95550f2ff07a)

![image](https://github.com/user-attachments/assets/4974bbc3-c8a4-4edc-85ea-6a5a8c426ceb)

**After**

![image](https://github.com/user-attachments/assets/eab4ca3a-059d-40b6-b95e-b5be1fecd745)

![image](https://github.com/user-attachments/assets/4933f71a-dcdf-48bb-8c93-a2baa4fd8cad)
