### PR TITLE
languages: add Java .properties file support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -184,6 +184,7 @@
 | powershell | ✓ |  |  |  |
 | prisma | ✓ | ✓ |  | `prisma-language-server` |
 | prolog | ✓ |  | ✓ | `swipl` |
+| properties | ✓ | ✓ |  |  |
 | protobuf | ✓ | ✓ | ✓ | `buf`, `pb`, `protols` |
 | prql | ✓ |  |  |  |
 | pug | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4450,3 +4450,14 @@ auto-format = true
 [[grammar]]
 name = "caddyfile"
 source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "b04bdb4ec53e40c44afbf001e15540f60a296aef" }
+
+[[language]]
+name = "properties"
+scope = "source.properties"
+injection-regex = "properties"
+file-types = ["properties", "prefs"]
+comment-tokens = ["#"]
+
+[[grammar]]
+name = "properties"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-properties", rev = "579b62f5ad8d96c2bb331f07d1408c92767531d9" }

--- a/runtime/queries/properties/highlights.scm
+++ b/runtime/queries/properties/highlights.scm
@@ -1,0 +1,40 @@
+(comment) @comment
+
+(key) @attribute
+
+(value) @string
+
+(value (escape) @constant.character.escape)
+
+((index) @constant.numeric.integer
+  (#match? @constant.numeric.integer "^[0-9]+$"))
+
+((substitution (key) @constant)
+  (#match? @constant "^[A-Z0-9_]+"))
+
+((value) @constant.builtin.boolean
+  (#any-of? @constant.builtin.boolean "true" "false" "enabled" "disabled"))
+
+((value) @constant.numeric.integer
+  (#match? @constant.numeric.integer "^-?[0-9]+$"))
+
+((value) @constant.numeric.float
+  (#match? @constant.numeric.float "^-?[0-9]+\.[0-9]$"))
+
+((value) @string.special.path
+  (#match? @string.special.path "^(\.{1,2})?/"))
+
+(substitution
+  (key) @function
+  "::" @punctuation.special
+  (secret) @string.special.symbol)
+
+(property [ "=" ":" ] @keyword.operator)
+
+[ "${" "}" ] @punctuation.special
+
+(substitution ":" @punctuation.special)
+
+[ "[" "]" ] @punctuation.bracket
+
+[ "." "\\" ] @punctuation.delimiter

--- a/runtime/queries/properties/injections.scm
+++ b/runtime/queries/properties/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/properties/locals.scm
+++ b/runtime/queries/properties/locals.scm
@@ -1,0 +1,5 @@
+(property
+  (key) @local.definition)
+
+(substitution
+  (key) @local.reference)

--- a/runtime/queries/properties/locals.scm
+++ b/runtime/queries/properties/locals.scm
@@ -1,5 +1,5 @@
 (property
-  (key) @local.definition)
+  (key) @local.definition.attribute)
 
 (substitution
   (key) @local.reference)

--- a/runtime/queries/properties/textobjects.scm
+++ b/runtime/queries/properties/textobjects.scm
@@ -1,0 +1,4 @@
+(comment) @comment.inside
+(comment)+ @comment.around
+
+(property (key) @parameter.inside) @parameter.around


### PR DESCRIPTION
Add support for [.properties](https://en.wikipedia.org/wiki/.properties) files, most commonly used in the Java ecosystem.

Most of the highlight queries are taken from the [tree-sitter-properties](https://github.com/tree-sitter-grammars/tree-sitter-properties) repository, where the parser is from. Modified to work with our highlight capture names. In addition, I have added some niceties like detecting values that are boolean, numeric and path file and highlighted them accordingly.

**Highlight Preview**

![image](https://github.com/user-attachments/assets/4154b31e-5cd0-4265-b986-26a6c36b3111)
