### PR TITLE
fix(helix-view/clipboard): use serde generated name for Win32Yank

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -61,7 +61,7 @@
 | `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`
 | `jump-label-alphabet` | The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. | `"abcdefghijklmnopqrstuvwxyz"`
 | `end-of-line-diagnostics` | Minimum severity of diagnostics to render at the end of the line. Set to `disable` to disable entirely. Refer to the setting about `inline-diagnostics` for more details | `"hint"`
-| `clipboard-provider` | Which API to use for clipboard interaction. One of `pasteboard` (MacOS), `wayland`, `x-clip`, `x-sel`, `win-32-yank`, `termux`, `tmux`, `windows`, `termcode`, `none`, or a custom command set. | Platform and environment specific. |
+| `clipboard-provider` | Which API to use for clipboard interaction. One of `pasteboard` (MacOS), `wayland`, `x-clip`, `x-sel`, `win32-yank`, `termux`, `tmux`, `windows`, `termcode`, `none`, or a custom command set. | Platform and environment specific. |
 | `editor-config` | Whether to read settings from [EditorConfig](https://editorconfig.org) files | `true` |
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `auto` |

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -193,7 +193,7 @@ mod external {
                 Self::Wayland => builtin_name("wayland", &WL_CLIPBOARD),
                 Self::XClip => builtin_name("x-clip", &XCLIP),
                 Self::XSel => builtin_name("x-sel", &XSEL),
-                Self::Win32Yank => builtin_name("win-32-yank", &WIN32),
+                Self::Win32Yank => builtin_name("win32-yank", &WIN32),
                 Self::Tmux => builtin_name("tmux", &TMUX),
                 Self::Termux => builtin_name("termux", &TERMUX),
                 #[cfg(windows)]


### PR DESCRIPTION
Win32Yank clipboard provider is referred to as `win-32-yank` in docs and in `:show-clipboard-provider`. But the actual name as per `serde`'s translation is `win32-yank`. 

Currently if you set `clipboard-provider` to `win-32-yank` it results in a bad config error. So I feel like it would be better to keep it same in all places to avoid confusion. 
```
Bad config: unknown variant `win-32-yank`, expected one of `pasteboard`, `wayland`, `x-clip`, `x-sel`, `win32-yank`, `tmux`, `termux`, `termcode`, `custom`, `none`
in `clipboard-provider`
```