### PR TITLE
ci(release): update runner os for windows and macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos] #, x86_64-win-gnu, win32-msvc
         include:
         - build: x86_64-linux
           # WARN: When changing this to a newer version, make sure that the GLIBC isnt too new, as this can cause issues
@@ -73,11 +73,6 @@ jobs:
           rust: stable
           target: aarch64-unknown-linux-gnu
           cross: false
-        # - build: riscv64-linux
-        #   os: ubuntu-22.04
-        #   rust: stable
-        #   target: riscv64gc-unknown-linux-gnu
-        #   cross: true
         - build: x86_64-macos
           os: macos-latest
           rust: stable
@@ -88,13 +83,16 @@ jobs:
           rust: stable
           target: x86_64-pc-windows-msvc
           cross: false
-        # 23.03: build issues
         - build: aarch64-macos
           os: macos-latest
           rust: stable
           target: aarch64-apple-darwin
           cross: false
-          skip_tests: true  # x86_64 host can't run aarch64 code
+        # - build: riscv64-linux
+        #   os: ubuntu-22.04
+        #   rust: stable
+        #   target: riscv64gc-unknown-linux-gnu
+        #   cross: true
         # - build: x86_64-win-gnu
         #   os: windows-2019
         #   rust: stable-x86_64-gnu
@@ -216,7 +214,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
             cp "target/${{ matrix.target }}/opt/hx.exe" "dist/"
           else
             cp "target/${{ matrix.target }}/opt/hx" "dist/"


### PR DESCRIPTION
Updates the releases CI job to the current OS for windows and macos. Starting with macos-14 the `macos-latest` image is solely ARM. There is a `macos-latest-large` for x86_64, which this changes for the x86_64 job. Tests are now not skipped, as it was before, bringing all platform to the same state now.

The windows image was changed to `windows-latest` and the check for when the built artifacts are moved is changed to check the `os` field for `windows-latest` rather than the now deprecated `windows-2019`.

https://github.com/actions/runner-images?tab=readme-ov-file#available-images

<img width="622" height="801" alt="image" src="https://github.com/user-attachments/assets/535fd3a7-a6d1-4c29-a46a-36eccc2f8871" />

A Windows 11 ARM exists, but does not come with Rust like the ubuntu one so leaving for later. Rust on Windows ARM is also only a tier 2 support.
https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md
https://doc.rust-lang.org/beta/rustc/platform-support.html#tier-2-with-host-tools
<img width="727" height="502" alt="image" src="https://github.com/user-attachments/assets/9ef51ece-e483-4ba7-afde-40b84e2a0a7f" />
