### PR TITLE
statusline: dynamic padding for unfocused mode

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use helix_core::indent::IndentStyle;
-use helix_core::{coords_at_pos, encoding, Position};
+use helix_core::{coords_at_pos, encoding, unicode::width::UnicodeWidthStr, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
@@ -185,7 +185,7 @@ where
             Mode::Select => &modenames.select,
             Mode::Normal => &modenames.normal,
         };
-        let width = mode_str.chars().count() + 2;
+        let width = mode_str.width() + 2;
         Cow::Owned(" ".repeat(width))
     };
     let style = if visible && config.color_modes {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use helix_core::indent::IndentStyle;
 use helix_core::{coords_at_pos, encoding, unicode::width::UnicodeWidthStr, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
@@ -169,24 +167,16 @@ where
     let visible = context.focused;
     let config = context.editor.config();
     let modenames = &config.statusline.mode;
+    let mode_str = match context.editor.mode() {
+        Mode::Insert => &modenames.insert,
+        Mode::Select => &modenames.select,
+        Mode::Normal => &modenames.normal,
+    };
     let content = if visible {
-        Cow::Owned(format!(
-            " {} ",
-            match context.editor.mode() {
-                Mode::Insert => &modenames.insert,
-                Mode::Select => &modenames.select,
-                Mode::Normal => &modenames.normal,
-            }
-        ))
+        format!(" {mode_str} ")
     } else {
         // If not focused, explicitly leave an empty space instead of returning None.
-        let mode_str = match context.editor.mode() {
-            Mode::Insert => &modenames.insert,
-            Mode::Select => &modenames.select,
-            Mode::Normal => &modenames.normal,
-        };
-        let width = mode_str.width() + 2;
-        Cow::Owned(" ".repeat(width))
+        " ".repeat(mode_str.width() + 2)
     };
     let style = if visible && config.color_modes {
         match context.editor.mode() {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -180,7 +180,13 @@ where
         ))
     } else {
         // If not focused, explicitly leave an empty space instead of returning None.
-        Cow::Borrowed("     ")
+        let mode_str = match context.editor.mode() {
+            Mode::Insert => &modenames.insert,
+            Mode::Select => &modenames.select,
+            Mode::Normal => &modenames.normal,
+        };
+        let width = mode_str.chars().count() + 2;
+        Cow::Owned(" ".repeat(width))
     };
     let style = if visible && config.color_modes {
         match context.editor.mode() {


### PR DESCRIPTION
Previously, when switching between split panes, the statusline for unfocused panes always used a fixed-width space, regardless of the actual mode string length. This caused the statusline to shift or jump inconsistently as panes gained or lost focus. Now, the empty space matches the mode string’s width, keeping the statusline aligned when moving between panes.

## Before

https://github.com/user-attachments/assets/8215b213-d25a-4131-97e8-c3a7dafbc67f

## After

https://github.com/user-attachments/assets/238676ae-4a85-4466-b797-5ef4f157fee8

## Used config
```toml
[editor.statusline]
left = ["mode", "spinner", "version-control"]
center = ["file-name"]
right = [
  "diagnostics",
  "selections",
  "position",
  "file-encoding",
  "file-line-ending",
  "file-type",
]
separator = "|"
mode.normal = "N"
mode.insert = "I"
mode.select = "S"
```

