### PR TITLE
feat: inject `jq` into `jq "..."` string literals in common shells

### DIFF
--- a/runtime/queries/bash/injections.scm
+++ b/runtime/queries/bash/injections.scm
@@ -9,3 +9,11 @@
 
 ((regex) @injection.content
   (#set! injection.language "regex"))
+
+(command
+  name: (command_name (word) @_command (#any-of? @_command "jq" "jaq"))
+  argument: [
+    (raw_string) @injection.content
+    (string (string_content) @injection.content)
+  ]
+  (#set! injection.language "jq"))

--- a/runtime/queries/fish/injections.scm
+++ b/runtime/queries/fish/injections.scm
@@ -1,2 +1,7 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+(command
+  name: (word) @_command (#any-of? @_command "jq" "jaq")
+  argument: [(double_quote_string) (single_quote_string)] @injection.content
+  (#set! injection.language "jq"))

--- a/runtime/queries/nu/injections.scm
+++ b/runtime/queries/nu/injections.scm
@@ -1,2 +1,7 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+(command
+  head: (cmd_identifier) @_command (#any-of? @_command "jq" "jaq")
+  arg: (val_string) @injection.content
+  (#set! injection.language "jq"))


### PR DESCRIPTION
When checking for the name of the command both `jq` and `jaq` is checked against. [`jaq`](https://github.com/01mf02/jaq) is an alternative implementation of `jq` that is compatible with its syntax.

PowerShell and Elvish support is not implemented due to limitations in their respective tree-sitter grammars, where the string literal delimiter pairs `''` and `""` are included in the string node as a single token, causing the string literal to be highlighted as a string literal again.

**Showcase** (bash)

<img width="490" height="84" alt="image" src="https://github.com/user-attachments/assets/975e2275-2297-426b-b21b-32194cb51e2a" />
