### PR TITLE
feat(langs): recognize `.sh_history`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1165,6 +1165,7 @@ file-types = [
   { glob = "sway/config" },
   { glob = ".tmux.conf" },
   { glob = "tmux.conf" },
+  { glob = ".sh_history" },
   { glob = ".bash_history" },
   { glob = ".bash_login" },
   { glob = ".bash_logout" },


### PR DESCRIPTION
See `HISTFILE` in [POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/sh.html)