### PR TITLE
Inject `regex` into `.*.coverage:` value for jobs in `gitlab-ci` lang

### DIFF
--- a/runtime/queries/gitlab-ci/injections.scm
+++ b/runtime/queries/gitlab-ci/injections.scm
@@ -58,9 +58,11 @@
 ;     <input>:
 ;       regex: <regex>
 ; ---
+; <job>:
+;   coverage: <regex>
 ; ```
 (block_mapping_pair
-  key: (flow_node) @_key (#eq? @_key "regex")
+  key: (flow_node) @_key (#any-of? @_key "regex" "coverage")
   value: (flow_node
            [
              (single_quote_scalar) @injection.content


### PR DESCRIPTION
Key documented here: <https://docs.gitlab.com/ci/yaml/#coverage>

**Showcase**

<img width="608" height="126" alt="image" src="https://github.com/user-attachments/assets/b284eb6d-d261-4a39-afa6-aff8cde68eec" />
