### PR TITLE
Always compute inlay hints

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1271,10 +1271,6 @@ pub fn select_references_to_symbol_under_cursor(cx: &mut Context) {
 }
 
 pub fn compute_inlay_hints_for_all_views(editor: &mut Editor, jobs: &mut crate::job::Jobs) {
-    if !editor.config().lsp.display_inlay_hints {
-        return;
-    }
-
     for (view, _) in editor.tree.views() {
         let doc = match editor.documents.get(&view.doc) {
             Some(doc) => doc,
@@ -1340,8 +1336,8 @@ fn compute_inlay_hints_for_view(
     let callback = super::make_job_callback(
         language_server.text_document_range_inlay_hints(doc.identifier(), range, None)?,
         move |editor, _compositor, response: Option<Vec<lsp::InlayHint>>| {
-            // The config was modified or the window was closed while the request was in flight
-            if !editor.config().lsp.display_inlay_hints || editor.tree.try_get(view_id).is_none() {
+            // The window was closed while the request was in flight
+            if editor.tree.try_get(view_id).is_none() {
                 return;
             }
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -449,31 +449,35 @@ impl View {
             text_annotations.add_overlay(labels, style);
         }
 
-        if let Some(DocumentInlayHints {
-            id: _,
-            type_inlay_hints,
-            parameter_inlay_hints,
-            other_inlay_hints,
-            padding_before_inlay_hints,
-            padding_after_inlay_hints,
-        }) = doc.inlay_hints.get(&self.id)
-        {
-            let type_style = theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint.type"));
-            let parameter_style =
-                theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint.parameter"));
-            let other_style = theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint"));
-
-            // Overlapping annotations are ignored apart from the first so the order here is not random:
-            // types -> parameters -> others should hopefully be the "correct" order for most use cases,
-            // with the padding coming before and after as expected.
-            text_annotations
-                .add_inline_annotations(padding_before_inlay_hints, None)
-                .add_inline_annotations(type_inlay_hints, type_style)
-                .add_inline_annotations(parameter_inlay_hints, parameter_style)
-                .add_inline_annotations(other_inlay_hints, other_style)
-                .add_inline_annotations(padding_after_inlay_hints, None);
-        };
         let config = doc.config.load();
+
+        // Only render the inlay hints if the config has them enabled
+        if config.lsp.display_inlay_hints {
+            if let Some(DocumentInlayHints {
+                id: _,
+                type_inlay_hints,
+                parameter_inlay_hints,
+                other_inlay_hints,
+                padding_before_inlay_hints,
+                padding_after_inlay_hints,
+            }) = doc.inlay_hints.get(&self.id)
+            {
+                let type_style = theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint.type"));
+                let parameter_style =
+                    theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint.parameter"));
+                let other_style = theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint"));
+
+                // Overlapping annotations are ignored apart from the first so the order here is not random:
+                // types -> parameters -> others should hopefully be the "correct" order for most use cases,
+                // with the padding coming before and after as expected.
+                text_annotations
+                    .add_inline_annotations(padding_before_inlay_hints, None)
+                    .add_inline_annotations(type_inlay_hints, type_style)
+                    .add_inline_annotations(parameter_inlay_hints, parameter_style)
+                    .add_inline_annotations(other_inlay_hints, other_style)
+                    .add_inline_annotations(padding_after_inlay_hints, None);
+            };
+        }
 
         if config.lsp.display_color_swatches {
             if let Some(DocumentColorSwatches {


### PR DESCRIPTION
This PR always computes the inlay hints and only _displays_ them if the configuration option is enabled.

I outlined the motivation for this a while ago in this discussion: https://github.com/helix-editor/helix/discussions/13712 but the TL;DR is I often enable/disable type hints, and there is currently a lag as they get computed each time.

I am happy to put "always computing them" behind a config option itself if this is preferable.