### PR TITLE
fix(theme): correct goto_word and comments background in `flatwhite.toml`

### DIFF
--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -2,11 +2,10 @@
 # Adopted from https://github.com/biletskyy/flatwhite-syntax
 
 "attribute" = { fg = "blue_text", bg = "blue_bg" }
-"comment" = { fg = "base3", modifiers = ["italic"] }
-"comment.line" = {}
-"comment.line.documentation" = { fg = "base2" }
-"comment.block" = {}
-"comment.block.documentation" = { fg = "base2" }
+"comment" = { fg = "base2", bg = "base6" }
+"comment.line" = { fg = "base2", bg = "base6" }
+"comment.block" = { fg = "base2", bg = "base6" }
+"comment.block.documentation" = { fg = "base2", bg = "base6" }
 "constant" = { fg = "blue_text", bg = "blue_bg" }
 "constructor" = { fg = "base1" }
 "function" = { fg = "base1", modifiers = ["bold"] }
@@ -62,12 +61,10 @@
 "ui.virtual" = { fg = "base5", bg = "base6" }
 "ui.virtual.whitespace" = { fg = "base5" }
 "ui.virtual.ruler" = { bg = "base6" }
-# Invalid modifier: "normal". See 'https://github.com/helix-editor/helix/issues/5709'
-# "ui.virtual.inlay-hint" = { fg = "base4", modifiers = ["normal"] }
-# "ui.virtual.inlay-hint.parameter" = { fg = "base3", modifiers = ["normal"] }
 "ui.virtual.inlay-hint" = "base4"
 "ui.virtual.inlay-hint.parameter" = "base3"
 "ui.virtual.inlay-hint.type" = { fg = "base3", modifiers = ["italic"] }
+"ui.virtual.jump-label" = { bg = "orange_bg", modifiers = ["bold"] }
 
 "ui.linenr" = { bg = "base6" }
 "ui.linenr.selected" = { bg = "base6", modifiers = ["reversed"] }


### PR DESCRIPTION
## Changelog
- Highlight goto_word (Before/After)
<img width="49%" alt="Before" src="https://github.com/user-attachments/assets/14a00eb0-1d41-4ac3-b54c-af0dc00a9084" />
<img width="49%" alt="After" src="https://github.com/user-attachments/assets/745d38a3-3841-4bee-a0e5-67c580f88b9f" />

- Comments (Before/After)
 
<img width="49%" alt="Before" src="https://github.com/user-attachments/assets/b553cf44-6644-4288-a421-309f0225d46a" />
<img width="49%" alt="After" src="https://github.com/user-attachments/assets/6c00b2d3-f2ed-4306-a581-4ff63896afef" />
</br></br>

- Also an unnecessary comment about a fixed bug was removed