### PR TITLE
languages: Add 'ros' to Common Lisp file types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1782,7 +1782,7 @@ grammar = "scheme"
 [[language]]
 name = "common-lisp"
 scope = "source.lisp"
-file-types = ["lisp", "asd", "cl", "l", "lsp", "ny", "podsl", "sexp"]
+file-types = ["lisp", "asd", "cl", "l", "lsp", "ny", "podsl", "ros", "sexp"]
 shebangs = ["lisp", "sbcl", "ccl", "clisp", "ecl"]
 comment-token = ";"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
`.ros` files are scripts written in Common Lisp and run with Roswell, a popular Common Lisp installer/launcher/runner.