### PR TITLE
feat: number of copied selections in statusline

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -160,6 +160,7 @@ The following statusline elements can be configured:
 | `version-control` | The current branch name or detached commit hash of the opened workspace |
 | `register` | The current selected register |
 | `code-action-hint` | Indicator for when code actions are available |
+| `yanked-selections` | The number of selections yanked in the selected register (displayed only if > 1) |
 
 ### `[editor.lsp]` Section
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -155,6 +155,7 @@ where
         helix_view::editor::StatusLineElement::Separator => render_separator,
         helix_view::editor::StatusLineElement::Spacer => render_spacer,
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
+        helix_view::editor::StatusLineElement::YankedSelections => render_yanked_selections,
         helix_view::editor::StatusLineElement::Register => render_register,
         helix_view::editor::StatusLineElement::CurrentWorkingDirectory => render_cwd,
         helix_view::editor::StatusLineElement::CodeActionHint => render_code_action_hint,
@@ -544,6 +545,25 @@ where
         .to_string();
 
     write(context, head.into());
+}
+
+fn render_yanked_selections<'a, F>(context: &mut RenderContext<'a>, write: F)
+where
+    F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
+{
+    let nb_values = context
+        .editor
+        .registers
+        .read(
+            context.editor.selected_register.unwrap_or('"'),
+            context.editor,
+        )
+        .map(|values| values.count())
+        .take_if(|count| *count > 1);
+
+    if let Some(nb) = nb_values {
+        write(context, format!(" {} sels yanked ", nb).into())
+    }
 }
 
 fn render_register<'a, F>(context: &mut RenderContext<'a>, write: F)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -796,6 +796,9 @@ pub enum StatusLineElement {
     /// Current version control information
     VersionControl,
 
+    /// Indicator for number of selections yanked in selected register
+    YankedSelections,
+
     /// Indicator for selected register
     Register,
 


### PR DESCRIPTION
Add to statusline an indication of the number of entries in the selected register, or in the default one if none is selected. This number is displayed only if it is greater than 1.

This implements the idea in #13788.

Maybe displayed format needs more discussion ? I just added the number, between parenthesis, at the end of the existing register element. It think this is quite clear when a specific register is selected, and its name displayed, but for the default register there is just a number in parenthesis…