### PR TITLE
Use the default terminal size when runtime detection fails

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -125,7 +125,7 @@ impl Application {
 
         let theme_mode = backend.get_theme_mode();
         let terminal = Terminal::new(backend)?;
-        let area = terminal.size().expect("couldn't get terminal size");
+        let area = terminal.size();
         let mut compositor = Compositor::new(area);
         let config = Arc::new(ArcSwap::from_pointee(config));
         let handlers = handlers::setup(config.clone());
@@ -542,7 +542,7 @@ impl Application {
                 }
 
                 // redraw the terminal
-                let area = self.terminal.size().expect("couldn't get terminal size");
+                let area = self.terminal.size();
                 self.compositor.resize(area);
                 self.terminal.clear().expect("couldn't clear terminal");
 
@@ -700,7 +700,7 @@ impl Application {
                     .resize(Rect::new(0, 0, cols, rows))
                     .expect("Unable to resize terminal");
 
-                let area = self.terminal.size().expect("couldn't get terminal size");
+                let area = self.terminal.size();
 
                 self.compositor.resize(area);
 
@@ -729,7 +729,7 @@ impl Application {
                     .resize(Rect::new(0, 0, width, height))
                     .expect("Unable to resize terminal");
 
-                let area = self.terminal.size().expect("couldn't get terminal size");
+                let area = self.terminal.size();
 
                 self.compositor.resize(area);
 

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -73,6 +73,14 @@ where
     viewport: Viewport,
 }
 
+/// Default terminal size: 80 columns, 24 lines
+pub const DEFAULT_TERMINAL_SIZE: Rect = Rect {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 24,
+};
+
 impl<B> Terminal<B>
 where
     B: Backend,
@@ -80,7 +88,7 @@ where
     /// Wrapper around Terminal initialization. Each buffer is initialized with a blank string and
     /// default colors for the foreground and the background
     pub fn new(backend: B) -> io::Result<Terminal<B>> {
-        let size = backend.size()?;
+        let size = backend.size().unwrap_or(DEFAULT_TERMINAL_SIZE);
         Terminal::with_options(
             backend,
             TerminalOptions {
@@ -159,7 +167,7 @@ where
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
     pub fn autoresize(&mut self) -> io::Result<Rect> {
-        let size = self.size()?;
+        let size = self.size();
         if size != self.viewport.area {
             self.resize(size)?;
         };
@@ -235,7 +243,7 @@ where
     }
 
     /// Queries the real size of the backend.
-    pub fn size(&self) -> io::Result<Rect> {
-        self.backend.size()
+    pub fn size(&self) -> Rect {
+        self.backend.size().unwrap_or(DEFAULT_TERMINAL_SIZE)
     }
 }


### PR DESCRIPTION
# About
This is a continuation of the work on https://github.com/helix-editor/helix/pull/14442.

This commit adds a fallback terminal size to use when runtime detection fails. Since calling `size` from `Terminal` will never fail now, it also changes the function’s signature.

If the client code wants to know whether the call succeeded or failed, it’s still possible to call `size` via `Backend`.

**Related PR**
https://github.com/helix-editor/helix/pull/14486 PR also solves the problem, but in a slightly different way. This allows us to review, compare, and select the best approach.

**Before**
<img width="969" height="182" alt="image" src="https://github.com/user-attachments/assets/af25635f-fa0a-41c4-877a-e5652b7f3b8f" />

**After**
<img width="872" height="597" alt="image" src="https://github.com/user-attachments/assets/a989408a-5bc6-4ad9-ae4c-c553b4f8326e" />

**Issue**
https://github.com/helix-editor/helix/issues/14101


Thank you
