### PR TITLE
chore(cargo-clippy): warn if `*ne_bytes` on all workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
 rust-version = "1.82"
+
+[workspace.lints.clippy]
+host_endian_bytes = "warn"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -61,3 +61,6 @@ regex-cursor = "0.1.5"
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }
 indoc = "2.0.6"
+
+[lints]
+workspace = true

--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -30,3 +30,6 @@ tokio-stream.workspace = true
 
 [dev-dependencies]
 fern = "0.7"
+
+[lints]
+workspace = true

--- a/helix-event/Cargo.toml
+++ b/helix-event/Cargo.toml
@@ -27,3 +27,6 @@ futures-executor = "0.3.31"
 
 [features]
 integration_test = []
+
+[lints]
+workspace = true

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -32,3 +32,6 @@ threadpool = { version = "1.0" }
 tempfile.workspace = true
 
 tree-house.workspace = true
+
+[lints]
+workspace = true

--- a/helix-lsp-types/Cargo.toml
+++ b/helix-lsp-types/Cargo.toml
@@ -31,3 +31,6 @@ default = []
 # Enables proposed LSP extensions.
 # NOTE: No semver compatibility is guaranteed for types enabled by this feature.
 proposed = []
+
+[lints]
+workspace = true

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -31,3 +31,6 @@ parking_lot.workspace = true
 arc-swap = "1"
 slotmap.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/helix-parsec/Cargo.toml
+++ b/helix-parsec/Cargo.toml
@@ -12,3 +12,6 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -30,3 +30,6 @@ rustix = { version = "1.0", features = ["fs"] }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -106,3 +106,6 @@ smallvec = "1.15"
 indoc = "2.0.6"
 tempfile.workspace = true
 same-file = "1.0.1"
+
+[lints]
+workspace = true

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -25,3 +25,6 @@ crossterm = { version = "0.28", optional = true }
 termini = "1.0"
 once_cell = "1.21"
 log = "~0.4"
+
+[lints]
+workspace = true

--- a/helix-vcs/Cargo.toml
+++ b/helix-vcs/Cargo.toml
@@ -28,3 +28,6 @@ git = ["gix"]
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -61,3 +61,6 @@ rustix = { version = "1.0", features = ["fs"] }
 
 [dev-dependencies]
 helix-tui = { path = "../helix-tui" }
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,3 +17,6 @@ helix-core = { path = "../helix-core" }
 helix-view = { path = "../helix-view" }
 helix-loader = { path = "../helix-loader" }
 toml = "0.8"
+
+[lints]
+workspace = true


### PR DESCRIPTION
closes #13189

reopening of #13944

~Taplo auto-formatted the files, that's why there are some style changes~

After `reset`&`restore`, I've ran:
```sh
printf %s $'\n[lints]\nworkspace = true' | tee -a helix-*/Cargo.toml xtask/Cargo.toml
```
Previously, I did it manually, to ensure the lines were always below dev-deps