### PR TITLE
feat: Add `kotlin-lsp` to `languages.toml`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -65,6 +65,7 @@ julia = { command = "julia", timeout = 60, args = [ "--startup-file=no", "--hist
 just-lsp = { command = "just-lsp" }
 koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
 koto-ls = { command = "koto-ls" }
+kotlin-lsp = { command = "kotlin-lsp", args = ["--stdio"] }
 kotlin-language-server = { command = "kotlin-language-server" }
 lean = { command = "lean", args = [ "--server", "--memory=1024" ] }
 ltex-ls = { command = "ltex-ls" }


### PR DESCRIPTION
There is a new official Kotlin language server being developed at https://github.com/Kotlin/kotlin-lsp.
This PR adds it to `language-servers` in `languages.toml`.

The language server is still relatively young and not feature complete, so I decided to hold off from enabling it for Kotlin by default.

For reference, [this is the configuration in `nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/v2.3.0/lsp/kotlin_lsp.lua).