### PR TITLE
OSC 52 compatible pasting

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -236,7 +236,17 @@ mod external {
             }
 
             match self {
-                Self::Pasteboard => yank_from_builtin(PASTEBOARD, clipboard_type),
+                Self::Pasteboard => {
+                    let output = std::process::Command::new("pbpaste").output()?;
+
+                    if !output.status.success() {
+                        log::error!("pbpaste failed with output {:?}", output);
+                        return Err(ClipboardError::CommandFailed);
+                    }
+
+                    let output = String::from_utf8(output.stdout)?;
+                    Ok(output)
+                }
                 Self::Wayland => yank_from_builtin(WL_CLIPBOARD, clipboard_type),
                 Self::XClip => yank_from_builtin(XCLIP, clipboard_type),
                 Self::XSel => yank_from_builtin(XSEL, clipboard_type),


### PR DESCRIPTION
To securely paste from my system clipboard over SSH, I use OSC52 pasting. Modern terminals like Ghostty support this and show a popup whenever a terminal application requests to read the clipboard contents:

<img width="630" height="404" alt="image" src="https://github.com/user-attachments/assets/36687d58-1c75-4f6b-acb4-95ea9bc15a7c" />

To do this, I created the following script that wraps [`pkgs.osc`](https://github.com/theimpostor/osc) in a way that works nicely with TUIs:

```nix
pkgs.writeShellApplication {
      name = "pbpaste";
      text = ''
        exec < /dev/tty
        oldstty=$(stty -g)
        stty raw -echo min 0 time 10


        # Turn off focus reporting
        printf '\e[?1004l' > /dev/tty


        # run your OSC52 client here
        osc paste -t 10 "$@"

        # Restore focus reporting
        printf '\e[?1004h' > /dev/tty

        stty "$oldstty"
      '';
    }
```

`pbpaste` here is the name of the macOS paste command, but here I created a script with the same way to run inside of my linux VMs.

However, this does not work by default with Helix with either of the following configs:

```nix
        # option 1
        clipboard-provider = "pasteboard";

        # option 2
        clipboard-provider.custom = {
          yank = {
            command = "pbpaste";
          };
          paste = {
            command = "pbpaste";
          };
        };

```

My suspicion for this is that there is a weird interaction with the child process helix spawns to read clipboard contents and the OSC model as it yields the following log:
```
2025-09-11T17:22:31.135 helix_view::clipboard::external [ERROR] Output { status: ExitStatus(unix_wait_status(256)), stdout: "2025/09/11 17:22:31 ERROR osc header mismatch: \"\\x1b[O\\x1b[I\\x1b]52;\"\nosc header mismatch: \"\\x1b[O\\x1b[I\\x1b]52;\"\n", stderr: "" }
```

Alternatively, helix' default `yank_from_builtin` may not play nicely with the fact that the user needs to click on the "allow" popup (perhaps a timeout somewhere?)

This draft PR provides a hacky, simplified implementation that DOES work for those on a similar journey.

I do not suggest that we merge this PR. What would be nice is if Helix `clipboard-provider.termcode` could implement this natively instead and use OSC 52 to read the contents.
