### PR TITLE
DAP: ConfigurationDone request: JDTLS expects arguments to be an object, not null

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -424,7 +424,8 @@ impl Client {
     }
 
     pub async fn configuration_done(&self) -> Result<()> {
-        self.request::<requests::ConfigurationDone>(()).await
+        self.request::<requests::ConfigurationDone>(Some(requests::ConfigurationDoneArguments {}))
+            .await
     }
 
     pub fn continue_thread(&self, thread_id: ThreadId) -> impl Future<Output = Result<Value>> {

--- a/helix-dap/src/types.rs
+++ b/helix-dap/src/types.rs
@@ -457,10 +457,13 @@ pub mod requests {
     pub enum ConfigurationDone {}
 
     impl Request for ConfigurationDone {
-        type Arguments = ();
+        type Arguments = Option<ConfigurationDoneArguments>;
         type Result = ();
         const COMMAND: &'static str = "configurationDone";
     }
+
+    #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
+    pub struct ConfigurationDoneArguments {}
 
     #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Fixes #14878 