### PR TITLE
Add Cachix binary cache support for aarch64-darwin

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   publish:
     name: Publish Flake
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v6


### PR DESCRIPTION
This PR enables pre-built binaries for Apple Silicon Macs in the Helix Cachix.

## Context
This revisits #4710, which was closed due to Cachix storage concerns. Two years later, this PR takes a more conservative approach by only adding Apple Silicon support. 