### PR TITLE
[Theme] Add acid.toml theme

### DIFF
--- a/runtime/themes/acid.toml
+++ b/runtime/themes/acid.toml
@@ -33,7 +33,7 @@
 "markup.heading" = "green"
 "markup.list" = "red"
 "markup.bold" = { fg = "yellow", modifiers = ["bold"] }
-"markup.italic" = { fg = "yelow", modifiers = ["italic"] }
+"markup.italic" = { fg = "yellow", modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = "cyan"
 "markup.link.text" = "yellow"


### PR DESCRIPTION
This is a theme I've made for helix a long time ago based on ayu_mirage and onedark and I've been using it ever since.
<img width="1483" height="1114" alt="screenshot" src="https://github.com/user-attachments/assets/42bcf796-efad-4dc9-b84e-45f3dae7122e" />
