### PR TITLE
Fix URL when clicking contributors on project root

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Some suggestions to get started:
 - If you don't use the Nix development shell and are getting your rust-analyzer binary from rustup, you may need to run `rustup component add rust-analyzer`.
   This is because `rust-toolchain.toml` selects our MSRV for the development toolchain but doesn't download the matching rust-analyzer automatically.
 
-We provide an [architecture.md][architecture.md] that should give you
+We provide an [architecture.md][https://github.com/helix-editor/helix/blob/master/docs/architecture.md] that should give you
 a good overview of the internals.
 
 # Auto generated documentation


### PR DESCRIPTION
If you  click on "Contributing" when looking at https://github.com/helix-editor/helix, the link to architecture.md does not work (as it is relative). It does work when you are in the docs folder viewing `CONTRIBUTING.md` but I imagine this is not the most common way to read the file -- so I propose making the link absolute.