### PR TITLE
feat: support scrolling in pickers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3289,6 +3290,12 @@ dependencies = [
  "helix-view",
  "toml",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -5,6 +5,7 @@
 - [`[editor.statusline]` Section](#editorstatusline-section)
 - [`[editor.lsp]` Section](#editorlsp-section)
 - [`[editor.cursor-shape]` Section](#editorcursor-shape-section)
+- [`[editor.picker]` Section](#editorpicker-section)
 - [`[editor.file-picker]` Section](#editorfile-picker-section)
 - [`[editor.auto-pairs]` Section](#editorauto-pairs-section)
 - [`[editor.auto-save]` Section](#editorauto-save-section)
@@ -188,6 +189,14 @@ Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
 [normal mode]: ./keymap.md#normal-mode
 [insert mode]: ./keymap.md#insert-mode
 [select mode]: ./keymap.md#select--extend-mode
+
+### `[editor.picker]` Section
+
+General options for pickers (will apply to file pickers, open buffers pickers, etc.).
+
+| Key         | Description                                                                                      | Default |
+| ----------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `scrolloff` | Padding to keep between the vertical edges of the picker and the selected element when scrolling | `3`     |
 
 ### `[editor.file-picker]` Section
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -570,7 +570,11 @@ impl Application {
             doc_save_event.revision
         );
 
-        doc.set_last_saved_revision(doc_save_event.revision, doc_save_event.save_time);
+        doc.set_last_saved(
+            doc_save_event.revision,
+            doc_save_event.save_time,
+            &doc_save_event.text,
+        );
 
         let lines = doc_save_event.text.len_lines();
         let mut sz = doc_save_event.text.len_bytes() as f32;

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -54,6 +54,8 @@ thiserror.workspace = true
 
 kstring = "2.0"
 
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4", features = ["std"] }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2242,7 +2242,7 @@ impl Editor {
                 };
 
                 let doc = doc_mut!(self, &save_event.doc_id);
-                doc.set_last_saved_revision(save_event.revision, save_event.save_time);
+                doc.set_last_saved(save_event.revision, save_event.save_time, &save_event.text);
             }
         }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -176,6 +176,20 @@ impl Default for GutterLineNumbersConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    /// Padding to keep between the vertical edges of the picker and the
+    /// selected element when scrolling. Defaults to 3.
+    pub scrolloff: usize,
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        Self { scrolloff: 3 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
     /// IgnoreOptions
     /// Enables ignoring hidden files.
@@ -317,6 +331,7 @@ pub struct Config {
     pub continue_comments: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
+    pub picker: PickerConfig,
     pub file_picker: FilePickerConfig,
     /// Configuration of the statusline elements
     pub statusline: StatusLineConfig,
@@ -1026,6 +1041,7 @@ impl Default for Config {
             preview_completion_insert: true,
             completion_trigger_len: 2,
             auto_info: true,
+            picker: PickerConfig::default(),
             file_picker: FilePickerConfig::default(),
             statusline: StatusLineConfig::default(),
             cursor_shape: CursorShapeConfig::default(),


### PR DESCRIPTION
This PR implements scrolling with a configurable `scrolloff` for the picker components. 

Currently, only paging is supported in pickers (i.e., when you scroll after the end of the view, the cursor will jump to the start of the view).

Notes:

- Although (in my opinion) this is much more comfortable than the current state for `move_by(1, ..)` calls (i.e., scrolling one element), when using `page_{up,down}` with a non-zero scrolloff, the scrolling is a bit weird.