### PR TITLE
Set position to EOF when no line number is specified after + argument

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -103,9 +103,9 @@ impl Args {
                     }
                 }
                 arg if arg.starts_with('+') => {
-                    match arg[1..].parse::<usize>() {
-                        Ok(n) => line_number = n.saturating_sub(1),
-                        _ => insert_file_with_position(arg),
+                    line_number = match arg[1..].parse::<usize>() {
+                        Ok(n) => n.saturating_sub(1),
+                        _ => usize::MAX,
                     };
                 }
                 arg => insert_file_with_position(arg),


### PR DESCRIPTION
Resolves #13705

I didn't want to try counting the lines in the file (it seemed like an expensive operation to do while parsing arguments), so I just set the line number to `usize::MAX` when no number follows the `+` argument. The line number is reduced to the real last line number in `helix-core/src/position.rs`.

P.S: This is my first open source contribution, so any comments about my code are more than welcome :)
