### PR TITLE
Support file path with lines and columns in `goto_file`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1367,7 +1367,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
 
     for sel in paths {
         let (path, pos) = crate::args::parse_file(&sel);
-        if let Ok(url) = Url::parse(&path.to_str().unwrap()) {
+        if let Ok(url) = Url::parse(path.to_str().unwrap()) {
             open_url(cx, url, action);
             continue;
         }
@@ -1380,7 +1380,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             rel_path
         };
         if path.is_dir() {
-            let picker = ui::file_picker(cx.editor, path.into());
+            let picker = ui::file_picker(cx.editor, path);
             cx.push_layer(Box::new(overlaid(picker)));
         } else if let Err(e) = cx.editor.open(path.as_path(), action) {
             cx.editor.set_error(format!("Open file failed: {:?}", e));


### PR DESCRIPTION
Resolves #9440, #5259 

Add position parsing, same as for `:e` or `:o`. For navigate, need to select all WORD (`file_path:LINE[:COL]`) manually, otherwise will navigate only to `file_path`.

Also implement navigation for file from `CWD` as suggested here https://github.com/helix-editor/helix/pull/9519#discussion_r1485346855:
1. Navigate relative document path if it exists;
2. Navigate CWD document path if it exists;
3. Navigate to relative document path.