### PR TITLE
initialize the `Jobs` before loading the files

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -151,6 +151,8 @@ impl Application {
         let editor_view = Box::new(ui::EditorView::new(Keymaps::new(keys)));
         compositor.push(editor_view);
 
+        let jobs = Jobs::new();
+
         if args.load_tutor {
             let path = helix_loader::runtime_file(Path::new("tutor"));
             editor.open(&path, Action::VerticalSplit)?;
@@ -260,7 +262,7 @@ impl Application {
             editor,
             config,
             signals,
-            jobs: Jobs::new(),
+            jobs,
             lsp_progress: LspProgressMap::new(),
             theme_mode,
         };


### PR DESCRIPTION
previously, when opening multiple files via `--vsplit`, it would hang indefinitely since #13620, as that would cause the `DocumentLostFocus` to be called, which would cause `job::dispatch_blocking`, which would then do `JOBS.wait()`, which would never be initialized, as it would not reach the `Jobs::new()` call further down in the file.

fixes #14758.