### PR TITLE
feat: improve nushell queries and add missing ones

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -168,7 +168,7 @@
 | nickel | ✓ |  | ✓ |  |  | `nls` |
 | nim | ✓ | ✓ | ✓ |  |  | `nimlangserver` |
 | nix | ✓ | ✓ | ✓ |  | ✓ | `nil`, `nixd` |
-| nu | ✓ |  |  |  |  | `nu` |
+| nu | ✓ | ✓ | ✓ | ✓ | ✓ | `nu` |
 | nunjucks | ✓ |  |  |  |  |  |
 | ocaml | ✓ |  | ✓ |  |  | `ocamllsp` |
 | ocaml-interface | ✓ |  |  |  |  | `ocamllsp` |

--- a/runtime/queries/nu/indents.scm
+++ b/runtime/queries/nu/indents.scm
@@ -1,0 +1,16 @@
+[
+  (block)
+  (val_closure)
+  (val_list)
+  (val_record)
+  (val_table)
+  (ctrl_match)
+  (collection_type)
+  (parameter_bracks)
+  (parameter_pipes)
+] @indent
+
+[
+  "]"
+  "}"
+] @outdent

--- a/runtime/queries/nu/injections.scm
+++ b/runtime/queries/nu/injections.scm
@@ -1,2 +1,33 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+; (find|parse) --regex <pattern>
+; str replace (-r|--regex)
+; split (column|list|row) (-r|--regex) <pattern>
+(command
+  flag: (_) @_flag (#any-of? @_flag "-r" "--regex")
+  .
+  arg: (val_string) @injection.content
+  (#set! injection.language "regex"))
+
+; polars str-replace(-all)? (-p|--pattern) <pattern>
+(command
+  head: (cmd_identifier) @_cmd (#eq? @_cmd "polars")
+  arg_str: (val_string) @_subcmd (#any-of? @_subcmd "str-replace" "str-replace-all")
+  flag: (_) @_flag (#any-of? @_flag "-p" "--pattern")
+  .
+  arg: (val_string) @injection.content
+  (#set! injection.language "regex"))
+
+; polars contains <pattern>
+(command
+  head: (cmd_identifier) @_cmd (#eq? @_cmd "polars")
+  arg_str: (val_string) @_subcmd (#eq? @_subcmd "contains")
+  .
+  arg: (val_string) @injection.content
+  (#set! injection.language "regex"))
+
+(expr_binary
+  ["=~" "!~"]
+  rhs: (val_string) @injection.content
+  (#set! injection.language "regex"))

--- a/runtime/queries/nu/locals.scm
+++ b/runtime/queries/nu/locals.scm
@@ -1,0 +1,10 @@
+[
+  (decl_def)
+  (val_closure)
+] @local.scope
+
+(parameter
+    param_name: (identifier) @local.definition.variable.parameter)
+
+(val_variable
+  name: (identifier) @local.reference)

--- a/runtime/queries/nu/rainbows.scm
+++ b/runtime/queries/nu/rainbows.scm
@@ -1,0 +1,16 @@
+[
+  (block)
+  (val_list)
+  (val_record)
+  (val_table)
+  (ctrl_match)
+  (collection_type)
+  (val_closure)
+] @rainbow.scope
+
+[
+  "(" ")"
+  "[" "]"
+  "{" "}"
+  "<" ">"
+] @rainbow.bracket

--- a/runtime/queries/nu/tags.scm
+++ b/runtime/queries/nu/tags.scm
@@ -1,0 +1,5 @@
+(decl_def
+  unquoted_name: (cmd_identifier) @definition.function)
+
+(stmt_const
+  var_name: (identifier) @definition.constant)

--- a/runtime/queries/nu/textobjects.scm
+++ b/runtime/queries/nu/textobjects.scm
@@ -1,0 +1,21 @@
+(comment) @comment.inside
+(comment)+ @comment.around
+
+(decl_def
+  parameters: (parameter_bracks
+    (parameter
+      param_name: (identifier) @parameter.inside) @parameter.around)
+  body: (block) @function.inside) @function.around
+
+(record_entry
+  value: (_) @entry.inside) @entry.around
+
+(val_list
+  item: (_) @entry.inside)
+
+(val_table
+  row: (val_list
+    item: (_) @entry.inside) @entry.around)
+
+(match_arm
+  expression: (block) @entry.inside) @entry.around


### PR DESCRIPTION
Adds missing queries `{textobjects,indents,locals}.scm`, and add support for the two recent ones `{tags,rainbows}.scm`

**Showcase**

- `rainbows.scm`
- `injections.scm` injecting `regex` grammar into all built-in parameters expecting a regex string

<img width="830" height="1089" alt="image" src="https://github.com/user-attachments/assets/0da6af1f-5a1b-4fe9-9713-54f993e7705b" />