### PR TITLE
feat: prioritize exact and smaller matches in completion

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -369,7 +369,13 @@ impl Completion {
         let min_score = (7 + pattern.needle_text().len() as u32 * 14) / 3;
         matches.sort_unstable_by_key(|&(i, score)| {
             let option = &options[i as usize];
+            let filter_text = option.filter_text();
+            let is_exact_match = Utf32Str::new(filter_text, &mut buf) == pattern.needle_text();
+            let match_length = filter_text.len() as u32;
+
             (
+                !is_exact_match,
+                match_length,
                 score <= min_score,
                 Reverse(option.preselect()),
                 option.provider_priority(),


### PR DESCRIPTION
This is a small PR to get some eyeballs and hopefully some feedback on these changes. As #14566 rightfully points out, it's unintuitive that exact matches are shown last after all the partial matches.

I just did the most straightforward thing, which is to check if the pattern exactly matches the text, and give that a higher priority sort over anything else. It also seems natural to me to display smaller matches first, but I don't think this is that important.

Closes #14566

Note: I wanted to add tests for this but AFAICT there are no tests currently which exercise the sorting of completion items. I was going to add my own, but since the `Completion` struct takes an `Editor`, and I couldn't find any tests which actually initialized a whole `Editor` instance, I wasn't sure if this was the right approach.