### PR TITLE
Add rainbow indentation guides

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -321,11 +321,12 @@ tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 
 Options for rendering vertical indent guides.
 
-| Key           | Description                                             | Default |
-| ---           | ---                                                     | ---     |
-| `render`      | Whether to render indent guides                         | `false` |
-| `character`   | Literal character to use for rendering the indent guide | `│`     |
-| `skip-levels` | Number of indent levels to skip                         | `0`     |
+| Key              | Description                                               | Default |
+| ---              | ---                                                       | ---     |
+| `render`         | Whether to render indent guides                           | `false` |
+| `character`      | Literal character to use for rendering the indent guide   | `│`     |
+| `skip-levels`    | Number of indent levels to skip                           | `0`     |
+| `rainbow-indent` | Enum to set rainbow indentations. `normal`, `dim`, `none` | `none`  |
 
 Example:
 
@@ -334,6 +335,7 @@ Example:
 render = true
 character = "╎" # Some characters that work well: "▏", "┆", "┊", "⸽"
 skip-levels = 1
+rainbow-indent = "normal"
 ```
 
 ### `[editor.gutters]` Section

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -321,12 +321,12 @@ tabpad = "·" # Tabs will look like "→···" (depending on tab width)
 
 Options for rendering vertical indent guides.
 
-| Key              | Description                                               | Default |
-| ---              | ---                                                       | ---     |
-| `render`         | Whether to render indent guides                           | `false` |
-| `character`      | Literal character to use for rendering the indent guide   | `│`     |
-| `skip-levels`    | Number of indent levels to skip                           | `0`     |
-| `rainbow-indent` | Enum to set rainbow indentations. `normal`, `dim`, `none` | `none`  |
+| Key           | Description                                             | Default |
+| ---           | ---                                                     | ---     |
+| `render`      | Whether to render indent guides                         | `false` |
+| `character`   | Literal character to use for rendering the indent guide | `│`     |
+| `skip-levels` | Number of indent levels to skip                         | `0`     |
+| `rainbow`     | Whether to render indent guides in rainbow colors       | `false` |
 
 Example:
 
@@ -335,7 +335,7 @@ Example:
 render = true
 character = "╎" # Some characters that work well: "▏", "┆", "┊", "⸽"
 skip-levels = 1
-rainbow-indent = "normal"
+rainbow = true
 ```
 
 ### `[editor.gutters]` Section

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -132,7 +132,7 @@ berry = "#2A2A4D"
 
 ### Rainbow
 
-The `rainbow` key is used for rainbow highlight for matching brackets.
+The `rainbow` key is used for rainbow highlight for matching brackets and indentation.
 The key is a list of styles.
 
 ```toml

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -132,7 +132,7 @@ berry = "#2A2A4D"
 
 ### Rainbow
 
-The `rainbow` key is used for rainbow highlight for matching brackets and indentation.
+The `rainbow` key is used for rainbow highlighting for matching brackets and indentation guides.
 The key is a list of styles.
 
 ```toml
