### PR TITLE
Render foreground rulers (`┊`) by default

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -32,7 +32,7 @@
 "ui.statusline.select" = { fg = "black", bg = "blue" }
 "ui.virtual" = { fg = "gray", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 
 "markup.heading" = "blue"
 "markup.list" = "red"

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -48,6 +48,7 @@
 | `true-color` | Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative | `false` |
 | `undercurl` | Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative | `false` |
 | `rulers` | List of column positions at which to display the rulers. Can be overridden by language specific `rulers` in `languages.toml` file | `[]` |
+| `ruler-char` | Character used to draw rulers | `┊` |
 | `bufferline` | Renders a line at the top of the editor displaying open buffers. Can be `always`, `never` or `multiple` (only shown if more than one buffer is in use) | `never` |
 | `color-modes` | Whether to color the mode indicator with different colors depending on the mode itself | `false` |
 | `text-width` | Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set | `80` |

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -333,6 +333,8 @@ pub struct Config {
     pub terminal: Option<TerminalConfig>,
     /// Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers.
     pub rulers: Vec<u16>,
+    /// Character used to draw rulers. Defaults to `┊`.
+    pub ruler_char: String,
     #[serde(default)]
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
@@ -1046,6 +1048,7 @@ impl Default for Config {
             lsp: LspConfig::default(),
             terminal: get_terminal_provider(),
             rulers: Vec::new(),
+            ruler_char: "┊".to_owned(),
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
             indent_guides: IndentGuidesConfig::default(),

--- a/runtime/themes/acme.toml
+++ b/runtime/themes/acme.toml
@@ -9,7 +9,7 @@
 "ui.statusline" = {fg="black", bg="acme_bar_bg"}
 "ui.statusline.inactive" = {fg="black", bg="acme_bar_inactive"}
 "ui.virtual" = "indent"
-"ui.virtual.ruler" = { bg = "acme_bar_bg" }
+"ui.virtual.ruler" = { fg = "acme_bar_bg" }
 "ui.cursor.match" = {bg="acme_bar_bg"}
 "ui.cursor" = {bg="cursor", fg="white"}
 "ui.debug" = {fg="orange"}

--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -82,7 +82,7 @@
 "ui.help" = { bg = "libadwaita_dark_alt" }
 "ui.text" = "light_4"
 "ui.virtual" = "dark_1"
-"ui.virtual.ruler" = { bg = "libadwaita_popup"}
+"ui.virtual.ruler" = { fg = "libadwaita_popup"}
 "ui.menu" = { fg = "light_4", bg = "libadwaita_popup" }
 "ui.menu.selected" = { fg = "light_4", bg = "blue_5" }
 "ui.menu.scroll" = { fg = "light_7", bg = "dark_3" }

--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -82,7 +82,7 @@ inherits="adwaita-dark"
 "ui.help" = { bg = "light_3" }
 "ui.text" = "dark_4"
 "ui.virtual" = "light_5"
-"ui.virtual.ruler" = { bg = "light_5"}
+"ui.virtual.ruler" = { fg = "light_5"}
 "ui.virtual.jump-label" = { modifiers = ["reversed"] }
 "ui.menu" = { fg = "dark_4", bg = "light_3" }
 "ui.menu.selected" = { fg = "dark_4", bg = "blue_1" }

--- a/runtime/themes/amberwood.toml
+++ b/runtime/themes/amberwood.toml
@@ -76,7 +76,7 @@
 "ui.text.focus" = { fg = "fg" }
 
 "ui.virtual" = { fg = "gray02" }
-"ui.virtual.ruler" = {bg="gray02"}
+"ui.virtual.ruler" = {fg="gray02"}
 "ui.virtual.indent-guide" = { fg = "gray02" }
 "ui.virtual.inlay-hint" = { fg = "gray03" }
 

--- a/runtime/themes/ao.toml
+++ b/runtime/themes/ao.toml
@@ -75,7 +75,7 @@
 "ui.bufferline" = { fg = "slate_gray", modifiers = ["bold"] }                                        # bufferline inactive tab
 "ui.bufferline.active" = { fg = "winter_sky", bg = "twilight_blue" }                                 # bufferline active tab
 "ui.bufferline.background" = { bg = "pitch_black" }                                                  # bufferline background
-"ui.virtual.ruler" = { bg = "stormy_night" }                                                         # ruler columns
+"ui.virtual.ruler" = { fg = "stormy_night" }                                                         # ruler columns
 "ui.virtual.whitespace" = { fg = "stormy_night" }                                                    # whitespace characters
 "ui.virtual.indent-guide" = { fg = "stormy_night" }                                                  # vertical indent width guides
 "ui.virtual.inlay-hint" = { fg = "slate_gray" }                                                      # inlay hints of all kinds

--- a/runtime/themes/ashen.toml
+++ b/runtime/themes/ashen.toml
@@ -114,7 +114,7 @@
 "ui.text.directory" = { fg = "red_ember" }
 
 "ui.virtual" = "g_5"
-"ui.virtual.ruler" = { bg = "cursorline" }
+"ui.virtual.ruler" = { fg = "cursorline" }
 "ui.virtual.whitespace" = "g_7"
 "ui.virtual.indent-guide" = "g_7"
 "ui.virtual.wrap" = "g_7"

--- a/runtime/themes/aura-dark-soft.toml
+++ b/runtime/themes/aura-dark-soft.toml
@@ -23,7 +23,7 @@
 "ui.text.inactive" = { fg = "gray" }
 
 "ui.virtual.indent-guide" = "accent13"
-"ui.virtual.ruler" = { bg = "accent13" }
+"ui.virtual.ruler" = { fg = "accent13" }
 "ui.virtual.whitespace" = { fg = "accent13" }
 "ui.virtual.inlay-hint" = { fg = "accent9", bg = "accent33" }
 "ui.virtual.jump-label" = { fg = "pink" , modifiers = ["bold"] }

--- a/runtime/themes/aura-dark.toml
+++ b/runtime/themes/aura-dark.toml
@@ -23,7 +23,7 @@
 "ui.text.inactive" = { fg = "gray" }
 
 "ui.virtual.indent-guide" = "accent13"
-"ui.virtual.ruler" = { bg = "accent13" }
+"ui.virtual.ruler" = { fg = "accent13" }
 "ui.virtual.whitespace" = { fg = "accent13" }
 "ui.virtual.inlay-hint" = { fg = "accent9", bg = "accent33" }
 "ui.virtual.jump-label" = { fg = "pink" , modifiers = ["bold"] }

--- a/runtime/themes/aurara.toml
+++ b/runtime/themes/aurara.toml
@@ -127,7 +127,7 @@
 'ui.linenr.selected' = { modifiers = [ "bold" ] } # Current line number.
 
 'ui.virtual' = { fg = "gray-stone" } # Namespace for additions to the editing area.
-'ui.virtual.ruler' = { bg = "selection-ui"} # Vertical rulers (colored columns in editing area).
+'ui.virtual.ruler' = { fg = "selection-ui"} # Vertical rulers (colored columns in editing area).
   # TODO: TEST: haven't seen these two yet..error
 # 'ui.virtual.whitespace' = { fg = "gray-stone"} # Whitespace markers in editing area: newline..
 # 'ui.virtual.wrap'

--- a/runtime/themes/autumn.toml
+++ b/runtime/themes/autumn.toml
@@ -74,7 +74,7 @@
 "ui.virtual.inlay-hint.parameter" = "my_gray4"
 "ui.virtual.inlay-hint.type" = { fg = "my_gray4", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "my_yellow2", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "my_gray1" }
+"ui.virtual.ruler" = { fg = "my_gray1" }
 "ui.virtual.whitespace" = { fg = "my_gray6" }
 "ui.virtual.wrap" = "my_gray4"
 "ui.window" = { fg = "my_gray3", bg = "my_gray2" }

--- a/runtime/themes/ayu_dark.toml
+++ b/runtime/themes/ayu_dark.toml
@@ -53,7 +53,7 @@
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 "ui.virtual.inlay-hint" = { fg = "#e6b450", bg = "#302a20" }  # original bg #e6b45033
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }

--- a/runtime/themes/ayu_light.toml
+++ b/runtime/themes/ayu_light.toml
@@ -53,7 +53,7 @@
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 "ui.virtual.inlay-hint" = { fg = "#f4a028", bg = "#fcf2e3" }  # bg original #ffaa3333
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }

--- a/runtime/themes/ayu_mirage.toml
+++ b/runtime/themes/ayu_mirage.toml
@@ -53,7 +53,7 @@
 "ui.text.focus" = { bg = "dark_gray", fg = "foreground" }
 "ui.text.info" = "foreground"
 "ui.virtual.whitespace" = "dark_gray"
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 "ui.virtual.inlay-hint" = { fg = "#ffcc66", bg = "#47433d" }  # original bg #ffcc6633
 "ui.menu" = { fg = "foreground", bg = "black" }
 "ui.menu.selected" = { bg = "gray", fg = "background" }

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -3,7 +3,7 @@
 "ui.background" = { bg = "base00" }
 "ui.virtual.whitespace" = "base03"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
-"ui.virtual.ruler" = { bg = "base01" }
+"ui.virtual.ruler" = { fg = "base01" }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base01", bg = "base04" }
 "ui.linenr" = { fg = "base03", bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -14,7 +14,7 @@
 "ui.cursor.primary" = { fg = "base05", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "base03"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
-"ui.virtual.ruler" = { bg = "base01" }
+"ui.virtual.ruler" = { fg = "base01" }
 "ui.text" = "base05"
 "operator" = "base05"
 "ui.text.focus" = "base05"

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -15,7 +15,7 @@
 "ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "light-gray"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 "variable" = "light-red"
 "constant.numeric" = "yellow"
 "constant" = "yellow"

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -28,7 +28,7 @@
 "ui.cursorline.secondary" = { underline = { color = "light-gray", style = "line" } }
 "ui.cursorcolumn.primary" = { bg = "gray" }
 "ui.cursorcolumn.secondary" = { bg = "gray" }
-"ui.virtual.ruler" = { bg = "gray" }
+"ui.virtual.ruler" = { fg = "gray" }
 "ui.virtual.whitespace" = "gray"
 "ui.virtual.indent-guide" = "gray"
 "ui.virtual.inlay-hint" = { fg = "white", bg = "gray" }

--- a/runtime/themes/beans.toml
+++ b/runtime/themes/beans.toml
@@ -80,7 +80,7 @@
 "ui.text" = "light_yellow"
 "ui.text.focus" = { fg = "white", bg = "dark_blue" }
 "ui.virtual" = "dark"
-"ui.virtual.ruler" = { bg = "darker" }
+"ui.virtual.ruler" = { fg = "darker" }
 "ui.virtual.jump-label" = { bg = "light_blue", fg = "darkest", modifiers = ["bold"] }
 "ui.menu" = { fg = "light_purple", bg = "darkest" }
 "ui.menu.selected" = { fg = "white", bg = "dark_blue" }

--- a/runtime/themes/bogster.toml
+++ b/runtime/themes/bogster.toml
@@ -58,7 +58,7 @@
 "ui.text" = { fg = "bogster-fg1" }
 "ui.text.focus" = { fg = "bogster-fg1", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "bogster-base5"
-"ui.virtual.ruler" = { bg = "bogster-base0" }
+"ui.virtual.ruler" = { fg = "bogster-base0" }
 "ui.virtual.jump-label" = { fg = "bogster-base0", bg = "bogster-yellow", modifiers = [ "bold" ] }
 
 "ui.selection" = { bg = "bogster-base2" }

--- a/runtime/themes/bogster_light.toml
+++ b/runtime/themes/bogster_light.toml
@@ -58,7 +58,7 @@
 "ui.text" = { fg = "bogster-fg1" }
 "ui.text.focus" = { fg = "bogster-fg1", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "bogster-base5"
-"ui.virtual.ruler" = { bg = "bogster-base00" }
+"ui.virtual.ruler" = { fg = "bogster-base00" }
 
 "ui.selection" = { bg = "bogster-base1" }
 "ui.cursor.match" = { fg = "bogster-base2", bg = "bogster-orange" }

--- a/runtime/themes/boo_berry.toml
+++ b/runtime/themes/boo_berry.toml
@@ -50,7 +50,7 @@
 "ui.menu.selected" = { fg = "mint", bg = "berry_saturated" }
 "ui.selection" = { bg = "berry_saturated" }
 "ui.virtual.whitespace" = { fg = "berry_desaturated" }
-"ui.virtual.ruler" = { bg = "berry_dim" }
+"ui.virtual.ruler" = { fg = "berry_dim" }
 "ui.virtual.indent-guide" = { fg = "berry_fade" }
 "ui.virtual.inlay-hint" = { fg = "berry_desaturated" }
 

--- a/runtime/themes/carbon.toml
+++ b/runtime/themes/carbon.toml
@@ -119,7 +119,7 @@
 "ui.text.inactive" = { fg = "gray50" }
 "ui.text.info" = { fg = "blue40" }
 
-"ui.virtual.ruler" = { bg = "gray20" }
+"ui.virtual.ruler" = { fg = "gray20" }
 "ui.virtual.whitespace" = "gray30"
 "ui.virtual.indent-guide" = "gray30"
 "ui.virtual.inlay-hint" = { fg = "gray50", bg = "gray10" }

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -91,7 +91,7 @@
 "ui.text.directory" = { fg = "blue" }
 
 "ui.virtual" = "overlay0"
-"ui.virtual.ruler" = { bg = "surface0" }
+"ui.virtual.ruler" = { fg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
 "ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
 "ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }

--- a/runtime/themes/curzon.toml
+++ b/runtime/themes/curzon.toml
@@ -44,7 +44,7 @@ label = "label"
 "ui.linenr.selected" = { fg = "light_blue" }
 "ui.statusline" = { fg = "statusline_foreground_color", bg = "black" }
 "ui.statusline.inactive" = { fg = "statusline_inactive_foreground_color", bg = "black" }
-"ui.virtual.ruler" = { bg = "dark"}
+"ui.virtual.ruler" = { fg = "dark"}
 
 "ui.popup" = {  fg = "menu_normal_text_color", bg = "menu_background_color"  }
 "ui.window" = { fg = "dark"}

--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -21,7 +21,7 @@
 "ui.cursorline.secondary" = { bg = "grey02" }
 "ui.text" = "white"
 "ui.text.focus" = "grey05"
-"ui.virtual.ruler" = { bg = "grey02" }
+"ui.virtual.ruler" = { fg = "grey02" }
 "ui.virtual.indent-guide" = "grey02"
 "ui.virtual.whitespace" = "grey03"
 "ui.virtual.inlay-hint" = { fg = "grey03", modifiers = ["italic"] }

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -76,7 +76,7 @@
 "ui.text.inactive"           = { fg = "dark_gray" }
 "ui.virtual.whitespace"      = { fg = "#3e3e3d" }
 "ui.virtual.wrap"            = { fg = "#3e3e3d" }
-"ui.virtual.ruler"           = { bg = "borders" }
+"ui.virtual.ruler"           = { fg = "borders" }
 "ui.virtual.indent-guide"    = { fg = "dark_gray4" }
 "ui.virtual.inlay-hint"      = { fg = "dark_gray5"}
 "ui.virtual.jump-label"      = { fg = "yellow", modifiers = ["bold"] }

--- a/runtime/themes/doom-one.toml
+++ b/runtime/themes/doom-one.toml
@@ -10,7 +10,7 @@
 "ui.statusline" = { fg = "blue" }
 "ui.selection" = { bg = "bg_highlight" } 
 "ui.selection.primary" = { bg = "bg_highlight" }  
-"ui.virtual.ruler" = { bg = "bg_highlight" }
+"ui.virtual.ruler" = { fg = "bg_highlight" }
 
 # Markdown Highlighting
 "markup.raw" = { fg = "blue", bg = "bg" } 

--- a/runtime/themes/doom_acario_dark.toml
+++ b/runtime/themes/doom_acario_dark.toml
@@ -65,7 +65,7 @@
 'ui.text.focus' = { bg = 'bg-alt', fg = 'fg' }
 'ui.text.info' = { fg = 'fg' }
 'ui.virtual.whitespace' = { fg = 'base2' }
-'ui.virtual.ruler' = { bg = 'black' }
+'ui.virtual.ruler' = { fg = 'black' }
 'ui.menu' = { fg = 'fg', bg = 'bg-alt' }
 'ui.menu.selected' = { bg = 'base3', fg = 'fg' }
 'ui.selection' = { bg = 'base2' }

--- a/runtime/themes/dracula.toml
+++ b/runtime/themes/dracula.toml
@@ -125,7 +125,7 @@
 "ui.virtual.inlay-hint.parameter" = { fg    = "cyan",            modifiers = ["italic", "dim"]              }
 "ui.virtual.inlay-hint.type"      = { fg    = "cyan",            modifiers = ["italic", "dim"]              }
 "ui.virtual.jump-label"           = { fg    = "pink",            modifiers = ["bold"]                       }
-"ui.virtual.ruler"                = { bg    = "black"                                                       }
+"ui.virtual.ruler"                = { fg    = "black"                                                       }
 "ui.virtual.whitespace"           = { fg    = "whitespace"                                                  }
 "ui.virtual.wrap"                 = { fg    = "current_line"                                                }
 "ui.window"                       = { fg    = "foreground"                                                  }

--- a/runtime/themes/dracula_at_night.toml
+++ b/runtime/themes/dracula_at_night.toml
@@ -45,7 +45,7 @@
 "ui.text.directory" = { fg = "cyan" }
 "ui.window" = { fg = "foreground" }
 "ui.virtual.jump-label" = { fg = "pink", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "background_dark" }
+"ui.virtual.ruler" = { fg = "background_dark" }
 
 "error" = { fg = "red" }
 "warning" = { fg = "cyan" }

--- a/runtime/themes/earl_grey.toml
+++ b/runtime/themes/earl_grey.toml
@@ -41,7 +41,7 @@
 "ui.virtual.indent-guide" = { fg = "space" }
 "ui.virtual.inlay-hint" = { fg = "lacquer" }
 "ui.virtual.jump-label" = { fg = "myrtle" }
-"ui.virtual.ruler" = { bg = "space" }
+"ui.virtual.ruler" = { fg = "space" }
 "ui.window" = { fg = "space" }
 "warning" = "maple"
 

--- a/runtime/themes/eiffel.toml
+++ b/runtime/themes/eiffel.toml
@@ -118,7 +118,7 @@
 #"ui.virtual.inlay-hint.parameter" = ""
 #"ui.virtual.inlay-hint.type" = ""
 "ui.virtual.jump-label" = { fg = "white", bg = "ui_jumplabel", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "ui_background_accent" }
+"ui.virtual.ruler" = { fg = "ui_background_accent" }
 "ui.virtual.whitespace" = "ui_text_dim"
 "ui.virtual.wrap" = "ui_text_dim"
 "ui.window" = "ui_split_line"

--- a/runtime/themes/emacs.toml
+++ b/runtime/themes/emacs.toml
@@ -70,7 +70,7 @@
 "ui.selection.primary" = { bg = "lightgoldenrod2" }
 # Malformed ANSI: highlight. See 'https://github.com/helix-editor/helix/issues/5709'
 # "ui.virtual.whitespace" = "highlight"
-"ui.virtual.ruler" = { bg = "gray95" }
+"ui.virtual.ruler" = { fg = "gray95" }
 "ui.virtual.inlay-hint" = { fg = "gray75" }
 "ui.cursorline.primary" = { bg = "darkseagreen2" }
 "ui.cursorline.secondary" = { bg = "darkseagreen2" }

--- a/runtime/themes/everblush.toml
+++ b/runtime/themes/everblush.toml
@@ -64,7 +64,7 @@
 "ui.statusline.select" = { fg = "magenta", bg = "background" }
 "ui.text" = { fg = "foreground" }
 "ui.text.focus" = { fg = "blue" }
-"ui.virtual.ruler" = { bg = "cursorline" }
+"ui.virtual.ruler" = { fg = "cursorline" }
 "ui.virtual.whitespace" = { fg = "comment" }
 "ui.virtual.wrap" = { fg = "comment" }
 "ui.virtual.indent-guide" = { fg = "comment" }

--- a/runtime/themes/everforest_dark.toml
+++ b/runtime/themes/everforest_dark.toml
@@ -98,7 +98,7 @@
 "ui.text.focus" = "fg"
 "ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
-"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.ruler" = { fg = "bg3" }
 "ui.virtual.whitespace" = { fg = "bg4" }
 "ui.virtual.indent-guide" = { fg = "bg4" }
 "ui.virtual.inlay-hint" = { fg = "grey0" }

--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -97,7 +97,7 @@
 "ui.text.focus" = "fg"
 "ui.menu" = { fg = "fg", bg = "bg3" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
-"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.ruler" = { fg = "bg3" }
 "ui.virtual.whitespace" = { fg = "bg4" }
 "ui.virtual.indent-guide" = { fg = "bg4" }
 "ui.virtual.inlay-hint" = { fg = "grey0" }

--- a/runtime/themes/ferra.toml
+++ b/runtime/themes/ferra.toml
@@ -51,7 +51,7 @@
 "ui.selection" = { bg = "ferra_umber" }
 "ui.virtual" = { fg = "ferra_bark" }
 "ui.virtual.whitespace" = { fg = "ferra_bark" }
-"ui.virtual.ruler" = { bg = "ferra_ash" }
+"ui.virtual.ruler" = { fg = "ferra_ash" }
 "ui.virtual.indent-guide" = { fg = "ferra_ash" }
 "ui.virtual.inlay-hint" = { fg = "ferra_bark" }
 

--- a/runtime/themes/flatwhite.toml
+++ b/runtime/themes/flatwhite.toml
@@ -60,7 +60,7 @@
 
 "ui.virtual" = { fg = "base5", bg = "base6" }
 "ui.virtual.whitespace" = { fg = "base5" }
-"ui.virtual.ruler" = { bg = "base6" }
+"ui.virtual.ruler" = { fg = "base6" }
 "ui.virtual.inlay-hint" = "base4"
 "ui.virtual.inlay-hint.parameter" = "base3"
 "ui.virtual.inlay-hint.type" = { fg = "base3", modifiers = ["italic"] }

--- a/runtime/themes/fleet_dark.toml
+++ b/runtime/themes/fleet_dark.toml
@@ -94,7 +94,7 @@
 
 "ui.virtual" = "Gray 90" # .whitespace
 "ui.virtual.inlay-hint" = { fg = "Gray 70" }
-"ui.virtual.ruler" = { bg = "Gray 20" }
+"ui.virtual.ruler" = { fg = "Gray 20" }
 
 "hint" = "Gray 80"
 "info" = "#A366C4"

--- a/runtime/themes/flexoki_light.toml
+++ b/runtime/themes/flexoki_light.toml
@@ -19,7 +19,7 @@
 "ui.text.focus" = { bg = "bg-2", fg = "tx" }
 "ui.text.info" = "tx"
 "ui.virtual.whitespace" = "bg-2"
-"ui.virtual.ruler" = { bg = "bg-2" }
+"ui.virtual.ruler" = { fg = "bg-2" }
 "ui.virtual.inlay-hint" = { fg = "tx-3", bg = "bg" }
 "ui.virtual.jump-label" = { bg = "bg-2", modifiers = ["bold"]}
 "ui.menu" = { fg = "tx", bg = "bg" }

--- a/runtime/themes/focus_nova.toml
+++ b/runtime/themes/focus_nova.toml
@@ -111,7 +111,7 @@
 "ui.text.directory" = { fg = "blue1" }
 "ui.virtual.inlay-hint" = { fg = "gray" }
 "ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.wrap" = { fg = "bg2" }
 "ui.window" = { bg = "bg1" }

--- a/runtime/themes/github_dark.toml
+++ b/runtime/themes/github_dark.toml
@@ -61,7 +61,7 @@ label = "scale.red.3"
 "ui.text.inactive" = "fg.subtle"
 "ui.text.directory" = { fg = "scale.blue.2" }
 "ui.virtual" = { fg = "scale.gray.6" }
-"ui.virtual.ruler" = { bg = "canvas.subtle" }
+"ui.virtual.ruler" = { fg = "canvas.subtle" }
 "ui.virtual.jump-label" = { fg = "scale.red.2", modifiers = ["bold"] }
 
 "ui.selection" = { bg = "scale.blue.8" }

--- a/runtime/themes/github_light.toml
+++ b/runtime/themes/github_light.toml
@@ -61,7 +61,7 @@ label = "scale.red.5"
 "ui.text.inactive" = "fg.subtle"
 "ui.text.directory" = { fg = "scale.blue.4" }
 "ui.virtual" = { fg = "scale.gray.2" }
-"ui.virtual.ruler" = { bg = "canvas.subtle" }
+"ui.virtual.ruler" = { fg = "canvas.subtle" }
 "ui.virtual.jump-label" = { modifiers = ["reversed"] }
 
 "ui.selection" = { bg = "scale.blue.0" }

--- a/runtime/themes/gruber-darker.toml
+++ b/runtime/themes/gruber-darker.toml
@@ -65,7 +65,7 @@
 
 "ui.virtual.whitespace" = "bg8"
 "ui.virtual.indent-guide" = "bg8"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.virtual.inlay-hint" = { fg = "bg7" }
 "ui.virtual.wrap" = { fg = "bg2" }
 "ui.virtual.jump-label" = { fg = "red3", modifiers = ["bold"] }

--- a/runtime/themes/gruvbox.toml
+++ b/runtime/themes/gruvbox.toml
@@ -110,7 +110,7 @@
 "ui.text.directory" = { fg = "blue1" }
 "ui.virtual.inlay-hint" = { fg = "gray" }
 "ui.virtual.jump-label" = { fg = "purple0", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.virtual.whitespace" = "bg2"
 "ui.virtual.wrap" = { fg = "bg2" }
 "ui.window" = { bg = "bg1" }

--- a/runtime/themes/gruvbox_material_dark_medium.toml
+++ b/runtime/themes/gruvbox_material_dark_medium.toml
@@ -102,7 +102,7 @@ warning = "yellow"
 "ui.virtual.indent-guide" = "bg3"
 "ui.virtual.inlay-hint" = "grey0"
 "ui.virtual.jump-label" = "grey2"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.window" = { fg = "bg3" }
 
 [palette]

--- a/runtime/themes/gruvbox_material_light_medium.toml
+++ b/runtime/themes/gruvbox_material_light_medium.toml
@@ -103,7 +103,7 @@ warning = "yellow"
 "ui.virtual.indent-guide" = "bg3"
 "ui.virtual.inlay-hint" = "grey0"
 "ui.virtual.jump-label" = "grey2"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.window" = { fg = "bg3" }
 
 [palette]

--- a/runtime/themes/heisenberg.toml
+++ b/runtime/themes/heisenberg.toml
@@ -49,7 +49,7 @@
 "ui.text.focus" = { bg = "background", fg = "barium_green" }
 "ui.text.info" = { fg = "crystal_blue" }
 "ui.virtual.whitespace" = { fg = "#08341B" }
-"ui.virtual.ruler" = { bg = "#041B0E" }
+"ui.virtual.ruler" = { fg = "#041B0E" }
 "ui.virtual.indent-guide" = { fg = "#08341B" }
 "ui.menu" = { fg = "crystal_blue", bg = "background" }
 "ui.menu.selected" = { bg = "hazmat_yellow", fg = "background" }

--- a/runtime/themes/hex_steel.toml
+++ b/runtime/themes/hex_steel.toml
@@ -60,7 +60,7 @@
 "ui.text" = { fg = "t4" }
 "ui.text.focus" = { fg = "highlight_three", modifiers = ["bold"] }
 
-"ui.virtual.ruler" = { bg = "ruler" }
+"ui.virtual.ruler" = { fg = "ruler" }
 "ui.virtual.indent-guide" = { fg = "t3" }
 "ui.virtual.whitespace" = { fg = "t3" }
 "ui.virtual.jump-label" = { fg = "t11", modifiers = ["bold"] }

--- a/runtime/themes/horizon-dark.toml
+++ b/runtime/themes/horizon-dark.toml
@@ -33,7 +33,7 @@ tag = "red"
 "ui.selection" = { bg = "selection" }
 "ui.virtual.indent-guide" = { fg = "gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
-"ui.virtual.ruler" = { bg = "dark-bg" }
+"ui.virtual.ruler" = { fg = "dark-bg" }
 "ui.statusline" = { bg = "dark-bg", fg = "light-gray" }
 "ui.popup" = { bg = "dark-bg", fg = "orange" }
 "ui.help" = { bg = "dark-bg", fg = "orange" }

--- a/runtime/themes/iceberg-dark.toml
+++ b/runtime/themes/iceberg-dark.toml
@@ -85,7 +85,7 @@
 "ui.virtual" = { fg = "linenr_fg" }
 "ui.virtual.indent-guide" = { fg = "linenr_fg" }
 "ui.virtual.jump-label" = {  fg = "orange", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "linenr_bg" }
+"ui.virtual.ruler" = { fg = "linenr_bg" }
 "ui.virtual.whitespace" = { fg = "sel_bg" }
 "ui.window" = { fg = "comment_fg", modifiers = ["bold"] }
 "variable" = { fg = "background_fg" }

--- a/runtime/themes/ingrid.toml
+++ b/runtime/themes/ingrid.toml
@@ -56,7 +56,7 @@
 "ui.text" = { fg = "#7B91B3" }
 "ui.text.focus" = { fg = "#250E07", modifiers= ["bold"] }
 "ui.virtual.whitespace" = "#A6B6CE"
-"ui.virtual.ruler" = { bg = "#F3EAE9" }
+"ui.virtual.ruler" = { fg = "#F3EAE9" }
 
 "ui.selection" = { bg = "#F3EAE9" }
 "ui.cursor.primary" = { bg = "#ED5466", fg = "#FFFCFD", modifiers = ["bold"] }

--- a/runtime/themes/iroaseta.toml
+++ b/runtime/themes/iroaseta.toml
@@ -75,7 +75,7 @@
 "ui.bufferline" = { fg = "slate_gray", modifiers = ["bold"] }                                        # bufferline inactive tab
 "ui.bufferline.active" = { fg = "misty_white", bg = "rustic_red" }                                   # bufferline active tab
 "ui.bufferline.background" = { bg = "pitch_black" }                                                  # bufferline background
-"ui.virtual.ruler" = { bg = "rustic_red" }                                                           # ruler columns
+"ui.virtual.ruler" = { fg = "rustic_red" }                                                           # ruler columns
 "ui.virtual.whitespace" = { fg = "brown" }                                                           # whitespace characters
 "ui.virtual.indent-guide" = { fg = "brown" }                                                         # vertical indent width guides
 "ui.virtual.inlay-hint" = { fg = "slate_gray" }                                                      # inlay hints of all kinds

--- a/runtime/themes/jellybeans.toml
+++ b/runtime/themes/jellybeans.toml
@@ -85,7 +85,7 @@
 "ui.text" = "light_yellow"
 "ui.text.focus" = { fg = "white", bg = "dark_blue" }
 "ui.virtual" = "dark"
-"ui.virtual.ruler" = { bg = "darker" }
+"ui.virtual.ruler" = { fg = "darker" }
 "ui.menu" = { fg = "light_purple", bg = "darkest" }
 "ui.menu.selected" = { fg = "white", bg = "dark_blue" }
 "ui.selection" = { bg = "darker" }

--- a/runtime/themes/jetbrains_cyan_light.toml
+++ b/runtime/themes/jetbrains_cyan_light.toml
@@ -101,7 +101,7 @@
 "ui.text.directory" = "blue"
 
 "ui.virtual" = "shade03"
-"ui.virtual.ruler" = { bg = "shade01" }
+"ui.virtual.ruler" = { fg = "shade01" }
 "ui.virtual.inlay-hint" = { fg = "shade03_darker" }
 "ui.virtual.jump-label" = { fg = "shade07", bg = "shade01", modifiers = ["bold" ] }
 

--- a/runtime/themes/jetbrains_dark.toml
+++ b/runtime/themes/jetbrains_dark.toml
@@ -40,7 +40,7 @@ tag = "red213"
 "ui.popup" = { bg = "blue48" }
 "ui.text.focus" = "blue247"
 "ui.virtual" = "blue122"
-"ui.virtual.ruler" = { bg = "blue64" }
+"ui.virtual.ruler" = { fg = "blue64" }
 "ui.virtual.whitespace" = "blue122"
 "ui.virtual.indent-guide" = "blue56"
 "ui.virtual.inlay-hint" = { fg = "blue145", bg = "blue50" }

--- a/runtime/themes/kanagawa-dragon.toml
+++ b/runtime/themes/kanagawa-dragon.toml
@@ -18,7 +18,7 @@ inherits = "kanagawa"
 "ui.linenr.selected" = { fg = "roninYellow", modifiers = ["bold"] }
 
 "ui.virtual" = "dragonBlack4"
-"ui.virtual.ruler" = { bg = "dragonBlack5" }
+"ui.virtual.ruler" = { fg = "dragonBlack5" }
 "ui.virtual.inlay-hint" = "dragonGray2"
 "ui.virtual.inlay-hint.parameter" = { fg = "dragonYellow", modifiers = ["dim"] }
 "ui.virtual.inlay-hint.type" = { fg = "dragonAqua", modifiers = ["dim"] }

--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -16,7 +16,7 @@
 "ui.gutter" = { fg = "sumiInk6", bg = "sumiInk4" }
 
 "ui.virtual" = "sumiInk6"
-"ui.virtual.ruler" = { bg = "sumiInk4" }
+"ui.virtual.ruler" = { fg = "sumiInk4" }
 "ui.virtual.inlay-hint" = "sumiInk6"
 "ui.virtual.jump-label" = { fg = "peachRed", modifiers = ["bold"] }
 

--- a/runtime/themes/kaolin-dark.toml
+++ b/runtime/themes/kaolin-dark.toml
@@ -73,7 +73,7 @@
 "ui.virtual.wrap" = "bg2"
 "ui.virtual.whitespace" = "fg1"
 "ui.virtual.indent-guide" = "bg2"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 "ui.virtual.inlay-hint" = "gray1"
 "ui.virtual.inlay-hint.parameter" = { fg = "gray1", modifiers = ["dim"] }
 "ui.virtual.inlay-hint.type" = { fg = "gray1", modifiers = ["dim"] }

--- a/runtime/themes/kaolin-valley-dark.toml
+++ b/runtime/themes/kaolin-valley-dark.toml
@@ -40,7 +40,7 @@ inherits = "kaolin-dark"
 "ui.virtual.wrap" = "gray1"
 "ui.virtual.whitespace" = "gray1"
 "ui.virtual.indent-guide" = "gray1"
-"ui.virtual.ruler" = { bg = "bg2" }
+"ui.virtual.ruler" = { fg = "bg2" }
 "ui.virtual.inlay-hint" = "gray0"
 "ui.virtual.inlay-hint.parameter" = { fg = "gray0", modifiers = ["italic"] }
 "ui.virtual.inlay-hint.type" = { fg = "gray0", modifiers = ["italic"] }

--- a/runtime/themes/kinda_nvim.toml
+++ b/runtime/themes/kinda_nvim.toml
@@ -49,7 +49,7 @@
 "ui.text.directory" = { fg = "fg_secondary" }
 
 "ui.virtual" = { fg = "fg_4" }
-"ui.virtual.ruler" = { bg = "bg_1" }
+"ui.virtual.ruler" = { fg = "bg_1" }
 "ui.virtual.indent-guide" = { fg = "bg_4" }
 "ui.virtual.inlay-hint" = { fg = "fg_2", modifiers = [ "dim" ] }
 "ui.virtual.wrap" = { fg = "fg_4" }

--- a/runtime/themes/lapis_aquamarine.toml
+++ b/runtime/themes/lapis_aquamarine.toml
@@ -9,7 +9,7 @@
 "ui.statusline" = { fg = "fg" }
 "ui.selection" = "green"
 "ui.selection.primary" = { bg = "bg_highlight" } 
-"ui.virtual.ruler" = { bg = "bg_highlight" }
+"ui.virtual.ruler" = { fg = "bg_highlight" }
 
 # Syntax Highlighting for Markdown 
 "markup.raw" = { fg = "purple", bg = "bg" } 

--- a/runtime/themes/material_deep_ocean.toml
+++ b/runtime/themes/material_deep_ocean.toml
@@ -80,7 +80,7 @@
 "ui.cursorline.primary" = { bg = "active" }
 
 "ui.virtual" = { fg = "gray" }
-"ui.virtual.ruler" = { bg = "highlight" }
+"ui.virtual.ruler" = { fg = "highlight" }
 "ui.virtual.indent-guide" = { fg = "gray" }
 
 "ui.highlight" = { bg = "highlight" }

--- a/runtime/themes/meliora.toml
+++ b/runtime/themes/meliora.toml
@@ -50,7 +50,7 @@
 "ui.text" = { fg = "white" }
 "ui.text.focus" = { fg = "orange" }
 
-"ui.virtual.ruler" = { bg = "light_black2" }
+"ui.virtual.ruler" = { fg = "light_black2" }
 "ui.virtual.indent-guide" = { fg = "dark_grey2" }
 "ui.virtual.whitespace" = { fg = "grey" }
  

--- a/runtime/themes/mellow.toml
+++ b/runtime/themes/mellow.toml
@@ -79,7 +79,7 @@
 "ui.text.focus" = { fg = "fg" }
 
 "ui.virtual" = { fg = "gray02" }
-"ui.virtual.ruler" = { bg ="gray02" }
+"ui.virtual.ruler" = { fg ="gray02" }
 "ui.virtual.indent-guide" = { fg = "gray02" }
 "ui.virtual.inlay-hint" = { fg = "gray04" }
 

--- a/runtime/themes/merionette.toml
+++ b/runtime/themes/merionette.toml
@@ -55,7 +55,7 @@
 "ui.virtual" = { fg = "pink1" }
 "ui.virtual.indent-guide" = { fg = "dark_red4" }
 "ui.virtual.inlay-hint" = { fg = "blue0" }
-"ui.virtual.ruler" = { bg = "dark_red2" }
+"ui.virtual.ruler" = { fg = "dark_red2" }
 "ui.virtual.whitespace" = "dark_red4"
 "ui.window" = { bg = "dark_red2" }
 

--- a/runtime/themes/modus_operandi.toml
+++ b/runtime/themes/modus_operandi.toml
@@ -79,7 +79,7 @@ punctuation = "fg-dim"
 "ui.text.focus" = { fg = "fg-main", bg = "bg-completion", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "fg-dim" }
 "ui.virtual" = "bg-active"
-"ui.virtual.ruler" = { bg = "bg-dim" }
+"ui.virtual.ruler" = { fg = "bg-dim" }
 "ui.virtual.inlay-hint" = { fg = "fg-dim", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "yellow-cooler", modifiers = ["bold"] }
 

--- a/runtime/themes/modus_vivendi.toml
+++ b/runtime/themes/modus_vivendi.toml
@@ -82,7 +82,7 @@ punctuation = "fg-dim"
 "ui.text.focus" = { fg = "fg-main", bg = "bg-completion", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "fg-dim" }
 "ui.virtual" = "bg-active"
-"ui.virtual.ruler" = { bg = "bg-dim" }
+"ui.virtual.ruler" = { fg = "bg-dim" }
 "ui.virtual.inlay-hint" = { fg = "fg-dim", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "yellow-cooler", modifiers = ["bold"] }
 

--- a/runtime/themes/monokai.toml
+++ b/runtime/themes/monokai.toml
@@ -35,7 +35,7 @@
 
 "comment" = { fg = "#88846F" }
 "ui.virtual.whitespace" = "#88846F"
-"ui.virtual.ruler" = { bg = "#24241e" }
+"ui.virtual.ruler" = { fg = "#24241e" }
 "ui.virtual.jump-label" = { fg = "special", modifiers = ["bold"] }
 
 "string" = { fg = "#e6db74" }

--- a/runtime/themes/monokai_pro.toml
+++ b/runtime/themes/monokai_pro.toml
@@ -7,7 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
-"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.ruler" = { fg = "base1" }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 "info" = "base8"

--- a/runtime/themes/monokai_pro_machine.toml
+++ b/runtime/themes/monokai_pro_machine.toml
@@ -7,7 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
-"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.ruler" = { fg = "base1" }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 "info" = "base8"

--- a/runtime/themes/monokai_pro_octagon.toml
+++ b/runtime/themes/monokai_pro_octagon.toml
@@ -7,7 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
-"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.ruler" = { fg = "base1" }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 "info" = "base8"

--- a/runtime/themes/monokai_pro_ristretto.toml
+++ b/runtime/themes/monokai_pro_ristretto.toml
@@ -7,7 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base5"
-"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.ruler" = { fg = "base1" }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 "info" = "base8"

--- a/runtime/themes/monokai_pro_spectrum.toml
+++ b/runtime/themes/monokai_pro_spectrum.toml
@@ -7,7 +7,7 @@
 "ui.menu" = { fg = "base8", bg = "base3" }
 "ui.menu.selected" = { fg = "base2", bg = "yellow" }
 "ui.virtual.whitespace" = "base4"
-"ui.virtual.ruler" = { bg = "base1" }
+"ui.virtual.ruler" = { fg = "base1" }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 
 "info" = "base8"

--- a/runtime/themes/monokai_soda.toml
+++ b/runtime/themes/monokai_soda.toml
@@ -103,7 +103,7 @@
 
 "ui.text.focus" = { fg = "yellow", modifiers = ["bold"] }
 "ui.virtual" = "darkgray"
-"ui.virtual.ruler" = { bg = "darkgray" }
+"ui.virtual.ruler" = { fg = "darkgray" }
 "ui.virtual.jump-label" = { fg = "softorange", modifiers = ["bold"] }
 
 # Palette

--- a/runtime/themes/naysayer.toml
+++ b/runtime/themes/naysayer.toml
@@ -12,7 +12,7 @@
 "ui.statusline" = { fg = "bg", bg = "text" }
 "ui.statusline.inactive" = { fg = "text", bg = "bg" }
 "ui.virtual" = "indent"
-"ui.virtual.ruler" = { bg = "line-fg" }
+"ui.virtual.ruler" = { fg = "line-fg" }
 "ui.cursor.match" = { bg = "cyan" }
 "ui.cursor" = { bg = "#777777" }
 "ui.cursor.primary" = { bg = "white" }

--- a/runtime/themes/new_moon.toml
+++ b/runtime/themes/new_moon.toml
@@ -85,7 +85,7 @@
 "ui.text.focus" = { fg = "lightest" }
 
 "ui.virtual.whitespace" = { fg = "dark_gray_virtual" }
-"ui.virtual.ruler" = { bg = "borders" }
+"ui.virtual.ruler" = { fg = "borders" }
 "ui.virtual.indent-guide" = { fg = "dark_gray_virtual" }
 "ui.virtual.inlay-hint" = { fg = "dark_gray_virtual"}
 

--- a/runtime/themes/night_owl.toml
+++ b/runtime/themes/night_owl.toml
@@ -36,7 +36,7 @@
 'ui.popup' = { fg = 'foreground', bg = 'background2' }
 'ui.popup.info' = { fg = 'gold', bg = 'background2'}
 'ui.help' = { fg = 'gold', bg = 'background2'}
-'ui.virtual.ruler' = { bg = 'grey4' }
+'ui.virtual.ruler' = { fg = 'grey4' }
 'ui.virtual.whitespace' = { fg = 'grey4' }
 'ui.cursorline.primary' = { bg = 'background2' }
 

--- a/runtime/themes/nightfox.toml
+++ b/runtime/themes/nightfox.toml
@@ -31,7 +31,7 @@
 "ui.linenr.selected" = { fg = "yellow", modifiers = ["bold"] } # Current line number.
 
 # "ui.virtual" = { } # Namespace for additions to the editing area.
-"ui.virtual.ruler" = { bg = "bg3" } # Vertical rulers (colored columns in editing area).
+"ui.virtual.ruler" = { fg = "bg3" } # Vertical rulers (colored columns in editing area).
 "ui.virtual.whitespace" = { fg = "bg3" } # Whitespace markers in editing area.
 "ui.virtual.indent-guide" = { fg = "black" } # Vertical indent width guides
 "ui.virtual.inlay-hint" = { fg = "comment", bg = "bg2" } # Default style for inlay hints of all kinds

--- a/runtime/themes/noctis.toml
+++ b/runtime/themes/noctis.toml
@@ -46,7 +46,7 @@
 'ui.linenr.selected' = { fg = "light-green", modifiers = [ "bold" ] } # Current line number.
 
 'ui.virtual' = { fg = "autocomp-green" } # Namespace for additions to the editing area.
-'ui.virtual.ruler' = { bg = "mid-green" } # Vertical rulers (colored columns in editing area).
+'ui.virtual.ruler' = { fg = "mid-green" } # Vertical rulers (colored columns in editing area).
 'ui.virtual.whitespace' = { fg = "mid-green"} # Whitespace markers in editing area.
 'ui.virtual.inlay-hint' = { fg = "autocomp-green" } # LSP inlay hints
 'ui.virtual.indent-guide' = { fg = "mid-green" } # Indentation guides.

--- a/runtime/themes/noctis_bordo.toml
+++ b/runtime/themes/noctis_bordo.toml
@@ -25,7 +25,7 @@
 
 "ui.background" = { bg = "base00" }
 "ui.virtual" = "base03"
-"ui.virtual.ruler" = { bg = "base01" }
+"ui.virtual.ruler" = { fg = "base01" }
 "ui.menu" = { fg = "base05", bg = "base01" }
 "ui.menu.selected" = { fg = "base0B", bg = "base01" }
 "ui.popup" = { bg = "base01" }

--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -130,7 +130,7 @@
 "ui.virtual.indent-guide" = "nord3"
 "ui.virtual.inlay-hint" = { fg = "nord3", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "nord11", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "nord1" }
+"ui.virtual.ruler" = { fg = "nord1" }
 "ui.virtual.whitespace" = "nord3"
 "ui.virtual.wrap" = "nord3"
 

--- a/runtime/themes/nord_light.toml
+++ b/runtime/themes/nord_light.toml
@@ -25,7 +25,7 @@
 
 # Virtual/invisible text
 "ui.virtual" = "nord8"
-"ui.virtual.ruler" = {bg="nord4"}
+"ui.virtual.ruler" = {fg="nord4"}
 "ui.virtual.inlay-hint" = { fg = "nord3", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "nord11", modifiers = ["bold"] }
 

--- a/runtime/themes/nvchad_solarized_dark.toml
+++ b/runtime/themes/nvchad_solarized_dark.toml
@@ -92,7 +92,7 @@
 "ui.virtual.inlay-hint" = { fg = "#586e75", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 "ui.virtual.indent-guide" = { fg = "base02" }
-"ui.virtual.ruler" = { bg = "base02" }
+"ui.virtual.ruler" = { fg = "base02" }
 
 "ui.linenr" = { fg = "base01", bg = "base03" }
 "ui.linenr.selected" = { fg = "base1", bg = "base03" }

--- a/runtime/themes/nvim-dark.toml
+++ b/runtime/themes/nvim-dark.toml
@@ -60,7 +60,7 @@ tabstop = { modifiers = ["italic"], bg = "panel"}
 "ui.text.inactive" = "stone"
 "ui.text.directory" = { fg = "sky" }
 "ui.virtual" = { fg = "slate" }
-"ui.virtual.ruler" = { bg = "panel" }
+"ui.virtual.ruler" = { fg = "panel" }
 "ui.virtual.jump-label" = { fg = "sun", modifiers = ["bold"] }
 
 "ui.virtual.indent-guide" = { fg = "slate" }

--- a/runtime/themes/nyxvamp-radiance.toml
+++ b/runtime/themes/nyxvamp-radiance.toml
@@ -24,7 +24,7 @@ rainbow = ["keyword_fg", "function_fg", "constant_fg", "string_fg"]
 "ui.popup.info"               = { fg = "menu_fg", bg = "menu_bg" }
 "ui.match_paren"              = { fg = "match_paren_fg", bg = "match_paren_bg", modifiers = ["bold"] }
 "ui.virtual"                  = { fg = "comment_fg" }
-"ui.virtual.ruler"            = { bg = "virtual_ruler_bg" }
+"ui.virtual.ruler"            = { fg = "virtual_ruler_bg" }
 "ui.highlight"                = { fg = "menu_sel_fg", bg = "menu_sel_bg" }
 "ui.picker.header"            = { fg = "menu_fg", bg = "menu_bg" }
 "ui.picker.header.column"     = { fg = "menu_fg", bg = "menu_bg" }

--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -57,7 +57,7 @@
 "ui.virtual" = { fg = "faint-gray" }
 "ui.virtual.indent-guide" = { fg = "faint-gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
-"ui.virtual.ruler" = { bg = "gray" }
+"ui.virtual.ruler" = { fg = "gray" }
 "ui.virtual.inlay-hint" = { fg = "light-gray" }
 "ui.virtual.jump-label" = { fg = "light-gray", modifiers = ["bold"] }
 

--- a/runtime/themes/onedarker.toml
+++ b/runtime/themes/onedarker.toml
@@ -59,7 +59,7 @@
 "ui.virtual" = { fg = "faint-gray" }
 "ui.virtual.indent-guide" = { fg = "faint-gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
-"ui.virtual.ruler" = { bg = "gray" }
+"ui.virtual.ruler" = { fg = "gray" }
 "ui.virtual.inlay-hint" = { fg = "light-gray" }
 "ui.virtual.jump-label" = { fg = "gold", modifiers = ["bold", "underlined"] }
 

--- a/runtime/themes/onelight.toml
+++ b/runtime/themes/onelight.toml
@@ -138,7 +138,7 @@
 "ui.text.directory" = { fg = "blue", underline = { style = "line" } }
 
 "ui.virtual" = { fg = "grey-500" }
-"ui.virtual.ruler" = { bg = "grey-200" }
+"ui.virtual.ruler" = { fg = "grey-200" }
 "ui.virtual.wrap" = { fg = "grey-500" }
 "ui.virtual.whitespace" = { fg = "grey-400" }
 "ui.virtual.indent-guide" = { fg = "grey-500" }

--- a/runtime/themes/peachpuff.toml
+++ b/runtime/themes/peachpuff.toml
@@ -21,7 +21,7 @@
 "ui.cursor.primary" = { fg = "light-gray", modifiers = ["reversed"] }
 "ui.virtual.whitespace" = "light-gray"
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
-"ui.virtual.ruler" = { bg = "black" }
+"ui.virtual.ruler" = { fg = "black" }
 "variable" = "white"
 "constant.numeric" = "red"
 "constant" = "white"

--- a/runtime/themes/penumbra+.toml
+++ b/runtime/themes/penumbra+.toml
@@ -83,7 +83,7 @@ error = "red"
 "ui.text.focus" = "blue"
 "ui.text.info" = "sky"
 
-"ui.virtual.ruler" = { bg = "shade-" }
+"ui.virtual.ruler" = { fg = "shade-" }
 "ui.virtual.whitespace" = "sky-"
 "ui.virtual.indent-guide" = "shade+"
 

--- a/runtime/themes/poimandres.toml
+++ b/runtime/themes/poimandres.toml
@@ -58,7 +58,7 @@ string = { fg = "brightMint" }
 "ui.text.inactive" = "darkerGray"
 "ui.virtual" = { fg = "darkerGray.b0" }
 "ui.virtual.indent-guide" = "#303442"
-"ui.virtual.ruler" = { bg ="selection" }
+"ui.virtual.ruler" = { fg ="selection" }
 
 "ui.selection" = { bg = "focus" }
 "ui.selection.primary" = { bg = "selection" }

--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -38,7 +38,7 @@ error = { fg = 'redE', modifiers = ['bold'] }
 'ui.help' = { fg = 'greyT', bg = 'brownD' }
 'ui.highlight' = { bg = 'brownH' }
 'ui.virtual' = { fg = 'brownV' }
-'ui.virtual.ruler' = { bg = 'brownR' }
+'ui.virtual.ruler' = { fg = 'brownR' }
 'ui.virtual.whitespace' = { fg = 'brownV' }
 'ui.virtual.indent-guide' = { fg = 'brownR' }
 'ui.virtual.inlay-hint' = {fg = 'brownD', bg = 'brownU'}

--- a/runtime/themes/rasmus.toml
+++ b/runtime/themes/rasmus.toml
@@ -84,7 +84,7 @@
 "ui.text.focus" = { fg = "white" }
 
 "ui.virtual" = { fg = "gray03" }
-"ui.virtual.ruler" = { bg = "gray03" }
+"ui.virtual.ruler" = { fg = "gray03" }
 "ui.virtual.indent-guide" = { fg = "gray04" }
 "ui.virtual.inlay-hint" = { fg = "gray05" }
 

--- a/runtime/themes/rose_pine.toml
+++ b/runtime/themes/rose_pine.toml
@@ -39,7 +39,7 @@
 "ui.text.directory" = { fg = "iris" }
 
 "ui.virtual.jump-label" = { fg = "love", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "overlay" }
+"ui.virtual.ruler" = { fg = "overlay" }
 "ui.virtual.whitespace" = { fg = "highlight_high" }
 "ui.virtual.indent-guide" = { fg = "muted" }
 "ui.virtual.inlay-hint" = { fg = "subtle" }

--- a/runtime/themes/seoul256-dark.toml
+++ b/runtime/themes/seoul256-dark.toml
@@ -59,7 +59,7 @@
 "ui.virtual" = { fg = "gray6" }
 "ui.virtual.indent-guide" = { fg = "gray6" }
 "ui.virtual.whitespace" = { fg = "gray6" }
-"ui.virtual.ruler" = { bg = "gray5" }
+"ui.virtual.ruler" = { fg = "gray5" }
 "ui.virtual.inlay-hint" = { fg = "gray9", modifiers = ["bold"] }
 "ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
 

--- a/runtime/themes/serika-dark.toml
+++ b/runtime/themes/serika-dark.toml
@@ -66,7 +66,7 @@
 "ui.selection.prime" = { underline.style = "line" }
 "ui.virtual.inlay-hint" = { fg = "grey2", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "nasty-red", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "bg1" } 
+"ui.virtual.ruler" = { fg = "bg1" } 
 "ui.virtual.whitespace" = { fg = "grey2", modifiers = [ "italic" ] }
 "ui.virtual.wrap" = { fg = "grey2", modifiers = [ "italic" ] }
 

--- a/runtime/themes/serika-light.toml
+++ b/runtime/themes/serika-light.toml
@@ -66,7 +66,7 @@
 "ui.selection.prime" = { underline.style = "line" }
 "ui.virtual.inlay-hint" = { fg = "grey2", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "nasty-red", modifiers = ["bold"] }
-"ui.virtual.ruler" = { bg = "bg0", modifiers = ["dim"] }
+"ui.virtual.ruler" = { fg = "bg0", modifiers = ["dim"] }
 "ui.virtual.whitespace" = { fg = "grey2", modifiers = [ "italic" ] }
 "ui.virtual.wrap" = { fg = "grey2", modifiers = [ "italic" ] }
 

--- a/runtime/themes/sidra.toml
+++ b/runtime/themes/sidra.toml
@@ -27,7 +27,7 @@
 "ui.text.inactive"            = {  fg = "fg_text_inactive"                                                                   }
 
 "ui.virtual"                  = {  fg = "fg_virtual"                                                                         }
-"ui.virtual.ruler"            = {                               bg = "bg_virtual_ruler"                                      }
+"ui.virtual.ruler"            = {  fg = "fg_virtual_ruler"                                                                   }
 "ui.virtual.indent-guide"     = {  fg = "fg_virtual_indent"                                                                  }
 
 "ui.debug"                    = {  fg = "fg_debug",                                      modifiers = ["bold"]                }
@@ -208,7 +208,7 @@ fg_text_inactive        = "#93a56f"        # Olive green (inactive text)
 # ===== VIRTUAL COLORS =====
 
 fg_virtual              = "#F1DCA7"        # Cream (virtual text)
-bg_virtual_ruler        = "#363638"        # Deep gray (ruler background)
+fg_virtual_ruler        = "#363638"        # Deep gray (ruler)
 fg_virtual_indent       = "#5B5B5A"        # Medium-dark gray (indent guides)
 
 # ===== DEBUGGING COLORS =====

--- a/runtime/themes/snazzy.toml
+++ b/runtime/themes/snazzy.toml
@@ -72,7 +72,7 @@
 "ui.text"                 = { fg = "foreground" }
 "ui.text.focus"           = { fg = "cyan" }
 "ui.virtual.indent-guide" = { fg = "opal" }
-"ui.virtual.ruler"        = { bg = "background_dark" }
+"ui.virtual.ruler"        = { fg = "background_dark" }
 "ui.virtual.inlay-hint" =   { bg = "background_dark", fg = "comment" }
 "ui.virtual.whitespace"   = { fg = "comment" }
 "ui.window"               = { fg = "foreground" }

--- a/runtime/themes/solarized_dark.toml
+++ b/runtime/themes/solarized_dark.toml
@@ -90,7 +90,7 @@
 "ui.selection.primary" = { bg = "base015" }
 
 "ui.virtual.indent-guide" = { fg = "base02" }
-"ui.virtual.ruler" = { bg = "base02" }
+"ui.virtual.ruler" = { fg = "base02" }
 
 # normal模式的光标
 "ui.cursor" = {fg = "base02", bg = "cyan"}

--- a/runtime/themes/solarized_light.toml
+++ b/runtime/themes/solarized_light.toml
@@ -104,7 +104,7 @@
 "ui.selection.primary" = { bg = "base015" }
 
 "ui.virtual.indent-guide" = { fg = "base02" }
-"ui.virtual.ruler" = { bg = "base02" }
+"ui.virtual.ruler" = { fg = "base02" }
 
 # normal模式的光标
 # normal mode cursor

--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -74,7 +74,7 @@
 "ui.menu" = { fg = "fg", bg = "bg2" }
 "ui.menu.selected" = { fg = "bg0", bg = "green" }
 "ui.virtual.whitespace" = "bg4" 
-"ui.virtual.ruler" = { bg = "bg3" }
+"ui.virtual.ruler" = { fg = "bg3" }
 "ui.virtual.inlay-hint" = { fg = "grey_dim" }
 
 info = { fg = 'green', bg = 'bg2' }

--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -73,7 +73,7 @@
 "ui.menu" = { fg = "fg1", bg = "bg2" }
 "ui.menu.selected" = { fg = "base", bg = "bg2", modifiers = ["bold"] }
 "ui.virtual" = "base-dim"
-"ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.ruler" = { fg = "bg1" }
 
 "diagnostic.warning" = { underline = { style = "curl", color = "meta" } }
 "diagnostic.error" = { underline = { style = "curl", color = "#e0211d" } }

--- a/runtime/themes/starlight.toml
+++ b/runtime/themes/starlight.toml
@@ -67,7 +67,7 @@
 "ui.text"                   = "light-fg"
 "ui.text.focus"             = { fg = "white", bg = "light-bg", modifiers = ["bold"] }
 "ui.virtual"                = "dark-fg"
-"ui.virtual.ruler"          = { bg = "medium-bg" }
+"ui.virtual.ruler"          = "medium-bg"
 "ui.virtual.indent-guide"   = "indent"
 "ui.virtual.whitespace"     = "indent"
 "ui.menu"                   = { fg = "light-fg", bg = "light-bg" }

--- a/runtime/themes/sunset.toml
+++ b/runtime/themes/sunset.toml
@@ -120,7 +120,7 @@ special = "wine"
 "ui.text.directory" = "sky"
 
 "ui.virtual" = { fg = "block" }
-"ui.virtual.ruler"        = { bg = "block" }
+"ui.virtual.ruler"        = { fg = "block" }
 "ui.virtual.jump-label"   = { fg = "attn", modifiers = ["bold"] }
 
 "ui.menu" = { fg = "text", bg = "base" }

--- a/runtime/themes/term16_light.toml
+++ b/runtime/themes/term16_light.toml
@@ -30,7 +30,7 @@ inherits = "term16_dark"
 "ui.statusline.select" = { fg = "white", bg = "magenta" }
 "ui.virtual" = { fg = "light-gray" }
 "ui.virtual.indent-guide" = { fg = "light-gray", modifiers = ["dim"] }
-"ui.virtual.ruler" = { bg = "white" }
+"ui.virtual.ruler" = { fg = "white" }
 "ui.virtual.wrap" = { fg = "light-gray" }
 "ui.window" = { fg = "gray", modifiers = ["dim"] }
 

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -91,7 +91,7 @@ hint = { fg = "hint" }
 "ui.text.inactive" = { fg = "comment", modifiers = ["italic"] }
 "ui.text.info" = { bg = "bg-menu", fg = "fg" }
 "ui.text.directory" = { fg = "cyan" }
-"ui.virtual.ruler" = { bg = "fg-gutter" }
+"ui.virtual.ruler" = { fg = "fg-gutter" }
 "ui.virtual.whitespace" = { fg = "fg-gutter" }
 "ui.virtual.inlay-hint" = {  bg = "bg-inlay", fg = "teal" }
 "ui.virtual.jump-label" = {  fg = "orange", modifiers = ["bold"] }

--- a/runtime/themes/varua.toml
+++ b/runtime/themes/varua.toml
@@ -67,7 +67,7 @@
 "ui.statusline.select" = { bg = "blue", fg = "bg2" }
 "ui.virtual.wrap" = { fg = "grey0" }
 "ui.virtual.inlay-hint" = { fg = "grey1" }
-"ui.virtual.ruler" = { bg = "bg2"}
+"ui.virtual.ruler" = { fg = "bg2"}
 
 "hint" = "blue"
 "info" = "aqua"

--- a/runtime/themes/vim_dark_high_contrast.toml
+++ b/runtime/themes/vim_dark_high_contrast.toml
@@ -18,7 +18,7 @@
 "ui.text.focus" = { fg = "yellow" }
 "ui.virtual.wrap" = { fg = "dark-blue" }
 "ui.virtual.indent-guide" = { fg = "dark-blue" }
-"ui.virtual.ruler" = { bg = "dark-white" }
+"ui.virtual.ruler" = { fg = "dark-white" }
 "ui.window" = { bg = "dark-white" }
 
 "diagnostic.error" = { bg = "dark-red" }

--- a/runtime/themes/vintage.toml
+++ b/runtime/themes/vintage.toml
@@ -58,7 +58,7 @@ label = "#abcc8a"
 "ui.text.inactive" = "#93a56f" 
 "ui.virtual" = { fg = "yellow" } 
 "ui.virtual.indent-guide" = { fg = "#5b5b5a" } 
-"ui.virtual.ruler" = { bg = "#363638" }
+"ui.virtual.ruler" = { fg = "#363638" }
 
 "ui.selection" = { fg = "white", bg = "gray" } 
 "ui.selection.primary" = { fg = "white", bg = "gray" } 

--- a/runtime/themes/voxed.toml
+++ b/runtime/themes/voxed.toml
@@ -60,7 +60,7 @@ label = "yellow"
 "ui.text.focus" = { fg = "maize", bg = "bgrey" }
 "ui.text.inactive" = "bgrey"
 "ui.virtual" = { fg = "blue" }
-"ui.virtual.ruler" = { bg = "bgrey-two" }
+"ui.virtual.ruler" = { fg = "bgrey-two" }
 "ui.virtual.indent-guide" = { fg = "gray" }
 
 

--- a/runtime/themes/yellowed.toml
+++ b/runtime/themes/yellowed.toml
@@ -84,7 +84,7 @@
 "ui.text.focus"                   = { bg = "gray" }
 "ui.text.inactive"                = { fg = "text" }
 "ui.text.info"                    = { fg = "text" }
-"ui.virtual.ruler"                = { bg = "light_gray" }
+"ui.virtual.ruler"                = { fg = "light_gray" }
 "ui.virtual.whitespace"           = { fg = "light_gray" }
 "ui.virtual.indent-guide"         = { fg = "light_gray" }
 "ui.virtual.inlay-hint"           = { fg = "light_gray" }

--- a/runtime/themes/yo.toml
+++ b/runtime/themes/yo.toml
@@ -51,7 +51,7 @@ diff = { fg = "p8" }
 
 # virtual
 "ui.virtual" = { fg = "p6" }
-"ui.virtual.ruler" = { bg = "p3" }
+"ui.virtual.ruler" = { fg = "p3" }
 "ui.virtual.inlay-hint" = { fg = "p7", underline.style = "dotted" }
 "ui.virtual.jump-label" = { fg = "p12", modifiers = [
   "bold",

--- a/runtime/themes/zed_onedark.toml
+++ b/runtime/themes/zed_onedark.toml
@@ -55,7 +55,7 @@
 "ui.virtual" = { fg = "faint-gray" }
 "ui.virtual.indent-guide" = { fg = "faint-gray" }
 "ui.virtual.whitespace" = { fg = "light-gray" }
-"ui.virtual.ruler" = { bg = "gray" }
+"ui.virtual.ruler" = { fg = "gray" }
 "ui.virtual.inlay-hint" = { fg = "blue-gray", modifiers = ["bold"] }
 "ui.virtual.jump-label" = { fg = "purple", modifiers = ["bold", "italic"] }
 

--- a/runtime/themes/zenburn.toml
+++ b/runtime/themes/zenburn.toml
@@ -33,7 +33,7 @@
 "keyword.storage-class" = { fg = "#c3bf9f", modifiers = ["bold"]}
 "label" = { fg = "#dfcfaf", modifiers = ["underlined"] }
 "ui.help" = { fg = "white", bg = "black" }
-"ui.virtual.ruler" = { bg = "#484848" }
+"ui.virtual.ruler" = { fg = "#484848" }
 "ui.virtual.whitespace" = { fg = "#5b605e", modifiers = ["bold"]}
 
 "punctuation.delimiter" = "#8f8f8f"

--- a/theme.toml
+++ b/theme.toml
@@ -58,7 +58,6 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "ui.text.inactive" = "sirocco"
 "ui.text.directory" = { fg = "lilac" }
 "ui.virtual" = { fg = "comet" }
-"ui.virtual.ruler" = { bg = "bossanova" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }
 
 "ui.virtual.indent-guide" = { fg = "comet" }


### PR DESCRIPTION
This is a continuation of https://github.com/helix-editor/helix/pull/11798 / https://github.com/helix-editor/helix/pull/9256. Before this patch rulers are drawn by theming the ruler's cell. With this patch `¦` characters (by default) are drawn on any cells without other text.

Before this patch the guidance for themes is to set `ui.virtual.ruler` as a background color so that a vertical bar of cells have a noticeable color. With this this change it's the opposite: you should set `ui.virtual.ruler` as a foreground color to theme the `¦`s. Recommending setting background colors prior to this patch is awkward because all other keys in `ui.virtual.*` typically theme the foreground. And it's easy to forget to theme it if you don't often use rulers.

This change updates all current themes to use foreground rulers. It's a naive change though. I expect that some themes will need follow-up changes to the colors.

<img width="676" height="161" alt="Screenshot 2025-09-14 at 19 29 38" src="https://github.com/user-attachments/assets/814c2248-9e02-4f41-9a38-0211a8166892" />
<img width="629" height="141" alt="Screenshot 2025-09-14 at 19 30 06" src="https://github.com/user-attachments/assets/17d2ccbe-8706-4fee-aafd-19c5a2e15b14" />
