### PR TITLE
Improve consistency of repeat_last_motion

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1559,7 +1559,13 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool) {
                 code: KeyCode::Enter,
                 ..
             } => {
-                find_char_line_ending(cx, count, direction, inclusive, cx.editor.should_extend());
+                find_char_line_ending(
+                    cx,
+                    count,
+                    direction,
+                    inclusive,
+                    cx.editor.mode == Mode::Select,
+                );
                 return;
             }
 
@@ -1581,7 +1587,7 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool) {
                     inclusive,
                     ch,
                     count,
-                    editor.should_extend(),
+                    editor.mode == Mode::Select,
                 ),
                 Direction::Backward => find_char_impl(
                     editor,
@@ -1589,7 +1595,7 @@ fn find_char(cx: &mut Context, direction: Direction, inclusive: bool) {
                     inclusive,
                     ch,
                     count,
-                    editor.should_extend(),
+                    editor.mode == Mode::Select,
                 ),
             };
         };
@@ -5527,7 +5533,7 @@ fn select_prev_sibling(cx: &mut Context) {
 
 fn move_node_bound_impl(cx: &mut Context, dir: Direction) {
     let motion = move |editor: &mut Editor| {
-        let extend = editor.should_extend();
+        let extend = editor.mode == Mode::Select;
         let (view, doc) = current!(editor);
 
         if let Some(syntax) = doc.syntax() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1308,10 +1308,6 @@ impl Editor {
             || self.config().popup_border == PopupBorderConfig::Menu
     }
 
-    pub fn should_extend(&self) -> bool {
-        self.mode == Mode::Select
-    }
-
     pub fn apply_motion<F: Fn(&mut Self) + 'static>(&mut self, motion: F) {
         motion(self);
         self.last_motion = Some(Box::new(motion));


### PR DESCRIPTION
Depending on the motion save to Editor.last_motion, the current Mode of the editor may or may not be observed. Updated all saved last_motions to obey to current state of the editor where appropriate.

Fixes #14476