### PR TITLE
Add support for matching function call arguments in Zig

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1602,7 +1602,7 @@ args = { console = "internalConsole", attachCommands = [ "platform select remote
 
 [[grammar]]
 name = "zig"
-source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-zig", rev = "b71affffdb4222ff2d2dea6e164f76603b0be6bc" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-zig", rev = "6479aa13f32f701c383083d8b28360ebd682fb7d" }
 
 [[language]]
 name = "prolog"

--- a/runtime/queries/zig/textobjects.scm
+++ b/runtime/queries/zig/textobjects.scm
@@ -18,5 +18,8 @@
 (parameters
   ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
 
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
 (comment) @comment.inside
 (comment)+ @comment.around


### PR DESCRIPTION
Operations like mia/maa currently don't work inside function calls, only function definitions, when editing Zig code.

Changes:
- upgrade tree-sitter grammar to the latest version:
- update the query to match them (both builtins and normal function calls)