### PR TITLE
feat(languages): specialize toml file-type for git-cliff config file

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -78,6 +78,7 @@
 | gherkin | ✓ |  |  |  |  |  |
 | ghostty | ✓ |  |  |  |  |  |
 | git-attributes | ✓ |  |  |  |  |  |
+| git-cliff-config | ✓ | ✓ |  |  | ✓ | `taplo`, `tombi` |
 | git-commit | ✓ | ✓ |  |  |  |  |
 | git-config | ✓ | ✓ |  |  |  |  |
 | git-ignore | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -4695,3 +4695,14 @@ comment-token = "#"
 file-types = [{glob = "Cross.toml"}]
 language-servers = [ "taplo", "tombi" ]
 indent = { tab-width = 2, unit = "  " }
+
+# https://git-cliff.org/docs/configuration/
+[[language]]
+name = "git-cliff-config"
+scope = "source.git-cliff-config"
+injection-regex = "git-cliff(-config)"
+grammar = "toml"
+comment-token = "#"
+file-types = [{ glob = "cliff.toml" }]
+language-servers = ["taplo", "tombi"]
+indent = { tab-width = 2, unit = "  " }

--- a/runtime/queries/git-cliff-config/highlights.scm
+++ b/runtime/queries/git-cliff-config/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/git-cliff-config/injections.scm
+++ b/runtime/queries/git-cliff-config/injections.scm
@@ -1,0 +1,53 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+; https://git-cliff.org/docs/configuration/changelog
+(table
+  (bare_key) @_table (#eq? @_table "changelog")
+  (pair
+    (bare_key) @_key (#any-of? @_key "header" "body" "footer")
+    (string) @injection.content
+  (#set! injection.language "tera")))
+
+; https://git-cliff.org/docs/configuration/git#commit_preprocessors
+; https://git-cliff.org/docs/configuration/git/#link_parsers
+; https://git-cliff.org/docs/configuration/changelog#postprocessors
+; https://git-cliff.org/docs/configuration/git/#tag_pattern
+; https://git-cliff.org/docs/configuration/git/#skip_tags
+; https://git-cliff.org/docs/configuration/git/#ignore_tags
+; https://git-cliff.org/docs/configuration/git/#count_tags
+; https://git-cliff.org/docs/configuration/bump/#custom_major_increment_regex--custom_minor_increment_regex
+(pair
+  (bare_key) @_key (#any-of? @_key
+    "pattern"
+    "tag_pattern"
+    "skip_tags"
+    "ignore_tags"
+    "count_tags"
+    "custom_major_increment_regex"
+    "custom_minor_increment_regex"
+  )
+  (string) @injection.content
+  (#set! injection.language "regex"))
+
+; https://git-cliff.org/docs/configuration/git/#commit_preprocessors
+; [[git.commit_preprocessors]]
+; replace_command = ""
+(pair
+  (bare_key) @_key (#eq? @_key "replace_command")
+  (string) @injection.content
+  (#set! injection.language "bash"))
+
+; https://git-cliff.org/docs/configuration/git/#commit_parsers
+; [[git.commit_parsers]]
+; message = "..."
+(table
+  (bare_key) @_table (#eq? @_table "git")
+  (pair
+    (bare_key) @_key (#eq? @_key "commit_parsers")
+    (array
+      (inline_table
+        (pair
+          (bare_key) @_message (#any-of? @_message "message" "body")
+          (string) @injection.content))))
+  (#set! injection.language "regex"))

--- a/runtime/queries/git-cliff-config/rainbows.scm
+++ b/runtime/queries/git-cliff-config/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: toml

--- a/runtime/queries/git-cliff-config/textobjects.scm
+++ b/runtime/queries/git-cliff-config/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: toml


### PR DESCRIPTION
This adds a bunch of injection queries for `cliff.toml` files used for configuration by [git-cliff](https://git-cliff.org/docs/configuration/). Most notably it injects [tera](https://keats.github.io/tera/docs/) into the `changelog.body` field. The goal of this commit is to aid readability.

**Showcase**
<img width="1056" height="1144" alt="image" src="https://github.com/user-attachments/assets/17e0fc4c-fa30-466d-abe7-6218cc21e1a5" />

**Before**
<img width="1056" height="1144" alt="image" src="https://github.com/user-attachments/assets/9086b772-c1b1-42dc-bd4e-c5b27596f84f" />
