### PR TITLE
fix adwaita-light ui.virtual color

### DIFF
--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -81,7 +81,7 @@ inherits="adwaita-dark"
 "ui.window" = "split_and_borders"
 "ui.help" = { bg = "light_3" }
 "ui.text" = "dark_4"
-"ui.virtual" = "light_1"
+"ui.virtual" = "light_6"
 "ui.virtual.ruler" = { bg = "light_5"}
 "ui.virtual.jump-label" = { modifiers = ["reversed"] }
 "ui.menu" = { fg = "dark_4", bg = "light_3" }

--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -81,7 +81,7 @@ inherits="adwaita-dark"
 "ui.window" = "split_and_borders"
 "ui.help" = { bg = "light_3" }
 "ui.text" = "dark_4"
-"ui.virtual" = "light_6"
+"ui.virtual" = "light_5"
 "ui.virtual.ruler" = { bg = "light_5"}
 "ui.virtual.jump-label" = { modifiers = ["reversed"] }
 "ui.menu" = { fg = "dark_4", bg = "light_3" }


### PR DESCRIPTION
Hi, the current `ui.virtual` setting for `adwaita-light` has too little contrast, rendering e.g. inlay hints almost invisible. I propose bumping the color to `light_6` for better visibility.

While at it, maybe we could also lower the `ui.virtual.ruler` `bg` to `light_3` to make it gentler? (I can commit to this PR, if we agree to a lighter color.