### PR TITLE
Make statusline and expansions use the same definition of "current working directory"

### DIFF
--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -49,6 +49,7 @@ The following variables are supported:
 | `file_path_absolute` | The absolute path of the currently focused document. For scratch buffers this will default to the current working directory. |
 | `line_ending` | A string containing the line ending of the currently focused document. For example on Unix systems this is usually a line-feed character (`\n`) but on Windows systems this may be a carriage-return plus a line-feed (`\r\n`). The line ending kind of the currently focused document can be inspected with the `:line-ending` command. |
 | `current_working_directory` | Current working directory |
+| `current_working_directory_name` | Basename of the current working directory |
 | `workspace_directory` | Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix` |
 | `language` | A string containing the language name of the currently focused document.|
 | `selection` | A string containing the contents of the primary selection of the currently focused document. |

--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -51,6 +51,7 @@ The following variables are supported:
 | `current_working_directory` | Current working directory |
 | `current_working_directory_name` | Basename of the current working directory |
 | `workspace_directory` | Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix` |
+| `workspace_directory_name` | Basename of the workspace directory |
 | `language` | A string containing the language name of the currently focused document.|
 | `selection` | A string containing the contents of the primary selection of the currently focused document. |
 | `selection_line_start` | The line number of the start of the primary selection in the currently focused document, starting at 1. |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -141,7 +141,8 @@ The following statusline elements can be configured:
 | `file-name` | The path/name of the opened file |
 | `file-absolute-path` | The absolute path/name of the opened file |
 | `file-base-name` | The basename of the opened file |
-| `current-working-directory` | The current working directory  |
+| `current-working-directory` | The path of the current working directory  |
+| `current-working-directory-name` | The basename of current working directory  |
 | `file-modification-indicator` | The indicator to show whether the file is modified (a `[+]` appears when there are unsaved changes) |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -143,6 +143,8 @@ The following statusline elements can be configured:
 | `file-base-name` | The basename of the opened file |
 | `current-working-directory` | The path of the current working directory  |
 | `current-working-directory-name` | The basename of current working directory  |