@@ -140,6 +140,20 @@ rainbow = ["#ff0000", "#ffa500", "#fff000", { fg = "#00ff00", modifiers = ["bold
 ```
 
 Colors from the palette and modifiers may be used.
+
+The `rainbow-brackets` and `rainbow-indents` keys are used for rainbow highlights for matching brackets and indentation guides, respectively.
+They inherit their default value from the `rainbow` key, but may be specified to provide different highlighting patterns for brackets and indentation.
+For example, it may be desirable for indentation markers to be dimmer than brackets. (This is the default, when these are left unspecified.)
+
+```toml
+rainbow-brackets = ["#ff0000", "#ffa500", "#fff000", "#00ff00"]
+rainbow-indents = [
+  { fg = "#ff0000", modifiers = ["dim"] },
+  { fg = "#ffa500", modifiers = ["dim"] },
+  { fg = "#fff000", modifiers = ["dim"] },
+  { fg = "#00ff00", modifiers = ["dim"] }
+]
+```
 
 ### Scopes
 

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -7,9 +7,9 @@ use helix_core::syntax::{self, HighlightEvent, Highlighter, OverlayHighlights};
 use helix_core::text_annotations::TextAnnotations;
 use helix_core::{visual_offset_from_block, Position, RopeSlice};
 use helix_stdx::rope::RopeSliceExt;
-use helix_view::editor::{WhitespaceConfig, WhitespaceRenderValue};
+use helix_view::editor::{RainbowIndent, WhitespaceConfig, WhitespaceRenderValue};
 use helix_view::graphics::Rect;
-use helix_view::theme::Style;
+use helix_view::theme::{Modifier, Style};
 use helix_view::view::ViewPosition;
 use helix_view::{Document, Theme};
 use tui::buffer::Buffer as Surface;
@@ -179,6 +179,8 @@ pub struct TextRenderer<'a> {
     pub whitespace_style: Style,
     pub indent_guide_char: String,
     pub indent_guide_style: Style,
+    pub indent_guide_rainbow: RainbowIndent,
+    pub theme: &'a Theme,
     pub newline: String,
     pub nbsp: String,
     pub nnbsp: String,
@@ -201,7 +203,7 @@ impl<'a> TextRenderer<'a> {
     pub fn new(
         surface: &'a mut Surface,
         doc: &Document,
-        theme: &Theme,
+        theme: &'a Theme,
         offset: Position,
         viewport: Rect,
     ) -> TextRenderer<'a> {
@@ -243,12 +245,19 @@ impl<'a> TextRenderer<'a> {
         };
 
         let text_style = theme.get("ui.text");
+        let basic_style = text_style.patch(
+            theme
+                .try_get("ui.virtual.indent-guide")
+                .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
+        );
 
         let indent_width = doc.indent_style.indent_width(tab_width) as u16;
 
         TextRenderer {
             surface,
             indent_guide_char: editor_config.indent_guides.character.into(),
+            indent_guide_rainbow: editor_config.indent_guides.rainbow_indent.clone(),
+            theme,
             newline,
             nbsp,
             nnbsp,
@@ -260,11 +269,7 @@ impl<'a> TextRenderer<'a> {
             starting_indent: offset.col / indent_width as usize
                 + (offset.col % indent_width as usize != 0) as usize
                 + editor_config.indent_guides.skip_levels as usize,
-            indent_guide_style: text_style.patch(
-                theme
-                    .try_get("ui.virtual.indent-guide")
-                    .unwrap_or_else(|| theme.get("ui.virtual.whitespace")),
-            ),
+            indent_guide_style: basic_style,
             text_style,
             draw_indent_guides: editor_config.indent_guides.render,
             viewport,
@@ -409,8 +414,16 @@ impl<'a> TextRenderer<'a> {
                 as u16;
             let y = self.viewport.y + row;
             debug_assert!(self.surface.in_bounds(x, y));
+            let style = match self.indent_guide_rainbow {
+                RainbowIndent::None => self.indent_guide_style,
+                RainbowIndent::Dim => self
+                    .indent_guide_style
+                    .patch(self.theme.get_rainbow(i))
+                    .add_modifier(Modifier::DIM),
+                RainbowIndent::Normal => self.indent_guide_style.patch(self.theme.get_rainbow(i)),
+            };
             self.surface
-                .set_string(x, y, &self.indent_guide_char, self.indent_guide_style);
+                .set_string(x, y, &self.indent_guide_char, style)
         }
     }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -334,7 +334,7 @@ impl EditorView {
         .map_or(visible_range.start as u32, |node| node.start_byte());
         let range = start..visible_range.end as u32;
 
-        Some(syntax.rainbow_highlights(text, theme.rainbow_length(), loader, range))
+        Some(syntax.rainbow_highlights(text, theme.rainbow_bracket_length(), loader, range))
     }
 
     /// Get highlight spans for document diagnostics

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -916,11 +916,20 @@ impl Default for WhitespaceCharacters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RainbowIndent {
+    None,
+    Dim,
+    Normal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
     pub skip_levels: u8,
+    pub rainbow_indent: RainbowIndent,
 }
 
 impl Default for IndentGuidesConfig {
@@ -929,6 +938,7 @@ impl Default for IndentGuidesConfig {
             skip_levels: 0,
             render: false,
             character: '│',
+            rainbow_indent: RainbowIndent::None,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -916,20 +916,12 @@ impl Default for WhitespaceCharacters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum RainbowIndent {
-    None,
-    Dim,
-    Normal,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct IndentGuidesConfig {
     pub render: bool,
     pub character: char,
     pub skip_levels: u8,
-    pub rainbow_indent: RainbowIndent,
+    pub rainbow: bool,
 }
 
 impl Default for IndentGuidesConfig {
@@ -938,7 +930,7 @@ impl Default for IndentGuidesConfig {
             skip_levels: 0,
             render: false,
             character: '│',
-            rainbow_indent: RainbowIndent::None,
+            rainbow: false,
         }
     }
 }

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -426,6 +426,10 @@ impl Theme {
         self.rainbow_length
     }
 
+    pub fn get_rainbow(&self, index: usize) -> Style {
+        self.highlights[index % self.rainbow_length]
+    }
+
     fn from_toml(value: Value) -> (Self, Vec<String>) {
         if let Value::Table(table) = value {
             Theme::from_keys(table)

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -227,7 +227,8 @@ pub struct Theme {
     // tree-sitter highlight styles are stored in a Vec to optimize lookups
     scopes: Vec<String>,
     highlights: Vec<Style>,
-    rainbow_length: usize,
+    rainbow_bracket_length: usize,
+    rainbow_indent_length: usize,
 }
 
 impl From<Value> for Theme {
@@ -262,12 +263,14 @@ fn build_theme_values(
     Vec<String>,
     Vec<Style>,
     usize,
+    usize,
     Vec<String>,
 ) {
     let mut styles = HashMap::new();
     let mut scopes = Vec::new();
     let mut highlights = Vec::new();
-    let mut rainbow_length = 0;
+    let mut rainbow_bracket_length = 0;
+    let mut rainbow_indent_length = 0;
 
     let mut warnings = Vec::new();
 
@@ -287,8 +290,10 @@ fn build_theme_values(
     scopes.reserve(values.len());
     highlights.reserve(values.len());
 
+    let rainbow = values.remove("rainbow");
     for (i, style) in values
-        .remove("rainbow")
+        .remove("rainbow-brackets")
+        .or(rainbow.clone())
         .and_then(|value| match palette.parse_style_array(value) {
             Ok(styles) => Some(styles),
             Err(err) => {
@@ -300,11 +305,32 @@ fn build_theme_values(
         .into_iter()
         .enumerate()
     {
-        let name = format!("rainbow.{i}");
+        let name = format!("rainbow-bracket.{i}");
         styles.insert(name.clone(), style);
         scopes.push(name);
         highlights.push(style);
-        rainbow_length += 1;
+        rainbow_bracket_length += 1;
+    }
+    for (i, style) in values
+        .remove("rainbow-indents")
+        .or(rainbow.clone())
+        .and_then(|value| match palette.parse_style_array(value) {
+            Ok(styles) => Some(styles),
+            Err(err) => {
+                warnings.push(err);
+                None
+            }
+        })
+        // indent guides should be dimmer than brackets, by default.
+        .unwrap_or_else(|| dim(default_rainbow()))
+        .into_iter()
+        .enumerate()
+    {
+        let name = format!("rainbow-indent.{i}");
+        styles.insert(name.clone(), style);
+        scopes.push(name);
+        highlights.push(style);
+        rainbow_indent_length += 1;
     }
 
     for (name, style_value) in values {
@@ -319,7 +345,14 @@ fn build_theme_values(
         highlights.push(style);
     }
 
-    (styles, scopes, highlights, rainbow_length, warnings)
+    (
+        styles,
+        scopes,
+        highlights,
+        rainbow_bracket_length,
+        rainbow_indent_length,
+        warnings,
+    )
 }
 
 fn default_rainbow() -> Vec<Style> {
@@ -332,6 +365,14 @@ fn default_rainbow() -> Vec<Style> {
         Style::default().fg(Color::Magenta),
     ]
 }
+
+fn dim(styles: Vec<Style>) -> Vec<Style> {
+    styles
+        .into_iter()
+        .map(|s| s.add_modifier(Modifier::DIM))
+        .collect()
+}
+
 impl Theme {
     /// To allow `Highlight` to represent arbitrary RGB colors without turning it into an enum,
     /// we interpret the last 256^3 numbers as RGB.
@@ -422,12 +463,16 @@ impl Theme {
         })
     }
 
-    pub fn rainbow_length(&self) -> usize {
-        self.rainbow_length
+    pub fn rainbow_bracket_length(&self) -> usize {
+        self.rainbow_bracket_length
     }
 
-    pub fn get_rainbow(&self, index: usize) -> Style {
-        self.highlights[index % self.rainbow_length]
+    pub fn get_bracket_rainbow(&self, index: usize) -> Style {
+        self.highlights[index % self.rainbow_bracket_length]
+    }
+
+    pub fn get_indent_rainbow(&self, index: usize) -> Style {
+        self.highlights[(index % self.rainbow_indent_length) + self.rainbow_bracket_length]
     }
 
     fn from_toml(value: Value) -> (Self, Vec<String>) {
@@ -440,14 +485,21 @@ impl Theme {
     }
 
     fn from_keys(toml_keys: Map<String, Value>) -> (Self, Vec<String>) {
-        let (styles, scopes, highlights, rainbow_length, load_errors) =
-            build_theme_values(toml_keys);
+        let (
+            styles,
+            scopes,
+            highlights,
+            rainbow_bracket_length,
+            rainbow_indent_length,
+            load_errors,
+        ) = build_theme_values(toml_keys);
 
         let theme = Self {
             styles,
             scopes,
             highlights,
-            rainbow_length,
+            rainbow_bracket_length,
+            rainbow_indent_length,
             ..Default::default()
         };
         (theme, load_errors)


### PR DESCRIPTION
Supercedes #4056 and #4493. Closes #4010.

This PR is a rebase of #4493 now that #13530 has been merged. It adds a `rainbow-indent` option to the `[editor.indent-guides]` configuration, taking three values: `"none"` (default), `"dim"`, or `"normal"`.

Rendered (normal, dim):
<img width="auto" height="200" alt="2025-07-29-025824" src="https://github.com/user-attachments/assets/27eb728c-f905-47c8-971c-52a8a0a590ef" /> <img width="auto" height="200" alt="2025-07-29-025828" src="https://github.com/user-attachments/assets/a3f8b3ed-4446-4eef-b73f-57eb71250b2a" />
