### PR TITLE
Detect `TrueColor` support on OpenBSD

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -34,6 +34,14 @@ fn true_color() -> bool {
         return true;
     }
 
+    // OpenBSD
+    if matches!(
+        std::env::var("TERM").map(|v| matches!(v.as_str(), "xterm-256color")),
+        Ok(true)
+    ) {
+        return true;
+    }
+
     match termini::TermInfo::from_env() {
         Ok(t) => {
             t.extended_cap("RGB").is_some()


### PR DESCRIPTION
Currently TrueColor support is not detected in OpenBSD. It works fine if enabled via `:set true-color true` but it does not work out of the box.

This PR implements the automatic detection following the same style as the check for COLORTERM. I am not the bittest fan of the `.map` syntax here, but it follows the already existing code and works fine.

This is checked against OpenBSD 7.5, 7.6 and 7.7