### PR TITLE
just: Fix highlighting in interpolations

### DIFF
--- a/runtime/queries/just/injections.scm
+++ b/runtime/queries/just/injections.scm
@@ -12,11 +12,14 @@
 
 ; ================ Global defaults ================
 
-; Default everything to be bash
+; Default recipe lines to be bash, but exclude interpolation nodes
+; This prevents bash's rainbow brackets from interfering with just's {{ }} markers
+; Use injection.combined to combine all recipe lines so bash can parse multi-line constructs
 (recipe_body
   !shebang
+  (recipe_line) @injection.content
   (#set! injection.language "bash")
-  (#set! injection.include-children)) @injection.content
+  (#set! injection.combined))
 
 (external_command
   (content) @injection.content
@@ -49,7 +52,8 @@
     (recipe
       (recipe_body
         !shebang
-        (#set! injection.include-children)) @injection.content)
+        (recipe_line) @injection.content
+        (#set! injection.combined)))
 
     (assignment
       (expression
@@ -65,7 +69,8 @@
     (recipe
       (recipe_body
         !shebang
-        (#set! injection.include-children)) @injection.content)
+        (recipe_line) @injection.content
+        (#set! injection.combined)))
 
     (assignment
       (expression
@@ -79,4 +84,5 @@
 ; Set highlighting for recipes that specify a language using builtin shebang matching
 (recipe_body
   (shebang_line) @injection.shebang
-  (#set! injection.include-children)) @injection.content
+  (recipe_line) @injection.content
+  (#set! injection.combined))


### PR DESCRIPTION
Why?
====

Justfile interpolations ({{ ... }}) had inconsistent bracket colors. Bash injection used include-children on recipe_body, causing bash's rainbow brackets to interfere with just's {{ }} markers.

How?
====

- Target recipe_line instead of recipe_body to exclude interpolations
- Replace include-children with injection.combined to preserve bash's ability to parse multi-line constructs

Demo
====

Before the change - notice the highlighting of `justfile()`

<img width="3456" height="2166" alt="Screenshot 2025-11-28 at 20 03 10@2x" src="https://github.com/user-attachments/assets/eedb5a9b-3fdc-4b60-b2d3-92553dda5c42" />

After

<img width="3456" height="2166" alt="Screenshot 2025-11-28 at 20 03 38@2x" src="https://github.com/user-attachments/assets/469f9c29-a2b4-4c22-83b4-de9b1dea0442" />


