### PR TITLE
feat: add uppercase file extensions for Fortran

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2678,7 +2678,7 @@ language-servers = [ "idris2-lsp" ]
 name = "fortran"
 scope = "source.fortran"
 injection-regex = "fortran"
-file-types = ["f", "for", "f90", "f95", "f03"]
+file-types = ["f", "for", "f90", "f95", "f03", "F", "F90", "F95", "F03"]
 roots = ["fpm.toml"]
 comment-token = "!"
 indent = { tab-width = 4, unit = "    "}


### PR DESCRIPTION
These are usually used to trigger automatic preprocessing with a C-like preprocessor.

Closes: https://github.com/helix-editor/helix/issues/14428