### PR TITLE
Remove Lean server memory limit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -67,7 +67,7 @@ koka = { command = "koka", args = ["--language-server", "--lsstdio"] }
 koto-ls = { command = "koto-ls" }
 kotlin-lsp = { command = "kotlin-lsp", args = ["--stdio"] }
 kotlin-language-server = { command = "kotlin-language-server" }
-lean = { command = "lean", args = [ "--server", "--memory=1024" ] }
+lean = { command = "lean", args = ["--server"] }
 ltex-ls = { command = "ltex-ls" }
 ltex-ls-plus = { command = "ltex-ls-plus" }
 markdoc-ls = { command = "markdoc-ls", args = ["--stdio"] }


### PR DESCRIPTION
The [issue](https://github.com/leanprover/lean4/issues/5321) that originally triggered the [addition of this flag](https://github.com/helix-editor/helix/pull/11683) appears to have been closed, so I believe it should be safe to remove. As [this comment](https://github.com/helix-editor/helix/pull/11683#issuecomment-2408720246) on the original pull request mentions, having a limit prevents the server from working with some large files, so I think it's probably best to remove it. Does that seem reasonable @gruhn, or do you still have situations where issues would occur without a limit?