### PR TITLE
feat: update Amber grammar and queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -4,7 +4,7 @@
 | adl | ✓ | ✓ | ✓ |  |  |  |
 | agda | ✓ |  |  |  |  |  |
 | alloy | ✓ |  |  |  |  |  |
-| amber | ✓ |  |  |  |  | `amber-lsp` |
+| amber | ✓ | ✓ | ✓ | ✓ | ✓ | `amber-lsp` |
 | astro | ✓ |  |  |  |  | `astro-ls` |
 | awk | ✓ | ✓ |  |  |  | `awk-language-server` |
 | bash | ✓ | ✓ | ✓ | ✓ | ✓ | `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -4486,7 +4486,7 @@ language-servers = ["amber-lsp"]
 
 [[grammar]]
 name = "amber"
-source = { git = "https://github.com/amber-lang/tree-sitter-amber", rev = "c6df3ec2ec243ed76550c525e7ac3d9a10c6c814" }
+source = { git = "https://github.com/amber-lang/tree-sitter-amber", rev = "dc69f42449fd3c807bacefa398263f62e581f755" }
 
 [[language]]
 name = "koto"

--- a/runtime/queries/amber/highlights.scm
+++ b/runtime/queries/amber/highlights.scm
@@ -38,7 +38,9 @@
 (null) @constant.numeric
 (string) @string
 (status) @keyword
-(command) @string
+; Highlight only command delimiters, not content (bash injection handles content)
+(command
+  ["$"] @string)
 (handler) @keyword
 (block) @punctuation.delimiter
 (variable_init) @keyword

--- a/runtime/queries/amber/indents.scm
+++ b/runtime/queries/amber/indents.scm
@@ -1,0 +1,49 @@
+; Block structures that increase indent
+[
+  (function_definition)
+  (block)
+  (main_block)
+
+  ; Control flow
+  (if_cond)
+  (if_chain)
+  (for_loop)
+  (while_loop)
+  (loop_infinite)
+
+  ; Collections
+  (array)
+  (parameter_list)
+  (function_parameter_list)
+  (parentheses)
+
+  ; Amber-specific
+  (command_modifier_block)
+  (handler_failed)
+  (handler_succeeded)
+  (handler_exited)
+] @indent
+
+; Closing delimiters
+[
+  "}"
+  "]"
+  ")"
+] @outdent
+
+; Multi-line construct support
+[
+  (function_definition)
+  (if_cond)
+  (if_chain)
+  (for_loop)
+  (while_loop)
+  (loop_infinite)
+  (main_block)
+] @extend
+
+; Prevent premature outdent
+[
+  (function_control_flow)
+  (loop_control_flow)
+] @extend.prevent-once

--- a/runtime/queries/amber/injections.scm
+++ b/runtime/queries/amber/injections.scm
@@ -1,0 +1,14 @@
+; Inject bash into command content
+((command_content) @injection.content
+ (#set! injection.language "bash"))
+
+; Inject markdown into documentation comments (///)
+((comment) @injection.content
+ (#match? @injection.content "^///")
+ (#set! injection.language "markdown")
+ (#set! injection.combined))
+
+; Regular comments (excluding doc comments)
+((comment) @injection.content
+ (#not-match? @injection.content "^///")
+ (#set! injection.language "comment"))

--- a/runtime/queries/amber/rainbows.scm
+++ b/runtime/queries/amber/rainbows.scm
@@ -1,0 +1,30 @@
+[ "(" ")" "[" "]" "{" "}" ] @rainbow.bracket
+
+[
+  ; Functions and main block
+  (function_definition)
+  (main_block)
+
+  ; Control flow blocks
+  (if_cond)
+  (if_chain)
+  (if_ternary)
+  (for_loop)
+  (while_loop)
+  (loop_infinite)
+
+  ; General blocks
+  (block)
+  (command_modifier_block)
+
+  ; Collections and grouping
+  (array)
+  (parameter_list)
+  (function_parameter_list)
+  (parentheses)
+
+  ; Handlers
+  (handler_failed)
+  (handler_succeeded)
+  (handler_exited)
+] @rainbow.scope

--- a/runtime/queries/amber/tags.scm
+++ b/runtime/queries/amber/tags.scm
@@ -1,0 +1,10 @@
+; Function definitions
+(function_definition
+  name: (variable) @name) @definition.function
+
+; Function calls
+(function_call
+  name: (variable) @name) @reference.call
+
+; Main block as entry point
+(main_block) @definition.function

--- a/runtime/queries/amber/textobjects.scm
+++ b/runtime/queries/amber/textobjects.scm
@@ -1,0 +1,23 @@
+; Functions - capture both definition and body
+(function_definition
+  body: (_) @function.inside) @function.around
+
+; Function parameters in definitions
+(function_parameter_list
+  (function_parameter_list_item) @parameter.inside)
+
+; Function call arguments
+(parameter_list
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+; Comments
+(comment) @comment.inside
+(comment)+ @comment.around
+
+; Arrays
+(array
+  (_) @entry.around)
+
+; Main Block looks like a function
+(main_block
+  (block) @function.inside) @function.around


### PR DESCRIPTION
Updates the Tree-sitter grammar and queries for the Amber programming language to align with the Amber v0.5.1 release.

- https://docs.amber-lang.com/0.5.1-alpha/getting_started/whats_new
- https://github.com/amber-lang/tree-sitter-amber/blob/dc69f42449fd3c807bacefa398263f62e581f755/grammar.js