### PR TITLE
nix: Remove debug ls -al

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -87,8 +87,6 @@
         $CC -c src/parser.c -o parser.o $FLAGS
         $CXX -shared -o $NAME.so *.o
 
-        ls -al
-
         runHook postBuild
       '';
 


### PR DESCRIPTION
There is a debug command in the grammars file which spams my output when building helix 