### PR TITLE
docs: fix typo

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -66,7 +66,7 @@
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
 
-[^3]: In most cases, you also need to enable the `auto-format` setting under `language.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
+[^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
 
 ### `[editor.clipboard-provider]` Section
 


### PR DESCRIPTION
Fixed filename typo: `langauge.toml` → `languages.toml`