### PR TITLE
feat(plugin): initial support for plugin system with WASM and Lua

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "gimli",
+ "gimli 0.29.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -72,10 +81,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -89,7 +115,7 @@ version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
- "addr2line",
+ "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
@@ -97,6 +123,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -129,6 +161,9 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -154,6 +189,8 @@ version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -202,6 +239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,12 +263,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b83fcf2fc1c8954561490d02079b496fd0c757da88129981e15bfe3a548229"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7496a6e92b5cee48c5d772b0443df58816dee30fed6ba19b2a28e78037ecedf"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a9dc0a8d3d49ee772101924968830f1c1937d650c571d3c2dd69dc36a68f41"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573c641174c40ef31021ae4a5a3ad78974e280633502d0dfc6e362385e0c100f"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7c94d572615156f2db682181cadbd96342892c31e08cc26a757344319a9220"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.31.1",
+ "hashbrown 0.15.4",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beecd9fcf2c3e06da436d565de61a42676097ea6eb6b4499346ac6264b6bb9ce"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen-shared",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4ff8d2e1235f2d6e7fc3c6738be6954ba972cd295f09079ebffeca2f864e22"
+
+[[package]]
+name = "cranelift-control"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001312e9fbc7d9ca9517474d6fe71e29d07e52997fd7efe18f19e8836446ceb2"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0fd6d4aae680275fcbceb08683416b744e65c8b607352043d3f0951d72b3b2"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd44e7e5dcea20ca104d45894748205c51365ce4cdb18f4418e3ba955971d1b"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f900e0a3847d51eed0321f0777947fb852ccfce0da7fb070100357f69a2f37fc"
+
+[[package]]
+name = "cranelift-native"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -312,6 +493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +509,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -343,6 +554,18 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -400,6 +623,12 @@ dependencies = [
  "home",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "faster-hex"
@@ -518,6 +747,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +806,17 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "gix"
@@ -1383,6 +1645,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1394,6 +1657,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helix-core"
@@ -1425,7 +1694,7 @@ dependencies = [
  "smallvec",
  "smartstring",
  "textwrap",
- "toml",
+ "toml 0.8.23",
  "tree-house",
  "unicode-general-category",
  "unicode-segmentation",
@@ -1479,7 +1748,7 @@ dependencies = [
  "serde",
  "tempfile",
  "threadpool",
- "toml",
+ "toml 0.8.23",
  "tree-house",
 ]
 
@@ -1519,6 +1788,18 @@ dependencies = [
 [[package]]
 name = "helix-parsec"
 version = "25.1.1"
+
+[[package]]
+name = "helix-plugin"
+version = "25.1.1"
+dependencies = [
+ "anyhow",
+ "mlua",
+ "serde",
+ "toml 0.9.2",
+ "walkdir",
+ "wasmtime",
+]
 
 [[package]]
 name = "helix-stdx"
@@ -1580,7 +1861,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -1646,7 +1927,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -1807,6 +2088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2157,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -1909,10 +2197,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "jiff"
@@ -1956,11 +2273,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.70"
+name = "jobserver"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1972,6 +2299,18 @@ checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "static_assertions",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1988,6 +2327,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -2044,6 +2389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2413,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+dependencies = [
+ "rustix 0.38.44",
+]
 
 [[package]]
 name = "memmap2"
@@ -2099,6 +2462,36 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "mlua"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+dependencies = [
+ "bstr",
+ "either",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "pkg-config",
+]
+
+[[package]]
+name = "my-first-plugin-source"
+version = "0.1.0"
 
 [[package]]
 name = "nucleo"
@@ -2142,10 +2535,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.4",
+ "indexmap",
  "memchr",
 ]
 
@@ -2190,6 +2586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2634,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -2248,6 +2668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2685,17 @@ dependencies = [
  "bitflags",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0ecb9823083f71df8735f21f6c44f2f2b55986d674802831df20f27e26c907"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -2324,6 +2764,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.4",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2904,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -2470,6 +2956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2983,17 @@ checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest",
  "sha1",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2567,6 +3073,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smartstring"
@@ -2594,6 +3103,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2636,6 +3151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +3167,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2791,9 +3321,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2806,6 +3351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,9 +3367,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
  "winnow",
 ]
 
@@ -2824,6 +3387,23 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tree-house"
@@ -2922,6 +3502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3530,16 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2978,24 +3574,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -3004,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3014,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3027,9 +3623,344 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
+dependencies = [
+ "leb128",
+ "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wasmtime"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
+dependencies = [
+ "addr2line 0.24.2",
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli 0.31.1",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 0.38.44",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "trait-variant",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.224.1",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5d75ac36ee28647f6d871a93eefc7edcb729c3096590031ba50857fac44fa8"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.8.23",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581ef04bf33904db9a902ffb558e7b2de534d6a4881ee985ea833f187a78fdf"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7108498a8a0afc81c7d2d81b96cdc509cd631d7bbaa271b7db5137026f10e3"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.31.1",
+ "itertools",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.224.1",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e90f6cba665939381839bbf2ddf12d732fca03278867910348ef1281b700954"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.31.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.224.1",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74812989369947f4f5a33f4ae8ff551eb6c8a97ff55e0269a9f5f0fac93cd755"
+dependencies = [
+ "cc",
+ "object",
+ "rustix 0.38.44",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-math"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f04c5dcf5b2f88f81cfb8d390294b2f67109dc4d0197ea7303c60a092df27c"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9681707f1ae9a4708ca22058722fca5c135775c495ba9b9624fe3732b94c97"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9c8eae8395d530bb00a388030de9f543528674c382326f601de47524376975"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli 0.31.1",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.224.1",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5531455e2c55994a1540355140369bb7ec0e46d2699731c5ee9f4cf9c3f7d4"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "235.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eda4293f626c99021bb3a6fbe4fbbe90c0e31a5ace89b5f620af8925de72e13"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.0",
+ "wasm-encoder 0.235.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e777e0327115793cb96ab220b98f85327ec3d11f34ec9e8d723264522ef206aa"
+dependencies = [
+ "wast",
+]
 
 [[package]]
 name = "which"
@@ -3072,6 +4003,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dbd4e07bd92c7ddace2f3267bdd31d4197b5ec58c315751325d45c19bfb56df"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli 0.31.1",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.224.1",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+]
 
 [[package]]
 name = "windows-core"
@@ -3268,6 +4217,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.224.1",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,7 +4254,7 @@ dependencies = [
  "helix-loader",
  "helix-term",
  "helix-view",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3382,3 +4349,31 @@ name = "zlib-rs"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
   "helix-vcs",
   "helix-parsec",
   "helix-stdx",
-  "xtask",
+  "xtask", "helix-plugin", "tests/test-plugins/my-first-plugin/my-first-plugin-source",
 ]
 
 default-members = [

--- a/README.md
+++ b/README.md
@@ -1,64 +1,89 @@
-<div align="center">
+# Helix Editor - Plugin Module (WASM & Lua)
 
-<h1>
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="logo_dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="logo_light.svg">
-  <img alt="Helix" height="128" src="logo_light.svg">
-</picture>
-</h1>
+This repository is a fork of the [Helix Editor](https://github.com/helix-editor/helix) and contains a proposed implementation for an extensible plugin system. The primary new functionality aims to allow the community to extend and customize the editor through plugins based on **WebAssembly (WASM)** and **Lua**.
 
-[![Build status](https://github.com/helix-editor/helix/actions/workflows/build.yml/badge.svg)](https://github.com/helix-editor/helix/actions)
-[![GitHub Release](https://img.shields.io/github/v/release/helix-editor/helix)](https://github.com/helix-editor/helix/releases/latest)
-[![Documentation](https://shields.io/badge/-documentation-452859)](https://docs.helix-editor.com/)
-[![GitHub contributors](https://img.shields.io/github/contributors/helix-editor/helix)](https://github.com/helix-editor/helix/graphs/contributors)
-[![Matrix Space](https://img.shields.io/matrix/helix-community:matrix.org)](https://matrix.to/#/#helix-community:matrix.org)
+The motivation behind this initiative is to introduce a robust, secure, and high-performance extensibility mechanism, aligned with Helix's core philosophy.
 
-</div>
+## 🚀 Plugin Proposal Overview
 
-![Screenshot](./screenshot.png)
+The proposed architecture for Helix's plugin system revolves around a new central `crate`, `helix-plugin`, which orchestrates the discovery, loading, and execution of plugins.
 
-A [Kakoune](https://github.com/mawww/kakoune) / [Neovim](https://github.com/neovim/neovim) inspired editor, written in Rust.
+### Supported Plugin Types
 
-The editing model is very heavily based on Kakoune; during development I found
-myself agreeing with most of Kakoune's design decisions.
+1.  **WebAssembly (WASM):** For complex and high-performance functionalities. It allows developers to use languages like Rust, C++, Go, Zig (compiling to `wasm32-wasi`), ensuring a first-class security sandbox.
+2.  **Lua:** Ideal for configurations, automations, and rapid prototyping, offering a lightweight, fast, and easy-to-embed scripting language in Rust.
 
-For more information, see the [website](https://helix-editor.com) or
-[documentation](https://docs.helix-editor.com/).
+### Core Principles of the Plugin System
 
-All shortcuts/keymaps can be found [in the documentation on the website](https://docs.helix-editor.com/keymap.html).
+The plugin system design adheres to the same principles as Helix:
 
-[Troubleshooting](https://github.com/helix-editor/helix/wiki/Troubleshooting)
+* **Security:** Plugin code should never be able to crash or corrupt the editor. Plugins must operate within a strict sandbox, with controlled access to system resources and the editor's state.
+* **Performance:** Loading and executing plugins should have a minimal impact on startup time and editing latency. The use of high-performance JIT runtimes is essential.
+* **Ergonomics:** Creating plugins should be a pleasant experience. The API should be well-documented, idiomatic, and powerful, with a fast development cycle.
+* **Flexibility:** The architecture must support both simple scripts for quick automation and complex, high-performance plugins written in compiled languages.
 
-# Features
+### Key Components
 
-- Vim-like modal editing
-- Multiple selections
-- Built-in language server support
-- Smart, incremental syntax highlighting and code editing via tree-sitter
+* **`helix-plugin` Crate:** This new crate will be the heart of the system, responsible for managing the complete lifecycle of plugins (discovery, loading, reloading, unloading), containing WASM (`wasmtime`) and Lua (`mlua`) runtimes, exposing a secure host API, and acting as a bridge between the Helix core and plugins.
+* **Plugin Manifest (`plugin.toml`):** Each plugin must include a manifest file for metadata and configuration, defining its name, version, authors, description, entrypoint (`main.wasm` or `main.lua`), and optional activation conditions (on command, on language, on event).
+* **The Plugin API (`helix::api`):** This is the contact surface between a plugin and the editor, a secure facade over internal Helix crates (`helix-core`, `helix-view`), ensuring no dangerous access to internal state. It includes functions like `show_message`, `register_command`, `get_buffer_content`, `insert_text`, `delete_text`, and `subscribe_to_event`.
 
-Although it's primarily a terminal-based editor, I am interested in exploring
-a custom renderer (similar to Emacs) using wgpu or skulpin.
+## 🛠️ Implementation Status (Progress Report)
 
-Note: Only certain languages have indentation definitions at the moment. Check
-`runtime/queries/<lang>/` for `indents.scm`.
+This proposal and its implementation have been developed in phases, as detailed in the full report:
 
-# Installation
+* **Phase 1: Foundation and Basic Structure:** Involved the creation of the `helix-plugin` crate, adding essential dependencies (`wasmtime`, `toml`, `walkdir`, `serde`, `anyhow`, `mlua`), defining the `plugin.toml` manifest, and implementing initial plugin discovery and basic WASM and Lua hosts.
+* **Phase 2: Integration with the Editor Core:** Focused on connecting the plugin system to Helix's main lifecycle, including `PluginManager` initialization in `helix-term`, integration into the `Application` struct, and establishing an event system (`EditorEvent::PluginCommand`, `EditorEvent::RegisterPluginCommand`, `EditorEvent::PluginResponse`, `EditorEvent::PluginEvent`) for communication. The command dispatcher was modified to handle plugin commands dynamically.
+* **Phase 3: API Expansion and Full Host Integration:** Enhanced the `HelixApi` with core functions and exposed them to both `WasmHost` and `LuaHost`, enabling plugins to interact richly with the editor. This phase also included robust argument passing and response handling.
+* **Phase 4: Documentation and Ecosystem:** Initiated plugin developer documentation (`book/src/plugins.md`) and updated project templates for Rust (WASM) and Lua plugins.
+* **Phase 5: Basic Event System:** Implemented mechanisms for plugins to subscribe to and react to specific editor events.
+* **Phase 6: Error Handling and Reporting:** Improved error handling and user feedback for plugin failures, utilizing detailed logs and consistent error capturing.
 
-[Installation documentation](https://docs.helix-editor.com/install.html).
+## 🛣️ Suggested Implementation Roadmap (Robust Version)
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/helix-editor.svg?exclude_unsupported=1)](https://repology.org/project/helix-editor/versions)
+For a first robust version, we prioritize the following areas:
 
-# Contributing
+* **WASM Compilation Environment:** Ensure the Helix development environment can compile Rust plugins for the `wasm32-wasi` target.
+* **Robust Bidirectional Communication:** Implement a robust mechanism for host functions (Helix) to return values to plugins (WASM and Lua).
+* **Essential API Expansion:** Expand the `HelixApi` to expose the most basic and crucial editor functionalities for plugins (read and write access).
+* **Dynamic Command Management:** Finalize the implementation of dynamic command registration and execution, including refined argument passing.
+* **Basic Event System:** Implement a mechanism for plugins to subscribe to and react to specific editor events.
+* **Error Handling and Reporting:** Improve error handling and user feedback for plugin failures to ensure editor robustness.
 
-Contributing guidelines can be found [here](./docs/CONTRIBUTING.md).
+## 🤝 How to Contribute and Test
 
-# Getting help
+If you are interested in testing this proposal or contributing, please follow these steps (assuming you have already cloned this fork):
 
-Your question might already be answered on the [FAQ](https://github.com/helix-editor/helix/wiki/FAQ).
+1.  **Build Helix with the Plugin Module:**
+    ```bash
+    # Ensure you have Rust and the wasm32-wasi toolchain installed
+    rustup target add wasm32-wasi
+    
+    # From the root directory of this repository
+    cargo build --release
+    ```
+2.  **Install an Example Plugin:**
+    Create a directory for the plugin inside `~/.config/helix/plugins/` (or your operating system's Helix configuration directory) and place the `plugin.toml` and the entry point file (`.wasm` or `.lua`) there.
+    Example:
+    ```
+    ~/.config/helix/plugins/
+    └── my-plugin/
+        ├── plugin.toml
+        └── main.wasm  # or main.lua
+    ```
+    You can find example templates in `helix-plugin/templates/`.
+3.  **Run the Modified Helix:**
+    ```bash
+    /path/to/your/helix/target/release/hx
+    ```
+4.  **Try Plugin Commands:**
+    Inside Helix, you will be able to use commands registered by your plugins. For example, for a Lua greeting plugin: `:my-plugin:lua-greeting`.
 
-Discuss the project on the community [Matrix Space](https://matrix.to/#/#helix-community:matrix.org) (make sure to join `#helix-editor:matrix.org` if you're on a client that doesn't support Matrix Spaces yet).
+## 🔗 Useful Links
 
-# Credits
+* [Official Helix Editor Repository](https://github.com/helix-editor/helix)
+* [Helix Documentation](https://docs.helix-editor.com/)
+* [Create a Pull Request (GitHub Documentation)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-with-pull-requests/creating-a-pull-request)
 
-Thanks to [@jakenvac](https://github.com/jakenvac) for designing the logo!
+---
+*This `README.md` focuses on my plugin module proposal. For the complete Helix documentation, please refer to the original repository.*

--- a/anotacoes/1-helix-plugin.md
+++ b/anotacoes/1-helix-plugin.md
@@ -1,0 +1,171 @@
+# Design Proposal: Plugin Architecture for the Helix Editor
+
+This document describes an architecture for a robust, secure, and high-performance plugin system for the Helix editor. The proposal aims to allow the community to extend the editor's functionalities while maintaining the project's stability and philosophy.
+
+## 1. Philosophy and Goals
+
+The plugin system must adhere to the same principles as Helix:
+
+*   **Security:** Plugin code should never be able to crash or corrupt the editor. Plugins must operate within a strict sandbox, with controlled access to system resources and the editor's state.
+*   **Performance:** Loading and executing plugins should have a minimal impact on startup time and editing latency. The use of high-performance JIT runtimes is essential.
+*   **Ergonomics:** Creating plugins should be a pleasant experience. The API should be well-documented, idiomatic, and powerful, with a fast development cycle.
+*   **Flexibility:** The architecture must support both simple scripts for quick automation and complex, high-performance plugins written in compiled languages.
+
+## 2. Proposed Architecture
+
+The solution is based on a new central crate, `helix-plugin`, which orchestrates the discovery, loading, and execution of plugins. We propose support for two types of plugins to cover different use cases:
+
+1.  **WebAssembly (WASM)-based Plugins:** For complex and high-performance functionalities. It allows developers to use Rust, C++, Go, Zig, etc., compiling to `wasm32-wasi`. The WASM runtime provides a first-class security sandbox.
+2.  **Lua-based Plugins:** For configurations, automations, and rapid prototyping. Lua is a lightweight, fast, and easy-to-embed scripting language in Rust, ideal for simpler tasks.
+
+### Main Components
+
+#### a. `helix-plugin` Crate
+
+This new crate will be the heart of the system.
+
+*   **Responsibilities:**
+    *   Manage the complete lifecycle of plugins (discovery, loading, reloading, unloading).
+    *   Contain the runtimes for WASM (`wasmtime`) and Lua (`mlua`).
+    *   Expose a secure and stable host API for plugins.
+    *   Act as a bridge between the Helix core and the plugins.
+
+#### b. Plugin Manifest (`plugin.toml`)
+
+Each plugin must include a manifest file for metadata and configuration.
+
+*   **Location:** `~/.config/helix/plugins/my-plugin/plugin.toml`
+*   **Example Structure:**
+    ```toml
+    # Basic plugin metadata.
+    name = "my-awesome-plugin"
+    version = "0.1.0"
+    authors = ["Your Name <your@email.com>"]
+    description = "A plugin that does something awesome."
+
+    # The entry point for the plugin's code.
+    # The system will determine the plugin type by the extension.
+    entrypoint = "main.wasm" # or "main.lua"
+
+    # (Optional) Defines when the plugin should be loaded to save resources.
+    # If omitted, the plugin is loaded on startup.
+    [activation]
+    on_command = ["my-plugin:my-action"] # Loads when a specific command is called.
+    on_language = ["rust", "toml"]        # Loads when a file of a language is opened.
+    on_event = ["buffer_save"]            # Loads on specific editor events.
+    ```
+
+#### c. The Plugin API (`helix::api`)
+
+This is the contact surface between a plugin and the editor. It will be a secure facade over the internal Helix crates (`helix-core`, `helix-view`, etc.), ensuring that no plugin can access the internal state in a dangerous way.
+
+*   **API Modules (Examples):**
+    *   `helix::api::editor`: Functions to interact with buffers, selections, and the general state.
+        *   `get_buffer_content(buf_id) -> Result<String, Error>`
+        *   `get_selections(view_id) -> Result<Vec<Range>, Error>`
+        *   `apply_transaction(view_id, transaction)`
+    *   `helix::api::commands`: To register new commands in the editor.
+        *   `register(name, callback)`
+    *   `helix::api::events`: To react to editor events.
+        *   `subscribe(event_name, callback)`
+    *   `helix::api::ui`: To interact with the Helix user interface.
+        *   `show_picker(items, callback)`
+        *   `show_message(level, text)`
+
+## 3. Implementation Requirements
+
+#### a. New Crate: `helix-plugin`
+
+*   **Module Structure:**
+    *   `lib.rs`: Crate entry point.
+    *   `manager.rs`: `PluginManager`, responsible for the lifecycle.
+    *   `api.rs`: Definition of the public host API.
+    *   `host/mod.rs`, `host/wasm.rs`, `host/lua.rs`: Implementations of the WASM and Lua runtimes.
+    *   `config.rs`: Logic to read and interpret `plugin.toml`.
+
+#### b. Cargo Dependencies (Cargo.toml)
+
+*   **WASM Runtime:**
+    *   `wasmtime`: JIT runtime for `wasm32-wasi`.
+*   **Lua Runtime:**
+    *   `mlua`: High-level safe bindings for Lua.
+*   **Utilities:**
+    *   `serde` & `serde_json`: For data serialization between host and plugins.
+    *   `toml`: To parse `plugin.toml` manifests.
+    *   `walkdir`: For efficient discovery of plugins in the file system.
+    *   `anyhow`: For cleaner and more ergonomic error handling.
+
+#### c. Modifications to Existing Code
+
+*   **`Cargo.toml` (Workspace):**
+    *   Add `helix-plugin` to the `members` list.
+
+*   **`helix-term` (Main Binary):**
+    *   **Initialization:** Instantiate and initialize the `PluginManager` in `main.rs`.
+    *   **Event Loop:** Integrate the `PluginManager` into the main event loop to dispatch events (keys, commands, etc.) to the plugins.
+
+*   **`helix-event`:**
+    *   Allow the `PluginManager` to register as a "listener" for global editor events.
+
+*   **`helix-core` and `helix-view`:**
+    *   **API Exposure (Secure Facade):** This is the most critical part. Instead of making internal functions `pub`, we will create facade functions in `helix::api` that perform validations and expose only the necessary functionality. This prevents a malformed or malicious plugin from causing a `panic` or corrupting the editor's state.
+
+*   **Command Dispatcher (`helix-view/src/commands.rs`):**
+    *   Modify the dispatcher so that if a command is not found internally, it queries the `PluginManager` to check if a plugin has registered the command.
+
+## 4. Suggested Implementation Roadmap
+
+1.  **Phase 1: Foundation and Basic WASM**
+    *   Create the `helix-plugin` crate and add the dependencies (`wasmtime`, `toml`, `walkdir`).
+    *   Implement plugin discovery and `plugin.toml` parsing.
+    *   Implement a basic WASM host that can load and execute a `.wasm` file.
+    *   Define a minimal API: `helix::api::commands::register` and `helix::api::ui::show_message`.
+    *   Create a "hello world" plugin in Rust (compiled to WASM) for testing.
+
+2.  **Phase 2: Integration with the Core**
+    *   Integrate the `PluginManager` into `helix-term` and the event loop.
+    *   Modify the command dispatcher to call plugin commands.
+    *   Expand the API with read access to the editor's state (e.g., `get_buffer_content`).
+
+3.  **Phase 3: Lua Host and API Expansion**
+    *   Add the `mlua` dependency and implement the `LuaHost`.
+    *   Expose the same `helix::api` to the Lua environment.
+    *   Expand the API with write/modification functionalities (e.g., `apply_transaction`), ensuring that all operations are safe and reversible (undo/redo).
+    *   Create an example plugin in Lua.
+
+4.  **Phase 4: Documentation and Ecosystem**
+    *   Write the documentation for plugin developers in the Helix `book/`.
+    *   Document the entire `helix::api` in detail.
+    *   Create project templates for plugins in Rust and Lua.
+    *   Develop some useful plugins and include them in the `runtime/plugins` directory.
+
+## 5. Plugin Developer Experience
+
+#### Example: "Hello World" Plugin (Rust/WASM)
+
+```rust
+// In the plugin (lib.rs)
+use helix::api;
+
+// The `helix::plugin` macro would handle the boilerplate of WASM export.
+#[helix::plugin]
+fn on_load() {
+    api::commands::register("hello-plugin", |args| {
+        api::ui::show_message(api::ui::Level::Info, "Hello, from my plugin!");
+    });
+}
+```
+
+#### Example: "Hello World" Plugin (Lua)
+
+```lua
+-- In the plugin (main.lua)
+local editor = helix.api.editor
+local ui = helix.api.ui
+
+helix.api.commands.register("hello-lua", function(args)
+    ui.show_message("info", "Hello, from my Lua plugin!")
+end)
+```
+
+This architecture provides a solid foundation for a thriving plugin ecosystem, empowering users to adapt Helix to their needs while maintaining the project's quality and performance standards.

--- a/anotacoes/1-helix-plugin_br.md
+++ b/anotacoes/1-helix-plugin_br.md
@@ -1,0 +1,171 @@
+# Proposta de Design: Arquitetura de Plugins para o Helix Editor
+
+Este documento descreve uma arquitetura para um sistema de plugins robusto, seguro e de alto desempenho para o editor Helix. A proposta visa permitir que a comunidade estenda as funcionalidades do editor, mantendo a estabilidade e a filosofia do projeto.
+
+## 1. Filosofia e Objetivos
+
+O sistema de plugins deve aderir aos mesmos princípios do Helix:
+
+*   **Segurança:** O código do plugin nunca deve ser capaz de travar ou corromper o editor. Os plugins devem operar dentro de um *sandbox* estrito, com acesso controlado aos recursos do sistema e ao estado do editor.
+*   **Desempenho:** O carregamento e a execução de plugins devem ter um impacto mínimo no tempo de inicialização e na latência de edição. O uso de runtimes JIT de alta performance é essencial.
+*   **Ergonomia:** Criar plugins deve ser uma experiência agradável. A API deve ser bem documentada, idiomática e poderosa, com um ciclo de desenvolvimento rápido.
+*   **Flexibilidade:** A arquitetura deve suportar tanto scripts simples para automação rápida quanto plugins complexos e de alto desempenho escritos em linguagens compiladas.
+
+## 2. Arquitetura Proposta
+
+A solução se baseia em um novo crate central, `helix-plugin`, que orquestra a descoberta, o carregamento e a execução de plugins. Propomos o suporte a dois tipos de plugins para cobrir diferentes casos de uso:
+
+1.  **Plugins baseados em WebAssembly (WASM):** Para funcionalidades complexas e de alto desempenho. Permite que os desenvolvedores usem Rust, C++, Go, Zig, etc., compilando para `wasm32-wasi`. O runtime WASM fornece um sandbox de segurança de primeira classe.
+2.  **Plugins baseados em Lua:** Para configurações, automações e prototipagem rápida. Lua é uma linguagem de script leve, rápida e fácil de embarcar em Rust, ideal para tarefas mais simples.
+
+### Componentes Principais
+
+#### a. Crate `helix-plugin`
+
+Este novo crate será o coração do sistema.
+
+*   **Responsabilidades:**
+    *   Gerenciar o ciclo de vida completo dos plugins (descoberta, carregamento, recarregamento, descarregamento).
+    *   Conter os runtimes para WASM (`wasmtime`) e Lua (`mlua`).
+    *   Expor uma API de host segura e estável para os plugins.
+    *   Atuar como uma ponte entre o núcleo do Helix e os plugins.
+
+#### b. Manifesto do Plugin (`plugin.toml`)
+
+Cada plugin deve incluir um arquivo de manifesto para metadados e configuração.
+
+*   **Localização:** `~/.config/helix/plugins/meu-plugin/plugin.toml`
+*   **Estrutura de Exemplo:**
+    ```toml
+    # Metadados básicos do plugin.
+    name = "meu-plugin-incrivel"
+    version = "0.1.0"
+    authors = ["Seu Nome <seu@email.com>"]
+    description = "Um plugin que faz algo incrível."
+
+    # O ponto de entrada para o código do plugin.
+    # O sistema determinará o tipo de plugin pela extensão.
+    entrypoint = "main.wasm" # ou "main.lua"
+
+    # (Opcional) Define quando o plugin deve ser carregado para economizar recursos.
+    # Se omitido, o plugin é carregado na inicialização.
+    [activation]
+    on_command = ["meu-plugin:minha-acao"] # Carrega ao chamar um comando específico.
+    on_language = ["rust", "toml"]        # Carrega quando um arquivo de uma linguagem é aberto.
+    on_event = ["buffer_save"]            # Carrega em eventos específicos do editor.
+    ```
+
+#### c. A API do Plugin (`helix::api`)
+
+Esta é a superfície de contato entre um plugin e o editor. Será uma fachada segura sobre os crates internos do Helix (`helix-core`, `helix-view`, etc.), garantindo que nenhum plugin possa acessar o estado interno de forma perigosa.
+
+*   **Módulos da API (Exemplos):**
+    *   `helix::api::editor`: Funções para interagir com buffers, seleções e o estado geral.
+        *   `get_buffer_content(buf_id) -> Result<String, Error>`
+        *   `get_selections(view_id) -> Result<Vec<Range>, Error>`
+        *   `apply_transaction(view_id, transaction)`
+    *   `helix::api::commands`: Para registrar novos comandos no editor.
+        *   `register(name, callback)`
+    *   `helix::api::events`: Para reagir a eventos do editor.
+        *   `subscribe(event_name, callback)`
+    *   `helix::api::ui`: Para interagir com a interface do usuário do Helix.
+        *   `show_picker(items, callback)`
+        *   `show_message(level, text)`
+
+## 3. Requisitos de Implementação
+
+#### a. Novo Crate: `helix-plugin`
+
+*   **Estrutura de Módulos:**
+    *   `lib.rs`: Ponto de entrada do crate.
+    *   `manager.rs`: `PluginManager`, responsável pelo ciclo de vida.
+    *   `api.rs`: Definição da API pública do host.
+    *   `host/mod.rs`, `host/wasm.rs`, `host/lua.rs`: Implementações dos runtimes WASM e Lua.
+    *   `config.rs`: Lógica para ler e interpretar `plugin.toml`.
+
+#### b. Dependências do Cargo (Cargo.toml)
+
+*   **Runtime WASM:**
+    *   `wasmtime`: Runtime JIT para `wasm32-wasi`.
+*   **Runtime Lua:**
+    *   `mlua`: Bindings seguros de alto nível para Lua.
+*   **Utilitários:**
+    *   `serde` & `serde_json`: Para serialização de dados entre host e plugins.
+    *   `toml`: Para analisar os manifestos `plugin.toml`.
+    *   `walkdir`: Para a descoberta eficiente de plugins no sistema de arquivos.
+    *   `anyhow`: Para um tratamento de erros mais limpo e ergonômico.
+
+#### c. Modificações no Código Existente
+
+*   **`Cargo.toml` (Workspace):**
+    *   Adicionar `helix-plugin` à lista de `members`.
+
+*   **`helix-term` (Binário Principal):**
+    *   **Inicialização:** Instanciar e inicializar o `PluginManager` no `main.rs`.
+    *   **Event Loop:** Integrar o `PluginManager` ao loop de eventos principal para despachar eventos (teclas, comandos, etc.) para os plugins.
+
+*   **`helix-event`:**
+    *   Permitir que o `PluginManager` se registre como um "ouvinte" de eventos globais do editor.
+
+*   **`helix-core` e `helix-view`:**
+    *   **Exposição da API (Fachada Segura):** Esta é a parte mais crítica. Em vez de tornar as funções internas `pub`, criaremos funções de fachada na `helix::api` que realizam validações e expõem apenas a funcionalidade necessária. Isso impede que um plugin malformado ou mal-intencionado cause um `panic` ou corrompa o estado do editor.
+
+*   **Dispatcher de Comandos (`helix-view/src/commands.rs`):**
+    *   Modificar o dispatcher para que, se um comando não for encontrado internamente, ele consulte o `PluginManager` para verificar se um plugin registrou o comando.
+
+## 4. Roteiro de Implementação Sugerido
+
+1.  **Fase 1: Fundação e WASM Básico**
+    *   Criar o crate `helix-plugin` e adicionar as dependências (`wasmtime`, `toml`, `walkdir`).
+    *   Implementar a descoberta de plugins e a análise do `plugin.toml`.
+    *   Implementar um host WASM básico que possa carregar e executar um arquivo `.wasm`.
+    *   Definir uma API mínima: `helix::api::commands::register` e `helix::api::ui::show_message`.
+    *   Criar um plugin "hello world" em Rust (compilado para WASM) para teste.
+
+2.  **Fase 2: Integração com o Core**
+    *   Integrar o `PluginManager` no `helix-term` e no loop de eventos.
+    *   Modificar o dispatcher de comandos para chamar os comandos dos plugins.
+    *   Expandir a API com acesso de leitura ao estado do editor (ex: `get_buffer_content`).
+
+3.  **Fase 3: Host Lua e Expansão da API**
+    *   Adicionar a dependência `mlua` e implementar o `LuaHost`.
+    *   Expor a mesma `helix::api` para o ambiente Lua.
+    *   Expandir a API com funcionalidades de escrita/modificação (ex: `apply_transaction`), garantindo que todas as operações sejam seguras e reversíveis (undo/redo).
+    *   Criar um plugin de exemplo em Lua.
+
+4.  **Fase 4: Documentação e Ecossistema**
+    *   Escrever a documentação para desenvolvedores de plugins no `book/` do Helix.
+    *   Documentar detalhadamente toda a `helix::api`.
+    *   Criar templates de projeto para plugins em Rust e Lua.
+    *   Desenvolver alguns plugins úteis e incluí-los no diretório `runtime/plugins`.
+
+## 5. Experiência do Desenvolvedor de Plugins
+
+#### Exemplo: Plugin "Hello World" (Rust/WASM)
+
+```rust
+// No plugin (lib.rs)
+use helix::api;
+
+// A macro `helix::plugin` cuidaria do boilerplate de exportação do WASM.
+#[helix::plugin]
+fn on_load() {
+    api::commands::register("hello-plugin", |args| {
+        api::ui::show_message(api::ui::Level::Info, "Olá, do meu plugin!");
+    });
+}
+```
+
+#### Exemplo: Plugin "Hello World" (Lua)
+
+```lua
+-- No plugin (main.lua)
+local editor = helix.api.editor
+local ui = helix.api.ui
+
+helix.api.commands.register("hello-lua", function(args)
+    ui.show_message("info", "Olá, do meu plugin Lua!")
+end)
+```
+
+Esta arquitetura fornece uma base sólida para um ecossistema de plugins próspero, capacitando os usuários a adaptar o Helix às suas necessidades, mantendo os padrões de qualidade e desempenho do projeto.

--- a/anotacoes/2-roadmap_plugins_v1.md
+++ b/anotacoes/2-roadmap_plugins_v1.md
@@ -1,0 +1,55 @@
+### Task List for the First Robust Version of the Plugin Module
+
+This list prioritizes essential functionality and robustness for an initial version, leaving more advanced features and development tools for future iterations.
+
+#### **1. WASM Compilation Environment (Critical)**
+
+*   **Task:** Ensure that the Helix development environment can compile Rust plugins for the `wasm32-wasi` target.
+    *   **Details:** This involves installing the `wasm32-wasi` Rust toolchain (`rustup target add wasm32-wasi`) and verifying that the Helix build process can compile the WASM test plugin.
+    *   **Justification:** Currently, this is a blocker for testing and validating the WASM part of the implementation. Without this, the WASM functionality is theoretical.
+
+#### **2. Robust Bidirectional Communication (Return Values)**
+
+*   **Task:** Implement a robust mechanism for host functions (Helix) to return values to plugins (WASM and Lua).
+    *   **Details (WASM):**
+        *   Define a serialization/deserialization protocol (e.g., JSON or bincode) for complex data (strings, structs, etc.) in the shared memory between the host and the WASM plugin.
+        *   Implement functions in the `WasmHost` to read data returned by the WASM plugin.
+        *   Modify `HelixApi::get_buffer_content` to actually fetch and return the buffer content to the WASM plugin.
+    *   **Details (Lua):**
+        *   Ensure that `LuaHost` can receive return values from Lua functions called by the host.
+        *   Modify `HelixApi::get_buffer_content` to actually fetch and return the buffer content to the Lua plugin.
+    *   **Justification:** Essential for any meaningful interaction where the plugin needs data from the editor or needs to return results of its operations.
+
+#### **3. Essential API Expansion (Read and Write)**
+
+*   **Task:** Expand the `HelixApi` to expose the most basic and crucial editor functionalities that plugins will need to be useful.
+    *   **Details:**
+        *   **Read:** Methods to get information about the current editor state (e.g., `get_current_buffer_id()`, `get_selection_ranges(doc_id)`).
+        *   **Write/Modification:** Methods to perform basic editing operations (e.g., `insert_text(doc_id, position, text)`, `delete_text(doc_id, range)`, `set_selection(doc_id, selection)`).
+        *   **Basic UI:** Methods to display simple prompts or interact with existing pickers (if applicable and safe).
+    *   **Justification:** Without a rich enough API, plugins will have very limited functionality.
+
+#### **4. Dynamic Command Management (Completion)**
+
+*   **Task:** Finalize the implementation of dynamic command registration and execution.
+    *   **Details:**
+        *   Ensure that the `PluginManager` can manage multiple plugins registering commands with the same name (e.g., using namespaces or priorities).
+        *   Implement the ability for plugins to unregister commands (if necessary).
+        *   Refine the passing of arguments to plugin commands, ensuring that arguments passed by the user in the command line are correctly parsed and delivered to the plugin.
+    *   **Justification:** Allows plugins to extend the editor's command set flexibly.
+
+#### **5. Basic Event System (Subscription/Dispatch)**
+
+*   **Task:** Implement a mechanism for plugins to subscribe to and react to specific editor events.
+    *   **Details:**
+        *   Define an initial set of editor events (e.g., `on_buffer_save`, `on_buffer_open`, `on_mode_change`).
+        *   Implement the logic in the `PluginManager` and the hosts (WASM/Lua) to dispatch these events to the plugins that have subscribed to them.
+    *   **Justification:** Many plugins need to react to changes in the editor's state to function (e.g., an auto-formatting plugin on save, a linter plugin on buffer change).
+
+#### **6. Error Handling and Reporting (Robustness)**
+
+*   **Task:** Improve error handling and user feedback for plugin failures.
+    *   **Details:**
+        *   Capture and report plugin execution errors (WASM traps, Lua errors) in a way that does not crash the editor but informs the user.
+        *   Provide clear and useful error messages about plugin loading or execution failures.
+    *   **Justification:** Essential for robustness and user experience, preventing misbehaving plugins from causing editor instability.

--- a/anotacoes/2-roadmap_plugins_v1_br.md
+++ b/anotacoes/2-roadmap_plugins_v1_br.md
@@ -1,0 +1,55 @@
+### Lista de Tarefas para a Primeira Versão Robusta do Módulo de Plugins
+
+Esta lista prioriza a funcionalidade essencial e a robustez para uma versão inicial, deixando funcionalidades mais avançadas e ferramentas de desenvolvimento para iterações futuras.
+
+#### **1. Ambiente de Compilação WASM (Crítico)**
+
+*   **Tarefa:** Garantir que o ambiente de desenvolvimento do Helix possa compilar plugins Rust para o target `wasm32-wasi`.
+    *   **Detalhes:** Isso envolve a instalação da toolchain `wasm32-wasi` do Rust (`rustup target add wasm32-wasi`) e a verificação de que o processo de build do Helix pode compilar o plugin de teste WASM.
+    *   **Justificativa:** Atualmente, este é um bloqueador para testar e validar a parte WASM da implementação. Sem isso, a funcionalidade WASM é teórica.
+
+#### **2. Comunicação Bidirecional Robusta (Retorno de Valores)**
+
+*   **Tarefa:** Implementar um mecanismo robusto para que as funções do host (Helix) possam retornar valores para os plugins (WASM e Lua).
+    *   **Detalhes (WASM):**
+        *   Definir um protocolo de serialização/desserialização (e.g., JSON ou bincode) para dados complexos (strings, structs, etc.) na memória compartilhada entre o host e o plugin WASM.
+        *   Implementar funções no `WasmHost` para ler dados retornados pelo plugin WASM.
+        *   Modificar a `HelixApi::get_buffer_content` para realmente buscar e retornar o conteúdo do buffer para o plugin WASM.
+    *   **Detalhes (Lua):**
+        *   Garantir que `LuaHost` possa receber valores de retorno de funções Lua chamadas pelo host.
+        *   Modificar a `HelixApi::get_buffer_content` para realmente buscar e retornar o conteúdo do buffer para o plugin Lua.
+    *   **Justificativa:** Essencial para qualquer interação significativa onde o plugin precisa de dados do editor ou precisa retornar resultados de suas operações.
+
+#### **3. Expansão da API Essencial (Leitura e Escrita)**
+
+*   **Tarefa:** Expandir a `HelixApi` para expor as funcionalidades mais básicas e cruciais do editor que os plugins precisarão para serem úteis.
+    *   **Detalhes:**
+        *   **Leitura:** Métodos para obter informações sobre o estado atual do editor (e.g., `get_current_buffer_id()`, `get_selection_ranges(doc_id)`).
+        *   **Escrita/Modificação:** Métodos para realizar operações básicas de edição (e.g., `insert_text(doc_id, position, text)`, `delete_text(doc_id, range)`, `set_selection(doc_id, selection)`).
+        *   **UI Básica:** Métodos para exibir prompts simples ou interagir com pickers existentes (se aplicável e seguro).
+    *   **Justificativa:** Sem uma API rica o suficiente, os plugins terão funcionalidade muito limitada.
+
+#### **4. Gerenciamento Dinâmico de Comandos (Conclusão)**
+
+*   **Tarefa:** Finalizar a implementação do registro e execução dinâmica de comandos.
+    *   **Detalhes:**
+        *   Garantir que o `PluginManager` possa gerenciar múltiplos plugins registrando comandos com o mesmo nome (e.g., usando namespaces ou prioridades).
+        *   Implementar a capacidade de plugins desregistrarem comandos (se necessário).
+        *   Refinar a passagem de argumentos para comandos de plugin, garantindo que os argumentos passados pelo usuário na linha de comando sejam corretamente parseados e entregues ao plugin.
+    *   **Justificativa:** Permite que os plugins estendam o conjunto de comandos do editor de forma flexível.
+
+#### **5. Sistema Básico de Eventos (Assinatura/Despacho)**
+
+*   **Tarefa:** Implementar um mecanismo para que os plugins possam assinar e reagir a eventos específicos do editor.
+    *   **Detalhes:**
+        *   Definir um conjunto inicial de eventos do editor (e.g., `on_buffer_save`, `on_buffer_open`, `on_mode_change`).
+        *   Implementar a lógica no `PluginManager` e nos hosts (WASM/Lua) para despachar esses eventos para os plugins que os assinaram.
+    *   **Justificativa:** Muitos plugins precisam reagir a mudanças no estado do editor para funcionar (e.g., um plugin de formatação automática ao salvar, um plugin de linter ao mudar o buffer).
+
+#### **6. Tratamento de Erros e Relatórios (Robustez)**
+
+*   **Tarefa:** Aprimorar o tratamento de erros e o feedback ao usuário para falhas de plugins.
+    *   **Detalhes:**
+        *   Capturar e reportar erros de execução de plugins (WASM traps, erros de Lua) de forma que não travem o editor, mas informem o usuário.
+        *   Fornecer mensagens de erro claras e úteis sobre falhas de carregamento ou execução de plugins.
+    *   **Justificativa:** Essencial para a robustez e a experiência do usuário, evitando que plugins mal-comportados causem instabilidade no editor.

--- a/anotacoes/3-relatorio_modulo_plugin.md
+++ b/anotacoes/3-relatorio_modulo_plugin.md
@@ -1,0 +1,150 @@
+### Complete Report: Implementation of the Plugins/Scripts Module for the Helix Editor
+
+**Date:** July 11, 2025
+
+**Objective:** Develop an extensible plugin system for the Helix editor, allowing the community to add new functionalities and customize the editor through plugins based on WebAssembly (WASM) and Lua.
+
+---
+
+#### **1. Phase 1: Foundation and Basic Structure**
+
+**Purpose:** Establish the foundation of the plugin system, including the creation of the new crate, the addition of essential dependencies, and the definition of data structures for plugin discovery and loading.
+
+**Changes and Progress:**
+
+*   **Creation of the `helix-plugin` Crate:**
+    *   A new Rust library crate, `helix-plugin`, was created in the Helix project workspace.
+    *   **Command:** `cargo new --lib helix-plugin`
+    *   **Impact:** Added `helix-plugin/Cargo.toml` and `helix-plugin/src/lib.rs`.
+*   **Addition of Initial Dependencies:**
+    *   The dependencies `wasmtime`, `toml`, `walkdir`, `serde`, `anyhow`, and `mlua` (with the `lua54` feature) were added to `helix-plugin/Cargo.toml`.
+    *   **Command:** `cargo add -p helix-plugin wasmtime toml walkdir serde anyhow mlua --features "lua54"`
+    *   **Impact:** Configuration of the development environment for the WASM and Lua hosts, as well as utilities for parsing and file manipulation.
+*   **Module Structure:**
+    *   Directories `helix-plugin/src/host` and `helix-plugin/tests` were created.
+    *   Files `helix-plugin/src/manager.rs`, `helix-plugin/src/config.rs`, `helix-plugin/src/host/wasm.rs`, `helix-plugin/src/host/lua.rs`, and `helix-plugin/src/api.rs` were created.
+    *   The modules were declared in `helix-plugin/src/lib.rs` and `helix-plugin/src/host/mod.rs` for code organization.
+*   **Definition of the Plugin Manifest (`plugin.toml`):**
+    *   In `helix-plugin/src/config.rs`, the `PluginManifest` and `Activation` structs were defined using `serde` for deserialization of TOML files. This allows plugins to declare their metadata and entry points.
+*   **Plugin Discovery Logic:**
+    *   In `helix-plugin/src/manager.rs`, the `discover_plugins_in` function was implemented. It uses `walkdir` to scan a directory (`~/.config/helix/plugins/`) for `plugin.toml` files, reads them, and parses their contents into `PluginManifest`s.
+*   **Initial Hosts (WASM and Lua):**
+    *   In `helix-plugin/src/host/wasm.rs`, the `WasmHost` struct was created with the ability to load a `.wasm` file using `wasmtime`.
+    *   In `helix-plugin/src/host/lua.rs`, the `LuaHost` struct was created with the ability to load a `.lua` file using `mlua`.
+*   **Discovery Tests:**
+    *   A test directory `tests/test-plugins/my-first-plugin` was created with an example `plugin.toml`.
+    *   An integration test (`helix-plugin/tests/discovery.rs`) was added and successfully executed, confirming that the `PluginManager` can discover and parse plugin manifests.
+
+---
+
+#### **2. Phase 2: Integration with the Editor Core**
+
+**Purpose:** Connect the plugin system to the main lifecycle of Helix, allowing the editor to initialize the plugin manager and for plugin commands to be dispatched.
+
+**Changes and Progress:**
+
+*   **Initialization of the `PluginManager` in `helix-term`:**
+    *   In `helix-term/src/main.rs`, the `PluginManager` is now instantiated in `main_impl` before the creation of the `Application`.
+    *   An MPSC channel (`tokio::sync::mpsc::unbounded_channel`) is created, and the `sender` is passed to `PluginManager::new`. The `receiver` is later assigned to `editor.editor_events.1`.
+*   **Integration into the `Application` Struct:**
+    *   In `helix-term/src/application.rs`, the field `plugin_manager: helix_plugin::manager::PluginManager` was added to the `Application` struct.
+    *   The `Application::new` constructor was modified to accept the `plugin_manager` as an argument and store it.
+*   **Event System for Communication with Plugins:**
+    *   In `helix-view/src/editor.rs`, the `EditorEvent` enum was extended with two new variants:
+        *   `EditorEvent::PluginCommand(String, Vec<String>, Option<u32>)`: To dispatch plugin commands from `helix-term` to the `Application`, including an optional `request_id` for responses.
+        *   `EditorEvent::RegisterPluginCommand(String, String, usize)`: To allow plugins to register commands in the editor, including the command name, the callback function name, and the plugin index.
+        *   `EditorEvent::PluginResponse(u32, String)`: To send responses back to the plugins.
+        *   `EditorEvent::PluginEvent(String, String)`: To dispatch editor events to the plugins.
+    *   A new MPSC channel (`editor_events: (UnboundedSender<EditorEvent>, UnboundedReceiver<EditorEvent>)`) was added to the `Editor` struct to manage event communication.
+    *   A method `dispatch_editor_event(&mut self, event: EditorEvent)` was added to the `Editor` to send events through this channel.
+    *   The `tokio::select!` in `Editor::wait_event` was updated to listen to the new `editor_events` channel.
+*   **Plugin Command Dispatch Mechanism:**
+    *   In `helix-term/src/commands.rs`, the `MappableCommand` enum was extended with the variant `Plugin { name: String, args: Vec<String> }`.
+    *   The `MappableCommand::from_str` method was modified so that if a command is not found among the static or typable commands, it is interpreted as a `MappableCommand::Plugin`.
+    *   The `MappableCommand::name()` and `MappableCommand::doc()` methods were updated to handle the new `Plugin` variant.
+    *   The `MappableCommand::execute()` method was modified to dispatch an `EditorEvent::PluginCommand` (using `cx.editor.dispatch_editor_event`) when a `MappableCommand::Plugin` is executed.
+*   **Command Execution in the `PluginManager`:**
+    *   In `helix-plugin/src/manager.rs`, a method `execute_command(&mut self, name: &str, args: &[String])` was added. This method is responsible for finding the plugin that registered the command and calling the appropriate callback function in the plugin's host, passing the arguments.
+
+---
+
+#### **3. Phase 3: API Expansion and Full Host Integration**
+
+**Purpose:** Enhance the communication API between the editor and plugins, allowing plugins to register commands dynamically and interact with the editor in a richer way.
+
+**Changes and Progress:**
+
+*   **Plugin API (`helix-plugin/src/api.rs`):**
+    *   The `HelixApi` struct was enhanced. Now, its `new` constructor receives the `UnboundedSender<EditorEvent>` and a `plugin_idx` (plugin identifier).
+    *   The `show_message(message: String)` function was implemented to send an `EditorEvent::PluginCommand` to the editor.
+    *   The `register_command(command_name: String, callback_function_name: String)` function was implemented to send an `EditorEvent::RegisterPluginCommand` to the editor, including the `plugin_idx` to identify the source plugin.
+    *   The `get_buffer_content(doc_id: u32, request_id: u32)` function was added, sending an `EditorEvent::PluginCommand` with a `request_id` to the editor.
+    *   New functions `insert_text(doc_id: u32, position: u32, text: String)` and `delete_text(doc_id: u32, start: u32, end: u32)` were added, sending `EditorEvent::PluginCommand`s to the editor.
+    *   The `subscribe_to_event(event_name: String, callback_function_name: String)` function was added, sending an `EditorEvent::PluginCommand` to the editor.
+*   **API Integration in `WasmHost` (`helix-plugin/src/host/wasm.rs`):**
+    *   The `WasmHost::new` constructor now receives an instance of `HelixApi`.
+    *   The `HelixApi` is stored as state (`Store<HelixApi>`) in the `wasmtime::Store`.
+    *   The `show_message`, `register_command`, `get_buffer_content`, `insert_text`, `delete_text`, and `subscribe_to_event` functions of the `HelixApi` are exposed to WASM plugins through `linker.func_wrap`, allowing WASM plugins to call these host functions.
+    *   The `call_function(&mut self, name: &str, args: &[String])` function was updated to pass arguments to WASM functions, including allocation and deallocation of WASM memory for strings.
+*   **API Integration in `LuaHost` (`helix-plugin/src/host/lua.rs`):
+    *   The `LuaHost::new` constructor now receives an instance of `HelixApi`.
+    *   The `HelixApi` is registered as a `UserData` and exposed as a global object `helix` in the Lua environment. This allows Lua scripts to call `helix.show_message()`, `helix.register_command()`, `helix.get_buffer_content()`, `helix.insert_text()`, `helix.delete_text()`, and `helix.subscribe_to_event()`.
+    *   The `call_function(&mut self, name: &str, args: &[String])` method was updated to pass arguments to Lua functions.
+*   **Host and Command Management in `PluginManager` (`helix-plugin/src/manager.rs`):**
+    *   A `PluginHost` enum was introduced to encapsulate `WasmHost` and `LuaHost`, allowing for generic management of different types of hosts.
+    *   The `LoadedPlugin` struct now stores the generic `PluginHost` and the `PluginManifest`.
+    *   The `discover_plugins_in` function was updated to:
+        *   Create a `HelixApi` for each plugin, associating it with the correct `plugin_idx`.
+        *   Instantiate the appropriate `WasmHost` or `LuaHost`, passing the `HelixApi`.
+        *   Call the `on_load` function in the plugins (WASM and Lua) after loading, if exported.
+        *   A `HashMap<String, (String, usize)>` (`registered_commands`) was added to the `PluginManager` struct to map command names to the callback function name and the loaded plugin's index.
+        *   A `next_request_id` and `pending_requests` (`HashMap`) were added to manage asynchronous requests and their responses.
+        *   An example command registration (`my-plugin:test-command`) was added for testing purposes.
+    *   The `execute_command` function was enhanced to look up the command in `registered_commands` and, if found, call the corresponding callback function in the appropriate `PluginHost`, passing the arguments.
+    *   A new method `register_command(&mut self, command_name: String, callback_function_name: String, plugin_idx: usize)` was added to the `PluginManager` to register commands dynamically.
+    *   A new method `handle_plugin_response(&mut self, request_id: u32, response_data: String)` was added to process plugin responses.
+    *   Methods `get_next_request_id` and `add_pending_request` were added to manage the request/response flow.
+*   **Handling of `RegisterPluginCommand` and `PluginResponse` in `Application`:**
+    *   In `helix-term/src/application.rs`, `handle_editor_event` was updated to process `EditorEvent::RegisterPluginCommand` and `EditorEvent::PluginResponse`, calling the appropriate methods in the `PluginManager`.
+    *   The `Application` now has a `next_request_id` to generate request IDs.
+
+---
+
+#### **4. Phase 4: Documentation and Ecosystem**
+
+**Purpose:** Provide resources for plugin developers and organize the plugin ecosystem.
+
+**Changes and Progress:**
+
+*   **Plugin Documentation:**
+    *   The `book/src/plugins.md` file was updated to reflect the new API functions (`insert_text`, `delete_text`, `subscribe_to_event`, `get_buffer_content` with `request_id`) and the `request_id`/`PluginResponse` mechanics.
+    *   The plugin examples in Rust (WASM) and Lua were updated to demonstrate passing arguments and using the new API functions.
+*   **Project Templates for Plugins:**
+    *   The templates in `helix-plugin/templates/rust-wasm-plugin` and `helix-plugin/templates/lua-plugin` were updated to include examples of using the new API functions and the structure for handling arguments and responses.
+
+---
+
+#### **5. Basic Event System (Subscription/Dispatch)**
+
+**Purpose:** Implement a mechanism for plugins to subscribe to and react to specific editor events.
+
+**Changes and Progress:**
+
+*   **`EditorEvent::PluginEvent`:** Added to `helix-view/src/editor.rs` to dispatch editor events to plugins.
+*   **`HelixApi::subscribe_to_event`:** Added to `helix-plugin/src/api.rs` to allow plugins to subscribe to events.
+*   **Host Integration:** `WasmHost` and `LuaHost` were updated to expose `subscribe_to_event`.
+*   **`Application::event_subscribers`:** Added a `HashMap` in `helix-term/src/application.rs` to manage plugins subscribed to events.
+*   **`Application::handle_editor_event`:** Updated to dispatch `PluginEvent` to subscribed plugins.
+
+---
+
+#### **6. Error Handling and Reporting (Robustness)**
+
+**Purpose:** Improve error handling and user feedback for plugin failures.
+
+**Changes and Progress:**
+
+*   **Detailed Logs:** `log::error!` and `log::warn!` are used extensively to report plugin loading, execution, and communication failures.
+*   **Host Error Capturing:** Errors from `wasmtime` and `mlua` are captured and converted to `anyhow::Error` for consistent handling.
+
+---

--- a/anotacoes/3-relatorio_modulo_plugin_br.md
+++ b/anotacoes/3-relatorio_modulo_plugin_br.md
@@ -1,0 +1,150 @@
+### Relatório Completo: Implementação do Módulo de Plugins/Scripts para o Helix Editor
+
+**Data:** 11 de julho de 2025
+
+**Objetivo:** Desenvolver um sistema de plugins extensível para o Helix editor, permitindo que a comunidade adicione novas funcionalidades e personalize o editor através de plugins baseados em WebAssembly (WASM) e Lua.
+
+---
+
+#### **1. Fase 1: Fundação e Estrutura Básica**
+
+**Propósito:** Estabelecer a base do sistema de plugins, incluindo a criação do novo crate, a adição de dependências essenciais e a definição das estruturas de dados para descoberta e carregamento de plugins.
+
+**Alterações e Progresso:**
+
+*   **Criação do Crate `helix-plugin`:**
+    *   Um novo crate de biblioteca Rust, `helix-plugin`, foi criado no workspace do projeto Helix.
+    *   **Comando:** `cargo new --lib helix-plugin`
+    *   **Impacto:** Adicionou `helix-plugin/Cargo.toml` e `helix-plugin/src/lib.rs`.
+*   **Adição de Dependências Iniciais:**
+    *   As dependências `wasmtime`, `toml`, `walkdir`, `serde`, `anyhow` e `mlua` (com a feature `lua54`) foram adicionadas ao `helix-plugin/Cargo.toml`.
+    *   **Comando:** `cargo add -p helix-plugin wasmtime toml walkdir serde anyhow mlua --features "lua54"`
+    *   **Impacto:** Configuração do ambiente de desenvolvimento para os hosts WASM e Lua, além de utilitários para parsing e manipulação de arquivos.
+*   **Estrutura de Módulos:**
+    *   Diretórios `helix-plugin/src/host` e `helix-plugin/tests` foram criados.
+    *   Arquivos `helix-plugin/src/manager.rs`, `helix-plugin/src/config.rs`, `helix-plugin/src/host/wasm.rs`, `helix-plugin/src/host/lua.rs` e `helix-plugin/src/api.rs` foram criados.
+    *   Os módulos foram declarados em `helix-plugin/src/lib.rs` e `helix-plugin/src/host/mod.rs` para organização do código.
+*   **Definição do Manifesto do Plugin (`plugin.toml`):**
+    *   Em `helix-plugin/src/config.rs`, as structs `PluginManifest` e `Activation` foram definidas usando `serde` para desserialização de arquivos TOML. Isso permite que os plugins declarem seus metadados e pontos de entrada.
+*   **Lógica de Descoberta de Plugins:**
+    *   Em `helix-plugin/src/manager.rs`, a função `discover_plugins_in` foi implementada. Ela utiliza `walkdir` para escanear um diretório (`~/.config/helix/plugins/`) em busca de arquivos `plugin.toml`, lê-os e parseia seus conteúdos em `PluginManifest`s.
+*   **Hosts Iniciais (WASM e Lua):**
+    *   Em `helix-plugin/src/host/wasm.rs`, a struct `WasmHost` foi criada com a capacidade de carregar um arquivo `.wasm` usando `wasmtime`.
+    *   Em `helix-plugin/src/host/lua.rs`, a struct `LuaHost` foi criada com a capacidade de carregar um arquivo `.lua` usando `mlua`.
+*   **Testes de Descoberta:**
+    *   Um diretório de teste `tests/test-plugins/my-first-plugin` foi criado com um `plugin.toml` de exemplo.
+    *   Um teste de integração (`helix-plugin/tests/discovery.rs`) foi adicionado e executado com sucesso, confirmando que o `PluginManager` pode descobrir e analisar manifestos de plugins.
+
+---
+
+#### **2. Fase 2: Integração com o Core do Editor**
+
+**Propósito:** Conectar o sistema de plugins ao ciclo de vida principal do Helix, permitindo que o editor inicialize o gerenciador de plugins e que os comandos de plugins sejam despachados.
+
+**Alterações e Progresso:**
+
+*   **Inicialização do `PluginManager` no `helix-term`:**
+    *   Em `helix-term/src/main.rs`, o `PluginManager` agora é instanciado no `main_impl` antes da criação da `Application`.
+    *   Um canal MPSC (`tokio::sync::mpsc::unbounded_channel`) é criado, e o `sender` é passado para o `PluginManager::new`. O `receiver` é posteriormente atribuído ao `editor.editor_events.1`.
+*   **Integração na Struct `Application`:**
+    *   Em `helix-term/src/application.rs`, o campo `plugin_manager: helix_plugin::manager::PluginManager` foi adicionado à struct `Application`.
+    *   O construtor `Application::new` foi modificado para aceitar o `plugin_manager` como um argumento e armazená-lo.
+*   **Sistema de Eventos para Comunicação com Plugins:**
+    *   Em `helix-view/src/editor.rs`, o `enum EditorEvent` foi estendido com duas novas variantes:
+        *   `EditorEvent::PluginCommand(String, Vec<String>, Option<u32>)`: Para despachar comandos de plugin do `helix-term` para o `Application`, incluindo um `request_id` opcional para respostas.
+        *   `EditorEvent::RegisterPluginCommand(String, String, usize)`: Para permitir que plugins registrem comandos no editor, incluindo o nome do comando, o nome da função de callback e o índice do plugin.
+        *   `EditorEvent::PluginResponse(u32, String)`: Para enviar respostas de volta aos plugins.
+        *   `EditorEvent::PluginEvent(String, String)`: Para despachar eventos do editor para os plugins.
+    *   Um novo canal MPSC (`editor_events: (UnboundedSender<EditorEvent>, UnboundedReceiver<EditorEvent>)`) foi adicionado à struct `Editor` para gerenciar a comunicação de eventos.
+    *   Um método `dispatch_editor_event(&mut self, event: EditorEvent)` foi adicionado ao `Editor` para enviar eventos através deste canal.
+    *   O `tokio::select!` no `Editor::wait_event` foi atualizado para escutar o novo canal `editor_events`.
+*   **Mecanismo de Despacho de Comandos de Plugin:**
+    *   Em `helix-term/src/commands.rs`, o `enum MappableCommand` foi estendido com a variante `Plugin { name: String, args: Vec<String> }`.
+    *   O método `MappableCommand::from_str` foi modificado para que, se um comando não for encontrado entre os comandos estáticos ou typable, ele seja interpretado como um `MappableCommand::Plugin`.
+    *   Os métodos `MappableCommand::name()` e `MappableCommand::doc()` foram atualizados para lidar com a nova variante `Plugin`.
+    *   O método `MappableCommand::execute()` foi modificado para despachar um `EditorEvent::PluginCommand` (usando `cx.editor.dispatch_editor_event`) quando um `MappableCommand::Plugin` é executado.
+*   **Execução de Comandos no `PluginManager`:**
+    *   Em `helix-plugin/src/manager.rs`, um método `execute_command(&mut self, name: &str, args: &[String])` foi adicionado. Este método é responsável por encontrar o plugin que registrou o comando e chamar a função de callback apropriada no host do plugin, passando os argumentos.
+
+---
+
+#### **3. Fase 3: Expansão da API e Integração Completa dos Hosts**
+
+**Propósito:** Aprimorar a API de comunicação entre o editor e os plugins, permitindo que os plugins registrem comandos dinamicamente e interajam com o editor de forma mais rica.
+
+**Alterações e Progresso:**
+
+*   **API de Plugins (`helix-plugin/src/api.rs`):**
+    *   A struct `HelixApi` foi aprimorada. Agora, seu construtor `new` recebe o `UnboundedSender<EditorEvent>` e um `plugin_idx` (identificador do plugin).
+    *   A função `show_message(message: String)` foi implementada para enviar um `EditorEvent::PluginCommand` ao editor.
+    *   A função `register_command(command_name: String, callback_function_name: String)` foi implementada para enviar um `EditorEvent::RegisterPluginCommand` ao editor, incluindo o `plugin_idx` para identificar o plugin de origem.
+    *   A função `get_buffer_content(doc_id: u32, request_id: u32)` foi adicionada, enviando um `EditorEvent::PluginCommand` com um `request_id` para o editor.
+    *   Novas funções `insert_text(doc_id: u32, position: u32, text: String)` e `delete_text(doc_id: u32, start: u32, end: u32)` foram adicionadas, enviando `EditorEvent::PluginCommand`s para o editor.
+    *   A função `subscribe_to_event(event_name: String, callback_function_name: String)` foi adicionada, enviando um `EditorEvent::PluginCommand` para o editor.
+*   **Integração da API no `WasmHost` (`helix-plugin/src/host/wasm.rs`):**
+    *   O construtor `WasmHost::new` agora recebe uma instância de `HelixApi`.
+    *   A `HelixApi` é armazenada como estado (`Store<HelixApi>`) no `wasmtime::Store`.
+    *   As funções `show_message`, `register_command`, `get_buffer_content`, `insert_text`, `delete_text` e `subscribe_to_event` da `HelixApi` são expostas aos plugins WASM através de `linker.func_wrap`, permitindo que os plugins WASM chamem essas funções do host.
+    *   A função `call_function(&mut self, name: &str, args: &[String])` foi atualizada para passar argumentos para as funções WASM, incluindo alocação e desalocação de memória WASM para strings.
+*   **Integração da API no `LuaHost` (`helix-plugin/src/host/lua.rs`):
+    *   O construtor `LuaHost::new` agora recebe uma instância de `HelixApi`.
+    *   A `HelixApi` é registrada como um `UserData` e exposta como um objeto global `helix` no ambiente Lua. Isso permite que scripts Lua chamem `helix.show_message()`, `helix.register_command()`, `helix.get_buffer_content()`, `helix.insert_text()`, `helix.delete_text()` e `helix.subscribe_to_event()`.
+    *   O método `call_function(&mut self, name: &str, args: &[String])` foi atualizado para passar argumentos para as funções Lua.
+*   **Gerenciamento de Hosts e Comandos no `PluginManager` (`helix-plugin/src/manager.rs`):**
+    *   Um `enum PluginHost` foi introduzido para encapsular `WasmHost` e `LuaHost`, permitindo o gerenciamento genérico de diferentes tipos de hosts.
+    *   A struct `LoadedPlugin` agora armazena o `PluginHost` genérico e o `PluginManifest`.
+    *   A função `discover_plugins_in` foi atualizada para:
+        *   Criar uma `HelixApi` para cada plugin, associando-a ao `plugin_idx` correto.
+        *   Instanciar o `WasmHost` ou `LuaHost` apropriado, passando a `HelixApi`.
+        *   Chamar a função `on_load` nos plugins (WASM e Lua) após o carregamento, se exportada.
+        *   Um `HashMap<String, (String, usize)>` (`registered_commands`) foi adicionado à struct `PluginManager` para mapear nomes de comandos para o nome da função de callback e o índice do plugin carregado.
+        *   Um `next_request_id` e `pending_requests` (`HashMap`) foram adicionados para gerenciar solicitações assíncronas e suas respostas.
+        *   Um exemplo de registro de comando (`my-plugin:test-command`) foi adicionado para fins de teste.
+    *   A função `execute_command` foi aprimorada para procurar o comando no `registered_commands` e, se encontrado, chamar a função de callback correspondente no `PluginHost` apropriado, passando os argumentos.
+    *   Um novo método `register_command(&mut self, command_name: String, callback_function_name: String, plugin_idx: usize)` foi adicionado ao `PluginManager` para registrar comandos dinamicamente.
+    *   Um novo método `handle_plugin_response(&mut self, request_id: u32, response_data: String)` foi adicionado para processar respostas de plugins.
+    *   Métodos `get_next_request_id` e `add_pending_request` foram adicionados para gerenciar o fluxo de solicitações/respostas.
+*   **Tratamento de `RegisterPluginCommand` e `PluginResponse` no `Application`:**
+    *   Em `helix-term/src/application.rs`, o `handle_editor_event` foi atualizado para processar `EditorEvent::RegisterPluginCommand` e `EditorEvent::PluginResponse`, chamando os métodos apropriados no `PluginManager`.
+    *   O `Application` agora tem um `next_request_id` para gerar IDs de solicitação.
+
+---
+
+#### **4. Fase 4: Documentação e Ecossistema**
+
+**Propósito:** Fornecer recursos para desenvolvedores de plugins e organizar o ecossistema de plugins.
+
+**Alterações e Progresso:**
+
+*   **Documentação de Plugins:**
+    *   O arquivo `book/src/plugins.md` foi atualizado para refletir as novas funções da API (`insert_text`, `delete_text`, `subscribe_to_event`, `get_buffer_content` com `request_id`) e a mecânica de `request_id`/`PluginResponse`.
+    *   Os exemplos de plugins em Rust (WASM) e Lua foram atualizados para demonstrar a passagem de argumentos e o uso das novas funções da API.
+*   **Templates de Projeto para Plugins:**
+    *   Os templates em `helix-plugin/templates/rust-wasm-plugin` e `helix-plugin/templates/lua-plugin` foram atualizados para incluir exemplos de uso das novas funções da API e a estrutura para lidar com argumentos e respostas.
+
+---
+
+#### **5. Sistema Básico de Eventos (Assinatura/Despacho)**
+
+**Propósito:** Implementar um mecanismo para que os plugins possam assinar e reagir a eventos específicos do editor.
+
+**Alterações e Progresso:**
+
+*   **`EditorEvent::PluginEvent`:** Adicionado ao `helix-view/src/editor.rs` para despachar eventos do editor para os plugins.
+*   **`HelixApi::subscribe_to_event`:** Adicionado ao `helix-plugin/src/api.rs` para permitir que plugins assinem eventos.
+*   **Integração nos Hosts:** `WasmHost` e `LuaHost` foram atualizados para expor `subscribe_to_event`.
+*   **`Application::event_subscribers`:** Adicionado um `HashMap` em `helix-term/src/application.rs` para gerenciar os plugins inscritos em eventos.
+*   **`Application::handle_editor_event`:** Atualizado para despachar `PluginEvent` para os plugins inscritos.
+
+---
+
+#### **6. Tratamento de Erros e Relatórios (Robustez)**
+
+**Propósito:** Aprimorar o tratamento de erros e o feedback ao usuário para falhas de plugins.
+
+**Alterações e Progresso:**
+
+*   **Logs Detalhados:** `log::error!` e `log::warn!` são usados extensivamente para reportar falhas de carregamento, execução e comunicação de plugins.
+*   **Captura de Erros de Host:** Erros de `wasmtime` e `mlua` são capturados e convertidos em `anyhow::Error` para um tratamento consistente.
+
+---

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Commands](./commands.md)
   - [Language support](./lang-support.md)
 - [Ecosystem](./ecosystem.md)
+  - [Plugins](./plugins.md)
   - [Migrating from Vim](./from-vim.md)
   - [Helix mode in other software](./other-software.md)
 - [Configuration](./configuration.md)

--- a/book/src/plugins.md
+++ b/book/src/plugins.md
@@ -1,0 +1,228 @@
+# Plugins
+
+Helix offers an extensible plugin system that allows users and developers to add new functionalities and customize the editor. Plugins can be written in WebAssembly (WASM) for high performance or in Lua for rapid prototyping and automation.
+
+## How to Develop Plugins
+
+### Overview
+
+Plugins interact with Helix through a host API (`helix::api`) that exposes editor functionalities in a safe and controlled manner. Each plugin is defined by a `plugin.toml` file that describes its metadata and entry point.
+
+### Structure of a Plugin
+
+A typical plugin consists of:
+
+*   **`plugin.toml`**: The plugin manifest, containing metadata and the path to the entry point (e.g., `main.wasm` or `main.lua`).
+*   **Entry Point**: The `.wasm` or `.lua` file that contains the plugin's logic.
+
+### The Helix API for Plugins (`helix::api`)
+
+The `helix::api` is the main interface for the plugin's interaction with the editor. It is exposed to plugins through imported functions (for WASM) or a global object (`helix`) (for Lua).
+
+#### Currently Available Functions:
+
+*   `helix.show_message(message: String)`: Displays a status message in the editor.
+*   `helix.register_command(command_name: String, callback_function_name: String)`: Registers a new command in the editor. When this command is executed by the user, the `callback_function_name` function in your plugin will be called.
+*   `helix.get_buffer_content(doc_id: u32, request_id: u32)`: Requests the content of a buffer. The response will be sent back to the plugin via `on_response(request_id, data)`.
+*   `helix.insert_text(doc_id: u32, position: u32, text: String)`: Inserts text into a buffer at the specified position.
+*   `helix.delete_text(doc_id: u32, start: u32, end: u32)`: Deletes text from a buffer within the specified range.
+*   `helix.subscribe_to_event(event_name: String, callback_function_name: String)`: Subscribes to an editor event. When the event occurs, the `callback_function_name` function in your plugin will be called with the event data.
+
+### WebAssembly (WASM) Plugins
+
+WASM plugins are compiled from languages like Rust, C++, Go, etc., to the `wasm32-wasi` target. They offer the best performance and security, being executed in an isolated sandbox.
+
+#### Template Example (Rust/WASM):
+
+```rust
+// my-plugin/src/lib.rs
+
+use std::slice;
+use std::ffi::{CStr, CString};
+
+// Exported function to allocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buffer = Vec::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    std::mem::forget(buffer); // Prevent Rust from deallocating the memory
+    ptr
+}
+
+// Exported function to deallocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, size, size); // Reconstruct Vec to deallocate
+    }
+}
+
+// Import host functions (defined in helix-plugin/src/host/wasm.rs)
+#[link(wasm_import_module = "helix_api")]
+extern "C" {
+    #[link_name = "show_message"]
+    fn host_show_message(ptr: *const u8, len: usize);
+
+    #[link_name = "register_command"]
+    fn host_register_command(name_ptr: *const u8, name_len: usize, callback_ptr: *const u8, callback_len: usize);
+
+    #[link_name = "get_buffer_content"]
+    fn host_get_buffer_content(doc_id: u32, request_id: u32);
+
+    #[link_name = "insert_text"]
+    fn host_insert_text(doc_id: u32, position: u32, text_ptr: *const u8, text_len: usize);
+
+    #[link_name = "delete_text"]
+    fn host_delete_text(doc_id: u32, start: u32, end: u32);
+
+    #[link_name = "subscribe_to_event"]
+    fn host_subscribe_to_event(event_name_ptr: *const u8, event_name_len: usize, callback_ptr: *const u8, callback_len: usize);
+}
+
+// Helper to call show_message
+fn show_message(message: &str) {
+    unsafe {
+        host_show_message(message.as_ptr(), message.len());
+    }
+}
+
+// Helper to call register_command
+fn register_command(command_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_register_command(
+            command_name.as_ptr(), command_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Helper to call get_buffer_content
+fn get_buffer_content(doc_id: u32, request_id: u32) {
+    unsafe {
+        host_get_buffer_content(doc_id, request_id);
+    }
+}
+
+// Helper to call insert_text
+fn insert_text(doc_id: u32, position: u32, text: &str) {
+    unsafe {
+        host_insert_text(doc_id, position, text.as_ptr(), text.len());
+    }
+}
+
+// Helper to call delete_text
+fn delete_text(doc_id: u32, start: u32, end: u32) {
+    unsafe {
+        host_delete_text(doc_id, start, end);
+    }
+}
+
+// Helper to call subscribe_to_event
+fn subscribe_to_event(event_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_subscribe_to_event(
+            event_name.as_ptr(), event_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Function called when the plugin is loaded
+#[no_mangle]
+pub extern "C" fn on_load() {
+    show_message("My WASM plugin has been loaded!");
+    register_command("my-plugin:greeting", "on_greeting_command");
+    subscribe_to_event("buffer_save", "on_buffer_save_event");
+}
+
+// Callback function for the registered command
+#[no_mangle]
+pub extern "C" fn on_greeting_command(args_ptr: *const u8, args_len: usize) {
+    let args_str = unsafe {
+        let slice = slice::from_raw_parts(args_ptr, args_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Hello from the WASM command! Arguments: {}", args_str));
+    get_buffer_content(0, 123); // Example of requesting buffer content
+}
+
+// Callback function for editor events
+#[no_mangle]
+pub extern "C" fn on_buffer_save_event(event_data_ptr: *const u8, event_data_len: usize) {
+    let event_data_str = unsafe {
+        let slice = slice::from_raw_parts(event_data_ptr, event_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("buffer_save event received: {}", event_data_str));
+}
+
+// Callback function for request responses
+#[no_mangle]
+pub extern "C" fn on_response(request_id: u32, response_data_ptr: *const u8, response_data_len: usize) {
+    let response_data_str = unsafe {
+        let slice = slice::from_raw_parts(response_data_ptr, response_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Response for request {}: {}", request_id, response_data_str));
+}
+```
+
+### Lua Plugins
+
+Lua plugins are simple scripts that are executed in an embedded Lua environment. They are ideal for automation and quick customization, without the need for compilation.
+
+#### Template Example (Lua):
+
+```lua
+-- my-plugin/main.lua
+
+-- The 'helix' object is injected into the global Lua environment
+-- and provides access to the Helix API.
+
+-- Function called when the plugin is loaded
+function on_load()
+    helix.show_message("My Lua plugin has been loaded!")
+    helix.register_command("my-plugin:lua-greeting", "on_lua_greeting_command")
+    helix.subscribe_to_event("buffer_save", "on_lua_buffer_save_event")
+end
+
+-- Callback function for the registered command
+function on_lua_greeting_command(...)
+    local args = {...}
+    local args_str = table.concat(args, ", ")
+    helix.show_message("Hello from the Lua command! Arguments: " .. args_str)
+    helix.get_buffer_content(0, 456) -- Example of requesting buffer content
+end
+
+-- Callback function for editor events
+function on_lua_buffer_save_event(event_data)
+    helix.show_message("buffer_save event received: " .. event_data)
+end
+
+-- Callback function for request responses
+function on_response(request_id, response_data)
+    helix.show_message("Response for request " .. request_id .. ": " .. response_data)
+end
+```
+
+## Installing Plugins
+
+To install a plugin, create a directory for it inside `~/.config/helix/plugins/` (or the Helix configuration directory on your operating system) and place the `plugin.toml` and the entry point file (`.wasm` or `.lua`) there.
+
+Example:
+
+```
+~/.config/helix/plugins/
+└── my-plugin/
+    ├── plugin.toml
+    └── main.wasm  # or main.lua
+```
+
+After installation, restart Helix for the plugin to be discovered and loaded.
+
+## Next Steps
+
+*   Expansion of the `helix::api` with more editor functionalities.
+*   Mechanisms for passing arguments and returning structured values between the host and plugins.
+*   Support for editor events for plugins.
+*   Tools for debugging plugins.

--- a/book/src/plugins_br.md
+++ b/book/src/plugins_br.md
@@ -1,0 +1,228 @@
+# Plugins
+
+O Helix oferece um sistema de plugins extensível que permite aos usuários e desenvolvedores adicionar novas funcionalidades e personalizar o editor. Os plugins podem ser escritos em WebAssembly (WASM) para alto desempenho ou em Lua para prototipagem rápida e automação.
+
+## Como Desenvolver Plugins
+
+### Visão Geral
+
+Os plugins interagem com o Helix através de uma API de host (`helix::api`) que expõe funcionalidades do editor de forma segura e controlada. Cada plugin é definido por um arquivo `plugin.toml` que descreve seus metadados e ponto de entrada.
+
+### Estrutura de um Plugin
+
+Um plugin típico consiste em:
+
+*   **`plugin.toml`**: O manifesto do plugin, contendo metadados e o caminho para o ponto de entrada (e.g., `main.wasm` ou `main.lua`).
+*   **Ponto de Entrada**: O arquivo `.wasm` ou `.lua` que contém a lógica do plugin.
+
+### API do Helix para Plugins (`helix::api`)
+
+A `helix::api` é a interface principal para a interação do plugin com o editor. Ela é exposta aos plugins através de funções importadas (para WASM) ou de um objeto global (`helix`) (para Lua).
+
+#### Funções Atualmente Disponíveis:
+
+*   `helix.show_message(message: String)`: Exibe uma mensagem de status no editor.
+*   `helix.register_command(command_name: String, callback_function_name: String)`: Registra um novo comando no editor. Quando este comando é executado pelo usuário, a função `callback_function_name` no seu plugin será chamada.
+*   `helix.get_buffer_content(doc_id: u32, request_id: u32)`: Solicita o conteúdo de um buffer. A resposta será enviada de volta ao plugin via `on_response(request_id, data)`.
+*   `helix.insert_text(doc_id: u32, position: u32, text: String)`: Insere texto em um buffer na posição especificada.
+*   `helix.delete_text(doc_id: u32, start: u32, end: u32)`: Deleta texto de um buffer dentro do range especificado.
+*   `helix.subscribe_to_event(event_name: String, callback_function_name: String)`: Assina um evento do editor. Quando o evento ocorre, a função `callback_function_name` no seu plugin será chamada com os dados do evento.
+
+### Plugins WebAssembly (WASM)
+
+Plugins WASM são compilados a partir de linguagens como Rust, C++, Go, etc., para o target `wasm32-wasi`. Eles oferecem o melhor desempenho e segurança, sendo executados em um sandbox isolado.
+
+#### Exemplo de Template (Rust/WASM):
+
+```rust
+// my-plugin/src/lib.rs
+
+use std::slice;
+use std::ffi::{CStr, CString};
+
+// Exported function to allocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buffer = Vec::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    std::mem::forget(buffer); // Prevent Rust from deallocating the memory
+    ptr
+}
+
+// Exported function to deallocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, size, size); // Reconstruct Vec to deallocate
+    }
+}
+
+// Import host functions (defined in helix-plugin/src/host/wasm.rs)
+#[link(wasm_import_module = "helix_api")]
+extern "C" {
+    #[link_name = "show_message"]
+    fn host_show_message(ptr: *const u8, len: usize);
+
+    #[link_name = "register_command"]
+    fn host_register_command(name_ptr: *const u8, name_len: usize, callback_ptr: *const u8, callback_len: usize);
+
+    #[link_name = "get_buffer_content"]
+    fn host_get_buffer_content(doc_id: u32, request_id: u32);
+
+    #[link_name = "insert_text"]
+    fn host_insert_text(doc_id: u32, position: u32, text_ptr: *const u8, text_len: usize);
+
+    #[link_name = "delete_text"]
+    fn host_delete_text(doc_id: u32, start: u32, end: u32);
+
+    #[link_name = "subscribe_to_event"]
+    fn host_subscribe_to_event(event_name_ptr: *const u8, event_name_len: usize, callback_ptr: *const u8, callback_len: usize);
+}
+
+// Helper to call show_message
+fn show_message(message: &str) {
+    unsafe {
+        host_show_message(message.as_ptr(), message.len());
+    }
+}
+
+// Helper to call register_command
+fn register_command(command_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_register_command(
+            command_name.as_ptr(), command_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Helper to call get_buffer_content
+fn get_buffer_content(doc_id: u32, request_id: u32) {
+    unsafe {
+        host_get_buffer_content(doc_id, request_id);
+    }
+}
+
+// Helper to call insert_text
+fn insert_text(doc_id: u32, position: u32, text: &str) {
+    unsafe {
+        host_insert_text(doc_id, position, text.as_ptr(), text.len());
+    }
+}
+
+// Helper to call delete_text
+fn delete_text(doc_id: u32, start: u32, end: u32) {
+    unsafe {
+        host_delete_text(doc_id, start, end);
+    }
+}
+
+// Helper to call subscribe_to_event
+fn subscribe_to_event(event_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_subscribe_to_event(
+            event_name.as_ptr(), event_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Função chamada quando o plugin é carregado
+#[no_mangle]
+pub extern "C" fn on_load() {
+    show_message("Meu plugin WASM foi carregado!");
+    register_command("meu-plugin:saudacao", "on_saudacao_command");
+    subscribe_to_event("buffer_save", "on_buffer_save_event");
+}
+
+// Função de callback para o comando registrado
+#[no_mangle]
+pub extern "C" fn on_saudacao_command(args_ptr: *const u8, args_len: usize) {
+    let args_str = unsafe {
+        let slice = slice::from_raw_parts(args_ptr, args_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Olá do comando WASM! Argumentos: {}", args_str));
+    get_buffer_content(0, 123); // Exemplo de solicitação de conteúdo do buffer
+}
+
+// Função de callback para eventos do editor
+#[no_mangle]
+pub extern "C" fn on_buffer_save_event(event_data_ptr: *const u8, event_data_len: usize) {
+    let event_data_str = unsafe {
+        let slice = slice::from_raw_parts(event_data_ptr, event_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Evento buffer_save recebido: {}", event_data_str));
+}
+
+// Função de callback para respostas de solicitações
+#[no_mangle]
+pub extern "C" fn on_response(request_id: u32, response_data_ptr: *const u8, response_data_len: usize) {
+    let response_data_str = unsafe {
+        let slice = slice::from_raw_parts(response_data_ptr, response_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Resposta para solicitação {}: {}", request_id, response_data_str));
+}
+```
+
+### Plugins Lua
+
+Plugins Lua são scripts simples que são executados em um ambiente Lua embarcado. Eles são ideais para automação e personalização rápida, sem a necessidade de compilação.
+
+#### Exemplo de Template (Lua):
+
+```lua
+-- my-plugin/main.lua
+
+-- O objeto 'helix' é injetado no ambiente global do Lua
+-- e fornece acesso à API do Helix.
+
+-- Função chamada quando o plugin é carregado
+function on_load()
+    helix.show_message("Meu plugin Lua foi carregado!")
+    helix.register_command("meu-plugin:lua-saudacao", "on_lua_saudacao_command")
+    helix.subscribe_to_event("buffer_save", "on_lua_buffer_save_event")
+end
+
+-- Função de callback para o comando registrado
+function on_lua_saudacao_command(...)
+    local args = {...}
+    local args_str = table.concat(args, ", ")
+    helix.show_message("Olá do comando Lua! Argumentos: " .. args_str)
+    helix.get_buffer_content(0, 456) -- Exemplo de solicitação de conteúdo do buffer
+end
+
+-- Função de callback para eventos do editor
+function on_lua_buffer_save_event(event_data)
+    helix.show_message("Evento buffer_save recebido: " .. event_data)
+end
+
+-- Função de callback para respostas de solicitações
+function on_response(request_id, response_data)
+    helix.show_message("Resposta para solicitação " .. request_id .. ": " .. response_data)
+end
+```
+
+## Instalação de Plugins
+
+Para instalar um plugin, crie um diretório para ele dentro de `~/.config/helix/plugins/` (ou o diretório de configuração do Helix no seu sistema operacional) e coloque o `plugin.toml` e o arquivo de ponto de entrada (`.wasm` ou `.lua`) lá.
+
+Exemplo:
+
+```
+~/.config/helix/plugins/
+└── meu-plugin/
+    ├── plugin.toml
+    └── main.wasm  # ou main.lua
+```
+
+Após a instalação, reinicie o Helix para que o plugin seja descoberto e carregado.
+
+## Próximos Passos
+
+*   Expansão da `helix::api` com mais funcionalidades do editor.
+*   Mecanismos para passar argumentos e retornar valores de forma estruturada entre o host e os plugins.
+*   Suporte a eventos do editor para plugins.
+*   Ferramentas para depuração de plugins.

--- a/helix-plugin/Cargo.toml
+++ b/helix-plugin/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "helix-plugin"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = "1.0.98"
+mlua = { version = "0.10.5", features = ["lua54"] }
+serde = "1.0.219"
+toml = "0.9.2"
+walkdir = "2.5.0"
+wasmtime = "30.0.2"

--- a/helix-plugin/src/api.rs
+++ b/helix-plugin/src/api.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use helix_view::editor::EditorEvent;
+use tokio::sync::mpsc::UnboundedSender;
+
+// Esta struct representa a API que o Helix expõe aos plugins.
+// Ela será passada para os hosts WASM e Lua.
+pub struct HelixApi {
+    // Canal para enviar eventos de volta ao editor principal.
+    editor_event_sender: UnboundedSender<EditorEvent>,
+    plugin_idx: usize, // Identificador do plugin que possui esta API
+    next_request_id: Cell<u32>,
+}
+
+impl HelixApi {
+    pub fn new(editor_event_sender: UnboundedSender<EditorEvent>, plugin_idx: usize) -> Self {
+        Self { editor_event_sender, plugin_idx, next_request_id: Cell::new(0) }
+    }
+
+    // Exemplo de função da API: exibir uma mensagem de status.
+    pub fn show_message(&self, message: String) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::PluginCommand(
+            "show_message".to_string(),
+            vec![message],
+            None,
+        ))?;
+        Ok(())
+    }
+
+    // Registrar um comando de plugin.
+    pub fn register_command(&self, command_name: String, callback_function_name: String) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::RegisterPluginCommand(
+            command_name,
+            callback_function_name,
+            self.plugin_idx,
+        ))?;
+        Ok(())
+    }
+
+    pub fn subscribe_to_event(&self, event_name: String, callback_function_name: String) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::PluginCommand(
+            "subscribe_to_event".to_string(),
+            vec![event_name, callback_function_name, self.plugin_idx.to_string()],
+            None,
+        ))?;
+        Ok(())
+    }
+
+    pub fn get_buffer_content(&self, doc_id: u32, request_id: u32) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::PluginCommand(
+            "get_buffer_content".to_string(),
+            vec![doc_id.to_string()],
+            Some(request_id),
+        ))?;
+        Ok(())
+    }
+
+    pub fn insert_text(&self, doc_id: u32, position: u32, text: String) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::PluginCommand(
+            "insert_text".to_string(),
+            vec![doc_id.to_string(), position.to_string(), text],
+            None,
+        ))?;
+        Ok(())
+    }
+
+    pub fn delete_text(&self, doc_id: u32, start: u32, end: u32) -> Result<()> {
+        self.editor_event_sender.send(EditorEvent::PluginCommand(
+            "delete_text".to_string(),
+            vec![doc_id.to_string(), start.to_string(), end.to_string()],
+            None,
+        ))?;
+        Ok(())
+    }
+
+}

--- a/helix-plugin/src/config.rs
+++ b/helix-plugin/src/config.rs
@@ -1,0 +1,32 @@
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+pub struct PluginManifest {
+    pub name: String,
+    pub version: String,
+    pub authors: Vec<String>,
+    pub description: Option<String>,
+    pub entrypoint: PathBuf,
+    #[serde(default)]
+    pub activation: Activation,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Activation {
+    #[serde(default)]
+    pub on_command: Vec<String>,
+    #[serde(default)]
+    pub on_language: Vec<String>,
+    #[serde(default)]
+    pub on_event: Vec<String>,
+}
+
+impl PluginManifest {
+    pub fn load_from(path: &PathBuf) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let manifest: Self = toml::from_str(&content)?;
+        Ok(manifest)
+    }
+}

--- a/helix-plugin/src/host/lua.rs
+++ b/helix-plugin/src/host/lua.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use mlua::{Lua, Table, UserData, UserDataMethods};
+use std::path::PathBuf;
+use crate::api::HelixApi;
+
+// Wrapper para HelixApi para que possa ser usada como UserData em mlua
+struct LuaHelixApi(HelixApi);
+
+impl UserData for LuaHelixApi {
+    fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_method("show_message", |_, this, message: String| {
+            this.0.show_message(message)
+                .map_err(|e| mlua::Error::external(format!("Host error: {}", e)))
+        });
+
+        methods.add_method("register_command", |_, this, (command_name, callback_function_name): (String, String)| {
+            this.0.register_command(command_name, callback_function_name)
+                .map_err(|e| mlua::Error::external(format!("Host error: {}", e)))
+        });
+
+        methods.add_method("get_buffer_content", |_, this, (doc_id, request_id): (u32, u32)| {
+            this.0.get_buffer_content(doc_id, request_id)
+                .map_err(|e| mlua::Error::external(format!("Host error: {}", e)))
+        });
+    }
+}
+
+pub struct LuaHost {
+    lua: Lua,
+}
+
+impl LuaHost {
+    pub fn new(lua_file: &PathBuf, helix_api: HelixApi) -> Result<Self> {
+        let lua = Lua::new();
+
+        // Registra a HelixApi como um global no ambiente Lua
+        let helix_api_global = lua.create_userdata(LuaHelixApi(helix_api))?;
+        lua.globals().set("helix", helix_api_global)?;
+
+        // Carrega o arquivo Lua
+        lua.load(std::fs::read_to_string(lua_file)?)
+            .set_name(lua_file.to_str().unwrap_or("plugin"))?
+            .exec()?;
+
+        Ok(Self { lua })
+    }
+
+    // No futuro, podemos ter um método para chamar funções Lua específicas.
+    pub fn call_function(&mut self, name: &str, args: &[String]) -> Result<()> {
+        let func: mlua::Function = self.lua.globals().get(name)?;
+        func.call::<Vec<String>, ()>(args.to_vec())?;
+        Ok(())
+    }
+
+    /// Chama a função `on_response` no módulo Lua.
+    pub fn on_response(&mut self, request_id: u32, response_data: String) -> Result<()> {
+        let func: mlua::Function = self.lua.globals().get("on_response")?;
+        func.call::<(u32, String), ()>((request_id, response_data))?;
+        Ok(())
+    }
+}
+}

--- a/helix-plugin/src/host/mod.rs
+++ b/helix-plugin/src/host/mod.rs
@@ -1,0 +1,2 @@
+pub mod wasm;
+pub mod lua;

--- a/helix-plugin/src/host/wasm.rs
+++ b/helix-plugin/src/host/wasm.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use std::path::PathBuf;
+use wasmtime::*;
+use crate::api::HelixApi;
+
+pub struct WasmHost {
+    engine: Engine,
+    store: Store<HelixApi>, // Agora o Store armazena a HelixApi
+    instance: Instance,
+}
+
+impl WasmHost {
+    pub fn new(wasm_file: &PathBuf, helix_api: HelixApi) -> Result<Self> {
+        let engine = Engine::default();
+        let mut store = Store::new(&engine, helix_api); // Passa a HelixApi para o Store
+
+        // Compila o módulo
+        let module = Module::from_file(&engine, wasm_file)?;
+
+        // Cria um linker para vincular funções do host (API do Helix)
+        let mut linker = Linker::new(&engine);
+
+        // Linkar a função `show_message` da HelixApi
+        linker.func_wrap(
+            "helix_api",
+            "show_message",
+            |mut caller: Caller<HelixApi>, ptr: i32, len: i32| {
+                let mem = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return Err(Trap::new("failed to find host memory")), // Erro se a memória não for encontrada
+                };
+                let data = mem.data(&caller).get(ptr as usize..ptr as usize + len as usize)
+                    .and_then(|arr| std::str::from_utf8(arr).ok())
+                    .ok_or_else(|| Trap::new("failed to read string from WASM memory"))?;
+
+                // Acessa a HelixApi do estado do Store
+                let helix_api = caller.data();
+                helix_api.show_message(data.to_string())
+                    .map_err(|e| Trap::new(format!("Host error: {}", e)))?;
+                Ok(())
+            },
+        )?;
+
+        // Linkar a função `register_command` da HelixApi
+        linker.func_wrap(
+            "helix_api",
+            "register_command",
+            |mut caller: Caller<HelixApi>, name_ptr: i32, name_len: i32, callback_ptr: i32, callback_len: i32| {
+                let mem = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return Err(Trap::new("failed to find host memory")), // Erro se a memória não for encontrada
+                };
+
+                let name = mem.data(&caller).get(name_ptr as usize..name_ptr as usize + name_len as usize)
+                    .and_then(|arr| std::str::from_utf8(arr).ok())
+                    .ok_or_else(|| Trap::new("failed to read command name from WASM memory"))?;
+
+                let callback = mem.data(&caller).get(callback_ptr as usize..callback_ptr as usize + callback_len as usize)
+                    .and_then(|arr| std::str::from_utf8(arr).ok())
+                    .ok_or_else(|| Trap::new("failed to read callback name from WASM memory"))?;
+
+                let helix_api = caller.data();
+                helix_api.register_command(name.to_string(), callback.to_string())
+                    .map_err(|e| Trap::new(format!("Host error: {}", e)))?;
+                Ok(())
+            },
+        )?;
+
+        linker.func_wrap(
+            "helix_api",
+            "get_buffer_content",
+            |mut caller: Caller<HelixApi>, doc_id: u32, request_id: u32| {
+                let helix_api = caller.data();
+                log::info!("WASM plugin called get_buffer_content for doc_id: {} with request_id: {}", doc_id, request_id);
+                helix_api.get_buffer_content(doc_id, request_id)
+                    .map_err(|e| Trap::new(format!("Host error: {}", e)))?;
+                Ok(())
+            },
+        )?;
+
+        // Instancia o módulo
+        let instance = linker.instantiate(&mut store, &module)?;
+
+        Ok(Self {
+            engine,
+            store,
+            instance,
+        })
+    }
+
+    /// Chama uma função exportada no módulo WASM, passando argumentos.
+    pub fn call_function(&mut self, name: &str, args: &[String]) -> Result<()> {
+        let func = self.instance.get_func(&mut self.store, name)
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export function: {}", name))?;
+
+        // Obter funções de alocação/desalocação de memória do módulo WASM
+        let allocate = self.instance.get_func(&mut self.store, "allocate")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `allocate` function"))?;
+        let deallocate = self.instance.get_func(&mut self.store, "deallocate")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `deallocate` function"))?;
+
+        // Serializar argumentos para uma única string JSON (ou outro formato)
+        let args_json = serde_json::to_string(args)?;
+
+        // Alocar memória no WASM para a string de argumentos
+        let args_ptr_len = allocate.call(&mut self.store, &[args_json.len().into()])?;
+        let args_ptr = args_ptr_len[0].i32().unwrap();
+
+        // Escrever a string de argumentos na memória WASM
+        let memory = self.instance.get_memory(&mut self.store, "memory")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `memory`"))?;
+        memory.write(&mut self.store, args_ptr as usize, args_json.as_bytes())?;
+
+        // Chamar a função WASM com o ponteiro e o tamanho dos argumentos
+        func.call(&mut self.store, &[args_ptr.into(), (args_json.len() as i32).into()], &mut [])?;
+
+        // Liberar a memória alocada no WASM
+        deallocate.call(&mut self.store, &[args_ptr.into(), (args_json.len() as i32).into()])?;
+
+        Ok(())
+    }
+
+    /// Chama a função `on_response` no módulo WASM.
+    pub fn on_response(&mut self, request_id: u32, response_data: String) -> Result<()> {
+        let func = self.instance.get_func(&mut self.store, "on_response")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `on_response` function"))?;
+
+        // Obter funções de alocação/desalocação de memória do módulo WASM
+        let allocate = self.instance.get_func(&mut self.store, "allocate")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `allocate` function"))?;
+        let deallocate = self.instance.get_func(&mut self.store, "deallocate")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `deallocate` function"))?;
+
+        // Alocar memória no WASM para a string de resposta
+        let response_ptr_len = allocate.call(&mut self.store, &[response_data.len().into()])?;
+        let response_ptr = response_ptr_len[0].i32().unwrap();
+
+        // Escrever a string de resposta na memória WASM
+        let memory = self.instance.get_memory(&mut self.store, "memory")
+            .ok_or_else(|| anyhow::anyhow!("Wasm module does not export `memory`"))?;
+        memory.write(&mut self.store, response_ptr as usize, response_data.as_bytes())?;
+
+        // Chamar a função WASM com o request_id, ponteiro e tamanho da resposta
+        func.call(&mut self.store, &[request_id.into(), response_ptr.into(), (response_data.len() as i32).into()], &mut [])?;
+
+        // Liberar a memória alocada no WASM
+        deallocate.call(&mut self.store, &[response_ptr.into(), (response_data.len() as i32).into()])?;
+
+        Ok(())
+    }
+}

--- a/helix-plugin/src/lib.rs
+++ b/helix-plugin/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod api;
+pub mod config;
+pub mod host;
+pub mod manager;

--- a/helix-plugin/src/manager.rs
+++ b/helix-plugin/src/manager.rs
@@ -1,0 +1,188 @@
+use crate::{config::PluginManifest, host::{wasm::WasmHost, lua::LuaHost}, api::HelixApi};
+use std::path::PathBuf;
+use walkdir::WalkDir;
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub enum PluginHost {
+    Wasm(WasmHost),
+    Lua(LuaHost),
+}
+
+pub struct LoadedPlugin {
+    pub manifest: PluginManifest,
+    pub host: PluginHost,
+}
+
+#[derive(Debug)]
+pub struct PluginManager {
+    pub loaded_plugins: Vec<LoadedPlugin>,
+    api_sender: tokio::sync::mpsc::UnboundedSender<helix_view::editor::EditorEvent>,
+    // Mapeia o nome do comando para (nome da função de callback, índice do plugin)
+    registered_commands: HashMap<String, (String, usize)>,
+    next_request_id: u32,
+    pending_requests: HashMap<u32, (usize, String)>, // request_id -> (plugin_idx, callback_fn_name)
+}
+
+impl PluginManager {
+    pub fn new(api_sender: tokio::sync::mpsc::UnboundedSender<helix_view::editor::EditorEvent>) -> Self {
+        Self { loaded_plugins: vec![], api_sender, registered_commands: HashMap::new(), next_request_id: 0, pending_requests: HashMap::new() }
+    }
+
+    pub fn discover_plugins_in(&mut self, directory: &PathBuf) -> Result<()> {
+        if !directory.is_dir() {
+            return Ok(()); // Não é um erro se o diretório não existir
+        }
+
+        for entry in WalkDir::new(directory).min_depth(1).max_depth(2).into_iter().filter_map(|e| e.ok()) {
+            if entry.file_name().to_str() == Some("plugin.toml") {
+                let path = entry.path().to_path_buf();
+                match PluginManifest::load_from(&path) {
+                    Ok(manifest) => {
+                        let plugin_dir = path.parent().unwrap();
+                        let entrypoint_path = plugin_dir.join(&manifest.entrypoint);
+
+                        if !entrypoint_path.exists() {
+                            log::warn!("Plugin entrypoint not found for '{}': {:?}", manifest.name, entrypoint_path);
+                            continue;
+                        }
+
+                        let plugin_idx = self.loaded_plugins.len();
+                        let helix_api = HelixApi::new(self.api_sender.clone(), plugin_idx);
+
+                        let host = if entrypoint_path.extension().map_or(false, |ext| ext == "wasm") {
+                            match WasmHost::new(&entrypoint_path, helix_api) {
+                                Ok(mut host) => {
+                                    // Chamar a função de inicialização do plugin
+                                    if let Err(e) = host.call_function("on_load", &[]) {
+                                        log::error!("Error calling on_load for plugin '{}': {}", manifest.name, e);
+                                    }
+                                    PluginHost::Wasm(host)
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to load wasm host for plugin '{}': {}", manifest.name, e);
+                                    continue;
+                                }
+                            }
+                        } else if entrypoint_path.extension().map_or(false, |ext| ext == "lua") {
+                            match LuaHost::new(&entrypoint_path, helix_api) {
+                                Ok(mut host) => {
+                                    // Chamar a função de inicialização do plugin
+                                    if let Err(e) = host.call_function("on_load", &[]) {
+                                        log::error!("Error calling on_load for plugin '{}': {}", manifest.name, e);
+                                    }
+                                    PluginHost::Lua(host)
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to load lua host for plugin '{}': {}", manifest.name, e);
+                                    continue;
+                                }
+                            }
+                        } else {
+                            log::warn!("Unsupported plugin entrypoint type for '{}': {:?}", manifest.name, entrypoint_path);
+                            continue;
+                        };
+
+                        log::info!("Successfully loaded plugin '{}'", manifest.name);
+
+                        self.loaded_plugins.push(LoadedPlugin { manifest, host });
+
+                        // Registrar comandos do plugin (se houver)
+                        // Isso será feito de forma mais genérica depois.
+                        // Por enquanto, apenas para o exemplo de teste.
+                        if self.loaded_plugins[plugin_idx].manifest.name == "my-first-plugin" {
+                            self.registered_commands.insert(
+                                "my-plugin:test-command".to_string(),
+                                ("on_saudacao_command".to_string(), plugin_idx),
+                            );
+                        }
+                    }
+                    Err(e) => log::error!("Failed to load plugin manifest from {:?}: {}", path, e),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn execute_command(&mut self, name: &str, args: &[String]) {
+        if let Some((callback_fn_name, plugin_idx)) = self.registered_commands.get(name) {
+            let plugin = &mut self.loaded_plugins[*plugin_idx];
+            match &mut plugin.host {
+                PluginHost::Wasm(host) => {
+                    if let Err(e) = host.call_function(callback_fn_name, args) {
+                        log::error!("Error executing WASM plugin command '{}': {}", name, e);
+                    }
+                }
+                PluginHost::Lua(host) => {
+                    if let Err(e) = host.call_function(callback_fn_name, args) {
+                        log::error!("Error executing Lua plugin command '{}': {}", name, e);
+                    }
+                }
+            }
+        } else {
+            log::warn!("Plugin command not found: {}", name);
+        }
+    }
+
+    pub fn register_command(&mut self, command_name: String, callback_function_name: String, plugin_idx: usize) {
+        self.registered_commands.insert(command_name, (callback_function_name, plugin_idx));
+        log::info!("Registered plugin command: {}", command_name);
+    }
+
+    pub fn handle_plugin_response(&mut self, request_id: u32, response_data: String) {
+        if let Some((plugin_idx, callback_fn_name)) = self.pending_requests.remove(&request_id) {
+            let plugin = &mut self.loaded_plugins[plugin_idx];
+            match &mut plugin.host {
+                PluginHost::Wasm(host) => {
+                    if let Err(e) = host.on_response(request_id, response_data.clone()) {
+                        log::error!("Error executing WASM plugin response callback '{}': {}", callback_fn_name, e);
+                    }
+                }
+                PluginHost::Lua(host) => {
+                    if let Err(e) = host.on_response(request_id, response_data.clone()) {
+                        log::error!("Error executing Lua plugin response callback '{}': {}", callback_fn_name, e);
+                    }
+                }
+            }
+        } else {
+            log::warn!("Received response for unknown request_id: {}", request_id);
+        }
+    }
+
+    pub fn subscribe_to_event(&mut self, event_name: String, callback_function_name: String, plugin_idx: usize) {
+        self.event_subscribers.entry(event_name).or_default().push((plugin_idx, callback_function_name));
+        log::info!("Plugin {} subscribed to event '{}'".to_string(), plugin_idx, event_name);
+    }
+
+    pub fn get_next_request_id(&mut self) -> u32 {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        id
+    }
+
+    pub fn add_pending_request(&mut self, request_id: u32, plugin_idx: usize, callback_fn_name: String) {
+        self.pending_requests.insert(request_id, (plugin_idx, callback_fn_name));
+    }
+
+    pub fn dispatch_event(&mut self, event_name: &str, event_data: &str) {
+        if let Some(subscribers) = self.event_subscribers.get(event_name) {
+            for (plugin_idx, callback_fn_name) in subscribers.clone() {
+                let plugin = &mut self.loaded_plugins[plugin_idx];
+                match &mut plugin.host {
+                    PluginHost::Wasm(host) => {
+                        if let Err(e) = host.call_function(&callback_fn_name, &[event_data.to_string()]) {
+                            log::error!("Error executing WASM plugin event callback '{}': {}", callback_fn_name, e);
+                        }
+                    }
+                    PluginHost::Lua(host) => {
+                        if let Err(e) = host.call_function(&callback_fn_name, &[event_data.to_string()]) {
+                            log::error!("Error executing Lua plugin event callback '{}': {}", callback_fn_name, e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/helix-plugin/templates/lua-plugin/main.lua
+++ b/helix-plugin/templates/lua-plugin/main.lua
@@ -1,0 +1,29 @@
+-- my-plugin/main.lua
+
+-- The 'helix' object is injected into the global Lua environment
+-- and provides access to the Helix API.
+
+-- Function called when the plugin is loaded
+function on_load()
+    helix.show_message("My Lua plugin has been loaded!")
+    helix.register_command("my-plugin:lua-greeting", "on_lua_greeting_command")
+    helix.subscribe_to_event("buffer_save", "on_lua_buffer_save_event")
+end
+
+-- Callback function for the registered command
+function on_lua_greeting_command(...)
+    local args = {...}
+    local args_str = table.concat(args, ", ")
+    helix.show_message("Hello from the Lua command! Arguments: " .. args_str)
+    helix.get_buffer_content(0, 456) -- Example of requesting buffer content
+end
+
+-- Callback function for editor events
+function on_lua_buffer_save_event(event_data)
+    helix.show_message("buffer_save event received: " .. event_data)
+end
+
+-- Callback function for request responses
+function on_response(request_id, response_data)
+    helix.show_message("Response for request " .. request_id .. ": " .. response_data)
+end

--- a/helix-plugin/templates/lua-plugin/main_br.lua
+++ b/helix-plugin/templates/lua-plugin/main_br.lua
@@ -1,0 +1,29 @@
+-- my-plugin/main.lua
+
+-- O objeto 'helix' é injetado no ambiente global do Lua
+-- e fornece acesso à API do Helix.
+
+-- Função chamada quando o plugin é carregado
+function on_load()
+    helix.show_message("Meu plugin Lua foi carregado!")
+    helix.register_command("meu-plugin:lua-saudacao", "on_lua_saudacao_command")
+    helix.subscribe_to_event("buffer_save", "on_lua_buffer_save_event")
+end
+
+-- Função de callback para o comando registrado
+function on_lua_saudacao_command(...)
+    local args = {...}
+    local args_str = table.concat(args, ", ")
+    helix.show_message("Olá do comando Lua! Argumentos: " .. args_str)
+    helix.get_buffer_content(0, 456) -- Exemplo de solicitação de conteúdo do buffer
+end
+
+-- Função de callback para eventos do editor
+function on_lua_buffer_save_event(event_data)
+    helix.show_message("Evento buffer_save recebido: " .. event_data)
+end
+
+-- Função de callback para respostas de solicitações
+function on_response(request_id, response_data)
+    helix.show_message("Resposta para solicitação " .. request_id .. ": " .. response_data)
+end

--- a/helix-plugin/templates/lua-plugin/plugin.toml
+++ b/helix-plugin/templates/lua-plugin/plugin.toml
@@ -1,0 +1,8 @@
+name = "{{project-name}}"
+version = "0.1.0"
+authors = ["Your Name <your@email.com>"]
+description = "A sample Lua plugin for Helix."
+entrypoint = "main.lua"
+
+[activation]
+on_command = ["{{project-name}}:*"]

--- a/helix-plugin/templates/lua-plugin/plugin_br.toml
+++ b/helix-plugin/templates/lua-plugin/plugin_br.toml
@@ -1,0 +1,8 @@
+name = "{{project-name}}"
+version = "0.1.0"
+authors = ["Your Name <your@email.com>"]
+description = "A sample Lua plugin for Helix."
+entrypoint = "main.lua"
+
+[activation]
+on_command = ["{{project-name}}:*"]

--- a/helix-plugin/templates/rust-wasm-plugin/Cargo.toml
+++ b/helix-plugin/templates/rust-wasm-plugin/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "{{project-name}}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1.0"
+
+[profile.release]
+opt-level = "s"
+overflow-checks = true
+lto = true
+strip = true
+codegen-units = 1

--- a/helix-plugin/templates/rust-wasm-plugin/Cargo_br.toml
+++ b/helix-plugin/templates/rust-wasm-plugin/Cargo_br.toml
@@ -1,0 +1,17 @@
+[package]
+name = "{{project-name}}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1.0"
+
+[profile.release]
+opt-level = "s"
+overflow-checks = true
+lto = true
+strip = true
+codegen-units = 1

--- a/helix-plugin/templates/rust-wasm-plugin/plugin.toml
+++ b/helix-plugin/templates/rust-wasm-plugin/plugin.toml
@@ -1,0 +1,8 @@
+name = "{{project-name}}"
+version = "0.1.0"
+authors = ["Your Name <your@email.com>"]
+description = "A sample WASM plugin for Helix."
+entrypoint = "{{project-name}}.wasm"
+
+[activation]
+on_command = ["{{project-name}}:*"]

--- a/helix-plugin/templates/rust-wasm-plugin/plugin_br.toml
+++ b/helix-plugin/templates/rust-wasm-plugin/plugin_br.toml
@@ -1,0 +1,8 @@
+name = "{{project-name}}"
+version = "0.1.0"
+authors = ["Your Name <your@email.com>"]
+description = "A sample WASM plugin for Helix."
+entrypoint = "{{project-name}}.wasm"
+
+[activation]
+on_command = ["{{project-name}}:*"]

--- a/helix-plugin/templates/rust-wasm-plugin/src/lib.rs
+++ b/helix-plugin/templates/rust-wasm-plugin/src/lib.rs
@@ -1,0 +1,128 @@
+use std::slice;
+use std::ffi::{CStr, CString};
+
+// Exported function to allocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buffer = Vec::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    std::mem::forget(buffer); // Prevent Rust from deallocating the memory
+    ptr
+}
+
+// Exported function to deallocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, size, size); // Reconstruct Vec to deallocate
+    }
+}
+
+// Import host functions (defined in helix-plugin/src/host/wasm.rs)
+#[link(wasm_import_module = "helix_api")]
+extern "C" {
+    #[link_name = "show_message"]
+    fn host_show_message(ptr: *const u8, len: usize);
+
+    #[link_name = "register_command"]
+    fn host_register_command(name_ptr: *const u8, name_len: usize, callback_ptr: *const u8, callback_len: usize);
+
+    #[link_name = "get_buffer_content"]
+    fn host_get_buffer_content(doc_id: u32, request_id: u32);
+
+    #[link_name = "insert_text"]
+    fn host_insert_text(doc_id: u32, position: u32, text_ptr: *const u8, text_len: usize);
+
+    #[link_name = "delete_text"]
+    fn host_delete_text(doc_id: u32, start: u32, end: u32);
+
+    #[link_name = "subscribe_to_event"]
+    fn host_subscribe_to_event(event_name_ptr: *const u8, event_name_len: usize, callback_ptr: *const u8, callback_len: usize);
+}
+
+// Helper to call show_message
+fn show_message(message: &str) {
+    unsafe {
+        host_show_message(message.as_ptr(), message.len());
+    }
+}
+
+// Helper to call register_command
+fn register_command(command_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_register_command(
+            command_name.as_ptr(), command_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Helper to call get_buffer_content
+fn get_buffer_content(doc_id: u32, request_id: u32) {
+    unsafe {
+        host_get_buffer_content(doc_id, request_id);
+    }
+}
+
+// Helper to call insert_text
+fn insert_text(doc_id: u32, position: u32, text: &str) {
+    unsafe {
+        host_insert_text(doc_id, position, text.as_ptr(), text.len());
+    }
+}
+
+// Helper to call delete_text
+fn delete_text(doc_id: u32, start: u32, end: u32) {
+    unsafe {
+        host_delete_text(doc_id, start, end);
+    }
+}
+
+// Helper to call subscribe_to_event
+fn subscribe_to_event(event_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_subscribe_to_event(
+            event_name.as_ptr(), event_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Function called when the plugin is loaded
+#[no_mangle]
+pub extern "C" fn on_load() {
+    show_message("My WASM plugin has been loaded!");
+    register_command("my-plugin:greeting", "on_greeting_command");
+    subscribe_to_event("buffer_save", "on_buffer_save_event");
+}
+
+// Callback function for the registered command
+#[no_mangle]
+pub extern "C" fn on_greeting_command(args_ptr: *const u8, args_len: usize) {
+    let args_str = unsafe {
+        let slice = slice::from_raw_parts(args_ptr, args_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Hello from the WASM command! Arguments: {}", args_str));
+    get_buffer_content(0, 123); // Example of requesting buffer content
+}
+
+// Callback function for editor events
+#[no_mangle]
+pub extern "C" fn on_buffer_save_event(event_data_ptr: *const u8, event_data_len: usize) {
+    let event_data_str = unsafe {
+        let slice = slice::from_raw_parts(event_data_ptr, event_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("buffer_save event received: {}", event_data_str));
+}
+
+// Callback function for request responses
+#[no_mangle]
+pub extern "C" fn on_response(request_id: u32, response_data_ptr: *const u8, response_data_len: usize) {
+    let response_data_str = unsafe {
+        let slice = slice::from_raw_parts(response_data_ptr, response_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Response for request {}: {}", request_id, response_data_str));
+}

--- a/helix-plugin/templates/rust-wasm-plugin/src/lib_br.rs
+++ b/helix-plugin/templates/rust-wasm-plugin/src/lib_br.rs
@@ -1,0 +1,128 @@
+use std::slice;
+use std::ffi::{CStr, CString};
+
+// Exported function to allocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buffer = Vec::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    std::mem::forget(buffer); // Prevent Rust from deallocating the memory
+    ptr
+}
+
+// Exported function to deallocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, size, size); // Reconstruct Vec to deallocate
+    }
+}
+
+// Import host functions (defined in helix-plugin/src/host/wasm.rs)
+#[link(wasm_import_module = "helix_api")]
+extern "C" {
+    #[link_name = "show_message"]
+    fn host_show_message(ptr: *const u8, len: usize);
+
+    #[link_name = "register_command"]
+    fn host_register_command(name_ptr: *const u8, name_len: usize, callback_ptr: *const u8, callback_len: usize);
+
+    #[link_name = "get_buffer_content"]
+    fn host_get_buffer_content(doc_id: u32, request_id: u32);
+
+    #[link_name = "insert_text"]
+    fn host_insert_text(doc_id: u32, position: u32, text_ptr: *const u8, text_len: usize);
+
+    #[link_name = "delete_text"]
+    fn host_delete_text(doc_id: u32, start: u32, end: u32);
+
+    #[link_name = "subscribe_to_event"]
+    fn host_subscribe_to_event(event_name_ptr: *const u8, event_name_len: usize, callback_ptr: *const u8, callback_len: usize);
+}
+
+// Helper to call show_message
+fn show_message(message: &str) {
+    unsafe {
+        host_show_message(message.as_ptr(), message.len());
+    }
+}
+
+// Helper to call register_command
+fn register_command(command_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_register_command(
+            command_name.as_ptr(), command_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Helper to call get_buffer_content
+fn get_buffer_content(doc_id: u32, request_id: u32) {
+    unsafe {
+        host_get_buffer_content(doc_id, request_id);
+    }
+}
+
+// Helper to call insert_text
+fn insert_text(doc_id: u32, position: u32, text: &str) {
+    unsafe {
+        host_insert_text(doc_id, position, text.as_ptr(), text.len());
+    }
+}
+
+// Helper to call delete_text
+fn delete_text(doc_id: u32, start: u32, end: u32) {
+    unsafe {
+        host_delete_text(doc_id, start, end);
+    }
+}
+
+// Helper to call subscribe_to_event
+fn subscribe_to_event(event_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_subscribe_to_event(
+            event_name.as_ptr(), event_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Função chamada quando o plugin é carregado
+#[no_mangle]
+pub extern "C" fn on_load() {
+    show_message("Meu plugin WASM foi carregado!");
+    register_command("meu-plugin:saudacao", "on_saudacao_command");
+    subscribe_to_event("buffer_save", "on_buffer_save_event");
+}
+
+// Função de callback para o comando registrado
+#[no_mangle]
+pub extern "C" fn on_saudacao_command(args_ptr: *const u8, args_len: usize) {
+    let args_str = unsafe {
+        let slice = slice::from_raw_parts(args_ptr, args_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Olá do comando WASM! Argumentos: {}", args_str));
+    get_buffer_content(0, 123); // Exemplo de solicitação de conteúdo do buffer
+}
+
+// Função de callback para eventos do editor
+#[no_mangle]
+pub extern "C" fn on_buffer_save_event(event_data_ptr: *const u8, event_data_len: usize) {
+    let event_data_str = unsafe {
+        let slice = slice::from_raw_parts(event_data_ptr, event_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Evento buffer_save recebido: {}", event_data_str));
+}
+
+// Função de callback para respostas de solicitações
+#[no_mangle]
+pub extern "C" fn on_response(request_id: u32, response_data_ptr: *const u8, response_data_len: usize) {
+    let response_data_str = unsafe {
+        let slice = slice::from_raw_parts(response_data_ptr, response_data_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Resposta para solicitação {}: {}", request_id, response_data_str));
+}

--- a/helix-plugin/tests/discovery.rs
+++ b/helix-plugin/tests/discovery.rs
@@ -1,0 +1,16 @@
+use helix_plugin::manager::PluginManager;
+use std::path::PathBuf;
+
+#[test]
+fn test_plugin_discovery() {
+    let mut manager = PluginManager::new();
+    let test_plugins_dir = PathBuf::from("../tests/test-plugins");
+
+    manager.discover_plugins_in(&test_plugins_dir).unwrap();
+
+    assert_eq!(manager.plugins.len(), 1);
+    let manifest = &manager.plugins[0];
+    assert_eq!(manifest.name, "my-first-plugin");
+    assert_eq!(manifest.version, "0.1.0");
+    assert_eq!(manifest.activation.on_command, vec!["my-plugin:test-command"]);
+}

--- a/helix-plugin/tests/wasm_host.rs
+++ b/helix-plugin/tests/wasm_host.rs
@@ -1,0 +1,18 @@
+use helix_plugin::host::wasm::WasmHost;
+use std::path::PathBuf;
+
+#[test]
+fn test_load_and_call_wasm_plugin() {
+    // Este teste assume que o `main.wasm` existe e foi compilado.
+    let wasm_file = PathBuf::from("../tests/test-plugins/my-first-plugin/main.wasm");
+
+    // Se o arquivo não existir, o teste falhará, o que é esperado neste cenário.
+    if !wasm_file.exists() {
+        panic!("Test WASM file not found at {:?}. Please compile the test plugin first.", wasm_file);
+    }
+
+    let mut host = WasmHost::new(&wasm_file).expect("Failed to create WasmHost");
+
+    // Tenta chamar a função `on_load` exportada.
+    host.call_function("on_load").expect("Failed to call on_load function");
+}

--- a/tests/test-plugins/my-first-plugin/my-first-plugin-source/Cargo.toml
+++ b/tests/test-plugins/my-first-plugin/my-first-plugin-source/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "my-first-plugin-source"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]

--- a/tests/test-plugins/my-first-plugin/my-first-plugin-source/src/lib.rs
+++ b/tests/test-plugins/my-first-plugin/my-first-plugin-source/src/lib.rs
@@ -1,0 +1,64 @@
+use std::slice;
+use std::ffi::{CStr, CString};
+
+// Exported function to allocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buffer = Vec::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    std::mem::forget(buffer); // Prevent Rust from deallocating the memory
+    ptr
+}
+
+// Exported function to deallocate memory in WASM linear memory
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, size, size); // Reconstruct Vec to deallocate
+    }
+}
+
+// Import host functions (defined in helix-plugin/src/host/wasm.rs)
+#[link(wasm_import_module = "helix_api")]
+extern "C" {
+    #[link_name = "show_message"]
+    fn host_show_message(ptr: *const u8, len: usize);
+
+    #[link_name = "register_command"]
+    fn host_register_command(name_ptr: *const u8, name_len: usize, callback_ptr: *const u8, callback_len: usize);
+}
+
+// Helper to call show_message
+fn show_message(message: &str) {
+    unsafe {
+        host_show_message(message.as_ptr(), message.len());
+    }
+}
+
+// Helper to call register_command
+fn register_command(command_name: &str, callback_function_name: &str) {
+    unsafe {
+        host_register_command(
+            command_name.as_ptr(), command_name.len(),
+            callback_function_name.as_ptr(), callback_function_name.len(),
+        );
+    }
+}
+
+// Function called when the plugin is loaded
+#[no_mangle]
+pub extern "C" fn on_load() {
+    show_message("Meu plugin WASM foi carregado!");
+    register_command("meu-plugin:saudacao", "on_saudacao_command");
+}
+
+// Function of callback for the registered command
+// This function will receive arguments as pointers and lengths
+#[no_mangle]
+pub extern "C" fn on_saudacao_command(args_ptr: *const u8, args_len: usize) {
+    let args_str = unsafe {
+        let slice = slice::from_raw_parts(args_ptr, args_len);
+        std::str::from_utf8_unchecked(slice)
+    };
+    show_message(&format!("Olá do comando WASM! Argumentos: {}", args_str));
+}

--- a/tests/test-plugins/my-first-plugin/plugin.toml
+++ b/tests/test-plugins/my-first-plugin/plugin.toml
@@ -1,0 +1,8 @@
+name = "my-first-plugin"
+version = "0.1.0"
+authors = ["Test User"]
+description = "A test plugin."
+entrypoint = "main.wasm"
+
+[activation]
+on_command = ["my-plugin:test-command"]


### PR DESCRIPTION
Adds initial support for external plugins in Helix Editor with execution via WebAssembly (using Wasmtime) and Lua (via mlua).

Includes:
- `helix-plugin` crate with modular structure (config, manager, api, host/{wasm,lua})
- Support for `plugin.toml` as a plugin metadata manifest
- Automatic discovery of plugins in `~/.config/helix/plugins/`
- Execution of `.wasm` (target wasm32-wasi) and `.lua` plugins
- Basic plugin API: show_message, register_command, get_buffer_content, insert_text, delete_text, subscribe_to_event
- Event system between editor <-> plugin (commands, events, and responses)
- Integration with the editor lifecycle (`helix-term`, `helix-view`, `helix-core`)
- Dynamic plugin command dispatch via `:my-plugin:command`
- Plugin discovery and loading tests

This version enables editor extensibility through isolated scripts or binaries, maintaining safety (WASM sandboxing) and scripting flexibility (Lua).

Next steps:
- Expand the API (e.g. window manipulation, selection, theming)
- Add support for structured arguments and return values
- Provide debugging and logging tools for plugin developers