### PR TITLE
Odin grammar and query updates

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2391,7 +2391,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "odin"
-source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-odin", rev = "b5f668ef8918aab13812ce73acd89fe191fb8c5e" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-odin", rev = "6c6b07e354a52f8f2a9bc776cbc262a74e74fd26" }
 
 [[language]]
 name = "meson"

--- a/runtime/queries/odin/highlights.scm
+++ b/runtime/queries/odin/highlights.scm
@@ -57,6 +57,7 @@
   "case"
   "where"
   "break"
+  "or_break"
   (fallthrough_statement)
 ] @keyword.control.conditional
 
@@ -73,6 +74,7 @@
   "for"
   "do"
   "continue"
+  "or_continue"
 ] @keyword.control.repeat
 
 [

--- a/runtime/queries/odin/indents.scm
+++ b/runtime/queries/odin/indents.scm
@@ -6,6 +6,7 @@
   (struct)
   (parameters)
   (tuple_type)
+  (struct_type)
   (call_expression)
   (switch_case)
 ] @indent
@@ -21,3 +22,4 @@
 (union_declaration "}" @outdent)
 (struct_declaration "}" @outdent)
 (struct "}" @outdent)
+(struct_type "}" @outdent)


### PR DESCRIPTION
The added keywords are used like this:
```odin
for {
	(foo == true) or_continue
	(bar == true) or_break
}
```