### PR TITLE
Update `tree-sitter-go` to `v0.23.4`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -779,7 +779,7 @@ args = { mode = "core", program = "{0}", coreFilePath = "{1}" }
 
 [[grammar]]
 name = "go"
-source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "64457ea6b73ef5422ed1687178d4545c3e91334a" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "3c3775faa968158a8b4ac190a7fda867fd5fb748" }
 
 [[language]]
 name = "gomod"


### PR DESCRIPTION
Last rev was mid-2022; this pulls the latest tagged release, not latest.

I found this while debugging a [gix hang (WIP)](https://github.com/GitoxideLabs/gitoxide/issues/2080) affecting my workflow; I thought it might have been tree-sitter related but turns out not.