### PR TITLE
fix: macro replay + async pickers

### DIFF
--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -99,6 +99,16 @@ impl Jobs {
         self.add(Job::with_callback(f));
     }
 
+    /// Like `callback` but the job is added to wait_futures, allowing synchronous code
+    /// to block and wait for it. Used during macro replay to ensure async operations
+    /// complete before subsequent keys are processed.
+    pub fn callback_wait<F: Future<Output = anyhow::Result<Callback>> + Send + 'static>(
+        &mut self,
+        f: F,
+    ) {
+        self.add(Job::with_callback(f).wait_before_exiting());
+    }
+
     pub fn handle_callback(
         &self,
         editor: &mut Editor,


### PR DESCRIPTION
Keybinding macros that open LSP-based pickers (like symbol picker) process subsequent keys before the async LSP request completes, causing those keys to be misrouted to the buffer instead of the picker’s search field.

**Cause:** Macro replay executes all keys synchronously in a tight loop without yielding to the async runtime, so UI components from background LSP operations aren’t available when subsequent keys are processed.

**Solution:** After each key during macro replay, drain all pending async callbacks and block on any in-flight futures using `tokio::task::block_in_place()` + `helix_lsp::block_on()`. This ensures async operations complete and their UI components are pushed before processing the next key.

**Trade-off:** Causes “overly long loop” warnings from LSP servers when intentionally blocking. Seems relatively harmless. The macro waits for operations to complete before continuing.

Summary of changes:

1. `helix-term/src/job.rs`
- Added `callback_wait()` method to allow jobs to be added to wait_futures for synchronous waiting

2. `helix-term/src/commands/lsp.rs`
- Modified `symbol_picker()` to use `callback_wait()` during macro replay

3. `helix-term/src/commands.rs`
- Added `drain_pending_jobs()` helper function
- Modified keybinding macro execution to call helper
- Modified `replay_macro()` to call helper