### PR TITLE
feat: detect `.wslconfig` as ini filetype

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3109,7 +3109,8 @@ file-types = [
   { glob = ".aws/config" },
   "properties",
   "cfg",
-  "directory"
+  "directory",
+  { glob = ".wslconfig" },
 ]
 injection-regex = "ini"
 comment-token = "#"


### PR DESCRIPTION
Used to configure the WSL2 VM on Windows. Format documented as being ini [here](https://learn.microsoft.com/en-us/windows/wsl/wsl-config).