### PR TITLE
queries/gomod: add "tool", "toolchain" to keywords

### DIFF
--- a/runtime/queries/gomod/highlights.scm
+++ b/runtime/queries/gomod/highlights.scm
@@ -2,6 +2,8 @@
   "require"
   "replace"
   "go"
+  "toolchain"
+  "tool"
   "exclude"
   "retract"
   "module"


### PR DESCRIPTION
Go 1.21 added a `toolchain` directive to `go.mod` files: https://tip.golang.org/doc/go1.21#tools
Go 1.24 added a `tool` directive to `go.mod` files: https://tip.golang.org/doc/go1.24#go-command