### PR TITLE
Add indentation-based text objects

### DIFF
--- a/book/src/textobjects.md
+++ b/book/src/textobjects.md
@@ -16,6 +16,8 @@ function or block of code.
 | `w`                    | Word                     |
 | `W`                    | WORD                     |
 | `p`                    | Paragraph                |
+| `i`                    | Indentation level        |
+| `I`                    | Indentation level (including surrounding lines) |
 | `(`, `[`, `'`, etc.    | Specified surround pairs |
 | `m`                    | The closest surround pair    |
 | `f`                    | Function                 |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6052,6 +6052,32 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                         'e' => textobject_treesitter("entry", range),
                         'x' => textobject_treesitter("xml-element", range),
                         'p' => textobject::textobject_paragraph(text, range, objtype, count),
+                        'i' => {
+                            let tab_width = doc.tab_width();
+                            let indent_width = doc.indent_width();
+                            textobject::textobject_indent(
+                                text,
+                                range,
+                                objtype,
+                                count,
+                                false,
+                                tab_width,
+                                indent_width,
+                            )
+                        }
+                        'I' => {
+                            let tab_width = doc.tab_width();
+                            let indent_width = doc.indent_width();
+                            textobject::textobject_indent(
+                                text,
+                                range,
+                                objtype,
+                                count,
+                                true,
+                                tab_width,
+                                indent_width,
+                            )
+                        }
                         'm' => textobject::textobject_pair_surround_closest(
                             doc.syntax(),
                             text,
@@ -6087,6 +6113,8 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
         ("w", "Word"),
         ("W", "WORD"),
         ("p", "Paragraph"),
+        ("i", "Indentation level"),
+        ("I", "Indentation level (+ surrounding lines)"),
         ("t", "Type definition (tree-sitter)"),
         ("f", "Function (tree-sitter)"),
         ("a", "Argument/parameter (tree-sitter)"),


### PR DESCRIPTION
This is the thing I most sorely miss from my vim config and I think this is generically useful.

Implements text objects based on indentation levels, similar to [vim-indent-object](https://github.com/michaeljsmith/vim-indent-object).

Four variants are provided:
- `mii` (inside): From first non-whitespace of first line to end of last line (excluding trailing newline)
- `mai` (around): From first non-whitespace of line above to end of line below at enclosing indentation level
- `miI` (inside, uppercase): From column 0 of first line to newline of last line (entire lines with leading whitespace)
- `maI` (around, uppercase): From column 0 of line above to newline of line below (entire lines)

If this is of interest I'm happy to keep iterating if necessary.