### PR TITLE
feat: dim text in unfocused views or while jumping to labels

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -70,6 +70,7 @@
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
+| `enable-focus-dimmer` |  Whether to dim text in unfocused views or while jumping to labels. | `false` |
 
 ### `[editor.clipboard-provider]` Section
 

--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -37,12 +37,19 @@ pub enum GraphemeSource {
     VirtualText {
         highlight: Option<Highlight>,
     },
+    Annotation {
+        codepoints: u32,
+    },
 }
 
 impl GraphemeSource {
     /// Returns whether this grapheme is virtual inline text
     pub fn is_virtual(self) -> bool {
         matches!(self, GraphemeSource::VirtualText { .. })
+    }
+
+    pub fn is_annotation(self) -> bool {
+        matches!(self, GraphemeSource::Annotation { .. })
     }
 
     pub fn is_eof(self) -> bool {
@@ -53,6 +60,7 @@ impl GraphemeSource {
     pub fn doc_chars(self) -> usize {
         match self {
             GraphemeSource::Document { codepoints } => codepoints as usize,
+            GraphemeSource::Annotation { codepoints } => codepoints as usize,
             GraphemeSource::VirtualText { .. } => 0,
         }
     }
@@ -266,12 +274,16 @@ impl<'t> DocumentFormatter<'t> {
                 let codepoints = grapheme.len_chars() as u32;
 
                 let overlay = self.annotations.overlay_at(char_pos);
-                let grapheme = match overlay {
-                    Some((overlay, _)) => overlay.grapheme.as_str().into(),
-                    None => Cow::from(grapheme).into(),
-                };
-
-                (grapheme, GraphemeSource::Document { codepoints })
+                match overlay {
+                    Some((overlay, _)) => (
+                        overlay.grapheme.as_str().into(),
+                        GraphemeSource::Annotation { codepoints },
+                    ),
+                    None => (
+                        Cow::from(grapheme).into(),
+                        GraphemeSource::Document { codepoints },
+                    ),
+                }
             } else {
                 if self.exhausted {
                     return None;

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -157,7 +157,7 @@ pub fn render_text(
                 syntax_style: style,
                 overlay_style: Style::default(),
             }
-        } else if is_focused || !renderer.dimmer_enabled {
+        } else if is_focused || grapheme.source.is_annotation() || !renderer.dimmer_enabled {
             GraphemeStyle {
                 syntax_style: syntax_highlighter.style,
                 overlay_style: overlay_highlighter.style,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -205,7 +205,9 @@ impl EditorView {
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
         ));
+        let view_id = view.id;
         render_document(
+            Some(view_id),
             surface,
             inner,
             doc,
@@ -215,6 +217,7 @@ impl EditorView {
             overlays,
             theme,
             decorations,
+            is_focused,
         );
 
         // if we're not at the edge of the screen, draw a right border

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1009,6 +1009,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             }
 
             render_document(
+                None,
                 surface,
                 inner,
                 doc,
@@ -1019,6 +1020,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 overlay_highlights,
                 &cx.editor.theme,
                 decorations,
+                true,
             );
         }
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2399,6 +2399,12 @@ impl Document {
         self.document_highlight_controllers
             .entry(view_id)
             .or_default()
+    pub fn has_jump_labels(&self, view_id: ViewId) -> bool {
+        !self
+            .jump_labels
+            .get(&view_id)
+            .unwrap_or(&Vec::new())
+            .is_empty()
     }
 
     /// Get the inlay hints for this document and `view_id`.

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2399,6 +2399,8 @@ impl Document {
         self.document_highlight_controllers
             .entry(view_id)
             .or_default()
+    }
+
     pub fn has_jump_labels(&self, view_id: ViewId) -> bool {
         !self
             .jump_labels

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -469,6 +469,8 @@ pub enum KittyKeyboardProtocolConfig {
     Auto,
     Disabled,
     Enabled,
+    /// Whether to dim text in unfocused views or while jumping to labels.
+    pub enable_focus_dimmer: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -1157,6 +1159,7 @@ impl Default for Config {
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
             insecure: false,
+            enable_focus_dimmer: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -434,6 +434,8 @@ pub struct Config {
     pub buffer_picker: BufferPickerConfig,
     /// Whether to implicitly trust every workspace or not
     pub insecure: bool,
+    /// Whether to dim text in unfocused views or while jumping to labels.
+    pub enable_focus_dimmer: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -469,8 +471,6 @@ pub enum KittyKeyboardProtocolConfig {
     Auto,
     Disabled,
     Enabled,
-    /// Whether to dim text in unfocused views or while jumping to labels.
-    pub enable_focus_dimmer: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
I prefer having text in inactive panes dimmed, so I added `enable-focus-dimmer` as a configuration option to dim text in unfocused views or while jumping to labels:

https://github.com/user-attachments/assets/3604b15d-d248-45a4-9b4f-9ffda238a270

This is working well with `st` terminal emulator but will require more testing in various environments and use-cases.

Let me know how you think this can be improved.