### PR TITLE
add rust-analyzer component to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.82.0"
-components = ["rustfmt", "rust-src", "clippy"]
+components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]


### PR DESCRIPTION
This automatically configures `rust-analyzer` to be added as a component in the specified toolchain, removing the need for it to be manually added during the initial toolchain install

```
rustup toolchain install
rustup component add rust-analyzer // <-- no longer needed
```