### PR TITLE
add window resizing (second revive of #2704)

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -155,6 +155,10 @@
 | `goto_prev_change` | Goto previous change | normal: `` [g ``, select: `` [g `` |
 | `goto_first_change` | Goto first change | normal: `` [G ``, select: `` [G `` |
 | `goto_last_change` | Goto last change | normal: `` ]G ``, select: `` ]G `` |
+| `grow_view_width` | Grow focused container width | normal: `` <C-w>rl ``, `` <space>wrl ``, `` <C-w>r<right> ``, `` <space>wr<right> ``, select: `` <C-w>rl ``, `` <space>wrl ``, `` <C-w>r<right> ``, `` <space>wr<right> `` |
+| `shrink_view_width` | Shrink focused container width | normal: `` <C-w>rh ``, `` <space>wrh ``, `` <C-w>r<left> ``, `` <space>wr<left> ``, select: `` <C-w>rh ``, `` <space>wrh ``, `` <C-w>r<left> ``, `` <space>wr<left> `` |
+| `grow_view_height` | Grow focused container height | normal: `` <C-w>rk ``, `` <C-w>r<up> ``, `` <space>wrk ``, `` <space>wr<up> ``, select: `` <C-w>rk ``, `` <C-w>r<up> ``, `` <space>wrk ``, `` <space>wr<up> `` |
+| `shrink_view_height` | Shrink focused container height | normal: `` <C-w>rj ``, `` <space>wrj ``, `` <C-w>r<down> ``, `` <space>wr<down> ``, select: `` <C-w>rj ``, `` <space>wrj ``, `` <C-w>r<down> ``, `` <space>wr<down> `` |
 | `goto_line_start` | Goto line start | normal: `` gh ``, `` <home> ``, select: `` gh ``, insert: `` <home> `` |
 | `goto_line_end` | Goto line end | normal: `` gl ``, `` <end> ``, select: `` gl `` |
 | `goto_column` | Goto column | normal: `` g\| `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -462,7 +462,7 @@ impl MappableCommand {
         shrink_buffer_width, "Shrink focused container width",
         grow_buffer_height, "Grow focused container height",
         shrink_buffer_height, "Shrink focused container height",
-        buffer_focus_mode, "Enable focus mode on buffer",
+        buffer_expand_mode, "Enable expand mode on buffer",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
         goto_column, "Goto column",
@@ -927,8 +927,8 @@ fn shrink_buffer_height(cx: &mut Context) {
     cx.editor.shrink_buffer_height();
 }
 
-fn buffer_focus_mode(cx: &mut Context) {
-    cx.editor.buffer_focus_mode();
+fn buffer_expand_mode(cx: &mut Context) {
+    cx.editor.buffer_expand_mode();
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -458,6 +458,11 @@ impl MappableCommand {
         goto_prev_change, "Goto previous change",
         goto_first_change, "Goto first change",
         goto_last_change, "Goto last change",
+        grow_buffer_width, "Grow focused container width",
+        shrink_buffer_width, "Shrink focused container width",
+        grow_buffer_height, "Grow focused container height",
+        shrink_buffer_height, "Shrink focused container height",
+        buffer_focus_mode, "Enable focus mode on buffer",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
         goto_column, "Goto column",
@@ -904,6 +909,26 @@ fn goto_line_start(cx: &mut Context) {
             Movement::Move
         },
     )
+}
+
+fn grow_buffer_width(cx: &mut Context) {
+    cx.editor.grow_buffer_width();
+}
+
+fn shrink_buffer_width(cx: &mut Context) {
+    cx.editor.shrink_buffer_width();
+}
+
+fn grow_buffer_height(cx: &mut Context) {
+    cx.editor.grow_buffer_height();
+}
+
+fn shrink_buffer_height(cx: &mut Context) {
+    cx.editor.shrink_buffer_height();
+}
+
+fn buffer_focus_mode(cx: &mut Context) {
+    cx.editor.buffer_focus_mode();
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -52,7 +52,7 @@ use helix_view::{
     input::KeyEvent,
     keyboard::KeyCode,
     theme::Style,
-    tree,
+    tree::{Dimension, Resize},
     view::View,
     Document, DocumentId, Editor, ViewId,
 };
@@ -912,19 +912,19 @@ fn goto_line_start(cx: &mut Context) {
 }
 
 fn grow_buffer_width(cx: &mut Context) {
-    cx.editor.grow_buffer_width();
+    cx.editor.resize_buffer(Resize::Grow, Dimension::Width);
 }
 
 fn shrink_buffer_width(cx: &mut Context) {
-    cx.editor.shrink_buffer_width();
+    cx.editor.resize_buffer(Resize::Shrink, Dimension::Width);
 }
 
 fn grow_buffer_height(cx: &mut Context) {
-    cx.editor.grow_buffer_height();
+    cx.editor.resize_buffer(Resize::Grow, Dimension::Height);
 }
 
 fn shrink_buffer_height(cx: &mut Context) {
-    cx.editor.shrink_buffer_height();
+    cx.editor.resize_buffer(Resize::Shrink, Dimension::Height);
 }
 
 fn buffer_expand_mode(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -458,11 +458,11 @@ impl MappableCommand {
         goto_prev_change, "Goto previous change",
         goto_first_change, "Goto first change",
         goto_last_change, "Goto last change",
-        grow_buffer_width, "Grow focused container width",
-        shrink_buffer_width, "Shrink focused container width",
-        grow_buffer_height, "Grow focused container height",
-        shrink_buffer_height, "Shrink focused container height",
-        toggle_focus_window, "Toggle focus mode on buffer",
+        grow_view_width, "Grow focused container width",
+        shrink_view_width, "Shrink focused container width",
+        grow_view_height, "Grow focused container height",
+        shrink_view_height, "Shrink focused container height",
+        toggle_view_focus, "Toggle focus mode on buffer",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
         goto_column, "Goto column",
@@ -911,24 +911,24 @@ fn goto_line_start(cx: &mut Context) {
     )
 }
 
-fn grow_buffer_width(cx: &mut Context) {
-    cx.editor.resize_buffer(Resize::Grow, Dimension::Width);
+fn grow_view_width(cx: &mut Context) {
+    cx.editor.resize_view(Resize::Grow, Dimension::Width);
 }
 
-fn shrink_buffer_width(cx: &mut Context) {
-    cx.editor.resize_buffer(Resize::Shrink, Dimension::Width);
+fn shrink_view_width(cx: &mut Context) {
+    cx.editor.resize_view(Resize::Shrink, Dimension::Width);
 }
 
-fn grow_buffer_height(cx: &mut Context) {
-    cx.editor.resize_buffer(Resize::Grow, Dimension::Height);
+fn grow_view_height(cx: &mut Context) {
+    cx.editor.resize_view(Resize::Grow, Dimension::Height);
 }
 
-fn shrink_buffer_height(cx: &mut Context) {
-    cx.editor.resize_buffer(Resize::Shrink, Dimension::Height);
+fn shrink_view_height(cx: &mut Context) {
+    cx.editor.resize_view(Resize::Shrink, Dimension::Height);
 }
 
-fn toggle_focus_window(cx: &mut Context) {
-    cx.editor.toggle_focus_window();
+fn toggle_view_focus(cx: &mut Context) {
+    cx.editor.toggle_view_focus();
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -52,7 +52,7 @@ use helix_view::{
     input::KeyEvent,
     keyboard::KeyCode,
     theme::Style,
-    tree::{Dimension, Resize},
+    tree::{self, Dimension, Resize},
     view::View,
     Document, DocumentId, Editor, ViewId,
 };
@@ -462,7 +462,7 @@ impl MappableCommand {
         shrink_buffer_width, "Shrink focused container width",
         grow_buffer_height, "Grow focused container height",
         shrink_buffer_height, "Shrink focused container height",
-        buffer_expand_mode, "Enable expand mode on buffer",
+        toggle_focus_window, "Toggle focus mode on buffer",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
         goto_column, "Goto column",
@@ -927,8 +927,8 @@ fn shrink_buffer_height(cx: &mut Context) {
     cx.editor.resize_buffer(Resize::Shrink, Dimension::Height);
 }
 
-fn buffer_expand_mode(cx: &mut Context) {
-    cx.editor.buffer_expand_mode();
+fn toggle_focus_window(cx: &mut Context) {
+    cx.editor.toggle_focus_window();
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -462,7 +462,6 @@ impl MappableCommand {
         shrink_view_width, "Shrink focused container width",
         grow_view_height, "Grow focused container height",
         shrink_view_height, "Shrink focused container height",
-        toggle_view_focus, "Toggle focus mode on buffer",
         goto_line_start, "Goto line start",
         goto_line_end, "Goto line end",
         goto_column, "Goto column",
@@ -925,10 +924,6 @@ fn grow_view_height(cx: &mut Context) {
 
 fn shrink_view_height(cx: &mut Context) {
     cx.editor.resize_view(Resize::Shrink, Dimension::Height);
-}
-
-fn toggle_view_focus(cx: &mut Context) {
-    cx.editor.toggle_view_focus();
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -911,19 +911,23 @@ fn goto_line_start(cx: &mut Context) {
 }
 
 fn grow_view_width(cx: &mut Context) {
-    cx.editor.resize_view(Resize::Grow, Dimension::Width);
+    cx.editor
+        .resize_view(Resize::Grow, Dimension::Width, cx.count());
 }
 
 fn shrink_view_width(cx: &mut Context) {
-    cx.editor.resize_view(Resize::Shrink, Dimension::Width);
+    cx.editor
+        .resize_view(Resize::Shrink, Dimension::Width, cx.count());
 }
 
 fn grow_view_height(cx: &mut Context) {
-    cx.editor.resize_view(Resize::Grow, Dimension::Height);
+    cx.editor
+        .resize_view(Resize::Grow, Dimension::Height, cx.count());
 }
 
 fn shrink_view_height(cx: &mut Context) {
-    cx.editor.resize_view(Resize::Shrink, Dimension::Height);
+    cx.editor
+        .resize_view(Resize::Shrink, Dimension::Height, cx.count());
 }
 
 fn goto_next_buffer(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -27,11 +27,11 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "end" => goto_line_end,
 
         "A-w" => { "Alter Window"
-            "A-h"|"A-left" => shrink_buffer_width,
-            "A-l"|"A-right" => grow_buffer_width,
-            "A-j"|"A-down" => shrink_buffer_height,
-            "A-k"|"A-up" => grow_buffer_height,
-            "A-f" => buffer_expand_mode,
+            "A-h"|"A-left" |"h"|"left" => shrink_buffer_width,
+            "A-l"|"A-right"|"l"|"right" => grow_buffer_width,
+            "A-j"|"A-down" |"j"|"down" => shrink_buffer_height,
+            "A-k"|"A-up"   |"k"|"up" => grow_buffer_height,
+            "A-f"|"f" => toggle_focus_window,
         },
 
         "A-W" => { "Alter Window" sticky=true
@@ -39,7 +39,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "l"|"right" => grow_buffer_width,
             "j"|"down" => shrink_buffer_height,
             "k"|"up" => grow_buffer_height,
-            "f" => buffer_expand_mode,
+            "f" => toggle_focus_window,
         },
 
         "w" => move_next_word_start,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -27,11 +27,19 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "end" => goto_line_end,
 
         "A-w" => { "Alter Window"
-            "A-w"|"A-left" => shrink_buffer_width,
+            "A-h"|"A-left" => shrink_buffer_width,
             "A-l"|"A-right" => grow_buffer_width,
             "A-j"|"A-down" => shrink_buffer_height,
             "A-k"|"A-up" => grow_buffer_height,
             "A-f" => buffer_expand_mode,
+        },
+
+        "A-W" => { "Alter Window" sticky=true
+            "h"|"left" => shrink_buffer_width,
+            "l"|"right" => grow_buffer_width,
+            "j"|"down" => shrink_buffer_height,
+            "k"|"up" => grow_buffer_height,
+            "f" => buffer_expand_mode,
         },
 
         "w" => move_next_word_start,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -26,6 +26,14 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "home" => goto_line_start,
         "end" => goto_line_end,
 
+        "A-w" => { "Alter Window"
+            "A-w"|"A-left" => shrink_buffer_width,
+            "A-l"|"A-right" => grow_buffer_width,
+            "A-j"|"A-down" => shrink_buffer_height,
+            "A-k"|"A-up" => grow_buffer_height,
+            "A-f" => buffer_focus_mode,
+        },
+
         "w" => move_next_word_start,
         "b" => move_prev_word_start,
         "e" => move_next_word_end,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -27,19 +27,19 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "end" => goto_line_end,
 
         "A-w" => { "Alter Window"
-            "A-h"|"A-left" |"h"|"left" => shrink_buffer_width,
-            "A-l"|"A-right"|"l"|"right" => grow_buffer_width,
-            "A-j"|"A-down" |"j"|"down" => shrink_buffer_height,
-            "A-k"|"A-up"   |"k"|"up" => grow_buffer_height,
-            "A-f"|"f" => toggle_focus_window,
+            "A-h"|"A-left" |"h"|"left" => shrink_view_width,
+            "A-l"|"A-right"|"l"|"right" => grow_view_width,
+            "A-j"|"A-down" |"j"|"down" => shrink_view_height,
+            "A-k"|"A-up"   |"k"|"up" => grow_view_height,
+            "A-f"|"f" => toggle_view_focus,
         },
 
         "A-W" => { "Alter Window" sticky=true
-            "h"|"left" => shrink_buffer_width,
-            "l"|"right" => grow_buffer_width,
-            "j"|"down" => shrink_buffer_height,
-            "k"|"up" => grow_buffer_height,
-            "f" => toggle_focus_window,
+            "h"|"left" => shrink_view_width,
+            "l"|"right" => grow_view_width,
+            "j"|"down" => shrink_view_height,
+            "k"|"up" => grow_view_height,
+            "f" => toggle_view_focus,
         },
 
         "w" => move_next_word_start,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -31,7 +31,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "A-l"|"A-right" => grow_buffer_width,
             "A-j"|"A-down" => shrink_buffer_height,
             "A-k"|"A-up" => grow_buffer_height,
-            "A-f" => buffer_focus_mode,
+            "A-f" => buffer_expand_mode,
         },
 
         "w" => move_next_word_start,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -273,7 +273,6 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
                     "l" | "right" => grow_view_width,
                     "j" | "down" => shrink_view_height,
                     "k" | "up" => grow_view_height,
-                    "f" => toggle_view_focus,
                 },
                 "f" => goto_file_hsplit,
                 "F" => goto_file_vsplit,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -26,22 +26,6 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "home" => goto_line_start,
         "end" => goto_line_end,
 
-        "A-w" => { "Alter Window"
-            "A-h"|"A-left" |"h"|"left" => shrink_view_width,
-            "A-l"|"A-right"|"l"|"right" => grow_view_width,
-            "A-j"|"A-down" |"j"|"down" => shrink_view_height,
-            "A-k"|"A-up"   |"k"|"up" => grow_view_height,
-            "A-f"|"f" => toggle_view_focus,
-        },
-
-        "A-W" => { "Alter Window" sticky=true
-            "h"|"left" => shrink_view_width,
-            "l"|"right" => grow_view_width,
-            "j"|"down" => shrink_view_height,
-            "k"|"up" => grow_view_height,
-            "f" => toggle_view_focus,
-        },
-
         "w" => move_next_word_start,
         "b" => move_prev_word_start,
         "e" => move_next_word_end,
@@ -211,6 +195,12 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C-s" | "s" => hsplit,
             "C-v" | "v" => vsplit,
             "C-t" | "t" => transpose_view,
+            "r" => { "Window resize mode" sticky=true
+                "h" | "left" => shrink_view_width,
+                "l" | "right" => grow_view_width,
+                "j" | "down" => shrink_view_height,
+                "k" | "up" => grow_view_height,
+            },
             "f" => goto_file_hsplit,
             "F" => goto_file_vsplit,
             "C-q" | "q" => wclose,
@@ -278,6 +268,13 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
                 "C-s" | "s" => hsplit,
                 "C-v" | "v" => vsplit,
                 "C-t" | "t" => transpose_view,
+                "r" => { "Window resize mode" sticky=true
+                    "h" | "left" => shrink_view_width,
+                    "l" | "right" => grow_view_width,
+                    "j" | "down" => shrink_view_height,
+                    "k" | "up" => grow_view_height,
+                    "f" => toggle_view_focus,
+                },
                 "f" => goto_file_hsplit,
                 "F" => goto_file_vsplit,
                 "C-q" | "q" => wclose,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2252,8 +2252,8 @@ impl Editor {
         self.tree.resize_buffer(Resize::Shrink, Dimension::Height);
     }
 
-    pub fn buffer_focus_mode(&mut self) {
-        self.tree.buffer_focus_mode();
+    pub fn buffer_expand_mode(&mut self) {
+        self.tree.buffer_expand_mode();
     }
 
     pub fn should_close(&self) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2236,6 +2236,26 @@ impl Editor {
         self.tree.transpose();
     }
 
+    pub fn grow_buffer_width(&mut self) {
+        self.tree.grow_buffer_width();
+    }
+
+    pub fn shrink_buffer_width(&mut self) {
+        self.tree.shrink_buffer_width();
+    }
+
+    pub fn grow_buffer_height(&mut self) {
+        self.tree.grow_buffer_height();
+    }
+
+    pub fn shrink_buffer_height(&mut self) {
+        self.tree.shrink_buffer_height();
+    }
+
+    pub fn buffer_focus_mode(&mut self) {
+        self.tree.buffer_focus_mode();
+    }
+
     pub fn should_close(&self) -> bool {
         self.tree.is_empty()
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2236,8 +2236,8 @@ impl Editor {
         self.tree.transpose();
     }
 
-    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension) {
-        self.tree.resize_view(resize_type, dimension);
+    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension, count: usize) {
+        self.tree.resize_view(resize_type, dimension, count);
     }
 
     pub fn should_close(&self) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2236,12 +2236,12 @@ impl Editor {
         self.tree.transpose();
     }
 
-    pub fn resize_buffer(&mut self, resize_type: Resize, dimension: Dimension) {
-        self.tree.resize_buffer(resize_type, dimension);
+    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension) {
+        self.tree.resize_view(resize_type, dimension);
     }
 
-    pub fn toggle_focus_window(&mut self) {
-        self.tree.toggle_focus_window();
+    pub fn toggle_view_focus(&mut self) {
+        self.tree.toggle_view_focus();
     }
 
     pub fn should_close(&self) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2236,20 +2236,8 @@ impl Editor {
         self.tree.transpose();
     }
 
-    pub fn grow_buffer_width(&mut self) {
-        self.tree.resize_buffer(Resize::Grow, Dimension::Width);
-    }
-
-    pub fn shrink_buffer_width(&mut self) {
-        self.tree.resize_buffer(Resize::Shrink, Dimension::Width);
-    }
-
-    pub fn grow_buffer_height(&mut self) {
-        self.tree.resize_buffer(Resize::Grow, Dimension::Height);
-    }
-
-    pub fn shrink_buffer_height(&mut self) {
-        self.tree.resize_buffer(Resize::Shrink, Dimension::Height);
+    pub fn resize_buffer(&mut self, resize_type: Resize, dimension: Dimension) {
+        self.tree.resize_buffer(resize_type, dimension);
     }
 
     pub fn buffer_expand_mode(&mut self) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -11,7 +11,7 @@ use crate::{
     input::KeyEvent,
     register::Registers,
     theme::{self, Theme},
-    tree::{self, Tree},
+    tree::{self, Dimension, Resize, Tree},
     Document, DocumentId, View, ViewId,
 };
 use helix_event::dispatch;
@@ -2237,19 +2237,19 @@ impl Editor {
     }
 
     pub fn grow_buffer_width(&mut self) {
-        self.tree.grow_buffer_width();
+        self.tree.resize_buffer(Resize::Grow, Dimension::Width);
     }
 
     pub fn shrink_buffer_width(&mut self) {
-        self.tree.shrink_buffer_width();
+        self.tree.resize_buffer(Resize::Shrink, Dimension::Width);
     }
 
     pub fn grow_buffer_height(&mut self) {
-        self.tree.grow_buffer_height();
+        self.tree.resize_buffer(Resize::Grow, Dimension::Height);
     }
 
     pub fn shrink_buffer_height(&mut self) {
-        self.tree.shrink_buffer_height();
+        self.tree.resize_buffer(Resize::Shrink, Dimension::Height);
     }
 
     pub fn buffer_focus_mode(&mut self) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2240,8 +2240,8 @@ impl Editor {
         self.tree.resize_buffer(resize_type, dimension);
     }
 
-    pub fn buffer_expand_mode(&mut self) {
-        self.tree.buffer_expand_mode();
+    pub fn toggle_focus_window(&mut self) {
+        self.tree.toggle_focus_window();
     }
 
     pub fn should_close(&self) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2240,10 +2240,6 @@ impl Editor {
         self.tree.resize_view(resize_type, dimension);
     }
 
-    pub fn toggle_view_focus(&mut self) {
-        self.tree.toggle_view_focus();
-    }
-
     pub fn should_close(&self) -> bool {
         self.tree.is_empty()
     }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -82,7 +82,7 @@ pub struct Container {
 pub struct ContainerBounds {
     width: usize,
     height: usize,
-    focus: bool,
+    expand: bool,
 }
 
 impl Container {
@@ -124,7 +124,7 @@ impl Container {
         self.node_bounds.push(ContainerBounds {
             width: 10,
             height: 10,
-            focus: false,
+            expand: false,
         });
         self
     }
@@ -135,7 +135,7 @@ impl Container {
             ContainerBounds {
                 width: 10,
                 height: 10,
-                focus: false,
+                expand: false,
             },
         );
         self
@@ -149,7 +149,7 @@ impl Container {
     fn calculate_slots_width(&self) -> usize {
         self.node_bounds
             .iter()
-            .map(|bounds| match bounds.focus {
+            .map(|bounds| match bounds.expand {
                 true => 40,
                 false => bounds.width,
             })
@@ -159,7 +159,7 @@ impl Container {
     fn calculate_slots_height(&self) -> usize {
         self.node_bounds
             .iter()
-            .map(|bounds| match bounds.focus {
+            .map(|bounds| match bounds.expand {
                 true => 40,
                 false => bounds.height,
             })
@@ -480,7 +480,7 @@ impl Tree {
 
                             for (i, child) in container.children.iter().enumerate() {
                                 let bounds = container.node_bounds[i];
-                                let height = match bounds.focus {
+                                let height = match bounds.expand {
                                     true => (40.0 * slot_height) as u16,
                                     false => (slot_height * bounds.height as f32).floor() as u16,
                                 };
@@ -518,7 +518,7 @@ impl Tree {
 
                             for (i, child) in container.children.iter().enumerate() {
                                 let bounds = container.node_bounds[i];
-                                let width = match bounds.focus {
+                                let width = match bounds.expand {
                                     true => (40.0 * slot_width) as u16,
                                     false => (slot_width * bounds.width as f32).floor() as u16,
                                 };
@@ -766,13 +766,13 @@ impl Tree {
         }
     }
 
-    pub fn buffer_focus_mode(&mut self) {
+    pub fn buffer_expand_mode(&mut self) {
         if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
-            bounds.focus = !bounds.focus;
+            bounds.expand = !bounds.expand;
         }
 
         if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
-            bounds.focus = !bounds.focus;
+            bounds.expand = !bounds.expand;
         }
 
         self.recalculate();

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -705,7 +705,7 @@ impl Tree {
         }
     }
 
-    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension) {
+    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension, count: usize) {
         let layout = match dimension {
             Dimension::Width => Layout::Vertical,
             Dimension::Height => Layout::Horizontal,
@@ -724,6 +724,7 @@ impl Tree {
                 Resize::Shrink => -diff,
                 Resize::Grow => diff,
             };
+            let diff = diff * count as f64;
 
             let bounds = &mut container.node_bounds;
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -114,12 +114,6 @@ impl Container {
         self
     }
 
-    fn remove_child(&mut self, index: usize) -> &mut Self {
-        self.children.remove(index);
-        self.remove_child_bounds(index);
-        self
-    }
-
     fn add_child_bounds(&mut self) -> &mut Self {
         self.node_bounds.push(ContainerBounds {
             width: 10,
@@ -138,11 +132,6 @@ impl Container {
                 expand: false,
             },
         );
-        self
-    }
-
-    fn remove_child_bounds(&mut self, index: usize) -> &mut Self {
-        self.node_bounds.remove(index);
         self
     }
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -96,10 +96,10 @@ impl Container {
     }
 
     fn get_child_by_view_id(&mut self, node: ViewId) -> Option<&mut ContainerBounds> {
-        if let Some(index) = self.children.iter().position(|child| child == &node) {
-            return self.node_bounds.get_mut(index);
-        };
-        None
+        self.children
+            .iter()
+            .position(|child| child == &node)
+            .and_then(|index| self.node_bounds.get_mut(index))
     }
 
     fn push_child(&mut self, node: ViewId) -> &mut Self {
@@ -766,7 +766,7 @@ impl Tree {
         }
     }
 
-    pub fn buffer_expand_mode(&mut self) {
+    pub fn toggle_focus_window(&mut self) {
         if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
             bounds.expand = !bounds.expand;
         }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -29,6 +29,16 @@ pub enum Content {
     Container(Box<Container>),
 }
 
+pub enum Resize {
+    Shrink,
+    Grow,
+}
+
+pub enum Dimension {
+    Width,
+    Height,
+}
+
 impl Node {
     pub fn container(layout: Layout) -> Self {
         Self {
@@ -717,38 +727,41 @@ impl Tree {
         None
     }
 
-    pub fn grow_buffer_width(&mut self) {
-        if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
-            if bounds.width < 20 {
-                bounds.width += 1;
-                self.recalculate();
+    pub fn resize_buffer(&mut self, resize_type: Resize, dimension: Dimension) {
+        match dimension {
+            Dimension::Width => {
+                if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
+                    match resize_type {
+                        Resize::Shrink => {
+                            if bounds.width > 1 {
+                                bounds.width -= 1;
+                            }
+                        }
+                        Resize::Grow => {
+                            if bounds.width < 20 {
+                                bounds.width += 1;
+                            }
+                        }
+                    };
+                    self.recalculate();
+                }
             }
-        }
-    }
-
-    pub fn shrink_buffer_width(&mut self) {
-        if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
-            if bounds.width > 1 {
-                bounds.width -= 1;
-                self.recalculate();
-            }
-        }
-    }
-
-    pub fn grow_buffer_height(&mut self) {
-        if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
-            if bounds.height < 20 {
-                bounds.height += 1;
-                self.recalculate();
-            }
-        }
-    }
-
-    pub fn shrink_buffer_height(&mut self) {
-        if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
-            if bounds.height > 1 {
-                bounds.height -= 1;
-                self.recalculate();
+            Dimension::Height => {
+                if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
+                    match resize_type {
+                        Resize::Shrink => {
+                            if bounds.height > 1 {
+                                bounds.height -= 1;
+                            }
+                        }
+                        Resize::Grow => {
+                            if bounds.height < 20 {
+                                bounds.height += 1;
+                            }
+                        }
+                    };
+                    self.recalculate();
+                }
             }
         }
     }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -93,13 +93,6 @@ impl Container {
         }
     }
 
-    fn get_child_by_view_id(&mut self, node: ViewId) -> Option<&mut ContainerBounds> {
-        self.children
-            .iter()
-            .position(|child| child == &node)
-            .and_then(|index| self.node_bounds.get_mut(index))
-    }
-
     fn push_child(&mut self, node: ViewId) -> &mut Self {
         self.children.push(node);
         self.add_child_bounds();
@@ -681,32 +674,6 @@ impl Tree {
         }
     }
 
-    fn get_active_node_bounds_mut(
-        &mut self,
-        expect_layout: Layout,
-    ) -> Option<&mut ContainerBounds> {
-        let mut focus = self.focus;
-        let mut parent = self.nodes[focus].parent;
-
-        // Parent expected to be container
-        if let Some(focused_layout) = match &self.nodes[parent].content {
-            Content::View(_) => unreachable!(),
-            Content::Container(node) => Some(node.layout),
-        } {
-            // if we want to make a width change and we have a `Horizontal` layout focused,
-            // alter the parent `Vertical` layout instead and vice versa
-            if focused_layout != expect_layout {
-                focus = parent;
-                parent = self.nodes[parent].parent;
-            }
-
-            if let Content::Container(node) = &mut self.nodes[parent].content {
-                return node.as_mut().get_child_by_view_id(focus);
-            };
-        }
-        None
-    }
-
     fn find_container(&mut self, layout: Layout) -> Option<(&mut Container, usize)> {
         let mut focus = self.focus;
         let mut parent = self.nodes[focus].parent;
@@ -770,18 +737,6 @@ impl Tree {
 
             self.recalculate();
         }
-    }
-
-    pub fn toggle_view_focus(&mut self) {
-        if let Some(_bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
-            // bounds.expand = !bounds.expand;
-        }
-
-        if let Some(_bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
-            // bounds.expand = !bounds.expand;
-        }
-
-        self.recalculate();
     }
 
     pub fn swap_split_in_direction(&mut self, direction: Direction) -> Option<()> {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -716,7 +716,7 @@ impl Tree {
         None
     }
 
-    pub fn resize_buffer(&mut self, resize_type: Resize, dimension: Dimension) {
+    pub fn resize_view(&mut self, resize_type: Resize, dimension: Dimension) {
         match dimension {
             Dimension::Width => {
                 if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Vertical) {
@@ -755,7 +755,7 @@ impl Tree {
         }
     }
 
-    pub fn toggle_focus_window(&mut self) {
+    pub fn toggle_view_focus(&mut self) {
         if let Some(bounds) = self.get_active_node_bounds_mut(Layout::Horizontal) {
             bounds.expand = !bounds.expand;
         }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -712,6 +712,10 @@ impl Tree {
         };
 
         if let Some((container, idx)) = self.find_container(layout) {
+            if container.children.len() == 1 {
+                return;
+            }
+
             let diff = match dimension {
                 Dimension::Width => 1.0 / container.area.width as f64 * 2.0,
                 Dimension::Height => 1.0 / container.area.height as f64 * 2.0,
@@ -722,8 +726,17 @@ impl Tree {
             };
 
             let bounds = &mut container.node_bounds;
-            bounds[idx].portion += diff;
 
+            let min = 0.05;
+            let max = 1.0 - ((container.children.len() - 1) as f64 * min);
+            if bounds[idx].portion <= min && bounds[idx].portion >= max {
+                return;
+            }
+
+            let portion = bounds[idx].portion;
+            bounds[idx].portion = f64::clamp(portion + diff, min, max);
+
+            let diff = bounds[idx].portion - portion;
             if let Some(prev) = idx.checked_sub(1) {
                 if let Some(next) = bounds.get_mut(idx + 1) {
                     next.portion -= diff / 2.0;


### PR DESCRIPTION
as #8546 is seemingly stale as well, this is a second attempt at reviving #2704.

while this pr is based on #2704 (and #8546), the resizing model has been changed significantly due to [this review comment of the last version](https://github.com/helix-editor/helix/pull/8546#discussion_r1720366956), away from a flex-based approach to a percentage and cell-based approach, that resembles the tiling resize model of sway:

internally, each child in a view has an associated `ContainerBounds`, which holds a percentage of how much of the space the content takes up in the parent container. resizing a view modifies the percentages by an even multiple of the percentage, that one cell takes up in the current view, and then resizes the neighboring cells to make space. resizing will resize by an even amount (`2 * cx.count()`) of cells, so that both of the sides of the active view can be resized by an integer amount of cells and doesn't have to deal with 0.5 cells. tracking the sizes in percentages makes it pretty much work-by-default, if the terminal gets resized.

the change to take `cx.count()` into account in the `resize_view` was made in [f6f601e9609edefe8e502af72f9a1f29210fd6cb].

due to this change, i was kind of forced to ditch the "focus mode" for windows, as i wasn't sure how to implement this with this (especially being able to toggle it off), so i just left it for now. if you have any idea on how to implement that, let me know and i'll do it.

additionally i also addressed the other two review comments: putting the sticky keybindings into `<space>-w-r` and removing the non-sticky keybindings from the default keymap in [4ad561f18626386f81ba637cd1762810908d01eb] to address [this review comment](https://github.com/helix-editor/helix/pull/8546#discussion_r1720363742) and adjusting the naming in [513e578923aae5f54c5794c8158fca2d04b5cb00] to address [this review comment](https://github.com/helix-editor/helix/pull/8546#discussion_r1720363742).

additionally, in a potentially more controversial refactor in [cb04d2d73dae833174f0096dce217688d21d1066], i refactored the two independent vecs in `node_bounds` and `children` into a `Children` struct, where i implemented the `push`, `insert`, `pop` and `remove` functions. this makes it harder to accidentally modify the views without modifying the bounds and vice-versa, but i can very easily revert it again if you prefer.

fixes #1176
closes #8546