### PR TITLE
FEAT: Tree-Sitter-Blade Upgrade

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -13,7 +13,7 @@
 | bibtex | ✓ |  |  |  |  | `texlab` |
 | bicep | ✓ |  |  |  |  | `bicep-langserver` |
 | bitbake | ✓ |  |  |  |  | `bitbake-language-server` |
-| blade | ✓ |  |  |  |  |  |
+| blade | ✓ | ✓ |  |  | ✓ |  |
 | blueprint | ✓ |  |  |  |  | `blueprint-compiler` |
 | c | ✓ | ✓ | ✓ | ✓ | ✓ | `clangd` |
 | c-sharp | ✓ | ✓ |  | ✓ |  | `OmniSharp` |

--- a/languages.toml
+++ b/languages.toml
@@ -1185,7 +1185,7 @@ roots = ["composer.json", "index.php"]
 
 [[grammar]]
 name = "blade"
-source = { git = "https://github.com/EmranMR/tree-sitter-blade", rev = "4c66efe1e05c639c555ee70092021b8223d2f440" }
+source = { git = "https://github.com/EmranMR/tree-sitter-blade", rev = "59ce5b68e288002e3aee6cf5a379bbef21adbe6c" }
 
 [[language]]
 name = "twig"

--- a/runtime/queries/blade/folds.scm
+++ b/runtime/queries/blade/folds.scm
@@ -1,7 +1,8 @@
+; inherits: html
+
 ((directive_start) @start
     (directive_end) @end.after
     (#set! role block))
-
 
 ((bracket_start) @start
     (bracket_end) @end

--- a/runtime/queries/blade/highlights.scm
+++ b/runtime/queries/blade/highlights.scm
@@ -1,8 +1,16 @@
-(directive) @tag
-(directive_start) @tag
-(directive_end) @tag
+; inherits: html
+
+(directive) @keyword.directive
+(directive_start) @keyword.directive
+(directive_end) @keyword.directive
 (comment) @comment
+
+; merged with blade punctuation
 [
- (bracket_start)
- (bracket_end)
+  "{{"
+  "}}"
+  "{!!"
+  "!!}"
+  "("
+  ")"
 ] @punctuation.bracket

--- a/runtime/queries/blade/injections.scm
+++ b/runtime/queries/blade/injections.scm
@@ -1,14 +1,108 @@
-((text) @injection.content
-    (#set! injection.combined)
-    (#set! injection.language "php"))
+; inherits: html
 
+; tree-sitter-comment injection
+; if available
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
 ((php_only) @injection.content
     (#set! injection.language "php-only"))
 
-((parameter) @injection.content                                                                                                 
-    (#set! injection.include-children)                                                                                          
-    (#set! injection.language "php-only")) 
+((parameter) @injection.content
+    (#set! injection.include-children) ; You may need this, depending on your editor e.g Helix
+    (#set! injection.language "php-only"))
+
+; ; Livewire attributes
+(attribute
+  (attribute_name) @_attr
+    (#any-of? @_attr
+      "wire:click"
+      "wire:submit"
+      "wire:model"
+      "wire:loading"
+      "wire:navigate"
+      "wire:current"
+      "wire:cloak"
+      "wire:dirty"
+      "wire:confirm"
+      "wire:transition"
+      "wire:init"
+      "wire:poll"
+      "wire:offline"
+      "wire:ignore"
+      "wire:replace"
+      "wire:show"
+      "wire:stream"
+      "wire:text"
+    )
+  (quoted_attribute_value
+    (attribute_value) @injection.content)
+  (#set! injection.language "javascript"))
+
+; ; See #33
+; ; AlpineJS attributes
+(attribute
+  (attribute_name) @_attr
+    (#match? @_attr "^x-[a-z]+")
+  (quoted_attribute_value
+    (attribute_value) @injection.content)
+  (#set! injection.language "javascript"))
+
+; ; Apline Events
+(attribute
+  (attribute_name) @_attr
+    (#match? @_attr "^@[a-z]+")
+  (quoted_attribute_value
+    (attribute_value) @injection.content)
+  (#set! injection.language "javascript"))
+
+; ; normal HTML element alpine attributes
+(element
+  (_
+    (tag_name) @_tag
+      (#match? @_tag "[^x][^-]")
+    (attribute
+      (attribute_name) @_attr
+        (#match? @_attr "^:[a-z]+")
+      (quoted_attribute_value
+        (attribute_value) @injection.content)
+      (#set! injection.combined)
+      (#set! injection.language "javascript"))))
+
+; ; ; Blade escaped JS attributes
+; ; <x-foo ::bar="baz" />
+(element
+  (_
+    (tag_name) @_tag
+      (#match? @_tag "^x-[a-z]+")
+    (attribute
+      (attribute_name) @_attr
+        (#match? @_attr "^::[a-z]+")
+      (quoted_attribute_value
+        (attribute_value) @injection.content)
+      (#set! injection.language "javascript"))))
+
+
+; ; ; Blade escaped JS attributes
+; ; <htmlTag :class="baz" />
+(element
+  (_
+    (attribute_name) @_attr
+      (#match? @_attr "^:[a-z]+")
+    (quoted_attribute_value
+      (attribute_value) @injection.content)
+    (#set! injection.language "javascript")))
+
+
+; Blade PHP attributes
+(element
+  (_
+    (tag_name) @_tag
+      (#match? @_tag "^x-[a-z]+")
+    (attribute
+      (attribute_name) @_attr
+        (#match? @_attr "^:[a-z]+")
+      (quoted_attribute_value
+        (attribute_value) @injection.content)
+      (#set! injection.language "php-only"))))
 

--- a/runtime/queries/blade/rainbows.scm
+++ b/runtime/queries/blade/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: html

--- a/runtime/queries/blade/textobjects.scm
+++ b/runtime/queries/blade/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: html


### PR DESCRIPTION
Hello!
This commit upgrades the very outdated `tree-sitter-blade` with the upstream repo and adds new features. Below is a brief summary of what has been changed and added:

- `tree-sitter-blade` upgraded to the latest `v0.12.0` (complete rewrite + ABI 15 + many bug fixes)
- As the parser now inherits from `html` rather than injection, I have duplicated/merged the latest `html` `.scm` files with the new `blade` `.scm` files. (unfortunately I do not think Helix supports query file inheritance? neovim supports something like `;inherits language` in the `.scm` files
- The highlighting selector has changed for the `blade directives` to `keyword.directive` from `tags` which is more semantic and clearly distinguishes blade markups
- Support for all sort of injections in the blade files have also been added, including `javascript`, `livewire`, `alpinejs` and various other forms of `js` injections.