### PR TITLE
ecma/injections: support more graphql injection modes

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -22,13 +22,49 @@
  (#eq? @_template_function_name "$")
  (#set! injection.language "bash"))
 
-; Parse the contents of gql template literals
+; GraphQL detection generally matches the rules provided by the 'GraphQL: Syntax Highlighting'
+; VSCode extension: https://github.com/graphql/graphiql/blob/8f25b38f4ab14dc99c046109f255fb283bccde52/packages/vscode-graphql-syntax/grammars/graphql.js.json
 
-((call_expression
-   function: (identifier) @_template_function_name
-   arguments: (template_string (string_fragment) @injection.content))
- (#eq? @_template_function_name "gql")
- (#set! injection.language "graphql"))
+; Parse the contents of 'gql' and 'graphql' template literals and function calls
+(
+  (call_expression
+    function: (identifier) @_template_function_name
+    arguments: [
+      ; Tagged template literal: NAME``
+      (template_string (string_fragment) @injection.content)
+      (
+        arguments . [
+          ; Function call containing a string literal: NAME('')
+          (string (string_fragment) @injection.content)
+          ; Function call containing a template literal: NAME(``)
+          (template_string (string_fragment) @injection.content)
+        ]
+      )
+    ]
+  )
+  (#any-of? @_template_function_name "gql" "graphql")
+  (#set! injection.language "graphql")
+)
+
+; Parse the contents of strings and tagged template literals that begin with a GraphQL comment '#graphql'
+(
+  [
+    (string (string_fragment) @injection.content)
+    (template_string (string_fragment) @injection.content)
+  ]
+  (#match? @injection.content "^\\s*#graphql")
+  (#set! injection.language "graphql")
+)
+
+; Parse the contents of strings and tagged template literals with leading ECMAScript comments '/* GraphQL */'
+(
+  ((comment) @_ecma_comment [
+    (string (string_fragment) @injection.content)
+    (template_string (string_fragment) @injection.content)
+  ])
+  (#eq? @_ecma_comment "/* GraphQL */")
+  (#set! injection.language "graphql")
+)
 
 ; Parse regex syntax within regex literals
 


### PR DESCRIPTION
GraphQL injections previously only operated on a 'gql' tagged template literal, but a few more options are supported by the official VSCode 'GraphQL: Syntax Highlighting' extension:

    // Already supported
    gql`query { foo }`;

    // New
    gql('query { foo }');
    gql(`query { foo }`);

    graphql`query { foo }`;
    graphql('query { foo }');
    graphql(`query { foo }`);

    '#graphql query { foo }';
    `#graphql query { foo }`;

    /* GraphQL */ 'query { foo }';
    /* GraphQL */ `query { foo }`;

Note that until a PR in tree-sitter-typescript[^1] is merged upstream and updated here, tagged template literals with type arguments (e.g. 'gql<SomeType>\`query { foo }\`;') won't have a working injection.

supports #14413

### Before
<img width="385" height="355" alt="Screenshot 2025-11-03 at 2 07 36 PM" src="https://github.com/user-attachments/assets/7c124075-6275-4e87-a7b6-f5600060f39f" />

### After
<img width="385" height="355" alt="Screenshot 2025-11-03 at 2 07 13 PM" src="https://github.com/user-attachments/assets/cf5d0e2b-f750-45eb-949f-5180d73a40db" />


[^1]: https://github.com/tree-sitter/tree-sitter-typescript/pull/350