### PR TITLE
Add instructions to install the debian package

### DIFF
--- a/book/src/package-managers.md
+++ b/book/src/package-managers.md
@@ -1,7 +1,8 @@
 ## Package managers
 
 - [Linux](#linux)
-  - [Ubuntu/Debian](#ubuntudebian)
+  - [Debian](#debian)
+  - [Ubuntu/Mint](#ubuntumint)
   - [Fedora/RHEL](#fedorarhel)
   - [Arch Linux extra](#arch-linux-extra)
   - [NixOS](#nixos)
@@ -23,7 +24,16 @@
 
 The following third party repositories are available:
 
-### Ubuntu/Debian
+### Debian
+
+```sh
+sudo apt install hx
+```
+
+If you are running a system older than Debian 13, follow the steps for
+[Ubuntu/Mint](#ubuntumint).
+
+### Ubuntu/Mint
 
 Install the Debian package [from the release page](https://github.com/helix-editor/helix/releases/latest).
 


### PR DESCRIPTION
The latest release of [Debian includes Helix in their repositories](https://packages.debian.org/trixie/source/hx). As a result, it should be the default way we recommend users get `hx` on Debian.