### PR TITLE
Update Buf LSP command

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -18,7 +18,7 @@ bass = { command = "bass", args = ["--lsp"] }
 beancount-language-server = { command = "beancount-language-server" }
 bicep-langserver = { command = "bicep-langserver" }
 bitbake-language-server = { command = "bitbake-language-server" }
-buf = { command = "buf", args = ["beta", "lsp", "--timeout", "0"] }
+buf = { command = "buf", args = ["lsp", "serve", "--timeout", "0"] }
 cairo-language-server = { command = "cairo-language-server", args = [] }
 circom-lsp = { command = "circom-lsp" }
 cl-lsp = { command = "cl-lsp" }


### PR DESCRIPTION
`buf beta lsp` has been promoted to `buf lsp serve` in the latest release of the CLI. The old command has been deprecated.
The languages.toml file is still using the old command, so this PR changes it to use the new one.

See [`buf/CHANGELOG.md`](https://github.com/bufbuild/buf/blob/bbc10769565c73b3ef16ab78c7b4ac9dd07cffc4/CHANGELOG.md?plain=1#L12)
