### PR TITLE
Add an tab-end padding character

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -315,7 +315,7 @@ Options for rendering whitespace with visible characters. Use `:set whitespace.r
 | Key | Description | Default |
 |-----|-------------|---------|
 | `render` | Whether to render whitespace. May either be `all` or `none`, or a table with sub-keys `space`, `nbsp`, `nnbsp`, `tab`, and `newline` | `"none"` |
-| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `nnbsp`, `newline` or `tabpad` | See example below |
+| `characters` | Literal characters to use when rendering whitespace. Sub-keys may be any of `tab`, `space`, `nbsp`, `nnbsp`, `newline`, `tabpad`, or `tabend` | See example below |
 
 Example
 
@@ -336,7 +336,9 @@ nbsp = "⍽"
 nnbsp = "␣"
 tab = "→"
 newline = "⏎"
-tabpad = "·" # Tabs will look like "→···" (depending on tab width)
+tabpad = "·"
+tabend = "←" # Tabs will look like "→··←" (depending on tab width)
+             # if tabend is not specified, it defaults to tabpad
 ```
 
 ### `[editor.indent-guides]` Section

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -213,9 +213,14 @@ impl<'a> TextRenderer<'a> {
 
         let tab_width = doc.tab_width();
         let tab = if ws_render.tab() == WhitespaceRenderValue::All {
-            std::iter::once(ws_chars.tab)
-                .chain(std::iter::repeat_n(ws_chars.tabpad, tab_width - 1))
-                .collect()
+            if tab_width == 1 {
+                ws_chars.tab.into()
+            } else {
+                std::iter::once(ws_chars.tab)
+                    .chain(std::iter::repeat_n(ws_chars.tabpad, tab_width - 2))
+                    .chain(std::iter::once(ws_chars.tabend.unwrap_or(ws_chars.tabpad)))
+                    .collect()
+            }
         } else {
             " ".repeat(tab_width)
         };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -954,6 +954,7 @@ pub struct WhitespaceCharacters {
     pub nnbsp: char,
     pub tab: char,
     pub tabpad: char,
+    pub tabend: Option<char>,
     pub newline: char,
 }
 
@@ -966,6 +967,7 @@ impl Default for WhitespaceCharacters {
             tab: '→',     // U+2192
             newline: '⏎', // U+23CE
             tabpad: ' ',
+            tabend: None,
         }
     }
 }


### PR DESCRIPTION
Adds an option `whitespace.characters.tabend` similar to `tabpad`, but for the *last* character of a tab.

```toml
[editor.whitespace.characters]
tab = "→"
tabpad = "·"
tabend = "←" # Tabs will look like "→··←" (depending on tab width)
```

By default, `tabend` is whatever `tabpad` is, so all current behavior is unchanged. My config uses the box-drawing characters `╶`, `─`, and `╴`, which makes `╶──╴` (how pretty!).