### PR TITLE
ecma/injections: inject graphql language on gql`…` contents

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -26,7 +26,7 @@
 
 ((call_expression
    function: (identifier) @_template_function_name
-   arguments: (template_string) @injection.content)
+   arguments: (template_string (string_fragment) @injection.content))
  (#eq? @_template_function_name "gql")
  (#set! injection.language "graphql"))
 


### PR DESCRIPTION
We previously injected the graphql language on 'gql`…`' template strings, but included the leading and trailing '\`' character. That's not valid graphQL syntax, so the injected syntax highlighting never worked. Match on the contents of that template string (i.e. its `string_fragment`) to omit the leading/trailing backtick and fix graphql-in-ecma highlighting.

### Before
<img width="938" height="502" alt="CleanShot 2025-10-30 at 14 51 35@2x" src="https://github.com/user-attachments/assets/40797ac9-474e-4c1e-86e1-12ad41599100" />

### After
<img width="938" height="502" alt="CleanShot 2025-10-30 at 14 50 58@2x" src="https://github.com/user-attachments/assets/446be24a-46de-4253-819e-5f470c4fb233" />
