### PR TITLE
:run-shell-command now doesn't show popup if output is only whitespace

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2489,7 +2489,7 @@ fn run_shell_command(
         let output = shell_impl_async(&shell, &args, None).await?;
         let call: job::Callback = Callback::EditorCompositor(Box::new(
             move |editor: &mut Editor, compositor: &mut Compositor| {
-                if !output.is_empty() {
+                if !output.trim().is_empty() {
                     let contents = ui::Markdown::new(
                         format!("```sh\n{}\n```", output.trim_end()),
                         editor.syn_loader.clone(),


### PR DESCRIPTION
Previously, there was only a check for if the output is completely *empty* \
Meaning that if the output was *just* a newline (two or more, specifically), you'd see a completely useless popup still.

I encountered this while running the following:
```
:sh systemctl --user restart eww.service ; eww open example
```

With this pr, the popup isn't shown if the output is just whitespace.
