### PR TITLE
Add filter_format field for Column in pickers

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -281,6 +281,16 @@ fn diag_picker(
                 } else {
                     Default::default()
                 }
+            })
+            .with_filter_format(|item: &PickerDiagnostic, _| {
+                if let Some(path) = item.location.uri.as_path() {
+                    path::get_relative_path(path)
+                        .to_string_lossy()
+                        .to_string()
+                        .into()
+                } else {
+                    Default::default()
+                }
             }),
         );
         primary_column += 1;


### PR DESCRIPTION
Add the option to provide a formatting function for the filtering of picker columns that is separate from the formatting function for displaying it in the view.
Use this new option for the "path" column of the workspace diagnostics picker, so that we are filtering on the full (relative) file path, instead of the truncated value.

Fixes #13608