### PR TITLE
fix: clarify that languages.toml can also be local to a project

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -30,6 +30,6 @@ You can use a custom configuration file by specifying it with the `-c` or
 You can reload the config file by issuing the `:config-reload` command. Alternatively, on Unix operating systems, you can reload it by sending the USR1
 signal to the Helix process, such as by using the command `pkill -USR1 hx`.
 
-Finally, you can have a `config.toml` local to a project by putting it under a `.helix` directory in your repository.
-Its settings will be merged with the configuration directory `config.toml` and the built-in configuration.
+Finally, you can have a `config.toml` and a `languages.toml` local to a project by putting it under a `.helix` directory in your repository.
+Its settings will be merged with the configuration directory and the built-in configuration.
 


### PR DESCRIPTION
I was periodically checking if this was possible and disappointed that it was not (according to the book), but today I decided to just try (by setting my formatter to my terminal emulator) and it does work.
This is just a small change so other people won't have to try themselves.