### PR TITLE
feat: flatten single-child dirs in file explorer

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -240,6 +240,7 @@ Note that the ignore files consulted by the file explorer when `ignore` is set t
 |`git-ignore` | Enables reading `.gitignore` files | `false`
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `false`
 |`git-exclude` | Enables reading `.git/info/exclude` files | `false`
+|`flatten-dirs` | Enables flattening single child directories | `true`
 
 
 ### `[editor.auto-pairs]` Section

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -402,7 +402,7 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
     Ok(content)
 }
 
-fn get_child_if_single_dir(path: &PathBuf) -> Option<PathBuf> {
+fn get_child_if_single_dir(path: &Path) -> Option<PathBuf> {
     path.read_dir()
         .and_then(|mut entries| {
             let first_entry = entries
@@ -801,19 +801,16 @@ mod tests {
     fn test_get_child_if_single_dir() {
         let root = tempfile::tempdir().unwrap();
 
-        assert_eq!(get_child_if_single_dir(&root.path().to_path_buf()), None);
+        assert_eq!(get_child_if_single_dir(root.path()), None);
 
         let dir = root.path().join("dir1");
         create_dir(&dir).unwrap();
 
-        assert_eq!(
-            get_child_if_single_dir(&root.path().to_path_buf()),
-            Some(dir.to_path_buf())
-        );
+        assert_eq!(get_child_if_single_dir(root.path()), Some(dir));
 
         let file = root.path().join("file");
         File::create(file).unwrap();
 
-        assert_eq!(get_child_if_single_dir(&root.path().to_path_buf()), None);
+        assert_eq!(get_child_if_single_dir(root.path()), None);
     }
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -403,19 +403,13 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
 }
 
 fn get_child_if_single_dir(path: &Path) -> Option<PathBuf> {
-    path.read_dir()
-        .and_then(|mut entries| {
-            let first_entry = entries
-                .next()
-                .unwrap_or(Err(std::io::Error::other("No entry in directory.")));
-            match entries.next() {
-                Some(_) => Err(std::io::Error::other("There is a second entry")),
-                None => first_entry,
-            }
-        })
-        .ok()
-        .filter(|e| e.file_type().is_ok_and(|file_type| file_type.is_dir()))
-        .map(|e| e.path())
+    let mut entries = path.read_dir().ok()?;
+    let entry = entries.next()?.ok()?;
+    if entries.next().is_none() && entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+        Some(entry.path())
+    } else {
+        None
+    }
 }
 
 pub mod completers {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -381,7 +381,7 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
                         .file_type()
                         .is_some_and(|file_type| file_type.is_dir());
                     let mut path = entry.path().to_path_buf();
-                    if is_dir && path != root {
+                    if is_dir && path != root && config.file_explorer.flatten_dirs {
                         while let Some(single_child_directory) = get_child_if_single_dir(&path) {
                             path = single_child_directory;
                         }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -613,8 +613,12 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                             let files = super::directory_content(&path, editor)?;
                             let file_names: Vec<_> = files
                                 .iter()
-                                .filter_map(|(path, is_dir)| {
-                                    let name = path.file_name()?.to_string_lossy();
+                                .filter_map(|(file_path, is_dir)| {
+                                    let name = file_path
+                                        .strip_prefix(&path)
+                                        .map(|p| Some(p.as_os_str()))
+                                        .unwrap_or_else(|_| file_path.file_name())?
+                                        .to_string_lossy();
                                     if *is_dir {
                                         Some((format!("{}/", name), true))
                                     } else {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -221,7 +221,7 @@ impl Default for FilePickerConfig {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FileExplorerConfig {
     /// IgnoreOptions
@@ -229,22 +229,39 @@ pub struct FileExplorerConfig {
     /// Whether to hide hidden files in file explorer and global search results. Defaults to false.
     pub hidden: bool,
     /// Enables following symlinks.
-    /// Whether to follow symbolic links in file picker and file or directory completions. Defaults to true.
+    /// Whether to follow symbolic links in file picker and file or directory completions. Defaults to false.
     pub follow_symlinks: bool,
-    /// Enables reading ignore files from parent directories. Defaults to true.
+    /// Enables reading ignore files from parent directories. Defaults to false.
     pub parents: bool,
     /// Enables reading `.ignore` files.
-    /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to true.
+    /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to false.
     pub ignore: bool,
     /// Enables reading `.gitignore` files.
-    /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to true.
+    /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to false.
     pub git_ignore: bool,
     /// Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-    /// Whether to hide files listed in global .gitignore in file picker and global search results. Defaults to true.
+    /// Whether to hide files listed in global .gitignore in file picker and global search results. Defaults to false.
     pub git_global: bool,
     /// Enables reading `.git/info/exclude` files.
-    /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to true.
+    /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to false.
     pub git_exclude: bool,
+    /// Whether to flatten single-child directories in file explorer. Defaults to true.
+    pub flatten_dirs: bool,
+}
+
+impl Default for FileExplorerConfig {
+    fn default() -> Self {
+        Self {
+            hidden: false,
+            follow_symlinks: false,
+            parents: false,
+            ignore: false,
+            git_ignore: false,
+            git_global: false,
+            git_exclude: false,
+            flatten_dirs: true,
+        }
+    }
 }
 
 fn serialize_alphabet<S>(alphabet: &[char], serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
This implements #14071.

Marked as draft because some things remain to do, such as making this configurable.

Also some potential IO errors are silently ignored, mostly unlikely to append (dir with no child, after it has been count to 1, possible if child dir is suppress after the count…). However, this should at least be tested on different environments (I have tested only on Linux, issues with file read rights can vary on different systems), and maybe better error handling could be made.

Selecting `..` goes only one dir up, so intermediate directories remain accessible.
