### PR TITLE
fix(tags): search for `@name` inside of tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,8 +2963,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 [[package]]
 name = "tree-house"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00ea55222392f171ae004dd13b62edd09d995633abf0c13406a8df3547fb999"
+source = "git+https://github.com/m4rch3n1ng/tree-house?branch=tags-iterator#4895d5863069eaf569c676f2dfb83dde6b09c9a1"
 dependencies = [
  "arc-swap",
  "hashbrown 0.15.5",
@@ -2979,9 +2978,8 @@ dependencies = [
 
 [[package]]
 name = "tree-house-bindings"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbcbb59cca301d903c11b48b722b7c85f0e0001be2f65655cd417d98c6f3121"
+version = "0.2.2"
+source = "git+https://github.com/m4rch3n1ng/tree-house?branch=tags-iterator#4895d5863069eaf569c676f2dfb83dde6b09c9a1"
 dependencies = [
  "cc",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
 [workspace.dependencies]
-tree-house = { version = "0.3.0", default-features = false }
+# tree-house = { version = "0.3.0", default-features = false }
+tree-house = { git = "https://github.com/m4rch3n1ng/tree-house", branch = "tags-iterator", default-features = false }
 nucleo = "0.5.0"
 slotmap = "1.1.1"
 thiserror = "2.0"

--- a/book/src/guides/tags.md
+++ b/book/src/guides/tags.md
@@ -29,6 +29,9 @@ The following [captures][tree-sitter-captures] are recognized:
 | `definition.struct`    |
 | `definition.type`      |
 
+If you want to specify a name for the capture, you can use a nested `name` capture,
+otherwise helix will fall back to displaying the entire match.
+
 [Example query files][example-queries] can be found in the Helix GitHub
 repository.
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -21,6 +21,7 @@ use ropey::RopeSlice;
 use tree_house::{
     highlighter,
     query_iter::QueryIter,
+    tags::TagQuery,
     tree_sitter::{
         query::{InvalidPredicateError, UserPredicate},
         Capture, Grammar, InactiveQueryCursor, InputEdit, Node, Pattern, Query, RopeInput, Tree,
@@ -33,6 +34,7 @@ use crate::{indent::IndentQuery, tree_sitter, ChangeSet, Language};
 pub use tree_house::{
     highlighter::{Highlight, HighlightEvent},
     query_iter::QueryIterEvent,
+    tags::TagCategory,
     Error as HighlighterError, LanguageLoader, TreeCursor, TREE_SITTER_MATCH_LIMIT,
 };
 
@@ -1066,11 +1068,6 @@ impl TextObjectQuery {
         });
         Some(capture_node)
     }
-}
-
-#[derive(Debug)]
-pub struct TagQuery {
-    pub query: Query,
 }
 
 pub fn pretty_print_tree<W: fmt::Write>(fmt: &mut W, node: Node) -> fmt::Result {

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashSet,
-    iter,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -10,7 +9,7 @@ use futures_util::FutureExt;
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
 use helix_core::{
-    syntax::{Loader, QueryIterEvent},
+    syntax::{Loader, TagCategory},
     Rope, RopeSlice, Selection, Syntax, Uri,
 };
 use helix_stdx::{
@@ -119,41 +118,37 @@ fn tags_iter<'a>(
     doc: UriOrDocumentId,
     pattern: Option<&'a rope::Regex>,
 ) -> impl Iterator<Item = Tag> + 'a {
-    let mut tags_iter = syntax.tags(text, loader, ..);
+    let Some(tag_query) = loader.tag_query(syntax.root_language()) else {
+        return None.into_iter().flatten();
+    };
 
-    iter::from_fn(move || loop {
-        let QueryIterEvent::Match(mat) = tags_iter.next()? else {
-            continue;
+    let root = syntax.tree().root_node();
+    let iter = tag_query.tags(root, text).filter_map(move |tag| {
+        let kind = match tag.category {
+            TagCategory::Definition(definition) => TagKind::from_name(definition)?,
         };
-        let query = &loader
-            .tag_query(tags_iter.current_language())
-            .expect("must have a tags query to emit matches")
-            .query;
-        let Some(kind) = query
-            .capture_name(mat.capture)
-            .strip_prefix("definition.")
-            .and_then(TagKind::from_name)
-        else {
-            continue;
-        };
-        let range = mat.node.byte_range();
-        if pattern.is_some_and(|pattern| {
-            !pattern.is_match(text.regex_input_at_bytes(range.start as usize..range.end as usize))
-        }) {
-            continue;
+
+        let start = text.byte_to_char(tag.range.start as usize);
+        let end = text.byte_to_char(tag.range.end as usize);
+
+        let name = tag.name.unwrap_or_else(|| text.slice(start..end));
+
+        if pattern.is_some_and(|pattern| !pattern.is_match(name.regex_input())) {
+            return None;
         }
-        let start = text.byte_to_char(range.start as usize);
-        let end = text.byte_to_char(range.end as usize);
-        return Some(Tag {
+
+        Some(Tag {
             kind,
-            name: text.slice(start..end).to_string(),
+            name: name.to_string(),
             start,
             end,
             start_line: text.char_to_line(start),
             end_line: text.char_to_line(end),
             doc: doc.clone(),
-        });
-    })
+        })
+    });
+
+    Some(iter).into_iter().flatten()
 }
 
 pub fn syntax_symbol_picker(cx: &mut Context) {

--- a/runtime/queries/c/tags.scm
+++ b/runtime/queries/c/tags.scm
@@ -1,15 +1,15 @@
 (function_declarator
-  declarator: [(identifier) (field_identifier)] @definition.function)
+  declarator: [(identifier) (field_identifier)] @name) @definition.function
 
-(preproc_function_def name: (identifier) @definition.function)
+(preproc_function_def name: (identifier) @name) @definition.function
 
-(preproc_def name: (identifier) @definition.constant)
+(preproc_def name: (identifier) @name) @definition.constant
 
 (type_definition
-  declarator: (type_identifier) @definition.type)
+  declarator: (type_identifier) @name) @definition.type
 
 (struct_specifier
-  name: (type_identifier) @definition.struct)
+  name: (type_identifier) @name) @definition.struct
 
 (enum_specifier
-  name: (type_identifier) @definition.enum)
+  name: (type_identifier) @name) @definition.enum

--- a/runtime/queries/rust/tags.scm
+++ b/runtime/queries/rust/tags.scm
@@ -1,29 +1,29 @@
 (struct_item
-  name: (type_identifier) @definition.struct)
+  name: (type_identifier) @name) @definition.struct
 
 (const_item
-  name: (identifier) @definition.constant)
+  name: (identifier) @name) @definition.constant
 
 (trait_item
-  name: (type_identifier) @definition.interface)
+  name: (type_identifier) @name) @definition.interface
 
 (function_item
-  name: (identifier) @definition.function)
+  name: (identifier) @name) @definition.function
 
 (function_signature_item
-  name: (identifier) @definition.function)
+  name: (identifier) @name) @definition.function
 
 (enum_item
-  name: (type_identifier) @definition.enum)
+  name: (type_identifier) @name) @definition.enum
 
 (enum_variant
-  name: (identifier) @definition.struct)
+  name: (identifier) @name) @definition.struct
 
 (type_item
-  name: (type_identifier) @definition.type)
+  name: (type_identifier) @name) @definition.type
 
 (mod_item
-  name: (identifier) @definition.module)
+  name: (identifier) @name) @definition.module
 
 (macro_definition
-  name: (identifier) @definition.macro)
+  name: (identifier) @name) @definition.macro


