### PR TITLE
Update lean.roots in languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1304,7 +1304,7 @@ name = "lean"
 scope = "source.lean"
 injection-regex = "lean"
 file-types = ["lean"]
-roots = [ "lakefile.lean" ]
+roots = [ "lakefile.lean", "lakefile.toml" ]
 comment-token = "--"
 block-comment-tokens = { start = "/-", end = "-/" }
 language-servers = [ "lean" ]


### PR DESCRIPTION
Since [v4.8.0](https://lean-lang.org/doc/reference/latest/releases/v4.8.0/#release-v4___8___0) (2024-06-05), Lean4 supports `lakefile.toml` as another package configuration format, but `lean.roots` in languages.toml is still defined as `[ "lakefile.lean" ]`. As a result, Helix may emit an "unknown module prefix" error in some repositories. This PR fixes the issue by updating the definition.