### PR TITLE
queries(rust): Highlight type infer in more places

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -88,8 +88,13 @@
 ((type_arguments (type_identifier) @constant)
  (#match? @constant "^[A-Z_]+$"))
 (type_arguments (type_identifier) @type)
+; `_` in `(_, _)`
 (tuple_struct_pattern "_" @comment.unused)
+; `_` in `Vec<_>`
 ((type_arguments (type_identifier) @comment.unused)
+ (#eq? @comment.unused "_"))
+; `_` in `Rc<[_]>`
+((array_type (type_identifier) @comment.unused)
  (#eq? @comment.unused "_"))
 
 ; ---


### PR DESCRIPTION
test file

```
fn main() {
    let a: Vec<_>;
}
```

split up from https://github.com/helix-editor/helix/pull/13932