### PR TITLE
Add Django language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -105,6 +105,7 @@
 | hoon | ✓ |  |  |  |
 | hosts | ✓ |  |  |  |
 | html | ✓ |  |  | `vscode-html-language-server`, `superhtml` |
+| htmldjango | ✓ |  |  | `djlsp`, `vscode-html-language-server`, `superhtml` |
 | hurl | ✓ | ✓ | ✓ |  |
 | hyprlang | ✓ |  | ✓ | `hyprls` |
 | idris |  |  |  | `idris2-lsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -32,6 +32,7 @@ csharp-ls = { command = "csharp-ls" }
 cuelsp = { command = "cuelsp" }
 dart = { command = "dart", args = ["language-server", "--client-id=helix"] }
 dhall-lsp-server = { command = "dhall-lsp-server" }
+djlsp = { command = "djlsp" }
 docker-langserver = { command = "docker-langserver", args = ["--stdio"] }
 docker-compose-langserver = { command = "docker-compose-langserver", args = ["--stdio"]}
 dot-language-server = { command = "dot-language-server", args = ["--stdio"] }
@@ -955,6 +956,25 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "html"
 source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "cbb91a0ff3621245e890d1c50cc811bffb77a26b" }
+
+[[language]]
+name = "htmldjango"
+scope = "source.htmldjango"
+injection-regex = "htmldjango"
+language-servers = ["djlsp", "vscode-html-language-server", "superhtml"]
+file-types = []
+
+[language.auto-pairs]
+'"' = '"'
+'(' = ')'
+'[' = ']'
+'{' = '}'
+'%' = '%'
+'<' = '>'
+
+[[grammar]]
+name = "htmldjango"
+source = { git = "https://github.com/interdependence/tree-sitter-htmldjango", rev = "3a643167ad9afac5d61e092f08ff5b054576fadf" }
 
 [[language]]
 name = "python"

--- a/runtime/queries/htmldjango/highlights.scm
+++ b/runtime/queries/htmldjango/highlights.scm
@@ -1,0 +1,26 @@
+[
+  (unpaired_comment)
+  (paired_comment)
+] @comment
+
+[
+  "{{"
+  "}}"
+  "{%"
+  "%}"
+  (end_paired_statement)
+] @punctuation.bracket
+
+[
+ (tag_name) 
+] @function
+
+(variable_name) @variable
+(filter_name) @function
+(filter_argument) @variable.parameter
+(keyword) @keyword
+(operator) @operator
+(keyword_operator) @keyword.operator
+(number) @constant.numeric
+(boolean) @constant.builtin.boolean
+(string) @string

--- a/runtime/queries/htmldjango/injections.scm
+++ b/runtime/queries/htmldjango/injections.scm
@@ -1,0 +1,3 @@
+((content) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))


### PR DESCRIPTION
I've been using this configuration for a while and have seen [this PR](https://github.com/helix-editor/helix/pull/3249). I believe having support that's disabled by default but can be explicitly enabled is still better than not having support at all.