### PR TITLE
feat: add `fods` and `fodt` extensions to `xml` filetype

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3006,6 +3006,8 @@ file-types = [
   "mpd",
   "smil",
   "gpx",
+  "fodt",
+  "fods",
 ]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
- `fods` is the file extension used for a flat xml representation of a OpenDocument Spreadsheet file
- and `fodt` is the one used for OpenDocument Text file
