### PR TITLE
don't set the row position to the empty last line with the `+` cli arg

### DIFF
--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -264,12 +264,12 @@ pub fn pos_at_coords(text: RopeSlice, coords: Position, limit_before_line_ending
     if limit_before_line_ending {
         let lines = text.len_lines() - 1;
 
-        if lines > 0 && text.line(lines).len_chars() == 0 {
+        row = row.min(if crate::line_ending::get_line_ending(&text).is_some() {
             // if the last line is empty, don't jump to it
-            row = row.min(lines - 1);
+            lines - 1
         } else {
-            row = row.min(lines);
-        }
+            lines
+        });
     };
     let line_start = text.line_to_char(row);
     let line_end = if limit_before_line_ending {


### PR DESCRIPTION
slight followup to #14571, as the behaviour was already there previously but is more noticeable with that pr.

helix, like most editors, always keeps an empty line around at the end. currently doing `hx + <file>` moves the cursor to the very last line, the one that is empty and doesn't even have a line number (just a ~). this is annoying, as there is never anything on the last line and you always have to `k` one extra time to get to the content. with this pr it will no longer jump to the very last line, if that is empty.

this now also matches the behaviour of goto last line and of doing `:<number>`, where `<number>` is higher than the number of lines in the file.