### PR TITLE
fix(helix-term): ensure cursor is in view after LSP jump commands

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -134,6 +134,7 @@ fn jump_to_position(
     offset_encoding: OffsetEncoding,
     action: Action,
 ) {
+    let scrolloff = editor.config().scrolloff;
     let doc = match editor.open(path, action) {
         Ok(id) => doc_mut!(editor, &id),
         Err(err) => {
@@ -157,6 +158,7 @@ fn jump_to_position(
     if action.align_view(view, doc.id()) {
         align_view(doc, view, Align::Center);
     }
+    view.ensure_cursor_in_view(doc, scrolloff);
 }
 
 fn display_symbol_kind(kind: lsp::SymbolKind) -> &'static str {


### PR DESCRIPTION
Currently, following a jump command from the language server (e.g., `goto_definition`), the view scrolls _vertically_ to reveal the definition but not _horizontally_. This often results in the newly highlighted definition being offscreen (specifically on vertical monitors), resulting in a confusing user experience.

This pull request fixes this by invoking `view.ensure_cursor_in_view()` at the end of `jump_to_position()` in `helix-term/src/commands/lsp.rs`. Please don't hesitate to suggest a better way of achieving this if there is one (which is likely.) My gut tells me both `align_view()` and `ensure_cursor_in_view()` do not _both_ need to be invoked, but removing the former resulted in buggy behavior when I tested it.

For regular (synchronous) commands, such as `rotate_selections_forward` (mapped to `)`), the view _is_ scrolled horizontally to reveal the primary cursor because `view.ensure_cursor_in_view()` is invoked following all command execution (currently line 1481 of `helix-term/src/ui/editor.rs`).

Before:
![hx-goto-def-scroll-horizontal-before](https://github.com/user-attachments/assets/89c82b4a-8a35-4e94-8d2b-5cbd974cd86b)

After:
![hx-goto-def-scroll-horizontal-after](https://github.com/user-attachments/assets/d1de5e60-e701-41af-9de3-b39452653077)

