### PR TITLE
Support mode 2031 dark/light mode detection

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -2,6 +2,16 @@
 
 To use a theme add `theme = "<name>"` to the top of your [`config.toml`](./configuration.md) file, or select it during runtime using `:theme <name>`.
 
+Separate themes can be configured for light and dark modes. On terminals supporting [mode 2031 dark/light detection](https://github.com/contour-terminal/contour/blob/master/docs/vt-extensions/color-palette-update-notifications.md), the theme mode is detected from the terminal.
+
+```toml
+[theme]
+dark = "catppuccin_frappe"
+light = "catppuccin_latte"
+# Optional. Defaults to the theme set for `dark` if not specified.
+# no-preference = "catppuccin_frappe"
+```
+
 ## Creating a theme
 
 Create a file with the name of your theme as the file name (i.e `mytheme.toml`) and place it in your `themes` directory (i.e `~/.config/helix/themes` or `%AppData%\helix\themes` on Windows). The directory might have to be created beforehand.

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -67,6 +67,8 @@ pub struct Application {
     signals: Signals,
     jobs: Jobs,
     lsp_progress: LspProgressMap,
+
+    theme_mode: Option<theme::Mode>,
 }
 
 #[cfg(feature = "integration")]
@@ -109,6 +111,7 @@ impl Application {
         #[cfg(feature = "integration")]
         let backend = TestBackend::new(120, 150);
 
+        let theme_mode = backend.get_theme_mode();
         let terminal = Terminal::new(backend)?;
         let area = terminal.size().expect("couldn't get terminal size");
         let mut compositor = Compositor::new(area);
@@ -127,6 +130,7 @@ impl Application {
             &mut editor,
             &config.load(),
             terminal.backend().supports_true_color(),
+            theme_mode,
         );
 
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
@@ -246,6 +250,7 @@ impl Application {
             signals,
             jobs: Jobs::new(),
             lsp_progress: LspProgressMap::new(),
+            theme_mode,
         };
 
         Ok(app)
@@ -404,6 +409,7 @@ impl Application {
                 &mut self.editor,
                 &default_config,
                 self.terminal.backend().supports_true_color(),
+                self.theme_mode,
             );
 
             // Re-parse any open documents with the new language config.
@@ -437,12 +443,18 @@ impl Application {
     }
 
     /// Load the theme set in configuration
-    fn load_configured_theme(editor: &mut Editor, config: &Config, terminal_true_color: bool) {
+    fn load_configured_theme(
+        editor: &mut Editor,
+        config: &Config,
+        terminal_true_color: bool,
+        mode: Option<theme::Mode>,
+    ) {
         let true_color = terminal_true_color || config.editor.true_color || crate::true_color();
         let theme = config
             .theme
             .as_ref()
-            .and_then(|theme| {
+            .and_then(|theme_config| {
+                let theme = theme_config.choose(mode);
                 editor
                     .theme_loader
                     .load(theme)
@@ -643,6 +655,8 @@ impl Application {
     }
 
     pub async fn handle_terminal_events(&mut self, event: std::io::Result<termina::Event>) {
+        use termina::escape::csi;
+
         let mut cx = crate::compositor::Context {
             editor: &mut self.editor,
             jobs: &mut self.jobs,
@@ -667,6 +681,15 @@ impl Application {
                 kind: termina::event::KeyEventKind::Release,
                 ..
             }) => false,
+            termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(mode))) => {
+                Self::load_configured_theme(
+                    &mut self.editor,
+                    &self.config.load(),
+                    self.terminal.backend().supports_true_color(),
+                    Some(mode.into()),
+                );
+                true
+            }
             event => self.compositor.handle_event(&event.into(), &mut cx),
         };
 
@@ -1117,9 +1140,16 @@ impl Application {
 
     #[cfg(not(feature = "integration"))]
     pub fn event_stream(&self) -> impl Stream<Item = std::io::Result<termina::Event>> + Unpin {
-        use termina::Terminal as _;
+        use termina::{escape::csi, Terminal as _};
         let reader = self.terminal.backend().terminal().event_reader();
-        termina::EventStream::new(reader, |event| !event.is_escape())
+        termina::EventStream::new(reader, |event| {
+            // Accept either non-escape sequences or theme mode updates.
+            !event.is_escape()
+                || matches!(
+                    event,
+                    termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(_)))
+                )
+        })
     }
 
     #[cfg(feature = "integration")]

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,7 +1,7 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
 use helix_loader::merge_toml_values;
-use helix_view::document::Mode;
+use helix_view::{document::Mode, theme};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -11,7 +11,7 @@ use toml::de::Error as TomlError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: HashMap<Mode, KeyTrie>,
     pub editor: helix_view::editor::Config,
 }
@@ -19,7 +19,7 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigRaw {
-    pub theme: Option<String>,
+    pub theme: Option<theme::Config>,
     pub keys: Option<HashMap<Mode, KeyTrie>>,
     pub editor: Option<toml::Value>,
 }

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -39,4 +39,5 @@ pub trait Backend {
     /// Flushes the terminal buffer
     fn flush(&mut self) -> Result<(), io::Error>;
     fn supports_true_color(&self) -> bool;
+    fn get_theme_mode(&self) -> Option<helix_view::theme::Mode>;
 }

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write as _};
 
 use helix_view::{
     graphics::{CursorKind, Rect, UnderlineStyle},
-    theme::{Color, Modifier},
+    theme::{self, Color, Modifier},
 };
 use termina::{
     escape::{
@@ -67,6 +67,7 @@ struct Capabilities {
     synchronized_output: bool,
     true_color: bool,
     extended_underlines: bool,
+    theme_mode: Option<theme::Mode>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -154,13 +155,15 @@ impl TerminaBackend {
         // If we only receive the device attributes then we know it is not.
         write!(
             terminal,
-            "{}{}{}{}{}{}{}",
+            "{}{}{}{}{}{}{}{}",
             // Kitty keyboard
             Csi::Keyboard(csi::Keyboard::QueryFlags),
             // Synchronized output
             Csi::Mode(csi::Mode::QueryDecPrivateMode(csi::DecPrivateMode::Code(
                 csi::DecPrivateModeCode::SynchronizedOutput
             ))),
+            // Mode 2031 theme updates. Query the current theme.
+            Csi::Mode(csi::Mode::QueryTheme),
             // True color and while we're at it, extended underlines:
             // <https://github.com/termstandard/colors?tab=readme-ov-file#querying-the-terminal>
             Csi::Sgr(csi::Sgr::Background(TEST_COLOR.into())),
@@ -191,6 +194,9 @@ impl TerminaBackend {
                         setting: csi::DecModeSetting::Set | csi::DecModeSetting::Reset,
                     })) => {
                         capabilities.synchronized_output = true;
+                    }
+                    Event::Csi(Csi::Mode(csi::Mode::ReportTheme(mode))) => {
+                        capabilities.theme_mode = Some(mode.into());
                     }
                     Event::Dcs(dcs::Dcs::Response {
                         value: dcs::DcsResponse::GraphicRendition(sgrs),
@@ -317,6 +323,11 @@ impl TerminaBackend {
             }
         }
 
+        if self.capabilities.theme_mode.is_some() {
+            // Enable mode 2031 theme mode notifications:
+            write!(self.terminal, "{}", decset!(Theme))?;
+        }
+
         Ok(())
     }
 
@@ -327,6 +338,11 @@ impl TerminaBackend {
                 "{}",
                 Csi::Keyboard(csi::Keyboard::PopFlags(1))
             )?;
+        }
+
+        if self.capabilities.theme_mode.is_some() {
+            // Mode 2031 theme notifications.
+            write!(self.terminal, "{}", decreset!(Theme))?;
         }
 
         Ok(())
@@ -546,6 +562,10 @@ impl Backend for TerminaBackend {
 
     fn supports_true_color(&self) -> bool {
         self.capabilities.true_color
+    }
+
+    fn get_theme_mode(&self) -> Option<theme::Mode> {
+        self.capabilities.theme_mode
     }
 }
 

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -160,4 +160,8 @@ impl Backend for TestBackend {
     fn supports_true_color(&self) -> bool {
         false
     }
+
+    fn get_theme_mode(&self) -> Option<helix_view::theme::Mode> {
+        None
+    }
 }


### PR DESCRIPTION
Fixes #13281.

For better compatibility in detection we can also look at querying OSC 11 for the terminal's background color and trying to detect its perceived lightness (also see https://github.com/helix-editor/helix/pull/12238). That will take a bit more work to add OSC 11 to Termina and then to handle the response.