### PR TITLE
fix: also escape \ when pretty printing anonymous nodes

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1090,8 +1090,8 @@ fn node_is_visible(node: &Node) -> bool {
 }
 
 fn format_anonymous_node_kind(kind: &str) -> Cow<'_, str> {
-    if kind.contains('"') {
-        Cow::Owned(kind.replace('"', "\\\""))
+    if kind.contains('"') || kind.contains('\\') {
+        Cow::Owned(kind.replace('\\', "\\\\").replace('"', "\\\""))
     } else {
         Cow::Borrowed(kind)
     }


### PR DESCRIPTION
previously, only double quotes were escaped when pretty printing anonymous nodes, leading to trees like this:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/22164a07-59e3-4ba7-be65-1ced3dd732a6" />

this is very easily fixed by just also escaping backslashes:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/9f26cea7-b28c-4998-ac6d-94f5bc07ed06" />
