### PR TITLE
Make buffer picker default to last file

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3199,9 +3199,11 @@ fn buffer_picker(cx: &mut Context) {
                 .into()
         }),
     ];
+    let initial_cursor = items.len().saturating_sub(1).min(1) as u32;
     let picker = Picker::new(columns, 2, items, (), |cx, meta, action| {
         cx.editor.switch(meta.id, action);
     })
+    .with_initial_cursor(initial_cursor)
     .with_preview(|editor, meta| {
         let doc = &editor.documents.get(&meta.id)?;
         let lines = doc.selections().values().next().map(|selection| {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3199,7 +3199,7 @@ fn buffer_picker(cx: &mut Context) {
                 .into()
         }),
     ];
-    let initial_cursor = items.len().saturating_sub(1).min(1) as u32;
+    let initial_cursor = if items.len() <= 1 { 0 } else { 1 };
     let picker = Picker::new(columns, 2, items, (), |cx, meta, action| {
         cx.editor.switch(meta.id, action);
     })

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -424,6 +424,11 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         self
     }
 
+    pub fn with_initial_cursor(mut self, cursor: u32) -> Self {
+        self.cursor = cursor;
+        self
+    }
+
     pub fn with_dynamic_query(
         mut self,
         callback: DynQueryCallback<T, D>,


### PR DESCRIPTION
When switching files, there is often a need
to swap to the prev file quickly.

This defaults the cursor to the last file if
present instead of keeping it on the current
file which almost always is never picked
as that is the file that is currently being
edited anyway.