### PR TITLE
Add hie.yaml as root file for Haskell repositories

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1569,7 +1569,7 @@ name = "haskell"
 scope = "source.haskell"
 injection-regex = "hs|haskell"
 file-types = ["hs", "hs-boot", "hsc"]
-roots = ["Setup.hs", "stack.yaml", "cabal.project"]
+roots = ["Setup.hs", "stack.yaml", "cabal.project", "hie.yaml"]
 shebangs = ["runhaskell", "stack"]
 comment-token = "--"
 block-comment-tokens = { start = "{-", end = "-}" }


### PR DESCRIPTION
A `hie.yaml` file marks the root of the repo for the Haskell LSP, `haskell-language-server`. [See LSP configuration documentation here](https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-project-build)