### PR TITLE
feat: highlight go string interpolation that use stdlib `fmt` package

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -86,6 +86,7 @@
 | glsl | ✓ | ✓ | ✓ |  | `glsl_analyzer` |
 | gn | ✓ |  |  |  |  |
 | go | ✓ | ✓ | ✓ | ✓ | `gopls`, `golangci-lint-langserver` |
+| go-format-string | ✓ |  |  |  |  |
 | godot-resource | ✓ | ✓ |  |  |  |
 | gomod | ✓ |  |  |  | `gopls` |
 | gotmpl | ✓ |  |  |  | `gopls` |

--- a/languages.toml
+++ b/languages.toml
@@ -824,6 +824,16 @@ name = "gowork"
 source = { git = "https://github.com/omertuc/tree-sitter-go-work", rev = "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2" }
 
 [[language]]
+name = "go-format-string"
+scope = "source.go-format-string"
+file-types = []
+injection-regex = "go-format-string"
+
+[[grammar]]
+name = "go-format-string"
+source = { git = "https://codeberg.org/kpbaks/tree-sitter-go-format-string", rev = "45b559b74be97535abfc77ade4405343a43e5ca4" }
+
+[[language]]
 name = "javascript"
 scope = "source.js"
 injection-regex = "(js|javascript)"

--- a/runtime/queries/go-format-string/highlights.scm
+++ b/runtime/queries/go-format-string/highlights.scm
@@ -1,0 +1,21 @@
+(escaped_percent_sign) @constant.character.escape
+
+"." @punctuation.delimiter
+"%" @punctuation.special
+
+[
+  "["
+  "]"
+] @punctuation.bracket
+
+(explicit_argument_index) @constant.numeric
+
+(flag) @constant.builtin
+
+(width) @constant.numeric.integer
+(precision) @constant.numeric.float
+(asterisk) @string.special.symbol
+
+(verb) @type
+
+(text) @string

--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -39,3 +39,48 @@
       (interpreted_string_literal)
     ] @injection.content
     (#set! injection.language "regex")))
+
+; https://pkg.go.dev/fmt#Printf
+; https://pkg.go.dev/fmt#Sprintf
+; https://pkg.go.dev/fmt#Scanf
+((call_expression
+  function: (selector_expression
+    operand: (identifier) @_module
+    field: (field_identifier) @_func)
+  arguments: (argument_list
+    . (interpreted_string_literal) @injection.content))
+  (#eq? @_module "fmt")
+  (#any-of? @_func "Printf" "Sprintf" "Scanf")
+  (#set! injection.language "go-format-string"))
+
+; https://pkg.go.dev/fmt#Fprintf
+; https://pkg.go.dev/fmt#Fscanf
+; https://pkg.go.dev/fmt#Sscanf
+((call_expression
+  function: (selector_expression
+    operand: (identifier) @_module
+    field: (field_identifier) @_func)
+  arguments: (argument_list
+    ; [(identifier) (interpreted_string_literal)]
+    (_)
+    ; (identifier)
+    .
+    (interpreted_string_literal) @injection.content))
+  (#eq? @_module "fmt")
+  (#any-of? @_func "Fprintf" "Fscanf" "Sscanf")
+  (#set! injection.language "go-format-string"))
+
+; https://pkg.go.dev/log#Printf
+; https://pkg.go.dev/log#Fatalf
+; https://pkg.go.dev/log#Panicf
+; https://pkg.go.dev/log#Logger.Printf
+; https://pkg.go.dev/log#Logger.Fatalf
+; https://pkg.go.dev/log#Logger.Panicf
+((call_expression
+  function: (selector_expression
+    operand: (identifier)
+    field: (field_identifier) @_func)
+  arguments: (argument_list
+    . (interpreted_string_literal) @injection.content))
+  (#any-of? @_func "Printf" "Fatalf" "Panicf")
+  (#set! injection.language "go-format-string"))


### PR DESCRIPTION
Inspired by #13533 I decided to write a grammar for Golang's [fmt](https://pkg.go.dev/fmt) package. Also works with the [log](https://pkg.go.dev/log@go1.24.5) package.

**Example**

<img width="1158" height="868" alt="image" src="https://github.com/user-attachments/assets/db80eefc-3dbc-4ff0-b61a-c91ebf2e7705" />
