### PR TITLE
Fix syntax highlighting for tmux configurations files stored in user home (`~/.tmux.conf`)

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1151,6 +1151,7 @@ file-types = [
   "zshrc_Apple_Terminal",
   { glob = "i3/config" },
   { glob = "sway/config" },
+  { glob = ".tmux.conf" },
   { glob = "tmux.conf" },
   { glob = ".bash_history" },
   { glob = ".bash_login" },


### PR DESCRIPTION
To fix syntax highlighting for tmux configuration files stored in user home, add `.tmux.conf` glob under bash file types.

See this excerpt from [tmux manual](https://man7.org/linux/man-pages/man1/tmux.1.html):

> By default, tmux loads the system configuration file from @SYSCONFDIR@/tmux.conf, if present, then looks for a user configuration file at ~/.tmux.conf or $XDG_CONFIG_HOME/tmux/tmux.conf.