### PR TITLE
Fix misleading error messages for goto LSP commands

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -900,14 +900,6 @@ where
         })
         .collect();
 
-    let error_msg = match feature {
-        LanguageServerFeature::GotoDeclaration => "No declaration found.",
-        LanguageServerFeature::GotoDefinition => "No definition found.",
-        LanguageServerFeature::GotoTypeDefinition => "No type definition found.",
-        LanguageServerFeature::GotoImplementation => "No implementation found.",
-        _ => "No location found.",
-    };
-
     cx.jobs.callback(async move {
         let mut locations = Vec::new();
         while let Some(response) = futures.next().await {
@@ -943,7 +935,13 @@ where
         }
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
-                editor.set_error(error_msg);
+                editor.set_error(match feature {
+                    LanguageServerFeature::GotoDeclaration => "No declaration found.",
+                    LanguageServerFeature::GotoDefinition => "No definition found.",
+                    LanguageServerFeature::GotoTypeDefinition => "No type definition found.",
+                    LanguageServerFeature::GotoImplementation => "No implementation found.",
+                    _ => "No location found.",
+                });
             } else {
                 goto_impl(editor, compositor, locations);
             }

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -900,6 +900,14 @@ where
         })
         .collect();
 
+    let error_msg = match feature {
+        LanguageServerFeature::GotoDeclaration => "No declaration found.",
+        LanguageServerFeature::GotoDefinition => "No definition found.",
+        LanguageServerFeature::GotoTypeDefinition => "No type definition found.",
+        LanguageServerFeature::GotoImplementation => "No implementation found.",
+        _ => "No location found.",
+    };
+
     cx.jobs.callback(async move {
         let mut locations = Vec::new();
         while let Some(response) = futures.next().await {
@@ -935,7 +943,7 @@ where
         }
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
-                editor.set_error("No definition found.");
+                editor.set_error(error_msg);
             } else {
                 goto_impl(editor, compositor, locations);
             }


### PR DESCRIPTION
 Fixes the confusing UX where pressing `gD`, for example, would show an error about definitions when the command is specifically for declarations.
 
Before:

https://github.com/user-attachments/assets/ec97c7f5-a578-48f3-915d-6211a0dec3ff

After:

https://github.com/user-attachments/assets/0ffc464c-a944-4369-a6da-7a729254d1d1

We can dynamically generate error messages based on the `LanguageServerFeature` type:
  - GotoDeclaration → "No declaration found."
  - GotoDefinition → "No definition found."
  - GotoTypeDefinition → "No type definition found."
  - GotoImplementation → "No implementation found."