### PR TITLE
add rainbow brackets to nord theme

### DIFF
--- a/runtime/themes/nord.toml
+++ b/runtime/themes/nord.toml
@@ -150,7 +150,7 @@
 "markup.raw" = "nord7"
 
 # Rainbow brackets
-rainbow = ["nord13", "nord9", "nord12", "nord15", "nord14", "nord8"]
+rainbow = ["nord13", "nord15", "nord14", "nord12"]
 
 [palette]
 # Polar Night is made up of four darker colors that are commonly used for base elements like backgrounds or text color in bright ambiance designs.


### PR DESCRIPTION
This PR adds rainbow brackets to the nord theme using some of the defined nord colors.

<img width="787" height="940" alt="image" src="https://github.com/user-attachments/assets/30ae7cdd-485a-472f-b79e-33abe6276e02" />

