### PR TITLE
feat(runtime): bash injection in go:generate comments

### DIFF
--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -30,6 +30,10 @@
   ]
   (#set! injection.language "markdown"))
 
+((comment) @injection.content
+ (#match? @injection.content "^//go:generate")
+ (#set! injection.language "bash"))
+
 (call_expression
   (selector_expression) @_function
   (#any-of? @_function "regexp.Match" "regexp.MatchReader" "regexp.MatchString" "regexp.Compile" "regexp.CompilePOSIX" "regexp.MustCompile" "regexp.MustCompilePOSIX")


### PR DESCRIPTION
Inject bash language for go:generate comments[^ref].

[^ref]: https://go.dev/blog/generate