### PR TITLE
docs: Correct expansion argument formatting

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -111,7 +111,7 @@ of the formatter command. In particular, the `%{buffer_name}` variable can be pa
 argument to the formatter:
 
 ```toml
-formatter = { command = "mylang-formatter" , args = ["--stdin", "--stdin-filename %{buffer_name}"] }
+formatter = { command = "mylang-formatter" , args = ["--stdin", "--stdin-filename", "%{buffer_name}"] }
 ```
 
 ## Language Server configuration


### PR DESCRIPTION
The example will result in a two arguments being passed to the formatter: `--stdin` and `--stdin-filename %{buffer_name}`. Most command line parsers expect option values as separate arguments so the second argument should be split into two `--stdin-filename` and `%{buffer_name}` for three arguments in total.