### PR TITLE
fix(theme): add line number colors to horizon-dark theme

### DIFF
--- a/runtime/themes/horizon-dark.toml
+++ b/runtime/themes/horizon-dark.toml
@@ -21,6 +21,8 @@ tag = "red"
 # User Interface
 "ui.background" = { bg = "bg", fg = "gray" }
 "ui.background.separator" = "light-gray"
+"ui.linenr" = { fg = "light-gray" }
+"ui.linenr.selected" = { fg = "white" }
 "ui.text" = "white"
 "ui.text.focus" = "green"
 "ui.text.inactive" = "selection"


### PR DESCRIPTION
The current horizon theme does not have enough contrast for the line numbers. This PR simply themes them so that they are easier to see.

## Screenshot

### Before

<img width="2943" height="1727" alt="image" src="https://github.com/user-attachments/assets/82f3fff5-02f4-40d0-92c3-9bc419336b7b" />

### After

<img width="2939" height="1723" alt="image" src="https://github.com/user-attachments/assets/6840fae1-67ea-4b5b-af6e-299e2734db66" />
