### PR TITLE
kdl: add slashdash comments highlight support

### DIFF
--- a/runtime/queries/kdl/highlights.scm
+++ b/runtime/queries/kdl/highlights.scm
@@ -1,5 +1,15 @@
-(single_line_comment) @comment
-(multi_line_comment) @comment
+[
+    (single_line_comment)
+    (multi_line_comment)
+
+    (node_comment)
+    (node_field_comment)
+
+    ; these do not show up as comments in Helix as they are also highlighted as
+    ; normal nodes
+    (node . (node_comment))
+    (node_field . (node_field_comment))
+] @comment
 
 (node
     (identifier) @variable)


### PR DESCRIPTION
Adds KDL highlight support for slashdash `/-` node comments.

It matches `node_comment` and `node_field_comment`, which are the `/-` prefix tags as `comment`.
Further more, it captures nodes and node_fields that start which such a prefix as comments. However, testing it in Helix with `:ts-highlight-name` shows that while the nodes are correctly identified, they are still captured by other highlight names and keep their normal color.

I tried to play with injection queries, but it does not seem to be the solution here.

Thanks