### PR TITLE
[theme] Fix zenburn doc comment color

### DIFF
--- a/runtime/themes/zenburn.toml
+++ b/runtime/themes/zenburn.toml
@@ -9,9 +9,9 @@
 "ui.selection" = { bg = "#304a3d" }
 "ui.selection.primary" = { bg = "#2f2f2f" }
 "comment" = { fg = "comment" }
+"comment.block.documentation" = { fg = "comment", modifiers = ["bold"] }
+"comment.line.documentation" = { fg = "comment", modifiers = ["bold"] }
 "ui.virtual.inlay-hint" = { fg = "#9f9f9f" }
-"comment.block.documentation" = { fg = "black", modifiers = ["bold"] }
-"comment.line.documentation" = { fg = "black", modifiers = ["bold"] }
 "ui.statusline" = { bg = "statusbg", fg = "#ccdc90" }
 "ui.statusline.inactive" = { fg = '#2e3330', bg = '#88b090' }
 "ui.cursor" = { fg = "#000d18", bg = "#8faf9f", modifiers = ["bold"] }


### PR DESCRIPTION
I assume black was auto-added when doc comment colors were added. This fixes it to use same color as other comments as black is completely out of place