### PR TITLE
Add --theme CLI flag to override theme file path

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -13,12 +13,20 @@ static RUNTIME_DIRS: once_cell::sync::Lazy<Vec<PathBuf>> =
 
 static CONFIG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
 
+static THEME_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
+
 static LOG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
 
 pub fn initialize_config_file(specified_file: Option<PathBuf>) {
     let config_file = specified_file.unwrap_or_else(default_config_file);
     ensure_parent_dir(&config_file);
     CONFIG_FILE.set(config_file).ok();
+}
+
+pub fn initialize_theme_file(specified_file: Option<PathBuf>) {
+    if let Some(theme_file) = specified_file {
+        THEME_FILE.set(theme_file).ok();
+    }
 }
 
 pub fn initialize_log_file(specified_file: Option<PathBuf>) {
@@ -134,6 +142,10 @@ pub fn cache_dir() -> PathBuf {
 
 pub fn config_file() -> PathBuf {
     CONFIG_FILE.get().map(|path| path.to_path_buf()).unwrap()
+}
+
+pub fn theme_file() -> Option<PathBuf> {
+    THEME_FILE.get().map(|path| path.to_path_buf())
 }
 
 pub fn log_file() -> PathBuf {

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     pub verbosity: u64,
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
+    pub theme_file: Option<PathBuf>,
     pub files: IndexMap<PathBuf, Vec<Position>>,
     pub working_directory: Option<PathBuf>,
 }
@@ -69,6 +70,10 @@ impl Args {
                 "-c" | "--config" => match argv.next().as_deref() {
                     Some(path) => args.config_file = Some(path.into()),
                     None => anyhow::bail!("--config must specify a path to read"),
+                },
+                "-t" | "--theme" => match argv.next().as_deref() {
+                    Some(path) => args.theme_file = Some(path.into()),
+                    None => anyhow::bail!("--theme must specify a path to read"),
                 },
                 "--log" => match argv.next().as_deref() {
                     Some(path) => args.log_file = Some(path.into()),

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -42,6 +42,7 @@ async fn main_impl() -> Result<i32> {
     let args = Args::parse_args().context("could not parse arguments")?;
 
     helix_loader::initialize_config_file(args.config_file.clone());
+    helix_loader::initialize_theme_file(args.theme_file.clone());
     helix_loader::initialize_log_file(args.log_file.clone());
 
     // Help has a higher priority and should be handled separately.
@@ -68,6 +69,7 @@ FLAGS:
                                    the default is the same as 'all', but with languages filtering.
     -g, --grammar {{fetch|build}}    Fetch or builds tree-sitter grammars listed in languages.toml
     -c, --config <file>            Specify a file to use for configuration
+    -t, --theme <file>             Specify a theme file to use
     -v                             Increase logging verbosity each use for up to 3 times
     --log <file>                   Specify a file to use for logging
                                    (default file: {})


### PR DESCRIPTION
Adds a new --theme (-t) command-line option that allows specifying a direct path to a CUSTOM theme file, similar to how --config works for _the_ configuration file. This is useful for environments like Nix where avoiding symlinks and using CLI overrides is preferred.

The --theme flag takes precedence over the theme specified in the config file (whether custom or not) and supports theme inheritance via the 'inherits' field (which the config override file does not).

Usage: hx --theme /path/to/theme.toml file.txt