### PR TITLE
Add tree-sitter injections for jj config files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -117,6 +117,7 @@
 | java | ✓ | ✓ | ✓ | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jinja | ✓ |  |  |  |
+| jjconfig | ✓ | ✓ | ✓ | `taplo`, `tombi` |
 | jjdescription | ✓ |  |  |  |
 | jq | ✓ | ✓ |  | `jq-lsp` |
 | jsdoc | ✓ |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -119,6 +119,7 @@
 | jinja | ✓ |  |  |  |
 | jjconfig | ✓ | ✓ | ✓ | `taplo`, `tombi` |
 | jjdescription | ✓ |  |  |  |
+| jjtemplate | ✓ |  |  |  |
 | jq | ✓ | ✓ |  | `jq-lsp` |
 | jsdoc | ✓ |  |  |  |
 | json | ✓ | ✓ | ✓ | `vscode-json-language-server` |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -119,6 +119,7 @@
 | jinja | ✓ |  |  |  |
 | jjconfig | ✓ | ✓ | ✓ | `taplo`, `tombi` |
 | jjdescription | ✓ |  |  |  |
+| jjrevset | ✓ |  |  |  |
 | jjtemplate | ✓ |  |  |  |
 | jq | ✓ | ✓ |  | `jq-lsp` |
 | jsdoc | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -3565,6 +3565,15 @@ name = "jjdescription"
 source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "1613b8c85b6ead48464d73668f39910dcbb41911" }
 
 [[language]]
+name = "jjrevset"
+scope = "jj.revset"
+file-types = ["jjrevset"]
+
+[[grammar]]
+name = "jjrevset"
+source = { git = "https://github.com/bryceberger/tree-sitter-jjrevset", rev = "d9af23944b884ec528b505f41d81923bb3136a51" }
+
+[[language]]
 name = "jjtemplate"
 scope = "jj.template"
 file-types = ["jjtemplate"]

