### PR TITLE
Add rainbows.scm queries for Janet

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -115,7 +115,7 @@
 | ini | ✓ |  |  |  |  |  |
 | ink | ✓ |  |  |  |  |  |
 | inko | ✓ | ✓ | ✓ | ✓ |  |  |
-| janet | ✓ |  | ✓ |  |  |  |
+| janet | ✓ |  | ✓ |  | ✓ |  |
 | java | ✓ | ✓ | ✓ |  | ✓ | `jdtls` |
 | javascript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jinja | ✓ |  |  |  |  |  |

--- a/runtime/queries/janet/rainbows.scm
+++ b/runtime/queries/janet/rainbows.scm
@@ -1,0 +1,16 @@
+[
+  (par_arr_lit)
+  (par_tup_lit)
+  (sqr_arr_lit)
+  (sqr_tup_lit)
+  (tbl_lit)
+  (struct_lit)
+  (short_fn_lit)
+] @rainbow.scope
+
+[
+  "(" "@(" ")"
+  "[" "@[" "]"
+  "{" "@{" "}"
+  "|"
+] @rainbow.bracket


### PR DESCRIPTION
These are pretty much analogous to the rainbow queries for clojure.

<img width="1114" height="699" alt="Screenshot from 2025-08-10 14-57-33" src="https://github.com/user-attachments/assets/91c3001d-aab2-4a35-b993-2440da101718" />