### PR TITLE
 fix(core): Fix `mdm` inconsistency for plaintext

### DIFF
--- a/helix-core/src/surround.rs
+++ b/helix-core/src/surround.rs
@@ -57,9 +57,7 @@ fn find_nth_closest_pairs_ts(
     mut skip: usize,
 ) -> Result<(usize, usize)> {
     let mut opening = range.from();
-    // We want to expand the selection if we are already on the found pair,
-    // otherwise we would need to subtract "-1" from "range.to()".
-    let mut closing = range.to();
+    let mut closing = range.to() - 1;
 
     while skip > 0 {
         closing = find_matching_bracket_fuzzy(syntax, text, closing).ok_or(Error::PairNotFound)?;
@@ -96,12 +94,12 @@ fn find_nth_closest_pairs_plain(
 ) -> Result<(usize, usize)> {
     let mut stack = Vec::with_capacity(2);
     let pos = range.from();
-    let mut close_pos = pos.saturating_sub(1);
 
-    for ch in text.chars_at(pos) {
-        close_pos += 1;
+    for (offset, ch) in text.chars_at(pos).enumerate() {
+        let close_pos = pos + offset;
 
-        if is_open_bracket(ch) {
+        // If cursor is on opening bracket, don't skip its resulting pair.
+        if is_open_bracket(ch) && offset != 0 {
             // Track open pairs encountered so that we can step over
             // the corresponding close pairs that will come up further
             // down the loop. We want to find a lone close pair whose


### PR DESCRIPTION
This fixes #11813 for plaintext surround matching. When combined with #10611 (which fixes inconsistency with treesitter surround matching), this completely fixes the inconsistency with `md`, `ma`, and `mi`. This breaks `mam`/`mim` when a pair is completely highlighted (for `mam` it should highlight the next closest pair), but #10611 will fix that.