### PR TITLE
fix(helix-term): correct health status for non-existent grammar paths

### DIFF
--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -365,8 +365,8 @@ fn probe_parser(grammar_name: &str) -> std::io::Result<()> {
     write!(stdout, "Tree-sitter parser: ")?;
 
     match helix_loader::grammar::get_language(grammar_name) {
-        Ok(_) => writeln!(stdout, "{}", "✓".green()),
-        Err(_) => writeln!(stdout, "{}", "None".yellow()),
+        Ok(Some(_)) => writeln!(stdout, "{}", "✓".green()),
+        Ok(None) | Err(_) => writeln!(stdout, "{}", "None".yellow()),
     }
 }
 


### PR DESCRIPTION
Hey all,

I recently encountered what I believe to be a minor bug in the health report that led to some confusion for my setup. Specifically, the health report seemingly incorrectly indicates that a language grammar exists as long as the `helix_loader::grammar::get_language` call does not return an error. However, it does not account for the case where the method does succeed, but the grammar path does not exist.

This minor change rectifies this by only indicating the `Ok(Some(_))` result of the `helix_loader::grammar::get_language` as a success in the context of the health report. I was considering adding a debug log statement in the `helix_loader::grammar::get_language` too, but I decided against it for now.

I am assuming that this was unlikely to be encountered because the grammars generally tend to be managed as a whole unit, and so as long as the grammars directory existed and no permission issues cropped up it generally meant things were fine. Nevertheless, assuming it is indeed a bug, perhaps this minor change can help others avoid some confusion in the future.