### PR TITLE
Enable inline diagnostics by default

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -470,16 +470,6 @@ fn main() {
 }
 ```
 
-
-The new diagnostic rendering is not yet enabled by default. As soon as end of line or inline diagnostics are enabled the old diagnostics rendering is automatically disabled. The recommended default setting are:
-
-```toml
-[editor]
-end-of-line-diagnostics = "hint"
-[editor.inline-diagnostics]
-cursor-line = "warning" # show warnings and errors on the cursorline inline
-```
-
 ### `[editor.word-completion]` Section
 
 Options for controlling completion of words from open buffers.

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -109,7 +109,7 @@ impl InlineDiagnosticsConfig {
 impl Default for InlineDiagnosticsConfig {
     fn default() -> Self {
         InlineDiagnosticsConfig {
-            cursor_line: DiagnosticFilter::Disable,
+            cursor_line: DiagnosticFilter::Enable(Severity::Warning),
             other_lines: DiagnosticFilter::Disable,
             min_diagnostic_width: 40,
             prefix_len: 1,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1055,7 +1055,7 @@ impl Default for Config {
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
             inline_diagnostics: InlineDiagnosticsConfig::default(),
-            end_of_line_diagnostics: DiagnosticFilter::Disable,
+            end_of_line_diagnostics: DiagnosticFilter::Enable(Severity::Hint),
             clipboard_provider: ClipboardProvider::default(),
             editor_config: true,
         }


### PR DESCRIPTION
As discussed in https://github.com/helix-editor/helix/discussions/13956

These are the settings we used to recommend in documentation. We could discuss switching up the defaults though. I believe @archseer uses info for the cursor-line severity while I use error.