### PR TITLE
build(deps): bump `unicode-width` from `=0.1.12` to `=0.1.14`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
  "tree-house",
  "unicode-general-category",
  "unicode-segmentation",
- "unicode-width 0.1.12",
+ "unicode-width 0.1.14",
  "url",
 ]
 
@@ -3015,9 +3015,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -29,7 +29,7 @@ unicode-segmentation.workspace = true
 # width definitions in terminals, we need to replace it.
 # For now lets lock the version to avoid rendering glitches
 # when installing without `--locked`
-unicode-width = "=0.1.12"
+unicode-width = "=0.1.14"
 unicode-general-category = "1.1"
 slotmap.workspace = true
 tree-house.workspace = true

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -113,8 +113,6 @@ pub fn grapheme_width(g: &str) -> usize {
         // We use max(1) here because all grapeheme clusters--even illformed
         // ones--should have at least some width so they can be edited
         // properly.
-        // TODO properly handle unicode width for all codepoints
-        // example of where unicode width is currently wrong: 🤦🏼‍♂️ (taken from https://hsivonen.fi/string-length/)
         UnicodeWidthStr::width(g).max(1)
     }
 }


### PR DESCRIPTION
This is the same as `0.1.13`, but without the newline width change: https://github.com/unicode-rs/unicode-width/pull/67

We are pinned to `0.1.12`, but this should be a seamless upgrade, and fixes a TODO for correct width. Any `0.2.*` upgrade needs more involved changes on our part: https://github.com/helix-editor/helix/issues/14642

`=0.1.12`:
<img width="1285" height="204" alt="Image" src="https://github.com/user-attachments/assets/954e1dd0-7f26-493c-b704-879f97f208d8" />

`=0.1.14`:
<img width="1285" height="204" alt="Image" src="https://github.com/user-attachments/assets/e036cc39-ff1c-4307-b119-ab419ee23a0c" />