### PR TITLE
Add Rust 'become' keyword

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -232,6 +232,7 @@
   "return"
   "await"
   "yield"
+  "become"
 ] @keyword.control.return
 
 "use" @keyword.control.import


### PR DESCRIPTION
`become` is a keyword for [guaranteed tail calls](https://doc.rust-lang.org/stable/std/keyword.become.html). While it is currently only available in nightly under a feature flag, the keyword is reserved for this use case in current stable versions.