### PR TITLE
docs: fix possible error when building the optimized version from source

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -42,7 +42,7 @@ RUSTFLAGS="-C target-feature=-crt-static"
    # Optimized
    cargo install \
       --profile opt \
-      --config 'build.rustflags="-C target-cpu=native"' \
+      --config 'build.rustflags=["-C", "target-cpu=native"]' \
       --path helix-term \
       --locked
    ```


### PR DESCRIPTION
Refs: #14329

This PR changes the command for building an optimized version of Helix to avoid a possible error when the user has set the `build.rustflags` option in their `~/.cargo/config.toml`.