### PR TITLE
Rose pine theme: improves contrast of selected menu item

### DIFF
--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -45,7 +45,7 @@
 "ui.virtual.inlay-hint" = { fg = "subtle" }
 
 "ui.menu" = { fg = "subtle", bg = "surface" }
-"ui.menu.selected" = { fg = "text" }
+"ui.menu.selected" = { fg = "text", bg = "overlay" }
 "ui.menu.scroll" = { fg = "muted", bg = "highlight_med" }
 
 "ui.selection" = { bg = "overlay" }


### PR DESCRIPTION
As mentioned [here](https://github.com/rose-pine/helix/issues/16#issuecomment-3040492474), the contrast of the selected item in the completion menu is quite low for the rose-pine themes, since the background color of the selected item does not change. This improves this by highlighting the background of the selected item.