### PR TITLE
Extend DebugArgumentValue to support toml tables

### DIFF
--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -446,6 +446,7 @@ pub enum DebugArgumentValue {
     String(String),
     Array(Vec<String>),
     Boolean(bool),
+    Table(HashMap<String, String>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -164,6 +164,13 @@ pub fn dap_start_impl(
                         arr.iter().map(|v| v.replace(&pattern, &param)).collect(),
                     ),
                     DebugArgumentValue::Boolean(_) => value,
+                    DebugArgumentValue::Table(map) => DebugArgumentValue::Table(
+                        map.into_iter()
+                            .map(|(mk, mv)| {
+                                (mk.replace(&pattern, &param), mv.replace(&pattern, &param))
+                            })
+                            .collect(),
+                    ),
                 };
             }
         }
@@ -181,6 +188,9 @@ pub fn dap_start_impl(
             }
             DebugArgumentValue::Boolean(bool) => {
                 args.insert(k, to_value(bool).unwrap());
+            }
+            DebugArgumentValue::Table(map) => {
+                args.insert(k, to_value(map).unwrap());
             }
         }
     }


### PR DESCRIPTION
Add support for JSON objects in debugger template args

```toml
[language.debugger.templates.args.pathMappings]
"/some/path/on/server" = "/some/path"
"/another/server/path" = "/another/local/path"
```
