### PR TITLE
Fix bold to dimmed transition in termina backend

### DIFF
--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -600,8 +600,11 @@ fn diff_modifiers(from: Modifier, to: Modifier) -> SgrModifiers {
     if removed.contains(Modifier::REVERSED) {
         modifiers |= SgrModifiers::NO_REVERSE;
     }
-    if removed.contains(Modifier::BOLD) && !to.contains(Modifier::DIM) {
+    if removed.contains(Modifier::BOLD) {
         modifiers |= SgrModifiers::INTENSITY_NORMAL;
+        if to.contains(Modifier::DIM) {
+            modifiers |= SgrModifiers::INTENSITY_DIM
+        }
     }
     if removed.contains(Modifier::DIM) {
         modifiers |= SgrModifiers::INTENSITY_NORMAL;


### PR DESCRIPTION
Fix a bug introduced by the switch to Termina where a transition from `bold + dimmed` to `regular + dimmed` would remain `bold + dimmed`.

When bold is removed, we must always set normal and then conditionally add dim on top. Previously, this code would inherit the dim from the previous cell, but the bold too, which causes rendering issues (this was quite noticeable in disabled code blocks with rust-analyzer in particular).

This also mirrors the relevant section in the Crossterm backend:

https://github.com/helix-editor/helix/blob/e2054b20c3b112de6a16a6552ee101dcd1b3b917/helix-tui/src/backend/crossterm.rs#L349-L354

Before:

<img width="674" height="467" alt="image" src="https://github.com/user-attachments/assets/934c419f-d7de-406c-888d-2858865650e4" />

After:

<img width="671" height="468" alt="image" src="https://github.com/user-attachments/assets/3ab9b8c1-ea62-4cd5-b624-92658a693c6b" />

(only keywords are bold in my theme)