### PR TITLE
Add config option to set signature help's pop up position (above/below)

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -45,7 +45,7 @@ use helix_core::{
 };
 use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
-    editor::Action,
+    editor::{Action, RelativePosition},
     info::Info,
     input::KeyEvent,
     keyboard::KeyCode,
@@ -3633,6 +3633,15 @@ async fn make_format_callback(
 pub enum Open {
     Below,
     Above,
+}
+
+impl Open {
+    pub fn from_relative_position(pos: &RelativePosition) -> Self {
+        match pos {
+            RelativePosition::Above => Self::Above,
+            RelativePosition::Below => Self::Below,
+        }
+    }
 }
 
 #[derive(PartialEq)]

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -266,9 +266,11 @@ pub fn show_signature_help(
         signatures,
     );
 
+    let position_bias = Open::from_relative_position(&config.lsp.signature_help_position);
+
     let mut popup = Popup::new(SignatureHelp::ID, contents)
         .position(old_popup.and_then(|p| p.get_position()))
-        .position_bias(Open::Above)
+        .position_bias(position_bias)
         .ignore_escape_key(true);
 
     // Don't create a popup if it intersects the auto-complete menu.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -453,6 +453,13 @@ pub fn get_terminal_provider() -> Option<TerminalConfig> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RelativePosition {
+    Above,
+    Below,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LspConfig {
     /// Enables LSP
@@ -463,6 +470,8 @@ pub struct LspConfig {
     pub display_messages: bool,
     /// Enable automatic pop up of signature help (parameter hints)
     pub auto_signature_help: bool,
+    /// Position of the automatic pop up of signature help
+    pub signature_help_position: RelativePosition,
     /// Display docs under signature help popup
     pub display_signature_help_docs: bool,
     /// Display inlay hints
@@ -485,6 +494,7 @@ impl Default for LspConfig {
             display_progress_messages: false,
             display_messages: true,
             auto_signature_help: true,
+            signature_help_position: RelativePosition::Above,
             display_signature_help_docs: true,
             display_inlay_hints: false,
             inlay_hints_length_limit: None,


### PR DESCRIPTION
### Details

The signature help pop up obstructs the pieces of code, and it isn't possible to move it.
The problem was also described here - https://github.com/helix-editor/helix/discussions/8972

Let me know if anything should be tuned.

### Testing

I just YOLO checked it with the configs below, built as

`nix build`

running as

`$ ~/source/helix-editor/helix/result/bin/hx --config ~/source/helix-editor/helix/_config.toml .`

(from a project directory, otherwise I don't have any languages and language servers installed)

### `signature-help-position = "above"` (default)

`_config.toml`
```toml
[editor.lsp]
signature-help-position = "above"
```

<img width="356" height="201" alt="image" src="https://github.com/user-attachments/assets/aebd1674-b564-4f73-be4e-79c3fb09c7c1" />

### `signature-help-position = "below"`

`_config.toml`
```toml
[editor.lsp]
signature-help-position = "below"
```

<img width="355" height="205" alt="image" src="https://github.com/user-attachments/assets/91875990-ea23-4a6a-b791-2ff719d6f831" />