+| `workspace-directory` | Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix` |
+| `workspace-directory-name` | Basename of the workspace directory |
 | `file-modification-indicator` | The indicator to show whether the file is modified (a `[+]` appears when there are unsaved changes) |
 | `file-encoding` | The encoding of the opened file if it differs from UTF-8 |
 | `file-line-ending` | The file line endings (CRLF or LF) |

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -159,6 +159,8 @@ where
         helix_view::editor::StatusLineElement::CurrentWorkingDirectory => render_cwd,
         helix_view::editor::StatusLineElement::CurrentWorkingDirectoryName => render_cwd_name,
         helix_view::editor::StatusLineElement::CodeActionHint => render_code_action_hint,
+        helix_view::editor::StatusLineElement::WorkspaceDirectory => render_workspace,
+        helix_view::editor::StatusLineElement::WorkspaceDirectoryName => render_workspace_name,
     }
 }
 
@@ -602,4 +604,28 @@ where
     if context.focused && context.doc.code_action_hints(context.view.id) {
         write(context, " ⋮ ".into())
     }
+}
+
+fn render_workspace<'a, F>(context: &mut RenderContext<'a>, write: F)
+where
+    F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
+{
+    let workspace = helix_loader::find_workspace()
+        .0
+        .to_string_lossy()
+        .to_string();
+    write(context, workspace.into())
+}
+
+fn render_workspace_name<'a, F>(context: &mut RenderContext<'a>, write: F)
+where
+    F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
+{
+    let workspace = helix_loader::find_workspace()
+        .0
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    write(context, workspace.into())
 }

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -157,6 +157,7 @@ where
         helix_view::editor::StatusLineElement::VersionControl => render_version_control,
         helix_view::editor::StatusLineElement::Register => render_register,
         helix_view::editor::StatusLineElement::CurrentWorkingDirectory => render_cwd,
+        helix_view::editor::StatusLineElement::CurrentWorkingDirectoryName => render_cwd_name,
         helix_view::editor::StatusLineElement::CodeActionHint => render_code_action_hint,
     }
 }
@@ -573,6 +574,15 @@ where
 }
 
 fn render_cwd<'a, F>(context: &mut RenderContext<'a>, write: F)
+where
+    F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
+{
+    let cwd = helix_stdx::env::current_working_dir();
+    let cwd = cwd.as_path().to_string_lossy().to_string();
+    write(context, cwd.into())
+}
+
+fn render_cwd_name<'a, F>(context: &mut RenderContext<'a>, write: F)
 where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -799,8 +799,11 @@ pub enum StatusLineElement {
     /// Indicator for selected register
     Register,
 
-    /// The base of current working directory
+    /// The path of current working directory
     CurrentWorkingDirectory,
+
+    /// The basename of current working directory
+    CurrentWorkingDirectoryName,
 
     /// Indicator for when code actions are available
     CodeActionHint,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -807,6 +807,11 @@ pub enum StatusLineElement {
 
     /// Indicator for when code actions are available
     CodeActionHint,
+    /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
+    WorkspaceDirectory,
+
+    /// Basename of the workspace directory
+    WorkspaceDirectoryName,
 }
 
 // Cursor shape is read and used on every rendered frame and so needs

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -42,13 +42,13 @@ pub enum Variable {
     CurrentWorkingDirectoryName,
     /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
     WorkspaceDirectory,
-    // The name of current buffers language as set in `languages.toml`
+    /// The name of current buffers language as set in `languages.toml`
     Language,
-    // Primary selection
+    /// Primary selection
     Selection,
-    // The one-indexed line number of the start of the primary selection in the currently focused document.
+    /// The one-indexed line number of the start of the primary selection in the currently focused document.
     SelectionLineStart,
-    // The one-indexed line number of the end of the primary selection in the currently focused document.
+    /// The one-indexed line number of the end of the primary selection in the currently focused document.
     SelectionLineEnd,
 }
 

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -42,6 +42,8 @@ pub enum Variable {
     CurrentWorkingDirectoryName,
     /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
     WorkspaceDirectory,
+    /// Basename of the workspace directory
+    WorkspaceDirectoryName,
     /// The name of current buffers language as set in `languages.toml`
     Language,
     /// Primary selection
@@ -62,6 +64,7 @@ impl Variable {
         Self::CurrentWorkingDirectory,
         Self::CurrentWorkingDirectoryName,
         Self::WorkspaceDirectory,
+        Self::WorkspaceDirectoryName,
         Self::Language,
         Self::Selection,
         Self::SelectionLineStart,
@@ -78,6 +81,7 @@ impl Variable {
             Self::CurrentWorkingDirectory => "current_working_directory",
             Self::CurrentWorkingDirectoryName => "current_working_directory_name",
             Self::WorkspaceDirectory => "workspace_directory",
+            Self::WorkspaceDirectoryName => "workspace_directory_name",
             Self::Language => "language",
             Self::Selection => "selection",
             Self::SelectionLineStart => "selection_line_start",
@@ -93,6 +97,7 @@ impl Variable {
             "file_path_absolute" => Some(Self::FilePathAbsolute),
             "line_ending" => Some(Self::LineEnding),
             "workspace_directory" => Some(Self::WorkspaceDirectory),
+            "workspace_directory_name" => Some(Self::WorkspaceDirectoryName),
             "current_working_directory" => Some(Self::CurrentWorkingDirectory),
             "current_working_directory_name" => Some(Self::CurrentWorkingDirectoryName),
             "language" => Some(Self::Language),
@@ -297,6 +302,14 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
         Variable::WorkspaceDirectory => Ok(std::borrow::Cow::Owned(
             helix_loader::find_workspace()
                 .0
+                .to_string_lossy()
+                .to_string(),
+        )),
+        Variable::WorkspaceDirectoryName => Ok(std::borrow::Cow::Owned(
+            helix_loader::find_workspace()
+                .0
+                .file_name()
+                .unwrap_or_default()
                 .to_string_lossy()
                 .to_string(),
         )),

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -36,8 +36,10 @@ pub enum Variable {
     FilePathAbsolute,
     /// A string containing the line-ending of the currently focused document.
     LineEnding,
-    /// Curreng working directory
+    /// Current working directory
     CurrentWorkingDirectory,
+    /// Basename of the current working directory
+    CurrentWorkingDirectoryName,
     /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
     WorkspaceDirectory,
     // The name of current buffers language as set in `languages.toml`
@@ -58,6 +60,7 @@ impl Variable {
         Self::FilePathAbsolute,
         Self::LineEnding,
         Self::CurrentWorkingDirectory,
+        Self::CurrentWorkingDirectoryName,
         Self::WorkspaceDirectory,
         Self::Language,
         Self::Selection,
@@ -73,6 +76,7 @@ impl Variable {
             Self::FilePathAbsolute => "file_path_absolute",
             Self::LineEnding => "line_ending",
             Self::CurrentWorkingDirectory => "current_working_directory",
+            Self::CurrentWorkingDirectoryName => "current_working_directory_name",
             Self::WorkspaceDirectory => "workspace_directory",
             Self::Language => "language",
             Self::Selection => "selection",
@@ -90,6 +94,7 @@ impl Variable {
             "line_ending" => Some(Self::LineEnding),
             "workspace_directory" => Some(Self::WorkspaceDirectory),
             "current_working_directory" => Some(Self::CurrentWorkingDirectory),
+            "current_working_directory_name" => Some(Self::CurrentWorkingDirectoryName),
             "language" => Some(Self::Language),
             "selection" => Some(Self::Selection),
             "selection_line_start" => Some(Self::SelectionLineStart),
@@ -279,6 +284,13 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
         Variable::LineEnding => Ok(Cow::Borrowed(doc.line_ending.as_str())),
         Variable::CurrentWorkingDirectory => Ok(std::borrow::Cow::Owned(
             helix_stdx::env::current_working_dir()
+                .to_string_lossy()
+                .to_string(),
+        )),
+        Variable::CurrentWorkingDirectoryName => Ok(std::borrow::Cow::Owned(
+            helix_stdx::env::current_working_dir()
+                .file_name()
+                .unwrap_or_default()
                 .to_string_lossy()
                 .to_string(),
         )),


### PR DESCRIPTION
Currently the status line item "current-working-directory" evaluates to the basename of the current directory, whereas the variable `%{current_working_directory}` evaluates to the full path.

This PR aligns those definitions, so "current-working-directory" always refers to the full path and "current-working-directory-name" refers just to the base name.

For the sake of parity it also adds "workspace_directory_name" to expansion variables, and adds both "workspace-directory" and "workspace-directory-name" to status line.