### PR TITLE
jj: Set the indent to four spaces for descriptions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3606,7 +3606,7 @@ name = "jjdescription"
 scope = "jj.description"
 file-types = [{ glob = "*.jjdescription" }]
 comment-token = "JJ:"
-indent = { tab-width = 2, unit = "  " }
+indent = { tab-width = 4, unit = "    " }
 rulers = [51, 73]
 text-width = 72
 


### PR DESCRIPTION
Code blocks in commit messages are typically set off by four spaces. This is also required when they are rendered as markdown (two leading spaces just gets stripped).

Update jj.description to use 4 spaces, which matches the config for git messages as well as Vim.