### PR TITLE
Deny unused fields in `languages.toml`

### DIFF
--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -1,6 +1,7 @@
 use crate::{auto_pairs::AutoPairs, diagnostic::Severity, Language};
 
 use globset::GlobSet;
+use helix_loader::grammar;
 use helix_stdx::rope;
 use serde::{ser::SerializeSeq as _, Deserialize, Serialize};
 
@@ -13,11 +14,14 @@ use std::{
 };
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Configuration {
     pub language: Vec<LanguageConfiguration>,
     #[serde(default)]
     pub language_server: HashMap<String, LanguageServerConfiguration>,
+    #[serde(rename = "use-grammars")]
+    grammar_selection: Option<grammar::GrammarSelection>,
+    grammar: Vec<grammar::GrammarConfiguration>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
The current architecture is designed in such a way that the same `languages.toml` is deserialized into 2 different structs: 1 for  language config and 1 for _grammars_. This means that unlike most other ser/de structs, we can't deny unused fields. That is, unless the _grammers_ are specified in the core language configuration.

This PR adds those fields as private, so that we can deny unknown fields on the file.

This would have saved me actual hours when I misspelled "grammar" as "grammer" and couldn't figure out why I wasn't getting my  highlights. And English is my first language!

I'm not sure if this is truly the right thing architecturally. It might make more sense to truly unify the two, but there would need to be more significant architectural changes.

Instead, this is a minimal way to save users a lot of time on dumb errors, with no downsides that I can see.