### PR TITLE
feat(helix-tui): add configuration to manually enable/disable KKP

### DIFF
--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -2,7 +2,7 @@
 //! Frontend for [Backend]
 
 use crate::{backend::Backend, buffer::Buffer};
-use helix_view::editor::Config as EditorConfig;
+use helix_view::editor::{Config as EditorConfig, KittyKeyboardProtocolConfig};
 use helix_view::graphics::{CursorKind, Rect};
 use std::io;
 
@@ -25,6 +25,7 @@ pub struct Viewport {
 pub struct Config {
     pub enable_mouse_capture: bool,
     pub force_enable_extended_underlines: bool,
+    pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
 }
 
 impl From<&EditorConfig> for Config {
@@ -32,6 +33,7 @@ impl From<&EditorConfig> for Config {
         Self {
             enable_mouse_capture: config.mouse,
             force_enable_extended_underlines: config.undercurl,
+            kitty_keyboard_protocol: config.kitty_keyboard_protocol,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -381,6 +381,17 @@ pub struct Config {
     pub editor_config: bool,
     /// Whether to render rainbow colors for matching brackets. Defaults to `false`.
     pub rainbow_brackets: bool,
+    // Whether to enable Kitty Keyboard Protocol
+    pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum KittyKeyboardProtocolConfig {
+    #[default]
+    Auto,
+    Disabled,
+    Enabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -1061,6 +1072,7 @@ impl Default for Config {
             clipboard_provider: ClipboardProvider::default(),
             editor_config: true,
             rainbow_brackets: false,
+            kitty_keyboard_protocol: Default::default(),
         }
     }
 }


### PR DESCRIPTION
# Context

Since the change from Crossterm to Termina (83abbe56), Helix now detects more precisely terminal's compatibility with the Kitty Keyboard Protocol.

Since this commit, if the terminal doesn't support both Disambiguate Escape Code and Report Alternate Keys, the support of KKP is automatically disabled. This is to avoid weird behavior when using complex keybinding such as `Ctrl+Shift+s`.

While this behavior is understandable, it impacted the compatibility with Zellij, which supports only Disambiguate Escape Code. It seems that both Helix and Zellij maintainer doesn't want to change the way they handle KKP, which means that this situation will probably last in the future.

# Problem

While the fix removes weird bugs from new users, it kind of forces a tradeoff: disallowing `Cmd` modifier to make complex keybinding work again.

This is perfectly fine, and probably the good default. But it would be great to let user decide if this tradeoff is worth for his usage or not.

# Solution

This PR adds an option `kitty_keyboard_protocol` to allow user to manually control the KKP support.

I've used an enum so that we can either manually enable/disable KKP, or let Helix detect the support of the terminal (the current behavior, that will stay the default).

This is also what Zellij has done: it tries its best to properly detect support, but offer an option to manually enable or disable it.