### PR TITLE
Update doom-one theme

### DIFF
--- a/runtime/themes/doom-one.toml
+++ b/runtime/themes/doom-one.toml
@@ -11,6 +11,7 @@
 "ui.selection" = { bg = "bg_highlight" } 
 "ui.selection.primary" = { bg = "bg_highlight" }  
 "ui.virtual.ruler" = { bg = "bg_highlight" }
+"ui.virtual.jump-label" = { fg = "cyan", modifiers = ["bold"] }
 
 # Markdown Highlighting
 "markup.raw" = { fg = "blue", bg = "bg" } 

--- a/runtime/themes/doom-one.toml
+++ b/runtime/themes/doom-one.toml
@@ -102,7 +102,7 @@
 
 # Popups for documentation or file picker
 "ui.popup" = { fg = "fg", bg = "bg" } 
-"ui.popup.info" = { fg = "fg", bg = "bg" } 
+"ui.popup.info" = { fg = "fg", bg = "bg_alt" } 
 "ui.menu" = { fg = "fg", bg = "bg" } 
 "ui.menu.selected" = { fg = "cyan", bg = "bg_highlight" }
 


### PR DESCRIPTION
- Updated `ui.popup.info` background color
- Added `ui.virtual.jump-label`

Updated doom-one theme popup color, because otherwise is very hard to see the popup.

Original

<img width="592" height="204" alt="Screenshot 2025-09-03 at 19 58 54" src="https://github.com/user-attachments/assets/88cf3dd8-e3c1-430f-a1ab-4852c3e3d96d" />

Updated theme

<img width="584" height="198" alt="Screenshot 2025-09-03 at 20 00 18" src="https://github.com/user-attachments/assets/dadddefb-5380-4138-8cb2-eeb14662c09f" />
