### PR TITLE
Fix signature help text cutoff

### DIFF
--- a/helix-term/src/ui/lsp/signature_help.rs
+++ b/helix-term/src/ui/lsp/signature_help.rs
@@ -156,9 +156,7 @@ impl Component for SignatureHelp {
             Some(doc) => Markdown::new(doc.clone(), Arc::clone(&self.config_loader)),
         };
         let sig_doc = sig_doc.parse(Some(&cx.editor.theme));
-        let sig_doc_area = area
-            .clip_top(sig_text_area.height + 2)
-            .clip_bottom(u16::from(cx.editor.popup_border()));
+        let sig_doc_area = area.clip_top(sig_text_area.height + 1);
         let sig_doc_para = Paragraph::new(&sig_doc)
             .wrap(Wrap { trim: false })
             .scroll((cx.scroll.unwrap_or_default() as u16, 0));

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -367,8 +367,11 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         use tui::widgets::TableState;
 
+        let render_borders = cx.editor.menu_border();
+        let padding = Self::LEFT_PADDING as u16 * !render_borders as u16;
+
         table.render_table(
-            area.clip_left(Self::LEFT_PADDING as u16).clip_right(1),
+            area.clip_left(padding).clip_right(padding),
             surface,
             &mut TableState {
                 offset: scroll,
@@ -376,8 +379,6 @@ impl<T: Item + 'static> Component for Menu<T> {
             },
             false,
         );
-
-        let render_borders = cx.editor.menu_border();
 
         if !render_borders {
             if let Some(cursor) = self.cursor {
@@ -402,7 +403,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
             let mut cell;
             for i in 0..win_height {
-                cell = &mut surface[(area.right() - 1, area.top() + i as u16)];
+                cell = &mut surface[(area.right() - padding, area.top() + i as u16)];
 
                 let half_block = if render_borders { "▌" } else { "▐" };
 

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -152,7 +152,7 @@ impl<T: Component> Popup<T> {
         // if there's a orientation preference, use that
         // if we're on the top part of the screen, do below
         // if we're on the bottom part, do above
-        let can_put_below = viewport.height > rel_y + MIN_HEIGHT;
+        let can_put_below = viewport.height > rel_y + MIN_HEIGHT + 2 * render_borders as u16;
         let can_put_above = rel_y.checked_sub(MIN_HEIGHT).is_some();
         let final_pos = match self.position_bias {
             Open::Below => match can_put_below {
@@ -185,12 +185,12 @@ impl<T: Component> Popup<T> {
             .expect("Component needs required_size implemented in order to be embedded in a popup");
 
         width = width.min(MAX_WIDTH);
-        let height = if render_borders {
+        let height = if render_borders && (is_menu || self.id == "dap-variables") {
             (child_height + 2).min(MAX_HEIGHT)
         } else {
             child_height.min(MAX_HEIGHT)
         };
-        if render_borders {
+        if render_borders && self.id == "dap-variables" {
             width += 2;
         }
         if viewport.width <= rel_x + width + 2 {
@@ -337,7 +337,9 @@ impl<T: Component> Component for Popup<T> {
 
         let mut inner = area;
         if render_borders {
-            inner = area.inner(Margin::all(1));
+            if is_menu || self.id == "dap-variables" {
+                inner = area.inner(Margin::all(1));
+            }
             Widget::render(Block::bordered(), area, surface);
         }
         let border = usize::from(render_borders);
@@ -359,14 +361,17 @@ impl<T: Component> Component for Popup<T> {
             let scroll_style = cx.editor.theme.get("ui.menu.scroll");
 
             if !fits {
-                let scroll_height = win_height.pow(2).div_ceil(len).min(win_height);
-                let scroll_line = (win_height - scroll_height) * scroll
+                let scrollbar_height = win_height.saturating_sub(2 * border);
+                let scroll_height = scrollbar_height
+                    .pow(2)
+                    .div_ceil(len)
+                    .min(scrollbar_height.saturating_sub(2 * border));
+                let scroll_line = (scrollbar_height - scroll_height) * scroll
                     / std::cmp::max(1, len.saturating_sub(win_height));
 
                 let mut cell;
-                for i in 0..win_height {
-                    cell =
-                        &mut surface[(inner.right() - 1 + border as u16, inner.top() + i as u16)];
+                for i in 0..scrollbar_height {
+                    cell = &mut surface[(inner.right() - 1, inner.top() + (border + i) as u16)];
 
                     let half_block = if render_borders { "▌" } else { "▐" };
 


### PR DESCRIPTION
PR #13566 introduced issues with signature help resulting in text cutoff, which this PR is intended to fix.

Before:
<img width="603" height="179" alt="push_str_bordered_before" src="https://github.com/user-attachments/assets/be82d28d-6f0a-486b-85a5-c0aa796b4516" />
<img width="585" height="134" alt="push_str_borderless_before" src="https://github.com/user-attachments/assets/cae45172-4117-4500-ab90-48e1647b767c" />
<img width="1226" height="244" alt="update_before_bordered_before" src="https://github.com/user-attachments/assets/060799fc-9eb9-4c30-9e10-cd09194c99bc" />
<img width="1209" height="203" alt="update_before_borderless_before" src="https://github.com/user-attachments/assets/03fa2159-a79a-4e43-8a32-bf645e49c86b" />

After:
<img width="585" height="137" alt="push_str_borderless_after" src="https://github.com/user-attachments/assets/a2757157-ff7a-4e79-8cfe-55b1d577dd81" />
<img width="602" height="131" alt="push_str_bordered_after" src="https://github.com/user-attachments/assets/f09e470b-1ccd-4f3b-90d7-c543318031c4" />
<img width="1207" height="200" alt="update_before_borderless_after" src="https://github.com/user-attachments/assets/f5445e4e-2c7c-4e9f-ad10-d66564c63ccf" />
<img width="1224" height="194" alt="update_before_bordered_after" src="https://github.com/user-attachments/assets/9086a520-421c-4735-b56d-7c90da0e1ddb" />

Update:
I also removed the extra whitespace between borders and text in popups.
Having these margins makes sense with borderless popups, since this space is used to separate the popup text from the background text, but having them in bordered popups makes no sense.

Before:
<img width="1000" height="600" alt="before_1" src="https://github.com/user-attachments/assets/9f7a64cc-2112-48ad-b88a-a4fd11afb409" />
<img width="1000" height="600" alt="before_2" src="https://github.com/user-attachments/assets/ea8c8fa7-43e9-4411-945c-3922732eefb5" />

After:
<img width="1000" height="600" alt="after_1" src="https://github.com/user-attachments/assets/a518ac48-f990-425b-aaf6-e833a296a86e" />
<img width="1000" height="600" alt="after_2" src="https://github.com/user-attachments/assets/81782e66-cddb-4c1a-8b32-4c3896c59d36" />
