### PR TITLE
feat: add `runhaskell` and `stack` as haskell shebangs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1521,6 +1521,7 @@ scope = "source.haskell"
 injection-regex = "hs|haskell"
 file-types = ["hs", "hs-boot", "hsc"]
 roots = ["Setup.hs", "stack.yaml", "cabal.project"]
+shebangs = ["runhaskell", "stack"]
 comment-token = "--"
 block-comment-tokens = { start = "{-", end = "-}" }
 language-servers = [ "haskell-language-server" ]


### PR DESCRIPTION
Examples of use:
- `runhaskell` is used in [Pandoc filters](https://pandoc.org/filters.html)
- `stack` is listed in the [official documentation](https://docs.haskellstack.org/en/stable/topics/scripts/) of stack.