### PR TITLE
Inject `regex` into `.spec.inputs.*.regex` value in `gitlab-ci` lang

### DIFF
--- a/runtime/queries/gitlab-ci/injections.scm
+++ b/runtime/queries/gitlab-ci/injections.scm
@@ -49,3 +49,22 @@
                  (single_quote_scalar)
                ] @injection.content)))
   (#set! injection.language "bash"))
+
+
+; https://docs.gitlab.com/ci/yaml/#specinputsregex
+; ```
+; spec:
+;   inputs:
+;     <input>:
+;       regex: <regex>
+; ---
+; ```
+(block_mapping_pair
+  key: (flow_node) @_key (#eq? @_key "regex")
+  value: (flow_node
+           [
+             (single_quote_scalar) @injection.content
+             (double_quote_scalar) @injection.content
+             (plain_scalar (string_scalar) @injection.content)
+           ])
+  (#set! injection.language "regex"))


### PR DESCRIPTION
Only match on a key called `regex` to simplify the pattern.
The key is used nowhere else in the schema, so this should not be an
issue.

**Showcase**

<img width="791" height="207" alt="image" src="https://github.com/user-attachments/assets/50d0c15f-2861-49ce-9eed-f94300ec3f55" />
