### PR TITLE
Add `yank-path` and `yank-path-relative` commands.

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -89,6 +89,8 @@
 | `:redraw` | Clear and re-render the whole UI |
 | `:move`, `:mv` | Move the current buffer and its corresponding file to a different path |
 | `:yank-diagnostic` | Yank diagnostic(s) under primary cursor to register, or clipboard by default |
+| `:yank-path` | Yank the path of the current document to register, or clipboard by default |
+| `:yank-path-relative` | Yank the path of the current document relative to the working directory to register, or clipboard by default |
 | `:read`, `:r` | Load a file into buffer |
 | `:echo` | Prints the given arguments to the statusline. |
 | `:noop` | Does nothing. |


### PR DESCRIPTION
This commit adds two typable commands that allow you to copy the full path of the current document, and the path relative to the cwd.

---

I found myself needing this today, when searching for a file in my file manager that I had edited in helix, so here we go! :p