### PR TITLE
feat: highlight lua and luau string interpolation in `string.format`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -147,6 +147,7 @@
 | log | ✓ |  |  |  |  |
 | lpf | ✓ |  |  |  |  |
 | lua | ✓ | ✓ | ✓ |  | `lua-language-server` |
+| lua-format-string | ✓ |  |  |  |  |
 | luau | ✓ | ✓ | ✓ |  | `luau-lsp` |
 | mail | ✓ | ✓ |  |  |  |
 | make | ✓ |  | ✓ |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -1416,6 +1416,16 @@ language-servers = [ "lua-language-server" ]
 name = "lua"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-lua", rev = "88e446476a1e97a8724dff7a23e2d709855077f2" }
 
+[[language]]
+name = "lua-format-string"
+scope = "source.lua-format-string"
+file-types = []
+injection-regex = "lua-format-string"
+
+[[grammar]]
+name = "lua-format-string"
+source = { git = "https://codeberg.org/kpbaks/tree-sitter-lua-format-string", rev = "b667c8cab109df307e1b4d56b0b43f5c4a353533" }
+
 [[grammar]]
 name = "teal"
 source = { git = "https://github.com/euclidianAce/tree-sitter-teal", rev = "3db655924b2ff1c54fdf6371b5425ea6b5dccefe" }

--- a/runtime/queries/lua-format-string/highlights.scm
+++ b/runtime/queries/lua-format-string/highlights.scm
@@ -1,0 +1,13 @@
+(escaped_percent_sign) @constant.character.escape
+
+(flag) @constant.builtin
+
+(text) @string
+
+(width) @constant.numeric.integer
+(precision) @constant.numeric.float
+
+(conversion_specifier) @type
+
+"." @punctuation.delimiter
+"%" @punctuation.special

--- a/runtime/queries/lua/injections.scm
+++ b/runtime/queries/lua/injections.scm
@@ -1,3 +1,26 @@
 ((comment) @injection.content
  (#set! injection.language "comment")
  (#set! injection.include-children))
+
+; string.format("format string", ...)
+((function_call
+  name: (dot_index_expression
+    table: (identifier) @_table
+    field: (identifier) @_function)
+  arguments: (arguments
+    .
+    (string
+      content: (string_content) @injection.content)))
+  (#eq? @_table "string")
+  (#eq? @_function "format")
+  (#set! injection.language "lua-format-string"))
+
+; ("format"):format(...)
+((function_call
+  name: (method_index_expression
+    table: (parenthesized_expression
+      (string
+        content: (string_content) @injection.content))
+    method: (identifier) @_function))
+  (#eq? @_function "format")
+  (#set! injection.language "lua-format-string"))

--- a/runtime/queries/luau/injections.scm
+++ b/runtime/queries/luau/injections.scm
@@ -1,2 +1,21 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+; string.format("format string", ...)
+((call_stmt
+  invoked: (var
+    table_name: (name) @_table
+    (key
+      field_name: (name) @_function))
+  (arglist
+    . (string) @injection.content))
+  (#eq? @_table "string")
+  (#eq? @_function "format")
+  (#set! injection.language "lua-format-string"))
+
+; ("format"):format(...)
+((call_stmt
+  method_table: (exp_wrap (string) @injection.content)
+  method_name: (name) @_function)
+  (#eq? @_function "format")
+  (#set! injection.language "lua-format-string"))


### PR DESCRIPTION
tree-sitter grammar for Lua's `string.format` syntax. Also works with the equivalent function in [Luau](https://luau.org/).

**Showcase**

<img width="1247" height="338" alt="image" src="https://github.com/user-attachments/assets/2f345e51-4aff-4f83-90be-843c4834be1a" />

