### PR TITLE
feat(theme): Sync catppuccin themes to include rainbow array.

### DIFF
--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -128,6 +128,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f5e0dc"
 flamingo = "#f2cdcd"


### PR DESCRIPTION
Effectivly sync the changes made in https://github.com/catppuccin/helix/pull/75 to support the addition of the Rainbow theme key made in https://github.com/helix-editor/helix/pull/13530