### PR TITLE
gha: fix potential release vulnerability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
     - '[0-9]+.[0-9]+.[0-9]+'
     branches:
     - 'patch/ci-release-*'
-  pull_request:
-    paths:
-    - '.github/workflows/release.yml'
 
 env:
   # Preview mode: Publishes the build output as a CI artifact instead of creating


### PR DESCRIPTION
* release workflow runs on pull requests with changes to release.yaml
* can modify this file, and remove the preview line blocking from pushing a bad release, similar to the recent npm attack
1. modify preview variable, set equal to 'true' (line 18 of ci)
2. insert malicious code into application
3. create a branch and pr, which will upload binaries to release

* Even if pr isn't merged, would have the new binaries uploaded