### PR TITLE
Show stderr on shell failure and an option to cancel `:pipe` on failure

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6263,6 +6263,22 @@ impl ShellOutput {
     pub fn is_empty(&self) -> bool {
         self.stdout.trim().is_empty() && self.stderr.trim().is_empty()
     }
+
+    pub fn shell_popup(cx: &mut compositor::Context, msg: String) {
+        let callback = async move {
+            let call: job::Callback = Callback::EditorCompositor(Box::new(
+                move |editor: &mut Editor, compositor: &mut Compositor| {
+                    let contents = ui::Markdown::new(msg, editor.syn_loader.clone());
+                    let popup = Popup::new("shell", contents).position(Some(
+                        helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
+                    ));
+                    compositor.replace_or_push("shell", popup);
+                },
+            ));
+            Ok(call)
+        };
+        cx.jobs.callback(callback);
+    }
 }
 
 impl fmt::Display for ShellOutput {
@@ -6428,6 +6444,7 @@ fn shell(
 
     let mut shell_output: Option<Tendril> = None;
     let mut offset = 0isize;
+    let mut popup_str = Vec::new();
     for range in selection.ranges() {
         let output = if let Some(output) = shell_output.as_ref() {
             output.clone()
@@ -6440,27 +6457,12 @@ fn shell(
                     success,
                 }) => {
                     if popup_stderr && !stderr.is_empty() {
-                        let popup_str = stderr.to_string();
-                        let callback = async move {
-                            let call: job::Callback = Callback::EditorCompositor(Box::new(
-                                move |editor: &mut Editor, compositor: &mut Compositor| {
-                                    let contents =
-                                        ui::Markdown::new(popup_str, editor.syn_loader.clone());
-                                    let popup = Popup::new("shell", contents).position(Some(
-                                        helix_core::Position::new(
-                                            editor.cursor().0.unwrap_or_default().row,
-                                            2,
-                                        ),
-                                    ));
-                                    compositor.replace_or_push("shell", popup);
-                                },
-                            ));
-                            Ok(call)
-                        };
-                        cx.jobs.callback(callback);
+                        popup_str.push(format!("```sh\n{}\n```", stderr));
                     }
 
                     if on_success && !success {
+                        ShellOutput::shell_popup(cx, popup_str.join("\n"));
+                        cx.editor.set_status("Shell process failed");
                         return;
                     }
 
@@ -6522,6 +6524,9 @@ fn shell(
     // after replace cursor may be out of bounds, do this to
     // make sure cursor is in view and update scroll as well
     view.ensure_cursor_in_view(doc, config.scrolloff);
+    if !popup_str.is_empty() {
+        ShellOutput::shell_popup(cx, popup_str.join("\n"));
+    }
 }
 
 fn shell_prompt(cx: &mut Context, prompt: Cow<'static, str>, behavior: ShellBehavior) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2404,10 +2404,7 @@ fn run_shell_command(
         let call: job::Callback = Callback::EditorCompositor(Box::new(
             move |editor: &mut Editor, compositor: &mut Compositor| {
                 if !output.is_empty() {
-                    let contents = ui::Markdown::new(
-                        format!("```sh\n{}\n```", output.trim_end()),
-                        editor.syn_loader.clone(),
-                    );
+                    let contents = ui::Markdown::new(output.to_string(), editor.syn_loader.clone());
                     let popup = Popup::new("shell", contents).position(Some(
                         helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
                     ));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2348,7 +2348,7 @@ fn append_output(
         return Ok(());
     }
 
-    shell(cx, &args.join(" "), &ShellBehavior::Append);
+    shell(cx, &args.join(" "), &ShellBehavior::Append, false, false);
     Ok(())
 }
 
@@ -2361,16 +2361,24 @@ fn insert_output(
         return Ok(());
     }
 
-    shell(cx, &args.join(" "), &ShellBehavior::Insert);
+    shell(cx, &args.join(" "), &ShellBehavior::Insert, false, false);
     Ok(())
 }
 
 fn pipe_to(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
-    pipe_impl(cx, args, event, &ShellBehavior::Ignore)
+    pipe_impl(cx, args, event, &ShellBehavior::Ignore, false, true)
 }
 
 fn pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
-    pipe_impl(cx, args, event, &ShellBehavior::Replace)
+    pipe_impl(cx, args, event, &ShellBehavior::Replace, false, false)
+}
+
+fn pipe_on_success(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::Replace, true, true)
 }
 
 fn pipe_impl(
@@ -2378,12 +2386,14 @@ fn pipe_impl(
     args: Args,
     event: PromptEvent,
     behavior: &ShellBehavior,
+    on_success: bool,
+    popup_stderr: bool,
 ) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
-    shell(cx, &args.join(" "), behavior);
+    shell(cx, &args.join(" "), behavior, on_success, popup_stderr);
     Ok(())
 }
 
@@ -3558,6 +3568,14 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["|"],
         doc: "Pipe each selection to the shell command.",
         fun: pipe,
+        completer: SHELL_COMPLETER,
+        signature: SHELL_SIGNATURE,
+    },
+    TypableCommand {
+        name: "pipe-on-success",
+        aliases: &[],
+        doc: "Pipe each selection to the shell command.",
+        fun: pipe_on_success,
         completer: SHELL_COMPLETER,
         signature: SHELL_SIGNATURE,
     },


### PR DESCRIPTION

- add `:pipe-on-success` which only affect buffer if shell returns a success code.
- make `:pipe-to` creates a popup to show stderr if it's not empty. Currently, no feedback on command results.
- make `:sh` output both stderr and stdout. For example, `$ ls existing_file non_existing_file` should contain both stdout and stderr results.

Could some of these features be merged into Helix? Thanks