### PR TITLE
feat(bash): inject bash into builtins expecting bash code as input

### DIFF
--- a/runtime/queries/bash/injections.scm
+++ b/runtime/queries/bash/injections.scm
@@ -17,3 +17,22 @@
     (string (string_content) @injection.content)
   ]
   (#set! injection.language "jq"))
+
+(command
+  name: (command_name (word) @_command (#eq? @_command "alias"))
+  argument: (concatenation
+    (word)
+    [
+      (raw_string) @injection.content
+      (string (string_content) @injection.content)
+    ])
+  (#set! injection.language "bash"))
+
+(command
+  name: (command_name (word) @_command (#any-of? @_command "eval" "trap"))
+  .
+  argument: [
+    (raw_string) @injection.content
+    (string (string_content) @injection.content)
+  ]
+  (#set! injection.language "bash"))


### PR DESCRIPTION
This applies to the builtins:
- `alias`
- `eval`
- `trap`

Only works with double quoted strings "..." i.e. `(string (string_content))` and not single quoted strings i.e. `(raw_string)`. This only seems to be an issue when the `@injection.language` is `bash`, as `(raw_string)` works for both the `awk` and `jq` injections already in the file. Nevertheless, the match for single quoted strings is kept in this commit, in case a change to the bash grammar allows this to work in the future.

**Showcase**

<img width="1123" height="389" alt="image" src="https://github.com/user-attachments/assets/15ce56ad-220d-4bbc-9b04-30fcee8b7b4f" />