### PR TITLE
Keep LSP completions active when typing server-trigger characters

### DIFF
--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -175,7 +175,30 @@ fn update_completion_filter(cx: &mut commands::Context, c: Option<char>) {
         let editor_view = compositor.find::<ui::EditorView>().unwrap();
         if let Some(completion) = &mut editor_view.completion {
             completion.update_filter(c);
-            if completion.is_empty() || c.is_some_and(|c| !char_is_word(c)) {
+            let keep_non_word = c.is_some_and(|c| {
+                let trigger = c.to_string();
+                cx.editor
+                    .handlers
+                    .completions
+                    .active_completions
+                    .keys()
+                    .any(|provider| match provider {
+                        CompletionProvider::Lsp(language_server_id) => cx
+                            .editor
+                            .language_servers
+                            .get_by_id(*language_server_id)
+                            .and_then(|ls| {
+                                ls.capabilities()
+                                    .completion_provider
+                                    .as_ref()
+                                    .and_then(|provider| provider.trigger_characters.as_deref())
+                            })
+                            .is_some_and(|chars| chars.iter().any(|ch| ch == &trigger)),
+                        _ => false,
+                    })
+            });
+
+            if completion.is_empty() || c.is_some_and(|c| !char_is_word(c) && !keep_non_word) {
                 editor_view.clear_completion(cx.editor);
                 // clearing completions might mean we want to immediately rerequest them (usually
                 // this occurs if typing a trigger char)


### PR DESCRIPTION
Tailwind’s language server advertises -, /, :, etc. as completion triggers. Helix treated those punctuation characters as “not word characters”, cleared the current completion popup, and asked the server for a fresh list. That made Tailwind’s suggestions reset on every -.

Changes
- On each typed character, before clearing the popup for a non-word char, look at the active LSP providers and see whether any of them list the character in completionProvider.triggerCharacters.
- If so, keep the existing menu and just rescore items instead of removing the list.
- Fall back to the old behaviour for punctuation that no connected server actually cares about.

**NOTE:** AI wrote this code but I did test it manually and check the code which looks like to me makes sense (I'm new to the codebase though)

fixes: #12541