### PR TITLE
Add rainbow brackets for `dark_plus`

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -94,6 +94,8 @@
 "diagnostic.unnecessary"     = { modifiers = ["dim"] }
 "diagnostic.deprecated"      = { modifiers = ["crossed_out"] }
 
+rainbow = ["#FFD700", "#DA70D6", "#179FFF"]
+
 [palette]
 white = "#ffffff"
 orange = "#ce9178"


### PR DESCRIPTION
I have added rainbow brackets to perfectly emulate the default VS Code Dark+ theme, which utilizes only three levels. According to a previous statement on the official VS Code blog (https://code.visualstudio.com/blogs/2021/09/29/bracket-pair-colorization), this limitation was initially implemented for performance reasons.

The config allows for up to six levels, but currently, no built-in theme takes advantage of more than three levels.

<details>
<summary>Click to expand</summary>

`src/vs/editor/common/core/editorColorRegistry.ts`

```ts
export const editorBracketHighlightingForeground1 = registerColor('editorBracketHighlight.foreground1', { dark: '#FFD700', light: '#0431FAFF', hcDark: '#FFD700', hcLight: '#0431FAFF' }, nls.localize('editorBracketHighlightForeground1', 'Foreground color of brackets (1). Requires enabling bracket pair colorization.'));
export const editorBracketHighlightingForeground2 = registerColor('editorBracketHighlight.foreground2', { dark: '#DA70D6', light: '#319331FF', hcDark: '#DA70D6', hcLight: '#319331FF' }, nls.localize('editorBracketHighlightForeground2', 'Foreground color of brackets (2). Requires enabling bracket pair colorization.'));
export const editorBracketHighlightingForeground3 = registerColor('editorBracketHighlight.foreground3', { dark: '#179FFF', light: '#7B3814FF', hcDark: '#87CEFA', hcLight: '#7B3814FF' }, nls.localize('editorBracketHighlightForeground3', 'Foreground color of brackets (3). Requires enabling bracket pair colorization.'));
export const editorBracketHighlightingForeground4 = registerColor('editorBracketHighlight.foreground4', '#00000000', nls.localize('editorBracketHighlightForeground4', 'Foreground color of brackets (4). Requires enabling bracket pair colorization.'));
export const editorBracketHighlightingForeground5 = registerColor('editorBracketHighlight.foreground5', '#00000000', nls.localize('editorBracketHighlightForeground5', 'Foreground color of brackets (5). Requires enabling bracket pair colorization.'));
export const editorBracketHighlightingForeground6 = registerColor('editorBracketHighlight.foreground6', '#00000000', nls.localize('editorBracketHighlightForeground6', 'Foreground color of brackets (6). Requires enabling bracket pair colorization.'));
```
</details>

## VS Code

<img width="836" height="947" alt="image" src="https://github.com/user-attachments/assets/2f787c71-171b-4776-8cc3-dc985280e178" />

## Helix

<img width="838" height="802" alt="image" src="https://github.com/user-attachments/assets/23c642e0-54d1-40bf-9234-99432b3ffa73" />


