### PR TITLE
Add default terminal size

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -125,7 +125,7 @@ impl Application {
 
         let theme_mode = backend.get_theme_mode();
         let terminal = Terminal::new(backend)?;
-        let area = terminal.size().unwrap_or(DEFAULT_TERMINAL_SIZE);
+        let area = terminal.backend().size().unwrap_or(DEFAULT_TERMINAL_SIZE);
         let mut compositor = Compositor::new(area);
         let config = Arc::new(ArcSwap::from_pointee(config));
         let handlers = handlers::setup(config.clone());
@@ -542,7 +542,11 @@ impl Application {
                 }
 
                 // redraw the terminal
-                let area = self.terminal.size().unwrap_or(DEFAULT_TERMINAL_SIZE);
+                let area = self
+                    .terminal
+                    .backend()
+                    .size()
+                    .unwrap_or(DEFAULT_TERMINAL_SIZE);
                 self.compositor.resize(area);
                 self.terminal.clear().expect("couldn't clear terminal");
 
@@ -700,7 +704,11 @@ impl Application {
                     .resize(Rect::new(0, 0, cols, rows))
                     .expect("Unable to resize terminal");
 
-                let area = self.terminal.size().unwrap_or(DEFAULT_TERMINAL_SIZE);
+                let area = self
+                    .terminal
+                    .backend()
+                    .size()
+                    .unwrap_or(DEFAULT_TERMINAL_SIZE);
 
                 self.compositor.resize(area);
 

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -167,7 +167,7 @@ where
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
     pub fn autoresize(&mut self) -> io::Result<Rect> {
-        let size = self.size().unwrap_or(DEFAULT_TERMINAL_SIZE);
+        let size = self.backend().size().unwrap_or(DEFAULT_TERMINAL_SIZE);
         if size != self.viewport.area {
             self.resize(size)?;
         };
@@ -240,10 +240,5 @@ where
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
         Ok(())
-    }
-
-    /// Queries the real size of the backend.
-    pub fn size(&self) -> io::Result<Rect> {
-        self.backend.size()
     }
 }


### PR DESCRIPTION
**About**
This is a continuation of the work on https://github.com/helix-editor/helix/pull/14442. 

This PR adds a constant for the default terminal size, which is used when runtime detection of the terminal size fails.
It allows Helix to run in minimal environments and over serial lines. It also removes the `size` method from `Terminal`, as it appears to do nothing.

**Related PR**
https://github.com/helix-editor/helix/pull/14487 PR also solves the problem, but in a slightly different way. This allows us to review, compare, and select the best approach.

**Before**
<img width="969" height="182" alt="image" src="https://github.com/user-attachments/assets/af25635f-fa0a-41c4-877a-e5652b7f3b8f" />

**After**
<img width="872" height="597" alt="image" src="https://github.com/user-attachments/assets/a989408a-5bc6-4ad9-ae4c-c553b4f8326e" />

**Issue**
https://github.com/helix-editor/helix/issues/14101


Thank you

