### PR TITLE
feat: add overtype edit mode

### DIFF
--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -753,6 +753,12 @@ impl Transaction {
         })
     }
 
+    pub fn replace(doc: &Rope, selection: &Selection, text: Tendril) -> Self {
+        Self::change_by_selection(doc, selection, |range| {
+            (range.from(), range.to(), Some(text.clone()))
+        })
+    }
+
     pub fn changes_iter(&self) -> ChangeIterator {
         self.changes.changes_iter()
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -355,6 +355,7 @@ impl MappableCommand {
         extend_prev_char, "Extend to previous occurrence of char",
         repeat_last_motion, "Repeat last motion",
         replace, "Replace with new char",
+        overtype_mode, "Enter overtype mode",
         switch_case, "Switch (toggle) case",
         switch_to_uppercase, "Switch to uppercase",
         switch_to_lowercase, "Switch to lowercase",
@@ -3026,6 +3027,29 @@ fn insert_mode(cx: &mut Context) {
     doc.set_selection(view.id, selection);
 }
 
+fn enter_overtype_mode(cx: &mut Context) {
+    cx.editor.mode = Mode::Overtype;
+}
+
+// inserts at the start of each selection
+fn overtype_mode(cx: &mut Context) {
+    enter_overtype_mode(cx);
+    let (view, doc) = current!(cx.editor);
+
+    log::trace!(
+        "entering replace mode with sel: {:?}, text: {:?}",
+        doc.selection(view.id),
+        doc.text().to_string()
+    );
+
+    let selection = doc
+        .selection(view.id)
+        .clone()
+        .transform(|range| Range::new(range.to(), range.from()));
+
+    doc.set_selection(view.id, selection);
+}
+
 // inserts at the end of each selection
 fn append_mode(cx: &mut Context) {
     enter_insert_mode(cx);
@@ -4137,7 +4161,7 @@ pub mod insert {
         Some(transaction)
     }
 
-    use helix_core::auto_pairs;
+    use helix_core::{auto_pairs, graphemes::nth_next_grapheme_boundary};
     use helix_view::editor::SmartTabConfig;
 
     pub fn insert_char(cx: &mut Context, c: char) {
@@ -4157,6 +4181,23 @@ pub mod insert {
         }
 
         helix_event::dispatch(PostInsertChar { c, cx });
+    }
+
+    pub fn replace_char(cx: &mut Context, c: char) {
+        let (view, doc) = current!(cx.editor);
+        let text = doc.text();
+        let selection = doc.selection(view.id);
+        let slice = text.slice(..);
+        let selection_update = selection.clone().transform(|range| {
+            let new_pos = nth_next_grapheme_boundary(slice, range.cursor(slice), 1);
+            range.put_cursor(slice, new_pos, false)
+        });
+        let mut t = Tendril::new();
+        t.push(c);
+        let transaction = Transaction::replace(text, &selection, t);
+        doc.apply(&transaction, view.id);
+        doc.append_changes_to_history(view);
+        doc.set_selection(view.id, selection_update);
     }
 
     pub fn smart_tab(cx: &mut Context) {
@@ -4776,7 +4817,7 @@ pub(crate) fn paste_bracketed_value(cx: &mut Context, contents: String) {
     let count = cx.count();
     let paste = match cx.editor.mode {
         Mode::Insert | Mode::Select => Paste::Cursor,
-        Mode::Normal => Paste::Before,
+        Mode::Normal | Mode::Overtype => Paste::Before,
     };
     let (view, doc) = current!(cx.editor);
     paste_impl(&[contents], doc, view, paste, count, cx.editor.mode);

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -338,6 +338,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
         "C-a" => increment,
         "C-x" => decrement,
+        "ins" => insert_mode,
+        "C-r" => overtype_mode,
     });
     let mut select = normal.clone();
     select.merge_nodes(keymap!({ "Select mode"
@@ -404,9 +406,31 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "home" => goto_line_start,
         "end" => goto_line_end_newline,
     });
+    let overtype = keymap!({ "Overtype mode"
+        "ins" => insert_mode,
+        "esc" => normal_mode,
+
+        "C-s" => commit_undo_checkpoint,
+
+        "C-w" | "A-backspace" => delete_word_backward,
+        "A-d" | "A-del" => delete_word_forward,
+        "C-h" | "backspace" | "S-backspace" => delete_char_backward,
+        "C-d" | "del" => delete_char_forward,
+        "C-j" | "ret" => insert_newline,
+
+        "up" => move_visual_line_up,
+        "down" => move_visual_line_down,
+        "left" => move_char_left,
+        "right" => move_char_right,
+        "pageup" => page_up,
+        "pagedown" => page_down,
+        "home" => goto_line_start,
+        "end" => goto_line_end_newline,
+    });
     hashmap!(
         Mode::Normal => normal,
         Mode::Select => select,
         Mode::Insert => insert,
+        Mode::Overtype => overtype,
     )
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -169,6 +169,7 @@ where
     let modenames = &config.statusline.mode;
     let mode_str = match context.editor.mode() {
         Mode::Insert => &modenames.insert,
+        Mode::Overtype => &modenames.overtype,
         Mode::Select => &modenames.select,
         Mode::Normal => &modenames.normal,
     };
@@ -181,6 +182,7 @@ where
     let style = if visible && config.color_modes {
         match context.editor.mode() {
             Mode::Insert => context.editor.theme.get("ui.statusline.insert"),
+            Mode::Overtype => context.editor.theme.get("ui.statusline.overtype"),
             Mode::Select => context.editor.theme.get("ui.statusline.select"),
             Mode::Normal => context.editor.theme.get("ui.statusline.normal"),
         }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -66,6 +66,7 @@ pub enum Mode {
     Normal = 0,
     Select = 1,
     Insert = 2,
+    Overtype = 3,
 }
 
 impl Display for Mode {
@@ -74,6 +75,7 @@ impl Display for Mode {
             Mode::Normal => f.write_str("normal"),
             Mode::Select => f.write_str("select"),
             Mode::Insert => f.write_str("insert"),
+            Mode::Overtype => f.write_str("overtype"),
         }
     }
 }
@@ -86,6 +88,7 @@ impl FromStr for Mode {
             "normal" => Ok(Mode::Normal),
             "select" => Ok(Mode::Select),
             "insert" => Ok(Mode::Insert),
+            "overtype" => Ok(Mode::Overtype),
             _ => bail!("Invalid mode '{}'", s),
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -560,6 +560,7 @@ impl Default for StatusLineConfig {
 pub struct ModeConfig {
     pub normal: String,
     pub insert: String,
+    pub overtype: String,
     pub select: String,
 }
 
@@ -568,6 +569,7 @@ impl Default for ModeConfig {
         Self {
             normal: String::from("NOR"),
             insert: String::from("INS"),
+            overtype: String::from("OVR"),
             select: String::from("SEL"),
         }
     }
@@ -649,7 +651,7 @@ pub enum StatusLineElement {
 // Cursor shape is read and used on every rendered frame and so needs
 // to be fast. Therefore we avoid a hashmap and use an enum indexed array.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CursorShapeConfig([CursorKind; 3]);
+pub struct CursorShapeConfig([CursorKind; 4]);
 
 impl CursorShapeConfig {
     pub fn from_mode(&self, mode: Mode) -> CursorKind {
@@ -668,6 +670,7 @@ impl<'de> Deserialize<'de> for CursorShapeConfig {
             into_cursor(Mode::Normal),
             into_cursor(Mode::Select),
             into_cursor(Mode::Insert),
+            into_cursor(Mode::Overtype),
         ]))
     }
 }
@@ -678,7 +681,7 @@ impl Serialize for CursorShapeConfig {
         S: serde::Serializer,
     {
         let mut map = serializer.serialize_map(Some(self.len()))?;
-        let modes = [Mode::Normal, Mode::Select, Mode::Insert];
+        let modes = [Mode::Normal, Mode::Select, Mode::Insert, Mode::Overtype];
         for mode in modes {
             map.serialize_entry(&mode, &self.from_mode(mode))?;
         }
@@ -687,7 +690,7 @@ impl Serialize for CursorShapeConfig {
 }
 
 impl std::ops::Deref for CursorShapeConfig {
-    type Target = [CursorKind; 3];
+    type Target = [CursorKind; 4];
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -696,7 +699,7 @@ impl std::ops::Deref for CursorShapeConfig {
 
 impl Default for CursorShapeConfig {
     fn default() -> Self {
-        Self([CursorKind::Block; 3])
+        Self([CursorKind::Block; 4])
     }
 }
 


### PR DESCRIPTION
pretty much directly lifted from
https://github.com/helix-editor/helix/pull/11265

all credit for the implementation goes to noktoborus, i only ported it to latest master commit

implements #5843

overall i was interested in this feature because it genuinely helps quite a bit for ASCII art, which i enjoy using helix for.
without this feature, if i wanted to insert a word in the art, i'd have to either manually count how many characters there are in said word or spell it out while selecting, then click `C`, then type the word in. it's not that bad for smaller words, but it does break the flow quite a bit, especially if you need to insert an entire sentence.

obviously, it also helps with drawing in-place. i usually click `r` before every character i place, which is fine most of the time, but if there's a pattern i need to repeat (for example a mirrored side of an item), then it would be quite nice to be able to just type it in instead of clicking `r` before each character like previously.

changes from the original pull:
- to enter overtype, do `C-r` when in normal or select mode.