### PR TITLE
Add oxlint language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -92,6 +92,7 @@ nls = { command = "nls" }
 nu-lsp = { command = "nu", args = [ "--lsp" ] }
 ocamllsp = { command = "ocamllsp" }
 ols = { command = "ols", args = [] }
+oxlint-language-server = {command = "oxlint", args = ["--lsp"]}
 omnisharp = { command = "OmniSharp", args = [ "--languageserver" ] }
 openscad-lsp = { command = "openscad-lsp", args = ["--stdio"] }
 pasls = { command = "pasls", args = [] }


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/linter.html

Recently oxlint was [fixed to work with Helix](https://github.com/oxc-project/oxc/issues/15374), and [changed to using`oxlint --lsp` to start the language server](https://github.com/oxc-project/oxc/issues/15119), so now is a great time to add it.