### PR TITLE
Code folding

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -313,3 +313,5 @@
 | `goto_prev_tabstop` | Goto next snippet placeholder |  |
 | `rotate_selections_first` | Make the first selection your primary one |  |
 | `rotate_selections_last` | Make the last selection your primary one |  |
+| `fold` | Fold text objects | normal: `` Zf ``, `` zf ``, select: `` Zf ``, `` zf `` |
+| `unfold` | Unfold text objects | normal: `` ZF ``, `` zF ``, select: `` ZF ``, `` zF `` |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -88,4 +88,6 @@
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |
 | `:echo` | Prints the given arguments to the statusline. |
+| `:fold` | Fold text. |
+| `:unfold` | Unfold text. |
 | `:noop` | Does nothing. |

--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -932,6 +932,10 @@ impl<'a> Args<'a> {
         self.positionals.join(sep)
     }
 
+    pub fn contains(&self, arg: &str) -> bool {
+        self.positionals.contains(&Cow::Borrowed(arg))
+    }
+
     /// Returns an iterator over all positional arguments.
     pub fn iter(&self) -> slice::Iter<'_, Cow<'_, str>> {
         self.positionals.iter()

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod surround;
 pub mod syntax;
 pub mod test;
 pub mod text_annotations;
+pub mod text_folding;
 pub mod textobject;
 mod transaction;
 pub mod uri;

--- a/helix-core/src/search.rs
+++ b/helix-core/src/search.rs
@@ -1,67 +1,132 @@
-use crate::RopeSlice;
+use helix_stdx::rope::RopeSliceExt;
 
-// TODO: switch to std::str::Pattern when it is stable.
-pub trait CharMatcher {
-    fn char_match(&self, ch: char) -> bool;
+use crate::{
+    graphemes::{
+        nth_next_folded_grapheme_boundary, nth_next_grapheme_boundary,
+        nth_prev_folded_grapheme_boundary, nth_prev_grapheme_boundary,
+    },
+    text_folding::{ropex::RopeSliceFoldExt, FoldAnnotations},
+    RopeSlice,
+};
+
+pub trait GraphemeMatcher {
+    fn grapheme_match(&self, g: RopeSlice) -> bool;
 }
 
-impl CharMatcher for char {
-    fn char_match(&self, ch: char) -> bool {
-        *self == ch
+impl GraphemeMatcher for char {
+    fn grapheme_match(&self, g: RopeSlice) -> bool {
+        g == RopeSlice::from(self.encode_utf8(&mut [0; 4]) as &str)
     }
 }
 
-impl<F: Fn(&char) -> bool> CharMatcher for F {
-    fn char_match(&self, ch: char) -> bool {
-        (*self)(&ch)
+impl<F: Fn(RopeSlice) -> bool> GraphemeMatcher for F {
+    fn grapheme_match(&self, g: RopeSlice) -> bool {
+        (*self)(g)
     }
 }
 
-pub fn find_nth_next<M: CharMatcher>(
+pub fn find_nth_next(
     text: RopeSlice,
-    char_matcher: M,
-    mut pos: usize,
-    n: usize,
+    matcher: impl GraphemeMatcher,
+    pos: usize,
+    mut n: usize,
 ) -> Option<usize> {
-    if pos >= text.len_chars() || n == 0 {
+    if n == 0 {
         return None;
     }
 
-    let mut chars = text.chars_at(pos);
-
-    for _ in 0..n {
-        loop {
-            let c = chars.next()?;
-
-            pos += 1;
-
-            if char_matcher.char_match(c) {
+    let mut count = 0;
+    for (i, g) in text.graphemes_at(pos).skip(1).enumerate() {
+        if matcher.grapheme_match(g) {
+            count = i + 1;
+            n -= 1;
+            if n == 0 {
                 break;
             }
         }
     }
 
-    Some(pos - 1)
+    (n == 0).then(|| nth_next_grapheme_boundary(text, pos, count))
 }
 
-pub fn find_nth_prev(text: RopeSlice, ch: char, mut pos: usize, n: usize) -> Option<usize> {
-    if pos == 0 || n == 0 {
+pub fn find_nth_prev(
+    text: RopeSlice,
+    matcher: impl GraphemeMatcher,
+    pos: usize,
+    mut n: usize,
+) -> Option<usize> {
+    if n == 0 {
         return None;
     }
 
-    let mut chars = text.chars_at(pos);
-
-    for _ in 0..n {
-        loop {
-            let c = chars.prev()?;
-
-            pos -= 1;
-
-            if c == ch {
+    let mut count = 0;
+    for (i, g) in text.graphemes_at(pos).reversed().enumerate() {
+        if matcher.grapheme_match(g) {
+            count = i + 1;
+            n -= 1;
+            if n == 0 {
                 break;
             }
         }
     }
 
-    Some(pos)
+    (n == 0).then(|| (nth_prev_grapheme_boundary(text, pos, count)))
+}
+
+pub fn find_folded_nth_next(
+    text: RopeSlice,
+    annotations: &FoldAnnotations,
+    matcher: impl GraphemeMatcher,
+    pos: usize,
+    mut n: usize,
+) -> Option<usize> {
+    if n == 0 {
+        return None;
+    }
+
+    let mut count = 0;
+    for (i, g) in text
+        .folded_graphemes_at(annotations, text.char_to_byte(pos))
+        .skip(1)
+        .enumerate()
+    {
+        if matcher.grapheme_match(g) {
+            count = i + 1;
+            n -= 1;
+            if n == 0 {
+                break;
+            }
+        }
+    }
+
+    (n == 0).then(|| nth_next_folded_grapheme_boundary(text, annotations, pos, count))
+}
+
+pub fn find_folded_nth_prev(
+    text: RopeSlice,
+    annotations: &FoldAnnotations,
+    matcher: impl GraphemeMatcher,
+    pos: usize,
+    mut n: usize,
+) -> Option<usize> {
+    if n == 0 {
+        return None;
+    }
+
+    let mut count = 0;
+    for (i, g) in text
+        .folded_graphemes_at(annotations, text.char_to_byte(pos))
+        .reversed()
+        .enumerate()
+    {
+        if matcher.grapheme_match(g) {
+            count = i + 1;
+            n -= 1;
+            if n == 0 {
+                break;
+            }
+        }
+    }
+
+    (n == 0).then(|| nth_prev_folded_grapheme_boundary(text, annotations, pos, count))
 }

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -23,7 +23,8 @@ use tree_house::{
     query_iter::QueryIter,
     tree_sitter::{
         query::{InvalidPredicateError, UserPredicate},
-        Capture, Grammar, InactiveQueryCursor, InputEdit, Node, Pattern, Query, RopeInput, Tree,
+        Capture, Grammar, InactiveQueryCursor, InputEdit, Node, Pattern, Query, QueryCursor,
+        RopeInput, Tree,
     },
     Error, InjectionLanguageMarker, LanguageConfig as SyntaxConfig, Layer,
 };
@@ -1031,24 +1032,34 @@ impl TextObjectQuery {
         node: &Node<'a>,
         slice: RopeSlice<'a>,
     ) -> Option<impl Iterator<Item = CapturedNode<'a>>> {
-        let capture = capture_names
+        capture_names
             .iter()
-            .find_map(|cap| self.query.get_capture(cap))?;
+            .find_map(|cap| self.query.get_capture(cap))
+            .map(|capture| {
+                let mut cursor = self.cursor(node, slice);
+                iter::from_fn(move || {
+                    cursor
+                        .next_match()
+                        .map(|mat| mat.nodes_for_capture(capture).cloned().collect::<Vec<_>>())
+                })
+                .filter_map(|nodes| match nodes.len() {
+                    0 => None,
+                    1 => nodes.into_iter().map(CapturedNode::Single).next(),
+                    2.. => Some(CapturedNode::Grouped(nodes)),
+                })
+            })
+    }
 
-        let mut cursor = InactiveQueryCursor::new(0..u32::MAX, TREE_SITTER_MATCH_LIMIT)
-            .execute_query(&self.query, node, RopeInput::new(slice));
-        let capture_node = iter::from_fn(move || {
-            let (mat, _) = cursor.next_matched_node()?;
-            Some(mat.nodes_for_capture(capture).cloned().collect())
-        })
-        .filter_map(move |nodes: Vec<_>| {
-            if nodes.len() > 1 {
-                Some(CapturedNode::Grouped(nodes))
-            } else {
-                nodes.into_iter().map(CapturedNode::Single).next()
-            }
-        });
-        Some(capture_node)
+    pub fn cursor<'a>(
+        &'a self,
+        node: &Node<'a>,
+        slice: RopeSlice<'a>,
+    ) -> QueryCursor<'_, '_, RopeInput> {
+        InactiveQueryCursor::new(0..u32::MAX, TREE_SITTER_MATCH_LIMIT).execute_query(
+            &self.query,
+            node,
+            RopeInput::new(slice),
+        )
     }
 }
 
@@ -1367,5 +1378,31 @@ mod test {
             0,
             source.len(),
         );
+    }
+
+    #[test]
+    fn test_match_around_comment() {
+        let text = RopeSlice::from(
+            "fn f() {}\n\
+            // abc\n\
+            // def\n\
+            // ghi\n\
+            fn g() {}",
+        );
+
+        let lang = LOADER.language_for_name("rust").unwrap();
+        let syntax = Syntax::new(text, lang, &LOADER).unwrap();
+        let root_node = &syntax.tree().root_node();
+        let textobject_query = LOADER.textobject_query(lang).unwrap();
+
+        let result = textobject_query
+            .capture_nodes("comment.around", root_node, text)
+            .unwrap()
+            .next()
+            .map(|node| node.byte_range())
+            .unwrap();
+        let expected = 10..30;
+
+        assert_eq!(result, expected);
     }
 }

--- a/helix-core/src/text_folding.rs
+++ b/helix-core/src/text_folding.rs
@@ -89,6 +89,9 @@ use crate::Range;
 use crate::RopeSlice;
 use crate::Selection;
 
+pub use ropex::RopeSliceFoldExt;
+
+pub mod ropex;
 mod transaction;
 
 #[cfg(test)]

--- a/helix-core/src/text_folding.rs
+++ b/helix-core/src/text_folding.rs
@@ -1,0 +1,730 @@
+//! This module provides text folding primitives.
+//!
+//! A fold consists of the following components:
+//!
+//! 1. **`Object`** - a type of fold, which indicates how a user has folded the text.
+//!     For example, the object is **Selection** when a user has folded arbitrarily selected text.
+//!     And the object is **TextObject** when a user has folded a text object, such as a function, class, and so on.
+//!
+//! 2. **`Header`** - a fragment that describes what is folded.
+//!     For example, the header of a folded function is its signature.
+//!     Additionally, headers are used to unfold text.
+//!
+//! 3. **`Target`** - a fragment that defines the block that will be folded.
+//!     For example, for a function, the target is a span of the **function.inside** capture.
+//!
+//! 4. **`Block`** - a folded (non-visible) text. It is a range of lines.
+//!
+//! Look at the following code:
+//! ```
+//! fn f(a: u32) -> u32 {
+//!     a + a
+//! }
+//! ```
+//! Let's assume that a user has folded the `f` function,
+//! thus the new fold has been created with the following components:
+//!
+//! - **`Object`** is **TextObject** with the value **function**.
+//!
+//! - **`Header`** is the fragment **"fn f(a: u32) -> u32"**.
+//!
+//! - **`Target`** is the fragment that spans the **function.inside** capture.
+//!
+//! - **`Block`** is the range of lines from 2 through 3.
+//!
+//! The block spans only two lines.
+//! This is because the start line of the target has supplementary non-whitespace text.
+//! The block must contain only the text described by the header.
+//! In this case, that text is the function definition (textobject function.inside).
+//!
+//! Consider the additional example:
+//! ```
+//! fn f<T>(a: T) -> T
+//! where
+//!     T: std::ops::Add<Output = T> + Copy
+//! /* interfering comment*/ {
+//!     a + a
+//! } /* interfering comment */
+//!
+//! fn g<U>(b: U) -> U
+//! where
+//!     U: std::ops::Sub<Output = U> + Copy
+//! {
+//!     b - b
+//! }
+//! ```
+//! The `f` and `g` functions are also folded. Let the folds be called `F` and `G`, respectively.
+//! These folds differ in their blocks. Their blocks span one line and three lines, respectively.
+//! This is because the `F` fold target has supplementary comments at its boundary lines, but the `G` fold target does not.
+//! However, if a user removes the interfering comments the `F` fold block will be extended to three lines.
+//!
+//! The process of calculating a block is called **normalization**.
+//!
+//! Folds can be nested within others.
+//! ```
+//! trait T {
+//!     fn f() {
+//!         println!("hello world");
+//!     }
+//! }
+//! ```
+//! If trait `T` and function `f` are folded.
+//! Then, the fold of function `f` is nested in the fold of trait `T`.
+//! Folds that span other folds are called **super** folds.
+//! Folds that are not nested are called **superest** folds.
+
+use std::cmp::{max, min, Ordering};
+use std::fmt;
+use std::iter::once;
+use std::ops;
+
+use helix_stdx::rope::RopeSliceExt;
+
+use crate::graphemes::prev_grapheme_boundary;
+use crate::line_ending::line_end_byte_index;
+use crate::line_ending::line_end_char_index;
+use crate::line_ending::rope_is_line_ending;
+use crate::Range;
+use crate::RopeSlice;
+use crate::Selection;
+
+#[cfg(test)]
+pub(crate) mod test_utils;
+
+#[cfg(test)]
+mod test;
+
+/// A kind of fold.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FoldObject {
+    /// Indicates an arbitrary folded text
+    Selection,
+    /// Indicates a folded text of text object (class, function, etc.)
+    TextObject(&'static str),
+}
+
+impl fmt::Display for FoldObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Selection => write!(f, "something"),
+            Self::TextObject(textobject) => write!(f, "{textobject}"),
+        }
+    }
+}
+
+/// A start of fold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartFoldPoint {
+    pub object: FoldObject,
+
+    /// The first char of header.
+    pub header: usize,
+
+    /// The first char of target.
+    pub target: usize,
+
+    /// The first byte of block.
+    pub byte: usize,
+    /// The first char of block.
+    pub char: usize,
+    /// The first line of block.
+    pub line: usize,
+
+    /// An index of `EndFoldPoint` relating to the same fold.
+    link: usize,
+    /// An index of `StartFoldPoint` relating to the super fold.
+    super_link: Option<usize>,
+}
+
+impl StartFoldPoint {
+    /// Returns the fold.
+    pub fn fold<'a>(&'a self, container: &'a FoldContainer) -> Fold {
+        Fold::new(self, &container.end_points[self.link])
+    }
+
+    pub fn is_superest(&self) -> bool {
+        self.super_link.is_none()
+    }
+
+    fn from(text: RopeSlice, object: FoldObject, header: usize, target: usize) -> Self {
+        let mut result = Self {
+            object,
+            header,
+            target,
+            byte: 0,
+            char: 0,
+            line: 0,
+            link: 0,
+            super_link: None,
+        };
+        result.set_block(text, result.block_line(text));
+        result
+    }
+
+    /// Returns the first line of the block.
+    fn block_line(&self, text: RopeSlice) -> usize {
+        let truncate = text
+            .graphemes_at(text.char_to_byte(self.target))
+            .reversed()
+            .take_while(|&g| !rope_is_line_ending(g))
+            .flat_map(|g| g.chars())
+            .any(|c| !c.is_whitespace());
+
+        text.char_to_line(self.target) + truncate as usize
+    }
+
+    /// Sets `byte`, `char`, `line` fields.
+    fn set_block(&mut self, text: RopeSlice, line: usize) {
+        self.byte = text.line_to_byte(line);
+        self.char = text.line_to_char(line);
+        self.line = line;
+    }
+}
+
+/// An end of fold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndFoldPoint {
+    /// The last char of target.
+    pub target: usize,
+
+    /// The last grapheme aligned byte of block
+    pub byte: usize,
+    /// The last grapheme aligned char of blcok.
+    pub char: usize,
+    /// The last line of block.
+    pub line: usize,
+
+    /// An index of `StartFoldPoint` of the same fold.
+    link: usize,
+}
+
+impl EndFoldPoint {
+    /// Returns the fold.
+    pub fn fold<'a>(&'a self, container: &'a FoldContainer) -> Fold {
+        Fold::new(&container.start_points[self.link], self)
+    }
+
+    fn from(text: RopeSlice, target: usize) -> Self {
+        let mut result = Self {
+            target,
+            byte: 0,
+            char: 0,
+            line: 0,
+            link: 0,
+        };
+        result.set_block(text, result.block_line(text));
+        result
+    }
+
+    /// Returns the last line of the block.
+    fn block_line(&self, text: RopeSlice) -> usize {
+        let truncate = text
+            .graphemes_at(text.char_to_byte(self.target))
+            .skip({
+                let end_char = line_end_char_index(&text, text.char_to_line(self.target));
+                (self.target != end_char) as usize
+            })
+            .take_while(|&g| !rope_is_line_ending(g))
+            .flat_map(|g| g.chars())
+            .any(|c| !c.is_whitespace());
+
+        text.char_to_line(self.target) - truncate as usize
+    }
+
+    /// Sets `byte`, `char`, `line` fields.
+    fn set_block(&mut self, text: RopeSlice, line: usize) {
+        self.byte = line_end_byte_index(&text, line);
+        self.char = line_end_char_index(&text, line);
+        self.line = line;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fold<'a> {
+    pub start: &'a StartFoldPoint,
+    pub end: &'a EndFoldPoint,
+}
+
+impl<'a> Fold<'a> {
+    /// Creates a pair of fold points.
+    pub fn new_points(
+        text: RopeSlice,
+        object: FoldObject,
+        header: usize,
+        target: &ops::RangeInclusive<usize>,
+    ) -> (StartFoldPoint, EndFoldPoint) {
+        (
+            StartFoldPoint::from(text, object, header, *target.start()),
+            EndFoldPoint::from(text, *target.end()),
+        )
+    }
+
+    pub fn new(start: &'a StartFoldPoint, end: &'a EndFoldPoint) -> Self {
+        Self { start, end }
+    }
+
+    pub fn object(self) -> &'a FoldObject {
+        &self.start.object
+    }
+
+    pub fn header(self) -> usize {
+        self.start.header
+    }
+
+    pub fn is_superest(self) -> bool {
+        self.start.super_link.is_none()
+    }
+
+    pub fn super_fold(self, container: &'a FoldContainer) -> Option<Self> {
+        self.start
+            .super_link
+            .map(|idx| container.start_points[idx].fold(container))
+    }
+
+    pub fn superest_fold(self, container: &'a FoldContainer) -> Option<Self> {
+        self.super_fold(container)
+            .map(|super_fold| super_fold.superest_fold(container).unwrap_or(super_fold))
+    }
+
+    /// Returns the index of the start fold point.
+    pub fn start_idx(self) -> usize {
+        self.end.link
+    }
+
+    /// Returns the index of the end fold point.
+    pub fn end_idx(self) -> usize {
+        self.start.link
+    }
+}
+
+/// A fold manager.
+/// All folds of `View` are contained in it.
+#[derive(Debug, Default, Clone)]
+pub struct FoldContainer {
+    start_points: Vec<StartFoldPoint>,
+    end_points: Vec<EndFoldPoint>,
+}
+
+impl FoldContainer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start_points.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.start_points.len()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.start_points.reserve(additional);
+        self.end_points.reserve(additional);
+    }
+
+    pub fn clear(&mut self) {
+        self.start_points.clear();
+        self.end_points.clear();
+    }
+
+    pub fn from(text: RopeSlice, points: Vec<(StartFoldPoint, EndFoldPoint)>) -> Self {
+        let mut ret = Self::new();
+        ret.add(text, points);
+        ret
+    }
+
+    /// Adds new folds to the container.
+    pub fn add(&mut self, text: RopeSlice, points: Vec<(StartFoldPoint, EndFoldPoint)>) {
+        self.reserve(points.len());
+
+        for (mut sfp, mut efp) in points.into_iter() {
+            sfp.link = self.len();
+            efp.link = self.len();
+            self.start_points.push(sfp);
+            self.end_points.push(efp);
+        }
+
+        self.sort_start_points();
+
+        let deletables = self.normalize(text);
+        self.delete(deletables);
+
+        self.sort_end_points();
+        self.set_super_links();
+    }
+
+    /// Adds new folds to the container and removes existing ones that overlap them.
+    pub fn replace(&mut self, text: RopeSlice, mut points: Vec<(StartFoldPoint, EndFoldPoint)>) {
+        // `true` if `f1` overlaps with `f2`
+        let overlap = |f1: Fold, f2: Fold| {
+            let range = |fold: Fold| {
+                let start = text.char_to_line(fold.start.header);
+                let end = text.char_to_line(fold.end.target);
+                start..=end
+            };
+
+            let r1 = range(f1);
+            let r2 = range(f2);
+
+            let start = max(*r1.start(), *r2.start());
+            let end = min(*r1.end(), *r2.end());
+
+            !(start..=end).is_empty()
+        };
+
+        for (sfp, efp) in points.iter_mut() {
+            let replacement = Fold::new(sfp, efp);
+
+            // collect folds that overlap with replacement
+            let overlappables: Vec<_> = self
+                .start_points
+                .iter()
+                .map(|sfp| sfp.fold(self))
+                .filter_map(|fold| overlap(fold, replacement).then_some(fold.start_idx()))
+                .collect();
+
+            // extend replacement
+            if let Some(fold) = overlappables
+                .last()
+                .map(|&i| self.start_points[i].fold(self))
+            {
+                efp.target = max(efp.target, fold.end.target);
+            }
+
+            self.remove(text, overlappables);
+        }
+
+        self.add(text, points);
+    }
+
+    /// Removes folds from the container for the passed `start_indices`.
+    /// # Invariant
+    /// Start indices must be sorted and unique.
+    pub fn remove(&mut self, text: RopeSlice, start_indices: Vec<usize>) {
+        self.delete(start_indices);
+
+        let removables = self.normalize(text);
+        self.delete(removables);
+
+        self.sort_end_points();
+        self.set_super_links();
+    }
+
+    /// Removes folds that contain the anchor or the head of a selection.
+    pub fn remove_by_selection(&mut self, text: RopeSlice, selection: &Selection) {
+        let mut removables: Vec<_> = selection
+            .iter()
+            .flat_map(|range| {
+                let (start, end) = range.line_range(text);
+                once(start).chain((start != end).then_some(end))
+            })
+            .filter_map(|line| {
+                // the range of folds that potentially contain `line`
+                let range = {
+                    let start = {
+                        let start_fold = self
+                            .end_points
+                            .get(self.end_points.partition_point(|efp| efp.line < line))
+                            .map(|efp| efp.fold(self))?;
+                        start_fold
+                            .superest_fold(self)
+                            .unwrap_or(start_fold)
+                            .start_idx()
+                    };
+                    let end =
+                        start + self.start_points[start..].partition_point(|sfp| sfp.line <= line);
+
+                    start..end
+                };
+
+                let self_ref = &*self;
+                Some(self_ref.start_points[range].iter().filter_map(move |sfp| {
+                    let fold = sfp.fold(self_ref);
+                    let block = fold.start.line..=fold.end.line;
+                    block.contains(&line).then_some(fold.start_idx())
+                }))
+            })
+            .flatten()
+            .collect();
+
+        removables.sort();
+        removables.dedup();
+
+        self.remove(text, removables);
+    }
+
+    /// Moves the left side of `range` to the start of the header if it is contained in the fold.
+    /// Moves the right side of `range` to the end of the header if it is contained in the fold.
+    pub fn throw_range_out_of_folds(&self, text: RopeSlice, range: Range) -> Range {
+        let block = |fold: Fold| fold.start.char..=fold.end.char;
+
+        let from = self
+            .superest_fold_containing(range.from(), block)
+            .map(|fold| fold.start.header);
+
+        let to = self
+            .superest_fold_containing(
+                if range.is_empty() {
+                    range.to()
+                } else {
+                    prev_grapheme_boundary(text, range.to())
+                },
+                block,
+            )
+            .map(|fold| match fold.start.char.cmp(&fold.start.target) {
+                Ordering::Greater => fold.start.target,
+                _ => fold.start.char,
+            });
+
+        Range::new(from.unwrap_or(range.from()), to.unwrap_or(range.to()))
+            .with_direction(range.direction())
+    }
+
+    /// Finds fold.
+    pub fn find(
+        &self,
+        object: &FoldObject,
+        range: &ops::RangeInclusive<usize>,
+        mut get_range: impl FnMut(Fold) -> ops::RangeInclusive<usize>,
+    ) -> Option<Fold> {
+        self.start_points
+            .binary_search_by(|sfp| {
+                let fold_range = get_range(sfp.fold(self));
+                fold_range
+                    .start()
+                    .cmp(range.start())
+                    .then(fold_range.end().cmp(range.end()).reverse())
+                    .then(sfp.object.cmp(object))
+            })
+            .map(|idx| self.start_points[idx].fold(self))
+            .ok()
+    }
+
+    pub fn start_points_in_range(
+        &self,
+        range: &ops::RangeInclusive<usize>,
+        mut get_idx: impl FnMut(&StartFoldPoint) -> usize,
+    ) -> &[StartFoldPoint] {
+        let start = self
+            .start_points
+            .partition_point(|sfp| get_idx(sfp) < *range.start());
+
+        let Some(start_points) = self.start_points.get(start..) else {
+            return &[];
+        };
+
+        let end = start + start_points.partition_point(|sfp| get_idx(sfp) <= *range.end());
+
+        &self.start_points[start..end]
+    }
+
+    pub fn fold_containing(
+        &self,
+        idx: usize,
+        mut get_range: impl FnMut(Fold) -> ops::RangeInclusive<usize>,
+    ) -> Option<Fold> {
+        let end_idx = self.end_points.partition_point(|efp| {
+            let range = get_range(efp.fold(self));
+            *range.end() < idx
+        });
+
+        let mut fold = self.end_points.get(end_idx)?.fold(self);
+        while !get_range(fold).contains(&idx) {
+            fold = match fold.super_fold(self) {
+                Some(fold) => fold,
+                None => return None,
+            }
+        }
+
+        Some(fold)
+    }
+
+    pub fn superest_fold_containing(
+        &self,
+        idx: usize,
+        get_range: impl FnMut(Fold) -> ops::RangeInclusive<usize>,
+    ) -> Option<Fold> {
+        self.fold_containing(idx, get_range)
+            .map(|fold| fold.superest_fold(self).unwrap_or(fold))
+    }
+
+    pub fn start_points(&self) -> &[StartFoldPoint] {
+        &self.start_points
+    }
+}
+
+impl FoldContainer {
+    fn sort_start_points(&mut self) {
+        self.start_points.sort_by(|sfp1, sfp2| {
+            let efp1 = &self.end_points[sfp1.link];
+            let efp2 = &self.end_points[sfp2.link];
+            sfp1.target
+                .cmp(&sfp2.target)
+                .then(efp1.target.cmp(&efp2.target).reverse())
+                .then(sfp1.object.cmp(&sfp2.object))
+                .then_with(|| unreachable!("Unexpected doubles."))
+        });
+
+        for (i, sfp) in self.start_points.iter().enumerate() {
+            self.end_points[sfp.link].link = i;
+        }
+    }
+
+    fn sort_end_points(&mut self) {
+        self.end_points.sort_by(|efp1, efp2| {
+            efp1.target
+                .cmp(&efp2.target)
+                .then(efp1.link.cmp(&efp2.link).reverse())
+                .then_with(|| unreachable!("Unexpected doubles."))
+        });
+
+        for (i, efp) in self.end_points.iter().enumerate() {
+            self.start_points[efp.link].link = i;
+        }
+    }
+
+    /// Normalizes folds and returns start indices of folds to remove.
+    ///
+    /// # Invariant
+    /// Returned folds must be removed.
+    fn normalize(&mut self, text: RopeSlice) -> Vec<usize> {
+        let range = |fold: Fold| {
+            let start = fold.header();
+            let end = fold.end.target;
+            start..=end
+        };
+
+        // Returns `true` if `r1` and `r2` overlap
+        let overlap = |r1: &ops::RangeInclusive<_>, r2: &ops::RangeInclusive<_>| {
+            let start = max(*r1.start(), *r2.start());
+            let end = min(*r1.end(), *r2.end());
+
+            !(start..=end).is_empty()
+        };
+
+        // Returns `true` if `r1` spans `r2`
+        let span = |r1: &ops::RangeInclusive<_>, r2: &ops::RangeInclusive<_>| {
+            let start = max(*r1.start(), *r2.start());
+            let end = min(*r1.end(), *r2.end());
+
+            (start..=end) == *r2
+        };
+
+        let mut removables = Vec::new();
+        for i in 0..self.len() {
+            let fold = self.start_points[i].fold(self);
+
+            // get the start line of the block
+            let block_start = {
+                let init = fold.start.block_line(text);
+                self.start_points
+                    .iter()
+                    .take(i)
+                    .rev()
+                    .map(|sfp| sfp.fold(self))
+                    .take_while(|&prev_fold| prev_fold.end.line == init - 1)
+                    .find_map(|prev_fold| {
+                        (!removables.contains(&prev_fold.start_idx())).then_some(init + 1)
+                    })
+                    .unwrap_or(init)
+            };
+
+            // if the subsequent fold that overlaps with the current fold is found,
+            // then add the current fold to removables
+            if self
+                .start_points
+                .iter()
+                .skip(i + 1)
+                .map(|next_sfp| next_sfp.fold(self))
+                .take_while(|&next_fold| overlap(&range(fold), &range(next_fold)))
+                .find_map(|next_fold| {
+                    let fold_range = &range(fold);
+                    let next_fold_range = &range(fold);
+
+                    (!span(fold_range, next_fold_range) && !span(next_fold_range, fold_range))
+                        .then(|| text.char_to_line(next_fold.header()) - 1)
+                })
+                .is_some()
+            {
+                removables.push(i);
+                continue;
+            }
+
+            let block_end = fold.end.block_line(text);
+
+            if block_start > block_end {
+                removables.push(i);
+                continue;
+            }
+
+            let sfp = &mut self.start_points[i];
+            let efp = &mut self.end_points[sfp.link];
+
+            sfp.set_block(text, block_start);
+            efp.set_block(text, block_end);
+        }
+
+        removables
+    }
+
+    // Sets hierarchy of folds.
+    fn set_super_links(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+        let full_range = 0..=self.len() - 1;
+        self.set_super_links_impl(&full_range, None, 0);
+    }
+
+    fn set_super_links_impl(
+        &mut self,
+        range: &ops::RangeInclusive<usize>,
+        super_link: Option<usize>,
+        nesting: usize,
+    ) {
+        let mut idx = *range.start();
+        while idx <= *range.end() {
+            self.start_points[idx].super_link = super_link;
+            if idx == *range.end() {
+                return;
+            }
+
+            let nested_range = {
+                let fold = self.start_points[idx].fold(self);
+                let start = fold.start_idx() + 1;
+                let end = min(*range.end(), fold.end_idx() + nesting);
+                start..=end
+            };
+
+            if nested_range.is_empty() {
+                idx += 1;
+            } else {
+                self.set_super_links_impl(&nested_range, Some(idx), nesting + 1);
+                idx = *nested_range.end() + 1;
+            }
+        }
+    }
+
+    /// Just deletes folds at `start_indices`
+    /// # Attention
+    /// It is service method.
+    /// It is probably not the method you want to use; see `remove` method.
+    fn delete(&mut self, start_indices: Vec<usize>) {
+        for start_idx in start_indices.into_iter().rev() {
+            let end_idx = self.start_points[start_idx].link;
+
+            // remove start point
+            self.start_points.remove(start_idx);
+            for sfp in self.start_points.iter().skip(start_idx) {
+                self.end_points[sfp.link].link -= 1;
+            }
+
+            // remove end point
+            self.end_points.remove(end_idx);
+            for efp in self.end_points.iter().skip(end_idx) {
+                self.start_points[efp.link].link -= 1;
+            }
+        }
+    }
+}

--- a/helix-core/src/text_folding.rs
+++ b/helix-core/src/text_folding.rs
@@ -88,6 +88,8 @@ use crate::Range;
 use crate::RopeSlice;
 use crate::Selection;
 
+mod transaction;
+
 #[cfg(test)]
 pub(crate) mod test_utils;
 

--- a/helix-core/src/text_folding/ropex.rs
+++ b/helix-core/src/text_folding/ropex.rs
@@ -1,0 +1,526 @@
+//! Implements fold-oriented methods for `RopeSlice`.
+
+use crate::ropey::iter::{Chars, Lines};
+use crate::RopeSlice;
+
+use helix_stdx::rope::{RopeGraphemes, RopeSliceExt};
+
+use super::FoldAnnotations;
+
+pub trait RopeSliceFoldExt<'a> {
+    /// Similar to the native `chars` method.
+    fn folded_chars(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedChars<'a>;
+
+    /// Similar to the extended `graphemes` method in the `RopeSliceExt` trait.
+    fn folded_graphemes(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedGraphemes<'a>;
+
+    /// Similar to the native `lines` method.
+    fn folded_lines(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedLines<'a>;
+
+    /// Similar to the native `chars_at` method.
+    fn folded_chars_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+    ) -> FoldedChars<'a>;
+
+    /// Similar to the extended `graphemes_at` method in the `RopeSliceExt` trait.
+    fn folded_graphemes_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+    ) -> FoldedGraphemes<'a>;
+
+    /// Similar to the native `lines_at` method.
+    fn folded_lines_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+    ) -> FoldedLines<'a>;
+
+    fn next_folded_char(&self, annotations: &'a FoldAnnotations<'a>, char_idx: usize) -> usize;
+    fn next_folded_grapheme(&self, annotations: &'a FoldAnnotations<'a>, byte_idx: usize) -> usize;
+    fn next_folded_line(&self, annotations: &'a FoldAnnotations<'a>, line_idx: usize) -> usize;
+    fn prev_folded_char(&self, annotations: &'a FoldAnnotations<'a>, char_idx: usize) -> usize;
+    fn prev_folded_grapheme(&self, annotations: &'a FoldAnnotations<'a>, byte_idx: usize) -> usize;
+    fn prev_folded_line(&self, annotations: &'a FoldAnnotations<'a>, line_idx: usize) -> usize;
+    fn nth_next_folded_char(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+        count: usize,
+    ) -> usize;
+    fn nth_next_folded_grapheme(
+        &self,
+        annotatins: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+        count: usize,
+    ) -> usize;
+    fn nth_next_folded_line(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+        count: usize,
+    ) -> usize;
+    fn nth_prev_folded_char(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+        count: usize,
+    ) -> usize;
+    fn nth_prev_folded_grapheme(
+        &self,
+        annotatins: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+        count: usize,
+    ) -> usize;
+    fn nth_prev_folded_line(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+        count: usize,
+    ) -> usize;
+}
+
+impl<'a> RopeSliceFoldExt<'a> for RopeSlice<'a> {
+    fn folded_chars(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedChars<'a> {
+        FoldedChars {
+            inner: FoldedTextItems::new(*self, annotations, 0),
+        }
+    }
+
+    fn folded_graphemes(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedGraphemes<'a> {
+        FoldedGraphemes {
+            inner: FoldedTextItems::new(*self, annotations, 0),
+        }
+    }
+
+    fn folded_lines(&self, annotations: &'a FoldAnnotations<'a>) -> FoldedLines<'a> {
+        FoldedLines {
+            inner: FoldedTextItems::new(*self, annotations, 0),
+        }
+    }
+
+    fn folded_chars_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+    ) -> FoldedChars<'a> {
+        FoldedChars {
+            inner: FoldedTextItems::new(*self, annotations, char_idx),
+        }
+    }
+
+    fn folded_graphemes_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+    ) -> FoldedGraphemes<'a> {
+        FoldedGraphemes {
+            inner: FoldedTextItems::new(*self, annotations, byte_idx),
+        }
+    }
+
+    fn folded_lines_at(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+    ) -> FoldedLines<'a> {
+        FoldedLines {
+            inner: FoldedTextItems::new(*self, annotations, line_idx),
+        }
+    }
+
+    fn next_folded_char(&self, annotations: &'a FoldAnnotations<'a>, char_idx: usize) -> usize {
+        self.nth_next_folded_char(annotations, char_idx, 1)
+    }
+
+    fn next_folded_grapheme(&self, annotations: &'a FoldAnnotations<'a>, byte_idx: usize) -> usize {
+        self.nth_next_folded_grapheme(annotations, byte_idx, 1)
+    }
+
+    fn next_folded_line(&self, annotations: &'a FoldAnnotations<'a>, line_idx: usize) -> usize {
+        self.nth_next_folded_line(annotations, line_idx, 1)
+    }
+
+    fn prev_folded_char(&self, annotations: &'a FoldAnnotations<'a>, char_idx: usize) -> usize {
+        self.nth_prev_folded_char(annotations, char_idx, 1)
+    }
+
+    fn prev_folded_grapheme(&self, annotations: &'a FoldAnnotations<'a>, byte_idx: usize) -> usize {
+        self.nth_prev_folded_grapheme(annotations, byte_idx, 1)
+    }
+
+    fn prev_folded_line(&self, annotations: &'a FoldAnnotations<'a>, line_idx: usize) -> usize {
+        self.nth_prev_folded_line(annotations, line_idx, 1)
+    }
+
+    fn nth_next_folded_char(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+        mut count: usize,
+    ) -> usize {
+        if count == 0 {
+            return char_idx;
+        }
+
+        let mut chars = self.folded_chars_at(annotations, char_idx);
+
+        // consume the initial char
+        chars.next();
+
+        // the initial char can be folded
+        if chars.last_idx().unwrap_or(self.len_chars()) != char_idx {
+            count -= 1;
+        }
+
+        chars.by_ref().take(count).for_each(|_| ());
+        chars
+            .last_idx()
+            .unwrap_or(self.len_chars().saturating_sub(1))
+    }
+
+    fn nth_next_folded_grapheme(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+        mut count: usize,
+    ) -> usize {
+        if count == 0 {
+            return byte_idx;
+        }
+
+        let mut graphemes = self.folded_graphemes_at(annotations, byte_idx);
+
+        // consume the initial grapheme
+        graphemes.next();
+
+        // the initial grapheme can be folded
+        if graphemes.last_idx().unwrap_or(self.len_bytes()) != byte_idx {
+            count -= 1;
+        }
+
+        graphemes.by_ref().take(count).for_each(|_| ());
+        graphemes
+            .last_idx()
+            .unwrap_or(self.len_bytes().saturating_sub(1))
+    }
+
+    fn nth_next_folded_line(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+        mut count: usize,
+    ) -> usize {
+        if count == 0 {
+            return line_idx;
+        }
+
+        let mut lines = self.folded_lines_at(annotations, line_idx);
+
+        // consume the initial line
+        lines.next();
+
+        // the initial line can be folded
+        if lines.last_idx().unwrap_or(self.len_lines()) != line_idx {
+            count -= 1;
+        }
+
+        lines.by_ref().take(count).for_each(|_| ());
+        lines
+            .last_idx()
+            .unwrap_or(self.len_lines().saturating_sub(1))
+    }
+
+    fn nth_prev_folded_char(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        char_idx: usize,
+        count: usize,
+    ) -> usize {
+        if count == 0 {
+            return char_idx;
+        }
+
+        let mut chars = self.folded_chars_at(annotations, char_idx).reversed();
+
+        chars.by_ref().take(count).for_each(|_| ());
+        chars.last_idx().unwrap_or(0)
+    }
+
+    fn nth_prev_folded_grapheme(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        byte_idx: usize,
+        count: usize,
+    ) -> usize {
+        if count == 0 {
+            return byte_idx;
+        }
+
+        let mut graphemes = self.folded_graphemes_at(annotations, byte_idx).reversed();
+
+        graphemes.by_ref().take(count).for_each(|_| ());
+        graphemes.last_idx().unwrap_or(0)
+    }
+
+    fn nth_prev_folded_line(
+        &self,
+        annotations: &'a FoldAnnotations<'a>,
+        line_idx: usize,
+        count: usize,
+    ) -> usize {
+        if count == 0 {
+            return line_idx;
+        }
+
+        let mut lines = self.folded_lines_at(annotations, line_idx).reversed();
+
+        lines.by_ref().take(count).for_each(|_| ());
+        lines.last_idx().unwrap_or(0)
+    }
+}
+
+macro_rules! FoldedWrapper {
+    ($Name:ident, $TextItems:ident) => {
+        pub struct $Name<'a> {
+            inner: FoldedTextItems<'a, $TextItems<'a>>,
+        }
+
+        impl<'a> $Name<'a> {
+            pub fn reverse(&mut self) {
+                self.inner.is_reversed = !self.inner.is_reversed;
+            }
+
+            pub fn reversed(mut self) -> Self {
+                self.reverse();
+                self
+            }
+
+            pub fn prev(&mut self) -> Option<<Self as Iterator>::Item> {
+                self.inner.prev()
+            }
+
+            pub fn last_idx(&self) -> Option<usize> {
+                self.inner.last_idx
+            }
+        }
+
+        impl<'a> Iterator for $Name<'a> {
+            type Item = <$TextItems<'a> as Iterator>::Item;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.inner.next()
+            }
+        }
+    };
+}
+
+FoldedWrapper!(FoldedChars, Chars);
+FoldedWrapper!(FoldedGraphemes, RopeGraphemes);
+FoldedWrapper!(FoldedLines, Lines);
+
+struct FoldedTextItems<'a, Items> {
+    items: Items,
+    slice: RopeSlice<'a>,
+    annotations: &'a FoldAnnotations<'a>,
+    idx: usize,
+    last_idx: Option<usize>,
+    is_reversed: bool,
+}
+
+impl<'a, Items: TextItems<'a>> FoldedTextItems<'a, Items> {
+    fn new(slice: RopeSlice<'a>, annotations: &'a FoldAnnotations<'a>, idx: usize) -> Self {
+        Items::reset_pos(annotations, idx);
+        Self {
+            items: Items::at(slice, idx),
+            slice,
+            annotations,
+            idx,
+            last_idx: None,
+            is_reversed: false,
+        }
+    }
+
+    #[inline(always)]
+    fn prev(&mut self) -> Option<Items::Item> {
+        if !self.is_reversed {
+            self.prev_impl()
+        } else {
+            self.next_impl()
+        }
+    }
+
+    fn prev_impl(&mut self) -> Option<Items::Item> {
+        if self.idx == 0 {
+            self.last_idx = None;
+            return None;
+        }
+
+        self.idx -= 1;
+        if let Some(position) = Items::consume_prev(self.annotations, self.idx) {
+            self.idx = position;
+            self.items = Items::at(self.slice, self.idx);
+
+            return self.prev_impl();
+        }
+
+        self.last_idx = Some(self.idx);
+
+        Some(
+            self.items
+                .prev_impl()
+                .expect("The `idx` field must equal the item index."),
+        )
+    }
+
+    fn next_impl(&mut self) -> Option<Items::Item> {
+        if self.idx == Items::len(self.slice) {
+            self.last_idx = None;
+            return None;
+        }
+
+        if let Some(position) = Items::consume_next(self.annotations, self.idx) {
+            self.idx = position + 1;
+            self.items = Items::at(self.slice, self.idx);
+
+            return self.next_impl();
+        }
+
+        self.last_idx = Some(self.idx);
+
+        let result = self
+            .items
+            .next_impl()
+            .expect("The `idx` field must equal the item index.");
+        self.idx += 1;
+
+        Some(result)
+    }
+}
+
+impl<'a, Items: TextItems<'a>> Iterator for FoldedTextItems<'a, Items> {
+    type Item = Items::Item;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.is_reversed {
+            self.next_impl()
+        } else {
+            self.prev_impl()
+        }
+    }
+}
+
+trait TextItems<'a>: Iterator {
+    fn at(slice: RopeSlice<'a>, idx: usize) -> Self;
+    fn reset_pos(annotations: &FoldAnnotations, idx: usize);
+    fn len(slice: RopeSlice) -> usize;
+    fn prev_impl(&mut self) -> Option<Self::Item>;
+    fn next_impl(&mut self) -> Option<Self::Item>;
+    fn consume_prev(annotations: &FoldAnnotations, idx: usize) -> Option<usize>;
+    fn consume_next(annotations: &FoldAnnotations, idx: usize) -> Option<usize>;
+}
+
+impl<'a> TextItems<'a> for Chars<'a> {
+    fn at(slice: RopeSlice<'a>, char_idx: usize) -> Self {
+        slice.chars_at(char_idx)
+    }
+
+    fn reset_pos(annotations: &FoldAnnotations, char_idx: usize) {
+        annotations.reset_pos(char_idx, |fold| fold.start.char)
+    }
+
+    fn len(slice: RopeSlice) -> usize {
+        slice.len_chars()
+    }
+
+    fn prev_impl(&mut self) -> Option<Self::Item> {
+        self.prev()
+    }
+
+    fn next_impl(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+
+    fn consume_prev(annotations: &FoldAnnotations, char_idx: usize) -> Option<usize> {
+        annotations
+            .consume_prev(char_idx, |fold| fold.end.char)
+            .map(|fold| fold.start.char)
+    }
+
+    fn consume_next(annotations: &FoldAnnotations, char_idx: usize) -> Option<usize> {
+        annotations
+            .consume_next(char_idx, |fold| fold.start.char)
+            .map(|fold| fold.end.char)
+    }
+}
+
+impl<'a> TextItems<'a> for RopeGraphemes<'a> {
+    fn at(slice: RopeSlice<'a>, byte_idx: usize) -> Self {
+        slice.graphemes_at(byte_idx)
+    }
+
+    fn reset_pos(annotations: &FoldAnnotations, byte_idx: usize) {
+        annotations.reset_pos(byte_idx, |fold| fold.start.byte)
+    }
+
+    fn len(slice: RopeSlice) -> usize {
+        slice.len_bytes()
+    }
+
+    fn prev_impl(&mut self) -> Option<Self::Item> {
+        self.prev()
+    }
+
+    fn next_impl(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+
+    fn consume_prev(annotations: &FoldAnnotations, byte_idx: usize) -> Option<usize> {
+        annotations
+            .consume_prev(byte_idx, |fold| fold.end.byte)
+            .map(|fold| fold.start.byte)
+    }
+
+    fn consume_next(annotations: &FoldAnnotations, byte_idx: usize) -> Option<usize> {
+        annotations
+            .consume_next(byte_idx, |fold| fold.start.byte)
+            .map(|fold| fold.end.byte)
+    }
+}
+
+impl<'a> TextItems<'a> for Lines<'a> {
+    fn at(slice: RopeSlice<'a>, line_idx: usize) -> Self {
+        slice.lines_at(line_idx)
+    }
+
+    fn reset_pos(annotations: &FoldAnnotations, line_idx: usize) {
+        annotations.reset_pos(line_idx, |fold| fold.start.line)
+    }
+
+    fn len(slice: RopeSlice) -> usize {
+        slice.len_lines()
+    }
+
+    fn prev_impl(&mut self) -> Option<Self::Item> {
+        self.prev()
+    }
+
+    fn next_impl(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+
+    fn consume_prev(annotations: &FoldAnnotations, line_idx: usize) -> Option<usize> {
+        annotations
+            .consume_prev(line_idx, |fold| fold.end.line)
+            .map(|fold| fold.start.line)
+    }
+
+    fn consume_next(annotations: &FoldAnnotations, line_idx: usize) -> Option<usize> {
+        annotations
+            .consume_next(line_idx, |fold| fold.start.line)
+            .map(|fold| fold.end.line)
+    }
+}

