### PR TITLE
feat: add `%quote{}` expansion

### DIFF
--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -60,6 +60,7 @@ Aside from editor variables, the following expansions may be used:
 * Unicode `%u{..}`. The contents may contain up to six hexadecimal numbers corresponding to a Unicode codepoint value. For example `:echo %u{25CF}` prints `●` to the statusline.
 * Shell `%sh{..}`. The contents are passed to the configured shell command. For example `:echo %sh{echo "20 * 5" | bc}` may print `100` on the statusline on when using a shell with `echo` and the `bc` calculator installed. Shell expansions are evaluated recursively. `%sh{echo '%{buffer_name}:%{cursor_line}'}` for example executes a command like `echo 'README.md:1'`: the variables within the `%sh{..}` expansion are evaluated before executing the shell command.
 * Register `%reg{..}`. The contents should be a single character representing the register name. For example, `:set-register a hello world` followed by `echo %reg{a}` prints `hello world` to the statusline.
+* Quote `%quote{..}`. The contents are surrounded with double quotes(`"`), and escapes internal backslashes(`\`) and double quotes(`"`), so that the result is a valid string literal. For example, `:echo %quote{"'"="foo"}` will print `"\"'\"=\"foo\""` to the statusline.
 
 As mentioned above, double quotes can be used to surround arguments containing spaces but also support expansions within the quoted content unlike single quotes or backticks. For example `:echo "circle: %u{25CF}"` prints `circle: ●` to the statusline while `:echo 'circle: %u{25CF}'` prints `circle: %u{25CF}`.
 

--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -257,11 +257,20 @@ pub enum ExpansionKind {
     ///
     /// For example `%reg{a}`.
     Register,
+    /// Quotes token's contents with double quotes, and escapes according to standard escaping conventions.
+    ///
+    /// For example, `%quote{ "'"="foo" }` -> `"\"'\"=foo\""`.
+    Quote,
 }
 
 impl ExpansionKind {
-    pub const VARIANTS: &'static [Self] =
-        &[Self::Variable, Self::Unicode, Self::Shell, Self::Register];
+    pub const VARIANTS: &'static [Self] = &[
+        Self::Variable,
+        Self::Unicode,
+        Self::Shell,
+        Self::Register,
+        Self::Quote,
+    ];
 
     pub const fn as_str(&self) -> &'static str {
         match self {
@@ -269,6 +278,7 @@ impl ExpansionKind {
             Self::Unicode => "u",
             Self::Shell => "sh",
             Self::Register => "reg",
+            Self::Quote => "quote",
         }
     }
 
@@ -278,6 +288,7 @@ impl ExpansionKind {
             "u" => Some(Self::Unicode),
             "sh" => Some(Self::Shell),
             "reg" => Some(Self::Register),
+            "quote" => Some(Self::Quote),
             _ => None,
         }
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -4260,10 +4260,10 @@ pub fn complete_command_args(
         TokenKind::Expansion(ExpansionKind::Variable) => {
             complete_variable_expansion(&token.content, offset + token.content_start)
         }
-        TokenKind::Expansion(ExpansionKind::Unicode) => Vec::new(),
         TokenKind::Expansion(ExpansionKind::Register) => {
             complete_register_expansion(editor, &token.content, offset + token.content_start)
         }
+        TokenKind::Expansion(ExpansionKind::Unicode | ExpansionKind::Quote) => Vec::new(),
         TokenKind::ExpansionKind => {
             complete_expansion_kind(&token.content, offset + token.content_start)
         }

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -126,6 +126,11 @@ pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
                 ))
             }
         }
+        TokenKind::Expansion(ExpansionKind::Quote) => Ok(Cow::Owned({
+            let expanded = expand_inner(editor, token.content)?;
+            let escaped = escape(&expanded);
+            format!("\"{escaped}\"")
+        })),
         TokenKind::Expand => expand_inner(editor, token.content),
         TokenKind::Expansion(ExpansionKind::Shell) => expand_shell(editor, token.content),
         TokenKind::Expansion(ExpansionKind::Register) => expand_register(editor, token.content),
@@ -134,6 +139,24 @@ pub fn expand<'a>(editor: &Editor, token: Token<'a>) -> Result<Cow<'a, str>> {
             "expansion name tokens cannot be emitted when command line validation is enabled"
         ),
     }
+}
+
+fn escape(string: &str) -> Cow<'_, str> {
+    if !string.contains('"') && !string.contains('\\') {
+        return Cow::Borrowed(string);
+    }
+
+    let mut escaped = String::new();
+
+    for ch in string.chars() {
+        match ch {
+            '"' => escaped.push_str(r#"\""#),
+            '\\' => escaped.push_str(r"\\"),
+            _ => escaped.push(ch),
+        }
+    }
+
+    Cow::Owned(escaped)
 }
 
 /// Expand a shell command.
@@ -303,5 +326,25 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             let end_line = doc.selection(view.id).primary().line_range(text).1;
             Ok(Cow::Owned((end_line + 1).to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn should_escape_only_double_quotes() {
+        assert_eq!(r#"\"'\"=\"foo\""#, escape(r#""'"="foo""#));
+    }
+
+    #[test]
+    fn should_escape_double_quotes_and_backslashes() {
+        assert_eq!(r#"\"'\"=\"f\\oo\""#, escape(r#""'"="f\oo""#));
+    }
+
+    #[test]
+    fn should_escape_double_quotes_and_backslashes_and_leave_spaces_alone() {
+        assert_eq!(r#"\"'\"=\"f\\o o\""#, escape(r#""'"="f\o o""#));
     }
 }


### PR DESCRIPTION
Not sure if this is the best solution, but thought it could be a path that could work. This is an alternative solution to the `%{selection:esc}` one offered in #14126.

`%quote{}` will take the tokens inside it and wrap them in double quotes and escape the tokens accordingly to ensure its a valid string according to standard(?) shell conventions.

One big benefit to this approach is the encoded expectation of using double quotes. With `%{selection:esc}`, you have to decide which quotes you use to wrap and escape those in the `esc` logic. That is not the case with this implementation, as it always picks double quotes to wrap, and therefore knows the escaping rules.. 

For example, `%quote{ "'"="foo" }` should yield `"\"'\"=\"foo\""`. This escapes knowing that it will be wrapped in double quotes. `%quote{ "f\oo" }` would yield `"\"f\\oo\""`, escaping the backslash.

<img width="468" height="221" alt="image" src="https://github.com/user-attachments/assets/15a3b31f-7693-40fc-8546-6db08c8ba02b" />

it would be nice to test this on Windows, as well as with more test cases added to the `test` module.

Resolves: #14126