### PR TITLE
TTOX Soft Theme

### DIFF
--- a/runtime/themes/ttox_soft.toml
+++ b/runtime/themes/ttox_soft.toml
@@ -13,6 +13,10 @@
 "ui.popup" = { fg = "white", bg = "black" }
 "ui.help" = { fg = "white", bg = "black" }
 "ui.virtual.ruler" = { underline = { style = "line" } }
+"ui.bufferline" = { fg = "white", bg = "black" }
+"ui.bufferline.active" = { fg = "black", bg = "white" }
+"ui.bufferline.background" = { bg = "black" }
+
 
 "string" = { fg = "light-green" }
 "constant" = { fg = "light-cyan" }


### PR DESCRIPTION
This theme is based on ttox. It moves the highlight from the background to the foreground and adds bufferline colors.

<img width="636" height="731" alt="Screenshot 2025-10-11 at 10 27 07 AM" src="https://github.com/user-attachments/assets/0f4d5d50-0854-4f1b-9d95-8699feae7df5" />
<img width="682" height="886" alt="Screenshot 2025-10-11 at 10 26 59 AM" src="https://github.com/user-attachments/assets/9b8ae614-43dc-4b40-9d5f-8119e4784849" />
