### PR TITLE
Add yarn.lock to languages

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1534,6 +1534,7 @@ file-types = [
   { glob = ".gem/credentials" },
   { glob = ".kube/config" },
   { glob = ".kube/kuberc" },
+  { glob = "yarn.lock" },
   "sublime-syntax"
 ]
 comment-token = "#"


### PR DESCRIPTION
In yarn 1, `yarn.lock` was yaml-like but since [yarn 2](https://yarnpkg.com/blog/release/2.0#new-lockfile-format) it's proper yaml