### PR TITLE
Use `RangeInclusive<usize>` instead of `(usize, usize)` for line ranges.

### DIFF
--- a/helix-core/src/comment.rs
+++ b/helix-core/src/comment.rs
@@ -89,9 +89,9 @@ pub fn toggle_line_comments(doc: &Rope, selection: &Selection, token: Option<&st
 
     let mut min_next_line = 0;
     for selection in selection {
-        let (start, end) = selection.line_range(text);
-        let start = start.clamp(min_next_line, text.len_lines());
-        let end = (end + 1).min(text.len_lines());
+        let line_range = selection.line_range(text);
+        let start = (*line_range.start()).clamp(min_next_line, text.len_lines());
+        let end = (line_range.end() + 1).min(text.len_lines());
 
         lines.extend(start..end);
         min_next_line = end;
@@ -314,9 +314,12 @@ pub fn toggle_block_comments(
 pub fn split_lines_of_selection(text: RopeSlice, selection: &Selection) -> Selection {
     let mut ranges = SmallVec::new();
     for range in selection.ranges() {
-        let (line_start, line_end) = range.line_range(text.slice(..));
-        let mut pos = text.line_to_char(line_start);
-        for line in text.slice(pos..text.line_to_char(line_end + 1)).lines() {
+        let line_range = range.line_range(text.slice(..));
+        let mut pos = text.line_to_char(*line_range.start());
+        for line in text
+            .slice(pos..text.line_to_char(line_range.end() + 1))
+            .lines()
+        {
             let start = pos;
             pos += line.len_chars();
             ranges.push(Range::new(start, pos));

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -243,11 +243,11 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             doc.selection(view.id).primary().fragment(text).to_string(),
         )),
         Variable::SelectionLineStart => {
-            let start_line = doc.selection(view.id).primary().line_range(text).0;
+            let start_line = *doc.selection(view.id).primary().line_range(text).start();
             Ok(Cow::Owned((start_line + 1).to_string()))
         }
         Variable::SelectionLineEnd => {
-            let end_line = doc.selection(view.id).primary().line_range(text).1;
+            let end_line = *doc.selection(view.id).primary().line_range(text).end();
             Ok(Cow::Owned((end_line + 1).to_string()))
         }
     }


### PR DESCRIPTION
Using `RangeInclusive<usize>`, as opposed to `(usize, usize)` for "(inclusive) range[s]" is more idiomatic and communicates more semantic information on the type level. More specifically that:
- The tuple is supposed to be interpreted as a range.
- The range is inclusive of both bounds.
