### PR TITLE
queries(rust): highlight `a` as function in `x.map(a)`

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -322,6 +322,21 @@
       field: (field_identifier) @function.method)
   ])
 
+; Special-case some methods who commonly accept a closure and also
+; where this closure can be specified by a single identifier
+; 
+; For example, highlights `foo` in `a.map(foo)` is a @function
+(call_expression
+  function: (field_expression
+    value: _
+    field: (field_identifier) @_method_name @function)
+  arguments:
+    ; first argument is `@function`
+    (arguments
+      .
+      (identifier) @function)
+  (#any-of? @_method_name "map" "flat_map"))
+
 (function_item
   name: (identifier) @function)
 


### PR DESCRIPTION
when you have `a.map(b)`, highlight `b` as a function

test file:

```rs
fn foo() {
    a.map(Some);
    a.flat_map(a);
}
```

split up from https://github.com/helix-editor/helix/pull/13932