### PR TITLE
languages: add Caddyfile support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -18,6 +18,7 @@
 | c | ✓ | ✓ | ✓ | `clangd` |
 | c-sharp | ✓ | ✓ |  | `OmniSharp` |
 | cabal |  |  |  | `haskell-language-server-wrapper` |
+| caddyfile | ✓ | ✓ | ✓ |  |
 | cairo | ✓ | ✓ | ✓ | `cairo-language-server` |
 | capnp | ✓ |  | ✓ |  |
 | cel | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4436,3 +4436,17 @@ language-servers = [ "luau" ]
 [[grammar]]
 name = "luau"
 source = { git = "https://github.com/polychromatist/tree-sitter-luau", rev = "ec187cafba510cddac265329ca7831ec6f3b9955" }
+
+[[language]]
+name = "caddyfile"
+scope = "source.caddyfile"
+injection-regex = "caddyfile"
+file-types = [{ glob = "Caddyfile" }]
+comment-tokens = ["#"]
+indent = { tab-width = 4, unit = "    " }
+formatter = { command = "caddy", args = ["fmt", "-"] }
+auto-format = true
+
+[[grammar]]
+name = "caddyfile"
+source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "b04bdb4ec53e40c44afbf001e15540f60a296aef" }

--- a/runtime/queries/caddyfile/highlights.scm
+++ b/runtime/queries/caddyfile/highlights.scm
@@ -1,0 +1,72 @@
+(comment) @comment
+[
+  (environment_variable)
+  (placeholder)
+] @constant
+
+[
+  (network_address)
+  (ip_address_or_cidr)
+] @string.special.url
+
+(path) @string.special.path
+
+[
+  (snippet_name)
+  (named_route_identifier)
+  (site_address)
+] @keyword
+
+(directive (directive_name) @variable.other.member)
+
+; declaration of a named matcher
+(named_matcher (matcher_identifier (matcher_name)) @function.macro)
+
+; reference to a named matcher
+(matcher (matcher_identifier (matcher_name)) @function.macro)
+
+; directive within a named matcher declaration
+(matcher_directive (matcher_directive_name) @function.method)
+
+; any other matcher (wildcard and path)
+(matcher) @function.macro
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (heredoc)
+  (cel_expression)
+] @string
+(escape_sequence) @escape
+
+[
+  (duration_literal)
+  (int_literal)
+] @number
+
+[
+  "{"
+  "}"
+] @punctuation.bracket
+
+(global_options
+  (directive) @keyword.directive)
+
+(directive
+  name: (directive_name)
+  (argument) @type)
+
+; matches directive arguments that looks like an absolute path
+; e.g.
+; log {
+;     output file /var/log/caddy.log
+; }
+(directive
+  (argument) @_file @string.path
+  (#match? @_file "^/"))
+
+((argument) @_arg @constant.builtin.boolean
+  (#any-of? @_arg "on" "off"))
+
+((argument) @_arg @type.enum.variant
+  (#any-of? @_arg "tcp" "udp" "ipv4" "ipv6"))

--- a/runtime/queries/caddyfile/highlights.scm
+++ b/runtime/queries/caddyfile/highlights.scm
@@ -37,12 +37,12 @@
   (heredoc)
   (cel_expression)
 ] @string
-(escape_sequence) @escape
+(escape_sequence) @constant.character.escape
 
 [
   (duration_literal)
   (int_literal)
-] @number
+] @constant.numeric
 
 [
   "{"
@@ -62,11 +62,11 @@
 ;     output file /var/log/caddy.log
 ; }
 (directive
-  (argument) @_file @string.path
-  (#match? @_file "^/"))
+  (argument) @string.special.path
+  (#match? @string.special.path "^/"))
 
-((argument) @_arg @constant.builtin.boolean
-  (#any-of? @_arg "on" "off"))
+((argument) @constant.builtin.boolean
+  (#any-of? @constant.builtin.boolean "on" "off"))
 
-((argument) @_arg @type.enum.variant
-  (#any-of? @_arg "tcp" "udp" "ipv4" "ipv6"))
+((argument) @type.enum.variant
+  (#any-of? @type.enum.variant "tcp" "udp" "ipv4" "ipv6"))

--- a/runtime/queries/caddyfile/indents.scm
+++ b/runtime/queries/caddyfile/indents.scm
@@ -1,0 +1,8 @@
+[
+  (block)
+  (matcher_block)
+] @indent
+
+((global_options) @indent)
+
+"}" @outdent

--- a/runtime/queries/caddyfile/injections.scm
+++ b/runtime/queries/caddyfile/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/caddyfile/locals.scm
+++ b/runtime/queries/caddyfile/locals.scm
@@ -1,5 +1,5 @@
 (block) @local.scope
 
-(named_matcher (matcher_identifier (matcher_name)) @local.definition)
+(named_matcher (matcher_identifier (matcher_name)) @local.definition.function.macro)
 
 (matcher) @local.reference

--- a/runtime/queries/caddyfile/locals.scm
+++ b/runtime/queries/caddyfile/locals.scm
@@ -1,0 +1,5 @@
+(block) @local.scope
+
+(named_matcher (matcher_identifier (matcher_name)) @local.definition)
+
+(matcher) @local.reference

--- a/runtime/queries/caddyfile/textobjects.scm
+++ b/runtime/queries/caddyfile/textobjects.scm
@@ -1,0 +1,16 @@
+(comment) @comment.inside
+(comment)+ @comment.around
+
+(directive
+  name: (directive_name) @parameter.inside) @parameter.around
+
+(global_options
+  "{" (_)* @class.inside "}") @class.around
+
+(snippet_definition
+  (block) @class.inside) @class.around
+
+(named_route
+  (block) @class.inside) @class.around
+
+(site_definition (block) @class.inside) @class.around


### PR DESCRIPTION
Add support for the Caddy configuration format aka. [Caddyfile](https://caddyserver.com/docs/caddyfile). It uses the official tree-sitter parser from the Caddy project. It does not fully parse the entire grammar properly yet, e.g. it does not handle multiple addresses for a site block. 

```Caddyfile
# Comma and new-line separated site addresses
localhost:8080,
example.com,
www.example.com {
	...
}
```

But, it is still very usable today. Fixes #12668


**Highlighting Preview**

![image](https://github.com/user-attachments/assets/a0947759-3a24-4884-a852-fae640554ae8)
