### PR TITLE
feat(keymap)!: add default keybindings for sub-word navigation

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -23,12 +23,12 @@
 | `move_prev_long_word_start` | Move to start of previous long word | normal: `` B `` |
 | `move_next_long_word_end` | Move to end of next long word | normal: `` E `` |
 | `move_prev_long_word_end` | Move to end of previous long word |  |
-| `move_next_sub_word_start` | Move to start of next sub word |  |
-| `move_prev_sub_word_start` | Move to start of previous sub word |  |
-| `move_next_sub_word_end` | Move to end of next sub word |  |
+| `move_next_sub_word_start` | Move to start of next sub word | normal: `` <A-w> `` |
+| `move_prev_sub_word_start` | Move to start of previous sub word | normal: `` <A-b> `` |
+| `move_next_sub_word_end` | Move to end of next sub word | normal: `` <A-e> `` |
 | `move_prev_sub_word_end` | Move to end of previous sub word |  |
-| `move_parent_node_end` | Move to end of the parent node | normal: `` <A-e> `` |
-| `move_parent_node_start` | Move to beginning of the parent node | normal: `` <A-b> `` |
+| `move_parent_node_end` | Move to end of the parent node | normal: `` <A-l> `` |
+| `move_parent_node_start` | Move to beginning of the parent node | normal: `` <A-h> `` |
 | `extend_next_word_start` | Extend to start of next word | select: `` w `` |
 | `extend_prev_word_start` | Extend to start of previous word | select: `` b `` |
 | `extend_next_word_end` | Extend to end of next word | select: `` e `` |
@@ -37,12 +37,12 @@
 | `extend_prev_long_word_start` | Extend to start of previous long word | select: `` B `` |
 | `extend_next_long_word_end` | Extend to end of next long word | select: `` E `` |
 | `extend_prev_long_word_end` | Extend to end of prev long word |  |
-| `extend_next_sub_word_start` | Extend to start of next sub word |  |
-| `extend_prev_sub_word_start` | Extend to start of previous sub word |  |
-| `extend_next_sub_word_end` | Extend to end of next sub word |  |
+| `extend_next_sub_word_start` | Extend to start of next sub word | select: `` <A-w> `` |
+| `extend_prev_sub_word_start` | Extend to start of previous sub word | select: `` <A-b> `` |
+| `extend_next_sub_word_end` | Extend to end of next sub word | select: `` <A-e> `` |
 | `extend_prev_sub_word_end` | Extend to end of prev sub word |  |
-| `extend_parent_node_end` | Extend to end of the parent node | select: `` <A-e> `` |
-| `extend_parent_node_start` | Extend to beginning of the parent node | select: `` <A-b> `` |
+| `extend_parent_node_end` | Extend to end of the parent node | select: `` <A-l> `` |
+| `extend_parent_node_start` | Extend to beginning of the parent node | select: `` <A-h> `` |
 | `find_till_char` | Move till next occurrence of char | normal: `` t `` |
 | `find_next_char` | Move to next occurrence of char | normal: `` f `` |
 | `extend_till_char` | Extend till next occurrence of char | select: `` t `` |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -49,6 +49,9 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `W`                   | Move next WORD start                               | `move_next_long_word_start` |
 | `B`                   | Move previous WORD start                           | `move_prev_long_word_start` |
 | `E`                   | Move next WORD end                                 | `move_next_long_word_end`   |
+| `Alt-w`               | Move next sub-word start                           | `move_next_sub_word_start`  |
+| `Alt-b`               | Move previous sub-word start                       | `move_prev_sub_word_start`  |
+| `Alt-e`               | Move next sub-word end                             | `move_next_sub_word_end`    |
 | `t`                   | Find till next char                                | `find_till_char`            |
 | `f`                   | Find next char                                     | `find_next_char`            |
 | `T`                   | Find till previous char                            | `till_prev_char`            |
@@ -149,8 +152,8 @@ Normal mode is the default mode when you launch helix. You can return to it from
 | `Alt-n`, `Alt-right`     | Select next sibling node in syntax tree (**TS**)                  | `select_next_sibling`                |
 | `Alt-a`                  | Select all sibling nodes in syntax tree (**TS**)                  | `select_all_siblings`                |
 | `Alt-I`, `Alt-Shift-down`| Select all children nodes in syntax tree (**TS**)                 | `select_all_children`                |
-| `Alt-e`                  | Move to end of parent node in syntax tree (**TS**)                | `move_parent_node_end`               |
-| `Alt-b`                  | Move to start of parent node in syntax tree (**TS**)              | `move_parent_node_start`             |
+| `Alt-l`                  | Move to end of parent node in syntax tree (**TS**)                | `move_parent_node_end`               |
+| `Alt-h`                  | Move to start of parent node in syntax tree (**TS**)              | `move_parent_node_start`             |
 
 ### Search
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -34,6 +34,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "B" => move_prev_long_word_start,
         "E" => move_next_long_word_end,
 
+        "A-w" => move_next_sub_word_start,
+        "A-b" => move_prev_sub_word_start,
+        "A-e" => move_next_sub_word_end,
+
         "v" => select_mode,
         "G" => goto_line,
         "g" => { "Goto"
@@ -91,8 +95,8 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "A-I" | "A-S-down" => select_all_children,
         "A-p" | "A-left" => select_prev_sibling,
         "A-n" | "A-right" => select_next_sibling,
-        "A-e" => move_parent_node_end,
-        "A-b" => move_parent_node_start,
+        "A-l" => move_parent_node_end,
+        "A-h" => move_parent_node_start,
         "A-a" => select_all_siblings,
 
         "%" => select_all,
@@ -352,9 +356,12 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "W" => extend_next_long_word_start,
         "B" => extend_prev_long_word_start,
         "E" => extend_next_long_word_end,
+        "A-w" => extend_next_sub_word_start,
+        "A-b" => extend_prev_sub_word_start,
+        "A-e" => extend_next_sub_word_end,
 
-        "A-e" => extend_parent_node_end,
-        "A-b" => extend_parent_node_start,
+        "A-l" => extend_parent_node_end,
+        "A-h" => extend_parent_node_start,
 
         "n" => extend_search_next,
         "N" => extend_search_prev,


### PR DESCRIPTION
Adds default keybindings for sub-word navigation to allow for more granular and efficient movement through `camelCase` and `snake_case` identifiers.

The new bindings are:
- `A-w`: `move_next_sub_word_start`
- `A-b`: `move_prev_sub_word_start`
- `A-e`: `move_next_sub_word_end`

To accommodate these intuitive bindings, the existing Tree-sitter commands for `move_parent_node_start` and `move_parent_node_end` have been remapped from `A-b` and `A-e`. Inspired by the existing `gh` (goto line start) and `gl` (goto line end) commands, the new bindings are `A-h` and `A-l` respectively, leveraging the strong mnemonic relationship of `h` (left/start) and `l` (right/end).

The corresponding keybindings in select/extend mode have also been updated for consistency.

BREAKING CHANGE: The default keybindings for `move_parent_node_start` and `move_parent_node_end` have been changed from `A-b` and `A-e` to `A-h` and `A-l`.