### PR TITLE
[WIP] View based refactoring in workspace v2

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -52,6 +52,7 @@ use helix_view::{
     view::View,
     Document, DocumentId, Editor, ViewId,
 };
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use anyhow::{anyhow, bail, ensure, Context as _};
 use insert::*;
@@ -378,7 +379,6 @@ impl MappableCommand {
         search_selection_detect_word_boundaries, "Use current selection as the search pattern, automatically wrapping with `\\b` on word boundaries",
         make_search_word_bounded, "Modify current search to make it word bounded",
         global_search, "Global search in workspace folder",
-        global_refactor, "Global refactoring in workspace folder",
         extend_line, "Select current line, if already selected, extend to another line based on the anchor",
         extend_line_below, "Select current line, if already selected, extend to next line",
         extend_line_above, "Select current line, if already selected, extend to previous line",
@@ -2663,280 +2663,296 @@ fn global_search(cx: &mut Context) {
     .with_preview(|_editor, FileResult { path, line_num, .. }| {
         Some((path.as_path().into(), Some((*line_num, *line_num))))
     })
+    .with_quickfix(move |cx, results: Vec<&FileResult>| {
+        let quickfix_line = results
+            .iter()
+            .map(|FileResult { path, line_num, .. }| format!("{}:{}", path.display(), line_num))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        log::info!("Quickfix entries: {}", quickfix_line);
+        cx.editor
+            .set_status(format!("Quickfix entries: {}", quickfix_line));
+        // cx.editor
+        //     .set_error(format!("Quickfix entries: {}", quickfix_line));
+    })
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
 
     cx.push_layer(Box::new(overlaid(picker)));
 }
 
-fn global_refactor(cx: &mut Context) {
-    let document_type = doc!(cx.editor).document_type.clone();
+// TODO make this worky again
+// fn global_refactor(cx: &mut Context) {
+//     let document_type = doc!(cx.editor).document_type.clone();
 
-    match &document_type {
-        helix_view::document::DocumentType::File => {
-            let (all_matches_sx, all_matches_rx) =
-                tokio::sync::mpsc::unbounded_channel::<(PathBuf, usize, String)>();
-            let config = cx.editor.config();
-            let smart_case = config.search.smart_case;
-            let file_picker_config = config.file_picker.clone();
+//     match &document_type {
+//         helix_view::document::DocumentType::File => {
+//             let (all_matches_sx, all_matches_rx) =
+//                 tokio::sync::mpsc::unbounded_channel::<(PathBuf, usize, String)>();
+//             let config = cx.editor.config();
+//             let smart_case = config.search.smart_case;
+//             let file_picker_config = config.file_picker.clone();
 
-            let reg = cx.register.unwrap_or('/');
+//             let reg = cx.register.unwrap_or('/');
 
-            // Restrict to current file type if possible
-            let file_extension = doc!(cx.editor).path().and_then(|f| f.extension());
-            let file_glob = if let Some(file_glob) = file_extension.and_then(|f| f.to_str()) {
-                let mut tb = ignore::types::TypesBuilder::new();
-                tb.add("p", &(String::from("*.") + file_glob))
-                    .ok()
-                    .and_then(|_| {
-                        tb.select("all");
-                        tb.build().ok()
-                    })
-            } else {
-                None
-            };
+//             // Restrict to current file type if possible
+//             let file_extension = doc!(cx.editor).path().and_then(|f| f.extension());
+//             let file_glob = if let Some(file_glob) = file_extension.and_then(|f| f.to_str()) {
+//                 let mut tb = ignore::types::TypesBuilder::new();
+//                 tb.add("p", &(String::from("*.") + file_glob))
+//                     .ok()
+//                     .and_then(|_| {
+//                         tb.select("all");
+//                         tb.build().ok()
+//                     })
+//             } else {
+//                 None
+//             };
 
-            let encoding = Some(doc!(cx.editor).encoding());
+//             let encoding = Some(doc!(cx.editor).encoding());
 
-            let completions = search_completions(cx, Some(reg));
-            ui::regex_prompt(
-                cx,
-                "global-refactor:".into(),
-                Some(reg),
-                move |_editor: &Editor, input: &str| {
-                    completions
-                        .iter()
-                        .filter(|comp| comp.starts_with(input))
-                        .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone())))
-                        .collect()
-                },
-                move |editor, regex, event| {
-                    if event != PromptEvent::Validate {
-                        return;
-                    }
+//             let completions = search_completions(cx, Some(reg));
+//             ui::regex_prompt(
+//                 cx,
+//                 "global-refactor:".into(),
+//                 Some(reg),
+//                 move |_editor: &Editor, input: &str| {
+//                     completions
+//                         .iter()
+//                         .filter(|comp| comp.starts_with(input))
+//                         .map(|comp| (0.., comp.clone().into()))
+//                         .collect()
+//                 },
+//                 move |editor, regex, event| {
+//                     if event != PromptEvent::Validate {
+//                         return;
+//                     }
 
-                    if let Ok(matcher) = RegexMatcherBuilder::new()
-                        .case_smart(smart_case)
-                        .build(regex.as_str())
-                    {
-                        let searcher = SearcherBuilder::new()
-                            .binary_detection(BinaryDetection::quit(b'\x00'))
-                            .build();
+//                     if let Ok(matcher) = RegexMatcherBuilder::new()
+//                         .case_smart(smart_case)
+//                         .build(regex.into())
+//                     {
+//                         let searcher = SearcherBuilder::new()
+//                             .binary_detection(BinaryDetection::quit(b'\x00'))
+//                             .build(query);
 
-                        let mut checked = HashSet::<PathBuf>::new();
-                        let file_extension = editor.documents
-                            [&editor.tree.get(editor.tree.focus).doc]
-                            .path()
-                            .and_then(|f| f.extension());
-                        for doc in editor.documents() {
-                            searcher
-                                .clone()
-                                .search_slice(
-                                    matcher.clone(),
-                                    doc.text().to_string().as_bytes(),
-                                    sinks::UTF8(|line_num, matched| {
-                                        if let Some(path) = doc.path() {
-                                            if let Some(extension) = path.extension() {
-                                                if let Some(file_extension) = file_extension {
-                                                    if file_extension == extension {
-                                                        all_matches_sx
-                                                            .send((
-                                                                path.clone(),
-                                                                line_num as usize - 1,
-                                                                String::from(
-                                                                    matched
-                                                                        .strip_suffix("\r\n")
-                                                                        .or_else(|| {
-                                                                            matched
-                                                                                .strip_suffix('\n')
-                                                                        })
-                                                                        .unwrap_or(matched),
-                                                                ),
-                                                            ))
-                                                            .unwrap();
-                                                    }
-                                                }
-                                            }
-                                            // Exclude from file search
-                                            checked.insert(path.clone());
-                                        }
-                                        Ok(true)
-                                    }),
-                                )
-                                .ok();
-                        }
+//                         let mut checked = HashSet::<PathBuf>::new();
+//                         let file_extension = editor.documents
+//                             [&editor.tree.get(editor.tree.focus).doc]
+//                             .path()
+//                             .and_then(|f| f.extension());
+//                         for doc in editor.documents() {
+//                             searcher
+//                                 .clone()
+//                                 .search_slice(
+//                                     matcher.clone(),
+//                                     doc.text().to_string().as_bytes(),
+//                                     sinks::UTF8(|line_num, matched| {
+//                                         if let Some(path) = doc.path() {
+//                                             if let Some(extension) = path.extension() {
+//                                                 if let Some(file_extension) = file_extension {
+//                                                     if file_extension == extension {
+//                                                         all_matches_sx
+//                                                             .send((
+//                                                                 path.clone(),
+//                                                                 line_num as usize - 1,
+//                                                                 String::from(
+//                                                                     matched
+//                                                                         .strip_suffix("\r\n")
+//                                                                         .or_else(|| {
+//                                                                             matched
+//                                                                                 .strip_suffix('\n')
+//                                                                         })
+//                                                                         .unwrap_or(matched),
+//                                                                 ),
+//                                                             ))
+//                                                             .unwrap();
+//                                                     }
+//                                                 }
+//                                             }
+//                                             // Exclude from file search
+//                                             checked.insert(path.clone());
+//                                         }
+//                                         Ok(true)
+//                                     }),
+//                                 )
+//                                 .ok();
+//                         }
 
-                        let search_root = std::env::current_dir()
-                            .expect("Global search error: Failed to get current dir");
-                        let mut wb = WalkBuilder::new(search_root);
-                        wb.hidden(file_picker_config.hidden)
-                            .parents(file_picker_config.parents)
-                            .ignore(file_picker_config.ignore)
-                            .git_ignore(file_picker_config.git_ignore)
-                            .git_global(file_picker_config.git_global)
-                            .git_exclude(file_picker_config.git_exclude)
-                            .max_depth(file_picker_config.max_depth);
-                        if let Some(file_glob) = &file_glob {
-                            wb.types(file_glob.clone());
-                        }
-                        wb.build_parallel().run(|| {
-                            let mut searcher = searcher.clone();
-                            let matcher = matcher.clone();
-                            let all_matches_sx = all_matches_sx.clone();
-                            let checked = checked.clone();
-                            Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
-                                let entry = match entry {
-                                    Ok(entry) => entry,
-                                    Err(_) => return WalkState::Continue,
-                                };
+//                         let search_root = std::env::current_dir()
+//                             .expect("Global search error: Failed to get current dir");
+//                         let mut wb = WalkBuilder::new(search_root);
+//                         wb.hidden(file_picker_config.hidden)
+//                             .parents(file_picker_config.parents)
+//                             .ignore(file_picker_config.ignore)
+//                             .git_ignore(file_picker_config.git_ignore)
+//                             .git_global(file_picker_config.git_global)
+//                             .git_exclude(file_picker_config.git_exclude)
+//                             .max_depth(file_picker_config.max_depth);
+//                         if let Some(file_glob) = &file_glob {
+//                             wb.types(file_glob.clone());
+//                         }
+//                         wb.build_parallel().run(|| {
+//                             let mut searcher = searcher.clone();
+//                             let matcher = matcher.clone();
+//                             let all_matches_sx = all_matches_sx.clone();
+//                             let checked = checked.clone();
+//                             Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
+//                                 let entry = match entry {
+//                                     Ok(entry) => entry,
+//                                     Err(_) => return WalkState::Continue,
+//                                 };
 
-                                match entry.file_type() {
-                                    Some(entry) if entry.is_file() => {}
-                                    // skip everything else
-                                    _ => return WalkState::Continue,
-                                };
+//                                 match entry.file_type() {
+//                                     Some(entry) if entry.is_file() => {}
+//                                     // skip everything else
+//                                     _ => return WalkState::Continue,
+//                                 };
 
-                                let result = searcher.search_path(
-                                    &matcher,
-                                    entry.path(),
-                                    sinks::UTF8(|line_num, matched| {
-                                        let path = entry.clone().into_path();
-                                        if !checked.contains(&path) {
-                                            all_matches_sx
-                                                .send((
-                                                    path,
-                                                    line_num as usize - 1,
-                                                    String::from(
-                                                        matched
-                                                            .strip_suffix("\r\n")
-                                                            .or_else(|| matched.strip_suffix('\n'))
-                                                            .unwrap_or(matched),
-                                                    ),
-                                                ))
-                                                .unwrap();
-                                        }
-                                        Ok(true)
-                                    }),
-                                );
+//                                 let result = searcher.search_path(
+//                                     &matcher,
+//                                     entry.path(),
+//                                     sinks::UTF8(|line_num, matched| {
+//                                         let path = entry.clone().into_path();
+//                                         if !checked.contains(&path) {
+//                                             all_matches_sx
+//                                                 .send((
+//                                                     path,
+//                                                     line_num as usize - 1,
+//                                                     String::from(
+//                                                         matched
+//                                                             .strip_suffix("\r\n")
+//                                                             .or_else(|| matched.strip_suffix('\n'))
+//                                                             .unwrap_or(matched),
+//                                                     ),
+//                                                 ))
+//                                                 .unwrap();
+//                                         }
+//                                         Ok(true)
+//                                     }),
+//                                 );
 
-                                if let Err(err) = result {
-                                    log::error!(
-                                        "Global search error: {}, {}",
-                                        entry.path().display(),
-                                        err
-                                    );
-                                }
-                                WalkState::Continue
-                            })
-                        });
-                    }
-                },
-            );
+//                                 if let Err(err) = result {
+//                                     log::error!(
+//                                         "Global search error: {}, {}",
+//                                         entry.path().display(),
+//                                         err
+//                                     );
+//                                 }
+//                                 WalkState::Continue
+//                             })
+//                         });
+//                     }
+//                 },
+//             );
 
