### PR TITLE
build(release): lower ubuntu version from `24.04` to `22.04`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,15 @@ jobs:
         build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
         include:
         - build: x86_64-linux
-          os: ubuntu-24.04
+          # WARN: When changing this to a newer version, make sure that the GLIBC isnt too new, as this can cause issues
+          # with portablity on older systems that dont follow ubuntus more rapid release cadence.
+          os: ubuntu-22.04
           rust: stable
           target: x86_64-unknown-linux-gnu
           cross: false
         - build: aarch64-linux
-          os: ubuntu-24.04-arm
+          # Version should be kept in lockstep with the x86_64 version
+          os: ubuntu-22.04-arm
           rust: stable
           target: aarch64-unknown-linux-gnu
           cross: false
@@ -291,7 +294,7 @@ jobs:
           file_glob: true
           tag: ${{ github.ref_name }}
           overwrite: true
-      
+
       - name: Upload binaries as artifact
         uses: actions/upload-artifact@v4
         if: env.preview == 'true'


### PR DESCRIPTION
Lower the version of ubuntu to `22.04` as `24.04` uses a much newer GLIBC version, causing issues for people who want to use the built binaries on systems not as up to date.

It also adds documentation to warn any changes made should be reviewed to make sure that this is caught earlier on, as this is now the second release in a row where this has happened.

Perhaps as a rule of thumb we use the older of an LTS release? And special case from there. Really not sure what other process we can have for this other than just making sure during the review/pr process to just verify that its not causing large issues.

Related #12464
Closes #13960