--- a/helix-core/src/text_folding/test.rs
+++ b/helix-core/src/text_folding/test.rs
@@ -276,6 +276,31 @@ fn fold_container_superest_fold_containing() {
 }
 
 #[test]
+fn fold_annotations_folded_lines_between() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+    let annotations = FoldAnnotations::new(Some(container));
+
+    // line range, expected
+    let cases = [
+        (0..=0, 0),
+        (3..=3, 0),
+        (0..=3, 1),
+        (0..=5, 2),
+        (5..=7, 0),
+        (5..=30, 22),
+        (30..=31, 0),
+        (30..=51, 13),
+        (51..=51, 0),
+        (62..=79, 5),
+    ];
+
+    for (case_idx, (line_range, expected)) in cases.into_iter().enumerate() {
+        let result = annotations.folded_lines_between(&line_range);
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}
+
+#[test]
 fn fold_container_update_by_transaction() {
     use crate::Rope;
     use crate::Transaction;

--- a/helix-core/src/text_folding/test.rs
+++ b/helix-core/src/text_folding/test.rs
@@ -3,9 +3,14 @@ use crate::graphemes::next_grapheme_boundary;
 use super::*;
 
 use test_utils::new_fold_points;
-use test_utils::TEXT_SAMPLE;
 use test_utils::{fold_points, fold_points_filtered_by};
 use test_utils::{folds_eq, folds_eq_by};
+use test_utils::{FOLDED_TEXT_SAMPLE, TEXT_SAMPLE};
+
+#[test]
+fn fold_text() {
+    _ = *FOLDED_TEXT_SAMPLE;
+}
 
 #[test]
 fn fold_container_from() {

--- a/helix-core/src/text_folding/test.rs
+++ b/helix-core/src/text_folding/test.rs
@@ -1,0 +1,276 @@
+use crate::graphemes::next_grapheme_boundary;
+
+use super::*;
+
+use test_utils::new_fold_points;
+use test_utils::TEXT_SAMPLE;
+use test_utils::{fold_points, fold_points_filtered_by};
+use test_utils::{folds_eq, folds_eq_by};
+
+#[test]
+fn fold_container_from() {
+    let mut points = fold_points();
+    // additional points will be removed
+    points.extend(
+        [("rm", 73, 77..=77)]
+            .into_iter()
+            .map(|(object, header_line, target_lines)| {
+                new_fold_points(*TEXT_SAMPLE, object, header_line, target_lines)
+            }),
+    );
+
+    let container = FoldContainer::from(*TEXT_SAMPLE, points.clone());
+
+    let partial_eq = |sfp1: &StartFoldPoint, sfp2: &StartFoldPoint| -> bool {
+        &sfp1.object == &sfp2.object && sfp1.header == sfp2.header && sfp1.target == sfp2.target
+    };
+    assert!(container.start_points.iter().enumerate().all(|(i, sfp)| {
+        let (expected, _) = &points[i];
+        if partial_eq(&sfp, expected) {
+            return true;
+        }
+        eprintln!(
+            "index = {i}\n\
+            sfp = {sfp:#?}\n\
+            expected = {expected:#?}"
+        );
+        false
+    }));
+
+    let partial_eq =
+        |efp1: &EndFoldPoint, efp2: &EndFoldPoint| -> bool { efp1.target == efp2.target };
+    assert!(container.end_points.iter().enumerate().all(|(i, efp)| {
+        let (_, expected) = &points[efp.link];
+        if partial_eq(&efp, expected) {
+            return true;
+        }
+        eprintln!(
+            "index = {i}\n\
+            efp = {efp:#?}\n\
+            expected = {expected:#?}"
+        );
+        false
+    }));
+}
+
+#[test]
+fn fold_container_add() {
+    let mut points = fold_points();
+    points.extend([]);
+
+    let container = &mut FoldContainer::from(
+        *TEXT_SAMPLE,
+        points
+            .iter()
+            .cloned()
+            .enumerate()
+            .filter(|(i, _)| i % 2 == 0)
+            .map(|(_, points)| points)
+            .collect(),
+    );
+    container.add(
+        *TEXT_SAMPLE,
+        points
+            .iter()
+            .cloned()
+            .enumerate()
+            .filter(|(i, _)| i % 2 != 0)
+            .map(|(_, points)| points)
+            .collect(),
+    );
+
+    let expected = &FoldContainer::from(*TEXT_SAMPLE, points);
+    assert!(folds_eq(container, expected));
+}
+
+#[test]
+fn fold_container_replace() {
+    // replacements, replaced
+    let cases = [
+        (&[0, 1][..], &[][..]),
+        (&[2][..], &[3, 4, 5, 6, 7, 8][..]),
+        (&[9][..], &[10, 11][..]),
+        (&[12][..], &[13][..]),
+        (&[14][..], &[15][..]),
+        (&[19][..], &[16, 17, 18][..]),
+    ];
+
+    for (case_idx, (replacements, replaced)) in cases.into_iter().enumerate() {
+        let container = &mut FoldContainer::from(
+            *TEXT_SAMPLE,
+            fold_points_filtered_by(|(i, _)| !replacements.contains(i)),
+        );
+        container.replace(
+            *TEXT_SAMPLE,
+            fold_points_filtered_by(|(i, _)| replacements.contains(i)),
+        );
+
+        let expected = &FoldContainer::from(
+            *TEXT_SAMPLE,
+            fold_points_filtered_by(|(i, _)| !replaced.contains(i)),
+        );
+
+        assert!(
+            folds_eq_by(
+                container,
+                expected,
+                |sfp1, sfp2| sfp1 == sfp2,
+                |efp1, efp2| efp1.link == efp2.link,
+            ),
+            "case index = {case_idx}"
+        );
+    }
+}
+
+#[test]
+fn fold_container_remove_by_selection() {
+    // line from, line to, removed
+    let cases = [
+        (0, 0, &[][..]),
+        (2, 3, &[][..]),
+        (5, 6, &[][..]),
+        (6, 7, &[][..]),
+        (8, 8, &[2][..]),
+        (17, 19, &[2, 4][..]),
+        (21, 34, &[2, 5, 6, 9, 10, 11][..]),
+        (40, 42, &[12][..]),
+        (45, 55, &[12, 13, 15][..]),
+    ];
+
+    for (case_idx, (from, to, removed)) in cases.into_iter().enumerate() {
+        let selection = &Selection::single(
+            TEXT_SAMPLE.line_to_char(from),
+            next_grapheme_boundary(*TEXT_SAMPLE, TEXT_SAMPLE.line_to_char(to)),
+        );
+
+        let container = &mut FoldContainer::from(*TEXT_SAMPLE, fold_points());
+        container.remove_by_selection(*TEXT_SAMPLE, selection);
+
+        let expected = &FoldContainer::from(
+            *TEXT_SAMPLE,
+            fold_points_filtered_by(|(i, _)| !removed.contains(i)),
+        );
+
+        assert!(folds_eq(container, expected), "case index = {case_idx}");
+    }
+}
+
+#[test]
+fn fold_container_throw_range_out_of_folds() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+
+    // line from, line to, expected (line from, line to)
+    let cases = [
+        ((1, 1), Range::new(0, 16)),       // (0, 0)
+        ((4, 4), Range::new(34, 50)),      // (3, 3)
+        ((1, 4), Range::new(0, 50)),       // (0, 3)
+        ((19, 63), Range::new(67, 827)),   // (6, 62)
+        ((44, 10), Range::new(576, 67)),   // (39, 6)
+        ((77, 45), Range::new(1009, 558)), // (72, 39)
+    ];
+
+    for (case_idx, ((from, to), expected)) in cases.into_iter().enumerate() {
+        let range = Range::new(
+            TEXT_SAMPLE.line_to_char(from),
+            line_end_char_index(&*TEXT_SAMPLE, to),
+        );
+
+        let result = container.throw_range_out_of_folds(*TEXT_SAMPLE, range);
+        let expected = expected.with_direction(result.direction());
+
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}
+
+#[test]
+fn fold_container_find() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+
+    // object, block line range, expected
+    let cases = [
+        ("0", 1..=1, Some(0)),
+        ("a", 1..=1, None),
+        ("0", 1..=2, None),
+        ("7", 28..=29, Some(7)),
+        ("6", 20..=22, Some(6)),
+        ("2", 8..=29, Some(2)),
+        ("10", 33..=35, Some(10)),
+    ];
+
+    for (case_idx, (object, block, expected)) in cases.into_iter().enumerate() {
+        let result = container.find(&FoldObject::TextObject(object), &block, |fold| {
+            fold.start.line..=fold.end.line
+        });
+        let expected = expected.map(|idx| container.start_points[idx].fold(container));
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}
+
+#[test]
+fn fold_container_start_points_in_range() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+
+    // block line range, expected
+    let cases = [
+        (0..=0, None),
+        (6..=40, Some(2..=11)),
+        (10..=15, Some(3..=3)),
+        (55..=70, Some(16..=19)),
+        (0..=9, Some(0..=2)),
+    ];
+
+    for (case_idx, (block, expected)) in cases.into_iter().enumerate() {
+        let result = container.start_points_in_range(&block, |sfp| sfp.line);
+        let expected = expected.map_or(&[][..], |range| &container.start_points[range]);
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}
+
+#[test]
+fn fold_container_fold_containing() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+
+    // line, expected
+    let cases = [
+        (0, None),
+        (1, Some(0)),
+        (7, None),
+        (11, Some(3)),
+        (9, Some(2)),
+        (57, None),
+        (78, Some(21)),
+        (12, Some(2)),
+        (19, Some(2)),
+    ];
+
+    for (case_idx, (line, expected)) in cases.into_iter().enumerate() {
+        let result = container.fold_containing(line, |fold| fold.start.line..=fold.end.line);
+        let expected = expected.map(|idx| container.start_points[idx].fold(container));
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}
+
+#[test]
+fn fold_container_superest_fold_containing() {
+    let container = &FoldContainer::from(*TEXT_SAMPLE, fold_points());
+
+    // line, expected
+    let cases = [
+        (0, None),
+        (1, Some(0)),
+        (7, None),
+        (11, Some(2)),
+        (9, Some(2)),
+        (57, None),
+        (78, Some(21)),
+        (12, Some(2)),
+        (19, Some(2)),
+    ];
+
+    for (case_idx, (line, expected)) in cases.into_iter().enumerate() {
+        let result =
+            container.superest_fold_containing(line, |fold| fold.start.line..=fold.end.line);
+        let expected = expected.map(|idx| container.start_points[idx].fold(container));
+        assert_eq!(result, expected, "case index = {case_idx}");
+    }
+}

--- a/helix-core/src/text_folding/test_utils.rs
+++ b/helix-core/src/text_folding/test_utils.rs
@@ -1,0 +1,137 @@
+use std::fs;
+use std::ops;
+use std::sync::LazyLock;
+
+use helix_stdx::rope::RopeSliceExt;
+
+use crate::{text_folding::FoldObject, RopeSlice};
+
+use super::{EndFoldPoint, Fold, FoldContainer, StartFoldPoint};
+
+pub(crate) static TEXT_SAMPLE: LazyLock<RopeSlice> = LazyLock::new(|| {
+    const PATH: &str = "src/text_folding/test_utils/text-sample.txt";
+    RopeSlice::from(fs::read_to_string(PATH).unwrap().leak() as &str)
+});
+
+pub(crate) fn new_fold_points(
+    text: RopeSlice,
+    object: &'static str,
+    header_line: usize,
+    target_lines: ops::RangeInclusive<usize>,
+) -> (StartFoldPoint, EndFoldPoint) {
+    let object = FoldObject::TextObject(object);
+    let header = text.line_to_char(header_line)
+        + text.line(header_line).first_non_whitespace_char().unwrap();
+    let target = {
+        let (from, to) = (*target_lines.start(), *target_lines.end());
+        let start = text.line_to_char(from) + text.line(from).first_non_whitespace_char().unwrap();
+        let end = text.line_to_char(to) + text.line(to).last_non_whitespace_char().unwrap();
+        start..=end
+    };
+    Fold::new_points(text, object, header, &target)
+}
+
+pub(crate) fn fold_points() -> Vec<(StartFoldPoint, EndFoldPoint)> {
+    // object, header line, target lines
+    [
+        ("0", 0, 1..=1),
+        ("1", 3, 4..=4),
+        ("2", 6, 8..=29),
+        ("3", 8, 10..=11),
+        ("4", 15, 16..=18),
+        ("5", 14, 19..=25), // block: 20..=25
+        ("6", 19, 20..=22),
+        ("7", 27, 28..=29),
+        ("8", 28, 29..=29),
+        ("9", 31, 32..=36),
+        ("10", 32, 33..=35),
+        ("11", 33, 34..=35),
+        ("12", 39, 41..=45),
+        ("13", 41, 43..=45),
+        ("14", 46, 48..=50),
+        ("15", 46, 52..=55),
+        ("16", 58, 59..=59),
+        ("17", 60, 61..=61),
+        ("18", 62, 63..=63),
+        ("19", 58, 66..=67),
+        ("20", 74, 76..=76),
+        ("21", 72, 78..=78),
+    ]
+    .into_iter()
+    .map(|(object, header_line, target_lines)| {
+        new_fold_points(*TEXT_SAMPLE, object, header_line, target_lines)
+    })
+    .collect()
+}
+
+pub(crate) fn fold_points_filtered_by(
+    f: impl Fn(&(usize, (StartFoldPoint, EndFoldPoint))) -> bool,
+) -> Vec<(StartFoldPoint, EndFoldPoint)> {
+    fold_points()
+        .into_iter()
+        .enumerate()
+        .filter(f)
+        .map(|(_, points)| points)
+        .collect()
+}
+
+pub(crate) fn folds_eq(container1: &FoldContainer, container2: &FoldContainer) -> bool {
+    folds_eq_by(
+        container1,
+        container2,
+        |sfp1, sfp2| sfp1 == sfp2,
+        |efp1, efp2| efp1 == efp2,
+    )
+}
+
+pub(crate) fn folds_eq_by(
+    container1: &FoldContainer,
+    container2: &FoldContainer,
+    sfp_eq: impl Fn(&StartFoldPoint, &StartFoldPoint) -> bool,
+    efp_eq: impl Fn(&EndFoldPoint, &EndFoldPoint) -> bool,
+) -> bool {
+    if container1.len() != container2.len() {
+        eprintln!(
+            "left has lenght = {}\n\
+            right has lenght = {}",
+            container1.len(),
+            container2.len(),
+        );
+        return false;
+    }
+
+    container1
+        .start_points
+        .iter()
+        .zip(&container2.start_points)
+        .enumerate()
+        .all(|(i, (sfp1, sfp2))| {
+            if sfp_eq(sfp1, sfp2) {
+                return true;
+            }
+
+            eprintln!(
+                "index = {i}\n\
+                left sfp = {sfp1:#?}\n\
+                right sfp = {sfp2:#?}"
+            );
+            false
+        })
+        && container1
+            .end_points
+            .iter()
+            .zip(&container2.end_points)
+            .enumerate()
+            .all(|(i, (efp1, efp2))| {
+                if efp_eq(efp1, efp2) {
+                    return true;
+                }
+
+                eprintln!(
+                    "index = {i}\n\
+                    left efp = {efp1:#?}\n\
+                    right efp = {efp2:#?}"
+                );
+                false
+            })
+}

--- a/helix-core/src/text_folding/test_utils/folded-text-sample
+++ b/helix-core/src/text_folding/test_utils/folded-text-sample
@@ -1,0 +1,32 @@
+丂 line index: 0
+
+	丅 line index: 3
+
+丏 line index: 6
+line index: 7 乕
+
+line index: 31 亃
+
+
+line index: 39 伬
+
+line index: 46 伳
+
+
+
+
+line num_ber: 58 伻
+line_index: 60 伻
+line_index: 62 伻
+
+
+line_index: 68 伻
+齞line_index: 69 伻
+line_index: 70 伻
+
+齠line_index: 72 伻
+		line_index: 73 伻
+	齢line_index: 74 伻
+			line_index: 75 伻
+			line_index: 77 伻
+line_index: 79

--- a/helix-core/src/text_folding/test_utils/text-sample.txt
+++ b/helix-core/src/text_folding/test_utils/text-sample.txt
@@ -1,0 +1,80 @@
+丂 line index: 0
+line index: 1 乄
+
+	丅 line index: 3
+line index: 4 乊
+
+丏 line index: 6
+line index: 7 乕
+		丗 line index: 8
+		line index: 9 乚
+		丠 line index: 10
+		line index: 11 乢
+
+
+	丣 line index: 14
+	line index: 15 乤
+	丩 line index: 16
+	line index: 17 乧
+	丯 line index: 18
+		line index: 19 乪
+		丳 line index: 20
+		line index: 21 乬
+		丷 line index: 22
+
+		line index: 24 乮
+		乀 line index: 25
+	line index: 26 乿
+	乴 line index: 27
+line index: 28 亁
+乶 line index: 29
+
+line index: 31 亃
+	乸 line index: 32
+line index: 33 亅
+	乺 line index: 34
+line index: 35 亊
+	伇 line index: 36
+
+
+line index: 39 伬
+
+伋 line index: 41
+
+line index: 43 伮
+
+伒 line index: 45
+line index: 46 伳
+
+	伔 line index: 48
+
+	line index: 50 伷
+
+	伖 line index: 52
+
+	line index: 54 伻
+齔line_index: 55
+
+
+line num_ber: 58 伻
+齖line_num_ber: 59
+line_index: 60 伻
+齘line_index: 61
+line_index: 62 伻
+齚line_index: 63
+
+
+line_index: 66 伻
+齜line_index: 67 伻
+line_index: 68 伻
+齞line_index: 69 伻
+line_index: 70 伻
+
+齠line_index: 72 伻
+		line_index: 73 伻
+	齢line_index: 74 伻
+			line_index: 75 伻
+齤line_index: 76 伻
+			line_index: 77 伻
+		齦line_index: 78 伻
+line_index: 79

--- a/helix-core/src/text_folding/transaction.rs
+++ b/helix-core/src/text_folding/transaction.rs
@@ -1,0 +1,289 @@
+//! Processing of folds when a transaction is applied.
+//!
+//! During a transaction, the fold container removes disturbed folds.
+//!
+//! Disturbed folds are folds that:
+//! 1. header has been mixed with the outer text
+//! 2. header has been completely removed
+//! 3. header and target have been mixed
+//! 4. start char of target has been removed
+//! 5. end char of target has been removed
+//!
+//! After that, the fold container normalizes its folds.
+
+use std::cmp::{max, min};
+use std::iter::once;
+use std::ops;
+
+use ropey::RopeSlice;
+
+use crate::ChangeSet;
+use crate::{graphemes::prev_grapheme_boundary, transaction::UpdatePosition, Transaction};
+
+use super::FoldContainer;
+
+impl FoldContainer {
+    pub fn update_by_transaction(
+        &mut self,
+        new_text: RopeSlice,
+        old_text: RopeSlice,
+        transaction: &Transaction,
+    ) {
+        let disturbed = self.disturbed_folds(old_text, transaction);
+        let mut sort = !disturbed.is_empty();
+
+        self.delete(disturbed);
+
+        self.update(new_text, transaction.changes());
+
+        let removables = self.normalize(new_text);
+        sort |= !removables.is_empty();
+
+        self.delete(removables);
+
+        if sort {
+            self.sort_end_points();
+            self.set_super_links();
+        }
+    }
+
+    /// Returns the start indices of folds that have been disturbed when the transaction is applied.
+    fn disturbed_folds(&self, text: RopeSlice, transaction: &Transaction) -> Vec<usize> {
+        let mut disturbed: Vec<_> = transaction
+            .changes_iter()
+            .filter_map(|(from, to, fragment)| {
+                // an insertion disturbs no folds
+                if from == to {
+                    return None;
+                }
+
+                let change_range = from..=to - 1;
+
+                // the range of potentially disturbed folds
+                let range = {
+                    let start = {
+                        let start_fold = self
+                            .end_points
+                            .get(self.end_points.partition_point(|efp| {
+                                max(efp.target, efp.char) < *change_range.start()
+                            }))
+                            .map(|efp| efp.fold(self))?;
+                        start_fold
+                            .superest_fold(self)
+                            .unwrap_or(start_fold)
+                            .start_idx()
+                    };
+                    let end = start
+                        + self.start_points[start..]
+                            .partition_point(|sfp| sfp.header <= *change_range.end());
+                    start..end
+                };
+
+                Some(
+                    self.start_points[range]
+                        .iter()
+                        .map(|sfp| sfp.fold(self))
+                        .filter_map(move |fold| {
+                            // returns the overlapping range of the passed `range` and `change_range`
+                            let overlap = |range: &ops::RangeInclusive<_>| {
+                                let start = max(*range.start(), *change_range.start());
+                                let end = min(*range.end(), *change_range.end());
+                                start..=end
+                            };
+
+                            let header = {
+                                let start = fold.header();
+                                let end = prev_grapheme_boundary(text, fold.start.target);
+                                start..=end
+                            };
+                            let target = {
+                                let start = fold.start.target;
+                                let end = fold.end.target;
+                                start..=end
+                            };
+
+                            let header_overlap = overlap(&header);
+                            let target_overlap = overlap(&target);
+
+                            // 1. header has been mixed with the outer text
+                            if !header_overlap.is_empty()
+                                && change_range.start() < header.start()
+                                && fragment.is_some()
+                            {
+                                return Some(fold.start_idx());
+                            }
+
+                            // 2. header has been completely removed
+                            if header_overlap == header && fragment.is_none() {
+                                return Some(fold.start_idx());
+                            }
+
+                            // 3. header and target have been mixed
+                            if !header_overlap.is_empty() && !target_overlap.is_empty() {
+                                return Some(fold.start_idx());
+                            }
+
+                            // 4. start char of target has been removed
+                            if target_overlap.contains(target.start()) {
+                                return Some(fold.start_idx());
+                            }
+
+                            // 5. end char of target has been removed
+                            if target_overlap.contains(target.end()) {
+                                return Some(fold.start_idx());
+                            }
+
+                            None
+                        }),
+                )
+            })
+            .flatten()
+            .collect();
+
+        disturbed.sort();
+        disturbed.dedup();
+
+        disturbed
+    }
+
+    /// Updates headers and targets.
+    fn update(&mut self, new_text: RopeSlice, changes: &ChangeSet) {
+        use Component::*;
+
+        let mut start_points = self.start_points.iter_mut().peekable();
+        let mut end_points = self.end_points.iter_mut().peekable();
+
+        // create a partially sorted positions iterator for a fast update
+        let sorted_positions =
+            std::iter::from_fn(move || match (start_points.peek(), end_points.peek()) {
+                (None, None) => None,
+
+                (Some(sfp), efp) if efp.map_or(true, |efp| sfp.header < efp.target) => {
+                    start_points.next().map(|sfp| {
+                        once(Header.update(&mut sfp.header))
+                            .chain(Some(StartTarget.update(&mut sfp.target)))
+                    })
+                }
+
+                (_, Some(_)) => end_points
+                    .next()
+                    .map(|efp| once(EndTarget.update(&mut efp.target)).chain(None)),
+
+                _ => unreachable!("Patterns must be exhausted."),
+            })
+            .flatten();
+
+        changes.update_positions_with_helper(new_text, sorted_positions);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Component {
+    Header,
+    StartTarget,
+    EndTarget,
+}
+
+impl Component {
+    fn update(self, position: &mut usize) -> ComponentUpdater<'_> {
+        ComponentUpdater {
+            component: self,
+            position,
+        }
+    }
+}
+
+struct ComponentUpdater<'a> {
+    component: Component,
+    position: &'a mut usize,
+}
+
+impl<'a> UpdatePosition<RopeSlice<'a>> for ComponentUpdater<'a> {
+    fn get_pos(&self) -> usize {
+        *self.position
+    }
+
+    fn set_pos(&mut self, new_pos: usize) {
+        *self.position = new_pos;
+    }
+
+    fn insert(&mut self, new_pos: usize, fragment: &str, text: &mut RopeSlice<'a>) {
+        use Component::*;
+
+        // abc -> aXYbc
+        // before insertion -> a
+        // start of insertion -> X
+        // end of insertion -> Y
+        // after insertion -> b
+        #[rustfmt::skip]
+        match self.component {
+            // before insertion
+            EndTarget
+                => self.set_pos(prev_grapheme_boundary(*text, new_pos)),
+
+            // start of insertion
+            // _ => self.set_pos(new_pos),
+
+            // end of insertion
+            // _ => self.set_pos(prev_grapheme_boundary(*text, new_pos + fragment.chars().count())),
+
+            // after insertion
+            Header
+            | StartTarget
+                => self.set_pos(new_pos + fragment.chars().count()),
+        };
+    }
+
+    fn delete(&mut self, _: usize, _: usize, new_pos: usize, text: &mut RopeSlice) {
+        use Component::*;
+
+        // abc -> ac
+        // before deletion -> a
+        // after deletion -> c
+        #[rustfmt::skip]
+        match self.component {
+            // before deletion
+            StartTarget
+                =>  self.set_pos(prev_grapheme_boundary(*text, new_pos)),
+
+            // after deletion
+            Header
+            | EndTarget
+                => self.set_pos(new_pos),
+        };
+    }
+
+    fn replace(
+        &mut self,
+        _: usize,
+        _: usize,
+        new_pos: usize,
+        fragment: &str,
+        text: &mut RopeSlice,
+    ) {
+        use Component::*;
+
+        // abc -> aXYc
+        // before replacement -> a
+        // start of replacement -> X
+        // end of replacement -> Y
+        // after replacement -> c
+        #[rustfmt::skip]
+        match self.component {
+            // before replacement
+            // _ => self.set_pos(prev_grapheme_boundary(*text, new_pos)),
+
+            // start of replacement
+            Header
+            | StartTarget
+                => self.set_pos(new_pos),
+
+            // end of replacement
+            EndTarget
+                => self.set_pos(prev_grapheme_boundary(*text, new_pos + fragment.chars().count())),
+
+            // after replacement
+            // _ => self.set_pos(new_pos + fragment.chars().count()),
+        };
+    }
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -199,7 +199,10 @@ impl Application {
                                 nr_of_files -= 1;
                                 doc_id
                             }
-                            Ok(doc_id) => doc_id,
+                            Ok(doc_id) => {
+                                ui::default_folding(&mut editor);
+                                doc_id
+                            }
                         };
                         // with Action::Load all documents have the same view
                         // NOTE: this isn't necessarily true anymore. If

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -615,6 +615,8 @@ impl MappableCommand {
         goto_prev_tabstop, "Goto next snippet placeholder",
         rotate_selections_first, "Make the first selection your primary one",
         rotate_selections_last, "Make the last selection your primary one",
+        fold, "Fold text objects",
+        unfold, "Unfold text objects",
     );
 }
 
