### PR TITLE
queries: Add locals.scm for C. Improve C parameter highlights

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -128,11 +128,36 @@
 (call_expression (argument_list (identifier) @variable))
 (function_declarator
   declarator: [(identifier) (field_identifier)] @function)
+
+; Up to 6 layers of declarators
 (parameter_declaration
   declarator: (identifier) @variable.parameter)
 (parameter_declaration
-  (pointer_declarator
-    declarator: (identifier) @variable.parameter))
+  (_
+    (identifier) @variable.parameter))
+(parameter_declaration
+  (_
+    (_
+      (identifier) @variable.parameter)))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (identifier) @variable.parameter))))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (_
+          (identifier) @variable.parameter)))))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (_
+          (_
+            (identifier) @variable.parameter))))))
+
 (preproc_function_def
   name: (identifier) @function.special)
 

--- a/runtime/queries/c/locals.scm
+++ b/runtime/queries/c/locals.scm
@@ -1,0 +1,38 @@
+;; Scopes
+(function_definition) @local.scope
+
+;; Definitions
+
+; Parameters
+; Up to 6 layers of declarators
+(parameter_declaration
+  (identifier) @local.definition.variable.parameter)
+(parameter_declaration
+  (_
+    (identifier) @local.definition.variable.parameter))
+(parameter_declaration
+  (_
+    (_
+      (identifier) @local.definition.variable.parameter)))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (identifier) @local.definition.variable.parameter))))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (_
+          (identifier) @local.definition.variable.parameter)))))
+(parameter_declaration
+  (_
+    (_
+      (_
+        (_
+          (_
+            (identifier) @local.definition.variable.parameter))))))
+
+;; References
+
+(identifier) @local.reference


### PR DESCRIPTION
C parsing is cursed. `void foo(int *****bar);` is legal. The nature of tree-sitter means that we have to explicitly choose how many layers we support. I arbitrarily selected 6 including the identifier. If someone hits this limit in the wild, they have larger problems than highlighting. This change also fixes things like `char** argv` not getting highlighted as a parameter. We also add a `locals.scm` capturing function parameters. Preprocessor parameters aren't included since the preprocessor body is currently parsed as an opaque block lol.

Closes: #12038