### PR TITLE
Remove the Ubuntu PPA installation method from the docs

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -2,7 +2,6 @@
 
 - [Linux](#linux)
   - [Ubuntu/Debian](#ubuntudebian)
-  - [Ubuntu (PPA)](#ubuntu-ppa)
   - [Fedora/RHEL](#fedorarhel)
   - [Arch Linux extra](#arch-linux-extra)
   - [NixOS](#nixos)
@@ -30,16 +29,6 @@ Install the Debian package from the release page.
 
 If you are running a system older than Ubuntu 22.04, Mint 21, or Debian 12, you can build the `.deb` file locally
 [from source](./building-from-source.md#building-the-debian-package).
-
-### Ubuntu (PPA)
-
-Add the `PPA` for Helix:
-
-```sh
-sudo add-apt-repository ppa:maveonair/helix-editor
-sudo apt update
-sudo apt install helix
-```
 
 ### Fedora/RHEL
 


### PR DESCRIPTION
Building the Helix PPA has become increasingly cumbersome, as newer versions of Helix often require newer Rust toolchains that are not available in older Ubuntu releases. This creates difficulties for Ubuntu LTS users who still want to run the latest Helix version.

With the availability of the Snap package, I have decided to stop building new Helix versions in my PPA. The PPA repository has been archived, and users are encouraged to either:

1. Build the Debian package themselves, or
2. Use the Snap version.

For more details, see the official documentation:

* [Ubuntu/Debian installation](https://docs.helix-editor.com/package-managers.html#ubuntudebian)
* [Snap installation](https://docs.helix-editor.com/package-managers.html#snap)