### PR TITLE
Add Puppet language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -229,6 +229,8 @@
 | prql | ✓ |  |  |  |  |  |
 | ptx | ✓ |  | ✓ |  |  |  |
 | pug | ✓ |  |  |  |  |  |
+| Language | Syntax Highlighting | Treesitter Textobjects | Auto Indent | Code Navigation Tags | Rainbow Brackets | Default language servers |
+| puppet | ✓ | ✓ |  |  |  | `puppet-languageserver`|
 | purescript | ✓ | ✓ |  |  |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | ✓ | ✓ | `ty`, `ruff`, `jedi-language-server`, `pylsp` |
 | qml | ✓ | ✓ | ✓ |  |  | `qmlls` |

--- a/languages.toml
+++ b/languages.toml
@@ -106,6 +106,7 @@ pest-language-server = { command = "pest-language-server" }
 pkl-lsp = { command = "pkl-lsp" }
 pony-lsp = { command = "pony-lsp", args = ["--stdio"], config = {defines = [], ponypath = []}}
 prisma-language-server = { command = "prisma-language-server", args = ["--stdio"], config.prisma.enableDiagnostics = true }
+puppet-languageserver = { command = "puppet-languageserver", args = ["--stdio"] }
 purescript-language-server = { command = "purescript-language-server", args = ["--stdio"] }
 pylsp = { command = "pylsp" }
 pyrefly = { command = "pyrefly", args = ["lsp"] }
@@ -3068,7 +3069,7 @@ source = { git = "https://github.com/hongquan/tree-sitter-esdl", rev = "c824fe2b
 name = "pascal"
 scope = "source.pascal"
 injection-regex = "pascal"
-file-types = ["pas", "pp", "inc", "lpr", "lfm"]
+file-types = ["pas", "inc", "lpr", "lfm"]
 comment-token = "//"
 block-comment-tokens = { start = "{", end = "}" }
 indent = { tab-width = 2, unit = "  " }
@@ -5428,3 +5429,17 @@ comment-token = "//"
 [[grammar]]
 name = "tql"
 source = { git = "https://github.com/tenzir/tree-sitter-tql", rev = "d3b3b2699bc09fd0c63e2c13f15f6e474665c62e" }
+
+[[language]]
+name = "puppet"
+scope = "source.puppet"
+injection-regex = "puppet"
+file-types = ["pp"]
+indent = { tab-width = 2, unit = " " }
+comment-token = "#"
+language-servers = [ "puppet-languageserver" ]
+formatter = { command = "puppet-fmt" }
+
+[[grammar]]
+name = "puppet"
+source = { git = "https://github.com/smoeding/tree-sitter-puppet", rev = "6bc409e0818b53d34ee775f51d88961e710037ac" }

--- a/runtime/queries/puppet/highlights.scm
+++ b/runtime/queries/puppet/highlights.scm
@@ -1,0 +1,69 @@
+(function) @function
+(variable) @variable
+[
+  (identifier)
+] @identifier
+
+[
+ "class"
+ "define"
+ "plan"
+ "node"
+ "type"
+] @keyword
+
+[
+  "contain"
+  "include"
+  "inherits"
+  "require"
+] @keyword.control.import
+
+[
+ "case"
+ "else"
+ "elsif"
+ "if"
+ "unless"
+] @keyword.control.conditional
+
+(string) @string
+(regex) @string.regex
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+(comment) @comment
+[(true) (false)] @constant.builtin.boolean
+
+(unprotected_string) @constant
+
+[
+ (chaining_arrow)
+ (operator)
+ "and"
+ "or"
+] @operator
+
+
+(interpolation
+  "${" @punctuation.special
+  "}" @punctuation.special) @none
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ ","
+ ":"
+ "::"
+] @punctuation.delimiter
+
+[(type) (type_identifier)] @type
+
+(escape_sequence) @escape
+


### PR DESCRIPTION
this is a rebased and (slightly) fixed version of https://github.com/helix-editor/helix/pull/6412

fixes #6073 

breaking change: 
- remove `pp` file type from `pascal` language so it doesn't conflict with Puppet `pp`  (`pp` is specific to FreePascal only afaik, major pascal IDEs don't recognize it)


Tested against master, builds, works (for me). 