### PR TITLE
update source for mail grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1854,7 +1854,7 @@ injection-regex = "mail|eml|email"
 
 [[grammar]]
 name = "mail"
-source = { git = "https://github.com/ficcdaf/tree-sitter-mail", rev = "8e60f38efbae1cc5f22833ae13c5500dd0f3b12f" }
+source = { git = "https://codeberg.org/ficd/tree-sitter-mail", rev = "8e60f38efbae1cc5f22833ae13c5500dd0f3b12f" }
 
 [[language]]
 name = "markdown"


### PR DESCRIPTION
For context I'm the author of the `tree-sitter-mail` grammar that's used in Helix. I also moved the primary repository to [Codeberg](https://codeberg.org/ficd/tree-sitter-mail), and the GitHub repository is just a mirror. However, I can't guarantee that I'll keep mirroring it forever, so it would be much better to change the source to the codeberg repo. 