### PR TITLE
helix-term:fix crash on unwrap graphemes

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -779,8 +779,7 @@ impl Component for Prompt {
             col += self.line[self.cursor..]
                 .graphemes(true)
                 .next()
-                .map(|g| g.width())
-                .unwrap_or(0);
+                .map_or(0, |g| g.width());
         }
 
         let line = area.height as usize - 1;

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -779,8 +779,8 @@ impl Component for Prompt {
             col += self.line[self.cursor..]
                 .graphemes(true)
                 .next()
-                .unwrap()
-                .width();
+                .map(|g| g.width())
+                .unwrap_or(0);
         }
 
         let line = area.height as usize - 1;


### PR DESCRIPTION
### About

This change helps to avoid crash due to unwrapping an empty value with graphemes.  The issue was discovered accidentally while porting the Helix editor to ARM-based platforms. The simplest way I found to reproduce the problem is to run Helix in QEMU and try entering some commands. 


#### Versions
The crash is actual only for fresh **25.07.1** version. **25.01.1** is fine. 


#### Without fix
<img width="802" height="272" alt="image_2025-07-23_11-45-46" src="https://github.com/user-attachments/assets/5f268f4d-7b24-4e7a-a70a-0063470ee864" />

#### With fix 
<img width="805" height="156" alt="image_2025-07-23_11-46-47" src="https://github.com/user-attachments/assets/1b9a844d-aa6d-41fc-bde7-4361b72a1644" />


### Notes

I modified the code to prevent the crash, but I haven’t investigated the root cause in depth. There’s a possibility that the issue originates from the environment rather than from Helix (I was using very minimal BusyBox-based environments). It’s also possible that crashing is preferable to continuing to run in this state — I’m not sure. This is something I’d like to discuss during the review.

Please let me know if you need any additional details, clarifications, or information.

Thank you
