### PR TITLE
feat: inject css into standard browser API methods that expect css selector as argument

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -47,3 +47,18 @@
  (#set! injection.language "comment")
  (#match? @injection.content "^//"))
 
+; Match string literals passed to standard browser API methods that expects a
+; css selector as argument.
+; - https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
+; - https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll
+; - https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+; - https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+; e.g.
+; `const el = document.querySelector("div.user-panel.main input[name='login']");`
+(call_expression
+  function: (member_expression
+    object: (identifier) @_object
+    property: (property_identifier) @_property (#any-of? @_property "querySelector" "querySelectorAll" "closest" "matches"))
+  arguments: (arguments
+               (string (string_fragment) @injection.content))
+  (#set! injection.language "css"))


### PR DESCRIPTION
**Showcase**

<img width="971" height="167" alt="image" src="https://github.com/user-attachments/assets/24c5cc50-3f60-4b79-95a5-b0d5d4b942d8" />
