### PR TITLE
fix(queries): typst function highlight (#14036)

### DIFF
--- a/runtime/queries/typst/highlights.scm
+++ b/runtime/queries/typst/highlights.scm
@@ -1,11 +1,3 @@
-(call
-  item: (ident) @function)
-(call
-  item: (field field: (ident) @function.method))
-(tagged field: (ident) @tag)
-(field field: (ident) @tag)
-(comment) @comment
-
 ; CONTROL
 (let "let" @keyword.storage.type)
 (branch ["if" "else"] @keyword.control.conditional)
@@ -49,6 +41,15 @@
 (none) @constant.builtin
 (auto) @constant.builtin
 (ident) @variable
+
+; FUNCTIONS
+(call
+  item: (ident) @function)
+(call
+  item: (field field: (ident) @function.method))
+(tagged field: (ident) @tag)
+(field field: (ident) @tag)
+(comment) @comment
 
 ; MARKUP
 (item "-" @markup.list)


### PR DESCRIPTION
Fixes #14036.

Since 5952d56, the last matching highlight pattern is chosen. All other highlight matches before are skipped. To avoid functions and parameters being highlighted as variables, the corresponding matches were moved after the ones for variables.

I’m not too familiar with these highlight patterns. Would be great if someone could double check that moving the patterns down is not braking more than it fixes ^^