### PR TITLE
queries(rust): highlight function parameter locals in more places

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -14,12 +14,64 @@
 
 ; Definitions
 
-(function_item
-  (parameters
-    (parameter
-      pattern: (identifier) @local.definition.variable.parameter)))
+(parameter
+  (mutable_specifier)?
+  pattern: [
+    ; `foo` in `fn x(foo: !) {}`
+    (identifier) @local.definition.variable.parameter @variable.parameter
+    ; `foo` and `bar` in `fn x((foo, bar): !) {}`
+    (tuple_pattern
+      [
+        (mut_pattern
+          (_)
+          (identifier))
+        (identifier)
+      ]*
+      [
+        (mut_pattern
+          (_)
+          (identifier) @local.definition.variable.parameter @variable.parameter)
+        (identifier) @local.definition.variable.parameter @variable.parameter
+      ])
+    ; `foo` and `bar` in `fn x(Struct { foo, bar }: !) {}`
+    (struct_pattern
+      (field_pattern)*
+      (field_pattern
+        name: (shorthand_field_identifier) @local.definition.variable.parameter @variable.parameter)
+    )
+    ; `foo` and `bar` in `fn x(TupleStruct(foo, bar): !) {}`
+    (tuple_struct_pattern
+      type: _
+      [
+        (mut_pattern
+          (_)
+          (identifier))
+        (identifier)
+      ]*
+      [
+        (mut_pattern
+          (_)
+          (identifier) @local.definition.variable.parameter @variable.parameter)
+        (identifier) @local.definition.variable.parameter @variable.parameter
+      ]
+    )
+    ; `foo` and `bar` in `fn x([foo, bar]: !) {}`
+    (slice_pattern
+      [
+        (mut_pattern
+          (_)
+          (identifier))
+        (identifier)
+      ]*
+      [
+        (mut_pattern
+          (_)
+          (identifier) @local.definition.variable.parameter @variable.parameter)
+        (identifier) @local.definition.variable.parameter @variable.parameter
+      ]
+    )
+  ])
 
-(closure_parameters (identifier) @local.definition.variable.parameter)
 
 ; References
 (identifier) @local.reference


### PR DESCRIPTION
test file:

```rs
fn x((a, b): !) {
    foo(a, b);
}
fn x(a: !, mut b: !) {
    foo(a, b);
}
fn x((a, mut b): !, mut b: !) {
    foo(a, b);
}
fn x(foo::TupleStruct(a, mut b): !) {
    foo(a, b);
}
fn x(foo::NamedStruct { a, mut b }: !) {
    foo(a, b);
}
fn x(bar::Struct(mut a, b): !) {
    foo(a, b);

    // just to test that it works with closures too
    let m = |bar::Struct(mut c, d): !| {
        bar(c, d);
    };
}
fn x([a, mut b]: !) {
    foo(a, b);
}
```

split up from https://github.com/helix-editor/helix/pull/13932