### PR TITLE
feat: Named scratched buffers

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3155,6 +3155,7 @@ fn buffer_picker(cx: &mut Context) {
     struct BufferMeta {
         id: DocumentId,
         path: Option<PathBuf>,
+        display_name: String,
         is_modified: bool,
         is_current: bool,
         focused_at: std::time::Instant,
@@ -3163,6 +3164,7 @@ fn buffer_picker(cx: &mut Context) {
     let new_meta = |doc: &Document| BufferMeta {
         id: doc.id(),
         path: doc.path().cloned(),
+        display_name: doc.display_name().to_string(),
         is_modified: doc.is_modified(),
         is_current: doc.id() == current,
         focused_at: doc.focused_at,
@@ -3191,15 +3193,7 @@ fn buffer_picker(cx: &mut Context) {
             flags.into()
         }),
         PickerColumn::new("path", |meta: &BufferMeta, _| {
-            let path = meta
-                .path
-                .as_deref()
-                .map(helix_stdx::path::get_relative_path);
-            path.as_deref()
-                .and_then(Path::to_str)
-                .unwrap_or(SCRATCH_BUFFER_NAME)
-                .to_string()
-                .into()
+            meta.display_name.as_str().into()
         }),
     ];
     let initial_cursor = if items.len() <= 1 { 0 } else { 1 };
@@ -3222,6 +3216,7 @@ fn jumplist_picker(cx: &mut Context) {
     struct JumpMeta {
         id: DocumentId,
         path: Option<PathBuf>,
+        display_name: String,
         selection: Selection,
         text: String,
         is_current: bool,
@@ -3247,6 +3242,7 @@ fn jumplist_picker(cx: &mut Context) {
         JumpMeta {
             id: doc_id,
             path: doc.and_then(|d| d.path().cloned()),
+            display_name: doc.map_or_else(|| SCRATCH_BUFFER_NAME.to_string(), |d| d.display_name().to_string()),
             selection,
             text,
             is_current: view.doc == doc_id,
@@ -3256,15 +3252,7 @@ fn jumplist_picker(cx: &mut Context) {
     let columns = [
         ui::PickerColumn::new("id", |item: &JumpMeta, _| item.id.to_string().into()),
         ui::PickerColumn::new("path", |item: &JumpMeta, _| {
-            let path = item
-                .path
-                .as_deref()
-                .map(helix_stdx::path::get_relative_path);
-            path.as_deref()
-                .and_then(Path::to_str)
-                .unwrap_or(SCRATCH_BUFFER_NAME)
-                .to_string()
-                .into()
+            item.display_name.as_str().into()
         }),
         ui::PickerColumn::new("flags", |item: &JumpMeta, _| {
             let mut flags = Vec::new();

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -206,6 +206,9 @@ pub struct Document {
 
     pub previous_diagnostic_id: Option<String>,
 
+    /// Custom name for scratch buffers (buffers without a file path)
+    pub scratch_buffer_name: Option<String>,
+
     /// Annotations for LSP document color swatches
     pub color_swatches: Option<DocumentColorSwatches>,
     // NOTE: ideally this would live on the handler for color swatches. This is blocked on a
@@ -733,6 +736,7 @@ impl Document {
             syn_loader,
             previous_diagnostic_id: None,
             pull_diagnostic_controller: TaskController::new(),
+            scratch_buffer_name: None,
         }
     }
 
@@ -1288,6 +1292,46 @@ impl Document {
         self.pickup_last_saved_time();
     }
 
+    /// Set the custom name for scratch buffers (buffers without a file path).
+    /// This name will be displayed instead of "[scratch]".
+    /// If the buffer has a path, this setting is ignored.
+    pub fn set_scratch_buffer_name(&mut self, name: Option<String>) {
+        self.scratch_buffer_name = name;
+    }
+
+    /// Update the scratch buffer name based on the first line of the document.
+    /// Only updates if this is a scratch buffer (no path).
+    fn update_scratch_buffer_name_from_first_line(&mut self) {
+        const MAX_NAME_LENGTH: usize = 50;
+        if self.path.is_some() {
+            return;
+        }
+
+        let text = self.text();
+        if text.len_lines() == 0 {
+            self.scratch_buffer_name = None;
+            return;
+        }
+
+        // Get the first line
+        let first_line = text.line(0);
+        let first_line_str = first_line.to_string();
+        let trimmed = first_line_str.trim();
+
+        if trimmed.is_empty() {
+            // First line is empty, use default scratch buffer name
+            self.scratch_buffer_name = None;
+        } else {
+            // Set buffer name limit
+            let name = if trimmed.len() > MAX_NAME_LENGTH {
+                format!("{}...", &trimmed[..MAX_NAME_LENGTH-3])
+            } else {
+                trimmed.to_string()
+            };
+            self.scratch_buffer_name = Some(name);
+        }
+    }
+
     /// Set the programming language for the file and load associated data (e.g. highlighting)
     /// if it exists.
     pub fn set_language(
@@ -1571,6 +1615,12 @@ impl Document {
                 changes.compose(transaction.changes().clone())
             });
         }
+
+        // Update scratch buffer name based on first line if this is a scratch buffer
+        if success && self.path.is_none() && !transaction.changes().is_empty() {
+            self.update_scratch_buffer_name_from_first_line();
+        }
+
         success
     }
     /// Apply a [`Transaction`] to the [`Document`] to change its text.
@@ -2000,8 +2050,16 @@ impl Document {
     }
 
     pub fn display_name(&self) -> Cow<'_, str> {
-        self.relative_path()
-            .map_or_else(|| SCRATCH_BUFFER_NAME.into(), |path| path.to_string_lossy())
+        self.relative_path().map_or_else(
+            || {
+                // For scratch buffers, use the custom name if set
+                self.scratch_buffer_name
+                    .as_deref()
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into())
+            },
+            |path| path.to_string_lossy(),
+        )
     }
 
     // transact(Fn) ?


### PR DESCRIPTION
I'm wondering if this has come up before. While working with buffer picker and more than a few scratch buffers, I find it to navigate to a buffer I'm after - as right now it is not possible to narrow down the list by a sub-string or specific buffer name.
This change updates scratch buffer name  based on the first line of each buffer and allows to better identify each in the buffer/jump pickers. 
