### PR TITLE
fix: empty editor.jump-label-alphabet doesn't lead to a crash anymore

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6728,6 +6728,10 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
     // Calculate the jump candidates: ranges for any visible words with two or
     // more characters.
     let alphabet = &cx.editor.config().jump_label_alphabet;
+    if alphabet.is_empty() {
+        return;
+    }
+
     let jump_label_limit = alphabet.len() * alphabet.len();
     let mut words = Vec::with_capacity(jump_label_limit);
     let (view, doc) = current_ref!(cx.editor);


### PR DESCRIPTION
Ensures that Helix doesn't crash if jump-label-alphabet is empty. If it is, jump_to_label() returns early instead of trying to find the correct character by erroneously dividing by zero (the length of the alphabet).

Closes https://github.com/helix-editor/helix/issues/13175