### PR TITLE
feat(languages): add podman `*.conf` files to `toml` file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -358,7 +358,20 @@ source = { git = "https://github.com/FuelLabs/tree-sitter-sway", rev = "e491a005
 name = "toml"
 scope = "source.toml"
 injection-regex = "toml"
-file-types = ["toml", { glob = "pdm.lock" }, { glob = "poetry.lock" }, { glob = "Cargo.lock" }, { glob = "uv.lock" }]
+file-types = [
+  "toml",
+  { glob = "pdm.lock" },
+  { glob = "poetry.lock" },
+  { glob = "Cargo.lock" },
+  { glob = "uv.lock" },
+  { glob = "containers.conf" },
+  { glob = "containers.conf.d/*.conf" },
+  { glob = "containers.conf.modules/*.conf" },
+  { glob = "mounts.conf" },
+  { glob = "policy.conf" },
+  { glob = "registries.conf" },
+  { glob = "storage.conf" },
+]
 comment-token = "#"
 language-servers = [ "taplo", "tombi" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
feat(languages): add podman `*.conf` files to `toml` file-types

File paths are documented here:
- https://docs.podman.io/en/latest/markdown/podman.1.html#configuration-files
- https://github.com/containers/common/blob/main/pkg/config/containers.conf
- https://man.archlinux.org/man/containers.conf.5.en