### PR TITLE
queries: update highlights/injections for jjconfig

### DIFF
--- a/runtime/queries/jjconfig/injections.scm
+++ b/runtime/queries/jjconfig/injections.scm
@@ -3,8 +3,8 @@
 
 (table
  (bare_key) @table-name (#any-of? @table-name "templates" "template-aliases")
- [(pair (_) ((string) @injection.content (#set! injection.language "jjtemplate"))) (comment)]*)
+ [(pair (_) ((string) @injection.content (#set! injection.language "jjtemplate"))) (comment)])
 
 (table
  (bare_key) @table-name (#any-of? @table-name "revsets" "revset-aliases")
- [(pair (_) ((string) @injection.content (#set! injection.language "jjrevset"))) (comment)]*)
+ [(pair (_) ((string) @injection.content (#set! injection.language "jjrevset"))) (comment)])

--- a/runtime/queries/jjtemplate/highlights.scm
+++ b/runtime/queries/jjtemplate/highlights.scm
@@ -12,3 +12,5 @@
 
 [(infix_ops) "++"] @operator
 [(string_literal) (raw_string_literal)] @string
+
+(integer_literal) @constant.numeric.integer


### PR DESCRIPTION
Unsure why I originally used the repetition operation. Repetition concatenates all templates/revsets, causing weird parse errors.

Additionally, add highlighting in templates for integer literals.