### PR TITLE
feat: add `.kube/kuberc` to list of `yaml` file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1505,6 +1505,7 @@ file-types = [
   { glob = ".clang-tidy" },
   { glob = ".gem/credentials" },
   { glob = ".kube/config" },
+  { glob = ".kube/kuberc" },
   "sublime-syntax"
 ]
 comment-token = "#"


### PR DESCRIPTION
Introduced in [Kubernetes v.1.34.0](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/#kuberc-file-for-kubectl-user-preferences)