### PR TITLE
Rainbow brackets support for Darcula themes

### DIFF
--- a/runtime/themes/darcula.toml
+++ b/runtime/themes/darcula.toml
@@ -88,6 +88,8 @@
 "warning" = "orange"
 "error" = "red"
 
+rainbow = ["rainbow_gold", "rainbow_blue", "rainbow_orange", "rainbow_purple", "rainbow_khaki", "rainbow_turquoise"]
+
 [palette]
 grey00 = "#181818" # Default Background
 grey01 = "#282828" # Lighter Background (Used for status bars, line number and folding marks)
@@ -108,3 +110,11 @@ grey = "#808080"
 darkgreen = "#629755"
 lightblue = "#6897bb"
 blue = "#104158"
+
+# Rainbow bracket colors
+rainbow_gold = "#FFD700"
+rainbow_blue = "#1E90FF"
+rainbow_orange = "#FF8C00"
+rainbow_purple = "#9370DB"
+rainbow_khaki = "#F0E68C"
+rainbow_turquoise = "#00CED1" 


### PR DESCRIPTION
Sample:
<img width="932" height="962" alt="2025-09-25_17-26" src="https://github.com/user-attachments/assets/d80eb449-81e5-47d9-80c4-5977b7fddb45" />
