### PR TITLE
queries(rust): properly highlight Dioxus' `rsx!` macro

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -150,6 +150,10 @@
 
     ; std
     "assert_eq" "debug_assert_eq" "assert_ne" "debug_assert_ne"
+
+    ; Dioxus's rsx! macro accepts string interpolation in all
+    ; strings, across the entire token tree
+    "rsx"
   )
   (#set! injection.language "rust-format-args-macro")
   (#set! injection.include-children)
@@ -166,11 +170,6 @@
     ; TODO: This only captures 1 level of string literals. But in dioxus you can have
     ; nested string literals. For instance:
     ; 
-    ; rsx! { "{hello} world" }:
-    ; -> (token_tree (string_literal))
-    ; rsx! { div { "{hello} world" } }
-    ; -> (token_tree (token_tree (string_literal)))
-    ; rsx! { div { div { "{hello} world" } } }
     ; -> (token_tree (token_tree (token_tree (string_literal))))
     (token_tree (string_literal) @injection.content)
   )

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -158,22 +158,3 @@
   (#set! injection.language "rust-format-args-macro")
   (#set! injection.include-children)
 )
-
-; Dioxus' "rsx!" macro relies heavily on string interpolation as well. The strings can be nested very deeply
-(
-  (macro_invocation
-    macro: [
-        (scoped_identifier
-          name: (_) @_macro_name)
-        (identifier) @_macro_name
-    ]
-    ; TODO: This only captures 1 level of string literals. But in dioxus you can have
-    ; nested string literals. For instance:
-    ; 
-    ; -> (token_tree (token_tree (token_tree (string_literal))))
-    (token_tree (string_literal) @injection.content)
-  )
-  (#eq? @_macro_name "rsx")
-  (#set! injection.language "rust-format-args")
-  (#set! injection.include-children)
-)


### PR DESCRIPTION
test file:

```rs
fn foo() {
    rsx! { "{hello} world" }:
    rsx! { div { "{hello} world" } }
    rsx! { div { div { "{hello} world" } } }
}
```

split up from https://github.com/helix-editor/helix/pull/13932