--- a/languages.toml
+++ b/languages.toml
@@ -3543,7 +3543,7 @@ source = { git = "https://github.com/varpeti/tree-sitter-jinja2", rev = "a533cd3
 
 [[language]]
 name = "jjconfig"
-scope = "source.toml"
+scope = "source.jjconfig"
 injection-regex = "jjconfig"
 grammar = "toml"
 file-types = [{ glob = "jj/config.toml" }, { glob = "jj/conf.d/*.toml" }, { glob = ".jj/repo/*.toml" }]

--- a/languages.toml
+++ b/languages.toml
@@ -3542,6 +3542,16 @@ name = "jinja2"
 source = { git = "https://github.com/varpeti/tree-sitter-jinja2", rev = "a533cd3c33aea6acb0f9bf9a56f35dcfe6a8eb53" }
 
 [[language]]
+name = "jjconfig"
+scope = "source.toml"
+injection-regex = "jjconfig"
+grammar = "toml"
+file-types = [{ glob = "jj/config.toml" }, { glob = "jj/conf.d/*.toml" }, { glob = ".jj/repo/*.toml" }]
+comment-token = "#"
+language-servers = [ "taplo", "tombi" ]
+indent = { tab-width = 2, unit = "  " }
+
+[[language]]
 name = "jjdescription"
 scope = "jj.description"
 file-types = [{ glob = "*.jjdescription" }]

--- a/languages.toml
+++ b/languages.toml
@@ -3565,6 +3565,15 @@ name = "jjdescription"
 source = { git = "https://github.com/kareigu/tree-sitter-jjdescription", rev = "1613b8c85b6ead48464d73668f39910dcbb41911" }
 
 [[language]]
+name = "jjtemplate"
+scope = "jj.template"
+file-types = ["jjtemplate"]
+
+[[grammar]]
+name = "jjtemplate"
+source = { git = "https://github.com/bryceberger/tree-sitter-jjtemplate", rev = "4313eda8ac31c60e550e3ad5841b100a0a686715" }
+
+[[language]]
 name = "jq"
 scope = "source.jq"
 injection-regex = "jq"

--- a/runtime/queries/jjconfig/highlights.scm
+++ b/runtime/queries/jjconfig/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/jjconfig/indents.scm
+++ b/runtime/queries/jjconfig/indents.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/jjconfig/injections.scm
+++ b/runtime/queries/jjconfig/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/jjconfig/injections.scm
+++ b/runtime/queries/jjconfig/injections.scm
@@ -1,2 +1,6 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+(table
+ (bare_key) @table-name (#any-of? @table-name "templates" "template-aliases")
+ [(pair (_) ((string) @injection.content (#set! injection.language "jjtemplate"))) (comment)]*)

--- a/runtime/queries/jjconfig/injections.scm
+++ b/runtime/queries/jjconfig/injections.scm
@@ -4,3 +4,7 @@
 (table
  (bare_key) @table-name (#any-of? @table-name "templates" "template-aliases")
  [(pair (_) ((string) @injection.content (#set! injection.language "jjtemplate"))) (comment)]*)
+
+(table
+ (bare_key) @table-name (#any-of? @table-name "revsets" "revset-aliases")
+ [(pair (_) ((string) @injection.content (#set! injection.language "jjrevset"))) (comment)]*)

--- a/runtime/queries/jjconfig/textobjects.scm
+++ b/runtime/queries/jjconfig/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/jjrevset/highlights.scm
+++ b/runtime/queries/jjrevset/highlights.scm
@@ -1,0 +1,18 @@
+(at_op) @variable.builtin
+
+[
+  "::" ".."
+  (negate_op)
+  (union_op) (intersection_op) (difference_op)
+] @operator
+
+["(" ")"] @punctuation.bracket
+"," @punctuation.comma
+[(raw_string_literal) (string_literal)] @string
+
+(function ((strict_identifier) @function))
+(function (function_arguments (keyword_argument (strict_identifier) @variable.parameter)))
+
+(primary ((identifier) @variable))
+
+(string_pattern (strict_identifier) @keyword)

--- a/runtime/queries/jjrevset/highlights.scm
+++ b/runtime/queries/jjrevset/highlights.scm
@@ -7,7 +7,7 @@
 ] @operator
 
 ["(" ")"] @punctuation.bracket
-"," @punctuation.comma
+"," @punctuation.delimiter
 [(raw_string_literal) (string_literal)] @string
 
 (function ((strict_identifier) @function))

--- a/runtime/queries/jjtemplate/highlights.scm
+++ b/runtime/queries/jjtemplate/highlights.scm
@@ -3,7 +3,7 @@
 (term (_) ("." @punctuation) ((function ((identifier) @function.method))))
 
 ["(" ")"] @punctuation.bracket
-"," @punctuation.comma
+"," @punctuation.delimiter
 
 ((identifier) @keyword.control.conditional (#eq? @keyword.control.conditional "if"))
 ((identifier) @keyword.control.repeat (#eq? @keyword.control.repeat "for"))

--- a/runtime/queries/jjtemplate/highlights.scm
+++ b/runtime/queries/jjtemplate/highlights.scm
@@ -1,0 +1,14 @@
+(function ((identifier) @function))
+; method calls
+(term (_) ("." @punctuation) ((function ((identifier) @function.method))))
+
+["(" ")"] @punctuation.bracket
+"," @punctuation.comma
+
+((identifier) @keyword.control.conditional (#eq? @keyword.control.conditional "if"))
+((identifier) @keyword.control.repeat (#eq? @keyword.control.repeat "for"))
+
+(term ((identifier) @variable))
+
+[(infix_ops) "++"] @operator
+[(string_literal) (raw_string_literal)] @string


### PR DESCRIPTION
The config file for [`jj`](https://github.com/jj-vcs/jj) has some tables that canonically contain a few domain-specific languages: all keys in `[revsets]` and `[revset-aliases]` are revsets, and similar for templates in `[templates]` and `[template-aliases]`.

This injects those languages where appropriate.

![screenshot](https://github.com/user-attachments/assets/43ca94e0-ed64-41c0-aa90-8ab8b0d688a1)
![screenshot](https://github.com/user-attachments/assets/9fcbc461-ab3b-4147-b209-aa00113d4ad0)
