### PR TITLE
languages: nix formatter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1022,6 +1022,7 @@ shebangs = []
 comment-token = "#"
 language-servers = [ "nil", "nixd" ]
 indent = { tab-width = 2, unit = "  " }
+formatter = { command = "nixfmt" }
 
 [[grammar]]
 name = "nix"


### PR DESCRIPTION
[`nixfmt`](https://github.com/NixOS/nixfmt) is the [official formatter](https://github.com/NixOS/rfcs/pull/166) for Nix.

fwiw, i have so far left auto-formatting settings untouched.

for those doing their packaging using Nix, this formatter may be installed using its nixpkgs package `pkgs.nixfmt-rfc-style`.
