### PR TITLE
queries(yaml): fix ordering and license notice in `injections.scm`

### DIFF
--- a/runtime/queries/yaml/injections.scm
+++ b/runtime/queries/yaml/injections.scm
@@ -1,39 +1,8 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
-;; GitHub actions: inline JavaScript for workflow scripting
-(block_mapping
-  (block_mapping_pair
-    key: (flow_node) @_uses (#eq? @_uses "uses")
-    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
-  (block_mapping_pair
-    key: (flow_node) @_with (#eq? @_with "with")
-    value: (block_node
-             (block_mapping
-               (block_mapping_pair
-                 key: (flow_node) @_run (#eq? @_run "script")
-                 value: (flow_node
-                          (plain_scalar
-                            (string_scalar) @injection.content
-                            (#set! injection.language "javascript"))))))))
-
-;; GitHub actions: block JavaScript for workflow scripting
-(block_mapping
-  (block_mapping_pair
-    key: (flow_node) @_uses (#eq? @_uses "uses")
-    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
-  (block_mapping_pair
-    key: (flow_node) @_with (#any-of? @_with "with")
-    value: (block_node
-             (block_mapping
-               (block_mapping_pair
-                 key: (flow_node) @_run (#any-of? @_run "script")
-                 value: (block_node
-                          (block_scalar) @injection.content
-                          (#set! injection.language "javascript")))))))
-
-; The remaining code in this file incorporates work covered by the following
-; copyright and permission notice:
+; The following code in this file until the ";;; END nvim-treesitter LICENSED CODE"
+; marker incorporates work covered by the following copyright and permission notice:
 ;
 ;   Copyright 2023 the nvim-treesitter authors
 ;
@@ -84,3 +53,37 @@
                (block_node
                   (block_scalar) @injection.content
                   (#set! injection.language "bash"))))))
+
+;;; END nvim-treesitter LICENSED CODE
+
+; GitHub actions: JavaScript for workflow scripting (inline)
+(block_mapping
+  (block_mapping_pair
+    key: (flow_node) @_uses (#eq? @_uses "uses")
+    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
+  (block_mapping_pair
+    key: (flow_node) @_with (#eq? @_with "with")
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @_run (#eq? @_run "script")
+                 value: (flow_node
+                          (plain_scalar
+                            (string_scalar) @injection.content
+                            (#set! injection.language "javascript"))))))))
+
+; GitHub actions: JavaScript for workflow scripting (block)
+(block_mapping
+  (block_mapping_pair
+    key: (flow_node) @_uses (#eq? @_uses "uses")
+    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
+  (block_mapping_pair
+    key: (flow_node) @_with (#any-of? @_with "with")
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @_run (#any-of? @_run "script")
+                 value: (block_node
+                          (block_scalar) @injection.content
+                          (#set! injection.language "javascript")))))))
+


### PR DESCRIPTION
This is a follow-up to #14890.

I'm terribly sorry, but in the last PR, after reading the license notice, I switched the query order right from GitHub's interface, all to prevent the legal comment from applying to it. However, that made the later queries override mine, rendering them useless.

Thus, in this pull request I:
1. Fixed the order back as it was in #14890 initially
2. Adjusted the license notice to be more flexible and only apply until the certain mark: `;;; END nvim-treesitter LICENSED CODE`

Sorry again for the inconvenience :pray: 