### PR TITLE
editorconfig: allow empty alternates

### DIFF
--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -228,6 +228,7 @@ impl FromStr for Ini {
                 let glob = GlobBuilder::new(&glob_str)
                     .literal_separator(true)
                     .backslash_escape(true)
+                    .empty_alternates(true)
                     .build()?;
                 ini.sections.push(Section {
                     glob: glob.compile_matcher(),


### PR DESCRIPTION
This makes it such that sections like `[*.y{,a}ml]` correctly match `.yml` and `.yaml` file extensions.