### PR TITLE
Reduced the weight of size 1 indents in the indent auto-detection system

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -153,6 +153,12 @@ pub fn auto_detect_indent_style(document_text: &Rope) -> Option<IndentStyle> {
         // Give more weight to tabs, because their presence is a very
         // strong indicator.
         histogram[0] *= 2;
+        // Gives less weight to single indent, as single spaces are
+        // often used in certain language's comment systems and rarely
+        // used as the actual document indentation.
+        if histogram[1] > 1 {
+            histogram[1] /= 2;
+        }
 
         histogram
     };

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -154,7 +154,7 @@ pub fn auto_detect_indent_style(document_text: &Rope) -> Option<IndentStyle> {
         // strong indicator.
         histogram[0] *= 2;
         // Gives less weight to single indent, as single spaces are
-        // often used in certain language's comment systems and rarely
+        // often used in certain languages' comment systems and rarely
         // used as the actual document indentation.
         if histogram[1] > 1 {
             histogram[1] /= 2;


### PR DESCRIPTION
A loose fix for #9556 that specifically targets the case of single indented comments that some languages use (see #9822).

In the rare case where a document is 1 size indented, it will still supply the correct indentation so long as there isn't a significant mix of other indentation sizes. If there is a significant mix, the indentation detection should fail.

Before: 
<img width="421" height="304" alt="output" src="https://github.com/user-attachments/assets/79f72cbc-30c6-48a3-b8cf-958427352f96" />

After:
<img width="464" height="304" alt="output2" src="https://github.com/user-attachments/assets/1e4f53e4-e201-4885-9479-5727dbdf9546" />
