### PR TITLE
Add support for KConfig

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -133,6 +133,7 @@
 | jsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ |  |  | `julia` |
 | just | ✓ | ✓ | ✓ | ✓ |  | `just-lsp` |
+| kconfig | ✓ |  | ✓ |  |  |  |
 | kdl | ✓ | ✓ | ✓ |  |  |  |
 | koka | ✓ |  | ✓ |  |  | `koka` |
 | kotlin | ✓ | ✓ | ✓ |  |  | `kotlin-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -4639,3 +4639,13 @@ file-types = [{ glob = "requirements.txt" }, { glob = "constraints.txt" }]
 [[grammar]]
 name = "requirements"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-requirements", rev = "caeb2ba854dea55931f76034978de1fd79362939" }
+
+[[language]]
+name = "kconfig"
+file-types = ["kconfig", "kconfig.*"]
+scope = "source.kconfig"
+
+[[grammar]]
+name = "kconfig"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-kconfig" , rev = "9ac99fe4c0c27a35dc6f757cef534c646e944881" }
+

--- a/languages.toml
+++ b/languages.toml
@@ -4642,7 +4642,7 @@ source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-requiremen
 
 [[language]]
 name = "kconfig"
-file-types = ["kconfig", "kconfig.*"]
+file-types = ["kconfig", { glob = "kconfig.*" }]
 scope = "source.kconfig"
 
 [[grammar]]

--- a/runtime/queries/kconfig/folds.scm
+++ b/runtime/queries/kconfig/folds.scm
@@ -1,0 +1,9 @@
+[
+  (config)
+  (menuconfig)
+  (choice)
+  (comment_entry)
+  (menu)
+  (if)
+  (help_text)
+] @fold

--- a/runtime/queries/kconfig/highlights.scm
+++ b/runtime/queries/kconfig/highlights.scm
@@ -84,5 +84,3 @@
 (source (string) @string.special.url @string.special)
 
 (comment) @comment
-
-(ERROR) @error

--- a/runtime/queries/kconfig/highlights.scm
+++ b/runtime/queries/kconfig/highlights.scm
@@ -1,0 +1,88 @@
+[
+  "source"
+  "osource"
+  "rsource"
+  "orsource"
+] @keyword.control.import
+
+[
+  "mainmenu"
+  "config"
+  "configdefault"
+  "menuconfig"
+  "choice"
+  "endchoice"
+  "comment"
+  "menu"
+  "endmenu"
+  "prompt"
+  "default"
+  "range"
+  "help"
+  (optional)
+  (modules)
+] @keyword
+
+[
+  "if"
+  "endif"
+  "depends on"
+  "select"
+  "imply"
+  "visible if"
+] @keyword.control.conditional
+
+[
+  "def_bool"
+  "def_tristate"
+] @keyword.function
+
+[
+  "||"
+  "&&"
+  "="
+  "!="
+  "<"
+  ">"
+  "<="
+  ">="
+  "!"
+] @operator
+
+[
+  "bool"
+  "tristate"
+  "int"
+  "hex"
+  "string"
+] @type.builtin
+
+[ "(" ")" ] @punctuation.bracket
+
+(macro_variable ["$(" ")"] @punctuation.special)
+
+(symbol) @variable
+
+[
+  (string)
+  (macro_content)
+  (text)
+] @string
+
+(config name: (name (symbol) @constant))
+(configdefault name: (name (symbol) @constant))
+(menuconfig name: (name (symbol) @constant))
+(choice name: (name (symbol) @constant))
+
+((symbol) @constant
+  (#match? @constant "[A-Z0-9]+"))
+
+(mainmenu name: (string) @markup.heading)
+(comment_entry name: (string) @markup.heading)
+(menu name: (string) @markup.heading)
+
+(source (string) @string.special.url @string.special)
+
+(comment) @comment
+
+(ERROR) @error

--- a/runtime/queries/kconfig/indents.scm
+++ b/runtime/queries/kconfig/indents.scm
@@ -1,0 +1,11 @@
+(help_text (text) @align)
+
+[
+  (config)
+  (menuconfig)
+  (choice)
+  (comment_entry)
+  (menu)
+  (if)
+  (help_text)
+] @indent

--- a/runtime/queries/kconfig/injections.scm
+++ b/runtime/queries/kconfig/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/kconfig/locals.scm
+++ b/runtime/queries/kconfig/locals.scm
@@ -1,0 +1,17 @@
+[
+  (symbol)
+  (string)
+] @local.reference
+
+[
+  (config)
+  (menuconfig)
+  (choice)
+  (comment_entry)
+  (menu)
+  (if)
+] @local.scope
+
+(type_definition (string) @local.definition.type)
+(type_definition (input_prompt (string) @local.definition.type))
+(type_definition_default (expression (string) @local.definition.type))


### PR DESCRIPTION
Uses: https://github.com/tree-sitter-grammars/tree-sitter-kconfig. Adapted from the original neovim queries. Screenshot: 
<img width="797" height="1368" alt="image" src="https://github.com/user-attachments/assets/ff7c5bd2-fa10-4f01-8688-467facdc03a6" />
