### PR TITLE
Add `.ghostty` extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4599,7 +4599,7 @@ source = { git = "https://github.com/MaeBrooks/tree-sitter-gren", rev = "76554f4
 [[language]]
 name = "ghostty"
 scope = "source.ghostty"
-file-types = [{ glob = "ghostty/config" }]
+file-types = ["ghostty", { glob = "ghostty/config" }]
 comment-tokens = "#"
 indent = { tab-width = 2, unit = "  " }
 


### PR DESCRIPTION
Ghostty now uses dedicated `.ghostty` extension in addition to the `ghostty/config` file.

> To configure Ghostty, you must use a configuration file. GUI-based configuration is on the roadmap but not yet supported. The configuration file must be placed at `$XDG_CONFIG_HOME/ghostty/config.ghostty`, which defaults to `~/.config/ghostty/config.ghostty` if the [XDG environment is not set](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

<https://github.com/ghostty-org/ghostty/blob/a4cb73db848c733a5fb686038a90abe6d175aabe/src/build/mdgen/ghostty_5_header.md?plain=1#L9-L12>