### PR TITLE
fix(helix-dap): seq number must start at 1

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -231,6 +231,10 @@ impl Client {
     }
 
     fn next_request_id(&self) -> u64 {
+        // > The `seq` for the first message sent by a client or debug adapter
+        // > is 1, and for each subsequent message is 1 greater than the
+        // > previous message sent by that actor
+        // <https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_ProtocolMessage>
         self.request_counter.fetch_add(1, Ordering::Relaxed) + 1
     }
 


### PR DESCRIPTION
Hi there, this is a bit outside of my expertise but I had some issues running the debugger for C projects, due to the following error: `helix_dap::transport [ERROR] err <- DAP session error: expected to not be '0' at (root).seq`
The user only sees `Failed to start debug client: server closed the stream`

it seems like lldb-dap is checking that the sequence number is non-zero:
https://github.com/llvm/llvm-project/blob/main/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp#L96

[The DAP specification](https://microsoft.github.io/debug-adapter-protocol/specification) says this:
> The `seq` for the first message sent by a client or debug adapter is 1

This made me assume that the lldb-dap check is probably correct. In this pull request I added an increment instead of setting the initial value of the request_counter to 1 in order to maintain the semantic meaning of the variable. This change has only been tested with lldb v21.1.3 with C on linux (arch).

