### PR TITLE
Allow `:move` command to accept directories as target

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2463,7 +2463,16 @@ fn move_buffer(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         .path()
         .context("Scratch buffer cannot be moved. Use :write instead")?
         .clone();
-    let new_path = args.first().unwrap().to_string();
+    let new_path: PathBuf = args.first().unwrap().to_string().into();
+
+    // if new_path is a directory, append the original file name
+    // to move the file into that directory.
+    let new_path = old_path
+        .file_name()
+        .filter(|_| new_path.is_dir())
+        .map(|old_file_name| new_path.join(old_file_name))
+        .unwrap_or(new_path);
+
     if let Err(err) = cx.editor.move_path(&old_path, new_path.as_ref()) {
         bail!("Could not move file: {err}");
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2463,7 +2463,7 @@ fn move_buffer(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         .path()
         .context("Scratch buffer cannot be moved. Use :write instead")?
         .clone();
-    let new_path: PathBuf = args.first().unwrap().to_string().into();
+    let new_path: PathBuf = args.first().unwrap().into();
 
     // if new_path is a directory, append the original file name
     // to move the file into that directory.


### PR DESCRIPTION
Currently, the `:move` command only accepts a file as the target. If a user wants to move a file to a different directory without changing its name, they must manually re-enter the file name, which can be inconvenient.

This PR checks whether the target path is a directory. If so, it automatically appends the original file name to the destination path.