### PR TITLE
languages: consider compose.yaml/.yml as docker compose language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1859,9 +1859,9 @@ source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = 
 [[language]]
 name = "docker-compose"
 scope = "source.yaml.docker-compose"
-roots = ["docker-compose.yaml", "docker-compose.yml"]
+roots = ["docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml"]
 language-servers = [ "docker-compose-langserver", "yaml-language-server" ]
-file-types = [{ glob = "docker-compose.yaml" }, { glob = "docker-compose.yml" }]
+file-types = [{ glob = "docker-compose.yaml" }, { glob = "docker-compose.yml" }, { glob = "compose.yaml" }, { glob = "compose.yml" }]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 grammar = "yaml"


### PR DESCRIPTION
Adds compose.yaml and compose.yml to the docker compose language. 

As of now, the [Docker Compose documentation](https://web.archive.org/web/20250705182827/https://docs.docker.com/compose/intro/compose-application-model/) specifies that the preferred way to declare a file is using this name. 

Let me know if anything needs changing. Thanks!