### PR TITLE
feat: add `pip-requirements` language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -185,6 +185,7 @@
 | pest | ✓ | ✓ | ✓ |  |  | `pest-language-server` |
 | php | ✓ | ✓ | ✓ | ✓ |  | `intelephense` |
 | php-only | ✓ |  |  | ✓ |  |  |
+| pip-requirements | ✓ |  |  |  |  |  |
 | pkgbuild | ✓ | ✓ | ✓ |  |  | `termux-language-server`, `bash-language-server` |
 | pkl | ✓ |  | ✓ |  |  | `pkl-lsp` |
 | po | ✓ | ✓ |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4628,3 +4628,14 @@ comment-token = "#"
 [[grammar]]
 name = "robots"
 source = { git = "https://github.com/opa-oz/tree-sitter-robots-txt", rev = "8e3a4205b76236bb6dbebdbee5afc262ce38bb62" }
+
+[[language]]
+name = "pip-requirements"
+scope = "source.pip-requirements"
+injection-regex = "(pip-)?requirements(\\.txt)?"
+grammar = "requirements"
+file-types = [{ glob = "requirements.txt" }, { glob = "constraints.txt" }]
+
+[[grammar]]
+name = "requirements"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-requirements", rev = "caeb2ba854dea55931f76034978de1fd79362939" }

--- a/runtime/queries/pip-requirements/highlights.scm
+++ b/runtime/queries/pip-requirements/highlights.scm
@@ -1,0 +1,41 @@
+(comment) @comment
+
+(requirement (package) @variable)
+(extras (package) @variable.parameter)
+
+; "==" | ">" | "<" | ">=" | "<="
+(version_cmp) @operator
+
+(version) @constant.numeric
+
+(marker_var) @attribute
+
+(marker_op) @keyword.operator
+
+[
+  "[" "]"
+  "(" ")"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  "@"
+] @punctuation.delimiter
+
+[
+  "${" "}"
+] @punctuation.special
+
+"=" @operator
+
+(path) @string.special.path
+(url) @string.special.url
+
+(option) @function
+
+(env_var) @constant
+
+(quoted_string) @string
+
+(linebreak) @constant.character.escape

--- a/runtime/queries/pip-requirements/injections.scm
+++ b/runtime/queries/pip-requirements/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Add the [pip requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/) format commonly known as just `requirements.txt`.

**Showcase**

<img width="1621" height="723" alt="image" src="https://github.com/user-attachments/assets/5b4385f3-f5d3-46dd-9605-aaf19c64cf9a" />

