### PR TITLE
fix: 2 bugs in the `Alt-)` and `Alt-(` commands

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5318,16 +5318,6 @@ enum ReorderStrategy {
     Reverse,
 }
 
-/// Like `usize::wrapping_sub`, but provide a custom range from `0` to `range_length`
-fn wrapping_sub_in_range(index: usize, range_length: usize, delta: usize) -> usize {
-    (index + range_length - delta) % range_length
-}
-
-/// Like `usize::wrapping_add`, but provide a custom range from `0` to `range_length`
-fn wrapping_add_in_range(index: usize, range_length: usize, delta: usize) -> usize {
-    (index + range_length + delta) % range_length
-}
-
 fn reorder_selection_contents(cx: &mut Context, strategy: ReorderStrategy) {
     let count = cx.count;
     let (view, doc) = current!(cx.editor);
@@ -5345,11 +5335,13 @@ fn reorder_selection_contents(cx: &mut Context, strategy: ReorderStrategy) {
     let primary_index = match strategy {
         ReorderStrategy::RotateForward => {
             ranges.rotate_right(rotate_by);
-            wrapping_add_in_range(selection.primary_index(), ranges.len(), rotate_by)
+            // Like `usize::wrapping_add`, but provide a custom range from `0` to `ranges.len()`
+            (selection.primary_index() + ranges.len() + rotate_by) % ranges.len()
         }
         ReorderStrategy::RotateBackward => {
             ranges.rotate_left(rotate_by);
-            wrapping_sub_in_range(selection.primary_index(), ranges.len(), rotate_by)
+            // Like `usize::wrapping_sub`, but provide a custom range from `0` to `ranges.len()`
+            (selection.primary_index() + ranges.len() - rotate_by) % ranges.len()
         }
         ReorderStrategy::Reverse => {
             if rotate_by % 2 == 0 {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5311,10 +5311,21 @@ fn rotate_selections_last(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
+#[derive(Debug)]
 enum ReorderStrategy {
     RotateForward,
     RotateBackward,
     Reverse,
+}
+
+/// Like `usize::wrapping_sub`, but provide a custom range from `0` to `range_length`
+fn wrapping_sub_in_range(index: usize, range_length: usize, delta: usize) -> usize {
+    (index + range_length - delta) % range_length
+}
+
+/// Like `usize::wrapping_add`, but provide a custom range from `0` to `range_length`
+fn wrapping_add_in_range(index: usize, range_length: usize, delta: usize) -> usize {
+    (index + range_length + delta) % range_length
 }
 
 fn reorder_selection_contents(cx: &mut Context, strategy: ReorderStrategy) {
@@ -5323,34 +5334,48 @@ fn reorder_selection_contents(cx: &mut Context, strategy: ReorderStrategy) {
     let text = doc.text().slice(..);
 
     let selection = doc.selection(view.id);
-    let mut fragments: Vec<_> = selection
+
+    let mut ranges: Vec<_> = selection
         .slices(text)
         .map(|fragment| fragment.chunks().collect())
         .collect();
 
-    let group = count
-        .map(|count| count.get())
-        .unwrap_or(fragments.len()) // default to rotating everything as one group
-        .min(fragments.len());
+    let rotate_by = count.map_or(1, |count| count.get().min(ranges.len()));
 
-    for chunk in fragments.chunks_mut(group) {
-        // TODO: also modify main index
-        match strategy {
-            ReorderStrategy::RotateForward => chunk.rotate_right(1),
-            ReorderStrategy::RotateBackward => chunk.rotate_left(1),
-            ReorderStrategy::Reverse => chunk.reverse(),
-        };
-    }
+    let primary_index = match strategy {
+        ReorderStrategy::RotateForward => {
+            ranges.rotate_right(rotate_by);
+            wrapping_add_in_range(selection.primary_index(), ranges.len(), rotate_by)
+        }
+        ReorderStrategy::RotateBackward => {
+            ranges.rotate_left(rotate_by);
+            wrapping_sub_in_range(selection.primary_index(), ranges.len(), rotate_by)
+        }
+        ReorderStrategy::Reverse => {
+            if rotate_by % 2 == 0 {
+                // nothing changed, if we reverse something an even
+                // amount of times, the output will be the same
+                return;
+            }
+            ranges.reverse();
+            // -1 to turn 1-based len into 0-based index
+            (ranges.len() - 1) - selection.primary_index()
+        }
+    };
 
     let transaction = Transaction::change(
         doc.text(),
         selection
             .ranges()
             .iter()
-            .zip(fragments)
+            .zip(ranges)
             .map(|(range, fragment)| (range.from(), range.to(), Some(fragment))),
     );
 
+    doc.set_selection(
+        view.id,
+        Selection::new(selection.ranges().into(), primary_index),
+    );
     doc.apply(&transaction, view.id);
 }
 

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -4,6 +4,8 @@ use super::*;
 
 mod insert;
 mod movement;
+mod reverse_selection_contents;
+mod rotate_selection_contents;
 mod write;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/helix-term/tests/test/commands/reverse_selection_contents.rs
+++ b/helix-term/tests/test/commands/reverse_selection_contents.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+const A: &str = indoc! {"
+    #(a|)#
+    #(b|)#
+    #(c|)#
+    #[d|]#
+    #(e|)#"
+};
+const A_REV: &str = indoc! {"
+    #(e|)#
+    #[d|]#
+    #(c|)#
+    #(b|)#
+    #(a|)#"
+};
+const B: &str = indoc! {"
+    #(a|)#
+    #(b|)#
+    #[c|]#
+    #(d|)#
+    #(e|)#"
+};
+const B_REV: &str = indoc! {"
+    #(e|)#
+    #(d|)#
+    #[c|]#
+    #(b|)#
+    #(a|)#"
+};
+
+const CMD: &str = "<space>?reverse_selection_contents<ret>";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_selection_contents() -> anyhow::Result<()> {
+    test((A, CMD, A_REV)).await?;
+    test((B, CMD, B_REV)).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_selection_contents_with_count() -> anyhow::Result<()> {
+    test((B, format!("2{CMD}"), B)).await?;
+    test((B, format!("3{CMD}"), B_REV)).await?;
+    test((B, format!("4{CMD}"), B)).await?;
+
+    Ok(())
+}

--- a/helix-term/tests/test/commands/rotate_selection_contents.rs
+++ b/helix-term/tests/test/commands/rotate_selection_contents.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+// Progression: A -> B -> C -> D
+//              as we press `A-)`
+const A: &str = indoc! {"
+    #(a|)#
+    #(b|)#
+    #(c|)#
+    #[d|]#
+    #(e|)#"
+};
+
+const B: &str = indoc! {"
+    #(e|)#
+    #(a|)#
+    #(b|)#
+    #(c|)#
+    #[d|]#"
+};
+
+const C: &str = indoc! {"
+    #[d|]#
+    #(e|)#
+    #(a|)#
+    #(b|)#
+    #(c|)#"
+};
+
+const D: &str = indoc! {"
+    #(c|)#
+    #[d|]#
+    #(e|)#
+    #(a|)#
+    #(b|)#"
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_selection_contents_forward_repeated() -> anyhow::Result<()> {
+    test((A, "<A-)>", B)).await?;
+    test((B, "<A-)>", C)).await?;
+    test((C, "<A-)>", D)).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_selection_contents_forward_with_count() -> anyhow::Result<()> {
+    test((A, "2<A-)>", C)).await?;
+    test((A, "3<A-)>", D)).await?;
+    test((B, "2<A-)>", D)).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_selection_contents_backward_repeated() -> anyhow::Result<()> {
+    test((D, "<A-(>", C)).await?;
+    test((C, "<A-(>", B)).await?;
+    test((B, "<A-(>", A)).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_selection_contents_backward_with_count() -> anyhow::Result<()> {
+    test((D, "2<A-(>", B)).await?;
+    test((D, "3<A-(>", A)).await?;
+    test((C, "2<A-(>", A)).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR fixes 2 bugs with the `rotate_selection_contents_forward` (`A-)`) and `rotate_selection_contents_backward` (`A-(`) commands.

# Bug 1: Passing a count to these commands has incorrect and unintuitive behaviour

Key: `[a]` means the letter `a` has a single selection around it.

Pressing `A-)` 2 times will go from file `A -> B -> C`:

```
 A      B      C
[a]    [e]    [d]   
[b]    [a]    [e]   
[c] -> [b] -> [a]
[d]    [c]    [b]   
[e]    [d]    [c]   
```

However, if you press 2 followed by `A-)` then the result is not the same:

```
 A      C      
[a]    [b]       
[b]    [a]      
[c] -> [d]
[d]    [c]      
[e]    [e]    
```

This PR fixes this problem. `<count><A-)>` is now the same as `<A-)>` `count` times

# Bug 2: The primary selection's index stays the same

Key: `{a}` means primary selection, `[a]` means secondary selection.

Pressing `A-)` 2 times does not change index of the primary selection:

```
 A      B      C
{a}    {e}    {d}   
[b]    [a]    [e]   
[c] -> [b] -> [a]
[d]    [c]    [b]   
[e]    [d]    [c]   
```

The primary selection index should move with the selections too.

This is fixed in this PR:

```
 A      B      C
{a}    [e]    [d]   
[b]    {a}    [e]   
[c] -> [b] -> {a}
[d]    [c]    [b]   
[e]    [d]    [c]   
```

These bugs are also fixed for the `reverse_selection_contents` command.