### PR TITLE
make command(inspired from vim)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "once_cell",
  "open",
  "pulldown-cmark",
+ "regex",
  "same-file",
  "serde",
  "serde_json",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -93,6 +93,8 @@ grep-searcher = "0.1.14"
 
 dashmap = "6.0"
 
+regex = "1"
+
 [target.'cfg(not(windows))'.dependencies]  # https://github.com/vorner/signal-hook/issues/100
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 libc = "0.2.175"

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3,6 +3,7 @@ pub(crate) mod lsp;
 pub(crate) mod syntax;
 pub(crate) mod typed;
 
+use crate::make::make_picker;
 pub use dap::*;
 use futures_util::FutureExt;
 use helix_event::status;
@@ -613,6 +614,7 @@ impl MappableCommand {
         goto_prev_tabstop, "Goto next snippet placeholder",
         rotate_selections_first, "Make the first selection your primary one",
         rotate_selections_last, "Make the last selection your primary one",
+        make_cmd_picker, "MAKE PICKER",
     );
 }
 
@@ -5368,6 +5370,16 @@ fn rotate_selections_last(cx: &mut Context) {
     let len = selection.len();
     selection.set_primary_index(len - 1);
     doc.set_selection(view.id, selection);
+}
+
+fn make_cmd_picker(cx: &mut Context) {
+    let root = find_workspace().0;
+    if !root.exists() {
+        cx.editor.set_error("Workspace directory does not exist");
+        return;
+    }
+    let picker = make_picker(cx, root);
+    cx.push_layer(Box::new(overlaid(picker)));
 }
 
 #[derive(Debug)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5384,14 +5384,7 @@ fn rotate_selections_last(cx: &mut Context) {
 
 fn make_cmd_picker(cx: &mut Context) {
     let root = find_workspace().0;
-
-    let picker;
-    if root.exists() {
-        picker = make_picker(cx, root);
-    } else {
-        picker = make_picker(cx, PathBuf::new());
-    }
-
+    let picker = make_picker(cx, root);
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5374,11 +5374,14 @@ fn rotate_selections_last(cx: &mut Context) {
 
 fn make_cmd_picker(cx: &mut Context) {
     let root = find_workspace().0;
-    if !root.exists() {
-        cx.editor.set_error("Workspace directory does not exist");
-        return;
+
+    let picker;
+    if root.exists() {
+        picker = make_picker(cx, root);
+    } else {
+        picker = make_picker(cx, PathBuf::new());
     }
-    let picker = make_picker(cx, root);
+
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2450,6 +2450,40 @@ fn make_search_word_bounded(cx: &mut Context) {
     }
 }
 
+// TODO(szulf): is there some more global function like this that doesnt depend on lsp stuff?
+pub fn goto_location(
+    cx: &mut compositor::Context,
+    path: &PathBuf,
+    line_num: &usize,
+    action: Action,
+) {
+    let doc = match cx.editor.open(path, action) {
+        Ok(id) => doc_mut!(cx.editor, &id),
+        Err(e) => {
+            cx.editor
+                .set_error(format!("Failed to open file '{}': {}", path.display(), e));
+            return;
+        }
+    };
+
+    let line_num = *line_num;
+    let view = view_mut!(cx.editor);
+    let text = doc.text();
+    if line_num >= text.len_lines() {
+        cx.editor.set_error(
+            "The line you jumped to does not exist anymore because the file has changed.",
+        );
+        return;
+    }
+    let start = text.line_to_char(line_num);
+    let end = text.line_to_char((line_num + 1).min(text.len_lines()));
+
+    doc.set_selection(view.id, Selection::single(start, end));
+    if action.align_view(view, doc.id()) {
+        align_view(doc, view, Align::Center);
+    }
+}
+
 fn global_search(cx: &mut Context) {
     #[derive(Debug)]
     struct FileResult {
@@ -2644,31 +2678,7 @@ fn global_search(cx: &mut Context) {
         [],
         config,
         move |cx, FileResult { path, line_num, .. }, action| {
-            let doc = match cx.editor.open(path, action) {
-                Ok(id) => doc_mut!(cx.editor, &id),
-                Err(e) => {
-                    cx.editor
-                        .set_error(format!("Failed to open file '{}': {}", path.display(), e));
-                    return;
-                }
-            };
-
-            let line_num = *line_num;
-            let view = view_mut!(cx.editor);
-            let text = doc.text();
-            if line_num >= text.len_lines() {
-                cx.editor.set_error(
-                    "The line you jumped to does not exist anymore because the file has changed.",
-                );
-                return;
-            }
-            let start = text.line_to_char(line_num);
-            let end = text.line_to_char((line_num + 1).min(text.len_lines()));
-
-            doc.set_selection(view.id, Selection::single(start, end));
-            if action.align_view(view, doc.id()) {
-                align_view(doc, view, Align::Center);
-            }
+            goto_location(cx, path, line_num, action);
         },
     )
     .with_preview(|_editor, FileResult { path, line_num, .. }| {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -32,7 +32,9 @@ use crate::{
     ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
 };
 
-use std::{cmp::Ordering, collections::HashSet, fmt::Display, future::Future, path::Path};
+use std::{
+    cmp::Ordering, collections::HashSet, fmt::Display, future::Future, path::Path, path::PathBuf,
+};
 
 /// Gets the first language server that is attached to a document which supports a specific feature.
 /// If there is no configured language server that supports the feature, this displays a status message.
@@ -59,10 +61,20 @@ macro_rules! language_server_with_feature {
 /// A wrapper around `lsp::Location` that swaps out the LSP URI for `helix_core::Uri` and adds
 /// the server's  offset encoding.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct Location {
+pub struct Location {
     uri: Uri,
     range: lsp::Range,
     offset_encoding: OffsetEncoding,
+}
+
+impl Location {
+    pub fn new(path: PathBuf, range: lsp::Range, offset_encoding: OffsetEncoding) -> Self {
+        Self {
+            uri: path.into(),
+            range: range,
+            offset_encoding: offset_encoding,
+        }
+    }
 }
 
 fn lsp_location_to_location(
@@ -109,7 +121,7 @@ fn location_to_file_location(location: &Location) -> Option<FileLocation> {
     Some((path.into(), line))
 }
 
-fn jump_to_location(editor: &mut Editor, location: &Location, action: Action) {
+pub fn jump_to_location(editor: &mut Editor, location: &Location, action: Action) {
     let (view, doc) = current!(editor);
     push_jump(view, doc);
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2652,18 +2652,19 @@ fn make(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     let shell = cx.editor.config().shell.clone();
     let args = args.join(" ");
     let make_format_type;
-    match MakeFormatType::from_str("rust") {
+    match MakeFormatType::from_str("clang") {
         Ok(format_type) => make_format_type = format_type,
         Err(_) => return Ok(()),
     }
 
     let callback = async move {
         let output = shell_impl_async(&shell, &args, None).await?;
-        // TODO(szulf): parsing and putting in make picker here
         let call: job::Callback = Callback::EditorCompositor(Box::new(
             move |editor: &mut Editor, _compositor: &mut Compositor| {
-                let entries = make::format(make_format_type, output.as_str());
-                editor.set_status(format!("Filled make list with {} entries.", entries.len()));
+                let entries = make::parse(make_format_type, output.as_str());
+                let entries_count = entries.len();
+                editor.make_list.set(entries);
+                editor.set_status(format!("Filled make list with {} entries.", entries_count));
             },
         ));
         Ok(call)
@@ -3704,10 +3705,11 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["mk"],
         doc: "Executes the command and fills the make picker with its output.",
         fun: make,
+        // TODO(szulf): change this to proper signature with specyfing type of make cmd
         completer: SHELL_COMPLETER,
         signature: Signature {
-            positionals: (2, Some(3)),
-            raw_after: Some(2),
+            positionals: (1, Some(2)),
+            raw_after: Some(1),
             ..Signature::DEFAULT
         },
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2663,7 +2663,10 @@ fn make(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
                 let entries = make::parse(make_format_type, output.as_str());
                 let entries_count = entries.len();
                 editor.make_list.set(entries);
-                editor.set_status(format!("Filled make list with {} entries.", entries_count));
+                editor.set_status(format!(
+                    "Command run. Filled make list with {} entries.",
+                    entries_count
+                ));
             },
         ));
         Ok(call)

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,8 +1,10 @@
 use std::fmt::Write;
 use std::io::BufReader;
 use std::ops::{self, Deref};
+use std::str::FromStr;
 
 use crate::job::Job;
+use crate::make::{self, MakeFormatType};
 
 use super::*;
 
@@ -2642,6 +2644,35 @@ fn noop(_cx: &mut compositor::Context, _args: Args, _event: PromptEvent) -> anyh
     Ok(())
 }
 
+fn make(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let shell = cx.editor.config().shell.clone();
+    let args = args.join(" ");
+    let make_format_type;
+    match MakeFormatType::from_str("rust") {
+        Ok(format_type) => make_format_type = format_type,
+        Err(_) => return Ok(()),
+    }
+
+    let callback = async move {
+        let output = shell_impl_async(&shell, &args, None).await?;
+        // TODO(szulf): parsing and putting in make picker here
+        let call: job::Callback = Callback::EditorCompositor(Box::new(
+            move |editor: &mut Editor, _compositor: &mut Compositor| {
+                let entries = make::format(make_format_type, output.as_str());
+                editor.set_status(format!("Filled make list with {} entries.", entries.len()));
+            },
+        ));
+        Ok(call)
+    };
+    cx.jobs.callback(callback);
+
+    Ok(())
+}
+
 /// This command accepts a single boolean --skip-visible flag and no positionals.
 const BUFFER_CLOSE_OTHERS_SIGNATURE: Signature = Signature {
     positionals: (0, Some(0)),
@@ -3665,6 +3696,18 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, None),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "make",
+        aliases: &["mk"],
+        doc: "Executes the command and fills the make picker with its output.",
+        fun: make,
+        completer: SHELL_COMPLETER,
+        signature: Signature {
+            positionals: (2, Some(3)),
+            raw_after: Some(2),
             ..Signature::DEFAULT
         },
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2648,11 +2648,10 @@ fn make(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
         return Ok(());
     }
 
-    let make_format_type;
-    match args.get_flag("format") {
-        Some(flag) => make_format_type = MakeFormatType::from(flag),
-        None => make_format_type = MakeFormatType::Default,
-    }
+    let make_format_type = match args.get_flag("format") {
+        Some(flag) => MakeFormatType::from(flag),
+        None => MakeFormatType::Default,
+    };
 
     let shell = cx.editor.config().shell.clone();
     let args = args.join(" ");

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 use std::io::BufReader;
 use std::ops::{self, Deref};
-use std::str::FromStr;
 
 use crate::job::Job;
 use crate::make::{self, MakeFormatType};
@@ -2649,13 +2648,14 @@ fn make(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
         return Ok(());
     }
 
+    let make_format_type;
+    match args.get_flag("format") {
+        Some(flag) => make_format_type = MakeFormatType::from(flag),
+        None => make_format_type = MakeFormatType::Default,
+    }
+
     let shell = cx.editor.config().shell.clone();
     let args = args.join(" ");
-    let make_format_type;
-    match MakeFormatType::from_str("clang") {
-        Ok(format_type) => make_format_type = format_type,
-        Err(_) => return Ok(()),
-    }
 
     let callback = async move {
         let output = shell_impl_async(&shell, &args, None).await?;
@@ -3705,12 +3705,17 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["mk"],
         doc: "Executes the command and fills the make picker with its output.",
         fun: make,
-        // TODO(szulf): change this to proper signature with specyfing type of make cmd
         completer: SHELL_COMPLETER,
         signature: Signature {
-            positionals: (1, Some(2)),
-            raw_after: Some(1),
-            ..Signature::DEFAULT
+            flags: &[
+                Flag {
+                    name: "format",
+                    alias: Some('f'),
+                    doc: "sets the make output format",
+                    completions: Some(&["rust", "gcc", "clang", "msvc"]),
+                },
+            ],
+            ..SHELL_SIGNATURE
         },
     },
 ];

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -292,6 +292,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C" => toggle_block_comments,
             "A-c" => toggle_line_comments,
             "?" => command_palette,
+            "m" => make_cmd_picker,
         },
         "z" => { "View"
             "z" | "c" => align_view_center,

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod health;
 pub mod job;
 pub mod keymap;
+pub mod make;
 pub mod ui;
 
 use std::path::Path;

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -8,15 +8,12 @@ use helix_view::{
     theme::Style,
     Align,
 };
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 use tui::text::Span;
 
 // TODO(szulf): check the not closing error after opening logs on a non modified version of helix
 // TODO(szulf): figure out how to display messages from the make_list the same way as diagnostics
-// and make it togglable i think
+// and make it togglable in the config i think
 
 #[derive(Debug, Clone)]
 pub struct MakePickerData {
@@ -100,25 +97,30 @@ pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
 }
 
 pub enum MakeFormatType {
+    Default,
     Rust,
     Gcc,
     Clang,
     Msvc,
 }
 
-impl FromStr for MakeFormatType {
-    // TODO(szulf): change this later
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "rust" => Ok(MakeFormatType::Rust),
-            "gcc" => Ok(MakeFormatType::Gcc),
-            "clang" => Ok(MakeFormatType::Clang),
-            "msvc" => Ok(MakeFormatType::Msvc),
-            _ => Err(()),
+impl From<&str> for MakeFormatType {
+    fn from(value: &str) -> Self {
+        match value {
+            "rust" => MakeFormatType::Rust,
+            "gcc" => MakeFormatType::Rust,
+            "clang" => MakeFormatType::Clang,
+            "msvc" => MakeFormatType::Msvc,
+            _ => MakeFormatType::Default,
         }
     }
+}
+
+pub fn parse_default<'a, T>(_lines: T) -> Vec<Entry>
+where
+    T: IntoIterator<Item = &'a str>,
+{
+    todo!();
 }
 
 pub fn parse_rust<'a, T>(_lines: T) -> Vec<Entry>
@@ -255,6 +257,7 @@ pub fn parse(format_type: MakeFormatType, source: &str) -> Vec<Entry> {
     let lines = source.lines();
 
     match format_type {
+        MakeFormatType::Default => parse_default(lines),
         MakeFormatType::Rust => parse_rust(lines),
         MakeFormatType::Gcc => parse_gcc(lines),
         MakeFormatType::Clang => parse_clang(lines),

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -1,0 +1,99 @@
+use crate::commands;
+use crate::commands::{jump_to_location, Context};
+use crate::ui::{Picker, PickerColumn};
+use helix_view::make::{Entry, Location};
+use std::{path::PathBuf, str::FromStr};
+
+fn make_location_to_location(location: &Location) -> commands::Location {
+    // TODO(szulf): take offet_encoding as an argument
+    commands::Location::new(
+        location.path.clone(),
+        location.range.clone(),
+        helix_lsp::OffsetEncoding::Utf8,
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct MakePickerData {
+    root: PathBuf,
+}
+
+type MakePicker = Picker<Entry, MakePickerData>;
+
+pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
+    let options = cx.editor.make_list.clone().into_iter();
+
+    let data = MakePickerData { root: root };
+
+    let columns = vec![
+        PickerColumn::new("path", |entry: &Entry, data: &MakePickerData| {
+            let path = match entry.location.path.strip_prefix(&data.root) {
+                Ok(path) => path.to_str(),
+                Err(_) => entry.location.path.to_str(),
+            };
+            match path {
+                Some(str) => str.into(),
+                None => "".into(),
+            }
+        }),
+        // TODO(szulf): change value to something else
+        PickerColumn::new("value", |entry: &Entry, _data: &MakePickerData| {
+            entry.value.err_msg.clone().into()
+        }),
+    ];
+
+    Picker::new(columns, 0, options, data, move |cx, item, action| {
+        jump_to_location(
+            cx.editor,
+            &make_location_to_location(&item.location),
+            action,
+        );
+    })
+}
+
+pub enum MakeFormatType {
+    Rust,
+    Gcc,
+    Clang,
+    Msvc,
+}
+
+impl FromStr for MakeFormatType {
+    // TODO(szulf): change this later
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rust" => Ok(MakeFormatType::Rust),
+            "gcc" => Ok(MakeFormatType::Gcc),
+            "clang" => Ok(MakeFormatType::Clang),
+            "msvc" => Ok(MakeFormatType::Msvc),
+            _ => Err(()),
+        }
+    }
+}
+
+pub fn format_rust(_source: &str) -> Vec<Entry> {
+    return vec![];
+}
+
+pub fn format_gcc(_source: &str) -> Vec<Entry> {
+    return vec![];
+}
+
+pub fn format_clang(_source: &str) -> Vec<Entry> {
+    return vec![];
+}
+
+pub fn format_msvc(_source: &str) -> Vec<Entry> {
+    return vec![];
+}
+
+pub fn format(format_type: MakeFormatType, source: &str) -> Vec<Entry> {
+    match format_type {
+        MakeFormatType::Rust => format_rust(source),
+        MakeFormatType::Gcc => format_gcc(source),
+        MakeFormatType::Clang => format_clang(source),
+        MakeFormatType::Msvc => format_msvc(source),
+    }
+}

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -1,21 +1,30 @@
-use crate::commands;
-use crate::commands::{jump_to_location, Context};
+use crate::commands::Context;
 use crate::ui::{Picker, PickerColumn};
-use helix_view::make::{Entry, Location};
-use std::{path::PathBuf, str::FromStr};
+use helix_core::Selection;
+use helix_lsp::lsp::DiagnosticSeverity;
+use helix_view::{
+    align_view,
+    make::{Entry, Location},
+    theme::Style,
+    Align,
+};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use tui::text::Span;
 
-fn make_location_to_location(location: &Location) -> commands::Location {
-    // TODO(szulf): take offet_encoding as an argument
-    commands::Location::new(
-        location.path.clone(),
-        location.range.clone(),
-        helix_lsp::OffsetEncoding::Utf8,
-    )
-}
+// TODO(szulf): check the not closing error after opening logs on a non modified version of helix
+// TODO(szulf): figure out how to display messages from the make_list the same way as diagnostics
+// and make it togglable i think
 
 #[derive(Debug, Clone)]
 pub struct MakePickerData {
     root: PathBuf,
+    hint: Style,
+    info: Style,
+    warning: Style,
+    error: Style,
 }
 
 type MakePicker = Picker<Entry, MakePickerData>;
@@ -23,9 +32,25 @@ type MakePicker = Picker<Entry, MakePickerData>;
 pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
     let options = cx.editor.make_list.clone().into_iter();
 
-    let data = MakePickerData { root: root };
+    let data = MakePickerData {
+        root: root,
+        hint: cx.editor.theme.get("hint"),
+        info: cx.editor.theme.get("info"),
+        warning: cx.editor.theme.get("warning"),
+        error: cx.editor.theme.get("error"),
+    };
 
     let columns = vec![
+        PickerColumn::new("severity", |entry: &Entry, data: &MakePickerData| {
+            match entry.severity {
+                DiagnosticSeverity::HINT => Span::styled("HINT", data.hint),
+                DiagnosticSeverity::INFORMATION => Span::styled("INFO", data.info),
+                DiagnosticSeverity::WARNING => Span::styled("WARN", data.warning),
+                DiagnosticSeverity::ERROR => Span::styled("ERROR", data.error),
+                _ => Span::raw(""),
+            }
+            .into()
+        }),
         PickerColumn::new("path", |entry: &Entry, data: &MakePickerData| {
             let path = match entry.location.path.strip_prefix(&data.root) {
                 Ok(path) => path.to_str(),
@@ -36,18 +61,41 @@ pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
                 None => "".into(),
             }
         }),
-        // TODO(szulf): change value to something else
-        PickerColumn::new("value", |entry: &Entry, _data: &MakePickerData| {
-            entry.value.err_msg.clone().into()
+        PickerColumn::new("message", |entry: &Entry, _data: &MakePickerData| {
+            entry.msg.clone().into()
         }),
     ];
 
     Picker::new(columns, 0, options, data, move |cx, item, action| {
-        jump_to_location(
-            cx.editor,
-            &make_location_to_location(&item.location),
-            action,
-        );
+        // TODO(szulf): this is copied from the global_search function should i maybe pull it out?
+        let doc = match cx.editor.open(&item.location.path, action) {
+            Ok(id) => doc_mut!(cx.editor, &id),
+            Err(e) => {
+                cx.editor.set_error(format!(
+                    "Failed to open file '{}': {}",
+                    item.location.path.display(),
+                    e
+                ));
+                return;
+            }
+        };
+
+        let line_num = item.location.line;
+        let view = view_mut!(cx.editor);
+        let text = doc.text();
+        if line_num >= text.len_lines() {
+            cx.editor.set_error(
+                "The line you jumped to does not exist anymore because the file has changed.",
+            );
+            return;
+        }
+        let start = text.line_to_char(line_num);
+        let end = text.line_to_char((line_num + 1).min(text.len_lines()));
+
+        doc.set_selection(view.id, Selection::single(start, end));
+        if action.align_view(view, doc.id()) {
+            align_view(doc, view, Align::Center);
+        }
     })
 }
 
@@ -73,27 +121,143 @@ impl FromStr for MakeFormatType {
     }
 }
 
-pub fn format_rust(_source: &str) -> Vec<Entry> {
-    return vec![];
+pub fn parse_rust<'a, T>(_lines: T) -> Vec<Entry>
+where
+    T: IntoIterator<Item = &'a str>,
+{
+    todo!();
 }
 
-pub fn format_gcc(_source: &str) -> Vec<Entry> {
-    return vec![];
+pub fn parse_gcc<'a, T>(lines: T) -> Vec<Entry>
+where
+    T: IntoIterator<Item = &'a str>,
+{
+    // NOTE(szulf): they should always be the same
+    return parse_clang(lines);
 }
 
-pub fn format_clang(_source: &str) -> Vec<Entry> {
-    return vec![];
+// TODO(szulf): better naming
+// TODO(szulf): make an error type?
+pub fn check(s: &str) -> Result<Location, ()> {
+    let mut loc = s.split(':').collect::<Vec<&str>>();
+    loc.retain(|&s| s != "");
+
+    if loc.len() < 3 {
+        return Err(());
+    }
+
+    let mut loc_fixed: Vec<String> = loc.iter().map(|s| (*s).to_string()).collect();
+    // NOTE(szulf): handle paths that contain ':'
+    while loc_fixed.len() != 3 {
+        let second = loc_fixed.remove(1);
+        loc_fixed[0].push_str(second.as_str());
+    }
+
+    let path = Path::new(loc_fixed[0].as_str());
+    if !path.exists() {
+        return Err(());
+    }
+
+    let line = match loc_fixed[1].parse::<usize>() {
+        Ok(l) => l - 1,
+        Err(_) => {
+            log::debug!("couldnt parse splits[1]: {:?}", loc_fixed[1]);
+            return Err(());
+        }
+    };
+
+    return Ok(Location {
+        path: PathBuf::from(loc_fixed.remove(0)),
+        line: line,
+    });
 }
 
-pub fn format_msvc(_source: &str) -> Vec<Entry> {
-    return vec![];
+pub fn parse_clang<'a, T>(lines: T) -> Vec<Entry>
+where
+    T: IntoIterator<Item = &'a str>,
+{
+    // TODO(szulf): better naming
+    let e = lines
+        .into_iter()
+        .map(|s| s.split_whitespace().collect::<Vec<&str>>())
+        .collect::<Vec<Vec<&str>>>();
+
+    let mut entries = Vec::new();
+
+    let mut message: String = String::default();
+    let mut location = None;
+    let mut severity = DiagnosticSeverity::ERROR;
+
+    for s in e {
+        let mut iter = s.into_iter().peekable();
+
+        // TODO(szulf): the naming man
+        // l loc locat location
+        // beautiful
+        while let Some(l) = iter.next() {
+            let loc = check(l);
+            match loc {
+                Ok(locat) => {
+                    location = Some(locat);
+
+                    if let Some(sever) = iter.peek() {
+                        match *sever {
+                            "warning:" => {
+                                severity = DiagnosticSeverity::WARNING;
+                                iter.next();
+                            }
+                            "note:" => {
+                                severity = DiagnosticSeverity::HINT;
+                                iter.next();
+                            }
+                            "error:" => {
+                                severity = DiagnosticSeverity::ERROR;
+                                iter.next();
+                            }
+                            _ => severity = DiagnosticSeverity::ERROR,
+                        }
+                    }
+
+                    message.clear();
+                }
+                Err(_) => {
+                    if message.len() != 0 {
+                        message.push_str(" ");
+                    }
+                    message.push_str(l);
+                }
+            }
+        }
+
+        match location {
+            Some(loc) => {
+                entries.push(Entry::new(loc, message.as_str(), severity));
+            }
+            None => {}
+        }
+
+        message.clear();
+        severity = DiagnosticSeverity::ERROR;
+        location = None;
+    }
+
+    entries
 }
 
-pub fn format(format_type: MakeFormatType, source: &str) -> Vec<Entry> {
+pub fn parse_msvc<'a, T>(_lines: T) -> Vec<Entry>
+where
+    T: IntoIterator<Item = &'a str>,
+{
+    todo!();
+}
+
+pub fn parse(format_type: MakeFormatType, source: &str) -> Vec<Entry> {
+    let lines = source.lines();
+
     match format_type {
-        MakeFormatType::Rust => format_rust(source),
-        MakeFormatType::Gcc => format_gcc(source),
-        MakeFormatType::Clang => format_clang(source),
-        MakeFormatType::Msvc => format_msvc(source),
+        MakeFormatType::Rust => parse_rust(lines),
+        MakeFormatType::Gcc => parse_gcc(lines),
+        MakeFormatType::Clang => parse_clang(lines),
+        MakeFormatType::Msvc => parse_msvc(lines),
     }
 }

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -123,10 +123,6 @@ fn parse_with_regex(source: &str, regex: &str) -> Vec<Entry> {
     results
 }
 
-fn parse_default(_source: &str) -> Vec<Entry> {
-    todo!();
-}
-
 fn parse_rust(source: &str) -> Vec<Entry> {
     parse_with_regex(
         source,
@@ -147,6 +143,16 @@ fn parse_msvc(source: &str) -> Vec<Entry> {
         source,
         r"^<(?P<path>.+)>\((?P<line>\d+)\):\s(?P<severity>error|warning|note)(?:[^:]+)?:\s(?P<message>.+)$",
     )
+}
+
+fn parse_default(source: &str) -> Vec<Entry> {
+    let mut entries = Vec::new();
+
+    entries.append(&mut parse_rust(source));
+    entries.append(&mut parse_gcc(source));
+    entries.append(&mut parse_msvc(source));
+
+    entries
 }
 
 pub fn parse(format_type: MakeFormatType, source: &str) -> Vec<Entry> {

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -96,6 +96,7 @@ pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
     })
 }
 
+// TODO(szulf): dont really see the point of this enum honestly
 pub enum MakeFormatType {
     Default,
     Rust,
@@ -116,31 +117,31 @@ impl From<&str> for MakeFormatType {
     }
 }
 
-pub fn parse_default<'a, T>(_lines: T) -> Vec<Entry>
+fn parse_default<'a, T>(_lines: T) -> Vec<Entry>
 where
     T: IntoIterator<Item = &'a str>,
 {
     todo!();
 }
 
-pub fn parse_rust<'a, T>(_lines: T) -> Vec<Entry>
+fn parse_rust<'a, T>(_lines: T) -> Vec<Entry>
 where
     T: IntoIterator<Item = &'a str>,
 {
     todo!();
 }
 
-pub fn parse_gcc<'a, T>(lines: T) -> Vec<Entry>
+fn parse_gcc<'a, T>(lines: T) -> Vec<Entry>
 where
     T: IntoIterator<Item = &'a str>,
 {
-    // NOTE(szulf): they should always be the same
+    // NOTE(szulf): they SHOULD always be the same
     return parse_clang(lines);
 }
 
 // TODO(szulf): better naming
 // TODO(szulf): make an error type?
-pub fn check(s: &str) -> Result<Location, ()> {
+fn check(s: &str) -> Result<Location, ()> {
     let mut loc = s.split(':').collect::<Vec<&str>>();
     loc.retain(|&s| s != "");
 
@@ -150,7 +151,7 @@ pub fn check(s: &str) -> Result<Location, ()> {
 
     let mut loc_fixed: Vec<String> = loc.iter().map(|s| (*s).to_string()).collect();
     // NOTE(szulf): handle paths that contain ':'
-    while loc_fixed.len() != 3 {
+    while loc_fixed.len() > 3 {
         let second = loc_fixed.remove(1);
         loc_fixed[0].push_str(second.as_str());
     }
@@ -174,7 +175,7 @@ pub fn check(s: &str) -> Result<Location, ()> {
     });
 }
 
-pub fn parse_clang<'a, T>(lines: T) -> Vec<Entry>
+fn parse_clang<'a, T>(lines: T) -> Vec<Entry>
 where
     T: IntoIterator<Item = &'a str>,
 {
@@ -246,7 +247,7 @@ where
     entries
 }
 
-pub fn parse_msvc<'a, T>(_lines: T) -> Vec<Entry>
+fn parse_msvc<'a, T>(_lines: T) -> Vec<Entry>
 where
     T: IntoIterator<Item = &'a str>,
 {

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -128,8 +128,11 @@ fn parse_default(_source: &str) -> Vec<Entry> {
     todo!();
 }
 
-fn parse_rust(_source: &str) -> Vec<Entry> {
-    todo!();
+fn parse_rust(source: &str) -> Vec<Entry> {
+    parse_with_regex(
+        source,
+        r"^(?P<severity>help|warning|error)(?:\[.+\])?:?\s(?P<message>.+)\n\s+-->\s(?P<path>[^:\n\s]+):(?P<line>\d+):(\d+)$",
+    )
 }
 
 fn parse_gcc(source: &str) -> Vec<Entry> {

--- a/helix-term/src/make.rs
+++ b/helix-term/src/make.rs
@@ -9,10 +9,8 @@ use regex::RegexBuilder;
 use std::path::PathBuf;
 use tui::text::Span;
 
-// TODO(szulf): check the not closing error after opening logs on a non modified version of helix
 // TODO(szulf): figure out how to display messages from the make_list the same way as diagnostics
 // and make it togglable in the config i think(off by default i think)
-// TODO(szulf): write the return code(success/fail) while writing 'filled make list with ? entries'
 // TODO(szulf): add keybindings for going to next/prev item in make list
 
 #[derive(Debug, Clone)]
@@ -67,7 +65,6 @@ pub fn make_picker(cx: &Context, root: PathBuf) -> MakePicker {
     })
 }
 
-// TODO(szulf): dont really see the point of this enum honestly
 #[derive(Debug)]
 pub enum MakeFormatType {
     Default,
@@ -137,7 +134,6 @@ fn parse_gcc(source: &str) -> Vec<Entry> {
     )
 }
 
-// TODO(szulf): test this
 fn parse_msvc(source: &str) -> Vec<Entry> {
     parse_with_regex(
         source,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -15,6 +15,7 @@ use crate::{
 
 use helix_core::{
     diagnostic::NumberOrString,
+    find_workspace,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
     syntax::{self, OverlayHighlights},
@@ -140,6 +141,7 @@ impl EditorView {
         }
 
         Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+        Self::doc_makelist_highlights_into(doc, editor, theme, &mut overlays);
 
         if is_focused {
             if let Some(tabstops) = Self::tabstop_highlights(doc, theme) {
@@ -158,6 +160,7 @@ impl EditorView {
             }
         }
 
+        // NOTE(szulf): gutter diagnostics HERE
         let gutter_overflow = view.gutter_offset(doc) == 0;
         if !gutter_overflow {
             Self::render_gutter(
@@ -185,6 +188,8 @@ impl EditorView {
         }
         let width = view.inner_width(doc);
         let config = doc.config.load();
+
+        // NOTE(szulf): text for diagnostics HERE
         let enable_cursor_line = view
             .diagnostics_handler
             .show_cursorline_diagnostics(doc, view.id);
@@ -196,6 +201,7 @@ impl EditorView {
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
         ));
+
         render_document(
             surface,
             inner,
@@ -439,6 +445,76 @@ impl EditorView {
                 ranges: deprecated_vec,
             });
         }
+        overlay_highlights.extend([
+            OverlayHighlights::Homogeneous {
+                highlight: get_scope_of("diagnostic.info"),
+                ranges: info_vec,
+            },
+            OverlayHighlights::Homogeneous {
+                highlight: get_scope_of("diagnostic.hint"),
+                ranges: hint_vec,
+            },
+            OverlayHighlights::Homogeneous {
+                highlight: get_scope_of("diagnostic.warning"),
+                ranges: warning_vec,
+            },
+            OverlayHighlights::Homogeneous {
+                highlight: get_scope_of("diagnostic.error"),
+                ranges: error_vec,
+            },
+        ]);
+    }
+
+    pub fn doc_makelist_highlights_into(
+        doc: &Document,
+        editor: &Editor,
+        theme: &Theme,
+        overlay_highlights: &mut Vec<OverlayHighlights>,
+    ) {
+        use helix_core::diagnostic::Severity;
+
+        let get_scope_of = |scope| {
+            theme
+                .find_highlight_exact(scope)
+                // get one of the themes below as fallback values
+                .or_else(|| theme.find_highlight_exact("diagnostic"))
+                .or_else(|| theme.find_highlight_exact("ui.cursor"))
+                .or_else(|| theme.find_highlight_exact("ui.selection"))
+                .expect(
+                    "at least one of the following scopes must be defined in the theme: `diagnostic`, `ui.cursor`, or `ui.selection`",
+                )
+        };
+
+        let mut info_vec = Vec::new();
+        let mut hint_vec = Vec::new();
+        let mut warning_vec = Vec::new();
+        let mut error_vec = Vec::new();
+
+        for entry in &editor.make_list {
+            let vec = match entry.severity {
+                Severity::Hint => &mut hint_vec,
+                Severity::Warning => &mut warning_vec,
+                Severity::Error => &mut error_vec,
+                Severity::Info => &mut info_vec,
+            };
+
+            // TODO(szulf): have to check here if im in the right file
+            let current_path = match doc.path() {
+                Some(path) => match path.strip_prefix(find_workspace().0) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                },
+                None => continue,
+            };
+
+            if current_path == entry.location.path {
+                let text = doc.text().slice(..);
+                let range_start = text.line_to_byte(entry.location.line);
+                let range_end = text.line_to_byte(entry.location.line + 1) - 1;
+                vec.push(range_start..range_end);
+            }
+        }
+
         overlay_highlights.extend([
             OverlayHighlights::Homogeneous {
                 highlight: get_scope_of("diagnostic.info"),

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -160,7 +160,6 @@ impl EditorView {
             }
         }
 
-        // NOTE(szulf): gutter diagnostics HERE
         let gutter_overflow = view.gutter_offset(doc) == 0;
         if !gutter_overflow {
             Self::render_gutter(
@@ -189,7 +188,6 @@ impl EditorView {
         let width = view.inner_width(doc);
         let config = doc.config.load();
 
-        // NOTE(szulf): text for diagnostics HERE
         let enable_cursor_line = view
             .diagnostics_handler
             .show_cursorline_diagnostics(doc, view.id);
@@ -498,7 +496,6 @@ impl EditorView {
                 Severity::Info => &mut info_vec,
             };
 
-            // TODO(szulf): have to check here if im in the right file
             let current_path = match doc.path() {
                 Some(path) => match path.strip_prefix(find_workspace().0) {
                     Ok(path) => path,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -9,6 +9,7 @@ use crate::{
     handlers::Handlers,
     info::Info,
     input::KeyEvent,
+    make,
     register::Registers,
     theme::{self, Theme},
     tree::{self, Tree},
@@ -1162,6 +1163,8 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+
+    pub make_list: make::List,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1283,6 +1286,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            make_list: make::List::new(),
         }
     }
 

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -14,6 +14,7 @@ pub mod handlers;
 pub mod info;
 pub mod input;
 pub mod keyboard;
+pub mod make;
 pub mod register;
 pub mod theme;
 pub mod tree;

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -1,4 +1,5 @@
-use helix_lsp::lsp::DiagnosticSeverity;
+use helix_core::diagnostic::Severity;
+use std::ops::{Index, IndexMut};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default)]
@@ -13,11 +14,11 @@ pub struct Location {
 pub struct Entry {
     pub location: Location,
     pub msg: String,
-    pub severity: DiagnosticSeverity,
+    pub severity: Severity,
 }
 
 impl Entry {
-    pub fn new(location: Location, msg: String, severity: DiagnosticSeverity) -> Self {
+    pub fn new(location: Location, msg: String, severity: Severity) -> Self {
         Self {
             location: location,
             msg: msg,
@@ -43,14 +44,42 @@ impl List {
     pub fn set(&mut self, entries: Vec<Entry>) {
         self.entries = entries;
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Index<usize> for List {
+    type Output = Entry;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.entries[index]
+    }
+}
+
+impl IndexMut<usize> for List {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.entries[index]
+    }
 }
 
 impl IntoIterator for List {
     type Item = Entry;
-
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.entries.into_iter()
+    }
+}
+
+// TODO(szulf): dont know if this is the right way to iterate over this collection without
+// consuming it
+impl<'a> IntoIterator for &'a List {
+    type Item = &'a Entry;
+    type IntoIter = std::slice::Iter<'a, Entry>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.iter()
     }
 }

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -1,44 +1,27 @@
-use helix_lsp::lsp::{Position, Range};
+use helix_lsp::lsp::{DiagnosticSeverity, Range};
 use std::path::PathBuf;
-
-// TODO(szulf): better naming cause god damn
-
-#[derive(Debug, Default, Clone)]
-pub struct Value {
-    // TODO(szulf): not sure about this
-    pub err_msg: String,
-}
-
-impl Value {
-    pub fn new(err_msg: &str) -> Self {
-        Self {
-            err_msg: err_msg.to_string(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct Location {
     pub path: PathBuf,
-    pub range: Range,
+    pub line: usize,
 }
 
-// NOTE(szulf): would absolutely love to use helix-term::commands::Location
-// but cannot access it from here whyyyyy
-#[derive(Debug, Clone, Default)]
+// TODO(szulf): maybe add a way for entries to reference other entries
+// so that things like note: can actually be linked back to the original error
+#[derive(Debug, Clone)]
 pub struct Entry {
     pub location: Location,
-    pub value: Value,
+    pub msg: String,
+    pub severity: DiagnosticSeverity,
 }
 
 impl Entry {
-    pub fn new(path: PathBuf, value: Value) -> Self {
+    pub fn new(location: Location, msg: &str, severity: DiagnosticSeverity) -> Self {
         Self {
-            location: Location {
-                path: path,
-                range: Range::new(Position::new(2, 5), Position::new(2, 6)),
-            },
-            value: value,
+            location: location,
+            msg: msg.to_string(),
+            severity: severity,
         }
     }
 }
@@ -59,5 +42,9 @@ impl List {
 
     pub fn into_iter(self) -> impl Iterator<Item = Entry> {
         self.entries.into_iter()
+    }
+
+    pub fn set(&mut self, entries: Vec<Entry>) {
+        self.entries = entries;
     }
 }

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -1,4 +1,4 @@
-use helix_lsp::lsp::{DiagnosticSeverity, Range};
+use helix_lsp::lsp::DiagnosticSeverity;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default)]
@@ -40,6 +40,7 @@ impl List {
         self.entries.push(entry);
     }
 
+    // TODO(szulf): change this to implementing the IntoIterator trait instead
     pub fn into_iter(self) -> impl Iterator<Item = Entry> {
         self.entries.into_iter()
     }

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -40,12 +40,17 @@ impl List {
         self.entries.push(entry);
     }
 
-    // TODO(szulf): change this to implementing the IntoIterator trait instead
-    pub fn into_iter(self) -> impl Iterator<Item = Entry> {
-        self.entries.into_iter()
-    }
-
     pub fn set(&mut self, entries: Vec<Entry>) {
         self.entries = entries;
+    }
+}
+
+impl IntoIterator for List {
+    type Item = Entry;
+
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
     }
 }

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -8,8 +8,6 @@ pub struct Location {
     pub line: usize,
 }
 
-// TODO(szulf): maybe add a way for entries to reference other entries
-// so that things like note: can actually be linked back to the original error
 #[derive(Debug, Clone)]
 pub struct Entry {
     pub location: Location,

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -1,0 +1,63 @@
+use helix_lsp::lsp::{Position, Range};
+use std::path::PathBuf;
+
+// TODO(szulf): better naming cause god damn
+
+#[derive(Debug, Default, Clone)]
+pub struct Value {
+    // TODO(szulf): not sure about this
+    pub err_msg: String,
+}
+
+impl Value {
+    pub fn new(err_msg: &str) -> Self {
+        Self {
+            err_msg: err_msg.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Location {
+    pub path: PathBuf,
+    pub range: Range,
+}
+
+// NOTE(szulf): would absolutely love to use helix-term::commands::Location
+// but cannot access it from here whyyyyy
+#[derive(Debug, Clone, Default)]
+pub struct Entry {
+    pub location: Location,
+    pub value: Value,
+}
+
+impl Entry {
+    pub fn new(path: PathBuf, value: Value) -> Self {
+        Self {
+            location: Location {
+                path: path,
+                range: Range::new(Position::new(2, 5), Position::new(2, 6)),
+            },
+            value: value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct List {
+    entries: Vec<Entry>,
+}
+
+impl List {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, entry: Entry) {
+        self.entries.push(entry);
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = Entry> {
+        self.entries.into_iter()
+    }
+}

--- a/helix-view/src/make.rs
+++ b/helix-view/src/make.rs
@@ -17,10 +17,10 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub fn new(location: Location, msg: &str, severity: DiagnosticSeverity) -> Self {
+    pub fn new(location: Location, msg: String, severity: DiagnosticSeverity) -> Self {
         Self {
             location: location,
-            msg: msg.to_string(),
+            msg: msg,
             severity: severity,
         }
     }


### PR DESCRIPTION
Dont think this is finished, its still missing things like displaying inline text in the same way diagnostics do(and also make it possible to turn it off in the config), or probably a few additional regex'es to make it more useful for more people, or probably some tests, but i won't have the time now to implement these now, so figured might as well send the pull request.

I still think its a good start for a feature i've seen was requested by people(and myself).
From testing for a couple days with mainly gcc/clang output it works great.

Here are some suggestions for future development if this ever gets integrated into the codebase, that i didnt have time to implement:
The fact you need to either retype the command(or press the up-arrow a few times) all the time is kind of annoying, maybe it would be nice to specify some commands in the config, and then have a picker over them.
It would be nice to somehow see the full output of the command.
It would be nice to see the returned code by the command.