### PR TITLE
kdl queries: basic tag.scm and niri injections

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -140,7 +140,7 @@
 | julia | ✓ | ✓ | ✓ |  |  | `julia` |
 | just | ✓ | ✓ | ✓ | ✓ |  | `just-lsp` |
 | kconfig | ✓ |  | ✓ |  |  |  |
-| kdl | ✓ | ✓ | ✓ |  |  |  |
+| kdl | ✓ | ✓ | ✓ | ✓ |  |  |
 | koka | ✓ |  | ✓ |  |  | `koka` |
 | kotlin | ✓ | ✓ | ✓ | ✓ |  | `kotlin-language-server` |
 | koto | ✓ | ✓ | ✓ |  |  | `koto-ls` |

--- a/runtime/queries/kdl/injections.scm
+++ b/runtime/queries/kdl/injections.scm
@@ -1,0 +1,63 @@
+; match/exclude regex with regular string
+(node
+  (identifier) @_section_name
+  (#any-of? @_section_name "window-rule" "layer-rule")
+  children: (node_children
+    (node
+      (identifier) @_node_name
+      (#any-of? @_node_name "match" "exclude")
+      (node_field
+        (prop
+          (identifier) @_prop_name
+          (#any-of? @_prop_name "app-id" "title" "namespace")
+          (value
+            (string
+              (string_fragment) @injection.content
+              (#set! injection.language "regex")
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+(node
+  (identifier) @_section
+  (#eq? @_section "binds")
+  children: (node_children
+    (node
+      (identifier)
+      children: (node_children
+        (node
+          (identifier) @_action_name
+          (#eq? @_action_name "spawn")
+          (node_field
+            (value
+              (string
+                (string_fragment) @_executable
+                (#eq? @_executable "fish")
+              )
+            )
+          )
+          (node_field
+            (value
+              (string
+                (string_fragment) @_flag
+                (#eq? @_flag "-c")
+              )
+            )
+          )
+          (node_field
+            (value
+              (string
+                (string_fragment) @injection.content
+                (#set! injection.language "fish")
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/runtime/queries/kdl/tags.scm
+++ b/runtime/queries/kdl/tags.scm
@@ -1,0 +1,3 @@
+(node (identifier) @definition.struct
+  children: _
+)


### PR DESCRIPTION
- **queries(kdl): basic tags.scm based on nodes that hold objects**

representing *every* named node is a bit overgrabby — ends up being annoying to filter through, when usually you want to get to some object to them do stuff in

- **queries(kdl): injections for niri**

I feel like most people's usage of kdl is the niri config file \
I wrote the queries in a way where they make double sure it's the niri config structure, before actually committing the injection, so that we don't annoy people with an unexpected injection
