### PR TITLE
queries: Stop Rust highlighting path as local

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -23,3 +23,6 @@
 
 ; References
 (identifier) @local.reference
+(scoped_identifier
+  path: (identifier)? @namespace
+  name: (identifier) @namespace)


### PR DESCRIPTION
See attached issue. I don't love the solution, but am not sure how else to attack the problem. We want to match *almost* every `identifier` in the scope. We don't want to match scoped identifiers, so the best I could come up with (without restating large chunks of `highlights.scm`) was to repeat the negative case. I think this could be another use case for `#has-ancestor?`, (or `#not-has-ancestor?` technically), but unless that gets added, I think this is the most straightforward solution.

Closes: #13194