### PR TITLE
chore: update forth with improved treesitter

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3664,7 +3664,7 @@ indent = { tab-width = 3, unit = "   " }
 
 [[grammar]]
 name = "forth"
-source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "90189238385cf636b9ee99ce548b9e5b5e569d48" }
+source = { git = "https://github.com/alexanderbrevig/tree-sitter-forth", rev = "360ef13f8c609ec6d2e80782af69958b84e36cd0" }
 
 [[language]]
 name = "fsharp"

--- a/runtime/queries/forth/highlights.scm
+++ b/runtime/queries/forth/highlights.scm
@@ -1,7 +1,37 @@
-([(start_definition)(end_definition)] @keyword)
-((number) @constant)
-((string) @string)
-((word) @function)
-((comment) @comment)
-([(core)] @type)
-([(operator)] @operator)
+; Definition keywords
+[
+  (start_definition)
+  (end_definition)
+] @keyword
+
+; Control flow - highlighted as keywords for prominence
+(control_flow) @keyword.control
+
+; I/O operations
+(io) @function.builtin
+
+; Operators - arithmetic, logic, stack manipulation
+(operator) @operator
+
+; Core builtins - defining words, memory, etc.
+(core) @type
+
+; Numbers - all subtypes
+(character_literal) @constant.character
+(hex_number) @constant.numeric
+(binary_number) @constant.numeric
+(octal_number) @constant.numeric
+(float_number) @constant.numeric
+(double_cell_number) @constant.numeric
+(decimal_number) @constant.numeric
+
+; Strings
+(string) @string
+
+; Comments - different types
+(line_comment) @comment.line
+(block_comment) @comment.block
+(stack_effect) @comment.block.documentation
+
+; User-defined words
+(word) @function


### PR DESCRIPTION
Quite a lot better.

(Sidenote, the [forth-lsp](https://github.com/AlexanderBrevig/forth-lsp) is also updated and worth a reinstall `cargo install forth-lsp`)

Preview with catppuccin:
<img width="2525" height="1293" alt="image" src="https://github.com/user-attachments/assets/ba967f3d-4d27-4818-a721-2be85379749d" />
