### PR TITLE
feat(view): render soft-wrap indicators in the gutter

### DIFF
--- a/helix-core/src/doc_formatter.rs
+++ b/helix-core/src/doc_formatter.rs
@@ -147,6 +147,9 @@ pub struct TextFormat {
     pub tab_width: u16,
     pub max_wrap: u16,
     pub max_indent_retain: u16,
+    /// Reserved for consumers that render soft-wrap indicators inline.
+    ///
+    /// The editor currently renders them in the gutter instead.
     pub wrap_indicator: Box<str>,
     pub wrap_indicator_highlight: Option<Highlight>,
     pub viewport_width: u16,
@@ -161,7 +164,7 @@ impl Default for TextFormat {
             tab_width: 4,
             max_wrap: 3,
             max_indent_retain: 4,
-            wrap_indicator: Box::from(" "),
+            wrap_indicator: Box::from(""),
             viewport_width: 17,
             wrap_indicator_highlight: None,
             soft_wrap_at_text_width: false,
@@ -310,25 +313,8 @@ impl<'t> DocumentFormatter<'t> {
                 .virtual_lines_at(self.char_pos, self.visual_pos, self.line_pos);
         self.visual_pos.col = indent_carry_over as usize;
         self.visual_pos.row += 1 + virtual_lines;
-        let mut i = 0;
         let mut word_width = 0;
-        let wrap_indicator = UnicodeSegmentation::graphemes(&*self.text_fmt.wrap_indicator, true)
-            .map(|g| {
-                i += 1;
-                let grapheme = GraphemeWithSource::new(
-                    g.into(),
-                    self.visual_pos.col + word_width,
-                    self.text_fmt.tab_width,
-                    GraphemeSource::VirtualText {
-                        highlight: self.text_fmt.wrap_indicator_highlight,
-                    },
-                );
-                word_width += grapheme.width();
-                grapheme
-            });
-        self.word_buf.splice(0..0, wrap_indicator);
-
-        for grapheme in &mut self.word_buf[i..] {
+        for grapheme in &mut self.word_buf {
             let visual_x = self.visual_pos.col + word_width;
             grapheme
                 .grapheme

--- a/helix-core/src/doc_formatter/test.rs
+++ b/helix-core/src/doc_formatter/test.rs
@@ -8,7 +8,7 @@ impl TextFormat {
             tab_width: 2,
             max_wrap: 3,
             max_indent_retain: 4,
-            wrap_indicator: ".".into(),
+            wrap_indicator: Box::from(""),
             wrap_indicator_highlight: None,
             // use a prime number to allow lining up too often with repeat
             viewport_width: 17,
@@ -59,11 +59,11 @@ fn softwrap_text(text: &str) -> String {
 fn basic_softwrap() {
     assert_eq!(
         softwrap_text(&"foo ".repeat(10)),
-        "foo foo foo foo \n.foo foo foo foo \n.foo foo  "
+        "foo foo foo foo \nfoo foo foo foo \nfoo foo  "
     );
     assert_eq!(
         softwrap_text(&"fooo ".repeat(10)),
-        "fooo fooo fooo \n.fooo fooo fooo \n.fooo fooo fooo \n.fooo  "
+        "fooo fooo fooo \nfooo fooo fooo \nfooo fooo fooo \nfooo  "
     );
 
     // check that we don't wrap unnecessarily
@@ -74,31 +74,31 @@ fn basic_softwrap() {
 fn softwrap_indentation() {
     assert_eq!(
         softwrap_text("\t\tfoo1 foo2 foo3 foo4 foo5 foo6\n"),
-        "    foo1 foo2 \n.....foo3 foo4 \n.....foo5 foo6 \n "
+        "    foo1 foo2 \n....foo3 foo4 \n....foo5 foo6 \n "
     );
     assert_eq!(
         softwrap_text("\t\t\tfoo1 foo2 foo3 foo4 foo5 foo6\n"),
-        "      foo1 foo2 \n.foo3 foo4 foo5 \n.foo6 \n "
+        "      foo1 foo2 \nfoo3 foo4 foo5 \nfoo6 \n "
     );
 }
 
 #[test]
 fn long_word_softwrap() {
     assert_eq!(
-        softwrap_text("\t\txxxx1xxxx2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n"),
-        "    xxxx1xxxx2xxx\n.....x3xxxx4xxxx5\n.....xxxx6xxxx7xx\n.....xx8xxxx9xxx \n "
+        softwrap_text("\t\txxxx1xxxx2xxxx3xxxx4xxxxx5xxxx6xxxx7xxx8xxxx9xxx\n"),
+        "    xxxx1xxxx2xxx\n....x3xxxx4xxxxx5\n....xxxx6xxxx7xxx\n....8xxxx9xxx \n "
     );
     assert_eq!(
         softwrap_text("xxxxxxxx1xxxx2xxx\n"),
-        "xxxxxxxx1xxxx2xxx\n. \n "
+        "xxxxxxxx1xxxx2xxx\n \n "
     );
     assert_eq!(
-        softwrap_text("\t\txxxx1xxxx 2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n"),
-        "    xxxx1xxxx \n.....2xxxx3xxxx4x\n.....xxx5xxxx6xxx\n.....x7xxxx8xxxx9\n.....xxx \n "
+        softwrap_text("\t\txxxx1xxxx 2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxxxxx9xxx\n"),
+        "    xxxx1xxxx \n....2xxxx3xxxx4xx\n....xx5xxxx6xxxx7\n....xxxx8xxxxxxx9\n....xxx \n "
     );
     assert_eq!(
-        softwrap_text("\t\txxxx1xxx 2xxxx3xxxx4xxxx5xxxx6xxxx7xxxx8xxxx9xxx\n"),
-        "    xxxx1xxx 2xxx\n.....x3xxxx4xxxx5\n.....xxxx6xxxx7xx\n.....xx8xxxx9xxx \n "
+        softwrap_text("\t\txxxx1xxx 2xxxx3xxxx4xxxxx5xxxx6xxxx7xxxxx8xxxx9xx\n"),
+        "    xxxx1xxx 2xxx\n....x3xxxx4xxxxx5\n....xxxx6xxxx7xxx\n....xx8xxxx9xx \n "
     );
 }
 
@@ -106,7 +106,7 @@ fn long_word_softwrap() {
 fn softwrap_multichar_grapheme() {
     assert_eq!(
         softwrap_text("xxxx xxxx xxx a\u{0301}bc\n"),
-        "xxxx xxxx xxx \n.ábc \n "
+        "xxxx xxxx xxx \nábc \n "
     )
 }
 
@@ -158,7 +158,7 @@ fn overlay() {
                 Overlay::new(16, "X"),
             ]
         ),
-        "fo   f  o foo \n.foo Xoo foo foo \n.foo foo foo  "
+        "fo   f  o foo \nfoo Xoo foo foo \nfoo foo foo  "
     );
 }
 
@@ -184,7 +184,7 @@ fn annotation() {
             true,
             &[InlineAnnotation::new(0, "foo ")]
         ),
-        "foo foo foo foo \n.foo foo foo foo \n.foo foo foo  "
+        "foo foo foo foo \nfoo foo foo foo \nfoo foo foo  "
     );
 }
 

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -98,7 +98,7 @@ impl InlineDiagnosticsConfig {
             tab_width: 4,
             max_wrap: self.max_wrap.min(width / 4),
             max_indent_retain: 0,
-            wrap_indicator: "".into(),
+            wrap_indicator: Box::from(""),
             wrap_indicator_highlight: None,
             viewport_width: width,
             soft_wrap_at_text_width: true,

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2389,20 +2389,16 @@ impl Document {
             .and_then(|soft_wrap| soft_wrap.max_indent_retain)
             .or(editor_soft_wrap.max_indent_retain)
             .unwrap_or(40);
-        let wrap_indicator = language_soft_wrap
-            .and_then(|soft_wrap| soft_wrap.wrap_indicator.clone())
-            .or_else(|| config.soft_wrap.wrap_indicator.clone())
-            .unwrap_or_else(|| "↪ ".into());
         let tab_width = self.tab_width() as u16;
         TextFormat {
             soft_wrap: enable_soft_wrap && viewport_width > 10,
             tab_width,
             max_wrap: max_wrap.min(viewport_width / 4),
             max_indent_retain: max_indent_retain.min(viewport_width * 2 / 5),
+            wrap_indicator: Box::from(""),
             // avoid spinning forever when the window manager
             // sets the size to something tiny
             viewport_width,
-            wrap_indicator: wrap_indicator.into_boxed_str(),
             wrap_indicator_highlight: theme
                 .and_then(|theme| theme.find_highlight("ui.virtual.wrap")),
             soft_wrap_at_text_width,

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -165,6 +165,15 @@ pub fn line_numbers<'doc>(
         .char_to_line(doc.selection(view.id).primary().cursor(text));
 
     let line_number = editor.config().line_number;
+    let wrap_indicator = editor
+        .config()
+        .soft_wrap
+        .wrap_indicator
+        .as_ref()
+        .map_or_else(
+            || "↪".into(),
+            |indicator| indicator.clone().chars().take(width).collect::<String>(),
+        );
     let mode = editor.mode;
 
     Box::new(
@@ -195,10 +204,10 @@ pub fn line_numbers<'doc>(
                 if first_visual_line {
                     write!(out, "{:>1$}", display_num, width).unwrap();
                 } else {
-                    write!(out, "{:>1$}", " ", width).unwrap();
+                    write!(out, "{:>1$}", wrap_indicator, width).unwrap();
                 }
 
-                first_visual_line.then_some(style)
+                Some(style)
             }
         },
     )


### PR DESCRIPTION
Moves the soft-wrap indicator into the gutter to keep the text flush and take an advantage of otherwise empty space.

Alternative approach would be to keep the `wrap_indicator` in `TextFormat` but use it for only e.g. diagnostics but not soft wraps. Open for suggestions.

Fixes: https://github.com/helix-editor/helix/issues/14802

Didn't notice that there's already https://github.com/helix-editor/helix/pull/14818, so this is pretty much the same thing, minus extra configuration options to keep things simple.

Before:

<img width="864" height="479" alt="image" src="https://github.com/user-attachments/assets/b82d2202-205b-4e78-9e99-4c0f774072db" />


After:

<img width="866" height="462" alt="image" src="https://github.com/user-attachments/assets/2588447e-d369-4da1-840c-3c000f0fdb26" />


