### PR TITLE
queries/dockerfile: injections for heredocs

### DIFF
--- a/runtime/queries/dockerfile/injections.scm
+++ b/runtime/queries/dockerfile/injections.scm
@@ -5,3 +5,12 @@
  (#set! injection.language "bash")
  (#set! injection.combined))
 
+((run_instruction
+ (heredoc_block (heredoc_line) @injection.content . "\n" @injection.content))
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+((copy_instruction
+ (path (heredoc_marker)) . (path) @injection.filename
+ (heredoc_block (heredoc_line) @injection.content . "\n" @injection.content))
+ (#set! injection.combined))


### PR DESCRIPTION
Inspired by https://github.com/helix-editor/helix/pull/13845, we can also add injections for heredocs to Dockerfiles.

`RUN` with heredoc:

![image](https://github.com/user-attachments/assets/846d443f-0af5-4cfb-b253-3537bc116a9f)

`COPY` with heredoc (language detected by file extension):

![image](https://github.com/user-attachments/assets/de7d4cfc-fde4-4bc0-8376-8c8d85206bff)
