### PR TITLE
Fix typo in languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4930,7 +4930,7 @@ formatter = { command = "zoo" , args = ["kcl", "fmt", "-"] }
 language-servers = [ "kcl-lsp" ]
 block-comment-tokens = { start = "/*", end = "*/"}
 
-[[grammer]]
+[[grammar]]
 name = "kcl"
 source = { git = "https://github.com/KittyCAD/tree-sitter-kcl", rev = "8905e0bdbf5870b50bc3f24345f1af27746f42e8"}
 


### PR DESCRIPTION
Single character change to fix typo for kcl grammar.

Shameless plug for https://github.com/helix-editor/helix/pull/14545, which would prevent this.