### PR DESCRIPTION
i noticed this while trying to improve the go and rust tags and noticed, that the go tags had some `@name` queries, that didn't seem to do anything, while the rust did not. when querying for the go syntax the picker showed the whole definition: (or at least the first line of it), while the rust picker (correctly) only displayed the name.

<details>
<summary>screenshots</summary>
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/a9854167-85db-4b3f-b4ed-fe206b17abb9" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/50315c40-c71f-4d36-b5e1-d13169adbae7" />

the go lsp only shows the name:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/8f273367-e05e-44c3-9aa4-e5ca2ca724a5" />
</details>

while the rust syntax picker showed the correct name, when selecting a symbol, only selected the name of the definition is selected, while the lsp symbol picker selects the entire definition.

<details>
<summary>screenshots</summary>
(after selecting the `Thing` struct in the picker):
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/09cd8d0a-6587-4a16-bf5f-6cdd79ccb5b3" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/681421a3-88b3-4a7d-9336-b4a9bbcdb7c4" />
</details>

this pr fixes that by just trying to find a `@name` in the `definition` capture and falling back to displaying whole match if none is found. i am not quite sure with my implementatio

with this pr i can also update the rust tags, so that the syntax query matches the whole definition, which i did in the second commit.

additional notes: the currently ignored `@name` captures are already used by quite a few grammars, including `go`, `ts`/`js`, `python`, `c#` and `elisp` to name a few.