### PR TITLE
add partial uiua support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -259,7 +259,7 @@
 | typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | typespec | ✓ | ✓ | ✓ |  |  | `tsp-server` |
 | typst | ✓ |  |  | ✓ |  | `tinymist` |
-| uiua |  |  |  |  |  |  |
+| uiua | ✓ |  |  |  |  | `uiua` |
 | ungrammar | ✓ |  |  |  |  |  |
 | unison | ✓ | ✓ | ✓ |  |  |  |
 | uxntal | ✓ |  |  |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -259,6 +259,7 @@
 | typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | typespec | ✓ | ✓ | ✓ |  |  | `tsp-server` |
 | typst | ✓ |  |  | ✓ |  | `tinymist` |
+| uiua |  |  |  |  |  |  |
 | ungrammar | ✓ |  |  |  |  |  |
 | unison | ✓ | ✓ | ✓ |  |  |  |
 | uxntal | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -152,6 +152,7 @@ teal-language-server = { command = "teal-language-server" }
 wasm-language-tools = { command = "wat_server" }
 sourcepawn-studio = { command = "sourcepawn-studio" }
 luau = { command = "luau-lsp", args = ["lsp"] }
+uiua-lsp = { command = "uiua", args = ["lsp"] }
 
 [language-server.ansible-language-server]
 command = "ansible-language-server"
@@ -4628,3 +4629,20 @@ comment-token = "#"
 [[grammar]]
 name = "robots"
 source = { git = "https://github.com/opa-oz/tree-sitter-robots-txt", rev = "8e3a4205b76236bb6dbebdbee5afc262ce38bb62" }
+
+[[language]]
+name = "uiua"
+scope = "source.uiua"
+language-servers = ["uiua-lsp"]
+injection-regex = "uiua"
+file-types = ["ua"]
+auto-format = true
+comment-token = "#"
+shebangs = ["uiua"]
+indent = { tab-width = 2, unit = "  " }
+auto-pairs = { "(" = ")", "[" = "]", "{" = "}" }
+formatter = { command = "uiua", args = ["fmt", "--io"] }
+
+[[grammar]]
+name = "uiua"
+source = { git = "https://github.com/magistau/tree-sitter-uiua", rev = "8abe2379c33d08fbf850629676a53ce50189acaa" }

--- a/runtime/queries/uiua/highlights.scm
+++ b/runtime/queries/uiua/highlights.scm
@@ -4,10 +4,6 @@
 
 (identifier) @variable
 
-(binding
-  (identifier) @variable.definition
-)
-
 (builtin_func0) @constant
 (builtin_func1) @function.builtin
 (builtin_func2) @operator

--- a/runtime/queries/uiua/highlights.scm
+++ b/runtime/queries/uiua/highlights.scm
@@ -1,0 +1,23 @@
+(comment) @comment
+(string) @string
+(number) @constant.numeric
+
+(identifier) @variable
+
+(binding
+  (identifier) @variable.definition
+)
+
+(builtin_func0) @constant
+(builtin_func1) @function.builtin
+(builtin_func2) @operator
+; (builtin_func3)
+
+(builtin_macro1) @function.macro
+(builtin_macro2) @keyword
+; (builtin_macro3)
+
+(func (_)) @function
+
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+["|" "_"] @punctuation.delimiter


### PR DESCRIPTION
"partial" because:
- the tree-sitter grammar isn't done yet, and is a bit annoying to work with (for example i don't think it's possible to write any/most of the other queries)
- diagnostics don't work (i'm unsure if `uiua lsp` provides them in a way helix can use)