### PR TITLE
feat: update go grammar and queries

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3733,7 +3733,7 @@ language-servers = [ "templ" ]
 
 [[grammar]]
 name = "templ"
-source = { git = "https://github.com/vrischmann/tree-sitter-templ", rev = "db662414ccd6f7c78b1e834e7abe11c224b04759" }
+source = { git = "https://github.com/vrischmann/tree-sitter-templ", rev = "47594c5cbef941e6a3ccf4ddb934a68cf4c68075" }
 
 [[language]]
 name = "dbml"

--- a/languages.toml
+++ b/languages.toml
@@ -779,7 +779,7 @@ args = { mode = "core", program = "{0}", coreFilePath = "{1}" }
 
 [[grammar]]
 name = "go"
-source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "64457ea6b73ef5422ed1687178d4545c3e91334a" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "12fe553fdaaa7449f764bc876fd777704d4fb752" }
 
 [[language]]
 name = "gomod"

--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -10,7 +10,7 @@
 (const_spec
   name: (identifier) @constant)
 
-(type_spec 
+(type_spec
   name: (type_identifier) @constructor)
 
 (keyed_element . (literal_element (identifier) @variable.other.member))
@@ -36,14 +36,14 @@
 
 (call_expression
   function: (identifier) @function.builtin
-  (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+  (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover|min|max|clear)$"))
 
 ; Types
 
 (type_identifier) @type
 
 (type_parameter_list
-  (parameter_declaration
+  (type_parameter_declaration
     name: (identifier) @type.parameter))
 
 ((type_identifier) @type.builtin
@@ -57,9 +57,8 @@
 (method_declaration
   name: (field_identifier) @function.method)
 
-(method_spec 
-  name: (field_identifier) @function.method) 
-
+(method_elem
+  name: (field_identifier) @function.method)
 
 ; Operators
 
@@ -100,6 +99,8 @@
   "|"
   "|="
   "||"
+  "&^"
+  "&^="
   "~"
 ] @operator
 
@@ -117,7 +118,7 @@
 ] @keyword.control
 
 [
-  "if"  
+  "if"
   "else"
   "switch"
   "select"

--- a/runtime/queries/go/textobjects.scm
+++ b/runtime/queries/go/textobjects.scm
@@ -12,7 +12,7 @@
   (type_spec (type_identifier) (struct_type (field_declaration_list (_)?) @class.inside))) @class.around
 
 (type_declaration
-  (type_spec (type_identifier) (interface_type (method_spec)+ @class.inside))) @class.around
+  (type_spec (type_identifier) (interface_type (method_elem)+ @class.inside))) @class.around
 
 (type_parameter_list
   ((_) @parameter.inside . ","? @parameter.around) @parameter.around)


### PR DESCRIPTION
Updated grammar.
Added builtins: `min`, `max`, `clear`.
Added operators: `&^`, `&^=`.
Had to update templ grammar too because it inherits golang highlights.scm.