### PR TITLE
refactor(document): change `path` output to `&Path`

### DIFF
--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -37,6 +37,12 @@ impl From<PathBuf> for Uri {
     }
 }
 
+impl From<&Path> for Uri {
+    fn from(path: &Path) -> Self {
+        Self::File(path.into())
+    }
+}
+
 impl fmt::Display for Uri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -74,7 +74,7 @@ impl Client {
         self: &Arc<Self>,
         root_markers: &RootMarkers,
         manual_roots: &[PathBuf],
-        doc_path: Option<&std::path::PathBuf>,
+        doc_path: Option<&std::path::Path>,
         may_support_workspace: bool,
     ) -> bool {
         let (workspace, workspace_is_cwd) = find_workspace();

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -612,7 +612,7 @@ impl Registry {
         &mut self,
         name: String,
         ls_config: &LanguageConfiguration,
-        doc_path: Option<&std::path::PathBuf>,
+        doc_path: Option<&std::path::Path>,
         root_dirs: &[PathBuf],
         enable_snippets: bool,
     ) -> Result<Arc<Client>, StartupError> {
@@ -645,7 +645,7 @@ impl Registry {
         &mut self,
         name: &str,
         language_config: &LanguageConfiguration,
-        doc_path: Option<&std::path::PathBuf>,
+        doc_path: Option<&std::path::Path>,
         root_dirs: &[PathBuf],
         enable_snippets: bool,
     ) -> Option<Result<Arc<Client>>> {
@@ -700,7 +700,7 @@ impl Registry {
     pub fn get<'a>(
         &'a mut self,
         language_config: &'a LanguageConfiguration,
-        doc_path: Option<&'a std::path::PathBuf>,
+        doc_path: Option<&'a std::path::Path>,
         root_dirs: &'a [PathBuf],
         enable_snippets: bool,
     ) -> impl Iterator<Item = (LanguageServerName, Result<Arc<Client>>)> + 'a {
@@ -888,7 +888,7 @@ fn start_client(
     name: String,
     config: &LanguageConfiguration,
     ls_config: &LanguageServerConfiguration,
-    doc_path: Option<&std::path::PathBuf>,
+    doc_path: Option<&std::path::Path>,
     root_dirs: &[PathBuf],
     enable_snippets: bool,
 ) -> Result<NewClient, StartupError> {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2552,7 +2552,7 @@ fn global_search(cx: &mut Context) {
 
         let documents: Vec<_> = editor
             .documents()
-            .map(|doc| (doc.path().cloned(), doc.text().to_owned()))
+            .map(|doc| (doc.pathbuf(), doc.text().to_owned()))
             .collect();
 
         let matcher = match RegexMatcherBuilder::new()
@@ -3212,7 +3212,7 @@ fn buffer_picker(cx: &mut Context) {
 
     let new_meta = |doc: &Document| BufferMeta {
         id: doc.id(),
-        path: doc.path().cloned(),
+        path: doc.pathbuf(),
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
         focused_at: doc.focused_at,
@@ -3309,7 +3309,7 @@ fn jumplist_picker(cx: &mut Context) {
 
         JumpMeta {
             id: doc_id,
-            path: doc.and_then(|d| d.path().cloned()),
+            path: doc.and_then(|doc| doc.pathbuf()),
             selection,
             text,
             is_current: view.doc == doc_id,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2552,7 +2552,7 @@ fn global_search(cx: &mut Context) {
 
         let documents: Vec<_> = editor
             .documents()
-            .map(|doc| (doc.pathbuf(), doc.text().to_owned()))
+            .map(|doc| (doc.path().map(ToOwned::to_owned), doc.text().to_owned()))
             .collect();
 
         let matcher = match RegexMatcherBuilder::new()
@@ -3212,7 +3212,7 @@ fn buffer_picker(cx: &mut Context) {
 
     let new_meta = |doc: &Document| BufferMeta {
         id: doc.id(),
-        path: doc.pathbuf(),
+        path: doc.path().map(ToOwned::to_owned),
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
         focused_at: doc.focused_at,
@@ -3309,7 +3309,7 @@ fn jumplist_picker(cx: &mut Context) {
 
         JumpMeta {
             id: doc_id,
-            path: doc.and_then(|doc| doc.pathbuf()),
+            path: doc.and_then(|doc| doc.path().map(ToOwned::to_owned)),
             selection,
             text,
             is_current: view.doc == doc_id,

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -389,14 +389,13 @@ fn debug_parameter_prompt(
 
 pub fn dap_toggle_breakpoint(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
-    let path = match doc.path() {
-        Some(path) => path.clone(),
-        None => {
-            cx.editor
-                .set_error("Can't set breakpoint: document has no path");
-            return;
-        }
+
+    let Some(path) = doc.pathbuf() else {
+        cx.editor
+            .set_error("Can't set breakpoint: document has no path");
+        return;
     };
+
     let text = doc.text().slice(..);
     let line = doc.selection(view.id).primary().cursor_line(text);
     dap_toggle_breakpoint_impl(cx, path, line);
@@ -644,9 +643,8 @@ pub fn dap_disable_exceptions(cx: &mut Context) {
 // TODO: both edit condition and edit log need to be stable: we might get new breakpoints from the debugger which can change offsets
 pub fn dap_edit_condition(cx: &mut Context) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
-        let path = match doc!(cx.editor).path() {
-            Some(path) => path.clone(),
-            None => return,
+        let Some(path) = doc!(cx.editor).pathbuf() else {
+            return;
         };
         let callback = Box::pin(async move {
             let call: Callback = Callback::EditorCompositor(Box::new(move |editor, compositor| {
@@ -686,9 +684,8 @@ pub fn dap_edit_condition(cx: &mut Context) {
 
 pub fn dap_edit_log(cx: &mut Context) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
-        let path = match doc!(cx.editor).path() {
-            Some(path) => path.clone(),
-            None => return,
+        let Some(path) = doc!(cx.editor).pathbuf() else {
+            return;
         };
         let callback = Box::pin(async move {
             let call: Callback = Callback::EditorCompositor(Box::new(move |editor, compositor| {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -390,7 +390,7 @@ fn debug_parameter_prompt(
 pub fn dap_toggle_breakpoint(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
-    let Some(path) = doc.pathbuf() else {
+    let Some(path) = doc.path().map(ToOwned::to_owned) else {
         cx.editor
             .set_error("Can't set breakpoint: document has no path");
         return;
@@ -643,7 +643,7 @@ pub fn dap_disable_exceptions(cx: &mut Context) {
 // TODO: both edit condition and edit log need to be stable: we might get new breakpoints from the debugger which can change offsets
 pub fn dap_edit_condition(cx: &mut Context) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
-        let Some(path) = doc!(cx.editor).pathbuf() else {
+        let Some(path) = doc!(cx.editor).path().map(ToOwned::to_owned) else {
             return;
         };
         let callback = Box::pin(async move {
@@ -684,7 +684,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
 
 pub fn dap_edit_log(cx: &mut Context) {
     if let Some((pos, breakpoint)) = get_breakpoint_at_current_line(cx.editor) {
-        let Some(path) = doc!(cx.editor).pathbuf() else {
+        let Some(path) = doc!(cx.editor).path().map(ToOwned::to_owned) else {
             return;
         };
         let callback = Box::pin(async move {

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -321,11 +321,9 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
         let pattern = Arc::new(pattern);
         let injector = injector.clone();
         let loader = editor.syn_loader.load();
-        let documents: HashSet<_> = editor
-            .documents()
-            .filter_map(Document::path)
-            .cloned()
-            .collect();
+
+        let documents: HashSet<_> = editor.documents().filter_map(Document::pathbuf).collect();
+
         async move {
             let searcher = state.searcher_builder.build();
             state.walk_builder.build_parallel().run(|| {

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -322,7 +322,11 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
         let injector = injector.clone();
         let loader = editor.syn_loader.load();
 
-        let documents: HashSet<_> = editor.documents().filter_map(Document::pathbuf).collect();
+        let documents: HashSet<_> = editor
+            .documents()
+            .filter_map(Document::path)
+            .map(ToOwned::to_owned)
+            .collect();
 
         async move {
             let searcher = state.searcher_builder.build();

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -222,7 +222,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: Args) -> Vec<DocumentId> 
     for arg in args {
         let doc_id = editor.documents().find_map(|doc| {
             let arg_path = Some(Path::new(arg.as_ref()));
-            if doc.path().map(|p| p.as_path()) == arg_path || doc.relative_path() == arg_path {
+            if doc.path() == arg_path || doc.relative_path() == arg_path {
                 Some(doc.id())
             } else {
                 None
@@ -1512,11 +1512,11 @@ fn reload(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyh
     doc.reload(view, &cx.editor.diff_providers).map(|_| {
         view.ensure_cursor_in_view(doc, scrolloff);
     })?;
-    if let Some(path) = doc.path() {
+    if let Some(path) = doc.pathbuf() {
         cx.editor
             .language_servers
             .file_event_handler
-            .file_changed(path.clone());
+            .file_changed(path);
     }
     Ok(())
 }
@@ -1558,11 +1558,11 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
             continue;
         }
 
-        if let Some(path) = doc.path() {
+        if let Some(path) = doc.pathbuf() {
             cx.editor
                 .language_servers
                 .file_event_handler
-                .file_changed(path.clone());
+                .file_changed(path);
         }
 
         for view_id in view_ids {
@@ -2736,9 +2736,8 @@ fn move_buffer_impl(
 ) -> anyhow::Result<()> {
     let doc = doc!(cx.editor);
     let old_path = doc
-        .path()
-        .context("Scratch buffer cannot be moved. Use :write instead")?
-        .clone();
+        .pathbuf()
+        .context("Scratch buffer cannot be moved. Use :write instead")?;
 
     // if new_path is a directory, append the original file name
     // to move the file into that directory.

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1512,7 +1512,7 @@ fn reload(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyh
     doc.reload(view, &cx.editor.diff_providers).map(|_| {
         view.ensure_cursor_in_view(doc, scrolloff);
     })?;
-    if let Some(path) = doc.pathbuf() {
+    if let Some(path) = doc.path().map(ToOwned::to_owned) {
         cx.editor
             .language_servers
             .file_event_handler
@@ -1558,7 +1558,7 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
             continue;
         }
 
-        if let Some(path) = doc.pathbuf() {
+        if let Some(path) = doc.path().map(ToOwned::to_owned) {
             cx.editor
                 .language_servers
                 .file_event_handler
@@ -2736,7 +2736,8 @@ fn move_buffer_impl(
 ) -> anyhow::Result<()> {
     let doc = doc!(cx.editor);
     let old_path = doc
-        .pathbuf()
+        .path()
+        .map(ToOwned::to_owned)
         .context("Scratch buffer cannot be moved. Use :write instead")?;
 
     // if new_path is a directory, append the original file name

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1257,9 +1257,8 @@ impl EditorView {
 
                     let (view, doc) = current!(cxt.editor);
 
-                    let path = match doc.path() {
-                        Some(path) => path.clone(),
-                        None => return EventResult::Ignored(None),
+                    let Some(path) = doc.pathbuf() else {
+                        return EventResult::Ignored(None);
                     };
 
                     if let Some(char_idx) =

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1257,7 +1257,7 @@ impl EditorView {
 
                     let (view, doc) = current!(cxt.editor);
 
-                    let Some(path) = doc.pathbuf() else {
+                    let Some(path) = doc.path().map(ToOwned::to_owned) else {
                         return EventResult::Ignored(None);
                     };
 

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -463,11 +463,11 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     let title = {
-        let path = context.doc.path();
-        let path = path
+        let path = context
+            .doc
+            .path()
             .as_ref()
-            .map(|p| p.to_string_lossy())
-            .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
+            .map_or_else(|| SCRATCH_BUFFER_NAME.into(), |p| p.to_string_lossy());
         format!(" {} ", path)
     };
 

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -118,7 +118,7 @@ async fn test_write_quit_fail() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(&path::normalize(file.path())), doc.path());
+            assert_eq!(Some(path::normalize(file.path())), doc.pathbuf());
             assert_eq!(&Severity::Error, app.editor.get_status().unwrap().1);
         }),
         false,
@@ -359,7 +359,7 @@ async fn test_write_scratch_to_new_path() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(&path::normalize(file.path())), doc.path());
+            assert_eq!(Some(path::normalize(file.path())), doc.pathbuf());
         }),
         false,
     )
@@ -385,7 +385,7 @@ async fn test_write_scratch_to_new_path_force_creates_file() -> anyhow::Result<(
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(&path::normalize(&new_path)), doc.path());
+            assert_eq!(Some(path::normalize(&new_path)), doc.pathbuf());
         }),
         false,
     )
@@ -772,7 +772,7 @@ async fn test_symlink_write_fail() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(&path::normalize(&symlink_path)), doc.path());
+            assert_eq!(Some(path::normalize(&symlink_path)), doc.pathbuf());
             assert_eq!(&Severity::Error, app.editor.get_status().unwrap().1);
         }),
         false,

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -118,7 +118,10 @@ async fn test_write_quit_fail() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(path::normalize(file.path())), doc.pathbuf());
+            assert_eq!(
+                Some(path::normalize(file.path())),
+                doc.path().map(ToOwned::to_owned)
+            );
             assert_eq!(&Severity::Error, app.editor.get_status().unwrap().1);
         }),
         false,
@@ -359,7 +362,10 @@ async fn test_write_scratch_to_new_path() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(path::normalize(file.path())), doc.pathbuf());
+            assert_eq!(
+                Some(path::normalize(file.path())),
+                doc.path().map(ToOwned::to_owned)
+            );
         }),
         false,
     )
@@ -385,7 +391,10 @@ async fn test_write_scratch_to_new_path_force_creates_file() -> anyhow::Result<(
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(path::normalize(&new_path)), doc.pathbuf());
+            assert_eq!(
+                Some(path::normalize(&new_path)),
+                doc.path().map(ToOwned::to_owned)
+            );
         }),
         false,
     )
@@ -772,7 +781,10 @@ async fn test_symlink_write_fail() -> anyhow::Result<()> {
             assert_eq!(1, docs.len());
 
             let doc = docs.pop().unwrap();
-            assert_eq!(Some(path::normalize(&symlink_path)), doc.pathbuf());
+            assert_eq!(
+                Some(path::normalize(&symlink_path)),
+                doc.path().map(ToOwned::to_owned)
+            );
             assert_eq!(&Severity::Error, app.editor.get_status().unwrap().1);
         }),
         false,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1996,8 +1996,14 @@ impl Document {
 
     #[inline]
     /// File path on disk.
-    pub fn path(&self) -> Option<&PathBuf> {
-        self.path.as_ref()
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    #[inline]
+    /// Owned file path on disk.
+    pub fn pathbuf(&self) -> Option<PathBuf> {
+        self.path.clone()
     }
 
     /// File path as a URL.
@@ -2006,7 +2012,7 @@ impl Document {
     }
 
     pub fn uri(&self) -> Option<helix_core::Uri> {
-        Some(self.path()?.clone().into())
+        Some(self.path()?.into())
     }
 
     #[inline]

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2000,12 +2000,6 @@ impl Document {
         self.path.as_deref()
     }
 
-    #[inline]
-    /// Owned file path on disk.
-    pub fn pathbuf(&self) -> Option<PathBuf> {
-        self.path.clone()
-    }
-
     /// File path as a URL.
     pub fn url(&self) -> Option<Url> {
         Url::from_file_path(self.path()?).ok()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1641,14 +1641,14 @@ impl Editor {
         let Some(doc_url) = doc.url() else {
             return;
         };
-        let (lang, path) = (doc.language.clone(), doc.path().cloned());
+        let (lang, path) = (doc.language.clone(), doc.path());
         let config = doc.config.load();
         let root_dirs = &config.workspace_lsp_roots;
 
         // store only successfully started language servers
         let language_servers = lang.as_ref().map_or_else(HashMap::default, |language| {
             self.language_servers
-                .get(language, path.as_ref(), root_dirs, config.lsp.snippets)
+                .get(language, path, root_dirs, config.lsp.snippets)
                 .filter_map(|(lang, client)| match client {
                     Ok(client) => Some((lang, client)),
                     Err(err) => {
@@ -2163,12 +2163,12 @@ impl Editor {
 
     pub fn document_by_path<P: AsRef<Path>>(&self, path: P) -> Option<&Document> {
         self.documents()
-            .find(|doc| doc.path().map(|p| p == path.as_ref()).unwrap_or(false))
+            .find(|doc| doc.path().is_some_and(|p| p == path.as_ref()))
     }
 
     pub fn document_by_path_mut<P: AsRef<Path>>(&mut self, path: P) -> Option<&mut Document> {
         self.documents_mut()
-            .find(|doc| doc.path().map(|p| p == path.as_ref()).unwrap_or(false))
+            .find(|doc| doc.path().is_some_and(|p| p == path.as_ref()))
     }
 
     /// Returns all supported diagnostics for the document

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -284,8 +284,9 @@ fn execution_pause_indicator<'doc>(
         frame
             .source
             .as_ref()
-            .and_then(|source| source.path.as_ref())
+            .and_then(|source| source.path.as_deref())
     });
+
     let should_display_for_current_doc =
         doc.path().is_some() && frame_source_path.unwrap_or(None) == doc.path();
 


### PR DESCRIPTION
Refactors `Document::path` to return a `Option<&Path>` and adds a new `Document::pathbuf` that clones and returns an owned `Option<PathBuff>`.

This was done to simplify use when just needing a `&Path` and when just needing a `PathBuf`, splitting the needs into two methods, moving much of the conversion boilerplate inside them, rather than needing to do so everywhere else. This can clean up some function signatures leaving them with just `doc.path()` or `doc.pathbuf()`.

The rest of the changes stem from propagating these new methods, such as taking a `&Path` rather than a `&PathBuf`, which I think is more idiomatic. This also provides a nice way to peacemeal places that take a `PathBuf` but really only need a `&Path`.

I was working on another feature and kept bumping into this as a small friction point. Its nothing groundbreaking, so if you feel its not worth to mess up blame history, then feel free to close.