### PR TITLE
Replace unsafe { NonZeroUsize::new_unchecked(1) } with NonZeroUsize::new(1).unwrap() in DocumentId::default()

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1819,7 +1819,7 @@ impl Editor {
     /// Generate an id for a new document and register it.
     fn new_document(&mut self, mut doc: Document) -> DocumentId {
         let id = self.next_document_id;
-        // Safety: adding 1 from 1 is fine, probably impossible to reach usize max
+        // Safety: adding 1 from 1 is fine, practically impossible to reach usize max
         self.next_document_id =
             DocumentId(unsafe { NonZeroUsize::new_unchecked(self.next_document_id.0.get() + 1) });
         doc.id = id;

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -26,8 +26,7 @@ pub struct DocumentId(NonZeroUsize);
 
 impl Default for DocumentId {
     fn default() -> DocumentId {
-        // Safety: 1 is non-zero
-        DocumentId(unsafe { NonZeroUsize::new_unchecked(1) })
+        DocumentId(NonZeroUsize::new(1).unwrap())
     }
 }
 


### PR DESCRIPTION
Since the input is a constant literal (1), the compiler optimizes
both versions to identical assembly. MIR analysis confirms both
compile to the same constant value with zero runtime overhead.

Minor: clarify comment in document ID increment (probably → practically).
