### PR TITLE
Implement basic preview scrolling for FilePicker

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -56,7 +56,7 @@ pub type Tendril = SmartString<smartstring::LazyCompact>;
 pub use {regex, tree_house::tree_sitter};
 
 pub use position::{
-    char_idx_at_visual_offset, coords_at_pos, pos_at_coords, softwrapped_dimensions,
+    char_idx_at_visual_block_offset, char_idx_at_visual_offset, coords_at_pos, pos_at_coords, softwrapped_dimensions,
     visual_offset_from_anchor, visual_offset_from_block, Position, VisualOffsetError,
 };
 #[allow(deprecated)]


### PR DESCRIPTION
## Behavior
  After pressing SPC f, the file picker for all files in a project is created. The picker also provides a preview widget on the right by default. This patch allows scrolling up and down this preview using Ctrl + j / Ctrl + k keys.

 ## Reason
  Seems like a pretty obvious and necessary feature for file picker preview. I guess I'm not aware of the deep reasons why it wasn't implemented already. So I create this PR as a proposition for further, more thorough work and look forward to it being rejected with a slap and a link showing that I missed something.