### PR TITLE
Simplify saving logic and make it well behaved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fern"
@@ -1625,6 +1625,7 @@ dependencies = [
  "chardetng",
  "clipboard-win",
  "crossterm",
+ "fastrand",
  "futures-util",
  "helix-core",
  "helix-dap",
@@ -1642,7 +1643,6 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
- "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -42,6 +42,9 @@ slotmap.workspace = true
 
 chardetng = "0.1"
 
+# For file saving. foo.toml <- foo.toml.abcdefgh.tmp
+fastrand = "2.3.0"
+
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -28,8 +28,6 @@ bitflags.workspace = true
 anyhow = "1"
 crossterm = { version = "0.28", optional = true }
 
-tempfile.workspace = true
-
 # Conversion traits
 once_cell = "1.21"
 url = "2.5.4"

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -14,7 +14,7 @@ use helix_core::syntax::config::LanguageServerFeature;
 use helix_core::text_annotations::{InlineAnnotation, Overlay};
 use helix_event::TaskController;
 use helix_lsp::util::lsp_pos_to_pos;
-use helix_stdx::faccess::{copy_metadata, readonly};
+use helix_stdx::faccess::readonly;
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
 use once_cell::sync::OnceCell;
 use thiserror;
@@ -25,7 +25,6 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::fmt::Display;
 use std::future::Future;
 use std::io;
@@ -1026,14 +1025,21 @@ impl Document {
             }
 
             let mut tmp_write_path = write_path.clone();
+
+            let tmp_write_path_extension: String = std::iter::repeat_with(fastrand::alphabetic)
+                .take(8)
+                .chain(".tmp".chars())
+                .collect();
+
             // add_extension is unstable.
             tmp_write_path.set_extension(match tmp_write_path.extension() {
                 Some(existing) => {
                     let mut existing = existing.to_owned();
-                    existing.push(".tmp");
+                    existing.push(".");
+                    existing.push(tmp_write_path_extension);
                     existing
                 }
-                None => OsString::from("tmp"),
+                None => tmp_write_path_extension.into(),
             });
 
             let mut tmp_write = fs::File::create(&tmp_write_path)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use arc_swap::access::DynAccess;
 use arc_swap::ArcSwap;
 use futures_util::future::BoxFuture;
@@ -25,6 +25,7 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fmt::Display;
 use std::future::Future;
 use std::io;
@@ -966,12 +967,7 @@ impl Document {
 
         let path = match path {
             Some(path) => helix_stdx::path::canonicalize(path),
-            None => {
-                if self.path.is_none() {
-                    bail!("Can't save with no path set!");
-                }
-                self.path.as_ref().unwrap().clone()
-            }
+            None => self.path.clone().context("Can't save with no path set!")?,
         };
 
         let identifier = self.path().map(|_| self.identifier());
@@ -987,6 +983,7 @@ impl Document {
         // We encode the file according to the `Document`'s encoding.
         let future = async move {
             use tokio::fs;
+
             if let Some(parent) = path.parent() {
                 // TODO: display a prompt asking the user if the directories should be created
                 if !parent.exists() {
@@ -1008,7 +1005,8 @@ impl Document {
                     }
                 }
             }
-            let write_path = tokio::fs::read_link(&path)
+
+            let write_path = fs::read_link(&path)
                 .await
                 .ok()
                 .and_then(|p| {
@@ -1027,88 +1025,33 @@ impl Document {
                 ));
             }
 
-            // Assume it is a hardlink to prevent data loss if the metadata cant be read (e.g. on certain Windows configurations)
-            let is_hardlink = helix_stdx::faccess::hardlink_count(&write_path).unwrap_or(2) > 1;
-            let backup = if path.exists() {
-                let path_ = write_path.clone();
-                // hacks: we use tempfile to handle the complex task of creating
-                // non clobbered temporary path for us we don't want
-                // the whole automatically delete path on drop thing
-                // since the path doesn't exist yet, we just want
-                // the path
-                tokio::task::spawn_blocking(move || -> Option<PathBuf> {
-                    let mut builder = tempfile::Builder::new();
-                    builder.prefix(path_.file_name()?).suffix(".bck");
+            let mut tmp_write_path = write_path.clone();
+            // add_extension is unstable.
+            tmp_write_path.set_extension(match tmp_write_path.extension() {
+                Some(existing) => {
+                    let mut existing = existing.to_owned();
+                    existing.push(".tmp");
+                    existing
+                }
+                None => OsString::from("tmp"),
+            });
 
-                    let backup_path = if is_hardlink {
-                        builder
-                            .make_in(path_.parent()?, |backup| std::fs::copy(&path_, backup))
-                            .ok()?
-                            .into_temp_path()
-                    } else {
-                        builder
-                            .make_in(path_.parent()?, |backup| std::fs::rename(&path_, backup))
-                            .ok()?
-                            .into_temp_path()
-                    };
-
-                    backup_path.keep().ok()
-                })
+            let mut tmp_write = fs::File::create(&tmp_write_path)
                 .await
-                .ok()
-                .flatten()
-            } else {
-                None
-            };
+                .context("can't create a temporary write file in directory")?;
 
-            let write_result: anyhow::Result<_> = async {
-                let mut dst = tokio::fs::File::create(&write_path).await?;
-                to_writer(&mut dst, encoding_with_bom_info, &text).await?;
-                dst.sync_all().await?;
-                Ok(())
-            }
-            .await;
+            to_writer(&mut tmp_write, encoding_with_bom_info, &text).await?;
+            tmp_write.sync_all().await?;
+
+            // Move temporary file into destination atomically.
+            fs::rename(&tmp_write_path, &write_path)
+                .await
+                .context("can't move temporary write file to destination")?;
 
             let save_time = match fs::metadata(&write_path).await {
                 Ok(metadata) => metadata.modified().map_or(SystemTime::now(), |mtime| mtime),
                 Err(_) => SystemTime::now(),
             };
-
-            if let Some(backup) = backup {
-                if is_hardlink {
-                    let mut delete = true;
-                    if write_result.is_err() {
-                        // Restore backup
-                        let _ = tokio::fs::copy(&backup, &write_path).await.map_err(|e| {
-                            delete = false;
-                            log::error!("Failed to restore backup on write failure: {e}")
-                        });
-                    }
-
-                    if delete {
-                        // Delete backup
-                        let _ = tokio::fs::remove_file(backup)
-                            .await
-                            .map_err(|e| log::error!("Failed to remove backup file on write: {e}"));
-                    }
-                } else if write_result.is_err() {
-                    // restore backup
-                    let _ = tokio::fs::rename(&backup, &write_path)
-                        .await
-                        .map_err(|e| log::error!("Failed to restore backup on write failure: {e}"));
-                } else {
-                    // copy metadata and delete backup
-                    let _ = tokio::task::spawn_blocking(move || {
-                        let _ = copy_metadata(&backup, &write_path)
-                            .map_err(|e| log::error!("Failed to copy metadata on write: {e}"));
-                        let _ = std::fs::remove_file(backup)
-                            .map_err(|e| log::error!("Failed to remove backup file on write: {e}"));
-                    })
-                    .await;
-                }
-            }
-
-            write_result?;
 
             let event = DocumentSavedEvent {
                 revision: current_rev,


### PR DESCRIPTION
Previously, Helix did the following when we saved a file:

1. Created a .bck (backup) file, copied the original's contents over.
2. Re-created the original, empty this time. Then wrote to it.
3. If writing or creating failed, it moved the backup back into the original file.
  3.1. Though, it did different stuff for hardlinks. Also not ideal.

The issue here is that if helix crashes / gets killed while executing
step 2 or 3, the file would be in an inconsistent state. This is not ideal
at all, file writing isn't atomic with this strategy.

This patch simplifies this logic into:

- Create a temporary file, write the stuff we want to write into it.
- If that fails, we don't need to do anything as the original file is
  untouched. (Though we do delete that tmp file if writing to it or moving it in-place fails)
- If it is successful, we rename the temporary file over the actual
  write destionation. This is atomic, and if it fails the destination is
  unmodified.

There are also other benefits from doing the latter, such as inotify.
Previously, we would get these events for an edit of `.cargo/config.toml`:

    Create /Users/pala/Projects/helix/.cargo/config.toml.bck
    Write /Users/pala/Projects/helix/.cargo/config.toml.bck
    Create /Users/pala/Projects/helix/.cargo/config.toml
    Write /Users/pala/Projects/helix/.cargo/config.toml
    Remove /Users/pala/Projects/helix/.cargo/config.toml.bck

Now, we get these:

    Create /Users/pala/Projects/helix/.cargo/config.toml.tmp
    Write /Users/pala/Projects/helix/.cargo/config.toml.tmp
    Write /Users/pala/Projects/helix/.cargo/config.toml

This is better and easier to handle, because inotify events
actually look like we are writing to the target file, instead of
re-creating it.