### PR TITLE
feat: add literal (non-regex) search commands, `search_literal` and `rsearch_literal`

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -72,6 +72,8 @@
 | `merge_consecutive_selections` | Merge consecutive selections | normal: `` <A-_> ``, select: `` <A-_> `` |
 | `search` | Search for regex pattern | normal: `` / ``, `` Z/ ``, `` z/ ``, select: `` / ``, `` Z/ ``, `` z/ `` |
 | `rsearch` | Reverse search for regex pattern | normal: `` ? ``, `` Z? ``, `` z? ``, select: `` ? ``, `` Z? ``, `` z? `` |
+| `search_literal` | Search for literal text (non-regex) |  |
+| `rsearch_literal` | Reverse search for literal text (non-regex) |  |
 | `search_next` | Select next search match | normal: `` n ``, `` Zn ``, `` zn ``, select: `` Zn ``, `` zn `` |
 | `search_prev` | Select previous search match | normal: `` N ``, `` ZN ``, `` zN ``, select: `` ZN ``, `` zN `` |
 | `extend_search_next` | Add next search match to selection | select: `` n `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -374,6 +374,8 @@ impl MappableCommand {
         merge_consecutive_selections, "Merge consecutive selections",
         search, "Search for regex pattern",
         rsearch, "Reverse search for regex pattern",
+        search_literal, "Search for literal text (non-regex)",
+        rsearch_literal, "Reverse search for literal text (non-regex)",
         search_next, "Select next search match",
         search_prev, "Select previous search match",
         extend_search_next, "Add next search match to selection",
@@ -2100,6 +2102,7 @@ fn select_regex(cx: &mut Context) {
                 cx.editor.set_error("nothing selected");
             }
         },
+        false,
     );
 }
 
@@ -2119,6 +2122,7 @@ fn split_selection(cx: &mut Context) {
             let selection = selection::split_on_matches(text, doc.selection(view.id), &regex);
             doc.set_selection(view.id, selection);
         },
+        false,
     );
 }
 
@@ -2234,14 +2238,22 @@ fn search_completions(cx: &mut Context, reg: Option<char>) -> Vec<String> {
 }
 
 fn search(cx: &mut Context) {
-    searcher(cx, Direction::Forward)
+    searcher(cx, Direction::Forward, false)
 }
 
 fn rsearch(cx: &mut Context) {
-    searcher(cx, Direction::Backward)
+    searcher(cx, Direction::Backward, false)
 }
 
-fn searcher(cx: &mut Context, direction: Direction) {
+fn search_literal(cx: &mut Context) {
+    searcher(cx, Direction::Forward, true)
+}
+
+fn rsearch_literal(cx: &mut Context) {
+    searcher(cx, Direction::Backward, true)
+}
+
+fn searcher(cx: &mut Context, direction: Direction, literal_search: bool) {
     let reg = cx.register.unwrap_or('/');
     let config = cx.editor.config();
     let scrolloff = config.scrolloff;
@@ -2282,6 +2294,7 @@ fn searcher(cx: &mut Context, direction: Direction) {
                 false,
             );
         },
+        literal_search,
     );
 }
 
@@ -5166,6 +5179,7 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
                 cx.editor.set_error("no selections remaining");
             }
         },
+        false,
     )
 }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -78,6 +78,7 @@ pub fn regex_prompt(
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
     fun: impl Fn(&mut crate::compositor::Context, rope::Regex, PromptEvent) + 'static,
+    literal_search: bool,
 ) {
     raw_regex_prompt(
         cx,
@@ -85,6 +86,7 @@ pub fn regex_prompt(
         history_register,
         completion_fn,
         move |cx, regex, _, event| fun(cx, regex, event),
+        literal_search,
     );
 }
 pub fn raw_regex_prompt(
@@ -93,6 +95,7 @@ pub fn raw_regex_prompt(
     history_register: Option<char>,
     completion_fn: impl FnMut(&Editor, &str) -> Vec<prompt::Completion> + 'static,
     fun: impl Fn(&mut crate::compositor::Context, rope::Regex, &str, PromptEvent) + 'static,
+    literal_search: bool,
 ) {
     let (view, doc) = current!(cx.editor);
     let doc_id = view.doc;
@@ -105,6 +108,11 @@ pub fn raw_regex_prompt(
         history_register,
         completion_fn,
         move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
+            let input = if literal_search {
+                &helix_core::regex::escape(input)
+            } else {
+                input
+            };
             match event {
                 PromptEvent::Abort => {
                     let (view, doc) = current!(cx.editor);


### PR DESCRIPTION
This is related to #4978 

Adds `search_literal` and `rsearch_literal`, which behave like `search`/`rsearch` but match raw text instead of regex.

**Motivation:** escaping common characters like `(`, `[`, `+` is tedious.

I didn't map them to any default key.