### PR TITLE
queries(scheme): mark the variables of do as `@variable`

### DIFF
--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -65,7 +65,7 @@
     (list
       (symbol) @variable.parameter))
   (#any-of? @_f
-    "let" "let*" "let-syntax" "let-values" "let*-values" "letrec" "letrec*" "letrec-syntax"))
+    "let" "let*" "let-syntax" "let-values" "let*-values" "letrec" "letrec*" "letrec-syntax" "do"))
 
 ; operators
 

--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -64,8 +64,8 @@
   (list
     (list
       (symbol) @variable.parameter))
-  (#match? @_f
-    "^(let|let\\*|let-syntax|let-values|let\\*-values|letrec|letrec\\*|letrec-syntax)$"))
+  (#any-of? @_f
+    "let" "let*" "let-syntax" "let-values" "let*-values" "letrec" "letrec*" "letrec-syntax"))
 
 ; operators
 

--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -13,10 +13,10 @@
 ; variables
 
 ((symbol) @variable.builtin
- (#eq? @variable.builtin "..."))
+  (#eq? @variable.builtin "..."))
 
 ((symbol) @variable.builtin
- (#eq? @variable.builtin "."))
+  (#eq? @variable.builtin "."))
 
 (symbol) @variable
 
@@ -36,58 +36,58 @@
 ; special forms
 
 (list
- "["
- (symbol)+ @variable
- "]")
+  "["
+  (symbol)+ @variable
+  "]")
 
 (list
- .
- (symbol) @_f
- .
- (list
-   (symbol) @variable)
- (#any-of? @_f "lambda" "λ"))
-
-(list
- .
- (symbol) @_f
- (list
+  .
+  (symbol) @_f
   .
   (list
-   (symbol) @variable))
- (#eq? @_f "case-lambda"))
+    (symbol) @variable)
+  (#any-of? @_f "lambda" "λ"))
 
 (list
- .
- (symbol) @_f
- .
- (list
-   (list
-     (symbol) @variable.parameter))
- (#match? @_f
-  "^(let|let\\*|let-syntax|let-values|let\\*-values|letrec|letrec\\*|letrec-syntax)$"))
+  .
+  (symbol) @_f
+  (list
+    .
+    (list
+      (symbol) @variable))
+  (#eq? @_f "case-lambda"))
+
+(list
+  .
+  (symbol) @_f
+  .
+  (list
+    (list
+      (symbol) @variable.parameter))
+  (#match? @_f
+    "^(let|let\\*|let-syntax|let-values|let\\*-values|letrec|letrec\\*|letrec-syntax)$"))
 
 ; operators
 
 ((symbol) @operator
- (#match? @operator "^(\\+|-|\\*|/|=|>|<|>=|<=)$"))
+  (#match? @operator "^(\\+|-|\\*|/|=|>|<|>=|<=)$"))
 
 ; library
 
 (list
- .
- (symbol) @_lib
- .
- (symbol) @namespace
+  .
+  (symbol) @_lib
+  .
+  (symbol) @namespace
 
- (#eq? @_lib "library"))
+  (#eq? @_lib "library"))
 
 ; quote
 
 (list
- .
- (symbol) @_f
- (#eq? @_f "quote")) @string.symbol
+  .
+  (symbol) @_f
+  (#eq? @_f "quote")) @string.symbol
 
 ; keywords
 
@@ -96,7 +96,7 @@
   ((symbol) @keyword.conditional
    (#match? @keyword.conditional "^(if|cond|case|when|unless)$"
   )))
- 
+
 (list
   .
   (symbol) @keyword


### PR DESCRIPTION
before:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/a5074b34-fc70-4229-9820-9fe5562551f3" />

after:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/652a6b61-7b8a-4eaa-9466-b426c1e2a1df" />

(note: i am using a custom version of the solarized light theme where variables are blue and functions are violet)

additionally i also converted all one-space indents to two spaces and switched from a `#match?` to a `#any-of?`.

(note: i wanted to add this to #14386, but i was too slow lol)