### PR TITLE
just: bump grammar support to handle module path in aliases and recipes dependencies

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3422,7 +3422,7 @@ language-servers = ["just-lsp"]
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "8d03cfdd7ab89ff76d935827de1b93450fa0ec0a" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "0f84211c637813bcf1eb32c9e35847cdaea8760d" }
 
 [[language]]
 name = "gn"

--- a/runtime/queries/just/highlights.scm
+++ b/runtime/queries/just/highlights.scm
@@ -61,6 +61,9 @@
 (mod
   name: (identifier) @namespace)
 
+(module_path
+  name: (identifier) @namespace)
+
 ; Paths
 
 (mod

--- a/runtime/queries/just/locals.scm
+++ b/runtime/queries/just/locals.scm
@@ -30,6 +30,9 @@
 (function_call
   name: (identifier) @local.reference)
 
+(module_path
+  name: (identifier) @local.reference)
+
 (recipe_dependency
   name: (identifier) @local.reference)
 


### PR DESCRIPTION
This brings Helix in line with Just 1.42 released recently.