### PR TITLE
Allow the wrap indicator to be displayed on the gutter

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -149,7 +149,9 @@ pub struct TextFormat {
     pub max_wrap: u16,
     pub max_indent_retain: u16,
     pub wrap_indicator: Box<str>,
+    pub wrap_indicator_width: u16,
     pub wrap_indicator_highlight: Option<Highlight>,
+    pub wrap_indicator_on_gutter: bool,
     pub viewport_width: u16,
     pub soft_wrap_at_text_width: bool,
 }
@@ -163,6 +165,8 @@ impl Default for TextFormat {
             max_wrap: 3,
             max_indent_retain: 4,
             wrap_indicator: Box::from(" "),
+            wrap_indicator_width: 1,
+            wrap_indicator_on_gutter: false,
             viewport_width: 17,
             wrap_indicator_highlight: None,
             soft_wrap_at_text_width: false,
@@ -313,21 +317,24 @@ impl<'t> DocumentFormatter<'t> {
         self.visual_pos.row += 1 + virtual_lines;
         let mut i = 0;
         let mut word_width = 0;
-        let wrap_indicator = UnicodeSegmentation::graphemes(&*self.text_fmt.wrap_indicator, true)
-            .map(|g| {
-                i += 1;
-                let grapheme = GraphemeWithSource::new(
-                    g.into(),
-                    self.visual_pos.col + word_width,
-                    self.text_fmt.tab_width,
-                    GraphemeSource::VirtualText {
-                        highlight: self.text_fmt.wrap_indicator_highlight,
-                    },
-                );
-                word_width += grapheme.width();
-                grapheme
-            });
-        self.word_buf.splice(0..0, wrap_indicator);
+
+        if !self.text_fmt.wrap_indicator_on_gutter {
+            let wrap_indicator =
+                UnicodeSegmentation::graphemes(&*self.text_fmt.wrap_indicator, true).map(|g| {
+                    i += 1;
+                    let grapheme = GraphemeWithSource::new(
+                        g.into(),
+                        self.visual_pos.col + word_width,
+                        self.text_fmt.tab_width,
+                        GraphemeSource::VirtualText {
+                            highlight: self.text_fmt.wrap_indicator_highlight,
+                        },
+                    );
+                    word_width += grapheme.width();
+                    grapheme
+                });
+            self.word_buf.splice(0..0, wrap_indicator);
+        }
 
         for grapheme in &mut self.word_buf[i..] {
             let visual_x = self.visual_pos.col + word_width;

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -9,6 +9,8 @@ impl TextFormat {
             max_wrap: 3,
             max_indent_retain: 4,
             wrap_indicator: ".".into(),
+            wrap_indicator_width: 1,
+            wrap_indicator_on_gutter: false,
             wrap_indicator_highlight: None,
             // use a prime number to allow lining up too often with repeat
             viewport_width: 17,

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -576,6 +576,8 @@ pub struct SoftWrap {
     ///
     /// Defaults to ↪
     pub wrap_indicator: Option<String>,
+    /// Show the indicator on the `line-numbers` gutter instead of as part of the document
+    pub indicator_on_gutter: Option<bool>,
     /// Softwrap at `text_width` instead of viewport width if it is shorter
     pub wrap_at_text_width: Option<bool>,
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -647,9 +647,9 @@ impl EditorView {
     pub fn render_gutter<'d>(
         editor: &'d Editor,
         doc: &'d Document,
-        view: &View,
+        view: &'d View,
         viewport: Rect,
-        theme: &Theme,
+        theme: &'d Theme,
         is_focused: bool,
         decoration_manager: &mut DecorationManager<'d>,
     ) {
@@ -674,7 +674,6 @@ impl EditorView {
             let mut text = String::with_capacity(width);
             let cursors = cursors.clone();
             let gutter_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
-                // TODO handle softwrap in gutters
                 let selected = cursors.contains(&pos.doc_line);
                 let x = viewport.x + offset;
                 let y = pos.visual_line;

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -99,6 +99,8 @@ impl InlineDiagnosticsConfig {
             max_wrap: self.max_wrap.min(width / 4),
             max_indent_retain: 0,
             wrap_indicator: "".into(),
+            wrap_indicator_width: 0,
+            wrap_indicator_on_gutter: false,
             wrap_indicator_highlight: None,
             viewport_width: width,
             soft_wrap_at_text_width: true,


### PR DESCRIPTION
I've added a `soft-wrap.indicator-on-gutter` config option, so that when `soft-wrap` is enabled and the `line-number` gutter is visible, the wrap indicators can be displayed on the gutter rather than as part of the document.

Resolves: #14802 