### PR TITLE
languages: Add doc comment token for C#

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -675,7 +675,7 @@ scope = "source.csharp"
 injection-regex = "c-?sharp"
 file-types = ["cs", "csx", "cake"]
 roots = ["sln", "csproj"]
-comment-token = "//"
+comment-tokens = ["//", "///"]
 block-comment-tokens = { start = "/*", end = "*/" }
 indent = { tab-width = 4, unit = "\t" }
 language-servers = [ "omnisharp" ]


### PR DESCRIPTION
Simple change, `///` is commonly used for doc comments in C# and that isn't currently being respected.