### PR TITLE
Added Kitty Multicursor Support

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -5,19 +5,14 @@ pub use helix_stdx::range::Range;
 use serde::{Deserialize, Serialize};
 
 /// Describes the severity level of a [`Diagnostic`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
+    #[default]
     Hint,
     Info,
     Warning,
     Error,
-}
-
-impl Default for Severity {
-    fn default() -> Self {
-        Self::Hint
-    }
 }
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -273,7 +273,7 @@ impl Drop for GraphemeStr<'_> {
         if self.len & Self::MASK_OWNED != 0 {
             // free allocation
             unsafe {
-                drop(Box::from_raw(slice::from_raw_parts_mut(
+                drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                     self.ptr.as_ptr(),
                     self.compute_len(),
                 )));

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -222,7 +222,7 @@ fn test_treesitter_indent(
             .unwrap()
             .to_string(&indent_style, tab_width);
             assert!(
-                line.get_slice(..pos).map_or(false, |s| s == suggested_indent),
+                line.get_slice(..pos).is_some_and(|s| s == suggested_indent),
                 "Wrong indentation for file {:?} on line {}:\n\"{}\" (original line)\n\"{}\" (suggested indentation)\n",
                 test_name,
                 i+1,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -124,6 +124,12 @@ impl Application {
         let backend = TestBackend::new(120, 150);
 
         let theme_mode = backend.get_theme_mode();
+
+        #[cfg(all(not(windows), not(feature = "integration")))]
+        let kitty_multi_cursor_support = backend.supports_kitty_multi_cursor();
+        #[cfg(any(windows, feature = "integration"))]
+        let kitty_multi_cursor_support = false;
+
         let terminal = Terminal::new(backend)?;
         let area = terminal.size();
         let mut compositor = Compositor::new(area);
@@ -138,6 +144,8 @@ impl Application {
             })),
             handlers,
         );
+        editor.kitty_multi_cursor_support = kitty_multi_cursor_support;
+
         Self::load_configured_theme(
             &mut editor,
             &config.load(),
@@ -298,7 +306,43 @@ impl Application {
         self.editor.cursor_cache.reset();
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
+
+        use helix_view::graphics::CursorKind;
+        let secondary_cursors = if !matches!(kind, CursorKind::Block | CursorKind::Hidden) {
+            self.get_secondary_cursor_positions()
+        } else {
+            Vec::new()
+        };
+
         self.terminal.draw(pos, kind).unwrap();
+        // Always update kitty cursors (clears if empty, sets if not)
+        self.terminal
+            .set_multiple_cursors(&secondary_cursors)
+            .unwrap();
+    }
+
+    fn get_secondary_cursor_positions(&self) -> Vec<(u16, u16)> {
+        use helix_view::current_ref;
+
+        let (view, doc) = current_ref!(&self.editor);
+        let text = doc.text().slice(..);
+        let selection = doc.selection(view.id);
+        let primary_idx = selection.primary_index();
+        let inner = view.inner_area(doc);
+
+        selection
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != primary_idx)
+            .filter_map(|(_, range)| {
+                let cursor = range.cursor(text);
+                view.screen_coords_at_pos(doc, text, cursor).map(|pos| {
+                    let x = (pos.col + inner.x as usize) as u16;
+                    let y = (pos.row + inner.y as usize) as u16;
+                    (x, y)
+                })
+            })
+            .collect()
     }
 
     pub async fn event_loop<S>(&mut self, input_stream: &mut S)

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -483,14 +483,11 @@ mod tests {
                 .len()
                 > 1
         );
-        assert!(
-            merged_keyamp
-                .get(&Mode::Insert)
-                .and_then(|key_trie| key_trie.node())
-                .unwrap()
-                .len()
-                > 0
-        );
+        assert!(!merged_keyamp
+            .get(&Mode::Insert)
+            .and_then(|key_trie| key_trie.node())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -517,10 +517,10 @@ impl EditorView {
 
             // Special-case: cursor at end of the rope.
             if range.head == range.anchor && range.head == text.len_chars() {
-                if selection_is_primary || !skip_secondary_cursors {
-                    if !selection_is_primary || (cursor_is_block && is_terminal_focused) {
-                        spans.push((cursor_scope, range.head..range.head + 1));
-                    }
+                if (selection_is_primary || !skip_secondary_cursors)
+                    && (!selection_is_primary || (cursor_is_block && is_terminal_focused))
+                {
+                    spans.push((cursor_scope, range.head..range.head + 1));
                 }
                 continue;
             }

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -37,6 +37,10 @@ pub trait Backend {
     fn show_cursor(&mut self, kind: CursorKind) -> Result<(), io::Error>;
     /// Sets the cursor to the given position
     fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error>;
+    /// Sets multiple cursors using terminal-specific protocols (e.g., kitty)
+    fn set_multiple_cursors(&mut self, _cursors: &[(u16, u16)]) -> Result<(), io::Error> {
+        Ok(())
+    }
     /// Clears the terminal
     fn clear(&mut self) -> Result<(), io::Error>;
     /// Gets the size of the terminal in cells

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -149,13 +149,15 @@ impl TerminaBackend {
         // If we only receive the device attributes then we know it is not.
         write!(
             terminal,
-            "{}{}\x1b[> q{}{}{}{}{}",
+            "{}{}{}{}{}{}{}{}",
             // Synchronized output
             Csi::Mode(csi::Mode::QueryDecPrivateMode(csi::DecPrivateMode::Code(
                 csi::DecPrivateModeCode::SynchronizedOutput
             ))),
             // Mode 2031 theme updates. Query the current theme.
             Csi::Mode(csi::Mode::QueryTheme),
+            // Kitty multi-cursor protocol support query
+            Csi::Cursor(csi::Cursor::QueryCursorShape),
             // True color and while we're at it, extended underlines:
             // <https://github.com/termstandard/colors?tab=readme-ov-file#querying-the-terminal>
             Csi::Sgr(csi::Sgr::Background(TEST_COLOR.into())),
@@ -199,15 +201,17 @@ impl TerminaBackend {
                         capabilities.extended_underlines =
                             sgrs.contains(&csi::Sgr::UnderlineColor(TEST_COLOR.into()));
                     }
+                    Event::Csi(Csi::Cursor(csi::Cursor::QueryCursorShape)) => {
+                        // Empty response to the query still means the protocol is supported
+                        capabilities.kitty_multi_cursor = true;
+                        log::debug!("Detected kitty multi-cursor support via protocol query");
+                    }
                     Event::Csi(Csi::Cursor(csi::Cursor::CursorShapeQueryResponse(shapes))) => {
-                        // Any numbers in the response means the protocol is supported
-                        if !shapes.is_empty() {
-                            capabilities.kitty_multi_cursor = true;
-                            log::debug!(
-                                "Detected kitty multi-cursor support via protocol query. Supported shapes: {:?}",
-                                shapes
-                            );
-                        }
+                        capabilities.kitty_multi_cursor = true;
+                        log::debug!(
+                            "Detected kitty multi-cursor support via protocol query. Supported shapes: {:?}",
+                            shapes
+                        );
                     }
                     event => {
                         log::trace!("Unhandled capability detection event: {event:?}");
@@ -569,18 +573,18 @@ impl Backend for TerminaBackend {
         )?;
 
         if !cursors.is_empty() {
-            // Convert to 1-indexed positions (helix uses 0-indexed)
-            let positions: Vec<(u16, u16)> = cursors
-                .iter()
-                .map(|(x, y)| (y + 1, x + 1)) // (line, col) both 1-indexed
-                .collect();
-
             write!(
                 self.terminal,
                 "{}",
                 Csi::Cursor(csi::Cursor::SetMultipleCursors {
-                    shape: 29, // Follow main cursor shape
-                    positions,
+                    shape: csi::MultiCursorShape::FollowMainCursor,
+                    positions: cursors
+                        .iter()
+                        .map(|(x, y)| (
+                            OneBased::from_zero_based(*y),
+                            OneBased::from_zero_based(*x),
+                        ))
+                        .collect(),
                 })
             )?;
         }

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -234,6 +234,10 @@ where
         self.backend.set_cursor(x, y)
     }
 
+    pub fn set_multiple_cursors(&mut self, cursors: &[(u16, u16)]) -> io::Result<()> {
+        self.backend.set_multiple_cursors(cursors)
+    }
+
     /// Clear the terminal and force a full redraw on the next draw call.
     pub fn clear(&mut self) -> io::Result<()> {
         self.backend.clear()?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1219,6 +1219,7 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+    pub kitty_multi_cursor_support: bool,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1340,6 +1341,7 @@ impl Editor {
             handlers,
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
+            kitty_multi_cursor_support: false,
         }
     }
 

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -5,11 +5,12 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
 /// UNSTABLE
 pub enum CursorKind {
     /// █
+    #[default]
     Block,
     /// |
     Bar,
@@ -17,12 +18,6 @@ pub enum CursorKind {
     Underline,
     /// Hidden cursor, can set cursor position with this to let IME have correct cursor position.
     Hidden,
-}
-
-impl Default for CursorKind {
-    fn default() -> Self {
-        Self::Block
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -957,8 +957,7 @@ mod test {
 
         assert_eq!(10, tree.views().count());
         assert_eq!(
-            std::iter::repeat(7)
-                .take(9)
+            std::iter::repeat_n(7, 9)
                 .chain(Some(8)) // Rounding in `recalculate`.
                 .collect::<Vec<_>>(),
             tree.views()


### PR DESCRIPTION
Added support for kitty's multiple cursors protocol to show real terminal cursors at all selection positions.

This closes/addresses issue [#14517](https://github.com/helix-editor/helix/issues/14517)