### PR TITLE
queries: Update highlights for Odin

### DIFF
--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -9,28 +9,31 @@
 ] @keyword.directive
 
 [
- "package"
-] @namespace
-
-[
   "import" 
 ] @keyword.control.import
 
 [
+  "package"
   "foreign"
   "using"
-  "struct"
-  "enum"
-  "union"
-  "defer"
   "cast"
   "transmute"
   "auto_cast"
+] @keyword
+
+[
+  "defer"
+] @keyword.control
+
+[
+  "struct"
+  "enum"
+  "union"
   "map"
   "bit_set"
   "matrix"
   "bit_field"
-] @keyword
+] @keyword.storage.type
 
 [
   "proc"
@@ -151,7 +154,7 @@
 
 (character) @string
 
-(escape_sequence) @string.special
+(escape_sequence) @constant.character.escape
 
 (boolean) @constant.builtin.boolean
 
@@ -193,6 +196,39 @@
 (overloaded_procedure_declaration (identifier) @function)
 
 (call_expression function: (identifier) @function)
+
+(call_expression
+  function: (identifier) @function.builtin
+  (#any-of? @function.builtin
+    "abs" "align_of" "append" "append_elem" "append_elem_string" 
+    "append_elems" "append_nothing" "append_soa" "append_soa_elem" 
+    "append_soa_elems" "append_string" "assert" "assert_contextless" 
+    "assign_at" "assign_at_elem" "assign_at_elem_string" "assign_at_elems" 
+    "cap" "card" "clamp" "clear" "clear_dynamic_array" "clear_map" "clear_soa" 
+    "complex" "conj" "container_of" "copy" "copy_from_string" "copy_slice" 
+    "delete" "delete_cstring" "delete_dynamic_array" "delete_key" 
+    "delete_map" "delete_slice" "delete_soa" "delete_string" 
+    "expand_values" "free" "free_all" "imag" "init_global_temporary_allocator" 
+    "inject_at" "inject_at_elem" "inject_at_elem_string" "inject_at_elems" 
+    "jmag" "kmag" "len" "make" "make_dynamic_array" "make_dynamic_array_len" 
+    "make_dynamic_array_len_cap" "make_map" "make_multi_pointer" "make_slice" 
+    "make_soa" "make_soa_aligned" "make_soa_dynamic_array" 
+    "make_soa_dynamic_array_len" "make_soa_dynamic_array_len_cap" 
+    "make_soa_slice" "map_insert" "map_upsert" "max" "min" 
+    "new_clone" "non_zero_append" "non_zero_append_elem" 
+    "non_zero_append_elem_string" "non_zero_append_elems" 
+    "non_zero_append_soa_elem" "non_zero_append_soa_elems" 
+    "non_zero_resize" "non_zero_resize_dynamic_array" "non_zero_resize_soa" 
+    "non_zero_reserve" "non_zero_reserve_dynamic_array" "non_zero_reserve_soa" 
+    "offset_of" "offset_of_by_string" "offset_of_member" "offset_of_selector" 
+    "ordered_remove" "panic" "panic_contextless" "pop" "pop_front" 
+    "pop_front_safe" "pop_safe" "raw_data" "raw_soa_footer_dynamic_array" 
+    "raw_soa_footer_slice" "real" "remove_range" "reserve" 
+    "reserve_dynamic_array" "reserve_map" "reserve_soa" "resize" 
+    "resize_dynamic_array" "resize_soa" "shrink" "shrink_map" 
+    "size_of" "soa_unzip" "soa_zip" "swizzle" "type_info_of" "type_of" 
+    "typeid_of" "unordered_remove" "unordered_remove_soa" 
+    "unimplemented" "unimplemented_contextless"))
 
 ; Types
 
@@ -239,6 +275,10 @@
 ; Fields
 
 (member_expression "." (identifier) @variable.other.member)
+(member_expression
+  (identifier) "."
+  (call_expression
+    function: (identifier) @function.method))
 
 (struct_type "{" (identifier) @variable.other.member)
 
@@ -256,7 +296,7 @@
 
 (using_statement (identifier) @namespace)
 
-(import_declaration (identifier) @keyword.storage.type)
+(import_declaration (identifier) @namespace)
 
 ; Parameters
 


### PR DESCRIPTION
Mostly taken from [the linked issue](https://github.com/helix-editor/helix/compare/master...antek-bizon:helix:master).

Closes: #11711