### PR TITLE
fix: gruvbox theme collision

### DIFF
--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -92,7 +92,7 @@
 "ui.linenr" = { fg = "bg3" }
 "ui.linenr.selected" = { fg = "yellow1" }
 "ui.menu" = { fg = "fg1", bg = "bg2" }
-"ui.menu.selected" = { fg = "bg2", bg = "blue1", modifiers = ["bold"] }
+"ui.menu.selected" = { fg = "green1", bg = "bg1", modifiers = ["bold"] }
 "ui.popup" = { bg = "bg1" }
 "ui.picker.header.column" = { underline.style = "line" }
 "ui.picker.header.column.active" = { modifiers = ["bold"], underline.style = "line" }
@@ -106,7 +106,7 @@
 "ui.statusline.select" = { fg = "bg1", bg = "orange1", modifiers = ["bold"] }
 
 "ui.text" = { fg = "fg1" }
-"ui.text.focus" = { fg = "green1" }
+"ui.text.focus" = { fg = "green1", bg="bg1" }
 "ui.text.directory" = { fg = "blue1" }
 "ui.virtual.inlay-hint" = { fg = "gray" }
 "ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }


### PR DESCRIPTION
Reference #14040 for issue, gruvbox directory color blue collided with menu selected blue, presents when autocomplete is used for a directory

Suggested fix
- change
  - menu selected
    - background `blue1` -> `bg1`
    - foreground `bg2` -> `green1`
  - text.focus
    - add background `bg1`

Reference images
<img width="627" height="117" alt="image" src="https://github.com/user-attachments/assets/899add41-62d4-4d07-a67a-fa0ea3c693eb" />
<img width="633" height="653" alt="image" src="https://github.com/user-attachments/assets/7874035d-662b-4890-bd7a-e03612d74ff9" />

