### PR TITLE
Add Code actions on save

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -75,6 +75,7 @@ These configuration keys are available:
 | `workspace-lsp-roots`     | Directories (relative to the workspace root) that stop the upward root search early. Meant for project-specific hard overrides in a local `.helix/config.toml`; |
 | `persistent-diagnostic-sources` | An array of LSP diagnostic sources assumed unchanged when the language server resends the same set of diagnostics. Helix can track the position for these diagnostics internally instead. Useful for diagnostics that are recomputed on save.
 | `rainbow-brackets` | Overrides the `editor.rainbow-brackets` config key for the language |
+| `code-actions-on-save`    | List of LSP code actions to be run in order on save, for example `["source.organizeImports"]` |
 
 ## Project and LSP root selection
 

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -56,6 +56,9 @@ pub struct LanguageConfiguration {
     #[serde(default)]
     pub auto_format: bool,
 
+    #[serde(default)]
+    pub code_actions_on_save: Option<Vec<String>>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formatter: Option<FormatterConfiguration>,
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -321,7 +321,9 @@ impl Application {
                     self.handle_terminal_events(event).await;
                 }
                 Some(callback) = self.jobs.callbacks.recv() => {
-                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, Ok(Some(callback)));
+                    if let Some(job) = self.jobs.handle_callback(&mut self.editor, &mut self.compositor, Ok(Some(callback))) {
+                        self.jobs.add(job);
+                    }
                     self.render().await;
                 }
                 Some(msg) = self.jobs.status_messages.recv() => {
@@ -336,7 +338,9 @@ impl Application {
                     helix_event::request_redraw();
                 }
                 Some(callback) = self.jobs.wait_futures.next() => {
-                    self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
+                    if let Some(job) = self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback) {
+                        self.jobs.add(job);
+                    }
                     self.render().await;
                 }
                 event = self.editor.wait_event() => {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -2,8 +2,8 @@ use futures_util::{stream::FuturesUnordered, FutureExt};
 use helix_lsp::{
     block_on,
     lsp::{
-        self, CodeAction, CodeActionOrCommand, CodeActionTriggerKind, DiagnosticSeverity,
-        NumberOrString,
+        self, CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionTriggerKind,
+        DiagnosticSeverity, NumberOrString,
     },
     util::{diagnostic_to_lsp_diagnostic, lsp_range_to_range, range_to_lsp_range},
     Client, LanguageServerId, OffsetEncoding,
@@ -23,12 +23,12 @@ use helix_view::{
     editor::Action,
     handlers::lsp::SignatureHelpInvoked,
     theme::Style,
-    Document, View,
+    Document, DocumentId, View,
 };
 
 use crate::{
     compositor::{self, Compositor},
-    job::Callback,
+    job::{self, Callback, Job},
     ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
 };
 
@@ -659,34 +659,8 @@ pub fn code_action(cx: &mut Context) {
 
     let selection_range = doc.selection(view.id).primary();
 
-    let mut seen_language_servers = HashSet::new();
-
-    let mut futures: FuturesUnordered<_> = doc
-        .language_servers_with_feature(LanguageServerFeature::CodeAction)
-        .filter(|ls| seen_language_servers.insert(ls.id()))
-        // TODO this should probably already been filtered in something like "language_servers_with_feature"
-        .filter_map(|language_server| {
-            let offset_encoding = language_server.offset_encoding();
-            let language_server_id = language_server.id();
-            let range = range_to_lsp_range(doc.text(), selection_range, offset_encoding);
-            // Filter and convert overlapping diagnostics
-            let code_action_context = lsp::CodeActionContext {
-                diagnostics: doc
-                    .diagnostics()
-                    .iter()
-                    .filter(|&diag| {
-                        selection_range
-                            .overlaps(&helix_core::Range::new(diag.range.start, diag.range.end))
-                    })
-                    .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, offset_encoding))
-                    .collect(),
-                only: None,
-                trigger_kind: Some(CodeActionTriggerKind::INVOKED),
-            };
-            let code_action_request =
-                language_server.code_actions(doc.identifier(), range, code_action_context)?;
-            Some((code_action_request, language_server_id))
-        })
+    let mut futures: FuturesUnordered<_> = code_actions_for_range(doc, selection_range, None)
+        .into_iter()
         .map(|(request, ls_id)| async move {
             let Some(mut actions) = request.await? else {
                 return anyhow::Ok(Vec::new());
@@ -788,19 +762,12 @@ pub fn code_action(cx: &mut Context) {
                     }
                     lsp::CodeActionOrCommand::CodeAction(code_action) => {
                         log::debug!("code action: {:?}", code_action);
-                        // we support lsp "codeAction/resolve" for `edit` and `command` fields
-                        let mut resolved_code_action = None;
-                        if code_action.edit.is_none() || code_action.command.is_none() {
-                            if let Some(future) = language_server.resolve_code_action(code_action) {
-                                if let Ok(code_action) = helix_lsp::block_on(future) {
-                                    resolved_code_action = Some(code_action);
-                                }
-                            }
-                        }
                         let resolved_code_action =
-                            resolved_code_action.as_ref().unwrap_or(code_action);
+                            resolve_code_action_blocking(code_action, language_server);
 
-                        if let Some(ref workspace_edit) = resolved_code_action.edit {
+                        if let Some(ref workspace_edit) =
+                            resolved_code_action.as_ref().unwrap_or(code_action).edit
+                        {
                             let _ = editor.apply_workspace_edit(offset_encoding, workspace_edit);
                         }
 
@@ -823,6 +790,181 @@ pub fn code_action(cx: &mut Context) {
 
         Ok(Callback::EditorCompositor(Box::new(call)))
     });
+}
+
+// Extracting this to a type alias would require boxing this future
+#[allow(clippy::type_complexity)]
+fn code_actions_for_range(
+    doc: &Document,
+    range: helix_core::Range,
+    only: Option<Vec<CodeActionKind>>,
+) -> Vec<(
+    impl Future<Output = Result<Option<Vec<CodeActionOrCommand>>, helix_lsp::Error>>,
+    LanguageServerId,
+)> {
+    let mut seen_language_servers = HashSet::new();
+
+    doc.language_servers_with_feature(LanguageServerFeature::CodeAction)
+        .filter(|ls| seen_language_servers.insert(ls.id()))
+        // TODO this should probably already been filtered in something like "language_servers_with_feature"
+        .filter_map(|language_server| {
+            let offset_encoding = language_server.offset_encoding();
+            let language_server_id = language_server.id();
+            let lsp_range = range_to_lsp_range(doc.text(), range, offset_encoding);
+            // Filter and convert overlapping diagnostics
+            let code_action_context = lsp::CodeActionContext {
+                diagnostics: doc
+                    .diagnostics()
+                    .iter()
+                    .filter(|&diag| {
+                        range.overlaps(&helix_core::Range::new(diag.range.start, diag.range.end))
+                    })
+                    .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, offset_encoding))
+                    .collect(),
+                only: only.clone(),
+                trigger_kind: Some(CodeActionTriggerKind::INVOKED),
+            };
+            let code_action_request =
+                language_server.code_actions(doc.identifier(), lsp_range, code_action_context)?;
+            Some((code_action_request, language_server_id))
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn code_actions_on_save(
+    cx: &compositor::Context,
+    doc_id: DocumentId,
+    make_format_job: Option<Job>,
+) -> Option<Job> {
+    let doc = doc!(cx.editor, &doc_id);
+
+    let Some(code_actions_on_save_cfg) = doc
+        .language_config()
+        .and_then(|c| c.code_actions_on_save.clone())
+    else {
+        return make_format_job;
+    };
+
+    let mut queued_job = make_format_job;
+    for action_kind in code_actions_on_save_cfg
+        .into_iter()
+        // To run the actions in the configured order, build the chain of callbacks in reverse
+        .rev()
+        .map(CodeActionKind::from)
+    {
+        let call: job::Callback = Callback::Followup(Box::new(move |editor| {
+            let doc = doc!(editor, &doc_id);
+            let full_range = helix_core::Range::new(0, doc.text().len_chars());
+            if let Some((actions, ls_id)) =
+                code_actions_for_range(doc, full_range, Some(vec![action_kind]))
+                    .into_iter()
+                    .next()
+            {
+                let call = make_code_action_callback(actions, ls_id, queued_job.take());
+                Some(Job::with_callback(call).wait_before_exiting())
+            } else {
+                queued_job.take()
+            }
+        }));
+        queued_job = Some(Job::with_callback(async { Ok(call) }).wait_before_exiting());
+    }
+    queued_job
+}
+
+async fn make_code_action_callback(
+    actions: impl Future<Output = Result<Option<Vec<CodeActionOrCommand>>, helix_lsp::Error>>
+        + Send
+        + Sync,
+    language_server_id: LanguageServerId,
+    queued: Option<Job>,
+) -> anyhow::Result<job::Callback> {
+    let actions = actions.await?;
+
+    let call: job::Callback = Callback::Followup(Box::new(move |editor| {
+        let Some(actions) = actions else {
+            return queued;
+        };
+
+        let code_actions: Vec<_> = actions
+            .iter()
+            .filter(|action| {
+                matches!(
+                    action,
+                    CodeActionOrCommand::CodeAction(CodeAction { disabled: None, .. })
+                )
+            })
+            .filter_map(|action| match action {
+                CodeActionOrCommand::CodeAction(code_action) => Some(code_action),
+                CodeActionOrCommand::Command(_) => None,
+            })
+            .collect();
+
+        if let Some(code_action) = code_actions.first() {
+            let Some(resolve) = editor
+                .language_server_by_id(language_server_id)
+                .and_then(|language_server| resolve_code_action(code_action, language_server))
+            else {
+                return queued;
+            };
+            let callback = make_code_action_resolve_callback(resolve, language_server_id, queued);
+            Some(Job::with_callback(callback).wait_before_exiting())
+        } else {
+            queued
+        }
+    }));
+
+    Ok(call)
+}
+
+async fn make_code_action_resolve_callback(
+    resolve: impl Future<Output = Result<lsp::CodeAction, helix_lsp::Error>> + Send + Sync,
+    language_server_id: LanguageServerId,
+    queued: Option<Job>,
+) -> anyhow::Result<job::Callback> {
+    let code_action = resolve.await?;
+
+    let call: job::Callback = Callback::Followup(Box::new(move |editor| {
+        let Some(language_server) = editor.language_server_by_id(language_server_id) else {
+            return queued;
+        };
+        let offset_encoding = language_server.offset_encoding();
+
+        if let Some(ref workspace_edit) = code_action.edit {
+            if let Err(e) = editor.apply_workspace_edit(offset_encoding, workspace_edit) {
+                log::error!("failed to apply workspace edit: {:?}", e);
+            }
+        };
+
+        queued
+    }));
+
+    Ok(call)
+}
+
+fn resolve_code_action(
+    code_action: &CodeAction,
+    language_server: &Client,
+) -> Option<impl Future<Output = Result<lsp::CodeAction, helix_lsp::Error>>> {
+    if code_action.edit.is_none() || code_action.command.is_none() {
+        language_server.resolve_code_action(code_action)
+    } else {
+        None
+    }
+}
+
+pub fn resolve_code_action_blocking(
+    code_action: &CodeAction,
+    language_server: &Client,
+) -> Option<CodeAction> {
+    let mut resolved_code_action = None;
+    if code_action.edit.is_none() || code_action.command.is_none() {
+        if let Some(future) = language_server.resolve_code_action(code_action) {
+            if let Ok(code_action) = helix_lsp::block_on(future) {
+                resolved_code_action = Some(code_action);
+            }
+        }
+    }
+    resolved_code_action
 }
 
 #[derive(Debug)]

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -873,6 +873,7 @@ fn code_action_on_save_step(
     // Runs with `&mut Editor`, so it sees the document the previous link left.
     let build_request = move |editor: &mut Editor| -> Option<Job> {
         let doc = doc!(editor, &doc_id);
+        let version = doc.version();
         let full_range = helix_core::Range::new(0, doc.text().len_chars());
         let Some((request, ls_id)) =
             code_actions_for_range(doc, full_range, Some(vec![kind.clone()]))
@@ -886,7 +887,7 @@ fn code_action_on_save_step(
         let future = async move {
             let actions = request.await?;
             let apply = move |editor: &mut Editor| -> Option<Job> {
-                apply_code_actions_of_kind(editor, ls_id, &kind, actions);
+                apply_code_actions_of_kind(editor, doc_id, version, ls_id, &kind, actions);
                 code_action_on_save_step(doc_id, kinds, tail)
             };
             Ok(Callback::Followup(Box::new(apply)))
@@ -914,9 +915,12 @@ fn code_action_kind_matches(action: &CodeAction, requested: &CodeActionKind) -> 
 
 /// Apply every returned action whose kind matches `kind` (servers may ignore the
 /// `only` filter, and `source.fixAll` legitimately resolves to several actions),
-/// resolving any that need it.
+/// resolving any that need it. Skips entirely if the document changed between the
+/// request and now, so a stale edit can't be applied at positions that moved.
 fn apply_code_actions_of_kind(
     editor: &mut Editor,
+    doc_id: DocumentId,
+    version: i32,
     ls_id: LanguageServerId,
     kind: &CodeActionKind,
     actions: Option<Vec<CodeActionOrCommand>>,
@@ -924,6 +928,10 @@ fn apply_code_actions_of_kind(
     let Some(actions) = actions else {
         return;
     };
+    if doc!(editor, &doc_id).version() != version {
+        log::debug!("code-actions-on-save: document changed, skipping {kind:?}");
+        return;
+    }
     let Some(language_server) = editor.language_server_by_id(ls_id) else {
         return;
     };

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -28,11 +28,17 @@ use helix_view::{
 
 use crate::{
     compositor::{self, Compositor},
-    job::{self, Callback, Job},
+    job::{Callback, Job},
     ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
 };
 
-use std::{cmp::Ordering, collections::HashSet, fmt::Display, future::Future, path::Path};
+use std::{
+    cmp::Ordering,
+    collections::{HashSet, VecDeque},
+    fmt::Display,
+    future::Future,
+    path::Path,
+};
 
 /// Gets the first language server that is attached to a document which supports a specific feature.
 /// If there is no configured language server that supports the feature, this displays a status message.
@@ -831,124 +837,103 @@ fn code_actions_for_range(
         .collect::<Vec<_>>()
 }
 
+/// Build the job chain that runs a document's configured `code-actions-on-save`
+/// kinds, in order, each against the latest document state, before running
+/// `tail` (the auto-format / save job). Returns `tail` unchanged when nothing is
+/// configured.
 pub fn code_actions_on_save(
     cx: &compositor::Context,
     doc_id: DocumentId,
-    make_format_job: Option<Job>,
+    tail: Option<Job>,
 ) -> Option<Job> {
-    let doc = doc!(cx.editor, &doc_id);
-
-    let Some(code_actions_on_save_cfg) = doc
+    let kinds = doc!(cx.editor, &doc_id)
         .language_config()
-        .and_then(|c| c.code_actions_on_save.clone())
-    else {
-        return make_format_job;
+        .and_then(|config| config.code_actions_on_save.clone());
+    let Some(kinds) = kinds else {
+        return tail;
+    };
+    let kinds: VecDeque<CodeActionKind> = kinds.into_iter().map(CodeActionKind::from).collect();
+    code_action_on_save_step(doc_id, kinds, tail)
+}
+
+/// One link of the on-save chain: request the next kind's actions on the current
+/// document, apply them, then recurse for the rest. Each link is built lazily (as
+/// a `Followup`) so it reads the document after the previous link's edits, and
+/// runs the configured kinds strictly in order.
+fn code_action_on_save_step(
+    doc_id: DocumentId,
+    mut kinds: VecDeque<CodeActionKind>,
+    tail: Option<Job>,
+) -> Option<Job> {
+    let Some(kind) = kinds.pop_front() else {
+        // All kinds applied. Fall through to auto-format / save.
+        return tail;
     };
 
-    let mut queued_job = make_format_job;
-    for action_kind in code_actions_on_save_cfg
-        .into_iter()
-        // To run the actions in the configured order, build the chain of callbacks in reverse
-        .rev()
-        .map(CodeActionKind::from)
-    {
-        let call: job::Callback = Callback::Followup(Box::new(move |editor| {
-            let doc = doc!(editor, &doc_id);
-            let full_range = helix_core::Range::new(0, doc.text().len_chars());
-            if let Some((actions, ls_id)) =
-                code_actions_for_range(doc, full_range, Some(vec![action_kind]))
-                    .into_iter()
-                    .next()
-            {
-                let call = make_code_action_callback(actions, ls_id, queued_job.take());
-                Some(Job::with_callback(call).wait_before_exiting())
-            } else {
-                queued_job.take()
-            }
-        }));
-        queued_job = Some(Job::with_callback(async { Ok(call) }).wait_before_exiting());
-    }
-    queued_job
-}
-
-async fn make_code_action_callback(
-    actions: impl Future<Output = Result<Option<Vec<CodeActionOrCommand>>, helix_lsp::Error>>
-        + Send
-        + Sync,
-    language_server_id: LanguageServerId,
-    queued: Option<Job>,
-) -> anyhow::Result<job::Callback> {
-    let actions = actions.await?;
-
-    let call: job::Callback = Callback::Followup(Box::new(move |editor| {
-        let Some(actions) = actions else {
-            return queued;
+    // Runs with `&mut Editor`, so it sees the document the previous link left.
+    let build_request = move |editor: &mut Editor| -> Option<Job> {
+        let doc = doc!(editor, &doc_id);
+        let full_range = helix_core::Range::new(0, doc.text().len_chars());
+        let Some((request, ls_id)) =
+            code_actions_for_range(doc, full_range, Some(vec![kind.clone()]))
+                .into_iter()
+                .next()
+        else {
+            // No server offers this kind for the document: skip to the next.
+            return code_action_on_save_step(doc_id, kinds, tail);
         };
 
-        let code_actions: Vec<_> = actions
-            .iter()
-            .filter(|action| {
-                matches!(
-                    action,
-                    CodeActionOrCommand::CodeAction(CodeAction { disabled: None, .. })
-                )
-            })
-            .filter_map(|action| match action {
-                CodeActionOrCommand::CodeAction(code_action) => Some(code_action),
-                CodeActionOrCommand::Command(_) => None,
-            })
-            .collect();
-
-        if let Some(code_action) = code_actions.first() {
-            let Some(resolve) = editor
-                .language_server_by_id(language_server_id)
-                .and_then(|language_server| resolve_code_action(code_action, language_server))
-            else {
-                return queued;
+        let future = async move {
+            let actions = request.await?;
+            let apply = move |editor: &mut Editor| -> Option<Job> {
+                apply_code_actions_of_kind(editor, ls_id, actions);
+                code_action_on_save_step(doc_id, kinds, tail)
             };
-            let callback = make_code_action_resolve_callback(resolve, language_server_id, queued);
-            Some(Job::with_callback(callback).wait_before_exiting())
-        } else {
-            queued
-        }
-    }));
+            Ok(Callback::Followup(Box::new(apply)))
+        };
+        Some(Job::with_callback(future).wait_before_exiting())
+    };
 
-    Ok(call)
+    Some(
+        Job::with_callback(async move { Ok(Callback::Followup(Box::new(build_request))) })
+            .wait_before_exiting(),
+    )
 }
 
-async fn make_code_action_resolve_callback(
-    resolve: impl Future<Output = Result<lsp::CodeAction, helix_lsp::Error>> + Send + Sync,
-    language_server_id: LanguageServerId,
-    queued: Option<Job>,
-) -> anyhow::Result<job::Callback> {
-    let code_action = resolve.await?;
+/// Apply the first returned, non-disabled code action, resolving it if needed.
+fn apply_code_actions_of_kind(
+    editor: &mut Editor,
+    ls_id: LanguageServerId,
+    actions: Option<Vec<CodeActionOrCommand>>,
+) {
+    let Some(actions) = actions else {
+        return;
+    };
+    let Some(language_server) = editor.language_server_by_id(ls_id) else {
+        return;
+    };
+    let offset_encoding = language_server.offset_encoding();
 
-    let call: job::Callback = Callback::Followup(Box::new(move |editor| {
-        let Some(language_server) = editor.language_server_by_id(language_server_id) else {
-            return queued;
-        };
-        let offset_encoding = language_server.offset_encoding();
-
-        if let Some(ref workspace_edit) = code_action.edit {
-            if let Err(e) = editor.apply_workspace_edit(offset_encoding, workspace_edit) {
-                log::error!("failed to apply workspace edit: {:?}", e);
+    let edit = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionOrCommand::CodeAction(code_action) if code_action.disabled.is_none() => {
+                Some(code_action)
             }
-        };
+            _ => None,
+        })
+        .next()
+        .and_then(
+            |code_action| match resolve_code_action_blocking(code_action, language_server) {
+                Some(resolved) => resolved.edit,
+                None => code_action.edit.clone(),
+            },
+        );
 
-        queued
-    }));
-
-    Ok(call)
-}
-
-fn resolve_code_action(
-    code_action: &CodeAction,
-    language_server: &Client,
-) -> Option<impl Future<Output = Result<lsp::CodeAction, helix_lsp::Error>>> {
-    if code_action.edit.is_none() || code_action.command.is_none() {
-        language_server.resolve_code_action(code_action)
-    } else {
-        None
+    if let Some(edit) = edit {
+        if let Err(err) = editor.apply_workspace_edit(offset_encoding, &edit) {
+            log::error!("code-actions-on-save: failed to apply workspace edit: {err:?}");
+        }
     }
 }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -886,7 +886,7 @@ fn code_action_on_save_step(
         let future = async move {
             let actions = request.await?;
             let apply = move |editor: &mut Editor| -> Option<Job> {
-                apply_code_actions_of_kind(editor, ls_id, actions);
+                apply_code_actions_of_kind(editor, ls_id, &kind, actions);
                 code_action_on_save_step(doc_id, kinds, tail)
             };
             Ok(Callback::Followup(Box::new(apply)))
@@ -900,10 +900,25 @@ fn code_action_on_save_step(
     )
 }
 
-/// Apply the first returned, non-disabled code action, resolving it if needed.
+/// An action matches a requested kind when its kind equals the request or is a
+/// sub-kind (`source.fixAll.eslint` matches `source.fixAll`, per the LSP kind
+/// hierarchy). Actions without a kind are skipped, so a server that ignores the
+/// `only` filter can't slip an unrelated action into a save.
+fn code_action_kind_matches(action: &CodeAction, requested: &CodeActionKind) -> bool {
+    action.kind.as_ref().is_some_and(|kind| {
+        let (kind, requested) = (kind.as_str(), requested.as_str());
+        kind == requested
+            || (kind.starts_with(requested) && kind[requested.len()..].starts_with('.'))
+    })
+}
+
+/// Apply every returned action whose kind matches `kind` (servers may ignore the
+/// `only` filter, and `source.fixAll` legitimately resolves to several actions),
+/// resolving any that need it.
 fn apply_code_actions_of_kind(
     editor: &mut Editor,
     ls_id: LanguageServerId,
+    kind: &CodeActionKind,
     actions: Option<Vec<CodeActionOrCommand>>,
 ) {
     let Some(actions) = actions else {
@@ -914,7 +929,9 @@ fn apply_code_actions_of_kind(
     };
     let offset_encoding = language_server.offset_encoding();
 
-    let edit = actions
+    // Collect the (resolved) edits while holding the immutable language-server
+    // borrow, then apply them once the borrow is dropped.
+    let edits: Vec<lsp::WorkspaceEdit> = actions
         .iter()
         .filter_map(|action| match action {
             CodeActionOrCommand::CodeAction(code_action) if code_action.disabled.is_none() => {
@@ -922,15 +939,16 @@ fn apply_code_actions_of_kind(
             }
             _ => None,
         })
-        .next()
-        .and_then(
-            |code_action| match resolve_code_action_blocking(code_action, language_server) {
+        .filter(|code_action| code_action_kind_matches(code_action, kind))
+        .filter_map(|code_action| {
+            match resolve_code_action_blocking(code_action, language_server) {
                 Some(resolved) => resolved.edit,
                 None => code_action.edit.clone(),
-            },
-        );
+            }
+        })
+        .collect();
 
-    if let Some(edit) = edit {
+    for edit in edits {
         if let Err(err) = editor.apply_workspace_edit(offset_encoding, &edit) {
             log::error!("code-actions-on-save: failed to apply workspace edit: {err:?}");
         }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -381,40 +381,51 @@ fn write_impl(
     options: WriteOptions,
 ) -> anyhow::Result<()> {
     let config = cx.editor.config();
-    let jobs = &mut cx.jobs;
     let (view, doc) = current!(cx.editor);
+    let doc_id = doc.id();
+    let view_id = view.id;
 
     if doc.trim_trailing_whitespace() {
-        trim_trailing_whitespace(doc, view.id);
+        trim_trailing_whitespace(doc, view_id);
     }
     if config.trim_final_newlines {
-        trim_final_newlines(doc, view.id);
+        trim_final_newlines(doc, view_id);
     }
     if doc.insert_final_newline() {
-        insert_final_newline(doc, view.id);
+        insert_final_newline(doc, view_id);
     }
 
     // Save an undo checkpoint for any outstanding changes.
     doc.append_changes_to_history(view);
 
-    let (view, doc) = current_ref!(cx.editor);
     let fmt = if config.auto_format && options.auto_format {
-        doc.auto_format(cx.editor).map(|fmt| {
-            let callback = make_format_callback(
-                doc.id(),
-                doc.version(),
-                view.id,
-                fmt,
-                Some((path.map(Into::into), options.force)),
-            );
+        let path = path.map(Into::into);
+        let write = Some((path.clone(), options.force));
+        let callback = Callback::Followup(Box::new(move |editor| {
+            let (view, doc) = current_ref!(editor);
+            let job = doc.auto_format(editor).map(|fmt| {
+                let call = make_format_callback(doc.id(), doc.version(), view.id, fmt, write);
+                Job::with_callback(call).wait_before_exiting()
+            });
+            if job.is_none() {
+                if let Err(err) = editor.save(doc.id(), path, options.force) {
+                    editor.set_error(format!("Error saving: {}", err));
+                }
+            };
+            job
+        }));
 
-            jobs.add(Job::with_callback(callback).wait_before_exiting());
-        })
+        Some(Job::with_callback(async { Ok(callback) }).wait_before_exiting())
     } else {
         None
     };
 
-    if fmt.is_none() {
+    let job = code_actions_on_save(cx, doc_id, fmt);
+
+    if let Some(job) = job {
+        cx.jobs.add(job);
+    } else {
+        let (_, doc) = current!(cx.editor);
         let id = doc.id();
         cx.editor.save(id, path, options.force)?;
     }
@@ -815,7 +826,6 @@ pub fn write_all_impl(
 ) -> anyhow::Result<()> {
     let mut errors: Vec<&'static str> = Vec::new();
     let config = cx.editor.config();
-    let jobs = &mut cx.jobs;
     let saves: Vec<_> = cx
         .editor
         .documents
@@ -858,23 +868,34 @@ pub fn write_all_impl(
         // Save an undo checkpoint for any outstanding changes.
         doc.append_changes_to_history(view);
 
-        let fmt = if options.auto_format && config.auto_format {
-            let doc = doc!(cx.editor, &doc_id);
-            doc.auto_format(cx.editor).map(|fmt| {
-                let callback = make_format_callback(
-                    doc_id,
-                    doc.version(),
-                    target_view,
-                    fmt,
-                    Some((None, options.force)),
-                );
-                jobs.add(Job::with_callback(callback).wait_before_exiting());
-            })
+        let fmt = if config.auto_format && options.auto_format {
+            let path = doc.path().map(Into::into);
+            let write = Some((path.clone(), options.force));
+            let callback: job::Callback = Callback::Followup(Box::new(move |editor| {
+                let doc = doc!(editor, &doc_id);
+                let view = view!(editor, target_view);
+                let job = doc.auto_format(editor).map(|fmt| {
+                    let call = make_format_callback(doc.id(), doc.version(), view.id, fmt, write);
+                    Job::with_callback(call).wait_before_exiting()
+                });
+                if job.is_none() {
+                    if let Err(err) = editor.save::<PathBuf>(doc.id(), path, options.force) {
+                        editor.set_error(format!("Error saving: {}", err));
+                    }
+                };
+                job
+            }));
+
+            Some(Job::with_callback(async { Ok(callback) }).wait_before_exiting())
         } else {
             None
         };
 
-        if fmt.is_none() {
+        let job = code_actions_on_save(cx, doc_id, fmt);
+
+        if let Some(job) = job {
+            cx.jobs.add(job);
+        } else {
             cx.editor.save::<PathBuf>(doc_id, None, options.force)?;
         }
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -80,6 +80,7 @@ fn exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
             WriteOptions {
                 force: false,
                 auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+                code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
             },
         )?;
     }
@@ -99,6 +100,7 @@ fn force_exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
             WriteOptions {
                 force: true,
                 auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+                code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
             },
         )?;
     }
@@ -420,7 +422,11 @@ fn write_impl(
         None
     };
 
-    let job = code_actions_on_save(cx, doc_id, fmt);
+    let job = if options.code_actions {
+        code_actions_on_save(cx, doc_id, fmt)
+    } else {
+        fmt
+    };
 
     if let Some(job) = job {
         cx.jobs.add(job);
@@ -496,6 +502,7 @@ fn insert_final_newline(doc: &mut Document, view_id: ViewId) {
 pub struct WriteOptions {
     pub force: bool,
     pub auto_format: bool,
+    pub code_actions: bool,
 }
 
 fn write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
@@ -509,6 +516,7 @@ fn write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
         WriteOptions {
             force: false,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )
 }
@@ -524,6 +532,7 @@ fn force_write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         WriteOptions {
             force: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )
 }
@@ -543,6 +552,7 @@ fn write_buffer_close(
         WriteOptions {
             force: false,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )?;
 
@@ -565,6 +575,7 @@ fn force_write_buffer_close(
         WriteOptions {
             force: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )?;
 
@@ -753,6 +764,7 @@ fn write_quit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
         WriteOptions {
             force: false,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )?;
     cx.block_try_flush_writes()?;
@@ -774,6 +786,7 @@ fn force_write_quit(
         WriteOptions {
             force: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )?;
     cx.block_try_flush_writes()?;
@@ -818,6 +831,7 @@ pub struct WriteAllOptions {
     pub force: bool,
     pub write_scratch: bool,
     pub auto_format: bool,
+    pub code_actions: bool,
 }
 
 pub fn write_all_impl(
@@ -891,7 +905,11 @@ pub fn write_all_impl(
             None
         };
 
-        let job = code_actions_on_save(cx, doc_id, fmt);
+        let job = if options.code_actions {
+            code_actions_on_save(cx, doc_id, fmt)
+        } else {
+            fmt
+        };
 
         if let Some(job) = job {
             cx.jobs.add(job);
@@ -918,6 +936,7 @@ fn write_all(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> an
             force: false,
             write_scratch: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )
 }
@@ -937,6 +956,7 @@ fn force_write_all(
             force: true,
             write_scratch: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )
 }
@@ -955,6 +975,7 @@ fn write_all_quit(
             force: false,
             write_scratch: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     )?;
     quit_all_impl(cx, false)
@@ -974,6 +995,7 @@ fn force_write_all_quit(
             force: true,
             write_scratch: true,
             auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+            code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
         },
     );
     quit_all_impl(cx, true)
@@ -1617,6 +1639,7 @@ fn update(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
             WriteOptions {
                 force: false,
                 auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+                code_actions: !args.has_flag(WRITE_NO_CODE_ACTIONS_FLAG.name),
             },
         )
     } else {
@@ -2922,6 +2945,12 @@ const WRITE_NO_FORMAT_FLAG: Flag = Flag {
     ..Flag::DEFAULT
 };
 
+const WRITE_NO_CODE_ACTIONS_FLAG: Flag = Flag {
+    name: "no-code-actions",
+    doc: "skip code actions on save",
+    ..Flag::DEFAULT
+};
+
 pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "exit",
@@ -2931,7 +2960,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -2943,7 +2972,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3070,7 +3099,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3082,7 +3111,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG,WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3094,7 +3123,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG,WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3106,7 +3135,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG,WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3187,7 +3216,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3199,7 +3228,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3211,7 +3240,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3223,7 +3252,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3235,7 +3264,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },
@@ -3247,7 +3276,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),
-            flags: &[WRITE_NO_FORMAT_FLAG],
+            flags: &[WRITE_NO_FORMAT_FLAG, WRITE_NO_CODE_ACTIONS_FLAG],
             ..Signature::DEFAULT
         },
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -400,40 +400,59 @@ fn write_impl(
     // Save an undo checkpoint for any outstanding changes.
     doc.append_changes_to_history(view);
 
-    let fmt = if config.auto_format && options.auto_format {
-        let path = path.map(Into::into);
-        let write = Some((path.clone(), options.force));
+    let auto_format = config.auto_format && options.auto_format;
+    let force = options.force;
+    let path: Option<PathBuf> = path.map(Into::into);
+
+    // Does the document configure any code actions to run on save?
+    let run_code_actions = options.code_actions
+        && doc!(cx.editor, &doc_id)
+            .language_config()
+            .and_then(|c| c.code_actions_on_save.as_deref())
+            .is_some_and(|kinds| !kinds.is_empty());
+
+    // The tail of the on-save chain: re-build the auto-format job against the
+    // latest document (so it formats after any code-action edits), or save
+    // directly when there's no formatter. Deferred via `Followup`, and always
+    // saves, so code-actions-on-save works even with auto-format off. Only
+    // built when there is pre-save work. A plain `:w` saves synchronously below.
+    let tail = (auto_format || run_code_actions).then(|| {
+        let path = path.clone();
         let callback = Callback::Followup(Box::new(move |editor| {
-            let (view, doc) = current_ref!(editor);
-            let job = doc.auto_format(editor).map(|fmt| {
-                let call = make_format_callback(doc.id(), doc.version(), view.id, fmt, write);
-                Job::with_callback(call).wait_before_exiting()
-            });
-            if job.is_none() {
-                if let Err(err) = editor.save(doc.id(), path, options.force) {
+            let doc = doc!(editor, &doc_id);
+            let fmt_job = auto_format
+                .then(|| doc.auto_format(editor))
+                .flatten()
+                .map(|fmt| {
+                    let call = make_format_callback(
+                        doc_id,
+                        doc.version(),
+                        view_id,
+                        fmt,
+                        Some((path.clone(), force)),
+                    );
+                    Job::with_callback(call).wait_before_exiting()
+                });
+            if fmt_job.is_none() {
+                if let Err(err) = editor.save(doc_id, path, force) {
                     editor.set_error(format!("Error saving: {}", err));
                 }
-            };
-            job
+            }
+            fmt_job
         }));
+        Job::with_callback(async { Ok(callback) }).wait_before_exiting()
+    });
 
-        Some(Job::with_callback(async { Ok(callback) }).wait_before_exiting())
+    let job = if run_code_actions {
+        code_actions_on_save(cx, doc_id, tail)
     } else {
-        None
-    };
-
-    let job = if options.code_actions {
-        code_actions_on_save(cx, doc_id, fmt)
-    } else {
-        fmt
+        tail
     };
 
     if let Some(job) = job {
         cx.jobs.add(job);
     } else {
-        let (_, doc) = current!(cx.editor);
-        let id = doc.id();
-        cx.editor.save(id, path, options.force)?;
+        cx.editor.save(doc_id, path, force)?;
     }
 
     Ok(())
@@ -882,39 +901,53 @@ pub fn write_all_impl(
         // Save an undo checkpoint for any outstanding changes.
         doc.append_changes_to_history(view);
 
-        let fmt = if config.auto_format && options.auto_format {
-            let path = doc.path().map(Into::into);
-            let write = Some((path.clone(), options.force));
+        let auto_format = config.auto_format && options.auto_format;
+        let force = options.force;
+
+        let run_code_actions = options.code_actions
+            && doc!(cx.editor, &doc_id)
+                .language_config()
+                .and_then(|c| c.code_actions_on_save.as_deref())
+                .is_some_and(|kinds| !kinds.is_empty());
+
+        // See `write_impl`: deferred format-or-save tail that always saves, only
+        // built when there is pre-save work; otherwise a synchronous save below.
+        let tail = (auto_format || run_code_actions).then(|| {
             let callback: job::Callback = Callback::Followup(Box::new(move |editor| {
                 let doc = doc!(editor, &doc_id);
-                let view = view!(editor, target_view);
-                let job = doc.auto_format(editor).map(|fmt| {
-                    let call = make_format_callback(doc.id(), doc.version(), view.id, fmt, write);
-                    Job::with_callback(call).wait_before_exiting()
-                });
-                if job.is_none() {
-                    if let Err(err) = editor.save::<PathBuf>(doc.id(), path, options.force) {
+                let fmt_job = auto_format
+                    .then(|| doc.auto_format(editor))
+                    .flatten()
+                    .map(|fmt| {
+                        let call = make_format_callback(
+                            doc_id,
+                            doc.version(),
+                            target_view,
+                            fmt,
+                            Some((None, force)),
+                        );
+                        Job::with_callback(call).wait_before_exiting()
+                    });
+                if fmt_job.is_none() {
+                    if let Err(err) = editor.save::<PathBuf>(doc_id, None, force) {
                         editor.set_error(format!("Error saving: {}", err));
                     }
-                };
-                job
+                }
+                fmt_job
             }));
+            Job::with_callback(async { Ok(callback) }).wait_before_exiting()
+        });
 
-            Some(Job::with_callback(async { Ok(callback) }).wait_before_exiting())
+        let job = if run_code_actions {
+            code_actions_on_save(cx, doc_id, tail)
         } else {
-            None
-        };
-
-        let job = if options.code_actions {
-            code_actions_on_save(cx, doc_id, fmt)
-        } else {
-            fmt
+            tail
         };
 
         if let Some(job) = job {
             cx.jobs.add(job);
         } else {
-            cx.editor.save::<PathBuf>(doc_id, None, options.force)?;
+            cx.editor.save::<PathBuf>(doc_id, None, force)?;
         }
     }
 

--- a/helix-term/src/handlers/auto_save.rs
+++ b/helix-term/src/handlers/auto_save.rs
@@ -91,6 +91,7 @@ fn request_auto_save(editor: &mut Editor) {
         force: false,
         write_scratch: false,
         auto_format: false,
+        code_actions: false,
     };
 
     if let Err(e) = commands::typed::write_all_impl(context, options) {

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -11,6 +11,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 pub type EditorCompositorCallback = Box<dyn FnOnce(&mut Editor, &mut Compositor) + Send>;
 pub type EditorCallback = Box<dyn FnOnce(&mut Editor) + Send>;
+pub type EditorCallbackFollowup = Box<dyn FnOnce(&mut Editor) -> Option<Job> + Send>;
 
 runtime_local! {
     static JOB_QUEUE: OnceCell<Sender<Callback>> = OnceCell::new();
@@ -35,6 +36,7 @@ pub fn dispatch_blocking(job: impl FnOnce(&mut Editor, &mut Compositor) + Send +
 pub enum Callback {
     EditorCompositor(EditorCompositorCallback),
     Editor(EditorCallback),
+    Followup(EditorCallbackFollowup),
 }
 
 pub type JobFuture = BoxFuture<'static, anyhow::Result<Option<Callback>>>;
@@ -104,15 +106,23 @@ impl Jobs {
         editor: &mut Editor,
         compositor: &mut Compositor,
         call: anyhow::Result<Option<Callback>>,
-    ) {
+    ) -> Option<Job> {
         match call {
-            Ok(None) => {}
+            Ok(None) => None,
             Ok(Some(call)) => match call {
-                Callback::EditorCompositor(call) => call(editor, compositor),
-                Callback::Editor(call) => call(editor),
+                Callback::EditorCompositor(call) => {
+                    call(editor, compositor);
+                    None
+                }
+                Callback::Editor(call) => {
+                    call(editor);
+                    None
+                }
+                Callback::Followup(call) => call(editor),
             },
             Err(e) => {
                 editor.set_error(format!("Async job failed: {}", e));
+                None
             }
         }
     }
@@ -148,14 +158,23 @@ impl Jobs {
                     if let Some(callback) = callback {
                         // clippy doesn't realize this is an error without the derefs
                         #[allow(clippy::needless_option_as_deref)]
-                        match callback {
+                        if let Some(job) = match callback {
                             Callback::EditorCompositor(call) if compositor.is_some() => {
-                                call(editor, compositor.as_deref_mut().unwrap())
+                                call(editor, compositor.as_deref_mut().unwrap());
+                                None
                             }
-                            Callback::Editor(call) => call(editor),
+                            Callback::Editor(call) => {
+                                call(editor);
+                                None
+                            }
+                            Callback::Followup(call) => call(editor),
 
                             // skip callbacks for which we don't have the necessary references
-                            _ => (),
+                            _ => None,
+                        } {
+                            if job.wait {
+                                wait_futures.push(job.future);
+                            }
                         }
                     }
                 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1589,6 +1589,7 @@ impl Component for EditorView {
                         force: false,
                         write_scratch: false,
                         auto_format: false,
+                        code_actions: false,
                     };
                     if let Err(e) = commands::typed::write_all_impl(context, options) {
                         context.editor.set_error(format!("{}", e));

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -476,6 +476,32 @@ async fn test_write_quit_auto_format_exits_after_format() -> anyhow::Result<()> 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_write_code_actions_on_save_without_server_still_saves() -> anyhow::Result<()> {
+    let mut file = tempfile::Builder::new().suffix(".rs").tempfile()?;
+
+    // Code actions are configured but no language server is attached in tests, so none run. With
+    // auto-format also off the on-save chain has no formatter tail either. The save should still
+    // occur.
+    let lang_conf = indoc! {r#"
+            [[language]]
+            name = "rust"
+            code-actions-on-save = ["source.organizeImports"]
+        "#};
+
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file.path(), None)
+        .with_input_text("#[l|]#et foo = 0;\n")
+        .with_lang_loader(helpers::test_syntax_loader(Some(lang_conf.into())))
+        .build()?;
+
+    test_key_sequences(&mut app, vec![(Some(":w --no-format<ret>"), None)], false).await?;
+
+    helpers::assert_file_has_content(&mut file, "let foo = 0;\n")?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_write_new_path() -> anyhow::Result<()> {
     let mut file1 = tempfile::NamedTempFile::new().unwrap();
     let mut file2 = tempfile::NamedTempFile::new().unwrap();

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -452,6 +452,30 @@ async fn test_write_auto_format_fails_still_writes() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_write_quit_auto_format_exits_after_format() -> anyhow::Result<()> {
+    let mut file = tempfile::Builder::new().suffix(".rs").tempfile()?;
+
+    let lang_conf = indoc! {r#"
+            [[language]]
+            name = "rust"
+            formatter = { command = "bash", args = [ "-c", "echo new content" ] }
+        "#};
+
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file.path(), None)
+        .with_input_text("#[l|]#et foo = 0;\n")
+        .with_lang_loader(helpers::test_syntax_loader(Some(lang_conf.into())))
+        .build()?;
+
+    test_key_sequences(&mut app, vec![(Some(":x<ret>"), None)], true).await?;
+
+    // file saves with new content and editor exits after save
+    helpers::assert_file_has_content(&mut file, "new content\n")?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_write_new_path() -> anyhow::Result<()> {
     let mut file1 = tempfile::NamedTempFile::new().unwrap();
     let mut file2 = tempfile::NamedTempFile::new().unwrap();


### PR DESCRIPTION
For now this is just https://github.com/helix-editor/helix/pull/6486 redone on top of latest master. Because there was no more discussion on that PR I thought I’d resubmit a working recent version and see if there’s anything left to do.
The only thing changed is making it work akin to autoformat so that code actions don’t trigger on auto save.