### PR TITLE
Support for Literate Haskell

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -106,7 +106,7 @@
 | gts | ✓ | ✓ | ✓ | ✓ |  | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | hare | ✓ |  |  |  |  |  |
 | haskell | ✓ | ✓ |  |  |  | `haskell-language-server-wrapper` |
-| haskell-literate |  |  |  |  |  | `haskell-language-server-wrapper` |
+| haskell-literate | ✓ |  |  |  |  | `haskell-language-server-wrapper` |
 | haskell-persistent | ✓ |  |  |  |  |  |
 | hcl | ✓ | ✓ | ✓ |  |  | `terraform-ls` |
 | hdl | ✓ |  |  |  |  | `hdls` |

--- a/languages.toml
+++ b/languages.toml
@@ -1603,6 +1603,10 @@ block-comment-tokens = { start = "{-", end = "-}" }
 language-servers = [ "haskell-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 
+[[grammar]]
+name = "haskell-literate"
+source = { git = "https://github.com/LaurentRDC/tree-sitter-haskell-literate", rev = "8ad7bd1b1595f4cc1a4ccc775d4a3c460f43a596" }
+
 [[language]]
 name = "purescript"
 scope = "source.purescript"

--- a/runtime/queries/haskell-literate/highlights.scm
+++ b/runtime/queries/haskell-literate/highlights.scm
@@ -1,0 +1,16 @@
+; Bird track marker
+(bird_line ">" @punctuation.special)
+
+; LaTeX delimiters
+(latex_begin) @keyword.directive
+(latex_end) @keyword.directive
+
+; Highlight LaTeX comments like comments
+(latex_comment) @comment
+
+; Markdown delimiters
+(markdown_begin) @keyword.directive
+(markdown_end) @keyword.directive
+
+; Normal prose is not highlighted. Haskell code will be
+; highlighted by the injected Haskell grammar

--- a/runtime/queries/haskell-literate/injections.scm
+++ b/runtime/queries/haskell-literate/injections.scm
@@ -1,0 +1,14 @@
+; Inject Haskell parser into bird-style code lines
+((bird_line
+  (haskell_code) @injection.content)
+ (#set! injection.language "haskell"))
+
+; Inject Haskell parser into LaTeX code blocks
+((latex_code_line
+  (haskell_code) @injection.content)
+ (#set! injection.language "haskell"))
+
+; Inject Haskell parser into Markdown code blocks
+((markdown_code_line
+  (haskell_code) @injection.content)
+ (#set! injection.language "haskell"))


### PR DESCRIPTION
This change adds support for Literate Haskell. Literate Haskell files are basically regular Haskell files, so I kept much of the same configuration as for `haskell`, for example the root files and comment structure. [The tree-sitter support is based on my own repo](https://github.com/LaurentRDC/tree-sitter-haskell-literate).

Here's an example of using an example file using `hx` built from this branch:

```bash
export HELIX_RUNTIME=./runtime 
cargo run hx --grammar fetch
cargo run hx --grammar build
cargo run hx
```

<img width="886" height="697" alt="image" src="https://github.com/user-attachments/assets/f0bd5d98-a41e-43e0-ac79-55300fa5b8fe" />
