### PR TITLE
Rust-based plugin system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "helix"
+version = "0.1.0"
+
+[[package]]
 name = "helix-core"
 version = "25.7.1"
 dependencies = [
@@ -1565,6 +1569,7 @@ dependencies = [
  "indexmap",
  "indoc",
  "libc",
+ "libloading",
  "log",
  "nucleo",
  "once_cell",
@@ -1983,9 +1988,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
   "helix-stdx",
   "xtask",
 ]
+exclude = [
+	"helix-plugins"
+]
 
 default-members = [
   "helix-term"
@@ -61,3 +64,11 @@ repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
 rust-version = "1.82"
+
+[package]
+name = "helix"
+version = "0.1.0"
+
+[lib]
+name = "helix"
+path = "helix-core/src/lib.rs"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -92,6 +92,7 @@ grep-regex = "0.1.13"
 grep-searcher = "0.1.14"
 
 dashmap = "6.0"
+libloading = "0.8.8"
 
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -63,6 +63,7 @@ use crate::{
     compositor::{self, Component, Compositor},
     filter_picker_entry,
     job::Callback,
+    plugins::Plugins,
     ui::{self, overlay::overlaid, Picker, PickerColumn, Popup, Prompt, PromptEvent},
 };
 
@@ -246,7 +247,9 @@ impl MappableCommand {
     pub fn execute(&self, cx: &mut Context) {
         match &self {
             Self::Typable { name, args, doc: _ } => {
-                if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
+                //if Plugins::call_typed_command(name, cx, args) {
+                if false {
+                } else if let Some(command) = typed::TYPABLE_COMMAND_MAP.get(name.as_str()) {
                     let mut cx = compositor::Context {
                         editor: cx.editor,
                         jobs: cx.jobs,

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -1,9 +1,10 @@
 use helix_event::{events, register_event};
 use helix_view::document::Mode;
 use helix_view::events::{
-    ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
-    DocumentFocusLost, LanguageServerExited, LanguageServerInitialized, SelectionDidChange,
+    DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusLost,
+    LanguageServerExited, LanguageServerInitialized, SelectionDidChange,
 };
+use helix_view::Editor;
 
 use crate::commands;
 use crate::keymap::MappableCommand;
@@ -12,12 +13,15 @@ events! {
     OnModeSwitch<'a, 'cx> { old_mode: Mode, new_mode: Mode, cx: &'a mut commands::Context<'cx> }
     PostInsertChar<'a, 'cx> { c: char, cx: &'a mut commands::Context<'cx> }
     PostCommand<'a, 'cx> { command: & 'a MappableCommand, cx: &'a mut commands::Context<'cx> }
+    ConfigDidChange<'a> { editor: &'a mut Editor, old: &'a crate::config::Config, new: &'a crate::config::Config }
+    PluginConfigDidChange<'a> { editor: &'a mut Editor, old: &'a crate::config::Config, new: &'a crate::config::Config }
 }
 
 pub fn register() {
     register_event::<OnModeSwitch>();
     register_event::<PostInsertChar>();
     register_event::<PostCommand>();
+    // register_event::<ConfigDidChange>();
     register_event::<DocumentDidOpen>();
     register_event::<DocumentDidChange>();
     register_event::<DocumentDidClose>();
@@ -26,5 +30,5 @@ pub fn register() {
     register_event::<DiagnosticsDidChange>();
     register_event::<LanguageServerInitialized>();
     register_event::<LanguageServerExited>();
-    register_event::<ConfigDidChange>();
+    register_event::<helix_view::events::ConfigDidChange>();
 }

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod health;
 pub mod job;
 pub mod keymap;
+pub mod plugins;
 pub mod ui;
 
 use std::path::Path;

--- a/helix-term/src/plugins.rs
+++ b/helix-term/src/plugins.rs
@@ -1,0 +1,148 @@
+use crate::{compositor::Context, config::Config};
+
+use anyhow::Error;
+use libloading::Library;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+
+enum PluginInstance {}
+type InitFn = fn(&Config) -> &'static mut PluginInstance;
+type ConfigUpdatedFn = fn(&mut PluginInstance, &Config);
+type AvailableCmdsFn = fn(&mut PluginInstance) -> Vec<String>;
+type CmdFn = fn(&mut PluginInstance, &mut Context, &str);
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub version: String,
+    pub lib_source: String,
+    pub build_command: String,
+    pub min_helix_version: Option<String>,
+    pub dependencies: Option<Vec<String>>,
+}
+
+struct Plugin {
+    info: PluginInfo,
+    lib: Library,
+    instance: &'static mut PluginInstance,
+}
+
+static PLUGINS: Mutex<Option<HashMap<String, Plugin>>> = Mutex::new(None);
+static PLUGINS_CONFIG: Mutex<Option<toml::Table>> = Mutex::new(None);
+
+pub struct Plugins {}
+
+impl Plugins {
+    // Utils for plugin developers
+
+    pub fn alloc<T>() -> &'static mut T {
+        let layout = std::alloc::Layout::new::<T>();
+        unsafe {
+            let t = std::alloc::alloc(layout) as *mut T;
+            t.as_mut().unwrap()
+        }
+    }
+
+    pub fn get_config_for(id: &str) -> Option<toml::Table> {
+        if let Some(plugins_config) = PLUGINS_CONFIG.lock().unwrap().as_ref() {
+            if let Some(config) = plugins_config.get(id) {
+                return Some(config.as_table().unwrap().to_owned());
+            }
+        }
+        None
+    }
+
+    // Internal plugin API
+
+    pub fn reconfigure(config: &Config) -> Result<(), Error> {
+        let plugin_config_path = helix_loader::config_dir().join("plugins.toml");
+        let plugin_config_str = std::fs::read_to_string(plugin_config_path)?;
+        let plugin_config: toml::Table = toml::from_str(&plugin_config_str)?;
+
+        let sources = plugin_config.get("sources").unwrap().as_array().unwrap();
+        let enabled = plugin_config.get("enabled").unwrap().as_array().unwrap();
+        let enabled: Vec<String> = enabled
+            .iter()
+            .map(|e| e.as_str().unwrap().to_owned())
+            .collect();
+
+        for source in sources {
+            // TODO: HTTP req or git fetch or etc. if necessary
+            let cwd = Path::new(source.as_str().unwrap());
+            let source = Path::join(cwd, "hx.toml");
+            let source = std::fs::read_to_string(source).unwrap();
+
+            let source: toml::Table = toml::from_str(&source).unwrap();
+            for (id, plugin_info) in source {
+                if enabled.contains(&id) {
+                    Self::load(cwd, id, plugin_info.try_into().unwrap(), config);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load(cwd: &Path, id: String, info: PluginInfo, config: &Config) {
+        let mut plugins_opt = PLUGINS.lock().unwrap();
+        if plugins_opt.is_none() {
+            plugins_opt.replace(HashMap::new());
+        }
+        let plugins = plugins_opt.as_mut().unwrap();
+
+        // TODO: do nothing if this version is too low
+        // if (VERSION_AND_GIT_HASH < info.min_helix_version) {
+        // 	return;
+        // }
+
+        // load the dynamic lib
+        let lib_path = cwd.join(&info.lib_source);
+        let lib = unsafe { Library::new(lib_path).unwrap() };
+
+        // call the plugin's init method (if it has one)
+        let func_opt = unsafe { lib.get::<InitFn>(b"init") };
+        let instance = func_opt.unwrap()(config);
+
+        plugins.insert(
+            id,
+            Plugin {
+                info,
+                lib,
+                instance,
+            },
+        );
+    }
+
+    pub fn available_commands() -> Vec<String> {
+        let mut commands = Vec::<String>::new();
+        if let Some(plugins) = PLUGINS.lock().unwrap().as_mut() {
+            for plugin in plugins.values_mut() {
+                let func_opt = unsafe { plugin.lib.get::<AvailableCmdsFn>(b"available_commands") };
+                if let Ok(func) = func_opt {
+                    let plugin_commands = func(plugin.instance);
+                    for command in plugin_commands {
+                        commands.push(command.to_string());
+                    }
+                }
+            }
+        }
+        commands
+    }
+
+    pub fn call_typed_command(cx: &mut Context, name: &str, args: &str) -> bool {
+        if let Some(plugins) = PLUGINS.lock().unwrap().as_mut() {
+            for plugin in plugins.values_mut() {
+                let func_opt = unsafe { plugin.lib.get::<CmdFn>(name.as_bytes()) };
+                if let Ok(func) = func_opt {
+                    func(plugin.instance, cx, args);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}


### PR DESCRIPTION
I know I'm late to the party, and that a lot of work has gone into the [Steel plugin system](#8675), but I only learned about Helix recently, and I had an idea for a different way to implement the plugin system. I'm a big fan of minimal software, and the idea of embedding a Steel interpreter initially seemed like a bad idea to me. Though I've since reconsidered this opinion (see **Problems**). With the plugin system I'm proposing, it would be possible to write a plugin which loads Steel-based plugins, so that plugins which are written in Steel could depend on this Steel-loader plugin to load them.

### Design

This is very much a work in progress, but it's much simpler, and possibly more versatile than the Steel plugin system. It was inspired by the Hyprland plugin system, and loads plugins as dynamic libraries. Plugins can be configured in TOML and can respond to config reloading. Plugins can have access to all Helix internals simply by adding the relevant projects as dependencies. Maybe there could be a helix-lib crate which re-exports everything for ease of use and compiles to a dynamic library so that plugins can share it.

In terms of plumbing with Helix, I think I will aim to use the `PluginSystem` interface as implemented in the Steel plugin system.

### Sandboxing

There's been some talk about sandboxing plugins for security. Sandboxing wouldn't really be possible with this plugin system. I don't think it's necessary to sandbox plugins, especially if there's going to be some sort of authoritative plugin source. It's the user's responsibility to make sure they're not installing anything fishy onto their system.

### Distribution

Plugins are defined by their TOML file `hx.toml`. They can be binaries or source code. If it's just source code, the TOML file can specify build dependencies and a build command for the plugin to get built on the user's machine. Otherwise the TOML can just point to a pre-built binary. Users can specify a list of plugin sources in their config, which could be Git repos, GitHub releases, or other arbitrary HTTP URLs. After fetching from a source, Helix would read it's `hx.toml` and do what's appropriate to load the plugin.

### Problems

Due to the design of Rust it generally compiles all dependencies into the binary. So it may not be the case that a pure Rust-based plugin system is more efficient. I guess we'll find out as I continue working on this.

### Plugin examples

Can be found at https://github.com/zacoons/helix-plugins

