### PR TITLE
feat(theme): add "omicron" (placeholder name)

### DIFF
--- a/runtime/themes/omicron_dark.toml
+++ b/runtime/themes/omicron_dark.toml
@@ -1,0 +1,110 @@
+error = "err"
+warning = "warn"
+hint = "diag"
+info = "diag"
+diagnostic = { underline = { color = "ghost", style = "curl" } }
+"diagnostic.error" = { underline = { color = "err", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
+"diagnostic.deprecated" = { fg = "code_unsafe", modifiers = ["crossed_out"] }
+
+"ui.background" = { bg = "bg" }
+"ui.window" = { bg = "bg_ui" }
+"ui.gutter" = { bg = "bg_ui" }
+"ui.text" = "default"
+"ui.text.focus" = { bg = "sel" }
+# secondary
+"ui.cursor" = { fg = "#111111", bg = "#cccccc" }
+# it only uses 1 cell, and it must be skimmable,
+# so force max contrast
+"ui.cursor.primary" = { fg = "#000000", bg = "#ffffff" }
+"ui.cursor.match" = { bg = "#333333" }
+"ui.debug" = "default"
+# it feels questionable, but it's more consistent and clean than `reversed`;
+# some web-browsers do the same
+"ui.selection" = { fg = "#222222", bg = "#aaaaaa" }
+"ui.cursorline" = { bg = "sel_weak" }
+"ui.cursorcolumn" = { bg = "sel_weak" }
+"ui.virtual" = "ghost"
+"ui.virtual.ruler" = { bg = "sel_weak" }
+"ui.virtual.inlay-hint" = "ghost"
+# these are ephemeral and user-controllable,
+# are not part of the buffer,
+# should be skimmable,
+# so override FG & BG to guarantee contrast
+# while also signaling that they are special text
+"ui.virtual.jump-label" = { fg = "#ffffff", bg = "sym" }
+"ui.statusline" = { fg = "default", bg = "bg_ui" }
+"ui.bufferline" = { fg = "default", bg = "bg_ui" }
+"ui.bufferline.active" = { bg = "sel", modifiers = ["bold"] }
+"ui.help" = { fg = "doc", bg = "bg_ui" }
+"ui.highlight" = { bg = "sel" }
+"ui.menu" = { fg = "code", bg = "bg_ui" }
+"ui.menu.selected" = { bg = "sel" }
+"ui.popup" = { fg = "#ffffff", bg = "#333333" }
+"ui.picker.header" = { modifiers = ["bold", "underlined"] }
+
+
+# Tree-Sitter scopes (syntax highlight)
+
+# NOTE: builtin HTML ones can be trivially auto-checked,
+# but custom ones (contain hyphens) need highlighting.
+#"attribute" = {}
+#"tag" = {}
+"tag.error" = { fg = "err", underline = { style = "line" } }
+"constant" = "literal"
+# TO-DO: escapes need highlight, but not unsafe
+"constant.character.escape" = "literal_unsafe"
+# floats are a plague!
+# https://github.com/you-dont-need/You-Dont-Need/issues/13
+"constant.numeric.float" = "literal_unsafe"
+"string" = "literal"
+"string.regexp" = "literal_unsafe"
+"string.special" = "sym"
+"comment" = "doc"
+# some are mutable and can be misused without triggering warns
+#"variable.builtin" = "literal_unsafe"
+"punctuation" = "default_weak"
+# beware of the Halting Problem!
+"keyword.control.repeat" = "code_unsafe"
+"markup.heading" = { modifiers = ["bold"] }
+"markup.heading.marker" = "sym"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = { fg = "sym", underline = { style = "line" } }
+"markup.quote" = "doc"
+
+"markup.normal" = "default"
+"markup.normal.raw" = "code"
+"markup.heading.raw" = "code"
+"markup.raw" = "code"
+
+"diff.plus" = "green" # + add
+"diff.minus" = "red" # - delete
+"diff.delta" = "yellow" # ± edit
+"diff.delta.moved" = "sym" # -> rename
+"diff.delta.conflict" = "err" # ❌
+
+[palette]
+bg = "#000000"
+bg_ui = "#111111"
+default = "#cccccc"
+default_weak = "#999999"
+ghost = "#666666"
+code = "#99cc99"
+code_unsafe = "#ffcc77"
+red = "#bb3333"
+green = "#33aa33"
+yellow = "#aaaa33"
+sel = "#333333"
+sel_weak = "#171717"
+# I call this "eye-piercing red" because
+# it's designed to be jarring like a laser
+err = "#ff2200"
+warn = "#eedd33"
+diag = "#0077ff"
+literal = "#00dd77"
+literal_unsafe = "#ff7700"
+sym = "#11aaff"
+# inspired by ⭐ Gleam's "faf pink"
+doc = "#cc77cc"

--- a/runtime/themes/omicron_light.toml
+++ b/runtime/themes/omicron_light.toml
@@ -1,0 +1,111 @@
+error = "err"
+warning = "warn"
+hint = "diag"
+info = "diag"
+diagnostic = { underline = { color = "ghost", style = "curl" } }
+"diagnostic.error" = { underline = { color = "err", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
+"diagnostic.deprecated" = { fg = "code_unsafe", bg = "code_bg_unsafe", modifiers = [
+	"crossed_out",
+] }
+
+"ui.background" = { bg = "bg" }
+"ui.window" = { bg = "bg_ui" }
+"ui.gutter" = { bg = "bg_ui" }
+"ui.text" = "default"
+"ui.text.focus" = { bg = "sel" }
+# secondary
+"ui.cursor" = { fg = "#eeeeee", bg = "#333333" }
+# it only uses 1 cell, and it must be skimmable,
+# so force max contrast
+"ui.cursor.primary" = { fg = "#ffffff", bg = "#000000" }
+"ui.cursor.match" = { bg = "#cccccc" }
+"ui.debug" = "default"
+# it feels questionable, but it's more consistent and clean than `reversed`;
+# some web-browsers do the same
+"ui.selection" = { fg = "#dddddd", bg = "#555555" }
+"ui.cursorline" = { bg = "sel_weak" }
+"ui.cursorcolumn" = { bg = "sel_weak" }
+"ui.virtual" = "ghost"
+"ui.virtual.ruler" = { bg = "sel_weak" }
+"ui.virtual.inlay-hint" = "ghost"
+# these are ephemeral and user-controllable,
+# are not part of the buffer,
+# should be skimmable,
+# so override FG & BG to guarantee contrast
+# while also signaling that they are special text
+"ui.virtual.jump-label" = { fg = "#000000", bg = "sym" }
+"ui.statusline" = { fg = "default", bg = "bg_ui" }
+"ui.bufferline" = { fg = "default", bg = "bg_ui" }
+"ui.bufferline.active" = { bg = "sel", modifiers = ["bold"] }
+"ui.help" = { fg = "doc", bg = "bg_ui" }
+"ui.highlight" = { bg = "sel" }
+"ui.menu" = { fg = "code", bg = "bg_ui" }
+"ui.menu.selected" = { bg = "sel" }
+"ui.popup" = { fg = "#000000", bg = "#cccccc" }
+"ui.picker.header" = { modifiers = ["bold", "underlined"] }
+
+
+# Tree-Sitter scopes (syntax highlight)
+
+# NOTE: builtin HTML ones can be trivially auto-checked,
+# but custom ones (contain hyphens) need highlighting.
+#"attribute" = {}
+#"tag" = {}
+"tag.error" = { fg = "err", underline = { style = "line" } }
+"constant" = "literal"
+# TO-DO: escapes need highlight, but not unsafe
+"constant.character.escape" = "literal_unsafe"
+# floats are a plague!
+# https://github.com/you-dont-need/You-Dont-Need/issues/13
+"constant.numeric.float" = { fg = "literal_unsafe", bg = "literal_bg_unsafe" }
+"string" = "literal"
+"string.regexp" = { fg = "literal_unsafe", bg = "literal_bg_unsafe" }
+"string.special" = "sym"
+"comment" = "doc"
+# some are mutable and can be misused without triggering warns
+#"variable.builtin" = "literal_unsafe"
+"punctuation" = "default_weak"
+# beware of the Halting Problem!
+"keyword.control.repeat" = { fg = "code_unsafe", bg = "code_bg_unsafe" }
+"markup.heading" = { modifiers = ["bold"] }
+"markup.heading.marker" = "sym"
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = { fg = "sym", underline = { style = "line" } }
+"markup.quote" = "doc"
+
+"markup.normal" = "default"
+"markup.normal.raw" = "code"
+"markup.heading.raw" = "code"
+"markup.raw" = "code"
+
+"diff.plus" = "green" # + add
+"diff.minus" = "red" # - delete
+"diff.delta" = "yellow" # ± edit
+"diff.delta.moved" = "sym" # -> rename
+"diff.delta.conflict" = "err" # ❌
+
+[palette]
+bg = "#eeeeee"
+bg_ui = "#dddddd"
+default = "#333333"
+default_weak = "#666666"
+ghost = "#999999"
+code = "#336633"
+code_unsafe = "#330000"
+code_bg_unsafe = "#eeddee"
+red = "#880000"
+green = "#007700"
+yellow = "#777700"
+sel = "#cccccc"
+sel_weak = "#e7e7e7"
+err = "#ff0000"
+warn = "#bbaa00"
+diag = "#0066aa"
+literal = "#009933"
+literal_unsafe = "#441100"
+literal_bg_unsafe = "#eeccaa"
+sym = "#00aaff"
+doc = "#770077"


### PR DESCRIPTION
As per #14786 I've decided to try making a minimal-color theme! These themes (dark & light) are mostly inspired by Alabaster (see also #15102).

As the title says, Omicron is "just a temporary name". I'm open to suggestions! But as the saying goes "There's nothing more permanent than a temporary solution". I think the current name is fine, as the theme is not meant to be unique, so the name can be "borrowed". It also represents the philosophy: "o" stands for "origin" (something "old"), "micron" is "small" ("minimal" in this context)

I guess it's finished. #14827 seems already fixed for this theme (except for `tabstop`; IDK what to do with that). This PR _could_ be merged as-is, but I want feedback. IDK if I should add blinking text anywhere, but a blinking cursor seems sensible.

> [!note]
> BTW, I've noticed that some `:tree-sitter-*` cmds print different stuff depending on the active theme. For example, Everforest is more detailed than this theme. There's cases where the output is radically different, for example if `lang` is `git-commit` the title has different scopes