### PR TITLE
feat(themes): add soft-wrap style for nightfox

### DIFF
--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -36,6 +36,7 @@
 "ui.virtual.indent-guide" = { fg = "black" } # Vertical indent width guides
 "ui.virtual.inlay-hint" = { fg = "comment", bg = "bg2" } # Default style for inlay hints of all kinds
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold"] } # Style for virtual jump labels
+"ui.virtual.wrap" = { fg = "fg3" } # Soft-wrap indicator.
 
 "ui.statusline" = { fg = "fg2", bg = "bg0" } # Status line.
 "ui.statusline.inactive" = { fg = "fg3", bg = "bg0" } # Status line in unfocused windows.


### PR DESCRIPTION
This makes soft-wrap indicator less distracting for nightfox.

Before:
<img width="912" height="809" alt="before" src="https://github.com/user-attachments/assets/07cbd04d-07fd-4fa6-b21f-02c8e2aa36fb" />

After:
<img width="913" height="821" alt="after" src="https://github.com/user-attachments/assets/a9e83605-17b5-434d-a07a-a4144b8385cf" />
