### PR TITLE
Docs: escape `|` in typeable command names

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -78,7 +78,7 @@
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output before each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |
-| `:pipe`, `:|` | Pipe each selection to the shell command. |
+| `:pipe`, `:\|` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh`, `:!` | Run a shell command |
 | `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |

--- a/xtask/src/docgen.rs
+++ b/xtask/src/docgen.rs
@@ -36,7 +36,8 @@ pub fn typable_commands() -> Result<String, DynError> {
         "Description".to_owned(),
     ]));
 
-    let cmdify = |s: &str| format!("`:{}`", s);
+    // escape | so it doesn't get rendered as a column separator
+    let cmdify = |s: &str| format!("`:{}`", s.replace('|', "\\|"));
 
     for cmd in TYPABLE_COMMAND_LIST {
         let names = std::iter::once(&cmd.name)


### PR DESCRIPTION
The same is already being done for static commands.

### Before

<img width="340" alt="Screenshot 2025-06-30 at 9 45 50 AM" src="https://github.com/user-attachments/assets/214f4e4e-9068-4920-a56e-58b5d199aa9a" />

### After

<img width="575" alt="Screenshot 2025-06-30 at 9 48 45 AM" src="https://github.com/user-attachments/assets/989c559f-540f-45aa-a5e1-ac3b4a249ff2" />
