### PR TITLE
queries(rust): add scope for mutable variables

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -190,6 +190,7 @@ We use a similar set of scopes as
 - `variable` - Variables
   - `builtin` - Reserved language variables (`self`, `this`, `super`, etc.)
   - `parameter` - Function parameters
+  - `mutable` - Mutable variables (e.g. marked with `mut` in Rust)
   - `other`
     - `member` - Fields of composite data types (e.g. structs, unions)
       - `private` - Private fields that use a unique syntax (currently just ECMAScript-based languages)

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -289,8 +289,6 @@
   "dyn"
 ] @keyword.storage.modifier
 
-; TODO: variable.mut to highlight mutable identifiers via locals.scm
-
 ; ---
 ; Remaining Paths
 ; ---

--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -21,5 +21,19 @@
 
 (closure_parameters (identifier) @local.definition.variable.parameter)
 
+; Mutable variables
+
+[
+  (let_declaration
+    (mutable_specifier)
+    pattern: (identifier) @local.definition.variable.mutable @variable.mutable)
+  (parameter
+    (mutable_specifier)
+    pattern: (identifier) @local.definition.variable.mutable @variable.mutable)
+  (mut_pattern
+    (mutable_specifier)
+    (identifier) @local.definition.variable.mutable @variable.mutable)
+]
+
 ; References
 (identifier) @local.reference


### PR DESCRIPTION
test file:

```rs
fn foo() {
    let mut a = 100;
}
```

split up https://github.com/helix-editor/helix/pull/13932