### PR TITLE
align / fill statusline elements for less jumpiness

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -341,7 +341,7 @@ where
             // Fill the current selection index in such a way, that `rotate_selections_…` actions will never make the widget
             // decrease or increase in length.
             format!(
-                " {:>count_len$}/{count} sel ",
+                " {:>count_len$}/{count} sels ",
                 selection.primary_index() + 1,
                 count_len = count.to_string().len()
             )


### PR DESCRIPTION
Currently, almost *anything* about the context changing, makes your statusline jump around jarringly. \
This property of it had made me *remove* the statusline altogether in my fork: it was that hard to look at.

But after making the elements fill / align a bit more, the statusline has become a *lot* more usable. \
I've converted my changes into this pr, a bit less opinionated than my true preferences, but hopefully I can get to improve the experience of other helixers with this.

> [!NOTE]
> When showing how the elements now render, I'll be wrapping everything in `|` to make the whitespace clearer. \
> The `|`s are NOT part of the actual rendered widget — just syntax for clarity.

# selections

When there are more than one selection, the current index is filled with spaces to occupy the same width as the total selections. \
*Always* `sel`, regardless of the count of selections, to keep consistency with `primary_selection_length` (next section)
```
| 1 sel |
|  1/10 sel |
|  67/133 sel |
```
With this, as you `rotate_selections_…` through your existing selections, the element will remain the same width.

# primary_selection_length

Filled up to 3. \
*Always* `char`, regardless of how many characters you have selected. With that, we avoid a jump when you change your selection size from 1 to not-1, or the other way around — something that happens VERY commonly.
```
|   1 char |
|  67 char |
| 420 char |
| 1337 char |
```

Selecting just a few lines already bumps up the count of selected characters to 100+; but it takes quite a bit longer to get to 1000+, so the jump there is not a big deal.

# position

Line number right aligned to 4, column number left aligned to 3.
```
|    1:1   |
|   67:12  |
|  326:133 |
| 4267:67  |
```
Lines pretty commonly get up to 4 digits big, but it's *very* rare that columns do.

# total_line_numbers

Displays the correct value. A blank, scratch buffer is now 1 line big, not 2.

# position_percentage

Aligned to 3. `top` is shown instead of 0%, `bot` is shown instead of 100%. \
The percentage calculation now happens with floats instead of integers, and then rounded; thanks to this `bot` kicks in a bit earlier, rather than only on the trailing final newline in the file. \
Being on the first line in the file *guarantees* `top` (previously would be 50% in an empty file). \
Being on the last *real* line in the file *guarantees* `bot` (previously only the trailing final newline would be considered `bot` if the file is small enough)

```
|top|
| 1%|
|23%|
|67%|
|bot|
```

# another frustration

All the elements in the statusline come included with a space on the start and end. Meaning that any two given elements put together will have *at least* 2 spaces between them. \
I hate that, because it gets rid of the user's agency to use the `spacer` element to decide on their own how many spaces they want between each element. \
I know my pr is kind of exactly *about* **adding** spaces, but in my fork at least I remove the surrounding spaces and use `spacer` when needed, to achieve a very clean but *filled* look:
```
chr: 1  sel: 1                                                52:188 52  bot
```
Something like this is impossible to achieve now with there being surrounding spaces in the implementation of each element. \
I want to **remove** them and force the user to use spacer where they want to, so that they could achieve a very compact statusline. \
But I realize this is *especially* opinionated, so it's not yet included in this pr. \
Would love to go and do this if the maintainers agree.