### PR TITLE
Add .itermcolors to xml file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3046,6 +3046,7 @@ file-types = [
   "gpx",
   "fodt",
   "fods",
+  "itermcolors",
 ]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }
@@ -4832,7 +4833,7 @@ indent = { tab-width = 2, unit = "  " }
 block-comment-tokens = { start = "<!--", end = "-->" }
 word-completion.trigger-length = 4
 
-[[language]] 
+[[language]]
 name = "slisp"
 scope = "source.sl"
 injection-regex = "sl"


### PR DESCRIPTION
As specified here: https://iterm2.com/documentation-preferences-profiles-colors.html

Apparently, a formatter removed a trailing space on another line as well. 🤷‍♂️ 