### PR TITLE
Add configurable gutter symbols

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -378,7 +378,24 @@ min-width = 1
 
 #### `[editor.gutters.diagnostics]` Section
 
-Currently unused
+Options for the diagnostics gutter
+
+| Key                              | Description                              | Default |
+| ---                              | ---                                      | ---     |
+| `symbol`                         | Symbol for diagnostic indicators         | `"●"`   |
+| `breakpoint-symbol`              | Symbol for verified breakpoints         | `"●"`   |
+| `unverified-breakpoint-symbol`   | Symbol for unverified breakpoints       | `"◯"`   |
+| `execution-pause-symbol`         | Symbol for execution pause indicator    | `"▶"`   |
+
+Example:
+
+```toml
+[editor.gutters.diagnostics]
+symbol = "!"
+breakpoint-symbol = "🔴"
+unverified-breakpoint-symbol = "⭕"
+execution-pause-symbol = "⏸"
+```
 
 #### `[editor.gutters.diff]` Section
 
@@ -387,7 +404,20 @@ These colors are controlled by the theme attributes `diff.plus`, `diff.minus` an
 
 Other diff providers will eventually be supported by a future plugin system.
 
-There are currently no options for this section.
+| Key             | Description                      | Default |
+| ---             | ---                              | ---     |
+| `plus-symbol`   | Symbol for added lines           | `"▍"`   |
+| `minus-symbol`  | Symbol for removed lines         | `"▔"`   |
+| `delta-symbol`  | Symbol for modified lines        | `"▍"`   |
+
+Example:
+
+```toml
+[editor.gutters.diff]
+plus-symbol = "+"
+minus-symbol = "-"
+delta-symbol = "~"
+```
 
 #### `[editor.gutters.spacer]` Section
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -91,6 +91,10 @@ pub struct GutterConfig {
     pub layout: Vec<GutterType>,
     /// Options specific to the "line-numbers" gutter
     pub line_numbers: GutterLineNumbersConfig,
+    /// Options specific to the "diagnostics" gutter
+    pub diagnostics: GutterDiagnosticsConfig,
+    /// Options specific to the "diff" gutter
+    pub diff: GutterDiffConfig,
 }
 
 impl Default for GutterConfig {
@@ -104,6 +108,8 @@ impl Default for GutterConfig {
                 GutterType::Diff,
             ],
             line_numbers: GutterLineNumbersConfig::default(),
+            diagnostics: GutterDiagnosticsConfig::default(),
+            diff: GutterDiffConfig::default(),
         }
     }
 }
@@ -171,6 +177,51 @@ pub struct GutterLineNumbersConfig {
 impl Default for GutterLineNumbersConfig {
     fn default() -> Self {
         Self { min_width: 3 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct GutterDiagnosticsConfig {
+    /// Symbol for diagnostic indicators. Defaults to "●".
+    pub symbol: String,
+    /// Symbol for verified breakpoints. Defaults to "●".
+    pub breakpoint_symbol: String,
+    /// Symbol for unverified breakpoints. Defaults to "◯".
+    pub unverified_breakpoint_symbol: String,
+    /// Symbol for execution pause indicator. Defaults to "▶".
+    pub execution_pause_symbol: String,
+}
+
+impl Default for GutterDiagnosticsConfig {
+    fn default() -> Self {
+        Self {
+            symbol: "●".to_string(),
+            breakpoint_symbol: "●".to_string(),
+            unverified_breakpoint_symbol: "◯".to_string(),
+            execution_pause_symbol: "▶".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct GutterDiffConfig {
+    /// Symbol for added lines. Defaults to "▍".
+    pub plus_symbol: String,
+    /// Symbol for modified lines. Defaults to "▍".
+    pub delta_symbol: String,
+    /// Symbol for removed lines. Defaults to "▔".
+    pub minus_symbol: String,
+}
+
+impl Default for GutterDiffConfig {
+    fn default() -> Self {
+        Self {
+            plus_symbol: "▍".to_string(),
+            delta_symbol: "▍".to_string(),
+            minus_symbol: "▔".to_string(),
+        }
     }
 }
 


### PR DESCRIPTION
Allow users to customize gutter symbols through config.toml:

- Diagnostic symbols (error, warning, info, hint indicators)
- Breakpoint symbols (verified and unverified)
- Execution pause indicator symbol
- Diff symbols (plus, minus, delta indicators)

This maintains backward compatibility with existing defaults while providing flexibility for users who want to customize their editor appearance. All symbols can be configured under [editor.gutters.diagnostics] and [editor.gutters.diff] sections.