### PR TITLE
queries(scheme): move `@function.builtin` next to `@function`

### DIFF
--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -33,6 +33,37 @@
   .
   (symbol) @function)
 
+(list
+  .
+  (symbol) @function.builtin
+  (#any-of? @function.builtin
+    "caar" "cadr" "call-with-input-file" "call-with-output-file" "cdar" "cddr" "list"
+    "open-input-file" "open-output-file" "with-input-from-file" "with-output-to-file" "*" "+" "-"
+    "/" "<" "<=" "=" ">" ">=" "abs" "acos" "angle" "append" "apply" "asin" "assoc" "assq" "assv"
+    "atan" "boolean?" "caaaar" "caaadr" "caaar" "caadar" "caaddr" "caadr" "cadaar" "cadadr" "cadar"
+    "caddar" "cadddr" "caddr" "call-with-current-continuation" "call-with-values" "car" "cdaaar"
+    "cdaadr" "cdaar" "cdadar" "cdaddr" "cdadr" "cddaar" "cddadr" "cddar" "cdddar" "cddddr" "cdddr"
+    "cdr" "ceiling" "char->integer" "char-alphabetic?" "char-ci<=?" "char-ci<?" "char-ci=?"
+    "char-ci>=?" "char-ci>?" "char-downcase" "char-lower-case?" "char-numeric?" "char-ready?"
+    "char-upcase" "char-upper-case?" "char-whitespace?" "char<=?" "char<?" "char=?" "char>=?"
+    "char>?" "char?" "close-input-port" "close-output-port" "complex?" "cons" "cos"
+    "current-error-port" "current-input-port" "current-output-port" "denominator" "display"
+    "dynamic-wind" "eof-object?" "eq?" "equal?" "eqv?" "eval" "even?" "exact->inexact" "exact?" "exp"
+    "expt" "floor" "flush-output" "for-each" "force" "gcd" "imag-part" "inexact->exact" "inexact?"
+    "input-port?" "integer->char" "integer?" "interaction-environment" "lcm" "length" "list->string"
+    "list->vector" "list-ref" "list-tail" "list?" "load" "log" "magnitude" "make-polar"
+    "make-rectangular" "make-string" "make-vector" "map" "max" "member" "memq" "memv" "min" "modulo"
+    "negative?" "newline" "not" "null-environment" "null?" "number->string" "number?" "numerator"
+    "odd?" "output-port?" "pair?" "peek-char" "positive?" "procedure?" "quotient" "rational?"
+    "rationalize" "read" "read-char" "real-part" "real?" "remainder" "reverse" "round"
+    "scheme-report-environment" "set-car!" "set-cdr!" "sin" "sqrt" "string" "string->list"
+    "string->number" "string->symbol" "string-append" "string-ci<=?" "string-ci<?" "string-ci=?"
+    "string-ci>=?" "string-ci>?" "string-copy" "string-fill!" "string-length" "string-ref"
+    "string-set!" "string<=?" "string<?" "string=?" "string>=?" "string>?" "string?" "substring"
+    "symbol->string" "symbol?" "tan" "transcript-off" "transcript-on" "truncate" "values" "vector"
+    "vector->list" "vector-fill!" "vector-length" "vector-ref" "vector-set!" "vector?" "write"
+    "write-char" "zero?"))
+
 ; special forms
 
 (list
@@ -105,34 +136,3 @@
     "syntax-rules" "unquote" "begin" "quote" "let-syntax" "and" "if" "quasiquote" "letrec" "delay"
     "or" "when" "unless" "identifier-syntax" "assert" "library" "export" "import" "rename" "only"
     "except" "prefix" "define-values"))
-
-(list
-  .
-  (symbol) @function.builtin
-  (#any-of? @function.builtin
-    "caar" "cadr" "call-with-input-file" "call-with-output-file" "cdar" "cddr" "list"
-    "open-input-file" "open-output-file" "with-input-from-file" "with-output-to-file" "*" "+" "-"
-    "/" "<" "<=" "=" ">" ">=" "abs" "acos" "angle" "append" "apply" "asin" "assoc" "assq" "assv"
-    "atan" "boolean?" "caaaar" "caaadr" "caaar" "caadar" "caaddr" "caadr" "cadaar" "cadadr" "cadar"
-    "caddar" "cadddr" "caddr" "call-with-current-continuation" "call-with-values" "car" "cdaaar"
-    "cdaadr" "cdaar" "cdadar" "cdaddr" "cdadr" "cddaar" "cddadr" "cddar" "cdddar" "cddddr" "cdddr"
-    "cdr" "ceiling" "char->integer" "char-alphabetic?" "char-ci<=?" "char-ci<?" "char-ci=?"
-    "char-ci>=?" "char-ci>?" "char-downcase" "char-lower-case?" "char-numeric?" "char-ready?"
-    "char-upcase" "char-upper-case?" "char-whitespace?" "char<=?" "char<?" "char=?" "char>=?"
-    "char>?" "char?" "close-input-port" "close-output-port" "complex?" "cons" "cos"
-    "current-error-port" "current-input-port" "current-output-port" "denominator" "display"
-    "dynamic-wind" "eof-object?" "eq?" "equal?" "eqv?" "eval" "even?" "exact->inexact" "exact?" "exp"
-    "expt" "floor" "flush-output" "for-each" "force" "gcd" "imag-part" "inexact->exact" "inexact?"
-    "input-port?" "integer->char" "integer?" "interaction-environment" "lcm" "length" "list->string"
-    "list->vector" "list-ref" "list-tail" "list?" "load" "log" "magnitude" "make-polar"
-    "make-rectangular" "make-string" "make-vector" "map" "max" "member" "memq" "memv" "min" "modulo"
-    "negative?" "newline" "not" "null-environment" "null?" "number->string" "number?" "numerator"
-    "odd?" "output-port?" "pair?" "peek-char" "positive?" "procedure?" "quotient" "rational?"
-    "rationalize" "read" "read-char" "real-part" "real?" "remainder" "reverse" "round"
-    "scheme-report-environment" "set-car!" "set-cdr!" "sin" "sqrt" "string" "string->list"
-    "string->number" "string->symbol" "string-append" "string-ci<=?" "string-ci<?" "string-ci=?"
-    "string-ci>=?" "string-ci>?" "string-copy" "string-fill!" "string-length" "string-ref"
-    "string-set!" "string<=?" "string<?" "string=?" "string>=?" "string>?" "string?" "substring"
-    "symbol->string" "symbol?" "tan" "transcript-off" "transcript-on" "truncate" "values" "vector"
-    "vector->list" "vector-fill!" "vector-length" "vector-ref" "vector-set!" "vector?" "write"
-    "write-char" "zero?"))


### PR DESCRIPTION
this makes it, so that `@operator` takes preference, and `<`, `+`, `-`, etc are actually highlighted as `@operator`.

this also fixes the case, where variables that were shadowing builtin procedures in, for example, `let`, were still marked as a builtin function, even though they should have been `@variable`.

additionally it just makes more sense to group `@function.builtin` together with `@function` instead of `@keyword`, where it was previously.

before:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/cef4186b-a1cb-4d6a-86a3-cb96de5234ca" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/2deac26a-ce65-4dc5-8506-7493ab14d3eb" />

after:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/f4bb5da6-6f66-426c-b712-3f00c201e826" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/b4acf9d5-8476-4fca-b9f8-9ac8d38d4b5a" />
