### PR TITLE
languages(html): add '<' to auto-pairs

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1013,6 +1013,14 @@ language-servers = [ "vscode-html-language-server", "superhtml" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+"'" = "'"
+"<" = ">"
+
 [[grammar]]
 name = "html"
 source = { git = "https://github.com/tree-sitter/tree-sitter-html", rev = "cbb91a0ff3621245e890d1c50cc811bffb77a26b" }


### PR DESCRIPTION
noticed in #14660.

in the future it might be smart to do something similar to #12759 for this, so that the injected javascript / css does not have those tokens as auto-closing, but i'll figure out how to do that relatively soon-ish, as it wasn't as easy as i hoped it would be ...