### PR TITLE
terminal: use fallback values for the terminal size

### DIFF
--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -80,7 +80,7 @@ where
     /// Wrapper around Terminal initialization. Each buffer is initialized with a blank string and
     /// default colors for the foreground and the background
     pub fn new(backend: B) -> io::Result<Terminal<B>> {
-        let size = backend.size()?;
+        let size = nonempty_terminal_size(backend.size());
         Terminal::with_options(
             backend,
             TerminalOptions {
@@ -236,6 +236,13 @@ where
 
     /// Queries the real size of the backend.
     pub fn size(&self) -> io::Result<Rect> {
-        self.backend.size()
+        Ok(nonempty_terminal_size(self.backend.size()))
     }
+}
+
+fn nonempty_terminal_size(size: io::Result<Rect>) -> Rect {
+    size.unwrap_or_else(|e| {
+        log::warn!("{}. Using default terminal size", e);
+        Rect::new(0, 0, 80, 24)
+    })
 }


### PR DESCRIPTION
**About**
This change allows using the default terminal size if it cannot be detected. Information about the error is logged. The default value is 80 columns by 24 rows. 

**Issue**
#14101

**Before**
<img width="969" height="182" alt="image" src="https://github.com/user-attachments/assets/e58fa62c-2ac1-49e7-876f-25e2cbb1d9eb" />

**After**
<img width="895" height="571" alt="image" src="https://github.com/user-attachments/assets/09ee9d62-ab38-49d7-b77d-af7156c7cb34" />

**Note**

This is an initial version for reviewing and discussion. There are two points I want to discuss and improve:
- Applying default values makes the Result usless at `size()`
- It could lead to many duplicate messages in the log when `size()` is called repeatedly. It might make sense to save the information about using the default value and log the failure only once.

What do you think?