### PR TITLE
queries(scheme): mark arguments of case-lambda as @variable, mark case-lambda as @keyword

### DIFF
--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -51,6 +51,15 @@
 (list
  .
  (symbol) @_f
+ (list
+  .
+  (list
+   (symbol) @variable))
+ (#eq? @_f "case-lambda"))
+
+(list
+ .
+ (symbol) @_f
  .
  (list
    (list
@@ -92,7 +101,7 @@
   .
   (symbol) @keyword
   (#match? @keyword
-   "^(define-syntax|let\\*|lambda|λ|case|=>|quote-splicing|unquote-splicing|set!|let|letrec|letrec-syntax|let-values|let\\*-values|do|else|define|cond|syntax-rules|unquote|begin|quote|let-syntax|and|if|quasiquote|letrec|delay|or|when|unless|identifier-syntax|assert|library|export|import|rename|only|except|prefix)$"
+   "^(define-syntax|let\\*|lambda|λ|case-lambda|case|=>|quote-splicing|unquote-splicing|set!|let|letrec|letrec-syntax|let-values|let\\*-values|do|else|define|cond|syntax-rules|unquote|begin|quote|let-syntax|and|if|quasiquote|letrec|delay|or|when|unless|identifier-syntax|assert|library|export|import|rename|only|except|prefix)$"
    ))
 
 (list


### PR DESCRIPTION
the arguments to each case of a `case-lambda` are variables, but the first one was previously marked as a function. additionally i think it makes sense to mark the case-lambda also as a keyword.

before:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/038b2967-103b-4841-8740-d279a9a25df2" />

after:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/e5ccae66-57d0-4ea3-bce4-99533bf1aa74" />


(note: i am using a custom version of the solarized light theme where variables are blue and functions are violet)