### PR TITLE
add a link to github release page on debian installation docs

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -25,7 +25,7 @@ The following third party repositories are available:
 
 ### Ubuntu/Debian
 
-Install the Debian package from the release page.
+Install the Debian package [from the release page](https://github.com/helix-editor/helix/releases/latest).
 
 If you are running a system older than Ubuntu 22.04, Mint 21, or Debian 12, you can build the `.deb` file locally
 [from source](./building-from-source.md#building-the-debian-package).


### PR DESCRIPTION
hej, i think it could be an small improvement to the docs, if you could include a direct link to the github release page.

i actually stumbled across this missing link 2-3 times - its not hard to find the location, but adding it might save someone a few seconds :)