### PR TITLE
Typst: remove quote query

### DIFF
--- a/runtime/queries/typst/highlights.scm
+++ b/runtime/queries/typst/highlights.scm
@@ -65,7 +65,6 @@
 (strong) @markup.bold
 (symbol) @constant.character
 (shorthand) @constant.builtin
-(quote) @markup.quote
 (align) @operator
 (letter) @constant.character
 (linebreak) @constant.builtin


### PR DESCRIPTION
Previously, single quotes were highlighted as `markup.quote` in typst markup. This looks wrong, since quotes are just normal text in markup mode. As far as I understand it, the `markup.quote` highlight is intended for blockquotes, such as `>` in markdown.