### PR TITLE
docs: Fix word-breaking and unclosed parenthess

### DIFF
--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -1,12 +1,13 @@
 ## Adding indent queries
 
-Helix uses tree-sitter to correctly indent new lines. This requires a tree-
-sitter grammar and an `indent.scm` query file placed in `runtime/queries/
-{language}/indents.scm`. The indentation for a line is calculated by traversing
-the syntax tree from the lowest node at the beginning of the new line (see
-[Indent queries](#indent-queries)). Each of these nodes contributes to the total
-indent when it is captured by the query (in what way depends on the name of
-the capture.
+Helix uses tree-sitter to correctly indent new lines. This requires a
+tree-sitter grammar and an `indent.scm` query file placed in
+`runtime/queries/{language}/indents.scm`. The indentation for a line is
+calculated by traversing the syntax tree from the lowest node at the
+beginning of the new line (see [Indent queries](#indent-queries)).
+Each of these nodes contributes to the total indent when it is
+captured by the query (in what way depends on the name of
+the capture).
 
 Note that it matters where these added indents begin. For example,
 multiple indent level increases that start on the same line only increase


### PR DESCRIPTION
<img width="637" height="161" alt="image" src="https://github.com/user-attachments/assets/b6041370-55ec-466f-b85f-bec53ca14deb" />

Removes the spaces.