### PR TITLE
feat(languages): add `gitlab-ci` language specialized from `yaml`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -86,6 +86,7 @@
 | git-ignore | ✓ |  |  |  |  |  |
 | git-notes | ✓ |  |  |  |  |  |
 | git-rebase | ✓ |  |  |  |  |  |
+| gitlab-ci | ✓ | ✓ | ✓ | ✓ | ✓ | `yaml-language-server`, `gitlab-ci-ls` |
 | gjs | ✓ | ✓ | ✓ | ✓ |  | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | gleam | ✓ | ✓ |  |  | ✓ | `gleam` |
 | glimmer | ✓ |  |  |  |  | `ember-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -50,6 +50,7 @@ forc = { command = "forc", args = ["lsp"] }
 forth-lsp = { command = "forth-lsp" }
 fortls = { command = "fortls", args = ["--lowercase_intrinsics"] }
 fsharp-ls = { command = "fsautocomplete", config = { AutomaticWorkspaceInit = true } }
+gitlab-ci-ls = { command = "gitlab-ci-ls" }
 gleam = { command = "gleam", args = ["lsp"] }
 glsl_analyzer = { command = "glsl_analyzer" }
 graphql-language-service = { command = "graphql-lsp", args = ["server", "-m", "stream"] }
@@ -4768,3 +4769,13 @@ comment-token = "#"
 block-comment-tokens = { start = "/*", end = "*/" }
 indent = { tab-width = 2, unit = "  " }
 language-servers = ["docker-language-server"]
+
+[[language]]
+name = "gitlab-ci"
+scope = "source.gitlab-ci"
+injection-regex = "^gitlab-ci$"
+file-types = [{ glob = ".gitlab-ci.yml" }]
+grammar = "yaml"
+indent = { tab-width = 2, unit = "  " }
+language-servers = ["yaml-language-server", "gitlab-ci-ls"]
+comment-token = "#"

--- a/runtime/queries/gitlab-ci/highlights.scm
+++ b/runtime/queries/gitlab-ci/highlights.scm
@@ -1,0 +1,89 @@
+(boolean_scalar) @constant.builtin.boolean
+(null_scalar) @constant.builtin
+(double_quote_scalar) @string
+(single_quote_scalar) @string
+(block_scalar) @string
+(string_scalar) @string
+(escape_sequence) @constant.character.escape
+(integer_scalar) @constant.numeric.integer
+(float_scalar) @constant.numeric.float
+(comment) @comment
+(anchor_name) @type
+(alias_name) @type
+(tag) @type
+(yaml_directive) @keyword
+
+(block_mapping_pair
+  key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable.other.member))
+(block_mapping_pair
+  key: (flow_node (plain_scalar (string_scalar) @variable.other.member)))
+
+(flow_mapping
+  (_ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable.other.member)))
+(flow_mapping
+  (_ key: (flow_node (plain_scalar (string_scalar) @variable.other.member))))
+
+[
+","
+"-"
+":"
+">"
+"?"
+"|"
+] @punctuation.delimiter
+
+[
+"["
+"]"
+"{"
+"}"
+] @punctuation.bracket
+
+["*" "&" "---" "..."] @punctuation.special
+
+
+; Highlight the toplevel keys differently as keywords
+(block_mapping_pair
+  key: (flow_node (plain_scalar (string_scalar) @keyword (#any-of? @keyword "variables" "stages" "default" "include" "workflow"))) )
+
+; Highlight the builtin stages differently
+; <https://docs.gitlab.com/ci/yaml/#stages>
+(block_mapping_pair
+  key: (flow_node
+         (plain_scalar
+           (string_scalar) @variable.other.member (#eq? @variable.other.member "stage")))
+  value: (flow_node
+           (plain_scalar
+             (string_scalar) @constant.builtin (#any-of? @constant.builtin ".pre" "build" "test" "deploy" ".post"))))
+; e.g.
+; ```
+; stages:
+;   - build
+;   - test
+; ```
+(block_mapping_pair
+  key: (flow_node
+         (plain_scalar
+           (string_scalar) @keyword (#eq? @keyword "stages")))
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+               (flow_node
+                 (plain_scalar
+                   (string_scalar) @constant.builtin (#any-of? @constant.builtin ".pre" "build" "test" "deploy" ".post")))))))
+
+
+; Highlight defined variable names as @variable
+; Matches on:
+; ```
+; variables:
+;   <variable>: ...
+; ```
+(block_mapping_pair
+  key: (flow_node
+         (plain_scalar
+           (string_scalar) @keyword (#eq? @keyword "variables")))
+  value: (block_node
+           (block_mapping
+             (block_mapping_pair
+               key: (flow_node) @variable)+)))

--- a/runtime/queries/gitlab-ci/indents.scm
+++ b/runtime/queries/gitlab-ci/indents.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/gitlab-ci/injections.scm
+++ b/runtime/queries/gitlab-ci/injections.scm
@@ -1,0 +1,51 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "script" "before_script" "after_script" "pre_get_sources_script" "command" "entrypoint")
+  value: (flow_node
+           (plain_scalar
+             (string_scalar) @injection.content)
+           (#set! injection.language "bash")))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "script" "before_script" "after_script" "pre_get_sources_script" "command" "entrypoint")
+  value: (block_node
+           (block_scalar) @injection.content
+           (#set! injection.language "bash")))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "script" "before_script" "after_script" "pre_get_sources_script" "command" "entrypoint")
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+                (flow_node
+                  (plain_scalar
+                    (string_scalar) @injection.content))
+                (#set! injection.language "bash")))))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "script" "before_script" "after_script" "pre_get_sources_script" "command" "entrypoint")
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+               (block_node
+                  (block_scalar) @injection.content
+                  (#set! injection.language "bash"))))))
+
+; e.g.
+; ```
+; job1:
+;   services:
+;     entrypoint: ["/usr/local/bin/docker-entrypoint.sh", "-c", 'max_connections=100']
+; ```
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "command" "entrypoint")
+  value: (flow_node
+           (flow_sequence
+             (flow_node
+               [
+                 (double_quote_scalar)
+                 (single_quote_scalar)
+               ] @injection.content)))
+  (#set! injection.language "bash"))

--- a/runtime/queries/gitlab-ci/rainbows.scm
+++ b/runtime/queries/gitlab-ci/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/gitlab-ci/tags.scm
+++ b/runtime/queries/gitlab-ci/tags.scm
@@ -1,0 +1,17 @@
+; select jobs
+(block_mapping
+  (block_mapping_pair
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @_key (#eq? @_key "stage"))))) @definition.struct)
+
+; select defined variables under `variables:`
+(block_mapping
+  (block_mapping_pair
+    key: (flow_node) @_key (#eq? @_key "variables")
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @name
+                 value: (_) @definition.constant)))))

--- a/runtime/queries/gitlab-ci/textobjects.scm
+++ b/runtime/queries/gitlab-ci/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/yaml/injections.scm
+++ b/runtime/queries/yaml/injections.scm
@@ -21,23 +21,22 @@
 ; Modified for Helix from https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/yaml/injections.scm
 
 ;; GitHub actions: run
-;; Gitlab CI: scripts, before_script, after_script
 ;; Buildkite: command, commands
 (block_mapping_pair
-  key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script" "command" "commands")
+  key: (flow_node) @_run (#any-of? @_run "run" "command" "commands")
   value: (flow_node
            (plain_scalar
              (string_scalar) @injection.content)
            (#set! injection.language "bash")))
 
 (block_mapping_pair
-  key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script" "command" "commands")
+  key: (flow_node) @_run (#any-of? @_run "run" "command" "commands")
   value: (block_node
            (block_scalar) @injection.content
            (#set! injection.language "bash")))
 
 (block_mapping_pair
-  key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script" "command" "commands")
+  key: (flow_node) @_run (#any-of? @_run "run" "command" "commands")
   value: (block_node
            (block_sequence
              (block_sequence_item
@@ -47,7 +46,7 @@
                 (#set! injection.language "bash")))))
 
 (block_mapping_pair
-  key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script" "command" "commands")
+  key: (flow_node) @_run (#any-of? @_run "run" "command" "commands")
   value: (block_node
            (block_sequence
              (block_sequence_item


### PR DESCRIPTION
Split injections specific to [GitLab CI](https://docs.gitlab.com/ci/) `.gitlab-ci.yml` files into its own separate language name `gitlab-ci`.

In addition this PR adds:
- [gitlab-ci-ls](https://github.com/alesbrelih/gitlab-ci-ls) as a language server for `gitlab-ci` language.
- Additional `bash` injections for keys: `command`, `entrypoint` and `pre_get_sources_script`.
- Adds `tags.scm` to select jobs and variables
- Extends the `highlights.scm` to add more specialized captures to elements that have unique meaning in the context of GitLab CI e.g. the stage names `.pre`, `build`, `test`, `deploy` and `.post`.


**Showcase**

<img width="1138" height="555" alt="image" src="https://github.com/user-attachments/assets/f778d44a-021b-4975-a124-087a6b6d2d27" />