### PR TITLE
languages(hy): add support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -122,6 +122,7 @@
 | html | ✓ | ✓ |  |  | ✓ | `vscode-html-language-server`, `superhtml` |
 | htmldjango | ✓ |  |  |  |  | `djlsp`, `vscode-html-language-server`, `superhtml` |
 | hurl | ✓ | ✓ | ✓ |  |  |  |
+| hy | ✓ |  |  |  |  | `hyuga` |
 | hyprlang | ✓ |  | ✓ |  |  | `hyprls` |
 | idris |  |  |  |  |  | `idris2-lsp` |
 | iex | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -60,6 +60,7 @@ harper-ls = { command = "harper-ls", args = ["--stdio"] }
 haskell-language-server = { command = "haskell-language-server-wrapper", args = ["--lsp"] }
 hdls = { command = "hdls" }
 hyprls = { command = "hyprls" }
+hyuga = { command = "hyuga" }
 idris2-lsp = { command = "idris2-lsp" }
 intelephense = { command = "intelephense", args = ["--stdio"] }
 jdtls = { command = "jdtls" }
@@ -4078,6 +4079,22 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "ld"
 source = { git = "https://github.com/mtoohey31/tree-sitter-ld", rev = "0e9695ae0ede47b8744a8e2ad44d4d40c5d4e4c9" }
+
+[[language]]
+name = "hy"
+scope = "source.hy"
+roots = ["pyproject.toml"]
+file-types = ["hy"]
+comment-token = ";"
+indent = { tab-width = 1, unit = " " }
+grammar = "scheme"
+language-servers = ["hyuga"]
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
 
 [[language]]
 name = "hyprlang"

--- a/runtime/queries/hy/highlights.scm
+++ b/runtime/queries/hy/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: scheme


### PR DESCRIPTION
Adding support for the [Hy/Hylang](https://hylang.org/) programming language, plus support to [hyuga](https://github.com/sakuraiyuta/hyuga) language server.

```sh
(hy-test) ❯ hx --health hy
Configured language servers:
  ✓ hyuga: /home/user/Python/hy-test/.devenv/state/venv/bin/hyuga
Configured debug adapter: None
Configured formatter: None
Tree-sitter parser: ✓
Highlight queries: ✓
Textobject queries: ✘
Indent queries: ✘
```

Snippet of code, highlighted:
<img width="463" height="146" alt="image" src="https://github.com/user-attachments/assets/e87dac7c-7695-4ddd-9944-28d92b38474c" />
