### PR TITLE
Add extend variants to `select_textobject_*`

### DIFF
--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -377,6 +377,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "j" => extend_line_down,
             "w" => extend_to_word,
         },
+        "m" => { "Match"
+            "a" => extend_textobject_around,
+            "i" => extend_textobject_inner,
+        },
     }));
     let insert = keymap!({ "Insert mode"
         "esc" => normal_mode,


### PR DESCRIPTION
This allows surround motions to extend in certain cases. Due to the nature of delimiter matching like `ma(` or `mdm` being based on the current range of your selection, this change has no observable effect. However, for semantic based matching like `map` or `maf`, this extends your selection rather than replacing it. This resolves #12927.

Also, I apologize for making a duplicate PR (the previous being #14742 ). I accidentally deleted it - it won't happen again. This PR is a lot cleaner (and more focused) anyways.