### PR TITLE
Add tag_search command for searching tag files generated via ctags.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "once_cell",
  "open",
  "pulldown-cmark",
+ "rayon",
  "same-file",
  "serde",
  "serde_json",

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -90,6 +90,7 @@ serde = { version = "1.0", features = ["derive"] }
 # ripgrep for global search
 grep-regex = "0.1.13"
 grep-searcher = "0.1.14"
+rayon = "1.7"
 
 dashmap = "6.0"
 


### PR DESCRIPTION
With discussions from #3518 and comment from @jphamina on #1252 

This pull request adds support for search functions/methods supported by ctags and provides quick navigation across large code-bases where LSP isn't always present.

This is my first pull request in Rust (very happy about it), it took a day to implement and some slight polishing over past few months. I use it regularly and haven't seen any problems as of yet.

Essential design is a simple grep over the tags file instead of the actual tag parser from ctags is because grep allows prefix/suffix search at cost of being less accurate. For example, an Java function named performABC has a JNI with cool_host_performABC. Tag parser would fail to search both methods with performABC but a simple grep wouldn't.

The underlying grep is the same grep used to search text inside files for helix-editor. I'm using this pull request on code-bases as large as 20 million LOC.

Since ctags also generates tags for anonymous/lambda functions, I generally clean it up using the following command:
```
  sed -i '/<anonymous>/d' tags
  sed -i '/<lambda>/d' tags
  sed -i '/`/d' tags
  sed -i '/!_/d' tags
  sed -i '/$	/d' tags
  sed -i '/out\/tests.rs/d' tags
  sed -i 's/\\\//\//g' tags
```

Other notes, this would be implemented as plugin as requested by the maintainers and hence a interim pull request to allow others to use this beautiful editor.
