### PR TITLE
Fix: Inhibit signature help when using multiple cursors to prevent obscuring the edits

### DIFF
--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -106,6 +106,11 @@ pub fn request_signature_help(
 ) {
     let (view, doc) = current!(editor);
 
+    // Prevent hiding multiple cursors
+    if doc.selection(view.id).len() > 1 {
+        return;
+    }
+
     // TODO merge multiple language server signature help into one instead of just taking the first language server that supports it
     let future = doc
         .language_servers_with_feature(LanguageServerFeature::SignatureHelp)


### PR DESCRIPTION
When I use multiple cursors to edit inside a function call or a struct, the rendered `SignatureHelp` annoyingly hides my edits:

https://github.com/user-attachments/assets/19962022-f2ee-46f6-9d58-d0e9c54069ad

This PR is suggesting a very simple fix to inhibit showing signature help when more than one selection is detected in the currently viewed document.