### PR TITLE
Add 'code-workspace' as a JSON extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -587,7 +587,8 @@ file-types = [
   "sublime-project",
   "sublime-settings",
   "sublime-theme",
-  "sublime-workspace"
+  "sublime-workspace",
+  "code-workspace"
 ]
 language-servers = [ "vscode-json-language-server" ]
 auto-format = true


### PR DESCRIPTION
This PR enables language support for VS Code's workspace settings files which are written in JSON.

**Reasons:**
- Currently to enable syntax highlighting and language support in `.code-workspace` files, one has to enter `:set-language json` every time.
- Copying ~50 lines of config for the JSON language into one's own `language.toml` just to add one more extension is not good UX.
- Sublime's many extensions are supported out of the box, so VS Code's one should not be too hard to support.