@@ -6971,4 +6973,14 @@ fn lsp_or_syntax_workspace_symbol_picker(cx: &mut Context) {
     } else {
         syntax_workspace_symbol_picker(cx);
     }
+}
+
+fn fold(cx: &mut Context) {
+    let command: MappableCommand = ":fold --all".parse().unwrap();
+    command.execute(cx);
+}
+
+fn unfold(cx: &mut Context) {
+    let command: MappableCommand = ":unfold --all".parse().unwrap();
+    command.execute(cx);
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6859,7 +6859,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
     // This is not necessarily exact if there is virtual text like soft wrap.
     // It's ok though because the extra jump labels will not be rendered.
     let start = text.line_to_char(text.char_to_line(doc.view_offset(view.id).anchor));
-    let end = text.line_to_char(view.estimate_last_doc_line(doc) + 1);
+    let end = text.line_to_char(view.estimate_last_doc_line(&annotations, doc) + 1);
 
     let primary_selection = doc.selection(view.id).primary();
     let cursor = primary_selection.cursor(text);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5757,11 +5757,15 @@ fn split(editor: &mut Editor, action: Action) {
     let id = doc.id();
     let selection = doc.selection(view.id).clone();
     let offset = doc.view_offset(view.id);
+    let container = doc.fold_container(view.id).cloned();
 
     editor.switch(id, action);
 
     // match the selection in the previous view
     let (view, doc) = current!(editor);
+    if let Some(container) = container {
+        doc.insert_fold_container(view.id, container);
+    }
     doc.set_selection(view.id, selection);
     // match the view scroll offset (switch doesn't handle this fully
     // since the selection is only matched after the split)

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -15,8 +15,7 @@ use super::{align_view, push_jump, Align, Context, Editor};
 
 use helix_core::{
     diagnostic::DiagnosticProvider, syntax::config::LanguageServerFeature,
-    text_annotations::InlineAnnotation, Selection, Uri,
-    text_folding::ropex::RopeSliceFoldExt,
+    text_annotations::InlineAnnotation, text_folding::ropex::RopeSliceFoldExt, Selection, Uri,
 };
 use helix_stdx::path;
 use helix_view::{
@@ -1309,7 +1308,11 @@ fn compute_inlay_hints_for_view(
     let first_visible_line =
         doc_text.char_to_line(doc.view_offset(view_id).anchor.min(doc_text.len_chars()));
     let first_line = first_visible_line.saturating_sub(view_height);
-    let last_line = doc_text.slice(..).nth_next_folded_line(annotations, first_visible_line, view_height.saturating_mul(2));
+    let last_line = doc_text.slice(..).nth_next_folded_line(
+        annotations,
+        first_visible_line,
+        view_height.saturating_mul(2),
+    );
 
     let new_doc_inlay_hints_id = DocumentInlayHintsId {
         first_line,

--- a/helix-term/src/handlers/completion/word.rs
+++ b/helix-term/src/handlers/completion/word.rs
@@ -1,7 +1,8 @@
 use std::{borrow::Cow, sync::Arc};
 
 use helix_core::{
-    self as core, chars::char_is_word, completion::CompletionProvider, movement, Transaction,
+    self as core, chars::char_is_word, completion::CompletionProvider, movement,
+    text_annotations::TextAnnotations, Transaction,
 };
 use helix_event::TaskHandle;
 use helix_stdx::rope::RopeSliceExt as _;
@@ -38,7 +39,12 @@ pub(super) fn completion(
     let selection = doc.selection(view.id).clone();
     let pos = selection.primary().cursor(text);
 
-    let cursor = movement::move_prev_word_start(text, core::Range::point(pos), 1);
+    let cursor = movement::move_prev_word_start(
+        text,
+        &TextAnnotations::default(),
+        core::Range::point(pos),
+        1,
+    );
     if cursor.head == pos {
         return None;
     }

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -305,6 +305,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C-u" | "backspace" => page_cursor_half_up,
             "C-d" | "space" => page_cursor_half_down,
 
+            "f" => fold,
+            "F" => unfold,
+
             "/" => search,
             "?" => rsearch,
             "n" => search_next,
@@ -321,6 +324,9 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C-f" | "pagedown" => page_down,
             "C-u" | "backspace" => page_cursor_half_up,
             "C-d" | "space" => page_cursor_half_down,
+
+            "f" => fold,
+            "F" => unfold,
 
             "/" => search,
             "?" => rsearch,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -307,6 +307,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
             "f" => fold,
             "F" => unfold,
+            "A-f" => toggle_fold,
 
             "/" => search,
             "?" => rsearch,
@@ -327,6 +328,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
             "f" => fold,
             "F" => unfold,
+            "A-f" => toggle_fold,
 
             "/" => search,
             "?" => rsearch,

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -783,6 +783,14 @@ pub mod completers {
 
         completions
     }
+
+    pub fn foldable_textobjects(_editor: &Editor, input: &str) -> Vec<Completion> {
+        let textobjects = ["class", "function", "comment"];
+        fuzzy_match(input, textobjects.iter(), false)
+            .into_iter()
+            .map(|(name, _)| ((0..), (*name).into()))
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -269,13 +269,23 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         },
     )];
     let picker = Picker::new(columns, 0, [], data, move |cx, path: &PathBuf, action| {
-        if let Err(e) = cx.editor.open(path, action) {
-            let err = if let Some(err) = e.source() {
-                format!("{}", err)
-            } else {
-                format!("unable to open \"{}\"", path.display())
-            };
-            cx.editor.set_error(err);
+        let path = helix_stdx::path::canonicalize(path);
+        let old_id = cx.editor.document_id_by_path(&path);
+
+        match cx.editor.open(&path, action) {
+            Ok(doc_id) => {
+                if old_id.map_or(true, |id| id != doc_id) {
+                    default_folding(cx.editor);
+                }
+            }
+            Err(e) => {
+                let err = if let Some(err) = e.source() {
+                    format!("{}", err)
+                } else {
+                    format!("unable to open \"{}\"", path.display())
+                };
+                cx.editor.set_error(err);
+            }
         }
     })
     .with_preview(|_editor, path| Some((path.as_path().into(), None)));
@@ -339,13 +349,25 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
                     Ok(call)
                 });
                 cx.jobs.callback(callback);
-            } else if let Err(e) = cx.editor.open(path, action) {
-                let err = if let Some(err) = e.source() {
-                    format!("{}", err)
-                } else {
-                    format!("unable to open \"{}\"", path.display())
-                };
-                cx.editor.set_error(err);
+            } else {
+                let path = helix_stdx::path::canonicalize(path);
+                let old_id = cx.editor.document_id_by_path(&path);
+
+                match cx.editor.open(&path, action) {
+                    Ok(doc_id) => {
+                        if old_id.map_or(true, |id| id != doc_id) {
+                            default_folding(cx.editor);
+                        }
+                    }
+                    Err(e) => {
+                        let err = if let Some(err) = e.source() {
+                            format!("{}", err)
+                        } else {
+                            format!("unable to open \"{}\"", path.display())
+                        };
+                        cx.editor.set_error(err);
+                    }
+                }
             }
         },
     )
