### PR TITLE
feat(languages): specilize toml file-type for cross-rs config file

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -31,6 +31,7 @@
 | common-lisp | ✓ |  | ✓ |  | ✓ | `cl-lsp` |
 | cpon | ✓ |  | ✓ |  |  |  |
 | cpp | ✓ | ✓ | ✓ | ✓ | ✓ | `clangd` |
+| cross-config | ✓ | ✓ |  |  | ✓ | `taplo`, `tombi` |
 | crystal | ✓ | ✓ | ✓ | ✓ |  | `crystalline`, `ameba-ls` |
 | css | ✓ |  | ✓ |  | ✓ | `vscode-css-language-server` |
 | csv | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4662,7 +4662,7 @@ scope = "source.kconfig"
 name = "kconfig"
 source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-kconfig" , rev = "9ac99fe4c0c27a35dc6f757cef534c646e944881" }
 
-[[language]] 
+[[language]]
 name = "doxyfile"
 scope = "source.doxyfile"
 injection-regex = "[Dd]oxyfile"
@@ -4673,3 +4673,13 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "doxyfile"
 source = { git = "https://github.com/tingerrr/tree-sitter-doxyfile/", rev = "18e44c6da639632a4e42264c7193df34be915f34" }
+
+[[language]]
+name = "cross-config"
+scope = "source.cross-config"
+injection-regex = "cross(-config)"
+grammar = "toml"
+comment-token = "#"
+file-types = [{glob = "Cross.toml"}]
+language-servers = [ "taplo", "tombi" ]
+indent = { tab-width = 2, unit = "  " }

--- a/runtime/queries/cross-config/highlights.scm
+++ b/runtime/queries/cross-config/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/cross-config/injections.scm
+++ b/runtime/queries/cross-config/injections.scm
@@ -1,0 +1,9 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+; https://github.com/cross-rs/cross/blob/main/docs/config_file.md
+(pair
+  (bare_key) @_key (#eq? @_key "pre-build")
+  (array
+    (string) @injection.content)
+  (#set! injection.language "bash"))

--- a/runtime/queries/cross-config/rainbows.scm
+++ b/runtime/queries/cross-config/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/cross-config/textobjects.scm
+++ b/runtime/queries/cross-config/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: toml


### PR DESCRIPTION
This adds an injection query only active for `Cross.toml` files used by [`cross`](https://github.com/cross-rs/cross) that highlight string literals in the `pre-build` array of each target as `bash`. This aids in readability for config files with multi-line pre-build instructions.

**Showcase**

<img width="1582" height="898" alt="image" src="https://github.com/user-attachments/assets/f5af2635-393e-496d-bdbb-3656763d2798" />
