### PR TITLE
Add highlighting for git notes editmsg

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -78,6 +78,7 @@
 | git-commit | ✓ | ✓ |  |  |
 | git-config | ✓ | ✓ |  |  |
 | git-ignore | ✓ |  |  |  |
+| git-notes | ✓ |  |  |  |
 | git-rebase | ✓ |  |  |  |
 | gjs | ✓ | ✓ | ✓ | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | gleam | ✓ | ✓ |  | `gleam` |

--- a/languages.toml
+++ b/languages.toml
@@ -1869,6 +1869,16 @@ name = "gitcommit"
 source = { git = "https://github.com/gbprod/tree-sitter-gitcommit", rev = "a716678c0f00645fed1e6f1d0eb221481dbd6f6d" }
 
 [[language]]
+name = "git-notes"
+scope = "git.notesmsg"
+file-types = [{ glob = "NOTES_EDITMSG" }]
+comment-token = "#"
+indent = { tab-width = 4, unit = "    " }
+rulers = [73]
+text-width = 72
+grammar = "gitcommit"
+
+[[language]]
 name = "diff"
 scope = "source.diff"
 file-types = ["diff", "patch", "rej"]

--- a/runtime/queries/git-notes/highlights.scm
+++ b/runtime/queries/git-notes/highlights.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
Piggybacking off the git-commit grammar seems a little fishy, but highlighting just the comments is already a win and that works well.