### PR TITLE
Add a separate timeout for LSP formatting requests (#1639)

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -143,6 +143,7 @@ These are the available options for a language server.
 | `args`                     | A list of arguments to pass to the language server binary                                                                         |
 | `config`                   | Language server initialization options                                                                                            |
 | `timeout`                  | The maximum time a request to the language server may take, in seconds. Defaults to `20`                                          |
+| `formatter-timeout`        | The maximum time a formatting request to the language server may take, in seconds. Defaults to `1`                                |
 | `environment`              | Any environment variables that will be used when starting the language server `{ "KEY1" = "Value1", "KEY2" = "Value2" }`          |
 | `required-root-patterns`   | A list of `glob` patterns to look for in the working directory. The language server is started if at least one of them is found.  |
 

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -408,6 +408,8 @@ pub struct LanguageServerConfiguration {
     pub config: Option<serde_json::Value>,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(default = "default_formatter_timeout")]
+    pub formatter_timeout: u64,
     #[serde(
         default,
         skip_serializing,
@@ -626,4 +628,8 @@ where
 
 fn default_timeout() -> u64 {
     20
+}
+
+fn default_formatter_timeout() -> u64 {
+    1
 }

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -62,6 +62,7 @@ pub struct Client {
     initialize_notify: Arc<Notify>,
     /// workspace folders added while the server is still initializing
     req_timeout: u64,
+    format_req_timeout: u64,
 }
 
 impl Client {
@@ -210,6 +211,7 @@ impl Client {
         id: LanguageServerId,
         name: String,
         req_timeout: u64,
+        format_req_timeout: u64,
     ) -> Result<(
         Self,
         UnboundedReceiver<(LanguageServerId, Call)>,
@@ -254,6 +256,7 @@ impl Client {
             file_operation_interest: OnceLock::new(),
             config,
             req_timeout,
+            format_req_timeout,
             root_path,
             root_uri,
             workspace_folders: Mutex::new(workspace_folders),
@@ -1199,7 +1202,7 @@ impl Client {
             work_done_progress_params: lsp::WorkDoneProgressParams { work_done_token },
         };
 
-        Some(self.call::<lsp::request::Formatting>(params))
+        Some(self.call_with_timeout::<lsp::request::Formatting>(&params, self.format_req_timeout))
     }
 
     pub fn text_document_range_formatting(
@@ -1226,7 +1229,12 @@ impl Client {
             work_done_progress_params: lsp::WorkDoneProgressParams { work_done_token },
         };
 
-        Some(self.call::<lsp::request::RangeFormatting>(params))
+        Some(
+            self.call_with_timeout::<lsp::request::RangeFormatting>(
+                &params,
+                self.format_req_timeout,
+            ),
+        )
     }
 
     pub fn text_document_document_highlight(

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -909,6 +909,7 @@ fn start_client(
         id,
         name,
         ls_config.timeout,
+        ls_config.formatter_timeout,
     )?;
 
     let client = Arc::new(client);


### PR DESCRIPTION
Solves #1639 

Add a separate timeout to language server configuration, that applies just to formatting requests. Defaults to 1 seconds.