### PR TITLE
fix(theme): add missing jump-label to everforest_light

### DIFF
--- a/runtime/themes/everforest_light.toml
+++ b/runtime/themes/everforest_light.toml
@@ -102,6 +102,9 @@
 "ui.virtual.indent-guide" = { fg = "bg4" }
 "ui.virtual.inlay-hint" = { fg = "grey0" }
 "ui.virtual.wrap" = { fg = "grey0" }
+"ui.virtual.jump-label" = { fg = "red", bg = "bg0", modifiers = [
+  "bold",
+] }
 
 "hint" = "green"
 "info" = "blue"


### PR DESCRIPTION
Fixes #14810

**Before**
<img width="1230" height="938" alt="Screenshot_20251117_231952" src="https://github.com/user-attachments/assets/7ce8feb6-daf5-4db3-afe9-8216973fc45a" />

**After**
<img width="1230" height="938" alt="Screenshot_20251117_230930" src="https://github.com/user-attachments/assets/87a87057-bb62-4b3d-a1fe-70f5d480473a" />
