### PR TITLE
feat(ruby): detect `.irbrc` file as ruby

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1091,6 +1091,7 @@ file-types = [
   { glob = "Scanfile" },
   { glob = "Snapfile" },
   { glob = "Gymfile" },
+  { glob = ".irbrc" },
 ]
 shebangs = ["ruby"]
 comment-token = "#"


### PR DESCRIPTION
`.irbrc` is an init script written in Ruby that gets sourced when starting `irb`