### PR TITLE
Expanding focused splits: easily edit the same file in different locations

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2276,6 +2276,8 @@ impl Editor {
             editor: self,
             doc: focus_lost,
         });
+        // expand the focused tab
+        self.tree.recalculate();
     }
 
     pub fn focus_next(&mut self) {
@@ -2290,7 +2292,6 @@ impl Editor {
         let current_view = self.tree.focus;
         if let Some(id) = self.tree.find_split_in_direction(current_view, direction) {
             self.focus(id);
-            self.tree.recalculate();
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2289,7 +2289,8 @@ impl Editor {
     pub fn focus_direction(&mut self, direction: tree::Direction) {
         let current_view = self.tree.focus;
         if let Some(id) = self.tree.find_split_in_direction(current_view, direction) {
-            self.focus(id)
+            self.focus(id);
+            self.tree.recalculate();
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -432,6 +432,8 @@ pub struct Config {
     /// Whether to enable Kitty Keyboard Protocol
     pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
     pub buffer_picker: BufferPickerConfig,
+    /// Expand the focused split and collapse siblings
+    pub expand_focused_split: bool,
     /// Workspace-trust configuration.
     pub workspace_trust: WorkspaceTrustConfig,
 }
@@ -1215,6 +1217,7 @@ impl Default for Config {
             rainbow_brackets: false,
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
+            expand_focused_split: false,
             workspace_trust: WorkspaceTrustConfig::default(),
         }
     }
@@ -1403,7 +1406,7 @@ impl Editor {
 
         Self {
             mode: Mode::Normal,
-            tree: Tree::new(area),
+            tree: Tree::new(area, config.clone()),
             next_document_id: DocumentId::default(),
             documents: BTreeMap::new(),
             saves: HashMap::new(),
@@ -2277,7 +2280,7 @@ impl Editor {
             doc: focus_lost,
         });
         // expand the focused tab
-        self.tree.recalculate();
+        self.tree.recalculate(self.config().expand_focused_split);
     }
 
     pub fn focus_next(&mut self) {

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -395,8 +395,6 @@ impl Tree {
                         Layout::Horizontal => {
                             let len = container.children.len();
 
-                            // let height = area.height / len as u16;
-
                             let mut child_y = area.y;
 
                             for child in container.children.iter() {
@@ -405,23 +403,17 @@ impl Tree {
                                 // Needs to account for children within containers
                                 // Crashes when maximizing above a vert. split with horz. children
                                 let height = if focus_node {
-                                    area.height - (len * 2) as u16
+                                    area.height - ((len - 1) * 2) as u16
                                 } else {
                                     2
                                 };
-                                let mut area = Rect::new(
+                                let area = Rect::new(
                                     container.area.x,
                                     child_y,
                                     container.area.width,
                                     height,
                                 );
                                 child_y += height;
-
-                                // last child takes the remaining width because we can get uneven
-                                // space from rounding
-                                if focus_node {
-                                    area.height = container.area.y + container.area.height - area.y;
-                                }
 
                                 self.stack.push((*child, area));
                             }

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+use arc_swap::access::DynAccess;
+use crate::editor::Config;
 use crate::{graphics::Rect, View, ViewId};
 use slotmap::{SlotMap, SecondaryMap};
 
 // the dimensions are recomputed on window resize/tree change.
 //
-#[derive(Debug)]
 pub struct Tree {
     root: ViewId,
     // (container, index inside the container)
@@ -15,6 +17,22 @@ pub struct Tree {
 
     // used for traversals
     stack: Vec<(ViewId, Rect)>,
+
+    // used for expand_focused_split
+    config: Arc<dyn DynAccess<Config>>,
+}
+
+impl std::fmt::Debug for Tree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tree")
+            .field("root", &self.root)
+            .field("focus", &self.focus)
+            .field("area", &self.area)
+            .field("nodes", &self.nodes)
+            .field("stack", &self.stack)
+            // .field("config", &self.config)
+            .finish()
+    }
 }
 
 #[derive(Debug)]
@@ -84,7 +102,10 @@ impl Default for Container {
 }
 
 impl Tree {
-    pub fn new(area: Rect) -> Self {
+    pub fn new(
+        area: Rect,
+        config: Arc<dyn DynAccess<Config>>,
+    ) -> Self {
         let root = Node::container(Layout::Vertical);
 
         let mut nodes = SlotMap::with_key();
@@ -100,6 +121,7 @@ impl Tree {
             area,
             nodes,
             stack: Vec::new(),
+            config,
         }
     }
 
@@ -136,7 +158,7 @@ impl Tree {
         self.focus = node;
 
         // recalculate all the sizes
-        self.recalculate();
+        self.recalculate(self.config().expand_focused_split);
 
         node
     }
@@ -209,7 +231,7 @@ impl Tree {
         self.focus = node;
 
         // recalculate all the sizes
-        self.recalculate();
+        self.recalculate(self.config().expand_focused_split);
 
         node
     }
@@ -266,7 +288,7 @@ impl Tree {
             self.remove_or_replace(parent, Some(sibling));
         }
 
-        self.recalculate()
+        self.recalculate(self.config().expand_focused_split)
     }
 
     pub fn views(&self) -> impl Iterator<Item = (&View, bool)> {
@@ -346,7 +368,7 @@ impl Tree {
     pub fn resize(&mut self, area: Rect) -> bool {
         if self.area != area {
             self.area = area;
-            self.recalculate();
+            self.recalculate(self.config().expand_focused_split);
             return true;
         }
         false
@@ -370,7 +392,7 @@ impl Tree {
         h
     }
 
-    pub fn recalculate(&mut self) {
+    pub fn recalculate(&mut self, expand_focused_split: bool) {
         if self.is_empty() {
             // There are no more views, so the tree should focus itself again.
             self.focus = self.root;
@@ -378,7 +400,9 @@ impl Tree {
             return;
         }
 
+        // TODO avoid this if expand_focused_split is disabled
         let nested_heights = self.get_nested_heights();
+
         self.stack.push((self.root, self.area));
 
         // get nodes containing the focus view
@@ -411,29 +435,51 @@ impl Tree {
 
                     match container.layout {
                         Layout::Horizontal => {
-                            // space for non focused nodes
-                            let len = container.children.iter()
-                                .filter(|c| !focus_nodes.contains_key(**c))
-                                .map(|c| nested_heights[*c])
-                                .sum();
-                            let focus_height = area.height.saturating_sub(len);
-
                             let mut child_y = area.y;
-                            for child in container.children.iter() {
-                                let height = if focus_nodes.contains_key(*child) {
-                                    focus_height
-                                } else {
-                                    nested_heights[*child]
-                                };
-                                let area = Rect::new(
-                                    container.area.x,
-                                    child_y,
-                                    container.area.width,
-                                    height,
-                                );
-                                child_y += height;
 
-                                self.stack.push((*child, area));
+                            if expand_focused_split {
+                                // space for non focused nodes
+                                let len = container.children.iter()
+                                    .filter(|c| !focus_nodes.contains_key(**c))
+                                    .map(|c| nested_heights[*c])
+                                    .sum();
+                                let focus_height = area.height.saturating_sub(len);
+
+                                for child in container.children.iter() {
+                                    let height = if focus_nodes.contains_key(*child) {
+                                        focus_height
+                                    } else {
+                                        nested_heights[*child]
+                                    };
+                                    let area = Rect::new(
+                                        container.area.x,
+                                        child_y,
+                                        container.area.width,
+                                        height,
+                                    );
+                                    child_y += height;
+
+                                    self.stack.push((*child, area));
+                                }
+                            } else {
+                                let len = container.children.len();
+                                let height = area.height / len as u16;
+                                for (i, child) in container.children.iter().enumerate() {
+                                    let mut area = Rect::new(
+                                        container.area.x,
+                                        child_y,
+                                        container.area.width,
+                                        height,
+                                    );
+                                    child_y += height;
+
+                                    // last child takes the remaining width because we can get uneven
+                                    // space from rounding
+                                    if i == len - 1 {
+                                        area.height = container.area.y + container.area.height - area.y;
+                                    }
+                                    self.stack.push((*child, area));
+                                }
                             }
                         }
                         Layout::Vertical => {
@@ -623,7 +669,7 @@ impl Tree {
                 Layout::Vertical => Layout::Horizontal,
                 Layout::Horizontal => Layout::Vertical,
             };
-            self.recalculate();
+            self.recalculate(self.config().expand_focused_split);
         }
     }
 
@@ -699,6 +745,10 @@ impl Tree {
 
     pub fn area(&self) -> Rect {
         self.area
+    }
+
+    fn config(&self) -> arc_swap::access::DynGuard<Config> {
+        self.config.load()
     }
 }
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -805,18 +805,23 @@ impl DoubleEndedIterator for Traverse<'_> {
 
 #[cfg(test)]
 mod test {
+    use arc_swap::ArcSwap;
+
     use super::*;
     use crate::editor::GutterConfig;
     use crate::DocumentId;
 
     #[test]
     fn find_split_in_direction() {
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: 180,
-            height: 80,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 180,
+                height: 80,
+            },
+            Arc::new(ArcSwap::new(Arc::new(Config::default()))),
+        );
         let mut view = View::new(DocumentId::default(), GutterConfig::default());
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
@@ -865,12 +870,15 @@ mod test {
 
     #[test]
     fn swap_split_in_direction() {
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: 180,
-            height: 80,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 180,
+                height: 80,
+            },
+            Arc::new(ArcSwap::new(Arc::new(Config::default()))),
+        );
 
         let doc_l0 = DocumentId::default();
         let mut view = View::new(doc_l0, GutterConfig::default());
@@ -983,12 +991,15 @@ mod test {
     #[test]
     fn all_vertical_views_have_same_width() {
         let tree_area_width = 180;
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: tree_area_width,
-            height: 80,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: tree_area_width,
+                height: 80,
+            },
+            Arc::new(ArcSwap::new(Arc::new(Config::default()))),
+        );
         let mut view = View::new(DocumentId::default(), GutterConfig::default());
         view.area = Rect::new(0, 0, 180, 80);
         tree.insert(view);
@@ -1021,12 +1032,15 @@ mod test {
     #[test]
     fn vsplit_gap_rounding() {
         let (tree_area_width, tree_area_height) = (80, 24);
-        let mut tree = Tree::new(Rect {
-            x: 0,
-            y: 0,
-            width: tree_area_width,
-            height: tree_area_height,
-        });
+        let mut tree = Tree::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: tree_area_width,
+                height: tree_area_height,
+            },
+            Arc::new(ArcSwap::new(Arc::new(Config::default()))),
+        );
         let mut view = View::new(DocumentId::default(), GutterConfig::default());
         view.area = Rect::new(0, 0, tree_area_width, tree_area_height);
         tree.insert(view);

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -1,5 +1,6 @@
 use crate::{graphics::Rect, View, ViewId};
 use slotmap::SlotMap;
+use std::collections::HashSet;
 
 // the dimensions are recomputed on window resize/tree change.
 //
@@ -362,6 +363,17 @@ impl Tree {
 
         self.stack.push((self.root, self.area));
 
+        // get nodes containing the focus view
+        let mut focus_nodes = HashSet::new();
+        let mut cur = self.focus;
+        loop {
+            focus_nodes.insert(cur);
+            if self.nodes[cur].parent == cur {
+                break;
+            }
+            cur = self.nodes[cur].parent
+        }
+
         // take the area
         // fetch the node
         // a) node is view, give it whole area
@@ -383,11 +395,20 @@ impl Tree {
                         Layout::Horizontal => {
                             let len = container.children.len();
 
-                            let height = area.height / len as u16;
+                            // let height = area.height / len as u16;
 
                             let mut child_y = area.y;
 
-                            for (i, child) in container.children.iter().enumerate() {
+                            for child in container.children.iter() {
+                                let focus_node = focus_nodes.contains(child);
+                                // WARN
+                                // Needs to account for children within containers
+                                // Crashes when maximizing above a vert. split with horz. children
+                                let height = if focus_node {
+                                    area.height - (len * 2) as u16
+                                } else {
+                                    2
+                                };
                                 let mut area = Rect::new(
                                     container.area.x,
                                     child_y,
@@ -398,7 +419,7 @@ impl Tree {
 
                                 // last child takes the remaining width because we can get uneven
                                 // space from rounding
-                                if i == len - 1 {
+                                if focus_node {
                                     area.height = container.area.y + container.area.height - area.y;
                                 }
 

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -1,6 +1,5 @@
 use crate::{graphics::Rect, View, ViewId};
-use slotmap::SlotMap;
-use std::collections::HashSet;
+use slotmap::{SlotMap, SecondaryMap};
 
 // the dimensions are recomputed on window resize/tree change.
 //
@@ -353,6 +352,24 @@ impl Tree {
         false
     }
 
+    fn get_nested_heights(&self) -> SecondaryMap<ViewId, u16> {
+        let mut nested_heights = SecondaryMap::new();
+        self.get_nested_heights_impl(self.root, &mut nested_heights);
+        nested_heights
+    }
+
+    fn get_nested_heights_impl(&self, key: ViewId, nested_heights: &mut SecondaryMap<ViewId, u16>) -> u16 {
+        let h = match &self.nodes[key].content {
+            Content::View(_) => 2,
+            Content::Container(c) => match c.layout {
+                Layout::Horizontal => c.children.iter().map(|k| self.get_nested_heights_impl(*k, nested_heights)).sum(),
+                Layout::Vertical => c.children.iter().map(|k| self.get_nested_heights_impl(*k, nested_heights)).max().expect("Container should have children"),
+            },
+        };
+        nested_heights.insert(key, h);
+        h
+    }
+
     pub fn recalculate(&mut self) {
         if self.is_empty() {
             // There are no more views, so the tree should focus itself again.
@@ -361,13 +378,14 @@ impl Tree {
             return;
         }
 
+        let nested_heights = self.get_nested_heights();
         self.stack.push((self.root, self.area));
 
         // get nodes containing the focus view
-        let mut focus_nodes = HashSet::new();
+        let mut focus_nodes = SecondaryMap::new();
         let mut cur = self.focus;
         loop {
-            focus_nodes.insert(cur);
+            focus_nodes.insert(cur, ());
             if self.nodes[cur].parent == cur {
                 break;
             }
@@ -393,19 +411,19 @@ impl Tree {
 
                     match container.layout {
                         Layout::Horizontal => {
-                            let len = container.children.len();
+                            // space for non focused nodes
+                            let len = container.children.iter()
+                                .filter(|c| !focus_nodes.contains_key(**c))
+                                .map(|c| nested_heights[*c])
+                                .sum();
+                            let height = area.height.saturating_sub(len);
 
                             let mut child_y = area.y;
-
                             for child in container.children.iter() {
-                                let focus_node = focus_nodes.contains(child);
-                                // WARN
-                                // Needs to account for children within containers
-                                // Crashes when maximizing above a vert. split with horz. children
-                                let height = if focus_node {
-                                    area.height - ((len - 1) * 2) as u16
+                                let height = if focus_nodes.contains_key(*child) {
+                                    height
                                 } else {
-                                    2
+                                    nested_heights[*child]
                                 };
                                 let area = Rect::new(
                                     container.area.x,

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -416,12 +416,12 @@ impl Tree {
                                 .filter(|c| !focus_nodes.contains_key(**c))
                                 .map(|c| nested_heights[*c])
                                 .sum();
-                            let height = area.height.saturating_sub(len);
+                            let focus_height = area.height.saturating_sub(len);
 
                             let mut child_y = area.y;
                             for child in container.children.iter() {
                                 let height = if focus_nodes.contains_key(*child) {
-                                    height
+                                    focus_height
                                 } else {
                                     nested_heights[*child]
                                 };


### PR DESCRIPTION
### Proposal

Utilize horizontal (or vertical) splits to make editing in large files easier by maximizing the focused view

### Motivation

My biggest issue with helix so far has been trying to use the jumplist to edit a large file. In these cases, I find it easier to create a vertical split, but that halves my screen real-estate, especially since resizable splits are not supported.

What I wanted was a stack, like a tiling window manager. That way each view maximizes the screen, but can easily be switched between. I realized horizontal splits, which I never used, are essentially stacks, if only they could maximize whenever I moved up or down.

This proof of concept shows that horizontal splits can easily be leveraged to improve large file editing without losing screen real-estate.

![working](https://github.com/user-attachments/assets/11bc5210-c4e5-4548-9ce6-7175e00f845d)


### Limitations

It's currently difficult to know how many children are nested inside of other containers with the current `recalculate` method. Currently horizontal splits nested inside a vertical container as illustrated below crashes the editor:

```
 _____________________________ 
|     ^                       |
|     | Can only maximize     |
|     | This large            |
|     |                       |
|     |                       |
|     v                       |
|_____________________________|
|              |______________|
|______________|______________|
|              |______________|
|______________|______________|

```
![fail](https://github.com/user-attachments/assets/41d08340-127f-486a-a19a-19205d084ce7)

Additionally, I am unable to compress splits further than 2 rows.
If I change the 2 to a 1:
```rust
let height = if focus_node {
    area.height - ((len - 1) * 2) as u16
} else {
    2
};
```
Then I get: 
```
thread 'main' panicked at helix-term/src/ui/text_decorations/diagnostics.rs:287:24:
attempt to add with overflow
```

### Discussion

Having a configuration option to also maximize vertical splits can benefit users of vertically rotated monitors that use horizontal splits.

However to implement this in a robust manner, the number of horizontal and vertical children within each layout needs to be kept track of. I don't see other PRs that do this. I am open to suggestions and feedback, as I am not a rust programmer and unsure of the best way to approach this.


Thanks!
