### PR TITLE
theme: Papercolor recognises `hint`, re-colored `warning`

### DIFF
--- a/runtime/themes/papercolor-light.toml
+++ b/runtime/themes/papercolor-light.toml
@@ -40,7 +40,8 @@
 "ui.menu" = { bg = "popupmenu_bg", fg = "foreground" }
 "ui.menu.selected" = { bg = "selection_bg", fg = "selection_fg" }
 
-"warning" = "bright5"
+"warning" = "bright4"
+"hint" = "bright6"
 "error" = { bg = "error_bg", fg = "error_fg" }
 "info" = "todo_fg"
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="286" height="91" alt="image" src="https://github.com/user-attachments/assets/fa49f485-1d26-442d-8d0f-329f827af66c" /> | <img width="289" height="90" alt="image" src="https://github.com/user-attachments/assets/f55cf6ae-54ed-44ff-b83c-144d67650e13" /> |
| <img width="282" height="88" alt="image" src="https://github.com/user-attachments/assets/99d21eb9-b535-4d71-bec9-a5447a3d5ad9" /> | <img width="294" height="91" alt="image" src="https://github.com/user-attachments/assets/f5b3a79a-c988-4014-ab45-bc3db0064b60" /> |

Added a color for hint comments.
Made warning comments yellow, because I feel that makes sense and it's less frequently used (previously matched constants in dark theme).