### PR TITLE
feat(lsp): advertise support for show document request

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -705,6 +705,7 @@ impl Client {
                 }),
                 window: Some(lsp::WindowClientCapabilities {
                     work_done_progress: Some(true),
+                    show_document: Some(lsp::ShowDocumentClientCapabilities { support: true }),
                     ..Default::default()
                 }),
                 general: Some(lsp::GeneralClientCapabilities {


### PR DESCRIPTION
It's supported but not advertised in the client capabilities. We already have:

```rs
lsp::request::ShowDocument::METHOD => {
    let params: lsp::ShowDocumentParams = params.parse()?;
    Self::ShowDocument(params)
}
```

in `helix-lsp/src/lib.rs`.
