### PR TITLE
queries(python): always mark kwarg names as `@variable.parameter`

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -75,6 +75,9 @@
 (lambda_parameters
   (identifier) @variable.parameter)
 
+(keyword_argument
+  name: (identifier) @variable.parameter)
+
 ; - Builtin
 ((identifier) @variable.builtin
  (#any-of? @variable.builtin "self" "cls"))

--- a/runtime/queries/python/locals.scm
+++ b/runtime/queries/python/locals.scm
@@ -45,3 +45,6 @@
 
 (identifier) @local.reference
 
+; don't make the name of kwargs locals
+(keyword_argument
+  name: (identifier) @variable.parameter)


### PR DESCRIPTION
and don't mark them as `@local.reference`

before:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/4ebf1469-c518-423b-b386-a089bd764b9f" />

after:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/386bd4e9-8973-4ecc-b68d-c7434cbc2f56" />

(using the onedark theme, which highlights `@variable.parameter` as red)

i was unsure of whether to mark kwarg arg names as parameters or as variables, so i did what neovim does, [which is mark it as `@variable.parameter`](https://github.com/nvim-treesitter/nvim-treesitter/blob/42fc28ba918343ebfd5565147a42a26580579482/queries/python/highlights.scm#L293-L295).

resolves: #14323