### PR TITLE
chore: Add `rust-analyzer` to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.82.0"
-components = ["rustfmt", "rust-src", "clippy"]
+components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]


### PR DESCRIPTION
When a contributor does not have the same rust-analyzer version installed as what Helix uses, they will just get a message "Language server exited" and in logs "Could not find rust-analyzer version".

This is fixed with:

```
rustup component add rust-analyzer
```

While in the Helix directory. However, if `rust-analyzer` is present in `rust-toolchain.toml` then the appropriate version will be automatically downloaded.