### PR TITLE
fix(lints): clippy 1.90

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, iter};
+use std::{borrow::Cow, collections::HashMap};
 
 use helix_stdx::rope::RopeSliceExt;
 use tree_house::TREE_SITTER_MATCH_LIMIT;
@@ -214,7 +214,10 @@ fn whitespace_with_same_width(text: RopeSlice) -> String {
         if grapheme == "\t" {
             s.push('\t');
         } else {
-            s.extend(std::iter::repeat(' ').take(grapheme_width(&Cow::from(grapheme))));
+            s.extend(std::iter::repeat_n(
+                ' ',
+                grapheme_width(&Cow::from(grapheme)),
+            ));
         }
     }
     s
@@ -243,10 +246,10 @@ pub fn normalize_indentation(
         original_len += 1;
     }
     if indent_style == IndentStyle::Tabs {
-        dst.extend(iter::repeat('\t').take(len / tab_width));
+        dst.extend(std::iter::repeat_n('\t', len / tab_width));
         len %= tab_width;
     }
-    dst.extend(iter::repeat(' ').take(len));
+    dst.extend(std::iter::repeat_n(' ', len));
     original_len
 }
 

--- a/helix-core/src/snippets/elaborate.rs
+++ b/helix-core/src/snippets/elaborate.rs
@@ -361,7 +361,7 @@ impl Transform {
                         }
                     }
                     FormatItem::Conditional(i, ref if_, ref else_) => {
-                        if cap.get_group(i).map_or(true, |mat| mat.is_empty()) {
+                        if cap.get_group(i).is_none_or(|mat| mat.is_empty()) {
                             buf.push_str(else_)
                         } else {
                             buf.push_str(if_)

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -562,15 +562,15 @@ impl Syntax {
         self.inner.tree_for_byte_range(start, end)
     }
 
-    pub fn named_descendant_for_byte_range(&self, start: u32, end: u32) -> Option<Node> {
+    pub fn named_descendant_for_byte_range(&self, start: u32, end: u32) -> Option<Node<'_>> {
         self.inner.named_descendant_for_byte_range(start, end)
     }
 
-    pub fn descendant_for_byte_range(&self, start: u32, end: u32) -> Option<Node> {
+    pub fn descendant_for_byte_range(&self, start: u32, end: u32) -> Option<Node<'_>> {
         self.inner.descendant_for_byte_range(start, end)
     }
 
-    pub fn walk(&self) -> TreeCursor {
+    pub fn walk(&self) -> TreeCursor<'_> {
         self.inner.walk()
     }
 
@@ -1073,7 +1073,7 @@ fn node_is_visible(node: &Node) -> bool {
     node.is_missing() || (node.is_named() && node.grammar().node_kind_is_visible(node.kind_id()))
 }
 
-fn format_anonymous_node_kind(kind: &str) -> Cow<str> {
+fn format_anonymous_node_kind(kind: &str) -> Cow<'_, str> {
     if kind.contains('"') {
         Cow::Owned(kind.replace('"', "\\\""))
     } else {
@@ -1130,7 +1130,6 @@ fn pretty_print_tree_impl<W: fmt::Write>(
 }
 
 /// Finds the child of `node` which contains the given byte range.
-
 pub fn child_for_byte_range<'a>(node: &Node<'a>, range: ops::Range<u32>) -> Option<Node<'a>> {
     for child in node.children() {
         let child_range = child.byte_range();

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -520,7 +520,7 @@ impl ChangeSet {
         pos
     }
 
-    pub fn changes_iter(&self) -> ChangeIterator {
+    pub fn changes_iter(&self) -> ChangeIterator<'_> {
         ChangeIterator::new(self)
     }
 }
@@ -753,7 +753,7 @@ impl Transaction {
         })
     }
 
-    pub fn changes_iter(&self) -> ChangeIterator {
+    pub fn changes_iter(&self) -> ChangeIterator<'_> {
         self.changes.changes_iter()
     }
 }

--- a/helix-lsp-types/src/code_action.rs
+++ b/helix-lsp-types/src/code_action.rs
@@ -129,6 +129,7 @@ pub struct CodeActionParams {
 /// response for CodeActionRequest
 pub type CodeActionResponse = Vec<CodeActionOrCommand>;
 
+#[allow(clippy::large_enum_variant)] // TODO: In a separate PR attempt the `Box<CodeAction>` pattern.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CodeActionOrCommand {

--- a/helix-lsp-types/src/progress.rs
+++ b/helix-lsp-types/src/progress.rs
@@ -40,14 +40,6 @@ pub struct WorkDoneProgressCancelParams {
     pub token: ProgressToken,
 }
 
-/// Options to signal work done progress support in server capabilities.
-#[derive(Debug, Eq, PartialEq, Default, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkDoneProgressOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_done_progress: Option<bool>,
-}
-
 /// An optional token that a server can use to report work done progress
 #[derive(Debug, Eq, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -85,7 +85,7 @@ fn find_brace_end(src: &[u8]) -> Option<usize> {
     None
 }
 
-fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>) -> Cow<OsStr> {
+fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>) -> Cow<'_, OsStr> {
     use regex_automata::meta::Regex;
 
     static REGEX: Lazy<Regex> = Lazy::new(|| {
@@ -157,7 +157,7 @@ fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>)
 /// * `${<var>:-<default>}`, `${<var>-<default>}`
 /// * `${<var>:=<default>}`, `${<var>=default}`
 ///
-pub fn expand<S: AsRef<OsStr> + ?Sized>(src: &S) -> Cow<OsStr> {
+pub fn expand<S: AsRef<OsStr> + ?Sized>(src: &S) -> Cow<'_, OsStr> {
     expand_impl(src.as_ref(), |var| std::env::var_os(var))
 }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -100,7 +100,7 @@ struct PickerDiagnostic {
     diag: lsp::Diagnostic,
 }
 
-fn location_to_file_location(location: &Location) -> Option<FileLocation> {
+fn location_to_file_location(location: &Location) -> Option<FileLocation<'_>> {
     let path = location.uri.as_path()?;
     let line = Some((
         location.range.start.line as usize,
@@ -589,7 +589,7 @@ struct CodeActionOrCommandItem {
 
 impl ui::menu::Item for CodeActionOrCommandItem {
     type Data = ();
-    fn format(&self, _data: &Self::Data) -> Row {
+    fn format(&self, _data: &Self::Data) -> Row<'_> {
         match &self.lsp_item {
             lsp::CodeActionOrCommand::CodeAction(action) => action.title.as_str().into(),
             lsp::CodeActionOrCommand::Command(command) => command.title.as_str().into(),
@@ -1146,7 +1146,7 @@ pub fn rename_symbol(cx: &mut Context) {
 
                 let Some(language_server) = doc
                     .language_servers_with_feature(LanguageServerFeature::RenameSymbol)
-                    .find(|ls| language_server_id.map_or(true, |id| id == ls.id()))
+                    .find(|ls| language_server_id.is_none_or(|id| id == ls.id()))
                 else {
                     cx.editor
                         .set_error("No configured language server supports symbol renaming");

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -3740,7 +3740,7 @@ pub(super) fn command_mode(cx: &mut Context) {
     cx.push_layer(Box::new(prompt));
 }
 
-fn command_line_doc(input: &str) -> Option<Cow<str>> {
+fn command_line_doc(input: &str) -> Option<Cow<'_, str>> {
     let (command, _, _) = command_line::split(input);
     let command = TYPABLE_COMMAND_MAP.get(command)?;
 

--- a/helix-term/src/handlers/completion/item.rs
+++ b/helix-term/src/handlers/completion/item.rs
@@ -67,6 +67,7 @@ impl LspCompletionItem {
     }
 }
 
+#[allow(clippy::large_enum_variant)] // TODO: In a separate PR attempt the `Box<LspCompletionItem>` pattern.
 #[derive(Debug, PartialEq, Clone)]
 pub enum CompletionItem {
     Lsp(LspCompletionItem),

--- a/helix-term/src/handlers/completion/request.rs
+++ b/helix-term/src/handlers/completion/request.rs
@@ -87,7 +87,7 @@ impl helix_event::AsyncHook for CompletionHandler {
                 if self
                     .trigger
                     .or(self.in_flight)
-                    .map_or(true, |trigger| trigger.doc != doc || trigger.view != view)
+                    .is_none_or(|trigger| trigger.doc != doc || trigger.view != view)
                 {
                     self.trigger = Some(Trigger {
                         pos: trigger_pos,

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -1,9 +1,9 @@
+use crate::handlers::completion::LspCompletionItem;
 use crate::ui::{menu, Markdown, Menu, Popup, PromptEvent};
 use crate::{
     compositor::{Component, Context, Event, EventResult},
     handlers::completion::{
-        trigger_auto_completion, CompletionItem, CompletionResponse, LspCompletionItem,
-        ResolveHandler,
+        trigger_auto_completion, CompletionItem, CompletionResponse, ResolveHandler,
     },
 };
 use helix_core::snippets::{ActiveSnippet, RenderedSnippet, Snippet};
@@ -28,7 +28,7 @@ use std::cmp::Reverse;
 impl menu::Item for CompletionItem {
     type Data = Style;
 
-    fn format(&self, dir_style: &Self::Data) -> menu::Row {
+    fn format(&self, dir_style: &Self::Data) -> menu::Row<'_> {
         let deprecated = match self {
             CompletionItem::Lsp(LspCompletionItem { item, .. }) => {
                 item.deprecated.unwrap_or_default()

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -214,7 +214,7 @@ impl<'a> TextRenderer<'a> {
         let tab_width = doc.tab_width();
         let tab = if ws_render.tab() == WhitespaceRenderValue::All {
             std::iter::once(ws_chars.tab)
-                .chain(std::iter::repeat(ws_chars.tabpad).take(tab_width - 1))
+                .chain(std::iter::repeat_n(ws_chars.tabpad, tab_width - 1))
                 .collect()
         } else {
             " ".repeat(tab_width)

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -13,7 +13,7 @@ pub trait Item: Sync + Send + 'static {
     /// Additional editor state that is used for label calculation.
     type Data: Sync + Send + 'static;
 
-    fn format(&self, data: &Self::Data) -> Row;
+    fn format(&self, data: &Self::Data) -> Row<'_>;
 }
 
 pub type MenuCallback<T> = Box<dyn Fn(&mut Editor, Option<&T>, MenuEvent)>;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -896,7 +896,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         if let Some((preview, range)) = self.get_preview(cx.editor) {
             let doc = match preview.document() {
                 Some(doc)
-                    if range.map_or(true, |(start, end)| {
+                    if range.is_none_or(|(start, end)| {
                         start <= end && end <= doc.text().len_lines()
                     }) =>
                 {

--- a/helix-vcs/src/diff.rs
+++ b/helix-vcs/src/diff.rs
@@ -72,7 +72,7 @@ impl DiffHandle {
     }
 
     /// Load the actual diff
-    pub fn load(&self) -> Diff {
+    pub fn load(&self) -> Diff<'_> {
         Diff {
             diff: self.diff.read(),
             inverted: self.inverted,

--- a/helix-vcs/src/diff/line_cache.rs
+++ b/helix-vcs/src/diff/line_cache.rs
@@ -128,7 +128,7 @@ impl InternedRopeLines {
     /// Returns the `InternedInput` for performing the diff.
     /// If `diff_base` or `doc` is so large that performing a diff could slow the editor
     /// this function returns `None`.
-    pub fn interned_lines(&self) -> Option<&InternedInput<RopeSlice>> {
+    pub fn interned_lines(&self) -> Option<&InternedInput<RopeSlice<'_>>> {
         if self.is_too_large() {
             None
         } else {

--- a/helix-vcs/src/diff/worker.rs
+++ b/helix-vcs/src/diff/worker.rs
@@ -102,7 +102,7 @@ struct EventAccumulator {
     render_lock: Option<RenderLock>,
 }
 
-impl<'a> EventAccumulator {
+impl EventAccumulator {
     fn new() -> EventAccumulator {
         EventAccumulator {
             diff_base: None,

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -186,7 +186,7 @@ impl<'a> InlineDiagnosticAccumulator<'a> {
                 .doc
                 .diagnostics
                 .get(self.idx)
-                .map_or(true, |diag| diag.range.start != grapheme.char_idx)
+                .is_none_or(|diag| diag.range.start != grapheme.char_idx)
             {
                 return false;
             }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1655,7 +1655,7 @@ impl Document {
         let savepoint_idx = self
             .savepoints
             .iter()
-            .position(|savepoint_ref| savepoint_ref.as_ptr() == savepoint as *const _)
+            .position(|savepoint_ref| std::ptr::eq(savepoint_ref.as_ptr(), savepoint))
             .expect("Savepoint must belong to this document");
 
         let savepoint_ref = self.savepoints.remove(savepoint_idx);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1627,7 +1627,7 @@ impl Editor {
             doc.language_servers.iter().filter(|(name, doc_ls)| {
                 language_servers
                     .get(*name)
-                    .map_or(true, |ls| ls.id() != doc_ls.id())
+                    .is_none_or(|ls| ls.id() != doc_ls.id())
             });
 
         for (_, language_server) in doc_language_servers_not_in_registry {
@@ -1637,7 +1637,7 @@ impl Editor {
         let language_servers_not_in_doc = language_servers.iter().filter(|(name, ls)| {
             doc.language_servers
                 .get(*name)
-                .map_or(true, |doc_ls| ls.id() != doc_ls.id())
+                .is_none_or(|doc_ls| ls.id() != doc_ls.id())
         });
 
         for (_, language_server) in language_servers_not_in_doc {

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -69,7 +69,7 @@ pub fn diagnostic<'doc>(
                 .iter()
                 .take_while(|d| {
                     d.line == line
-                        && d.provider.language_server_id().map_or(true, |id| {
+                        && d.provider.language_server_id().is_none_or(|id| {
                             doc.language_servers_with_feature(LanguageServerFeature::Diagnostics)
                                 .any(|ls| ls.id() == id)
                         })

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -355,7 +355,7 @@ impl Editor {
                         && diagnostic
                             .source
                             .as_ref()
-                            .map_or(true, |source| !unchanged_diag_sources.contains(source))
+                            .is_none_or(|source| !unchanged_diag_sources.contains(source))
                 };
             let diagnostics = Self::doc_diagnostics_with_filter(
                 &self.language_servers,

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -441,7 +441,7 @@ impl Tree {
         }
     }
 
-    pub fn traverse(&self) -> Traverse {
+    pub fn traverse(&self) -> Traverse<'_> {
         Traverse::new(self)
     }
 


### PR DESCRIPTION
Most of these are pretty straight forward, but the `large_enum_variant` lint probably needs its own PR as there is some discussion around the impacts from the size of the enum vs boxing and another layer of indirection + allocation. For now, I have just added an allow with a TODO.

Another part that is a bit unfortunate is that as these enums are often used in pattern matching, there isnt a way to destruct a `Box` without the `box_patterns` or the `deref_patterns` features, which are both unstable.