### PR TITLE
build(Cargo): `release` with opt-lvl2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default-members = [
 
 [profile.release]
 lto = "thin"
+opt-level = 2
 
 [profile.opt]
 inherits = "release"


### PR DESCRIPTION
[default is `-O3`](https://doc.rust-lang.org/cargo/reference/profiles.html#release) and it might be a diminishing return compared to `-O2`. Since the `opt` profile is `-O3`, I think it's a good idea to make `release` compile faster