@@ -400,6 +422,24 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
     }
 
     Ok(content)
+}
+
+pub fn default_folding(editor: &mut Editor) {
+    use crate::commands::typed::{fold_textobjects, FOLD_SIGNATURE};
+    use helix_core::command_line::Args;
+
+    let textobjects = editor.config.load().fold_textobjects.join(" ");
+    if textobjects.is_empty() {
+        return;
+    }
+
+    let loader = editor.syn_loader.load();
+
+    let str = format!("--document {textobjects}");
+    let args = Args::parse(&str, FOLD_SIGNATURE, true, |token| Ok(token.content)).unwrap();
+
+    let (view, doc) = current!(editor);
+    _ = fold_textobjects(doc, view, &loader, args);
 }
 
 fn get_child_if_single_dir(path: &Path) -> Option<PathBuf> {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -960,8 +960,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
             let loader = cx.editor.syn_loader.load();
 
-            let syntax_highlighter =
-                EditorView::doc_syntax_highlighter(doc, offset.anchor, area.height, &loader);
+            let syntax_highlighter = EditorView::doc_syntax_highlighter(
+                doc,
+                &TextAnnotations::default(),
+                offset.anchor,
+                area.height,
+                &loader,
+            );
             let mut overlay_highlights = Vec::new();
 
             EditorView::doc_diagnostics_highlights_into(

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -6,6 +6,7 @@ mod insert;
 mod movement;
 mod reverse_selection_contents;
 mod rotate_selection_contents;
+mod text_folding;
 mod write;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/helix-term/tests/test/commands/text_folding.rs
+++ b/helix-term/tests/test/commands/text_folding.rs
@@ -1,0 +1,1446 @@
+use super::*;
+
+use std::cell::Cell;
+
+use helix_core::doc_formatter::{DocumentFormatter, TextFormat};
+use helix_core::graphemes::prev_grapheme_boundary;
+use helix_core::{coords_at_pos, Position, Range};
+use helix_core::{Rope, RopeSlice};
+
+use helix_view::current_ref;
+
+const RUST_CODE: &str = "tests/test/commands/text_folding/rust-code.rs";
+const PYTHON_CODE: &str = "tests/test/commands/text_folding/python-code.py";
+
+const FOLDED_RUST_CODE: &str = "tests/test/commands/text_folding/folded-rust-code";
+const FOLDED_PYTHON_CODE: &str = "tests/test/commands/text_folding/folded-python-code";
+
+fn fold_text(app: &Application) -> Rope {
+    use helix_core::graphemes::Grapheme;
+    use std::fmt::Write;
+
+    let (view, doc) = current_ref!(&app.editor);
+    let text = doc.text().slice(..);
+    let text_format = &TextFormat::default();
+    let annotations = &view.text_annotations(doc, None);
+
+    let formatter = DocumentFormatter::new_at_prev_checkpoint(text, text_format, annotations, 0);
+
+    let mut folded_text = String::new();
+    for g in formatter {
+        match g.raw {
+            Grapheme::Newline => write!(folded_text, "\n").unwrap(),
+            other => write!(folded_text, "{other}").unwrap(),
+        }
+    }
+    // remove EOF
+    folded_text.remove(folded_text.len() - 1);
+
+    Rope::from(folded_text)
+}
+
+// NOTE: positions are one-based indexing
+// Returns (from, to)
+fn positions_from_range(text: RopeSlice, range: Range) -> (Position, Position) {
+    let Position { row, col } = coords_at_pos(text, range.from());
+    let from = Position {
+        row: row + 1,
+        col: col + 1,
+    };
+
+    let Position { row, col } = coords_at_pos(text, prev_grapheme_boundary(text, range.to()));
+    let to = Position {
+        row: row + 1,
+        col: col + 1,
+    };
+
+    (from, to)
+}
+
+// NOTE: position is one-based indexing
+fn position_from_char(text: RopeSlice, char: usize) -> Position {
+    let Position { row, col } = coords_at_pos(text, char);
+    Position {
+        row: row + 1,
+        col: col + 1,
+    }
+}
+
+// INFO: to update the folded text, set the environment variable HELIX_UPDATE_FOLDED_RUST_CODE
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_rust_code() -> anyhow::Result<()> {
+    use std::fs::File;
+
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    test_key_sequence(
+        app,
+        Some(":fold --all --document<ret>"),
+        Some(&|app| {
+            let folded_rust_code = fold_text(app);
+            match std::env::var("HELIX_UPDATE_FOLDED_RUST_CODE") {
+                Ok(_) => {
+                    folded_rust_code
+                        .write_to(File::create(FOLDED_RUST_CODE).unwrap())
+                        .unwrap();
+                }
+                Err(_) => {
+                    let expected =
+                        Rope::from_reader(File::open(FOLDED_RUST_CODE).unwrap()).unwrap();
+                    assert_eq!(folded_rust_code, expected);
+                }
+            }
+        }),
+        false,
+    )
+    .await
+}
+
+// INFO: to update the folded text, set the environment variable HELIX_UPDATE_FOLDED_PYTHON_CODE
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_python_code() -> anyhow::Result<()> {
+    use std::fs::File;
+
+    let app = &mut AppBuilder::new()
+        .with_file(PYTHON_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    test_key_sequence(
+        app,
+        Some(":fold --all --document<ret>"),
+        Some(&|app| {
+            let folded_python_code = fold_text(app);
+            match std::env::var("HELIX_UPDATE_FOLDED_PYTHON_CODE") {
+                Ok(_) => {
+                    folded_python_code
+                        .write_to(File::create(FOLDED_PYTHON_CODE).unwrap())
+                        .unwrap();
+                }
+                Err(_) => {
+                    let expected =
+                        Rope::from_reader(File::open(FOLDED_PYTHON_CODE).unwrap()).unwrap();
+                    assert_eq!(folded_python_code, expected);
+                }
+            }
+        }),
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_class() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: positions are one-based indexing
+    // ((from, to), additional folds number)
+    type TestResult = ((Position, Position), isize);
+
+    let prev_folds_number = Cell::new(0);
+    let result = |app: &Application| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+        let text = doc.text().slice(..);
+
+        let (from, to) = {
+            let range = doc.selection(view.id).primary();
+            positions_from_range(text, range)
+        };
+
+        let additional_folds_number = {
+            let folds_number = doc
+                .fold_container(view.id)
+                .map_or(0, |container| container.len());
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        ((from, to), additional_folds_number)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "g10g\
+                    g5\
+                    |zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(10, 5), Position::new(10, 5)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g48g\
+                    g2|\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(48, 2), Position::new(48, 2)), 0);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g46g\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(44, 1), Position::new(44, 13)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g105g\
+                    xx\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(104, 17), Position::new(104, 36)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g93g\
+                    v\
+                    g100g\
+                    :fold class<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(90, 9), Position::new(98, 20)), 2);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g51g\
+                    g6|\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(51, 6), Position::new(51, 6)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_function() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: positions are one-based indexing
+    // ((from, to), additional folds number)
+    type TestResult = ((Position, Position), isize);
+
+    let prev_folds_number = Cell::new(0);
+    let result = |app: &Application| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+        let text = doc.text().slice(..);
+
+        let (from, to) = {
+            let range = doc.selection(view.id).primary();
+            positions_from_range(text, range)
+        };
+
+        let additional_folds_number = {
+            let folds_number = doc
+                .fold_container(view.id)
+                .map_or(0, |container| container.len());
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        ((from, to), additional_folds_number)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "g77g\
+                    v\
+                    g83g\
+                    :fold function<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(77, 1), Position::new(80, 20)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g105g\
+                    g21|\
+                    :fold function<ret>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(99, 13), Position::new(99, 19)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g64g\
+                    v\
+                    g77g\
+                    :fold function<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(60, 5), Position::new(75, 22)), 2);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g50g\
+                    mat\
+                    :fold function<ret>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(50, 1), Position::new(115, 1)), 0);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "gg\
+                    :fold -a -d class comment<ret>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(1, 1), Position::new(1, 1)), 0);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_comment() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: positions are one-based indexing
+    // ((from, to), additional folds number)
+    type TestResult = ((Position, Position), isize);
+
+    let prev_folds_number = Cell::new(0);
+    let result = |app: &Application| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+        let text = doc.text().slice(..);
+
+        let (from, to) = {
+            let range = doc.selection(view.id).primary();
+            positions_from_range(text, range)
+        };
+
+        let additional_folds_number = {
+            let folds_number = doc
+                .fold_container(view.id)
+                .map_or(0, |container| container.len());
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        ((from, to), additional_folds_number)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "gg\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(1, 1), Position::new(1, 1)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g8g\
+                    g27|\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(7, 5), Position::new(7, 27)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g12g\
+                    g27|
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(12, 27), Position::new(12, 27)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g15g\
+                    g7|
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(15, 7), Position::new(15, 7)), 0);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g18g\
+                    g16|\
+                    v\
+                    g30g\
+                    g9|\
+                    :fold comment<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(18, 16), Position::new(29, 28)), 2);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g32g\
+                    v\
+                    g37g
+                    :fold comment<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(32, 1), Position::new(36, 17)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g53g\
+                    g5|
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(53, 5), Position::new(53, 5)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g102g\
+                    g40|\
+                    zf",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(100, 17), Position::new(100, 41)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fold_selection() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: positions are one-based indexing
+    // ((from, to), additional folds number)
+    type TestResult = ((Position, Position), isize);
+
+    let prev_folds_number = Cell::new(0);
+    let result = |app: &Application| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+        let text = doc.text().slice(..);
+
+        let (from, to) = {
+            let range = doc.selection(view.id).primary();
+            positions_from_range(text, range)
+        };
+
+        let additional_folds_number = {
+            let folds_number = doc
+                .fold_container(view.id)
+                .map_or(0, |container| container.len());
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        ((from, to), additional_folds_number)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "g2g\
+                    v\
+                    g10g\
+                    :fold -s<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(2, 1), Position::new(2, 22)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g15g\
+                    v\
+                    g25g\
+                    :fold -s<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(15, 1), Position::new(15, 29)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g11g\
+                    v\
+                    g14g\
+                    :fold -s<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(11, 1), Position::new(11, 8)), 1);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g2g\
+                    v\
+                    2j<esc>",
+                ),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let text = doc.text().slice(..);
+
+                    let range = doc.selection(view.id).primary();
+                    let (start, end) = range.line_range(text);
+
+                    let expected = (1, 14);
+                    assert_eq!((start, end), expected, "select fold headers");
+                }),
+            ),
+            (
+                Some(":fold -s<ret>"),
+                Some(&|app| {
+                    let expected = ((Position::new(2, 1), Position::new(2, 22)), -2);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "v\
+                    j<esc>",
+                ),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let text = doc.text().slice(..);
+
+                    let range = doc.selection(view.id).primary();
+                    let (start, end) = range.line_range(text);
+
+                    let expected = (1, 25);
+                    assert_eq!((start, end), expected, "select fold");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fold() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: positions are one-based indexing
+    // ((from, to), additional folds number)
+    type TestResult = ((Position, Position), isize);
+
+    let prev_folds_number = Cell::new(0);
+    let result = |app: &Application| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+        let text = doc.text().slice(..);
+
+        let (from, to) = {
+            let range = doc.selection(view.id).primary();
+            positions_from_range(text, range)
+        };
+
+        let additional_folds_number = {
+            let folds_number = doc
+                .fold_container(view.id)
+                .map_or(0, |container| container.len());
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        ((from, to), additional_folds_number)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "g5g\
+                    gl\
+                    mam\
+                    <A-;>\
+                    v\
+                    gg\
+                    :fold -a<ret><esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(1, 1), Position::new(34, 1)), 7);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g37g\
+                    v\
+                    g46g\
+                    zf<esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(36, 1), Position::new(44, 13)), 3);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g64g\
+                    v\
+                    g80g\
+                    zf<esc>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(60, 5), Position::new(75, 22)), 4);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g50g\
+                    mat\
+                    :fold comment<ret>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(50, 1), Position::new(115, 1)), 6);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some("zf"),
+                Some(&|app| {
+                    let expected = ((Position::new(50, 1), Position::new(58, 13)), 6);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+            (
+                Some(
+                    "g5g\
+                    g22|\
+                    mam\
+                    :fold -s<ret>",
+                ),
+                Some(&|app| {
+                    let expected = ((Position::new(5, 22), Position::new(5, 23)), -5);
+                    assert_eq!(result(app), expected);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn format() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    let prev_folds_number = Cell::new(0);
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(":fold -a -d<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some(":format<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    assert_eq!(
+                        container.len(),
+                        prev_folds_number.get(),
+                        "All folds must be retained."
+                    );
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfold_class() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: header is one-based indexing (row, col)
+    // (additional folds number, unexpected fold headers)
+    type TestResult = (isize, Vec<Position>);
+
+    let prev_folds_number = Cell::new(0);
+    // NOTE: header is one-based indexing (row, col)
+    let result = |app: &Application, headers: &[(usize, usize)]| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+
+        let text = doc.text().slice(..);
+        let container = doc
+            .fold_container(view.id)
+            .expect("Container must be initialized.");
+
+        let additional_folds_number = {
+            let folds_number = container.len();
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        let unexpected_fold_headers = container
+            .start_points()
+            .iter()
+            .map(|sfp| position_from_char(text, sfp.header))
+            .filter(|&header| {
+                let Position { row, col } = header;
+                headers.contains(&(row, col))
+            })
+            .collect();
+
+        (additional_folds_number, unexpected_fold_headers)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(":fold -a -d<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some(
+                    "g15g\
+                    g6|\
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(app, &[]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, 0);
+                }),
+            ),
+            (
+                Some(
+                    "g15g\
+                    g5|
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(10, 5)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g18g\
+                    g5|
+                    :unfold class<ret>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(17, 17)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g35g\
+                    v\
+                    g49g\
+                    :unfold class<ret><esc>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(44, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g52g\
+                    g5|
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(50, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g89g\
+                    v\
+                    g110g\
+                    :unfold -r class<ret><esc>",
+                ),
+                Some(&|app| {
+                    // NOTE: when navigating to line 89, the function `g` is unfolded
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(75, 5), (90, 9), (98, 9), (104, 17)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -4);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfold_function() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: header is one-based indexing (row, col)
+    // (additional folds number, unexpected fold headers)
+    type TestResult = (isize, Vec<Position>);
+
+    let prev_folds_number = Cell::new(0);
+    // NOTE: header is one-based indexing (row, col)
+    let result = |app: &Application, headers: &[(usize, usize)]| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+
+        let text = doc.text().slice(..);
+        let container = doc
+            .fold_container(view.id)
+            .expect("Container must be initialized.");
+
+        let additional_folds_number = {
+            let folds_number = container.len();
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        let unexpected_fold_headers = container
+            .start_points()
+            .iter()
+            .map(|sfp| position_from_char(text, sfp.header))
+            .filter(|&header| {
+                let Position { row, col } = header;
+                headers.contains(&(row, col))
+            })
+            .collect();
+
+        (additional_folds_number, unexpected_fold_headers)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(":fold -a -d class<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some(
+                    "g71g\
+                    g6|\
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(app, &[]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, 0);
+                }),
+            ),
+            (
+                Some(
+                    "g71g\
+                    g5|\
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(60, 5)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g50g\
+                    mat\
+                    :unfold -r function<ret>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(75, 5), (80, 9), (99, 13)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -3);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfold_comment() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: header is one-based indexing (row, col)
+    // (additional folds number, unexpected fold headers)
+    type TestResult = (isize, Vec<Position>);
+
+    let prev_folds_number = Cell::new(0);
+    // NOTE: header is one-based indexing (row, col)
+    let result = |app: &Application, headers: &[(usize, usize)]| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+
+        let text = doc.text().slice(..);
+        let container = doc
+            .fold_container(view.id)
+            .expect("Container must be initialized.");
+
+        let additional_folds_number = {
+            let folds_number = container.len();
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        let unexpected_fold_headers = container
+            .start_points()
+            .iter()
+            .map(|sfp| position_from_char(text, sfp.header))
+            .filter(|&header| {
+                let Position { row, col } = header;
+                headers.contains(&(row, col))
+            })
+            .collect();
+
+        (additional_folds_number, unexpected_fold_headers)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    ":fold -a -d<ret>\
+                    g50g\
+                    mat\
+                    :unfold -r class<ret>\
+                    gg",
+                ),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some("zF"),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(app, &[(1, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g5g\
+                    g22|\
+                    mam\
+                    :unfold comment<ret>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(7, 5), (18, 5)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -2);
+                }),
+            ),
+            (
+                Some(
+                    "g5g\
+                    g22|\
+                    mam\
+                    :unfold -r comment<ret>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(12, 13), (29, 9)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -2);
+                }),
+            ),
+            (
+                Some(
+                    "g17g\
+                    v\
+                    g40g\
+                    :unfold comment<ret><esc>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(36, 1), (40, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -2);
+                }),
+            ),
+            (
+                Some(
+                    "g61g\
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(61, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g71g\
+                    g7|\
+                    zF",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(71, 7)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g75g\
+                    g5|\
+                    maf\
+                    :unfold -r comment<ret>",
+                ),
+                Some(&|app| {
+                    // NOTE: when navigating to line 75, the function `g` is unfolded
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(75, 5), (76, 9), (90, 23), (100, 17), (111, 9)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -5);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfold_selection() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: header is one-based indexing (row, col)
+    // (additional folds number, unexpected fold headers)
+    type TestResult = (isize, Vec<Position>);
+
+    let prev_folds_number = Cell::new(0);
+    // NOTE: header is one-based indexing (row, col)
+    let result = |app: &Application, headers: &[(usize, usize)]| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+
+        let text = doc.text().slice(..);
+        let container = doc
+            .fold_container(view.id)
+            .expect("Container must be initialized.");
+
+        let additional_folds_number = {
+            let folds_number = container.len();
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        let unexpected_fold_headers = container
+            .start_points()
+            .iter()
+            .map(|sfp| position_from_char(text, sfp.header))
+            .filter(|&header| {
+                let Position { row, col } = header;
+                headers.contains(&(row, col))
+            })
+            .collect();
+
+        (additional_folds_number, unexpected_fold_headers)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(
+                    "g2g\
+                    v\
+                    g5g\
+                    :fold -s<ret><esc>\
+                    g7g\
+                    v\
+                    g10g\
+                    :fold -s<ret><esc>\
+                    g12g\
+                    v\
+                    g15g\
+                    :fold -s<ret><esc>\
+                    gg",
+                ),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some(
+                    "g2g\
+                    :unfold -s<ret>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(app, &[(2, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -1);
+                }),
+            ),
+            (
+                Some(
+                    "g7g\
+                    v\
+                    g12g\
+                    :unfold -s<ret><esc>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(7, 1), (12, 1)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -2);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfold() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    // NOTE: header is one-based indexing (row, col)
+    // (additional folds number, unexpected fold headers)
+    type TestResult = (isize, Vec<Position>);
+
+    let prev_folds_number = Cell::new(0);
+    // NOTE: header is one-based indexing (row, col)
+    let result = |app: &Application, headers: &[(usize, usize)]| -> TestResult {
+        let (view, doc) = current_ref!(&app.editor);
+
+        let text = doc.text().slice(..);
+        let container = doc
+            .fold_container(view.id)
+            .expect("Container must be initialized.");
+
+        let additional_folds_number = {
+            let folds_number = container.len();
+            folds_number as isize - prev_folds_number.replace(folds_number) as isize
+        };
+
+        let unexpected_fold_headers = container
+            .start_points()
+            .iter()
+            .map(|sfp| position_from_char(text, sfp.header))
+            .filter(|&header| {
+                let Position { row, col } = header;
+                headers.contains(&(row, col))
+            })
+            .collect();
+
+        (additional_folds_number, unexpected_fold_headers)
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some(":fold -a -d<ret>"),
+                Some(&|app| {
+                    let (view, doc) = current_ref!(&app.editor);
+                    let container = doc
+                        .fold_container(view.id)
+                        .expect("Container must be initialized.");
+
+                    prev_folds_number.set(container.len());
+                }),
+            ),
+            (
+                Some(
+                    "g5g\
+                    g22|\
+                    mam\
+                    <A-;>\
+                    v\
+                    gg\
+                    :unfold -a<ret><esc>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) =
+                        result(app, &[(1, 1), (7, 5), (10, 5), (17, 17), (18, 5)]);
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -5);
+                }),
+            ),
+            (
+                Some(
+                    "g50g\
+                    v\
+                    g116g\
+                    :unfold -a -r comment<ret><esc>",
+                ),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(
+                        app,
+                        &[
+                            (50, 1),
+                            (50, 5),
+                            (75, 5),
+                            (80, 9),
+                            (90, 9),
+                            (98, 9),
+                            (99, 13),
+                            (104, 17),
+                        ],
+                    );
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -8);
+                }),
+            ),
+            (
+                Some(":unfold -a -d -r<ret>"),
+                Some(&|app| {
+                    let (additional_folds_number, unexpected_fold_headers) = result(
+                        app,
+                        &[
+                            (12, 13),
+                            (29, 9),
+                            (36, 1),
+                            (40, 1),
+                            (44, 1),
+                            (53, 5),
+                            (56, 5),
+                            (61, 1),
+                            (71, 7),
+                            (76, 9),
+                            (90, 23),
+                            (100, 17),
+                            (111, 9),
+                        ],
+                    );
+
+                    assert!(
+                        unexpected_fold_headers.is_empty(),
+                        "{unexpected_fold_headers:#?}"
+                    );
+                    assert_eq!(additional_folds_number, -13);
+                }),
+            ),
+        ],
+        false,
+    )
+    .await
+}

--- a/helix-term/tests/test/commands/text_folding.rs
+++ b/helix-term/tests/test/commands/text_folding.rs
@@ -1629,3 +1629,86 @@ async fn default_folding() -> anyhow::Result<()> {
     )
     .await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn toggle_fold() -> anyhow::Result<()> {
+    let app = &mut AppBuilder::new()
+        .with_file(RUST_CODE, None)
+        .with_lang_loader(helpers::test_syntax_loader(None))
+        .build()
+        .unwrap();
+
+    let folds_number = |app: &Application| {
+        let (view, doc) = current_ref!(&app.editor);
+        doc.fold_container(view.id)
+            .map_or(0, |container| container.len())
+    };
+
+    test_key_sequences(
+        app,
+        vec![
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g7gz<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g5|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g10gg5|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g12gg13|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g17gg17|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g93gg13|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+            (
+                Some("g105gg21|z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 1)),
+            ),
+            (
+                Some("z<A-f>"),
+                Some(&|app| assert_eq!(folds_number(app), 0)),
+            ),
+        ],
+        false,
+    )
+    .await
+}

--- a/helix-term/tests/test/commands/text_folding/folded-python-code
+++ b/helix-term/tests/test/commands/text_folding/folded-python-code
@@ -1,0 +1,24 @@
+# top comment
+
+
+class Fizz:
+
+
+# comment
+def f(a, b):
+    """
+    doc comment
+    doc comment
+    doc comment
+    """
+
+    class Nested:
+
+    def nested(a, b):
+        # interfering comment
+        """
+
+    c = a + b
+    d = a + b + c
+    # nested comment
+    return c + d  # interfering comment

--- a/helix-term/tests/test/commands/text_folding/folded-rust-code
+++ b/helix-term/tests/test/commands/text_folding/folded-rust-code
@@ -1,0 +1,28 @@
+//! top-level comment
+
+mod format_is_needed {
+
+    /// `Bazz` doc comment
+    pub struct Bazz {
+    } // interfering comment
+
+                pub struct Fizz<T, U, V>
+    // `where` block comment
+where
+T: Copy,
+U: Copy,
+        V: Copy,
+}
+
+/* block comment
+
+/// `TraitA` doc comment
+trait TraitA {
+
+impl<T, U, V> TraitA for format_is_needed::Fizz<T, U, V>
+where
+    T: Copy,
+    /* block comment
+    U: Copy,
+    /* block comment
+    V: Copy,

--- a/helix-term/tests/test/commands/text_folding/python-code.py
+++ b/helix-term/tests/test/commands/text_folding/python-code.py
@@ -1,0 +1,75 @@
+# top comment
+# top comment
+# top comment
+
+
+class Fizz:
+    def __init__(self, a):
+        """
+        doc comment
+        doc comment
+        doc comment
+        """
+        b = a + a
+        self.b = b
+
+    def f(self):
+        a = self.b // 2
+        c = a + b
+
+
+# comment
+# comment
+# comment
+def f(a, b):
+    """
+    doc comment
+    doc comment
+    doc comment
+    """
+
+    class Nested:
+        def __init__(self, b):
+            self.b = b
+            # really nested comment
+            # really nested comment
+            # really nested comment
+            print("log")
+
+        def f(self):
+            """
+            really nested doc comment
+            really nested doc comment
+            really nested doc comment
+            """
+
+            class ReallyNested:
+                def f(self):
+                    print(1 + 1)
+                    print(2 + 2)
+
+                def g(self):
+                    print(1 + 1)
+                    print(2 + 2)
+
+            print("log")
+            print(f"b = {self.b}")  # interfering comment
+
+    def nested(a, b):
+        # interfering comment
+        # interfering comment
+        # interfering comment
+        """
+        nested doc comment
+        nested doc comment
+        nested doc comment
+        """
+        print("log")
+        print(a + b)
+
+    c = a + b
+    d = a + b + c
+    # nested comment
+    # nested comment
+    # nested comment
+    return c + d  # interfering comment

--- a/helix-term/tests/test/commands/text_folding/rust-code.rs
+++ b/helix-term/tests/test/commands/text_folding/rust-code.rs
@@ -1,0 +1,115 @@
+//! top-level comment
+//! top-level comment
+//! top-level comment
+
+mod format_is_needed {
+
+    /// `Bazz` doc comment
+    /// `Bazz` doc comment
+    /// `Bazz` doc comment
+    pub struct Bazz {
+g: i32,
+            // `b` comment
+            // `b` comment
+b: i32,
+    } // interfering comment
+
+                pub struct Fizz<T, U, V>
+    // `where` block comment
+    // `where` block comment
+    // `where` block comment
+where
+T: Copy,
+U: Copy,
+        V: Copy,
+    {
+        // interfering comment
+        a    :     T   ,
+        b    :     U   ,
+        /// `c` doc comment
+        /// `c` doc comment
+        /// `c` doc comment
+        c: V,
+    }
+}
+
+/* block comment
+block comment
+block comment */
+
+/// `TraitA` doc comment
+/// `TraitA` doc comment
+/// `TraitA` doc comment
+/// `TraitA` doc comment
+trait TraitA {
+    fn f(self, a: u32, b: u32) -> u32;
+
+    fn g(self) -> u32;
+}
+
+impl<T, U, V> TraitA for format_is_needed::Fizz<T, U, V>
+where
+    T: Copy,
+    /* block comment
+    block comment */
+    U: Copy,
+    /* block comment
+    block comment */
+    V: Copy,
+{
+    fn f(self, a: u32, b: u32) -> u32
+/* interfering block comment
+     interfering block comment
+     interfering block comment */ {
+        todo!(
+            "
+            write some code
+            write some code
+            write some code
+            "
+        );
+    } // interfering comment
+      // interfering comment
+      // interfering comment
+
+    fn g(self) -> u32 {
+        // comment inside function
+        // comment inside function
+        // comment inside function
+
+        fn nested() {
+            todo!(
+                "
+                    write some code
+                    write some code
+                    write some code
+                "
+            );
+        }
+
+        struct Nested /* interfering block comment
+        interfering block comment
+        interfering block comment */ {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+
+        impl Nested {
+            fn h() {
+                // really nested comment
+                // really nested comment
+                // really nested comment
+
+                struct ReallyNested {
+                    a: i32,
+                    b: i32,
+                }
+            }
+        }
+
+        /* block comment inside function
+        block comment inside function
+        block comment inside function */
+    }
+}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -12,6 +12,7 @@ use helix_core::encoding::Encoding;
 use helix_core::snippets::{ActiveSnippet, SnippetRenderCtx};
 use helix_core::syntax::config::LanguageServerFeature;
 use helix_core::text_annotations::{InlineAnnotation, Overlay};
+use helix_core::text_folding::FoldContainer;
 use helix_event::TaskController;
 use helix_lsp::util::lsp_pos_to_pos;
 use helix_stdx::faccess::{copy_metadata, readonly};
@@ -150,6 +151,7 @@ pub struct Document {
     /// To know if they're up-to-date, check the `id` field in `DocumentInlayHints`.
     pub(crate) inlay_hints: HashMap<ViewId, DocumentInlayHints>,
     pub(crate) jump_labels: HashMap<ViewId, Vec<Overlay>>,
+    pub fold_container: HashMap<ViewId, FoldContainer>,
     /// Set to `true` when the document is updated, reset to `false` on the next inlay hints
     /// update from the LSP
     pub inlay_hints_oudated: bool,
@@ -317,6 +319,7 @@ impl fmt::Debug for Document {
             .field("modified_since_accessed", &self.modified_since_accessed)
             .field("diagnostics", &self.diagnostics)
             // .field("language_server", &self.language_server)
+            .field("fold_container", &self.fold_container)
             .finish()
     }
 }
@@ -704,6 +707,7 @@ impl Document {
             text,
             selections: HashMap::default(),
             inlay_hints: HashMap::default(),
+            fold_container: HashMap::default(),
             inlay_hints_oudated: false,
             view_data: Default::default(),
             indent_style: DEFAULT_INDENT,
@@ -1330,6 +1334,15 @@ impl Document {
         // TODO: use a transaction?
         self.selections
             .insert(view_id, selection.ensure_invariants(self.text().slice(..)));
+
+        if let Some((container, selection)) = self
+            .fold_container
+            .get_mut(&view_id)
+            .zip(self.selections.get(&view_id))
+        {
+            container.remove_by_selection(self.text.slice(..), selection)
+        }
+
         helix_event::dispatch(SelectionDidChange {
             doc: self,
             view: view_id,
@@ -1393,14 +1406,10 @@ impl Document {
 
         if changes.is_empty() {
             if let Some(selection) = transaction.selection() {
-                self.selections.insert(
+                self.set_selection(
                     view_id,
                     selection.clone().ensure_invariants(self.text.slice(..)),
                 );
-                helix_event::dispatch(SelectionDidChange {
-                    doc: self,
-                    view: view_id,
-                });
             }
             return true;
         }
@@ -1408,13 +1417,23 @@ impl Document {
         self.modified_since_accessed = true;
         self.version += 1;
 
-        for selection in self.selections.values_mut() {
-            *selection = selection
+        for container in self.fold_container.values_mut() {
+            container.update_by_transaction(self.text.slice(..), old_doc.slice(..), transaction);
+        }
+
+        for (id, selection) in &mut self.selections {
+            let ensured_selection = selection
                 .clone()
                 // Map through changes
                 .map(transaction.changes())
                 // Ensure all selections across all views still adhere to invariants.
                 .ensure_invariants(self.text.slice(..));
+
+            if let Some(container) = self.fold_container.get_mut(id) {
+                container.remove_by_selection(self.text.slice(..), &ensured_selection);
+            }
+
+            *selection = ensured_selection;
         }
 
         for view_data in self.view_data.values_mut() {
@@ -1535,14 +1554,10 @@ impl Document {
 
         // if specified, the current selection should instead be replaced by transaction.selection
         if let Some(selection) = transaction.selection() {
-            self.selections.insert(
+            self.set_selection(
                 view_id,
                 selection.clone().ensure_invariants(self.text.slice(..)),
             );
-            helix_event::dispatch(SelectionDidChange {
-                doc: self,
-                view: view_id,
-            });
         }
 
         true
@@ -2292,6 +2307,17 @@ impl Document {
 
     pub fn has_language_server_with_feature(&self, feature: LanguageServerFeature) -> bool {
         self.language_servers_with_feature(feature).next().is_some()
+    }
+
+    pub fn insert_fold_container(&mut self, view_id: ViewId, container: FoldContainer) {
+        self.fold_container.insert(view_id, container);
+    }
+
+    /// `None` when container is empty.
+    pub fn fold_container(&self, view_id: ViewId) -> Option<&FoldContainer> {
+        self.fold_container
+            .get(&view_id)
+            .filter(|container| !container.is_empty())
     }
 }
 

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2313,8 +2313,11 @@ impl Document {
         self.fold_container.insert(view_id, container);
     }
 
+    /// `None` when container is empty.
     pub fn fold_container(&self, view_id: ViewId) -> Option<&FoldContainer> {
-        self.fold_container.get(&view_id)
+        self.fold_container
+            .get(&view_id)
+            .filter(|container| !container.is_empty())
     }
 
     fn add_folds_impl(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -427,6 +427,8 @@ pub struct Config {
     pub rainbow_brackets: bool,
     /// Whether to enable Kitty Keyboard Protocol
     pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
+    /// Defines which text objects will be folded when a document is opened.
+    pub fold_textobjects: Vec<String>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1118,6 +1120,7 @@ impl Default for Config {
             editor_config: true,
             rainbow_brackets: false,
             kitty_keyboard_protocol: Default::default(),
+            fold_textobjects: Vec::new(),
         }
     }
 }

--- a/helix-view/src/handlers/word_index.rs
+++ b/helix-view/src/handlers/word_index.rs
@@ -6,7 +6,8 @@
 use std::{borrow::Cow, collections::HashMap, iter, mem, sync::Arc, time::Duration};
 
 use helix_core::{
-    chars::char_is_word, fuzzy::fuzzy_match, movement, ChangeSet, Range, Rope, RopeSlice,
+    chars::char_is_word, fuzzy::fuzzy_match, movement, text_annotations::TextAnnotations,
+    ChangeSet, Range, Rope, RopeSlice,
 };
 use helix_event::{register_hook, AsyncHook};
 use helix_stdx::rope::RopeSliceExt as _;
@@ -263,7 +264,8 @@ fn words(text: RopeSlice) -> impl Iterator<Item = RopeSlice> {
         .get_char(cursor.anchor)
         .is_some_and(|ch| !ch.is_whitespace())
     {
-        let cursor_word_end = movement::move_next_word_end(text, cursor, 1);
+        let cursor_word_end =
+            movement::move_next_word_end(text, &TextAnnotations::default(), cursor, 1);
         if cursor_word_end.anchor == 0 {
             cursor = cursor_word_end;
         }
@@ -290,7 +292,7 @@ fn words(text: RopeSlice) -> impl Iterator<Item = RopeSlice> {
                 }
             }
             let head = cursor.head;
-            cursor = movement::move_next_word_end(text, cursor, 1);
+            cursor = movement::move_next_word_end(text, &TextAnnotations::default(), cursor, 1);
             if cursor.head == head {
                 cursor.head = usize::MAX;
             }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -12,7 +12,7 @@ use helix_core::{
     char_idx_at_visual_offset,
     doc_formatter::TextFormat,
     text_annotations::TextAnnotations,
-    text_folding::RopeSliceFoldExt,
+    text_folding::{FoldAnnotations, RopeSliceFoldExt},
     visual_offset_from_anchor, visual_offset_from_block, Position, RopeSlice, Selection,
     Transaction,
     VisualOffsetError::{PosAfterMaxRow, PosBeforeAnchorRow},
@@ -517,6 +517,10 @@ impl View {
         }
 
         text_annotations
+    }
+
+    pub fn fold_annotations<'a>(&self, doc: &'a Document) -> FoldAnnotations<'a> {
+        FoldAnnotations::new(doc.fold_container(self.id))
     }
 
     pub fn text_pos_at_screen_coords(

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -12,6 +12,7 @@ use helix_core::{
     char_idx_at_visual_offset,
     doc_formatter::TextFormat,
     text_annotations::TextAnnotations,
+    text_folding::RopeSliceFoldExt,
     visual_offset_from_anchor, visual_offset_from_block, Position, RopeSlice, Selection,
     Transaction,
     VisualOffsetError::{PosAfterMaxRow, PosBeforeAnchorRow},
@@ -356,13 +357,14 @@ impl View {
     /// The actual last visible line may be smaller if softwrapping occurs
     /// or virtual text lines are visible
     #[inline]
-    pub fn estimate_last_doc_line(&self, doc: &Document) -> usize {
+    pub fn estimate_last_doc_line(&self, annotations: &TextAnnotations, doc: &Document) -> usize {
         let doc_text = doc.text().slice(..);
         let line = doc_text.char_to_line(doc.view_offset(self.id).anchor.min(doc_text.len_chars()));
-        // Saturating subs to make it inclusive zero indexing.
-        (line + self.inner_height())
-            .min(doc_text.len_lines())
-            .saturating_sub(1)
+        doc_text.nth_next_folded_line(
+            &annotations.folds,
+            line,
+            self.inner_height().saturating_sub(1),
+        )
     }
 
     /// Calculates the last non-empty visual line on screen
@@ -378,7 +380,7 @@ impl View {
         let visual_height = doc.view_offset(self.id).vertical_offset + viewport.height as usize;
 
         // fast path when the EOF is not visible on the screen,
-        if self.estimate_last_doc_line(doc) < doc_text.len_lines() - 1 {
+        if self.estimate_last_doc_line(&annotations, doc) < doc_text.len_lines() - 1 {
             return visual_height.saturating_sub(1);
         }
 
@@ -508,6 +510,10 @@ impl View {
                 doc.view_offset(self.id).horizontal_offset,
                 config,
             ));
+        }
+
+        if let Some(fold_container) = doc.fold_container(self.id) {
+            text_annotations.add_folds(fold_container);
         }
 
         text_annotations

--- a/theme.toml
+++ b/theme.toml
@@ -62,6 +62,7 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }
 
 "ui.virtual.indent-guide" = { fg = "comet" }
+"ui.virtual.fold-decoration" = { bg = "revolver", fg = "honey", modifiers = ["italic"] }
 
 "ui.selection" = { bg = "#540099" }
 "ui.selection.primary" = { bg = "#540099" }


### PR DESCRIPTION
Related to https://github.com/helix-editor/helix/issues/1840


https://github.com/user-attachments/assets/efbc88b3-2d0d-4731-b525-f3b645d46e17



# New user-level items

Introduced text folding commands:
  1. `fold` (default key-mapping is `zf`)
  2. `unfold` (default key-mapping is `zF`)
  3. `:fold`
  4. `:unfold`

Added the field `fold_textobjects` to `editor` (default list is empty, try to add some of the following available textobjects: class, function, comment)
Added the style `ui.virtual.fold-decoration`

# Commands that ignore folded text
The following commands behave as if there is no folded text.

Move word:
  1. `move_next_word_start`
  2. `move_prev_word_start`
  3. `move_prev_word_end`
  4. `move_next_word_end`
  5. `move_next_long_word_start`
  6. `move_prev_long_word_start`
  7. `move_prev_long_word_end`
  8. `move_next_long_word_end`
  9. `move_next_sub_word_start`
  10. `move_prev_sub_word_start`
  11. `move_prev_sub_word_end`
  12. `move_next_sub_word_end`

Extend word:
  1. `extend_next_word_start`
  2. `extend_prev_word_start`
  3. `extend_next_word_end`
  4. `extend_prev_word_end`
  5. `extend_next_long_word_start`
  6. `extend_prev_long_word_start`
  7. `extend_prev_long_word_end`
  8. `extend_next_long_word_end`
  9. `extend_next_sub_word_start`
  10. `extend_prev_sub_word_start`
  11. `extend_prev_sub_word_end`
  12. `extend_next_sub_word_end`

Move paragraph:
  1. `goto_prev_paragraph`
  2. `goto_next_paragraph`

Find char:
  1. `find_till_char`
  2. `find_next_char`
  3. `extend_till_char`
  4. `extend_next_char`
  5. `till_prev_char`
  6. `find_prev_char`
  7. `extend_till_prev_char`
  8. `extend_prev_char`

Extend line:
  1. `extend_line`
  2. `extend_line_above`
  3. `extend_line_below`

Open:
  1. `open_below`

To last line:
  1. `goto_last_line`
  2. `extend_to_last_line`

Paste:
  1. `paste_after`

Goto TS object:
NOTE: the commands skip only entire folded TS objects
  1. `goto_next_function`
  2. `goto_prev_function`
  3. `goto_next_class`
  4. `goto_prev_class`
  5. `goto_next_parameter`
  6. `goto_prev_parameter`
  7. `goto_next_comment`
  8. `goto_prev_comment`
  9. `goto_next_test`
  10. `goto_prev_test`
  11. `goto_next_xml_element`
  12. `goto_prev_xml_element`
  13. `goto_next_entry`
  14. `goto_prev_entry`

To word:
  1. `goto_word`
  2. `extend_to_word`

# Actions that create folds

Split:
NOTE: commands copy folds to the new view
  1. `hsplit`
  2. `vsplit`
  3. `:hsplit`
  4. `:vsplit`

File:
NOTE: when a new buffer is opened the specified text objects in the field `fold_textobjects` are folded.
  1. `file_picker`
  2. `file_explorer`
  3. cli pathspec (e.g., the command `hx -- src/main.rs` will open the file and fold the text objects defined in `fold_textobjects`)

# Accompanying changes

1. Replaced `CharMatcher` with `GraphemeMatcher`.
  For more details, check the commit f3202707e571e678a1df6ca3b2f9922ca7c819d8.
2. Fixed the method `TextObjectQuery::capture_nodes_any` (issue https://github.com/helix-editor/helix/issues/11087)
  Also, the fix was pushed as PR https://github.com/helix-editor/helix/pull/14591.

# Speech
Fold primitives have been implemented, including all components related to rendering and text processing. 
However, user-items are currently in draft form. Perhaps someone could suggest more convenient commands. Therefore, the documentation has not yet been written.
I suggest applying this PR in order for master-users to test the new feature and open an issue related to text folding.

Check the commit history for details. I have been trying to make it readable, consistent, and organized.
Start by reading the top-level documentation of the `text_folding` module.

# Planned improvements
Enable language-specific text folding.