### PR TITLE
Update `go-format-string` grammar and queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -86,7 +86,7 @@
 | glsl | ✓ | ✓ | ✓ |  |  | `glsl_analyzer` |
 | gn | ✓ |  |  |  |  |  |
 | go | ✓ | ✓ | ✓ | ✓ | ✓ | `gopls`, `golangci-lint-langserver` |
-| go-format-string | ✓ |  |  |  |  |  |
+| go-format-string | ✓ |  |  |  | ✓ |  |
 | godot-resource | ✓ | ✓ |  |  |  |  |
 | gomod | ✓ |  |  |  |  | `gopls` |
 | gotmpl | ✓ |  |  |  |  | `gopls` |

--- a/languages.toml
+++ b/languages.toml
@@ -831,7 +831,7 @@ injection-regex = "go-format-string"
 
 [[grammar]]
 name = "go-format-string"
-source = { git = "https://codeberg.org/kpbaks/tree-sitter-go-format-string", rev = "45b559b74be97535abfc77ade4405343a43e5ca4" }
+source = { git = "https://codeberg.org/kpbaks/tree-sitter-go-format-string", rev = "06587ea641155db638f46a32c959d68796cd36bb" }
 
 [[language]]
 name = "javascript"

--- a/runtime/queries/go-format-string/rainbows.scm
+++ b/runtime/queries/go-format-string/rainbows.scm
@@ -1,0 +1,5 @@
+(explicit_argument_index_expr) @rainbow.scope
+
+[
+  "[" "]"
+] @rainbow.bracket

--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -43,6 +43,7 @@
 ; https://pkg.go.dev/fmt#Printf
 ; https://pkg.go.dev/fmt#Sprintf
 ; https://pkg.go.dev/fmt#Scanf
+; https://pkg.go.dev/fmt#Errorf
 ((call_expression
   function: (selector_expression
     operand: (identifier) @_module
@@ -50,7 +51,7 @@
   arguments: (argument_list
     . (interpreted_string_literal) @injection.content))
   (#eq? @_module "fmt")
-  (#any-of? @_func "Printf" "Sprintf" "Scanf")
+  (#any-of? @_func "Printf" "Sprintf" "Scanf" "Errorf")
   (#set! injection.language "go-format-string"))
 
 ; https://pkg.go.dev/fmt#Fprintf


### PR DESCRIPTION
- add `rainbows.scm` queries for explicit argument index e.g. `%[2]d`
- detect '%w' as verb for `fmt.Errorf`
- inject into string argument for `fmt.Errorf`
