### PR TITLE
languages.toml: Add GPX extension to XML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2996,7 +2996,7 @@ file-types = [
   "xsl",
   "mpd",
   "smil",
-  "gpx"
+  "gpx",
 ]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
The [GPS Exchange Format](https://en.wikipedia.org/wiki/GPS_Exchange_Format), with a `gpx` file extension, is XML.