### PR TITLE
add a tree-sitter grammar for scfg

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -237,6 +237,7 @@
 | rust-format-args-macro | ✓ | ✓ | ✓ |  | ✓ |  |
 | sage | ✓ | ✓ |  |  |  |  |
 | scala | ✓ | ✓ | ✓ |  |  | `metals` |
+| scfg | ✓ |  |  |  |  |  |
 | scheme | ✓ | ✓ | ✓ |  | ✓ |  |
 | scss | ✓ |  |  |  | ✓ | `vscode-css-language-server` |
 | shellcheckrc | ✓ | ✓ |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -5034,3 +5034,13 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "freebasic"
 source = { git = "https://github.com/Ra77a3l3-jar/tree-sitter-freebasic", rev = "dbf696adb4c0b9c020074e75043c90592981ee7f" }
+
+[[language]]
+name = "scfg"
+scope = "source.scfg"
+file-types = [{ glob = "kanshi/config" }]
+comment-token = "#"
+
+[[grammar]]
+name = "scfg"
+source = { git = "https://github.com/rockorager/tree-sitter-scfg", rev = "d850fd470445d73de318a21d734d1e09e29b773c" }

--- a/runtime/queries/scfg/highlights.scm
+++ b/runtime/queries/scfg/highlights.scm
@@ -1,0 +1,9 @@
+[
+ "{"
+ "}"
+ ] @punctuation.bracket
+
+
+(comment) @comment
+(directive_name) @type
+(directive_params) @parameter


### PR DESCRIPTION
This adds a grammar and highlights for [scfg](https://git.sr.ht/~emersion/scfg).

I could only find it used for [kanshi](https://gitlab.freedesktop.org/emersion/kanshi) so that's the only `file-type`, I can add more if someone knows of other configs that use scfg (source: `dnf repoquery --whatrequires libscfg`).

Notably, the tree sitter parser comes from a "mirror" of the repo on sourcehut, but the GitHub repo has commits with the generated parser.c that the sourcehut repo does not.