### PR TITLE
fix default <space>-s/S keybinds in keymap.md

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -295,8 +295,8 @@ This layer is a kludge of mappings, mostly pickers.
 | `g`     | Open changed file picker                                                | `changed_file_picker`                      |
 | `G`     | Debug (experimental)                                                    | N/A                                        |
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
-| `s`     | Open document symbol picker (**LSP**)                                   | `symbol_picker`                            |
-| `S`     | Open workspace symbol picker (**LSP**)                                  | `workspace_symbol_picker`                  |
+| `s`     | Open document symbol picker (**LSP** or **TS**)                         | `lsp_or_syntax_symbol_picker`              |
+| `S`     | Open workspace symbol picker (**LSP** or **TS**)                        | `lsp_or_syntax_workspace_symbol_picker`    |
 | `d`     | Open document diagnostics picker (**LSP**)                              | `diagnostics_picker`                       |
 | `D`     | Open workspace diagnostics picker (**LSP**)                             | `workspace_diagnostics_picker`             |
 | `r`     | Rename symbol (**LSP**)                                                 | `rename_symbol`                            |


### PR DESCRIPTION
updates the `keymap.md` for the new defaults added / changed in #12275, where it was apparently forgotten.