### PR TITLE
Default root_uri to the workspace

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -897,10 +897,9 @@ fn start_client(
         workspace_is_cwd,
     );
 
-    // `root_uri` and `workspace_folder` can be empty in case there is no workspace
-    // `root_url` can not, use `workspace` as a fallback
+    // in case there is no root use `workspace` as a fallback
     let root_path = root.clone().unwrap_or_else(|| workspace.clone());
-    let root_uri = root.and_then(|root| lsp::Url::from_file_path(root).ok());
+    let root_uri = lsp::Url::from_file_path(&root_path).ok();
 
     if let Some(globset) = &ls_config.required_root_patterns {
         if !root_path


### PR DESCRIPTION
On windows using JDT Language server the LSP would crash on opening a .java file in which it would not resolve a `root` path when calling `find_lsp_workspace`. 

This is because the JDT language server does not accept non URI paths on windows for example `C:\foo\bar` which is being passed by the `root_path` variable. 

If we always set `root_uri` when possible it will use that and get the correctly formatted file:// URI.

To reproduce this issue on windows you just need to make create a java file anywhere it will not find the lsp workspace, for example `hx C:\tmp\main.java` then look at the log and see the below:

```
2025-11-07T21:27:19.374 helix_lsp::transport [ERROR] jdtls err <- "Caused by: java.net.URISyntaxException: Illegal character in opaque part at index 2: C:\\tmp\r\n"
```

I am not very familiar with the codebase so not sure of why we cant do this, just wanted to make a PR as it resolved my issue. Not sure about the implications on other OS's language servers.