### PR TITLE
chore: Add `helix_stdx::dbg!` for easier print debugging

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Some suggestions to get started:
 
 - You can look at the [good first issue][good-first-issue] label on the issue tracker.
 - Help with packaging on various distributions needed!
-- To use print debugging to the [Helix log file][log-file], you must:
-  * Print using `log::info!`, `warn!`, or `error!`. (`log::info!("helix!")`)
+- To use print debugging, you have to use macros which output to the [Helix log file][log-file], as outputting to stdout/stderr won't work because *that's where Helix renders!*:
+  * Print using `log::info!`, `warn!`, or `error!`. (`log::info!("helix!")`). There is also `helix_stdx::dbg!` which is the same as the regular `dbg!` macro, but it outputs to the log file at the `ERROR` level.
   * Pass the appropriate verbosity level option for the desired log level. (`hx -v <file>` for info, more `v`s for higher verbosity)
   * Want to display the logs in a separate file instead of using the `:log-open` command in your compiled Helix editor? Start your debug version with `cargo run -- --log foo.log` and in a new terminal use `tail -f foo.log`
 - Instead of running a release version of Helix, while developing you may want to run in debug mode with `cargo run` which is way faster to compile

--- a/helix-stdx/src/dbg.rs
+++ b/helix-stdx/src/dbg.rs
@@ -1,0 +1,32 @@
+/// A macro for debugging purposes. The implementation  is taken directly from `std::dbg`,
+/// but instead of using `eprintln!` it uses `log::error!`.
+///
+/// The regular `dbg!` macro does not work because it print to stderr, but that's where
+/// Helix renders.
+///
+/// To see output, check `:log-open`
+// implementation copied from the standard library's `dbg!` implementation
+#[macro_export]
+macro_rules! dbg {
+    // NOTE: We cannot use `concat!` to make a static string as a format argument
+    // of `eprintln!` because `file!` could contain a `{` or
+    // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
+    // will be malformed.
+    () => {
+        log::error!("[{}:{}:{}]", file!(), line!(), column!())
+    };
+    ($val:expr $(,)?) => {
+        // Use of `match` here is intentional because it affects the lifetimes
+        // of temporaries - https://stackoverflow.com/a/48732525/1063961
+        match $val {
+            tmp => {
+                log::error!("[{}:{}:{}] {} = {:#?}",
+                    file!(), line!(), column!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($(dbg!($val)),+,)
+    };
+}

--- a/helix-stdx/src/lib.rs
+++ b/helix-stdx/src/lib.rs
@@ -1,6 +1,7 @@
 //! Extensions to the standard library. A collection of helper functions
 //! used throughout helix.
 
+pub mod dbg;
 pub mod env;
 pub mod faccess;
 pub mod path;


### PR DESCRIPTION
I often reach for the `dbg!` macro before realizing it does not work, and there is no good alternative. The best that currently exists is `log::error!` which always prints, but it lacks many features of `dbg!`

This `dbg!` macro is the same as `std`'s `dbg!`, the only difference being the fact that it uses `log::error!` instead of `eprintln!` under the hood

I've also added instructions to `CONTRIBUTING.md` to use it - as I believe it is really useful

---

Fun fact: Did you know Rust analyzer has a code action to remove all `dbg!`s? If you have this

```rs
let path = dbg!(helix_stdx::path::get_relative_path(&item.path));

let directories = dbg!(dbg!(path
    .parent())
    .filter(|p| dbg!(dbg!(!p).as_os_str()).is_empty())
    .map(|p| dbg!(format!("{}{}", p.display(), std::path::MAIN_SEPARATOR)))
    .unwrap_or_default());
```

Pressing `<space>a` and selecting the `"Remove dbg!"` code action turns the above file into:

```rs
let path = helix_stdx::path::get_relative_path(&item.path);

let directories = path
    .parent()
    .filter(|p| (!p).as_os_str().is_empty())
    .map(|p| format!("{}{}", p.display(), std::path::MAIN_SEPARATOR))
    .unwrap_or_default();
```