### PR TITLE
update tree-sitter-javascript and tree-sitter-typescript

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4241,7 +4241,7 @@ language-servers = [
     "ember-language-server",
 ]
 indent = { tab-width = 2, unit = "  " }
-grammar = "javascript"
+grammar = "glimmer-javascript"
 
 [language.auto-pairs]
 '<' = '>'
@@ -4249,6 +4249,10 @@ grammar = "javascript"
 "{" = "}"
 "(" = ")"
 '"' = '"'
+
+[[grammar]]
+name = "glimmer-javascript"
+source = { git = "https://github.com/ember-tooling/tree-sitter-glimmer-javascript", rev = "5cc865a2a0a77cbfaf5062c8fcf2a9919bd54f87" }
 
 [[language]]
 name = "gts"
@@ -4265,7 +4269,7 @@ language-servers = [
     "ember-language-server",
 ]
 indent = { tab-width = 2, unit = "  " }
-grammar = "typescript"
+grammar = "glimmer-typescript"
 
 [language.auto-pairs]
 '<' = '>'
@@ -4273,6 +4277,10 @@ grammar = "typescript"
 "{" = "}"
 "(" = ")"
 '"' = '"'
+
+[[grammar]]
+name = "glimmer-typescript"
+source = { git = "https://github.com/ember-tooling/tree-sitter-glimmer-typescript", rev = "12d98944c1d5077b957cbdb90d663a7c4d50118c" }
 
 [[language]]
 name = "gherkin"

--- a/languages.toml
+++ b/languages.toml
@@ -906,7 +906,7 @@ args = { program = "{0}", skipFiles = [ "<node_internals>/**" ] }
 
 [[grammar]]
 name = "javascript"
-source = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "f772967f7b7bc7c28f845be2420a38472b16a8ee" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "3a837b6f3658ca3618f2022f8707e29739c91364" }
 
 [[language]]
 name = "jsx"
@@ -936,7 +936,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "typescript"
-source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf", subpath = "typescript" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "75b3874edb2dc714fb1fd77a32013d0f8699989f", subpath = "typescript" }
 
 [[language]]
 name = "typespec"
@@ -969,7 +969,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "tsx"
-source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf", subpath = "tsx" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "75b3874edb2dc714fb1fd77a32013d0f8699989f", subpath = "tsx" }
 
 [[language]]
 name = "css"

--- a/runtime/queries/_javascript/tags.scm
+++ b/runtime/queries/_javascript/tags.scm
@@ -25,7 +25,7 @@
   (comment)* @doc
   .
   [
-    (function
+    (function_expression
       name: (identifier) @name)
     (function_declaration
       name: (identifier) @name)
@@ -44,7 +44,7 @@
   (lexical_declaration
     (variable_declarator
       name: (identifier) @name
-      value: [(arrow_function) (function)]) @definition.function)
+      value: [(arrow_function) (function_expression)]) @definition.function)
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
   (#select-adjacent! @doc @definition.function)
 )
@@ -55,7 +55,7 @@
   (variable_declaration
     (variable_declarator
       name: (identifier) @name
-      value: [(arrow_function) (function)]) @definition.function)
+      value: [(arrow_function) (function_expression)]) @definition.function)
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
   (#select-adjacent! @doc @definition.function)
 )
@@ -66,12 +66,12 @@
     (member_expression
       property: (property_identifier) @name)
   ]
-  right: [(arrow_function) (function)]
+  right: [(arrow_function) (function_expression)]
 ) @definition.function
 
 (pair
   key: (property_identifier) @name
-  value: [(arrow_function) (function)]) @definition.function
+  value: [(arrow_function) (function_expression)]) @definition.function
 
 (
   (call_expression

--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -161,7 +161,7 @@
 ; Function and method definitions
 ;--------------------------------
 
-(function
+(function_expression
   name: (identifier) @function)
 (function_declaration
   name: (identifier) @function)
@@ -172,27 +172,27 @@
 
 (pair
   key: (property_identifier) @function.method
-  value: [(function) (arrow_function)])
+  value: [(function_expression) (arrow_function)])
 (pair
   key: (private_property_identifier) @function.method.private
-  value: [(function) (arrow_function)])
+  value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
     property: (property_identifier) @function.method)
-  right: [(function) (arrow_function)])
+  right: [(function_expression) (arrow_function)])
 (assignment_expression
   left: (member_expression
     property: (private_property_identifier) @function.method.private)
-  right: [(function) (arrow_function)])
+  right: [(function_expression) (arrow_function)])
 
 (variable_declarator
   name: (identifier) @function
-  value: [(function) (arrow_function)])
+  value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (identifier) @function
-  right: [(function) (arrow_function)])
+  right: [(function_expression) (arrow_function)])
 
 ; Function and method parameters
 ;-------------------------------

--- a/runtime/queries/ecma/locals.scm
+++ b/runtime/queries/ecma/locals.scm
@@ -3,8 +3,8 @@
 
 [
   (statement_block)
-  (function)
   (arrow_function)
+  (function_expression)
   (function_declaration)
   (method_definition)
 ] @local.scope

--- a/runtime/queries/ecma/locals.scm
+++ b/runtime/queries/ecma/locals.scm
@@ -7,6 +7,10 @@
   (function_expression)
   (function_declaration)
   (method_definition)
+  (for_statement)
+  (for_in_statement)
+  (catch_clause)
+  (finally_clause)
 ] @local.scope
 
 ; Definitions

--- a/runtime/queries/ecma/textobjects.scm
+++ b/runtime/queries/ecma/textobjects.scm
@@ -1,7 +1,7 @@
 (function_declaration
   body: (_) @function.inside) @function.around
 
-(function
+(function_expression
   body: (_) @function.inside) @function.around
 
 (arrow_function


### PR DESCRIPTION
i only updated to the latest 0.23 tree-sitter-javascript commit, as that is what tree-sitter-typescript [depends on currently](https://github.com/tree-sitter/tree-sitter-typescript/blob/75b3874edb2dc714fb1fd77a32013d0f8699989f/package.json#L38). this also adds the dedicated grammars for gjs, as that was removed from the javascript grammar.

notable changes:

- https://github.com/tree-sitter/tree-sitter-javascript/commit/84c57eeb0eb28046e72f08d77b4c00efc5819a24 renamed the `(function)` node to `(function_expression)`
- https://github.com/tree-sitter/tree-sitter-javascript/commit/a2ef0796e8b9db9107c9ad210b3121b8ad918d5e removed support for the gjs and gts templating languages in favor of dedicated grammars at https://github.com/ember-tooling/tree-sitter-glimmer-javascript/ and https://github.com/ember-tooling/tree-sitter-glimmer-typescript/

fixes #13462