### PR TITLE
Optimize color detection and add WSL support

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -12,6 +12,7 @@ pub mod job;
 pub mod keymap;
 pub mod ui;
 
+use std::env::var_os;
 use std::path::Path;
 
 use futures_util::Future;
@@ -27,10 +28,9 @@ fn true_color() -> bool {
 
 #[cfg(not(windows))]
 fn true_color() -> bool {
-    if matches!(
-        std::env::var("COLORTERM").map(|v| matches!(v.as_str(), "truecolor" | "24bit")),
-        Ok(true)
-    ) {
+    if var_os("COLORTERM").is_some_and(|v| v == "truecolor" || v == "24bit")
+        || var_os("WSL_DISTRO_NAME").is_some()
+    {
         return true;
     }
 


### PR DESCRIPTION
This PR fixes an issue where Helix would not correctly detect color support on Windows when run inside WSL, and optimizes color detection by using `std::env::var_os()` to skip unnecessary UTF-8 checks and conversions. I know that checking for `WSL_DISTRO_NAME` as *the* way to check for WSL looks kinda silly, but it is by far the most straightforward way that's supported in both WSL1 and WSL2.