### PR TITLE
fix(htmldjango): add roots to htmldjango language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -986,6 +986,7 @@ scope = "source.htmldjango"
 injection-regex = "htmldjango"
 language-servers = ["djlsp", "vscode-html-language-server", "superhtml"]
 file-types = []
+roots = ["manage.py"]
 
 [language.auto-pairs]
 '"' = '"'


### PR DESCRIPTION
The htmldjango language is used in no files with the default languages config, originally because it clashed with normal html files. We can use `file-types` and `roots` to use htmldjango when we are in template folders. The root of a django project can also most of the times be assumed to be where `manage.py` resides, so we also add that to the config.