### PR TITLE
docker: Update the default indentation to match other editors

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1905,7 +1905,7 @@ file-types = [
   { glob = "containerfile.*" },
 ]
 comment-token = "#"
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 4, unit = "  " }
 language-servers = [ "docker-langserver" ]
 
 [[grammar]]


### PR DESCRIPTION
This matches the default for Vim, VSCode, Lapce, and probably others. I believe indenting with four spaces is more common with Docker because it indents past the commonly wrapped instructions, e.g. this:

```dockerfile
RUN apt-get update && apt-get install -y \
  gcc \
  binutils
```

Becomes this:

```dockerfile
RUN apt-get update && apt-get install -y \
    gcc \
    binutils
```