### PR TITLE
fix: add runtimeDir as propagated build input

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,8 @@ in
       allowBuiltinFetchGit = true;
     };
 
+    propagatedBuildInputs = [ runtimeDir ];
+    
     nativeBuildInputs = [
       installShellFiles
       git


### PR DESCRIPTION
The rutime directory wasn't referenced as a dependency with `nix-store --query --references ...`, this change means to propagate it correctly:

```bash
❯ nix-store --query --references /nix/store/nn9vdi0mx71vjgk971l33jljm53xl6h2-helix-term
/nix/store/9bqmb4b87l2bsbpipg2bi5qv1s9g2f7f-helix-runtime
/nix/store/j2wn93axgpip7m3nb5ccbqz7b48h9vkm-libiconv-109
```

_Note: before only libiconv was listed_

I belive this should fix #13636