### PR TITLE
feat(languages): update python grammar version

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1061,7 +1061,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "python"
-source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "4bfdd9033a2225cc95032ce77066b7aeca9e2efc" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "293fdc02038ee2bf0e2e206711b69c90ac0d413f" }
 
 [[language]]
 name = "nickel"

--- a/runtime/queries/python/tags.scm
+++ b/runtime/queries/python/tags.scm
@@ -1,3 +1,5 @@
+(module (expression_statement (assignment left: (identifier) @name) @definition.constant))
+
 (class_definition
   name: (identifier) @name) @definition.class
 


### PR DESCRIPTION
Updates to the latest release, jumping from Nov 17, 2023 to Sep 10, 2025 in terms of time. The `tags.scm` had added support for `module` in the interim, so added that as well.