### PR TITLE
themes: Add `fg = "light-gray"` for `ui.linenr` in `base16_transparent`

### DIFF
--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -8,8 +8,8 @@
 "ui.menu" = { fg = "white" }
 "ui.menu.selected" = { modifiers = ["reversed"] }
 "ui.menu.scroll" = { fg = "light-gray" }
-"ui.linenr" = { modifiers = ["dim"] }
-"ui.linenr.selected" = { fg = "white",  modifiers = ["bold"] }
+"ui.linenr" = { fg = "light-gray", modifiers = ["dim"] }
+"ui.linenr.selected" = { fg = "white", modifiers = ["bold"] }
 "ui.popup" = { fg = "white" }
 "ui.window" = { fg = "gray" }
 "ui.selection" = { bg = "gray" }
@@ -42,7 +42,7 @@
 "constant" = "yellow"
 "attribute" = "yellow"
 "type" = "light-yellow"
-"string"  = "light-green"
+"string" = "light-green"
 "variable.other.member" = "green"
 "constant.character.escape" = "light-cyan"
 "function" = "light-blue"


### PR DESCRIPTION
Relative PR: https://github.com/helix-editor/helix/pull/13080

Relative Comment: https://github.com/helix-editor/helix/pull/13080#issuecomment-3084576523

It would be better to add `fg = "light-gray"` back. If what I said is incorrect, please correct me.

PS: Terminal is alacritty.

| With `fg = "light-gray"` | Without `fg = "light-gray"` |
| ----------- | ----------- |
| <img width="1795" height="502" alt="image" src="https://github.com/user-attachments/assets/daf2de13-aac2-45d5-93d0-71a4c92ee5ef" /> | <img width="1795" height="502" alt="image" src="https://github.com/user-attachments/assets/829f8609-9e61-492c-9767-eb17b1e8567c" /> |