### PR TITLE
feat(picker): file_picker_in_current_buffer_directory use cwd if path is None

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3077,8 +3077,17 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
     let path = match doc_dir {
         Some(path) => path,
         None => {
-            cx.editor.set_error("current buffer has no path or parent");
-            return;
+            let cwd = helix_stdx::env::current_working_dir();
+            if !cwd.exists() {
+                cx.editor.set_error(
+                    "Current buffer has no parent and current working directory does not exist",
+                );
+                return;
+            }
+            cx.editor.set_error(
+                "Current buffer has no parent, opening file picker in current working directory",
+            );
+            cwd
         }
     };
 


### PR DESCRIPTION
Hello, made a small change to `file_picker_in_current_buffer_directory` to use CWD if path is None (ex: scratch buffer). Currently it just throws error, so I just took the implementation from `file_explorer_in_current_buffer_directory` and applied it over here.