### PR TITLE
Fix symlinked directories being recognized as a file

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -32,6 +32,7 @@ pub use text::Text;
 use helix_view::Editor;
 use tui::text::{Span, Spans};
 
+use std::fs::metadata;
 use std::path::Path;
 use std::{error::Error, path::PathBuf};
 
@@ -356,7 +357,7 @@ fn directory_content(path: &Path) -> Result<Vec<(PathBuf, bool)>, std::io::Error
         .map(|entry| {
             (
                 entry.path(),
-                entry.file_type().is_ok_and(|file_type| file_type.is_dir()),
+                metadata(entry.path()).is_ok_and(|metadata| metadata.is_dir()),
             )
         })
         .collect();

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -32,7 +32,6 @@ pub use text::Text;
 use helix_view::Editor;
 use tui::text::{Span, Spans};
 
-use std::fs::metadata;
 use std::path::Path;
 use std::{error::Error, path::PathBuf};
 
@@ -357,7 +356,7 @@ fn directory_content(path: &Path) -> Result<Vec<(PathBuf, bool)>, std::io::Error
         .map(|entry| {
             (
                 entry.path(),
-                metadata(entry.path()).is_ok_and(|metadata| metadata.is_dir()),
+                std::fs::metadata(entry.path()).is_ok_and(|metadata| metadata.is_dir()),
             )
         })
         .collect();


### PR DESCRIPTION
Previously `fn directory_content` did not traverse symbolic links to query about the destination of the symlink and therefore symlinks were always treated as files in the file picker

If you would like me to add a test, I'd be happy to do so

## Steps to reproduce:

- `ln -s helix-dap example-symlink`
- `cargo run` and select "example-symlink" in the filepicker
- Fails with "unable to open..." 

## Documentation

- [`DirEntry::file_type`](https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_type:~:text=type%20for%20the%20file%20that%20this%20entry%20points%20at.-,This%20function%20will%20not%20traverse%20symlinks%20if%20this%20entry%20points%20at%20a%20symlink,-.)
- [`fs::metadata`](https://doc.rust-lang.org/std/fs/fn.metadata.html#:~:text=This%20function%20will%20traverse%20symbolic%20links)

