### PR TITLE
fix(sonokai): add primary cursor colors

### DIFF
--- a/runtime/themes/sonokai.toml
+++ b/runtime/themes/sonokai.toml
@@ -53,9 +53,13 @@
 
 "ui.background" = { bg = "bg0" }
 "ui.cursor" = { modifiers = ['reversed'] }
+"ui.cursor.primary" = { modifiers = ['reversed'] }
 "ui.cursor.match" = { bg = "bg4" }
+"ui.cursor.primary.match" = { bg = "bg4" }
 "ui.cursor.insert" = { fg = "black", bg = "grey" }
+"ui.cursor.primary.insert" = { fg = "black", bg = "grey" }
 "ui.cursor.select" = { fg = "bg0", bg = "blue" }
+"ui.cursor.primary.select" = { fg = "bg0", bg = "blue" }
 "ui.selection" = { bg = "bg5" }
 "ui.selection.primary" = { bg = "bg4" }
 "ui.linenr" = "grey"


### PR DESCRIPTION
Many themes, including my personal favorite sonokai, specify the `ui.cursor.*` settings but don't yet have `ui.cursor.primary.*` settings configured. This causes primary cursor colors not to change correctly when switching to visual mode (for example).

I've fixed it for sonokai at least in this PR. A similar issue has been previously discussed [here](https://github.com/helix-editor/helix/discussions/10428#discussioncomment-9106988).

This strikes me as a band-aid, however. I think the issue should be solved more fundamentally, though I'm unsure which approach the Helix project would prefer:

* Would it be useful to make a similar change for all the themes that specify a cursor color without specifying a primary? Like [this commit](https://github.com/pcrockett/helix/commit/535c3340469413e3593f74a5f77ef46fb92669ab)?
  * _I'd be happy to adjust this PR to make that change, though I wouldn't want to test every single theme myself._
* Or would it be a better approach to change theme logic to make the primary cursor color default to the general cursor color setting, so you don't have to duplicate the settings in all themes?
