### PR TITLE
Detach spawned LSP client from helix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "helix-loader",
  "helix-lsp-types",
  "helix-stdx",
+ "libc",
  "log",
  "parking_lot",
  "serde",
@@ -1519,6 +1520,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -32,3 +32,5 @@ arc-swap = "1"
 slotmap.workspace = true
 thiserror.workspace = true
 sonic-rs.workspace = true
+libc = "0.2"
+windows-sys = "0.61"

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -216,9 +216,10 @@ impl Client {
         Arc<Notify>,
     )> {
         // Resolve path to the binary
-        let cmd = helix_stdx::env::which(cmd)?;
+        let cmd_binary_path = helix_stdx::env::which(cmd)?;
 
-        let process = Command::new(cmd)
+        let mut command = Command::new(cmd_binary_path);
+        let mut command_mut = command
             .envs(server_environment)
             .args(args)
             .stdin(Stdio::piped())
@@ -226,10 +227,25 @@ impl Client {
             .stderr(Stdio::piped())
             .current_dir(&root_path)
             // make sure the process is reaped on drop
-            .kill_on_drop(true)
-            .spawn();
+            .kill_on_drop(true);
 
-        let mut process = process?;
+        #[cfg(unix)]
+        unsafe {
+            command_mut = command_mut.pre_exec(|| match libc::setsid() {
+                -1 => Err(std::io::Error::last_os_error()),
+                _ => Ok(()),
+            });
+        }
+
+        #[cfg(windows)]
+        {
+            command_mut = command_mut.creation_flags(
+                windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP
+                    | windows_sys::Win32::System::Threading::DETACHED_PROCESS,
+            );
+        }
+
+        let mut process = command_mut.spawn()?;
 
         // TODO: do we need bufreader/writer here? or do we use async wrappers on unblock?
         let writer = BufWriter::new(process.stdin.take().expect("Failed to open stdin"));

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -219,7 +219,7 @@ impl Client {
         let cmd_binary_path = helix_stdx::env::which(cmd)?;
 
         let mut command = Command::new(cmd_binary_path);
-        let mut command_mut = command
+        command
             .envs(server_environment)
             .args(args)
             .stdin(Stdio::piped())
@@ -231,7 +231,7 @@ impl Client {
 
         #[cfg(unix)]
         unsafe {
-            command_mut = command_mut.pre_exec(|| match libc::setsid() {
+            command.pre_exec(|| match libc::setsid() {
                 -1 => Err(std::io::Error::last_os_error()),
                 _ => Ok(()),
             });
@@ -239,13 +239,13 @@ impl Client {
 
         #[cfg(windows)]
         {
-            command_mut = command_mut.creation_flags(
+            command.creation_flags(
                 windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP
                     | windows_sys::Win32::System::Threading::DETACHED_PROCESS,
             );
         }
 
-        let mut process = command_mut.spawn()?;
+        let mut process = command.spawn()?;
 
         // TODO: do we need bufreader/writer here? or do we use async wrappers on unblock?
         let writer = BufWriter::new(process.stdin.take().expect("Failed to open stdin"));


### PR DESCRIPTION
This PR does the same as https://github.com/neovim/neovim/pull/18477. Neovim does not spawn the LSP process themself but use [libuv](https://github.com/libuv/libuv/tree/v1.x). The relevant code for spawning the process can be found [here (unix)](https://github.com/libuv/libuv/blob/v1.x/src/unix/process.c#L317) and [here (windows)](https://github.com/libuv/libuv/blob/v1.x/src/win/process.c#L1052). What I didn't include is the `CREATE_SUSPENDED` flag for windows. Since I was not sure what its purpose is, I didn't include it.

Fixes https://github.com/helix-editor/helix/issues/2578