### PR TITLE
languages: create dedicated language for json-ld

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -120,6 +120,7 @@
 | jq | ✓ | ✓ |  | `jq-lsp` |
 | jsdoc | ✓ |  |  |  |
 | json | ✓ | ✓ | ✓ | `vscode-json-language-server` |
+| json-ld | ✓ | ✓ | ✓ | `vscode-json-language-server` |
 | json5 | ✓ |  |  |  |
 | jsonc | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsonnet | ✓ |  |  | `jsonnet-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -514,7 +514,6 @@ file-types = [
   "css.map",
   { glob = ".jslintrc" },
   "jsonl",
-  "jsonld",
   { glob = ".vuerc" },
   { glob = "composer.lock" },
   { glob = ".watchmanconfig" },
@@ -552,6 +551,17 @@ comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
 grammar = "json"
 language-servers = [ "vscode-json-language-server" ]
+auto-format = true
+indent = { tab-width = 2, unit = "  " }
+
+# https://www.w3.org/TR/json-ld/
+[[language]]
+name = "json-ld"
+scope = "source.json-ld"
+injection-regex = "json-ld"
+grammar = "json"
+file-types = ["jsonld"]
+language-servers = ["vscode-json-language-server"]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
 

--- a/runtime/queries/json-ld/highlights.scm
+++ b/runtime/queries/json-ld/highlights.scm
@@ -1,0 +1,43 @@
+; inherits: json
+
+; https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords
+((string (string_content) @keyword)
+ (#any-of? @keyword
+   "@base"
+   "@container"
+   "@context"
+   "@direction"
+   "@graph"
+   "@id"
+   "@import"
+   "@included"
+   "@index"
+   "@json"
+   "@language"
+   "@list"
+   "@nest"
+   "@none"
+   "@prefix"
+   "@propagate"
+   "@protected"
+   "@reverse"
+   "@set"
+   "@type"
+   "@value"
+   "@version"
+   "@vocab"))
+
+((pair
+  value: (string (string_content) @string.special.url))
+ (#match? @string.special.url "^https?://"))
+
+((array
+  (string (string_content) @string.special.url))
+  (#match? @string.special.url "^https?://"))
+
+; https://www.w3.org/TR/json-ld/#dfn-base-direction
+((pair
+  key: (string (string_content) @keyword)
+  value: (string (string_content) @type.enum.variant))
+ (#eq? @keyword "@direction")
+ (#any-of? @type.enum.variant "ltr" "rtl"))

--- a/runtime/queries/json-ld/indents.scm
+++ b/runtime/queries/json-ld/indents.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/runtime/queries/json-ld/textobjects.scm
+++ b/runtime/queries/json-ld/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: json


### PR DESCRIPTION
Split [json-ld](https://www.w3.org/TR/json-ld/) into its own language, while inheriting the json grammar.

The main motivation for this is to provide better syntax highlighting for the special keys, such as `@context`, `@type`, `@id`, by using dedicated highlight queries, that would be superfluous for regular json documents. json-ld focuses on linking data on the web using hyperlinks. For that reason, `https?://` urls are highlighted using the `@string.special.url` capture.

**Highlight**

![screenshot-2025-07-09 21-31-24](https://github.com/user-attachments/assets/242c634a-de9d-4e4a-bac0-7ef6fe4f30f7)
