### PR TITLE
Improve onedarker theme by adding highlight scopes.

### DIFF
--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -20,6 +20,7 @@
 "keyword.operator" = { fg = "white" }
 "special" = { fg = "blue" }
 "string" = { fg = "green" }
+"tag" = { fg = "purple" }
 "type" = { fg = "yellow" }
 "variable" = { fg = "white" }
 "variable.builtin" = { fg = "red" }
@@ -60,6 +61,7 @@
 "ui.virtual.whitespace" = { fg = "light-gray" }
 "ui.virtual.ruler" = { bg = "gray" }
 "ui.virtual.inlay-hint" = { fg = "light-gray" }
+"ui.virtual.jump-label" = { fg = "gold", modifiers = ["bold", "underlined"] }
 
 "ui.cursor" = { fg = "white", modifiers = ["reversed"] }
 "ui.cursor.primary" = { fg = "white", modifiers = ["reversed"] }


### PR DESCRIPTION
Styling is added for two new scopes in a single commit. I'm happy to split them across commits or cut changes where consensus can't be reached.

`tag` -- tags didn't stand out very well from text. Note how `<title>Helix</title>` blends together.

Before:
<img width="516" height="329" alt="image" src="https://github.com/user-attachments/assets/f8e6587a-29a5-4e66-938a-fead1e0622ef" />

After:
<img width="509" height="328" alt="image" src="https://github.com/user-attachments/assets/7a4097d5-c65a-4bea-892d-c9cdc16ed305" />

`ui.virtual.jump-label` -- jump labels were very hard to see in documents with a lot of default styled text.

Before:
<img width="712" height="268" alt="image" src="https://github.com/user-attachments/assets/bdc32fc7-014c-4c30-86e2-f440c8734406" />

After:
<img width="709" height="271" alt="image" src="https://github.com/user-attachments/assets/1bbe4f69-94ed-42c4-8ab2-dc2767fc499a" />