### PR TITLE
adjust cyan in modus_vivendi rainbow (and yellow in _tritanopia)

### DIFF
--- a/runtime/themes/modus_vivendi.toml
+++ b/runtime/themes/modus_vivendi.toml
@@ -112,7 +112,7 @@ warning = "yellow-warmer"
 info = "cyan-cooler"
 hint = "blue-cooler"
 
-rainbow = ["red", "yellow-warmer", "green-intense", "cyan-cooler", "blue", "magenta-intense"]
+rainbow = ["red", "yellow-warmer", "green-intense", "cyan", "blue", "magenta-intense"]
 
 [palette]
 # Basic values

--- a/runtime/themes/modus_vivendi_deuteranopia.toml
+++ b/runtime/themes/modus_vivendi_deuteranopia.toml
@@ -23,7 +23,7 @@ warning = "magenta-faint"
 info = "cyan"
 hint = "blue"
 
-rainbow = ["red", "yellow-intense", "green-intense", "cyan-cooler", "blue", "magenta-intense"]
+rainbow = ["red", "yellow-intense", "green-intense", "cyan", "blue", "magenta-intense"]
 
 [palette]
 # Basic values

--- a/runtime/themes/modus_vivendi_tritanopia.toml
+++ b/runtime/themes/modus_vivendi_tritanopia.toml
@@ -37,7 +37,7 @@ warning = "magenta"
 info = "cyan"
 hint = "blue"
 
-rainbow = ["red", "yellow-cooler", "green-intense", "cyan-cooler", "blue", "magenta-intense"]
+rainbow = ["red", "magenta", "green-intense", "cyan", "blue", "magenta-intense"]
 
 [palette]
 # Basic values


### PR DESCRIPTION
<img width="370" height="55" alt="Screenshot_20250811_220321" src="https://github.com/user-attachments/assets/d647d7e6-3433-46ee-a31e-e1508d3918dd" />

modus_vivendi_tritanopia uses `magenta` instead of a `yellow*` for diagnostic warnings etc

`cyan-cooler` felt too similar to `green` when they were right next to each other