### PR TITLE
feat(languages): detect more vim file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4496,6 +4496,8 @@ indent = { tab-width = 4, unit = "\t" }
 file-types = [
   "vim",
   { glob = ".vimrc" },
+  { glob = ".nvimrc" },
+  { glob = ".exrc" }
 ]
 
 [[language]]


### PR DESCRIPTION
- `.nvimrc` is generated with `mkvimrc` in neovim
- `.exrc` is generated with `mkexrc` in vim and neovim