### PR TITLE
Fix soft-wrap handling of wide punctuation graphemes for better layout and readability

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -416,10 +416,10 @@ impl<'t> DocumentFormatter<'t> {
 
             if grapheme.width() > 1
                 && (word_width >= viewport_width
-                    || self.visual_pos.col + grapheme.width() >= viewport_width)
+                    || self.visual_pos.col + word_width >= viewport_width)
             {
                 self.peeked_grapheme = Some(grapheme);
-                if word_width < viewport_width {
+                if word_chars == 1 {
                     self.wrap_word();
                 }
                 return;

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -414,15 +414,23 @@ impl<'t> DocumentFormatter<'t> {
             let is_word_boundary = grapheme.is_word_boundary();
             word_width += grapheme.width();
 
-            if grapheme.width() > 1
-                && (word_width >= viewport_width
-                    || self.visual_pos.col + word_width >= viewport_width)
-            {
-                self.peeked_grapheme = Some(grapheme);
-                if word_chars == 1 {
-                    self.wrap_word();
+            if grapheme.width() > 1 {
+                if is_word_boundary && self.visual_pos.col + word_width >= viewport_width {
+                    if word_chars == 2 {
+                        self.peeked_grapheme = Some(grapheme);
+                        self.wrap_word();
+                        return;
+                    } else if word_chars == 1 {
+                        self.word_buf.push(grapheme);
+                        self.wrap_word();
+                        return;
+                    }
                 }
-                return;
+
+                if word_chars > 1 {
+                    self.peeked_grapheme = Some(grapheme);
+                    return;
+                }
             }
 
             self.word_buf.push(grapheme);

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -369,7 +369,8 @@ impl<'t> DocumentFormatter<'t> {
         loop {
             let mut col = self.visual_pos.col + word_width;
             let char_pos = self.char_pos + word_chars;
-            match col.cmp(&(self.text_fmt.viewport_width as usize)) {
+            let viewport_width = self.text_fmt.viewport_width as usize;
+            match col.cmp(&viewport_width) {
                 // The EOF char and newline chars are always selectable in helix. That means
                 // that wrapping happens "too-early" if a word fits a line perfectly. This
                 // is intentional so that all selectable graphemes are always visible (and
@@ -415,6 +416,14 @@ impl<'t> DocumentFormatter<'t> {
             self.word_buf.push(grapheme);
 
             if is_word_boundary {
+                if word_width > viewport_width {
+                    self.peeked_grapheme = self.word_buf.pop();
+                    return;
+                }
+                if word_width + self.visual_pos.col > viewport_width {
+                    self.wrap_word();
+                    return;
+                }
                 return;
             }
         }

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -415,16 +415,13 @@ impl<'t> DocumentFormatter<'t> {
             word_width += grapheme.width();
 
             if grapheme.width() > 1 {
-                if is_word_boundary && self.visual_pos.col + word_width >= viewport_width {
-                    if word_chars == 2 {
-                        self.peeked_grapheme = Some(grapheme);
-                        self.wrap_word();
-                        return;
-                    } else if word_chars == 1 {
-                        self.word_buf.push(grapheme);
-                        self.wrap_word();
-                        return;
-                    }
+                if is_word_boundary
+                    && self.visual_pos.col + word_width >= viewport_width
+                    && word_chars <= 2
+                {
+                    self.word_buf.push(grapheme);
+                    self.wrap_word();
+                    return;
                 }
 
                 if word_chars > 1 {

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -413,17 +413,21 @@ impl<'t> DocumentFormatter<'t> {
 
             let is_word_boundary = grapheme.is_word_boundary();
             word_width += grapheme.width();
+
+            if grapheme.width() > 1
+                && (word_width >= viewport_width
+                    || self.visual_pos.col + grapheme.width() >= viewport_width)
+            {
+                self.peeked_grapheme = Some(grapheme);
+                if word_width < viewport_width {
+                    self.wrap_word();
+                }
+                return;
+            }
+
             self.word_buf.push(grapheme);
 
             if is_word_boundary {
-                if word_width > viewport_width {
-                    self.peeked_grapheme = self.word_buf.pop();
-                    return;
-                }
-                if word_width + self.visual_pos.col > viewport_width {
-                    self.wrap_word();
-                    return;
-                }
                 return;
             }
         }

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -122,7 +122,7 @@ fn softwrap_cjk_grapheme() {
     );
     assert_eq!(
         softwrap_text("这应该是一句中文。\n"),
-        "这应该是一句中文\n.。 \n "
+        "这应该是一句中\n.文。 \n "
     );
 }
 

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -110,6 +110,22 @@ fn softwrap_multichar_grapheme() {
     )
 }
 
+#[test]
+fn softwrap_cjk_grapheme() {
+    assert_eq!(
+        softwrap_text("xxxx1xxxx2xxxx3x《\n"),
+        "xxxx1xxxx2xxxx3x\n.《 \n "
+    );
+    assert_eq!(
+        softwrap_text("xxxx1xxxx》xxxx2》\n"),
+        "xxxx1xxxx》xxxx2\n.》 \n "
+    );
+    assert_eq!(
+        softwrap_text("这应该是一句中文。\n"),
+        "这应该是一句中文\n.。 \n "
+    );
+}
+
 fn softwrap_text_at_text_width(text: &str) -> String {
     let mut text_fmt = TextFormat::new_test(true);
     text_fmt.soft_wrap_at_text_width = true;


### PR DESCRIPTION
This PR improves soft-wrap behavior in the formatter:

* Fixes an issue where wide punctuation could be hidden at wrap points.
* Correctly handles wide punctuation, wrapping as late as possible while ensuring punctuation does not appear at the start of a new line.
* Avoids overly early wrapping that leaves excessive whitespace at line ends, improving overall layout and readability.

Fixes #13897
Fixes #6585