-            let show_refactor = async move {
-                let all_matches: Vec<(PathBuf, usize, String)> =
-                    UnboundedReceiverStream::new(all_matches_rx).collect().await;
-                let call: job::Callback = Callback::Editor(Box::new(move |editor: &mut Editor| {
-                    if all_matches.is_empty() {
-                        editor.set_status("No matches found");
-                        return;
-                    }
-                    let mut matches: HashMap<PathBuf, Vec<(usize, String)>> = HashMap::new();
-                    for (path, line, text) in all_matches {
-                        if let Some(vec) = matches.get_mut(&path) {
-                            vec.push((line, text));
-                        } else {
-                            let v = Vec::from([(line, text)]);
-                            matches.insert(path, v);
-                        }
-                    }
+//             let show_refactor = async move {
+//                 let all_matches: Vec<(PathBuf, usize, String)> =
+//                     UnboundedReceiverStream::new(all_matches_rx).collect().await;
+//                 let call: job::Callback = Callback::Editor(Box::new(move |editor: &mut Editor| {
+//                     if all_matches.is_empty() {
+//                         editor.set_status("No matches found");
+//                         return;
+//                     }
+//                     let mut matches: HashMap<PathBuf, Vec<(usize, String)>> = HashMap::new();
+//                     for (path, line, text) in all_matches {
+//                         if let Some(vec) = matches.get_mut(&path) {
+//                             vec.push((line, text));
+//                         } else {
+//                             let v = Vec::from([(line, text)]);
+//                             matches.insert(path, v);
+//                         }
+//                     }
 
-                    let language_id = doc!(editor).language_id().map(String::from);
+//                     let language_id = doc!(editor).language_id().map(String::from);
 
-                    let mut doc_text = Rope::new();
-                    let mut line_map = HashMap::new();
+//                     let mut doc_text = Rope::new();
+//                     let mut line_map = HashMap::new();
 
-                    let mut count = 0;
-                    for (key, value) in &matches {
-                        for (line, text) in value {
-                            doc_text.insert(doc_text.len_chars(), text);
-                            doc_text.insert(doc_text.len_chars(), "\n");
-                            line_map.insert((key.clone(), *line), count);
-                            count += 1;
-                        }
-                    }
-                    doc_text.split_off(doc_text.len_chars().saturating_sub(1));
-                    let mut doc = Document::refactor(
-                        doc_text,
-                        matches,
-                        line_map,
-                        encoding,
-                        editor.config.clone(),
-                    );
-                    if let Some(language_id) = language_id {
-                        doc.set_language_by_language_id(&language_id, editor.syn_loader.clone())
-                            .ok();
-                    };
-                    editor.new_file_from_document(Action::Replace, doc);
-                }));
-                Ok(call)
-            };
-            cx.jobs.callback(show_refactor);
-        }
-        helix_view::document::DocumentType::Refactor { matches, line_map } => {
-            let refactor_id = doc!(cx.editor).id();
-            let replace_text = doc!(cx.editor).text().clone();
-            let view = view!(cx.editor).clone();
-            let mut documents: usize = 0;
-            let mut count: usize = 0;
-            for (key, value) in matches {
-                let mut changes = Vec::<(usize, usize, String)>::new();
-                for (line, text) in value {
-                    if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
-                        let mut replace = replace_text
-                            .get_line(*re_line)
-                            .unwrap_or_else(|| "\n".into())
-                            .to_string()
-                            .clone();
-                        replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
-                        if text != &replace {
-                            changes.push((*line, text.chars().count(), replace));
-                        }
-                    }
-                }
-                if !changes.is_empty() {
-                    if let Some(doc) = cx
-                        .editor
-                        .open(key, Action::Load)
-                        .ok()
-                        .and_then(|id| cx.editor.document_mut(id))
-                    {
-                        documents += 1;
-                        let mut applychanges = Vec::<(usize, usize, Option<Tendril>)>::new();
-                        for (line, length, text) in changes {
-                            if doc.text().len_lines() > line {
-                                let start = doc.text().line_to_char(line);
-                                applychanges.push((
-                                    start,
-                                    start + length,
-                                    Some(Tendril::from(text.to_string())),
-                                ));
-                                count += 1;
-                            }
-                        }
-                        let transaction = Transaction::change(doc.text(), applychanges.into_iter());
-                        doc.apply(&transaction, view.id);
-                    }
-                }
-            }
-            cx.editor.set_status(format!(
-                "Refactored {} documents, {} lines changed.",
-                documents, count
-            ));
-            cx.editor.close_document(refactor_id, true).ok();
-        }
-    }
-}
+//                     let mut count = 0;
+//                     for (key, value) in &matches {
+//                         for (line, text) in value {
+//                             doc_text.insert(doc_text.len_chars(), text);
+//                             doc_text.insert(doc_text.len_chars(), "\n");
+//                             line_map.insert((key.clone(), *line), count);
+//                             count += 1;
+//                         }
+//                     }
+//                     doc_text.split_off(doc_text.len_chars().saturating_sub(1));
+//                     let mut doc = Document::refactor(
+//                         doc_text,
+//                         matches,
+//                         line_map,
+//                         // TODO: actually learn how to detect encoding
+//                         None,
+//                         editor.config.clone(),
+//                         editor.syn_loader.clone(),
+//                     );
+//                     // if let Some(language_id) = language_id {
+//                     //     doc.set_language_by_language_id(&language_id, editor.syn_loader.clone())
+//                     //         .ok();
+//                     // };
+//                     editor.new_file_from_document(Action::Replace, doc);
+//                 }));
+//                 Ok(call)
+//             };
+//             cx.jobs.callback(show_refactor);
+//         }
+//         helix_view::document::DocumentType::Refactor { matches, line_map } => {
+//             let refactor_id = doc!(cx.editor).id();
+//             let replace_text = doc!(cx.editor).text().clone();
+//             let view = view!(cx.editor).clone();
+//             let mut documents: usize = 0;
+//             let mut count: usize = 0;
+//             for (key, value) in matches {
+//                 let mut changes = Vec::<(usize, usize, String)>::new();
+//                 for (line, text) in value {
+//                     if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
+//                         let mut replace = replace_text
+//                             .get_line(*re_line)
+//                             .unwrap_or_else(|| "\n".into())
+//                             .to_string()
+//                             .clone();
+//                         replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
+//                         if text != &replace {
+//                             changes.push((*line, text.chars().count(), replace));
+//                         }
+//                     }
+//                 }
+//                 if !changes.is_empty() {
+//                     if let Some(doc) = cx
+//                         .editor
+//                         .open(key, Action::Load)
+//                         .ok()
+//                         .and_then(|id| cx.editor.document_mut(id))
+//                     {
+//                         documents += 1;
+//                         let mut applychanges = Vec::<(usize, usize, Option<Tendril>)>::new();
+//                         for (line, length, text) in changes {
+//                             if doc.text().len_lines() > line {
+//                                 let start = doc.text().line_to_char(line);
+//                                 applychanges.push((
+//                                     start,
+//                                     start + length,
+//                                     Some(Tendril::from(text.to_string())),
+//                                 ));
+//                                 count += 1;
+//                             }
+//                         }
+//                         let transaction = Transaction::change(doc.text(), applychanges.into_iter());
+//                         doc.apply(&transaction, view.id);
+//                     }
+//                 }
+//             }
+//             cx.editor.set_status(format!(
+//                 "Refactored {} documents, {} lines changed.",
+//                 documents, count
+//             ));
+//             cx.editor.close_document(refactor_id, true).ok();
+//         }
+//     }
+// }
 
 enum Extend {
     Above,
@@ -3414,40 +3430,8 @@ fn buffer_picker(cx: &mut Context) {
         path: Option<PathBuf>,
         is_modified: bool,
         is_current: bool,
-<<<<<<< HEAD
         focused_at: std::time::Instant,
-=======
         is_refactor: bool,
-    }
-
-    impl ui::menu::Item for BufferMeta {
-        type Data = ();
-
-        fn format(&self, _data: &Self::Data) -> Row {
-            let path = self
-                .path
-                .as_deref()
-                .map(helix_core::path::get_relative_path);
-            let path = if self.is_refactor {
-                REFACTOR_BUFFER_NAME
-            } else {
-                match path.as_deref().and_then(Path::to_str) {
-                    Some(path) => path,
-                    None => SCRATCH_BUFFER_NAME,
-                }
-            };
-
-            let mut flags = String::new();
-            if self.is_modified {
-                flags.push('+');
-            }
-            if self.is_current {
-                flags.push('*');
-            }
-
-            Row::new([self.id.to_string(), flags, path.to_string()])
-        }
->>>>>>> f55507e4 (Impl refactoring view)
     }
 
     let new_meta = |doc: &Document| BufferMeta {
@@ -3455,9 +3439,7 @@ fn buffer_picker(cx: &mut Context) {
         path: doc.path().cloned(),
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
-<<<<<<< HEAD
         focused_at: doc.focused_at,
-=======
         is_refactor: matches!(
             &doc.document_type,
             helix_view::document::DocumentType::Refactor {
@@ -3465,7 +3447,6 @@ fn buffer_picker(cx: &mut Context) {
                 line_map: _
             }
         ),
->>>>>>> f55507e4 (Impl refactoring view)
     };
 
     let mut items = cx
@@ -3491,6 +3472,10 @@ fn buffer_picker(cx: &mut Context) {
             flags.into()
         }),
         PickerColumn::new("path", |meta: &BufferMeta, _| {
+            // TODO: make this rust look like actual rust
+            if meta.is_refactor {
+                return helix_view::document::REFACTOR_BUFFER_NAME.into();
+            }
             let path = meta
                 .path
                 .as_deref()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -42,7 +42,7 @@ use helix_core::{
     Selection, SmallVec, Syntax, Tendril, Transaction,
 };
 use helix_view::{
-    document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
+    document::{FormatterError, Mode, REFACTOR_BUFFER_NAME, SCRATCH_BUFFER_NAME},
     editor::Action,
     info::Info,
     input::KeyEvent,
@@ -378,6 +378,7 @@ impl MappableCommand {
         search_selection_detect_word_boundaries, "Use current selection as the search pattern, automatically wrapping with `\\b` on word boundaries",
         make_search_word_bounded, "Modify current search to make it word bounded",
         global_search, "Global search in workspace folder",
+        global_refactor, "Global refactoring in workspace folder",
         extend_line, "Select current line, if already selected, extend to another line based on the anchor",
         extend_line_below, "Select current line, if already selected, extend to next line",
         extend_line_above, "Select current line, if already selected, extend to previous line",
@@ -2668,6 +2669,275 @@ fn global_search(cx: &mut Context) {
     cx.push_layer(Box::new(overlaid(picker)));
 }
 
+fn global_refactor(cx: &mut Context) {
+    let document_type = doc!(cx.editor).document_type.clone();
+
+    match &document_type {
+        helix_view::document::DocumentType::File => {
+            let (all_matches_sx, all_matches_rx) =
+                tokio::sync::mpsc::unbounded_channel::<(PathBuf, usize, String)>();
+            let config = cx.editor.config();
+            let smart_case = config.search.smart_case;
+            let file_picker_config = config.file_picker.clone();
+
+            let reg = cx.register.unwrap_or('/');
+
+            // Restrict to current file type if possible
+            let file_extension = doc!(cx.editor).path().and_then(|f| f.extension());
+            let file_glob = if let Some(file_glob) = file_extension.and_then(|f| f.to_str()) {
+                let mut tb = ignore::types::TypesBuilder::new();
+                tb.add("p", &(String::from("*.") + file_glob))
+                    .ok()
+                    .and_then(|_| {
+                        tb.select("all");
+                        tb.build().ok()
+                    })
+            } else {
+                None
+            };
+
+            let encoding = Some(doc!(cx.editor).encoding());
+
+            let completions = search_completions(cx, Some(reg));
+            ui::regex_prompt(
+                cx,
+                "global-refactor:".into(),
+                Some(reg),
+                move |_editor: &Editor, input: &str| {
+                    completions
+                        .iter()
+                        .filter(|comp| comp.starts_with(input))
+                        .map(|comp| (0.., std::borrow::Cow::Owned(comp.clone())))
+                        .collect()
+                },
+                move |editor, regex, event| {
+                    if event != PromptEvent::Validate {
+                        return;
+                    }
+
+                    if let Ok(matcher) = RegexMatcherBuilder::new()
+                        .case_smart(smart_case)
+                        .build(regex.as_str())
+                    {
+                        let searcher = SearcherBuilder::new()
+                            .binary_detection(BinaryDetection::quit(b'\x00'))
+                            .build();
+
+                        let mut checked = HashSet::<PathBuf>::new();
+                        let file_extension = editor.documents
+                            [&editor.tree.get(editor.tree.focus).doc]
+                            .path()
+                            .and_then(|f| f.extension());
+                        for doc in editor.documents() {
+                            searcher
+                                .clone()
+                                .search_slice(
+                                    matcher.clone(),
+                                    doc.text().to_string().as_bytes(),
+                                    sinks::UTF8(|line_num, matched| {
+                                        if let Some(path) = doc.path() {
+                                            if let Some(extension) = path.extension() {
+                                                if let Some(file_extension) = file_extension {
+                                                    if file_extension == extension {
+                                                        all_matches_sx
+                                                            .send((
+                                                                path.clone(),
+                                                                line_num as usize - 1,
+                                                                String::from(
+                                                                    matched
+                                                                        .strip_suffix("\r\n")
+                                                                        .or_else(|| {
+                                                                            matched
+                                                                                .strip_suffix('\n')
+                                                                        })
+                                                                        .unwrap_or(matched),
+                                                                ),
+                                                            ))
+                                                            .unwrap();
+                                                    }
+                                                }
+                                            }
+                                            // Exclude from file search
+                                            checked.insert(path.clone());
+                                        }
+                                        Ok(true)
+                                    }),
+                                )
+                                .ok();
+                        }
+
+                        let search_root = std::env::current_dir()
+                            .expect("Global search error: Failed to get current dir");
+                        let mut wb = WalkBuilder::new(search_root);
+                        wb.hidden(file_picker_config.hidden)
+                            .parents(file_picker_config.parents)
+                            .ignore(file_picker_config.ignore)
+                            .git_ignore(file_picker_config.git_ignore)
+                            .git_global(file_picker_config.git_global)
+                            .git_exclude(file_picker_config.git_exclude)
+                            .max_depth(file_picker_config.max_depth);
+                        if let Some(file_glob) = &file_glob {
+                            wb.types(file_glob.clone());
+                        }
+                        wb.build_parallel().run(|| {
+                            let mut searcher = searcher.clone();
+                            let matcher = matcher.clone();
+                            let all_matches_sx = all_matches_sx.clone();
+                            let checked = checked.clone();
+                            Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
+                                let entry = match entry {
+                                    Ok(entry) => entry,
+                                    Err(_) => return WalkState::Continue,
+                                };
+
+                                match entry.file_type() {
+                                    Some(entry) if entry.is_file() => {}
+                                    // skip everything else
+                                    _ => return WalkState::Continue,
+                                };
+
+                                let result = searcher.search_path(
+                                    &matcher,
+                                    entry.path(),
+                                    sinks::UTF8(|line_num, matched| {
+                                        let path = entry.clone().into_path();
+                                        if !checked.contains(&path) {
+                                            all_matches_sx
+                                                .send((
+                                                    path,
+                                                    line_num as usize - 1,
+                                                    String::from(
+                                                        matched
+                                                            .strip_suffix("\r\n")
+                                                            .or_else(|| matched.strip_suffix('\n'))
+                                                            .unwrap_or(matched),
+                                                    ),
+                                                ))
+                                                .unwrap();
+                                        }
+                                        Ok(true)
+                                    }),
+                                );
+
+                                if let Err(err) = result {
+                                    log::error!(
+                                        "Global search error: {}, {}",
+                                        entry.path().display(),
+                                        err
+                                    );
+                                }
+                                WalkState::Continue
+                            })
+                        });
+                    }
+                },
+            );
+
+            let show_refactor = async move {
+                let all_matches: Vec<(PathBuf, usize, String)> =
+                    UnboundedReceiverStream::new(all_matches_rx).collect().await;
+                let call: job::Callback = Callback::Editor(Box::new(move |editor: &mut Editor| {
+                    if all_matches.is_empty() {
+                        editor.set_status("No matches found");
+                        return;
+                    }
+                    let mut matches: HashMap<PathBuf, Vec<(usize, String)>> = HashMap::new();
+                    for (path, line, text) in all_matches {
+                        if let Some(vec) = matches.get_mut(&path) {
+                            vec.push((line, text));
+                        } else {
+                            let v = Vec::from([(line, text)]);
+                            matches.insert(path, v);
+                        }
+                    }
+
+                    let language_id = doc!(editor).language_id().map(String::from);
+
+                    let mut doc_text = Rope::new();
+                    let mut line_map = HashMap::new();
+
+                    let mut count = 0;
+                    for (key, value) in &matches {
+                        for (line, text) in value {
+                            doc_text.insert(doc_text.len_chars(), text);
+                            doc_text.insert(doc_text.len_chars(), "\n");
+                            line_map.insert((key.clone(), *line), count);
+                            count += 1;
+                        }
+                    }
+                    doc_text.split_off(doc_text.len_chars().saturating_sub(1));
+                    let mut doc = Document::refactor(
+                        doc_text,
+                        matches,
+                        line_map,
+                        encoding,
+                        editor.config.clone(),
+                    );
+                    if let Some(language_id) = language_id {
+                        doc.set_language_by_language_id(&language_id, editor.syn_loader.clone())
+                            .ok();
+                    };
+                    editor.new_file_from_document(Action::Replace, doc);
+                }));
+                Ok(call)
+            };
+            cx.jobs.callback(show_refactor);
+        }
+        helix_view::document::DocumentType::Refactor { matches, line_map } => {
+            let refactor_id = doc!(cx.editor).id();
+            let replace_text = doc!(cx.editor).text().clone();
+            let view = view!(cx.editor).clone();
+            let mut documents: usize = 0;
+            let mut count: usize = 0;
+            for (key, value) in matches {
+                let mut changes = Vec::<(usize, usize, String)>::new();
+                for (line, text) in value {
+                    if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
+                        let mut replace = replace_text
+                            .get_line(*re_line)
+                            .unwrap_or_else(|| "\n".into())
+                            .to_string()
+                            .clone();
+                        replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
+                        if text != &replace {
+                            changes.push((*line, text.chars().count(), replace));
+                        }
+                    }
+                }
+                if !changes.is_empty() {
+                    if let Some(doc) = cx
+                        .editor
+                        .open(key, Action::Load)
+                        .ok()
+                        .and_then(|id| cx.editor.document_mut(id))
+                    {
+                        documents += 1;
+                        let mut applychanges = Vec::<(usize, usize, Option<Tendril>)>::new();
+                        for (line, length, text) in changes {
+                            if doc.text().len_lines() > line {
+                                let start = doc.text().line_to_char(line);
+                                applychanges.push((
+                                    start,
+                                    start + length,
+                                    Some(Tendril::from(text.to_string())),
+                                ));
+                                count += 1;
+                            }
+                        }
+                        let transaction = Transaction::change(doc.text(), applychanges.into_iter());
+                        doc.apply(&transaction, view.id);
+                    }
+                }
+            }
+            cx.editor.set_status(format!(
+                "Refactored {} documents, {} lines changed.",
+                documents, count
+            ));
+            cx.editor.close_document(refactor_id, true).ok();
+        }
+    }
+}
+
 enum Extend {
     Above,
     Below,
@@ -3144,7 +3414,40 @@ fn buffer_picker(cx: &mut Context) {
         path: Option<PathBuf>,
         is_modified: bool,
         is_current: bool,
+<<<<<<< HEAD
         focused_at: std::time::Instant,
+=======
+        is_refactor: bool,
+    }
+
+    impl ui::menu::Item for BufferMeta {
+        type Data = ();
+
+        fn format(&self, _data: &Self::Data) -> Row {
+            let path = self
+                .path
+                .as_deref()
+                .map(helix_core::path::get_relative_path);
+            let path = if self.is_refactor {
+                REFACTOR_BUFFER_NAME
+            } else {
+                match path.as_deref().and_then(Path::to_str) {
+                    Some(path) => path,
+                    None => SCRATCH_BUFFER_NAME,
+                }
+            };
+
+            let mut flags = String::new();
+            if self.is_modified {
+                flags.push('+');
+            }
+            if self.is_current {
+                flags.push('*');
+            }
+
+            Row::new([self.id.to_string(), flags, path.to_string()])
+        }
+>>>>>>> f55507e4 (Impl refactoring view)
     }
 
     let new_meta = |doc: &Document| BufferMeta {
@@ -3152,7 +3455,17 @@ fn buffer_picker(cx: &mut Context) {
         path: doc.path().cloned(),
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
+<<<<<<< HEAD
         focused_at: doc.focused_at,
+=======
+        is_refactor: matches!(
+            &doc.document_type,
+            helix_view::document::DocumentType::Refactor {
+                matches: _,
+                line_map: _
+            }
+        ),
+>>>>>>> f55507e4 (Impl refactoring view)
     };
 
     let mut items = cx

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -379,6 +379,7 @@ impl MappableCommand {
         search_selection_detect_word_boundaries, "Use current selection as the search pattern, automatically wrapping with `\\b` on word boundaries",
         make_search_word_bounded, "Modify current search to make it word bounded",
         global_search, "Global search in workspace folder",
+        global_refactor, "Global refactoring in workspace folder",
         extend_line, "Select current line, if already selected, extend to another line based on the anchor",
         extend_line_below, "Select current line, if already selected, extend to next line",
         extend_line_above, "Select current line, if already selected, extend to previous line",
@@ -2445,13 +2446,15 @@ fn global_search(cx: &mut Context) {
         path: PathBuf,
         /// 0 indexed lines
         line_num: usize,
+        line_content: String,
     }
 
     impl FileResult {
-        fn new(path: &Path, line_num: usize) -> Self {
+        fn new(path: &Path, line_num: usize, line_content: String) -> Self {
             Self {
                 path: path.to_path_buf(),
                 line_num,
+                line_content: line_content.into(),
             }
         }
     }
@@ -2576,9 +2579,13 @@ fn global_search(cx: &mut Context) {
                         };
 
                         let mut stop = false;
-                        let sink = sinks::UTF8(|line_num, _line_content| {
+                        let sink = sinks::UTF8(|line_num, line_content| {
                             stop = injector
-                                .push(FileResult::new(entry.path(), line_num as usize - 1))
+                                .push(FileResult::new(
+                                    entry.path(),
+                                    line_num as usize - 1,
+                                    line_content.into(),
+                                ))
                                 .is_err();
 
                             Ok(!stop)
@@ -2664,17 +2671,43 @@ fn global_search(cx: &mut Context) {
         Some((path.as_path().into(), Some((*line_num, *line_num))))
     })
     .with_quickfix(move |cx, results: Vec<&FileResult>| {
-        let quickfix_line = results
-            .iter()
-            .map(|FileResult { path, line_num, .. }| format!("{}:{}", path.display(), line_num))
-            .collect::<Vec<_>>()
-            .join(" ");
+        if results.is_empty() {
+            cx.editor.set_status("No matches found");
+            return;
+        }
 
-        log::info!("Quickfix entries: {}", quickfix_line);
-        cx.editor
-            .set_status(format!("Quickfix entries: {}", quickfix_line));
-        // cx.editor
-        //     .set_error(format!("Quickfix entries: {}", quickfix_line));
+        let mut matches: HashMap<PathBuf, Vec<(usize, String)>> = HashMap::new();
+
+        for result in results {
+            let path = result.path.clone();
+            let line = result.line_num;
+            let text = result.line_content.clone();
+
+            matches.entry(path).or_default().push((line, text));
+        }
+
+        let mut doc_text = Rope::new();
+        let mut line_map = HashMap::new();
+
+        let mut count = 0;
+        for (key, value) in &matches {
+            for (line, text) in value {
+                doc_text.insert(doc_text.len_chars(), text);
+                line_map.insert((key.clone(), *line), count);
+                count += 1;
+            }
+        }
+        doc_text.split_off(doc_text.len_chars().saturating_sub(1));
+        let doc = Document::refactor(
+            doc_text,
+            matches,
+            line_map,
+            // TODO: actually learn how to detect encoding
+            None,
+            cx.editor.config.clone(),
+            cx.editor.syn_loader.clone(),
+        );
+        cx.editor.new_file_from_document(Action::Replace, doc);
     })
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
@@ -2682,277 +2715,65 @@ fn global_search(cx: &mut Context) {
     cx.push_layer(Box::new(overlaid(picker)));
 }
 
-// TODO make this worky again
-// fn global_refactor(cx: &mut Context) {
-//     let document_type = doc!(cx.editor).document_type.clone();
+fn global_refactor(cx: &mut Context) {
+    let document_type = doc!(cx.editor).document_type.clone();
 
-//     match &document_type {
-//         helix_view::document::DocumentType::File => {
-//             let (all_matches_sx, all_matches_rx) =
-//                 tokio::sync::mpsc::unbounded_channel::<(PathBuf, usize, String)>();
-//             let config = cx.editor.config();
-//             let smart_case = config.search.smart_case;
-//             let file_picker_config = config.file_picker.clone();
-
-//             let reg = cx.register.unwrap_or('/');
-
-//             // Restrict to current file type if possible
-//             let file_extension = doc!(cx.editor).path().and_then(|f| f.extension());
-//             let file_glob = if let Some(file_glob) = file_extension.and_then(|f| f.to_str()) {
-//                 let mut tb = ignore::types::TypesBuilder::new();
-//                 tb.add("p", &(String::from("*.") + file_glob))
-//                     .ok()
-//                     .and_then(|_| {
-//                         tb.select("all");
-//                         tb.build().ok()
-//                     })
-//             } else {
-//                 None
-//             };
-
-//             let encoding = Some(doc!(cx.editor).encoding());
-
-//             let completions = search_completions(cx, Some(reg));
-//             ui::regex_prompt(
-//                 cx,
-//                 "global-refactor:".into(),
-//                 Some(reg),
-//                 move |_editor: &Editor, input: &str| {
-//                     completions
-//                         .iter()
-//                         .filter(|comp| comp.starts_with(input))
-//                         .map(|comp| (0.., comp.clone().into()))
-//                         .collect()
-//                 },
-//                 move |editor, regex, event| {
-//                     if event != PromptEvent::Validate {
-//                         return;
-//                     }
-
-//                     if let Ok(matcher) = RegexMatcherBuilder::new()
-//                         .case_smart(smart_case)
-//                         .build(regex.into())
-//                     {
-//                         let searcher = SearcherBuilder::new()
-//                             .binary_detection(BinaryDetection::quit(b'\x00'))
-//                             .build(query);
-
-//                         let mut checked = HashSet::<PathBuf>::new();
-//                         let file_extension = editor.documents
-//                             [&editor.tree.get(editor.tree.focus).doc]
-//                             .path()
-//                             .and_then(|f| f.extension());
-//                         for doc in editor.documents() {
-//                             searcher
-//                                 .clone()
-//                                 .search_slice(
-//                                     matcher.clone(),
-//                                     doc.text().to_string().as_bytes(),
-//                                     sinks::UTF8(|line_num, matched| {
-//                                         if let Some(path) = doc.path() {
-//                                             if let Some(extension) = path.extension() {
-//                                                 if let Some(file_extension) = file_extension {
-//                                                     if file_extension == extension {
-//                                                         all_matches_sx
-//                                                             .send((
-//                                                                 path.clone(),
-//                                                                 line_num as usize - 1,
-//                                                                 String::from(
-//                                                                     matched
-//                                                                         .strip_suffix("\r\n")
-//                                                                         .or_else(|| {
-//                                                                             matched
-//                                                                                 .strip_suffix('\n')
-//                                                                         })
-//                                                                         .unwrap_or(matched),
-//                                                                 ),
-//                                                             ))
-//                                                             .unwrap();
-//                                                     }
-//                                                 }
-//                                             }
-//                                             // Exclude from file search
-//                                             checked.insert(path.clone());
-//                                         }
-//                                         Ok(true)
-//                                     }),
-//                                 )
-//                                 .ok();
-//                         }
-
-//                         let search_root = std::env::current_dir()
-//                             .expect("Global search error: Failed to get current dir");
-//                         let mut wb = WalkBuilder::new(search_root);
-//                         wb.hidden(file_picker_config.hidden)
-//                             .parents(file_picker_config.parents)
-//                             .ignore(file_picker_config.ignore)
-//                             .git_ignore(file_picker_config.git_ignore)
-//                             .git_global(file_picker_config.git_global)
-//                             .git_exclude(file_picker_config.git_exclude)
-//                             .max_depth(file_picker_config.max_depth);
-//                         if let Some(file_glob) = &file_glob {
-//                             wb.types(file_glob.clone());
-//                         }
-//                         wb.build_parallel().run(|| {
-//                             let mut searcher = searcher.clone();
-//                             let matcher = matcher.clone();
-//                             let all_matches_sx = all_matches_sx.clone();
-//                             let checked = checked.clone();
-//                             Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
-//                                 let entry = match entry {
-//                                     Ok(entry) => entry,
-//                                     Err(_) => return WalkState::Continue,
-//                                 };
-
-//                                 match entry.file_type() {
-//                                     Some(entry) if entry.is_file() => {}
-//                                     // skip everything else
-//                                     _ => return WalkState::Continue,
-//                                 };
-
-//                                 let result = searcher.search_path(
-//                                     &matcher,
-//                                     entry.path(),
-//                                     sinks::UTF8(|line_num, matched| {
-//                                         let path = entry.clone().into_path();
-//                                         if !checked.contains(&path) {
-//                                             all_matches_sx
-//                                                 .send((
-//                                                     path,
-//                                                     line_num as usize - 1,
-//                                                     String::from(
-//                                                         matched
-//                                                             .strip_suffix("\r\n")
-//                                                             .or_else(|| matched.strip_suffix('\n'))
-//                                                             .unwrap_or(matched),
-//                                                     ),
-//                                                 ))
-//                                                 .unwrap();
-//                                         }
-//                                         Ok(true)
-//                                     }),
-//                                 );
-
-//                                 if let Err(err) = result {
-//                                     log::error!(
-//                                         "Global search error: {}, {}",
-//                                         entry.path().display(),
-//                                         err
-//                                     );
-//                                 }
-//                                 WalkState::Continue
-//                             })
-//                         });
-//                     }
-//                 },
-//             );
-
-//             let show_refactor = async move {
-//                 let all_matches: Vec<(PathBuf, usize, String)> =
-//                     UnboundedReceiverStream::new(all_matches_rx).collect().await;
-//                 let call: job::Callback = Callback::Editor(Box::new(move |editor: &mut Editor| {
-//                     if all_matches.is_empty() {
-//                         editor.set_status("No matches found");
-//                         return;
-//                     }
-//                     let mut matches: HashMap<PathBuf, Vec<(usize, String)>> = HashMap::new();
-//                     for (path, line, text) in all_matches {
-//                         if let Some(vec) = matches.get_mut(&path) {
-//                             vec.push((line, text));
-//                         } else {
-//                             let v = Vec::from([(line, text)]);
-//                             matches.insert(path, v);
-//                         }
-//                     }
-
-//                     let language_id = doc!(editor).language_id().map(String::from);
-
-//                     let mut doc_text = Rope::new();
-//                     let mut line_map = HashMap::new();
-
-//                     let mut count = 0;
-//                     for (key, value) in &matches {
-//                         for (line, text) in value {
-//                             doc_text.insert(doc_text.len_chars(), text);
-//                             doc_text.insert(doc_text.len_chars(), "\n");
-//                             line_map.insert((key.clone(), *line), count);
-//                             count += 1;
-//                         }
-//                     }
-//                     doc_text.split_off(doc_text.len_chars().saturating_sub(1));
-//                     let mut doc = Document::refactor(
-//                         doc_text,
-//                         matches,
-//                         line_map,
-//                         // TODO: actually learn how to detect encoding
-//                         None,
-//                         editor.config.clone(),
-//                         editor.syn_loader.clone(),
-//                     );
-//                     // if let Some(language_id) = language_id {
-//                     //     doc.set_language_by_language_id(&language_id, editor.syn_loader.clone())
-//                     //         .ok();
-//                     // };
-//                     editor.new_file_from_document(Action::Replace, doc);
-//                 }));
-//                 Ok(call)
-//             };
-//             cx.jobs.callback(show_refactor);
-//         }
-//         helix_view::document::DocumentType::Refactor { matches, line_map } => {
-//             let refactor_id = doc!(cx.editor).id();
-//             let replace_text = doc!(cx.editor).text().clone();
-//             let view = view!(cx.editor).clone();
-//             let mut documents: usize = 0;
-//             let mut count: usize = 0;
-//             for (key, value) in matches {
-//                 let mut changes = Vec::<(usize, usize, String)>::new();
-//                 for (line, text) in value {
-//                     if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
-//                         let mut replace = replace_text
-//                             .get_line(*re_line)
-//                             .unwrap_or_else(|| "\n".into())
-//                             .to_string()
-//                             .clone();
-//                         replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
-//                         if text != &replace {
-//                             changes.push((*line, text.chars().count(), replace));
-//                         }
-//                     }
-//                 }
-//                 if !changes.is_empty() {
-//                     if let Some(doc) = cx
-//                         .editor
-//                         .open(key, Action::Load)
-//                         .ok()
-//                         .and_then(|id| cx.editor.document_mut(id))
-//                     {
-//                         documents += 1;
-//                         let mut applychanges = Vec::<(usize, usize, Option<Tendril>)>::new();
-//                         for (line, length, text) in changes {
-//                             if doc.text().len_lines() > line {
-//                                 let start = doc.text().line_to_char(line);
-//                                 applychanges.push((
-//                                     start,
-//                                     start + length,
-//                                     Some(Tendril::from(text.to_string())),
-//                                 ));
-//                                 count += 1;
-//                             }
-//                         }
-//                         let transaction = Transaction::change(doc.text(), applychanges.into_iter());
-//                         doc.apply(&transaction, view.id);
-//                     }
-//                 }
-//             }
-//             cx.editor.set_status(format!(
-//                 "Refactored {} documents, {} lines changed.",
-//                 documents, count
-//             ));
-//             cx.editor.close_document(refactor_id, true).ok();
-//         }
-//     }
-// }
+    match &document_type {
+        helix_view::document::DocumentType::File => return,
+        helix_view::document::DocumentType::Refactor { matches, line_map } => {
+            let refactor_id = doc!(cx.editor).id();
+            let replace_text = doc!(cx.editor).text().clone();
+            let view = view!(cx.editor).clone();
+            let mut documents: usize = 0;
+            let mut count: usize = 0;
+            for (key, value) in matches {
+                let mut changes = Vec::<(usize, usize, String)>::new();
+                for (line, text) in value {
+                    if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
+                        let mut replace = replace_text
+                            .get_line(*re_line)
+                            .unwrap_or_else(|| "\n".into())
+                            .to_string()
+                            .clone();
+                        replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
+                        if text != &replace {
+                            changes.push((*line, text.chars().count(), replace));
+                        }
+                    }
+                }
+                if !changes.is_empty() {
+                    if let Some(doc) = cx
+                        .editor
+                        .open(key, Action::Load)
+                        .ok()
+                        .and_then(|id| cx.editor.document_mut(id))
+                    {
+                        documents += 1;
+                        let mut applychanges = Vec::<(usize, usize, Option<Tendril>)>::new();
+                        for (line, length, text) in changes {
+                            if doc.text().len_lines() > line {
+                                let start = doc.text().line_to_char(line);
+                                applychanges.push((
+                                    start,
+                                    start + length,
+                                    Some(Tendril::from(text.to_string())),
+                                ));
+                                count += 1;
+                            }
+                        }
+                        let transaction = Transaction::change(doc.text(), applychanges.into_iter());
+                        doc.apply(&transaction, view.id);
+                    }
+                }
+            }
+            cx.editor.set_status(format!(
+                "Refactored {} documents, {} lines changed.",
+                documents, count
+            ));
+            cx.editor.close_document(refactor_id, true).ok();
+        }
+    }
+}
 
 enum Extend {
     Above,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2688,6 +2688,7 @@ fn global_search(cx: &mut Context) {
 
         let mut doc_text = Rope::new();
         let mut line_map = HashMap::new();
+        let language_id = doc!(cx.editor).language_id().map(String::from);
 
         let mut count = 0;
         for (key, value) in &matches {
@@ -2698,7 +2699,7 @@ fn global_search(cx: &mut Context) {
             }
         }
         doc_text.split_off(doc_text.len_chars().saturating_sub(1));
-        let doc = Document::refactor(
+        let mut doc = Document::refactor(
             doc_text,
             matches,
             line_map,
@@ -2707,6 +2708,10 @@ fn global_search(cx: &mut Context) {
             cx.editor.config.clone(),
             cx.editor.syn_loader.clone(),
         );
+        if let Some(language_id) = language_id {
+            doc.set_language_by_language_id(&language_id, &cx.editor.syn_loader.load())
+                .ok();
+        };
         cx.editor.new_file_from_document(Action::Replace, doc);
     })
     .with_history_register(Some(reg))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2721,6 +2721,7 @@ fn global_refactor(cx: &mut Context) {
     match &document_type {
         helix_view::document::DocumentType::File => return,
         helix_view::document::DocumentType::Refactor { matches, line_map } => {
+            let line_ending: LineEnding = cx.editor.config.load().default_line_ending.into();
             let refactor_id = doc!(cx.editor).id();
             let replace_text = doc!(cx.editor).text().clone();
             let view = view!(cx.editor).clone();
@@ -2732,10 +2733,15 @@ fn global_refactor(cx: &mut Context) {
                     if let Some(re_line) = line_map.get(&(key.clone(), *line)) {
                         let mut replace = replace_text
                             .get_line(*re_line)
-                            .unwrap_or_else(|| "\n".into())
+                            .unwrap_or_else(|| "".into())
                             .to_string()
                             .clone();
-                        replace = replace.strip_suffix('\n').unwrap_or(&replace).to_string();
+
+                        replace = replace
+                            .strip_suffix(line_ending.as_str())
+                            .unwrap_or(&replace)
+                            .to_string();
+                        replace.push_str(line_ending.as_str());
                         if text != &replace {
                             changes.push((*line, text.chars().count(), replace));
                         }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -583,13 +583,19 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = doc
-                .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let fname = match &doc.document_type {
+                helix_view::document::DocumentType::File => doc
+                    .path()
+                    .unwrap_or(&scratch)
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default(),
+                helix_view::document::DocumentType::Refactor {
+                    matches: _,
+                    line_map: _,
+                } => helix_view::document::REFACTOR_BUFFER_NAME,
+            };
 
             let style = if current_doc == doc.id() {
                 bufferline_active

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -5,7 +5,7 @@ use helix_core::{coords_at_pos, encoding, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
-    document::{Mode, SCRATCH_BUFFER_NAME},
+    document::{Mode, REFACTOR_BUFFER_NAME, SCRATCH_BUFFER_NAME},
     graphics::Rect,
     theme::Style,
     Document, Editor, View,
@@ -450,12 +450,20 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     let title = {
-        let rel_path = context.doc.relative_path();
-        let path = rel_path
-            .as_ref()
-            .map(|p| p.to_string_lossy())
-            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
-        format!(" {} ", path)
+        match &context.doc.document_type {
+            helix_view::document::DocumentType::File => {
+                let rel_path = context.doc.relative_path();
+                let path = rel_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy())
+                    .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+                format!(" {} ", path)
+            }
+            helix_view::document::DocumentType::Refactor {
+                matches: _,
+                line_map: _,
+            } => REFACTOR_BUFFER_NAME.into(),
+        }
     };
 
     write(context, title.into());

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1746,7 +1746,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
Rebased and modified from the original author: https://github.com/helix-editor/helix/pull/4381
As is disclaimer this is heavily WIP and I'm fairly new to Rust so things aren't the cleanest

A couple changes:
- It also now uses the `global_search` command rather than bespoke query logic
- Keybind to put the results from the search into the `refactor` buffer is (ctrl-q). The keybind is mainly because of vim muscle memory so it's subject to change
- The `global_refactor` command still exists as a way to "write out" the changes to the buffers, though I think it might be nice to eventually make it work on the `:write` command

This is also still using the `enum` in `Document` since using `View`  (seems) to require much deeper knowledge of Helix's codebase and rewriting/reusing much of the document editing code.

This PR is mainly meant to document my changes but feedback/reviews are welcome, though I don't expect this to be merged, especially as-is. This might also be better suited as a plugin