### PR TITLE
fix(helix-term): Defer mutation of editor config to the application

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -376,6 +376,27 @@ impl Application {
         }
     }
 
+    fn update_config(
+        &mut self,
+        pointer: String,
+        new_value: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let mut app_config = (*self.config.load().clone()).clone();
+        let mut editor_config = serde_json::json!(app_config.editor);
+
+        let old_value = editor_config
+            .pointer_mut(&pointer)
+            .ok_or_else(|| anyhow::anyhow!("Unknown key `{}`", pointer))?;
+        *old_value = new_value;
+
+        app_config.editor = serde_json::from_value(editor_config)
+            .map_err(|_| anyhow::anyhow!("Could not parse field"))?;
+
+        self.terminal.reconfigure((&app_config.editor).into())?;
+        self.config.store(Arc::new(app_config));
+        Ok(())
+    }
+
     pub fn handle_config_events(&mut self, config_event: ConfigEvent) {
         let old_editor_config = self.editor.config();
 
@@ -383,15 +404,13 @@ impl Application {
             ConfigEvent::Refresh => self.refresh_config(),
 
             // Since only the Application can make changes to Editor's config,
-            // the Editor must send up a new copy of a modified config so that
-            // the Application can apply it.
-            ConfigEvent::Update(editor_config) => {
-                let mut app_config = (*self.config.load().clone()).clone();
-                app_config.editor = *editor_config;
-                if let Err(err) = self.terminal.reconfigure((&app_config.editor).into()) {
+            // the Editor must send an update request so that the Application
+            // can apply it. Each update request includes a path to the field
+            // that should be updated and the new value for that field.
+            ConfigEvent::Update(pointer, new_value) => {
+                if let Err(err) = self.update_config(pointer, new_value) {
                     self.editor.set_error(err.to_string());
                 };
-                self.config.store(Arc::new(app_config));
             }
         }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2060,22 +2060,21 @@ fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
     let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
     let field_error = |_| anyhow::anyhow!("Could not parse field `{}`", arg);
 
-    let mut config = serde_json::json!(&cx.editor.config().deref());
+    let config = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
-    let value = config.pointer_mut(&pointer).ok_or_else(key_error)?;
+    let value = config.pointer(&pointer).ok_or_else(key_error)?;
 
-    *value = if value.is_string() {
+    let value = if value.is_string() {
         // JSON strings require quotes, so we can't .parse() directly
         Value::String(arg.to_string())
     } else {
         arg.parse().map_err(field_error)?
     };
-    let config = serde_json::from_value(config).map_err(field_error)?;
 
     cx.editor
         .config_events
         .0
-        .send(ConfigEvent::Update(config))?;
+        .send(ConfigEvent::Update(pointer, value))?;
     Ok(())
 }
 
@@ -2095,11 +2094,11 @@ fn toggle_option(
 
     let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
 
-    let mut config = serde_json::json!(&cx.editor.config().deref());
+    let config = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
-    let value = config.pointer_mut(&pointer).ok_or_else(key_error)?;
+    let value = config.pointer(&pointer).ok_or_else(key_error)?;
 
-    *value = match value {
+    let value = match value {
         Value::Bool(ref value) => {
             ensure!(
                 args.len() == 1,
@@ -2149,7 +2148,7 @@ fn toggle_option(
 
             if let Some(wrongly_typed_value) = values
                 .iter()
-                .find(|v| std::mem::discriminant(*v) != std::mem::discriminant(&*value))
+                .find(|v| std::mem::discriminant(*v) != std::mem::discriminant(value))
             {
                 bail!("value '{wrongly_typed_value}' has a different type than '{value}'");
             }
@@ -2164,13 +2163,11 @@ fn toggle_option(
     };
 
     let status = format!("'{key}' is now set to {value}");
-    let config = serde_json::from_value(config)
-        .map_err(|err| anyhow::anyhow!("Failed to parse config: {err}"))?;
 
     cx.editor
         .config_events
         .0
-        .send(ConfigEvent::Update(config))?;
+        .send(ConfigEvent::Update(pointer, value))?;
     cx.editor.set_status(status);
     Ok(())
 }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -6,6 +6,7 @@ mod insert;
 mod movement;
 mod reverse_selection_contents;
 mod rotate_selection_contents;
+mod typed;
 mod write;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/helix-term/tests/test/commands/typed.rs
+++ b/helix-term/tests/test/commands/typed.rs
@@ -1,0 +1,126 @@
+use std::{
+    io::{Read, Seek, Write},
+    ops::RangeInclusive,
+};
+
+use helix_core::diagnostic::Severity;
+use helix_core::hashmap;
+use helix_stdx::path;
+use helix_term::application::Application;
+use helix_term::config::ConfigRaw;
+use helix_term::keymap;
+use helix_view::doc;
+
+use super::*;
+
+fn build_app(config_toml: toml::Table) -> anyhow::Result<Application> {
+    let config_raw: ConfigRaw = config_toml.try_into()?;
+
+    let config = Config {
+        theme: config_raw.theme,
+        keys: config_raw.keys.unwrap(),
+        editor: config_raw.editor.unwrap().try_into()?,
+    };
+
+    let app = helpers::AppBuilder::new().with_config(config).build()?;
+
+    Ok(app)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_config_single() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = ":set trim-trailing-whitespace true"
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(!config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_config_multi() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = [
+            ":set trim-final-newlines true",
+            ":set trim-trailing-whitespace true",
+        ]
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_toggle_config_single() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = ":toggle trim-trailing-whitespace"
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(!config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_toggle_config_multi() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = [
+            ":toggle trim-final-newlines",
+            ":toggle trim-trailing-whitespace",
+        ]
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -56,6 +56,7 @@ use helix_lsp::lsp;
 use helix_stdx::path::canonicalize;
 
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 use arc_swap::{
     access::{DynAccess, DynGuard},
@@ -1236,7 +1237,7 @@ pub enum EditorEvent {
 #[derive(Debug, Clone)]
 pub enum ConfigEvent {
     Refresh,
-    Update(Box<Config>),
+    Update(String, Value),
 }
 
 enum ThemeAction {


### PR DESCRIPTION
# Description

This is a proposed fix for https://github.com/helix-editor/helix/issues/13187.

## Commits
There are 2 commits in this PR.

### `997da16`: Add integration tests to reproduce multi-command key binding bug
This commit adds 4 integration tests, one for each of the following scenarios:
- Binding a key to a single `:set` command.
- Binding a key to multiple `:set` commands.
- Binding a key to a single `:toggle` command.
- Binding a key to multiple `:toggle` commands.

### `a4eefb1`: Defer mutation of editor config to the application
This commit reworks how the `:set` and `:toggle` commands communicate config changes to the application. In the existing design, these commands do the following:
1. Load the current config.
2. Determine the path to the target field according to the provided `key` argument.
3. Mutate the loaded config according to the provided `value` argument.
4. Pass the new mutated config to the application.
5. The application then overwrites its entire config with the new config.

The bug arises when multiple commands are mapped to a single key. In this case, the commands are executed serially. When each command is executed it loads the config, mutates it, and passes the result to the application. Because all of the bound commands execute before the results from any of them are applied, they all load the same config rather than each command loading the result from the previous command. This means the result of each command gets clobbered by the command following it and only the final command result actually gets applied.

In the new design, the commands do the following:
1. Load the current config.
2. Determine the path to the target field according to the provided `key` argument.
3. Determine the new value that should be applied.
4. Pass the path and new value to the application.
5. The application then loads the config, mutates it, and stores the changes.

The key difference is that the command is only passing a path and value to the application, not an entire config. This avoids the command capturing stale values for fields that it's not actually operating on.

This does result in some duplicated work since both the command and application need to load the config, convert it to a `serde_json::Value`, etc. I think this is desirable because it keeps the behavior for each command in it's command handler. To deduplicate this work, we'd have to pass the raw arguments to the application, and then the command logic would need to move to the application as well. This logic is pretty trivial for `:set` but it's somewhat complex for `:toggle`. Moving that logic to the application seems like it would be confusing and generally less than ideal.

# Testing

## Integration Tests

I tested this by first adding a set of integration tests to reproduce the issue. Running these tests at `997da16` (prior to the fix) I get the following result:

```
running 4 tests
test test::commands::typed::test_toggle_config_single ... ok
test test::commands::typed::test_set_config_single ... ok
test test::commands::typed::test_set_config_multi ... FAILED
test test::commands::typed::test_toggle_config_multi ... FAILED
```

Running these tests again at `a4eefb1` (with the fix) I get:

```
running 4 tests
test test::commands::typed::test_set_config_single ... ok
test test::commands::typed::test_toggle_config_single ... ok
test test::commands::typed::test_toggle_config_multi ... ok
test test::commands::typed::test_set_config_multi ... ok
```

## Manual Testing

I also verified the behavior is as expected when running the new build interactively.

I have the following snippet in my config:

```
[keys.normal]
z.d = [
  ":set end-of-line-diagnostics hint",
  ":set inline-diagnostics.other-lines hint",
  ":set inline-diagnostics.cursor-line hint",
]
z.n = [
  ":set end-of-line-diagnostics disable",
  ":set inline-diagnostics.other-lines disable",
  ":set inline-diagnostics.cursor-line disable",
]
```

Prior to this fix (and the reason I found the original bug report) these two bindings would only change the `inline-diagnostics.cursor-line` setting. With the fix, all three settings are adjusted as expected in both cases.