### PR TITLE
Koto updates

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4247,7 +4247,7 @@ formatter = {command = "koto", args = ["--format"]}
 
 [[grammar]]
 name = "koto"
-source = { git = "https://github.com/koto-lang/tree-sitter-koto", rev = "b420f7922d0d74905fd0d771e5b83be9ee8a8a9a" }
+source = { git = "https://github.com/koto-lang/tree-sitter-koto", rev = "2ffc77c14f0ac1674384ff629bfc207b9c57ed89" }
 
 [[language]]
 name = "gpr"

--- a/languages.toml
+++ b/languages.toml
@@ -4243,6 +4243,7 @@ comment-token = "#"
 block-comment-tokens = ["#-", "-#"]
 indent = { tab-width = 2, unit = "  " }
 language-servers = ["koto-ls"]
+formatter = {command = "koto", args = ["--format"]}
 
 [[grammar]]
 name = "koto"

--- a/runtime/queries/koto/highlights.scm
+++ b/runtime/queries/koto/highlights.scm
@@ -5,11 +5,13 @@
   "*"
   "/"
   "%"
+  "^"
   "+="
   "-="
   "*="
   "/="
   "%="
+  "^="
   "=="
   "!="
   "<"
@@ -99,11 +101,17 @@
 (export
   (identifier) @namespace)
 
-(call
-  function: (identifier) @function.method)
+(chain
+  start: (identifier) @function)
 
 (chain
   lookup: (identifier) @variable.other.member)
+
+(call
+  function: (identifier)) @function
+
+(call_arg
+  (identifier) @variable.other.member)
 
 [
   (true)
@@ -139,13 +147,10 @@
 
 (self) @variable.builtin
 
-(variable
-  type: (identifier) @type)
+(type
+  _ @type)
 
 (arg
   (_ (identifier) @variable.parameter))
 
 (ellipsis) @variable.parameter
-
-(function
-  output_type: (identifier) @type)

--- a/runtime/queries/koto/textobjects.scm
+++ b/runtime/queries/koto/textobjects.scm
@@ -11,10 +11,6 @@
 (call_args
   ((call_arg) @parameter.inside . ","? @parameter.around) @parameter.around)
 
-(chain
-  call: (tuple
-    ((element) @parameter.inside . ","? @parameter.around) @parameter.around))
-
 (map
   ((entry_inline) @entry.inside . ","? @entry.around) @entry.around)
 


### PR DESCRIPTION
This PR updates Koto's tree-sitter queries, and adds a `formatter` definition.
