### PR TITLE
refactor!: change default windows shell to `powershell`

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1005,7 +1005,7 @@ impl Default for Config {
             scroll_lines: 3,
             mouse: true,
             shell: if cfg!(windows) {
-                vec!["cmd".to_owned(), "/C".to_owned()]
+                vec!["powershell".to_owned(), "-c".to_owned()]
             } else {
                 vec!["sh".to_owned(), "-c".to_owned()]
             },


### PR DESCRIPTION
This follows discussion from https://github.com/helix-editor/helix/issues/14229#issuecomment-3239422552. This follows a generally understood position that `cmd`  can be finicky, and even buggy, but wont be fixed to be compatibility issues:
> PowerShell is installed by default on Windows 7 SP1 and Windows Server 2008 R2 S1 and later, and cmd.exe is quite fiddly, so PowerShell is recommended for most Windows users. \- https://github.com/casey/just

BREAKING: If user previously relied on specific `cmd` features or behavior, they will need to update their config.