### PR TITLE
Auto pair deletions with selections

### DIFF
--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -110,17 +110,22 @@ impl Default for AutoPairs {
 //   middle of triple quotes, and more exotic pairs like Jinja's {% %}
 
 #[must_use]
-pub fn hook(doc: &Rope, range: &Range, ch: char, pairs: &AutoPairs) -> Option<(Change, Range)> {
+pub fn hook_insert(
+    doc: &Rope,
+    range: &Range,
+    ch: char,
+    pairs: &AutoPairs,
+) -> Option<(Change, Range)> {
     log::trace!("autopairs hook range: {:#?}", range);
 
     if let Some(pair) = pairs.get(ch) {
         if pair.same() {
-            return handle_same(doc, range, pair);
+            return handle_insert_same(doc, range, pair);
         } else if pair.open == ch {
-            return handle_open(doc, range, pair);
+            return handle_insert_open(doc, range, pair);
         } else if pair.close == ch {
             // && char_at pos == close
-            return handle_close(doc, range, pair);
+            return handle_insert_close(doc, range, pair);
         }
     }
 
@@ -243,7 +248,7 @@ fn get_next_range(doc: &Rope, start_range: &Range, len_inserted: usize) -> Range
     Range::new(end_anchor, end_head)
 }
 
-fn handle_open(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
+fn handle_insert_open(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
     let cursor = range.cursor(doc.slice(..));
     let next_char = doc.get_char(cursor);
     let len_inserted;
@@ -271,7 +276,7 @@ fn handle_open(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)
     Some(result)
 }
 
-fn handle_close(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
+fn handle_insert_close(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
     let cursor = range.cursor(doc.slice(..));
     let next_char = doc.get_char(cursor);
 
@@ -291,7 +296,7 @@ fn handle_close(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range
 }
 
 /// handle cases where open and close is the same, or in triples ("""docstring""")
-fn handle_same(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
+fn handle_insert_same(doc: &Rope, range: &Range, pair: &Pair) -> Option<(Change, Range)> {
     let cursor = range.cursor(doc.slice(..));
     let mut len_inserted = 0;
     let next_char = doc.get_char(cursor);

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -746,6 +746,55 @@ impl Transaction {
         Self::delete(doc, selection.iter().map(f))
     }
 
+    /// Generate a transaction with a change per selection range, which
+    /// generates a new selection as well. Each range is operated upon by
+    /// the given function and can optionally produce a new range. If none
+    /// is returned by the function, that range is dropped from the resulting
+    /// selection.
+    pub fn change_by_and_with_selection<F>(doc: &Rope, selection: &Selection, mut f: F) -> Self
+    where
+        F: FnMut(&Range) -> (Change, Option<Range>),
+    {
+        let mut end_ranges = SmallVec::with_capacity(selection.len());
+        let mut offset = 0;
+
+        let transaction = Transaction::change_by_selection(doc, selection, |start_range| {
+            let ((from, to, replacement), end_range) = f(start_range);
+            let mut change_size = to as isize - from as isize;
+
+            if let Some(ref text) = replacement {
+                change_size = text.chars().count() as isize - change_size;
+            } else {
+                change_size = -change_size;
+            }
+
+            if let Some(end_range) = end_range {
+                let offset_range = Range::new(
+                    (end_range.anchor as isize + offset) as usize,
+                    (end_range.head as isize + offset) as usize,
+                );
+
+                log::trace!("end range {:?} offset to: {:?}", end_range, offset_range);
+
+                end_ranges.push(offset_range);
+            }
+
+            offset += change_size;
+
+            log::trace!(
+                "from: {}, to: {}, replacement: {:?}, offset: {}",
+                from,
+                to,
+                replacement,
+                offset
+            );
+
+            (from, to, replacement)
+        });
+
+        transaction.with_selection(Selection::new(end_ranges, selection.primary_index()))
+    }
+
     /// Insert text at each selection head.
     pub fn insert(doc: &Rope, selection: &Selection, text: Tendril) -> Self {
         Self::change_by_selection(doc, selection, |range| {

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -823,10 +823,13 @@ impl Transaction {
     {
         let mut end_ranges = SmallVec::with_capacity(selection.len());
         let mut offset = 0;
+        let mut last = 0;
 
         let transaction = Transaction::delete_by_selection(doc, selection, |start_range| {
             let ((from, to), end_range) = f(start_range);
-            let change_size = to - from;
+
+            // must account for possibly overlapping deletes
+            let change_size = if last > from { to - last } else { to - from };
 
             let new_range = if let Some(end_range) = end_range {
                 end_range
@@ -840,10 +843,18 @@ impl Transaction {
                 new_range.head.saturating_sub(offset),
             );
 
+            log::trace!(
+                "delete from: {}, to: {}, offset: {}, new_range: {:?}, offset_range: {:?}",
+                from,
+                to,
+                offset,
+                new_range,
+                offset_range
+            );
+
             end_ranges.push(offset_range);
             offset += change_size;
-
-            log::trace!("delete from: {}, to: {}, offset: {}", from, to, offset);
+            last = to;
 
             (from, to)
         });

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -770,21 +770,19 @@ impl Transaction {
                 change_size = -change_size;
             }
 
-            if let Some(end_range) = end_range {
-                let offset_range = Range::new(
-                    (end_range.anchor as isize + offset) as usize,
-                    (end_range.head as isize + offset) as usize,
-                );
-
-                log::trace!("end range {:?} offset to: {:?}", end_range, offset_range);
-
-                end_ranges.push(offset_range);
+            let new_range = if let Some(end_range) = end_range {
+                end_range
             } else {
                 let changeset = ChangeSet::from_change(doc, (from, to, replacement.clone()));
-                let end_range = start_range.map(&changeset);
-                end_ranges.push(end_range);
-            }
+                start_range.map(&changeset)
+            };
 
+            let offset_range = Range::new(
+                (new_range.anchor as isize + offset) as usize,
+                (new_range.head as isize + offset) as usize,
+            );
+
+            end_ranges.push(offset_range);
             offset += change_size;
 
             log::trace!(
@@ -830,21 +828,19 @@ impl Transaction {
             let ((from, to), end_range) = f(start_range);
             let change_size = to - from;
 
-            if let Some(end_range) = end_range {
-                let offset_range = Range::new(
-                    end_range.anchor.saturating_sub(offset),
-                    end_range.head.saturating_sub(offset),
-                );
-
-                log::trace!("end range {:?} offset to: {:?}", end_range, offset_range);
-
-                end_ranges.push(offset_range);
+            let new_range = if let Some(end_range) = end_range {
+                end_range
             } else {
                 let changeset = ChangeSet::from_change(doc, (from, to, None));
-                let end_range = start_range.map(&changeset);
-                end_ranges.push(end_range);
-            }
+                start_range.map(&changeset)
+            };
 
+            let offset_range = Range::new(
+                new_range.anchor.saturating_sub(offset),
+                new_range.head.saturating_sub(offset),
+            );
+
+            end_ranges.push(offset_range);
             offset += change_size;
 
             log::trace!("delete from: {}, to: {}, offset: {}", from, to, offset);

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -523,6 +523,49 @@ impl ChangeSet {
     pub fn changes_iter(&self) -> ChangeIterator<'_> {
         ChangeIterator::new(self)
     }
+
+    pub fn from_change(doc: &Rope, change: Change) -> Self {
+        Self::from_changes(doc, std::iter::once(change))
+    }
+
+    /// Generate a ChangeSet from a set of changes.
+    pub fn from_changes<I>(doc: &Rope, changes: I) -> Self
+    where
+        I: Iterator<Item = Change>,
+    {
+        let len = doc.len_chars();
+
+        let (lower, upper) = changes.size_hint();
+        let size = upper.unwrap_or(lower);
+        let mut changeset = ChangeSet::with_capacity(2 * size + 1); // rough estimate
+
+        let mut last = 0;
+        for (from, to, tendril) in changes {
+            // Verify ranges are ordered and not overlapping
+            debug_assert!(last <= from);
+            // Verify ranges are correct
+            debug_assert!(
+                from <= to,
+                "Edit end must end before it starts (should {from} <= {to})"
+            );
+
+            // Retain from last "to" to current "from"
+            changeset.retain(from - last);
+            let span = to - from;
+            match tendril {
+                Some(text) => {
+                    changeset.insert(text);
+                    changeset.delete(span);
+                }
+                None => changeset.delete(span),
+            }
+            last = to;
+        }
+
+        changeset.retain(len - last);
+
+        changeset
+    }
 }
 
 /// Transaction represents a single undoable unit of changes. Several changes can be grouped into
@@ -616,38 +659,7 @@ impl Transaction {
     where
         I: Iterator<Item = Change>,
     {
-        let len = doc.len_chars();
-
-        let (lower, upper) = changes.size_hint();
-        let size = upper.unwrap_or(lower);
-        let mut changeset = ChangeSet::with_capacity(2 * size + 1); // rough estimate
-
-        let mut last = 0;
-        for (from, to, tendril) in changes {
-            // Verify ranges are ordered and not overlapping
-            debug_assert!(last <= from);
-            // Verify ranges are correct
-            debug_assert!(
-                from <= to,
-                "Edit end must end before it starts (should {from} <= {to})"
-            );
-
-            // Retain from last "to" to current "from"
-            changeset.retain(from - last);
-            let span = to - from;
-            match tendril {
-                Some(text) => {
-                    changeset.insert(text);
-                    changeset.delete(span);
-                }
-                None => changeset.delete(span),
-            }
-            last = to;
-        }
-
-        changeset.retain(len - last);
-
-        Self::from(changeset)
+        Self::from(ChangeSet::from_changes(doc, changes))
     }
 
     /// Generate a transaction from a set of potentially overlapping deletions
@@ -749,8 +761,8 @@ impl Transaction {
     /// Generate a transaction with a change per selection range, which
     /// generates a new selection as well. Each range is operated upon by
     /// the given function and can optionally produce a new range. If none
-    /// is returned by the function, that range is dropped from the resulting
-    /// selection.
+    /// is returned by the function, that range is mapped through the change
+    /// as usual.
     pub fn change_by_and_with_selection<F>(doc: &Rope, selection: &Selection, mut f: F) -> Self
     where
         F: FnMut(&Range) -> (Change, Option<Range>),
@@ -777,6 +789,10 @@ impl Transaction {
                 log::trace!("end range {:?} offset to: {:?}", end_range, offset_range);
 
                 end_ranges.push(offset_range);
+            } else {
+                let changeset = ChangeSet::from_change(doc, (from, to, replacement.clone()));
+                let end_range = start_range.map(&changeset);
+                end_ranges.push(end_range);
             }
 
             offset += change_size;

--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -748,16 +748,6 @@ impl Transaction {
         )
     }
 
-    /// Generate a transaction with a deletion per selection range.
-    /// Compared to using `change_by_selection` directly these ranges may overlap.
-    /// In that case they are merged
-    pub fn delete_by_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
-    where
-        F: FnMut(&Range) -> Deletion,
-    {
-        Self::delete(doc, selection.iter().map(f))
-    }
-
     /// Generate a transaction with a change per selection range, which
     /// generates a new selection as well. Each range is operated upon by
     /// the given function and can optionally produce a new range. If none
@@ -806,6 +796,60 @@ impl Transaction {
             );
 
             (from, to, replacement)
+        });
+
+        transaction.with_selection(Selection::new(end_ranges, selection.primary_index()))
+    }
+
+    /// Generate a transaction with a deletion per selection range.
+    /// Compared to using `change_by_selection` directly these ranges may overlap.
+    /// In that case they are merged.
+    pub fn delete_by_selection<F>(doc: &Rope, selection: &Selection, f: F) -> Self
+    where
+        F: FnMut(&Range) -> Deletion,
+    {
+        Self::delete(doc, selection.iter().map(f))
+    }
+
+    /// Generate a transaction with a delete per selection range, which
+    /// generates a new selection as well. Each range is operated upon by
+    /// the given function and can optionally produce a new range. If none
+    /// is returned by the function, that range is mapped through the change
+    /// as usual.
+    ///
+    /// Compared to using `change_by_and_with_selection` directly these ranges
+    /// may overlap. In that case they are merged.
+    pub fn delete_by_and_with_selection<F>(doc: &Rope, selection: &Selection, mut f: F) -> Self
+    where
+        F: FnMut(&Range) -> (Deletion, Option<Range>),
+    {
+        let mut end_ranges = SmallVec::with_capacity(selection.len());
+        let mut offset = 0;
+
+        let transaction = Transaction::delete_by_selection(doc, selection, |start_range| {
+            let ((from, to), end_range) = f(start_range);
+            let change_size = to - from;
+
+            if let Some(end_range) = end_range {
+                let offset_range = Range::new(
+                    end_range.anchor.saturating_sub(offset),
+                    end_range.head.saturating_sub(offset),
+                );
+
+                log::trace!("end range {:?} offset to: {:?}", end_range, offset_range);
+
+                end_ranges.push(offset_range);
+            } else {
+                let changeset = ChangeSet::from_change(doc, (from, to, None));
+                let end_range = start_range.map(&changeset);
+                end_ranges.push(end_range);
+            }
+
+            offset += change_size;
+
+            log::trace!("delete from: {}, to: {}, offset: {}", from, to, offset);
+
+            (from, to)
         });
 
         transaction.with_selection(Selection::new(end_ranges, selection.primary_index()))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4158,16 +4158,6 @@ pub mod insert {
         }
     }
 
-    // The default insert hook: simply insert the character
-    #[allow(clippy::unnecessary_wraps)] // need to use Option<> because of the Hook signature
-    fn insert(doc: &Rope, selection: &Selection, ch: char) -> Option<Transaction> {
-        let cursors = selection.clone().cursors(doc.slice(..));
-        let mut t = Tendril::new();
-        t.push(ch);
-        let transaction = Transaction::insert(doc, &cursors, t);
-        Some(transaction)
-    }
-
     use helix_core::auto_pairs;
     use helix_view::editor::SmartTabConfig;
 
@@ -4179,15 +4169,25 @@ pub mod insert {
         let loader: &helix_core::syntax::Loader = &cx.editor.syn_loader.load();
         let auto_pairs = doc.auto_pairs(cx.editor, loader, view);
 
-        let transaction = auto_pairs
-            .as_ref()
-            .and_then(|ap| auto_pairs::hook(text, selection, c, ap))
-            .or_else(|| insert(text, selection, c));
+        let insert_char = |range: Range, ch: char| {
+            let cursor = range.cursor(text.slice(..));
+            let t = Tendril::from_iter([ch]);
+            ((cursor, cursor, Some(t)), None)
+        };
 
-        let (view, doc) = current!(cx.editor);
-        if let Some(t) = transaction {
-            doc.apply(&t, view.id);
-        }
+        let transaction = Transaction::change_by_and_with_selection(text, selection, |range| {
+            auto_pairs
+                .as_ref()
+                .and_then(|ap| {
+                    auto_pairs::hook(text, range, c, ap)
+                        .map(|(change, range)| (change, Some(range)))
+                        .or(Some(insert_char(*range, c)))
+                })
+                .unwrap_or_else(|| insert_char(*range, c))
+        });
+
+        let doc = doc_mut!(cx.editor, &doc.id());
+        doc.apply(&transaction, view.id);
 
         helix_event::dispatch(PostInsertChar { c, cx });
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4179,7 +4179,7 @@ pub mod insert {
             auto_pairs
                 .as_ref()
                 .and_then(|ap| {
-                    auto_pairs::hook(text, range, c, ap)
+                    auto_pairs::hook_insert(text, range, c, ap)
                         .map(|(change, range)| (change, Some(range)))
                         .or(Some(insert_char(*range, c)))
                 })
@@ -4442,11 +4442,13 @@ pub mod insert {
         let loader: &helix_core::syntax::Loader = &cx.editor.syn_loader.load();
         let auto_pairs = doc.auto_pairs(cx.editor, loader, view);
 
-        let transaction =
-            Transaction::delete_by_selection(doc.text(), doc.selection(view.id), |range| {
+        let transaction = Transaction::delete_by_and_with_selection(
+            doc.text(),
+            doc.selection(view.id),
+            |range| {
                 let pos = range.cursor(text);
                 if pos == 0 {
-                    return (pos, pos);
+                    return ((pos, pos), None);
                 }
                 let line_start_pos = text.line_to_char(range.cursor_line(text));
                 // consider to delete by indent level if all characters before `pos` are indent units.
@@ -4454,7 +4456,10 @@ pub mod insert {
                 if !fragment.is_empty() && fragment.chars().all(|ch| ch == ' ' || ch == '\t') {
                     if text.get_char(pos.saturating_sub(1)) == Some('\t') {
                         // fast path, delete one char
-                        (graphemes::nth_prev_grapheme_boundary(text, pos, 1), pos)
+                        (
+                            (graphemes::nth_prev_grapheme_boundary(text, pos, 1), pos),
+                            None,
+                        )
                     } else {
                         let width: usize = fragment
                             .chars()
@@ -4481,7 +4486,7 @@ pub mod insert {
                                 _ => break,
                             }
                         }
-                        (start, pos) // delete!
+                        ((start, pos), None) // delete!
                     }
                 } else {
                     match (
@@ -4497,18 +4502,26 @@ pub mod insert {
                         // delete both autopaired characters
                         {
                             (
-                                graphemes::nth_prev_grapheme_boundary(text, pos, count),
-                                graphemes::nth_next_grapheme_boundary(text, pos, count),
+                                (
+                                    graphemes::nth_prev_grapheme_boundary(text, pos, count),
+                                    graphemes::nth_next_grapheme_boundary(text, pos, count),
+                                ),
+                                None,
                             )
                         }
                         _ =>
                         // delete 1 char
                         {
-                            (graphemes::nth_prev_grapheme_boundary(text, pos, count), pos)
+                            (
+                                (graphemes::nth_prev_grapheme_boundary(text, pos, count), pos),
+                                None,
+                            )
                         }
                     }
                 }
-            });
+            },
+        );
+
         let (view, doc) = current!(cx.editor);
         doc.apply(&transaction, view.id);
     }

--- a/helix-term/tests/test/auto_pairs.rs
+++ b/helix-term/tests/test/auto_pairs.rs
@@ -567,3 +567,552 @@ async fn append_inside_nested_pair_multi() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_basic() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!("{}#[|{}]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("#[{}|]#", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_multi() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!("{}#[|{}]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("#[{}|]#", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_configured_multi_byte_chars() -> anyhow::Result<()> {
+    // NOTE: these are multi-byte Unicode characters
+    let pairs = hashmap!('„' => '“', '‚' => '‘', '「' => '」');
+
+    let config = Config {
+        editor: helix_view::editor::Config {
+            auto_pairs: AutoPairConfig::Pairs(pairs.clone()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    for (open, close) in pairs.iter() {
+        test_with_config(
+            AppBuilder::new().with_config(config.clone()),
+            (
+                format!("{}#[|{}]#{}", open, close, LINE_END),
+                "i<backspace>",
+                format!("#[{}|]#", LINE_END),
+            ),
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_after_word() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!("foo{}#[|{}]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("foo#[{}|]#", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_before_word() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        // sanity check unclosed pair delete
+        test((
+            format!("{}#[|f]#oo{}", pair.0, LINE_END),
+            "i<backspace>",
+            format!("#[|f]#oo{}", LINE_END),
+        ))
+        .await?;
+
+        // deleting the closing pair should NOT delete the whole pair
+        test((
+            format!("{}{}#[|f]#oo{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("{}#[|f]#oo{}", pair.0, LINE_END),
+        ))
+        .await?;
+
+        // deleting whole pair before word
+        test((
+            format!("{}#[|{}]#foo{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("#[f|]#oo{}", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_before_word_selection() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        // sanity check unclosed pair delete
+        test((
+            format!("{}#[|foo]#{}", pair.0, LINE_END),
+            "i<backspace>",
+            format!("#[foo|]#{}", LINE_END),
+        ))
+        .await?;
+
+        // deleting the closing pair should NOT delete the whole pair
+        test((
+            format!("{}{}#[|foo]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("{}#[foo|]#{}", pair.0, LINE_END),
+        ))
+        .await?;
+
+        // deleting whole pair before word
+        test((
+            format!("{}#[|{}foo]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("#[foo|]#{}", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_before_word_selection_trailing_word() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!("foo{}#[|{} wor]#{}", pair.0, pair.1, LINE_END),
+            "i<backspace>",
+            format!("foo#[ wor|]#{}", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_before_eol() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "{eol}{open}#[|{close}]#{eol}",
+                eol = LINE_END,
+                open = pair.0,
+                close = pair.1
+            ),
+            "i<backspace>",
+            format!("{0}#[{0}|]#", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_auto_pairs_disabled() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test_with_config(
+            AppBuilder::new().with_config(Config {
+                editor: helix_view::editor::Config {
+                    auto_pairs: AutoPairConfig::Enable(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            (
+                format!("{}#[|{}]#{}", pair.0, pair.1, LINE_END),
+                "i<backspace>",
+                format!("#[|{}]#{}", pair.1, LINE_END),
+            ),
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_multi_range() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "{open}#[|{close}]#{eol}{open}#(|{close})#{eol}{open}#(|{close})#{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "i<backspace>",
+            format!("#[{eol}|]##({eol}|)##({eol}|)#", eol = LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_before_multi_code_point_graphemes() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!("hello {}#[|👨‍👩‍👧‍👦]# goodbye{}", pair.1, LINE_END),
+            "i<backspace>",
+            format!("hello #[|👨‍👩‍👧‍👦]# goodbye{}", LINE_END),
+        ))
+        .await?;
+
+        test((
+            format!(
+                "hello {}{}#[|👨‍👩‍👧‍👦]# goodbye{}",
+                pair.0, pair.1, LINE_END
+            ),
+            "i<backspace>",
+            format!("hello {}#[|👨‍👩‍👧‍👦]# goodbye{}", pair.0, LINE_END),
+        ))
+        .await?;
+
+        test((
+            format!(
+                "hello {}#[|{}]#👨‍👩‍👧‍👦 goodbye{}",
+                pair.0, pair.1, LINE_END
+            ),
+            "i<backspace>",
+            format!("hello #[👨‍👩‍👧‍👦|]# goodbye{}", LINE_END),
+        ))
+        .await?;
+
+        test((
+            format!(
+                "hello {}#[|{}👨‍👩‍👧‍👦]# goodbye{}",
+                pair.0, pair.1, LINE_END
+            ),
+            "i<backspace>",
+            format!("hello #[👨‍👩‍👧‍👦|]# goodbye{}", LINE_END),
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_at_end_of_document() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test(TestCase {
+            in_text: format!("{}{}{}", LINE_END, pair.0, pair.1),
+            in_selection: Selection::single(LINE_END.len() + 1, LINE_END.len() + 2),
+            in_keys: String::from("i<backspace>"),
+            out_text: String::from(LINE_END),
+            out_selection: Selection::single(LINE_END.len(), LINE_END.len()),
+        })
+        .await?;
+
+        test(TestCase {
+            in_text: format!("foo{}{}{}", LINE_END, pair.0, pair.1),
+            in_selection: Selection::single(LINE_END.len() + 4, LINE_END.len() + 5),
+            in_keys: String::from("i<backspace>"),
+            out_text: format!("foo{}", LINE_END),
+            out_selection: Selection::single(3 + LINE_END.len(), 3 + LINE_END.len()),
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_nested_open_inside_pair() -> anyhow::Result<()> {
+    for pair in differing_pairs() {
+        test((
+            format!(
+                "{open}{open}#[|{close}]#{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "i<backspace>",
+            format!(
+                "{open}#[{close}|]#{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_nested_open_inside_pair_multi() -> anyhow::Result<()> {
+    for outer_pair in DEFAULT_PAIRS {
+        for inner_pair in DEFAULT_PAIRS {
+            if inner_pair.0 == outer_pair.0 {
+                continue;
+            }
+
+            test((
+                format!(
+                    "{outer_open}{inner_open}#[|{inner_close}]#{outer_close}{eol}{outer_open}{inner_open}#(|{inner_close})#{outer_close}{eol}{outer_open}{inner_open}#(|{inner_close})#{outer_close}{eol}",
+                    outer_open = outer_pair.0,
+                    outer_close = outer_pair.1,
+                    inner_open = inner_pair.0,
+                    inner_close = inner_pair.1,
+                    eol = LINE_END
+                ),
+                "i<backspace>",
+                format!(
+                    "{outer_open}#[{outer_close}|]#{eol}{outer_open}#({outer_close}|)#{eol}{outer_open}#({outer_close}|)#{eol}",
+                    outer_open = outer_pair.0,
+                    outer_close = outer_pair.1,
+                    eol = LINE_END
+                ),
+            ))
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_basic() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "#[{eol}{open}|]#{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!("#[{eol}{eol}|]#", eol = LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_multi_range() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "#[ {open}|]#{close}{eol}#( {open}|)#{close}{eol}#( {open}|)#{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!("#[ {eol}|]##( {eol}|)##( {eol}|)#", eol = LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_end_of_word() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "fo#[o{open}|]#{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!("fo#[o{}|]#", LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_mixed_dedent() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            helpers::platform_line(&format!(
+                indoc! {"\
+                    bar = {}#[|{}]#
+                        #(|\n)#
+                    foo#(|\n)#
+                "},
+                pair.0, pair.1,
+            )),
+            "i<backspace>",
+            helpers::platform_line(indoc! {"\
+                bar = #[\n|]#
+                #(|\n)#
+                fo#(|\n)#
+            "}),
+        ))
+        .await?;
+
+        test((
+            helpers::platform_line(&format!(
+                indoc! {"\
+                    bar = {}#[|{}woop]#
+                        #(|word)#
+                    fo#(|o)#
+                "},
+                pair.0, pair.1,
+            )),
+            "i<backspace>",
+            helpers::platform_line(indoc! {"\
+                bar = #[woop|]#
+                #(|word)#
+                f#(|o)#
+            "}),
+        ))
+        .await?;
+
+        // delete from the right with append
+        test((
+            helpers::platform_line(&format!(
+                indoc! {"\
+                    bar = #[|woop{}]#{}
+                    #(|   )# word
+                    #(|fo)#o
+                "},
+                pair.0, pair.1,
+            )),
+            "a<backspace>",
+            helpers::platform_line(indoc! {"\
+                bar = #[woop|]#
+                #(|w)#ord
+                #(|fo)#
+            "}),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_end_of_word_multi() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "fo#[o{open}|]#{close}{eol}fo#(o{open}|)#{close}{eol}fo#(o{open}|)#{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!("fo#[o{eol}|]#fo#(o{eol}|)#fo#(o{eol}|)#", eol = LINE_END),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_inside_nested_pair() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "f#[oo{open}{open}|]#{close}{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!(
+                "f#[oo{open}{close}|]#{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_middle_of_word() -> anyhow::Result<()> {
+    for pair in DEFAULT_PAIRS {
+        test((
+            format!(
+                "f#[oo{open}{open}|]#{close}{close}{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+            "a<backspace>",
+            format!(
+                "f#[oo{open}{close}|]#{eol}",
+                open = pair.0,
+                close = pair.1,
+                eol = LINE_END
+            ),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_append_inside_nested_pair_multi() -> anyhow::Result<()> {
+    for outer_pair in DEFAULT_PAIRS {
+        for inner_pair in DEFAULT_PAIRS {
+            if inner_pair.0 == outer_pair.0 {
+                continue;
+            }
+
+            test((
+                format!(
+                    "f#[oo{outer_open}{inner_open}|]#{inner_close}{outer_close}{eol}f#(oo{outer_open}{inner_open}|)#{inner_close}{outer_close}{eol}f#(oo{outer_open}{inner_open}|)#{inner_close}{outer_close}{eol}",
+                    outer_open = outer_pair.0,
+                    outer_close = outer_pair.1,
+                    inner_open = inner_pair.0,
+                    inner_close = inner_pair.1,
+                    eol = LINE_END
+                ),
+                "a<backspace>",
+                format!(
+                    "f#[oo{outer_open}{outer_close}|]#{eol}f#(oo{outer_open}{outer_close}|)#{eol}f#(oo{outer_open}{outer_close}|)#{eol}",
+                    outer_open = outer_pair.0,
+                    outer_close = outer_pair.1,
+                    eol = LINE_END
+                ),
+            ))
+            .await?;
+        }
+    }
+
+    Ok(())
+}

--- a/helix-term/tests/test/auto_pairs.rs
+++ b/helix-term/tests/test/auto_pairs.rs
@@ -684,6 +684,7 @@ async fn delete_basic() -> anyhow::Result<()> {
             format!("{}#[|{}]#{}", pair.0, pair.1, LINE_END),
             "i<backspace>",
             format!("#[|{}]#", LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }
@@ -857,6 +858,7 @@ async fn delete_configured_multi_byte_chars() -> anyhow::Result<()> {
                 format!("{}#[|{}]#{}", open, close, LINE_END),
                 "i<backspace>",
                 format!("#[|{}]#", LINE_END),
+                LineFeedHandling::AsIs,
             ),
         )
         .await?;
@@ -1053,6 +1055,7 @@ async fn delete_before_eol() -> anyhow::Result<()> {
             ),
             "i<backspace>",
             format!("{0}#[|{0}]#", LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }
@@ -1221,6 +1224,7 @@ async fn delete_append_basic() -> anyhow::Result<()> {
             ),
             "a<backspace>",
             format!("#[{eol}{eol}|]#", eol = LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }
@@ -1240,6 +1244,7 @@ async fn delete_append_multi_range() -> anyhow::Result<()> {
             ),
             "a<backspace>",
             format!("#[ {eol}|]##( {eol}|)##( {eol}|)#", eol = LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }
@@ -1259,6 +1264,7 @@ async fn delete_append_end_of_word() -> anyhow::Result<()> {
             ),
             "a<backspace>",
             format!("fo#[o{}|]#", LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }
@@ -1340,6 +1346,7 @@ async fn delete_append_end_of_word_multi() -> anyhow::Result<()> {
             ),
             "a<backspace>",
             format!("fo#[o{eol}|]#fo#(o{eol}|)#fo#(o{eol}|)#", eol = LINE_END),
+            LineFeedHandling::AsIs,
         ))
         .await?;
     }

--- a/helix-term/tests/test/auto_pairs.rs
+++ b/helix-term/tests/test/auto_pairs.rs
@@ -676,7 +676,7 @@ async fn delete_before_word_selection() -> anyhow::Result<()> {
         test((
             format!("{}#[|foo]#{}", pair.0, LINE_END),
             "i<backspace>",
-            format!("#[foo|]#{}", LINE_END),
+            format!("#[|foo]#{}", LINE_END),
         ))
         .await?;
 
@@ -684,7 +684,7 @@ async fn delete_before_word_selection() -> anyhow::Result<()> {
         test((
             format!("{}{}#[|foo]#{}", pair.0, pair.1, LINE_END),
             "i<backspace>",
-            format!("{}#[foo|]#{}", pair.0, LINE_END),
+            format!("{}#[|foo]#{}", pair.0, LINE_END),
         ))
         .await?;
 
@@ -692,7 +692,7 @@ async fn delete_before_word_selection() -> anyhow::Result<()> {
         test((
             format!("{}#[|{}foo]#{}", pair.0, pair.1, LINE_END),
             "i<backspace>",
-            format!("#[foo|]#{}", LINE_END),
+            format!("#[|foo]#{}", LINE_END),
         ))
         .await?;
     }
@@ -706,7 +706,7 @@ async fn delete_before_word_selection_trailing_word() -> anyhow::Result<()> {
         test((
             format!("foo{}#[|{} wor]#{}", pair.0, pair.1, LINE_END),
             "i<backspace>",
-            format!("foo#[ wor|]#{}", LINE_END),
+            format!("foo#[| wor]#{}", LINE_END),
         ))
         .await?;
     }
@@ -811,7 +811,7 @@ async fn delete_before_multi_code_point_graphemes() -> anyhow::Result<()> {
                 pair.0, pair.1, LINE_END
             ),
             "i<backspace>",
-            format!("hello #[👨‍👩‍👧‍👦|]# goodbye{}", LINE_END),
+            format!("hello #[|👨‍👩‍👧‍👦]# goodbye{}", LINE_END),
         ))
         .await?;
     }
@@ -988,7 +988,7 @@ async fn delete_mixed_dedent() -> anyhow::Result<()> {
             )),
             "i<backspace>",
             helpers::platform_line(indoc! {"\
-                bar = #[woop|]#
+                bar = #[|woop]#
                 #(|word)#
                 f#(|o)#
             "}),
@@ -1000,16 +1000,16 @@ async fn delete_mixed_dedent() -> anyhow::Result<()> {
             helpers::platform_line(&format!(
                 indoc! {"\
                     bar = #[|woop{}]#{}
-                    #(|   )# word
+                    #(|    )#word
                     #(|fo)#o
                 "},
                 pair.0, pair.1,
             )),
             "a<backspace>",
             helpers::platform_line(indoc! {"\
-                bar = #[woop|]#
-                #(|w)#ord
-                #(|fo)#
+                bar = #[woop\n|]#
+                #(w|)#ord
+                #(fo|)#
             "}),
         ))
         .await?;


### PR DESCRIPTION
>[!NOTE]
>This replaces #7269, which I closed accidentally by deleting the branch.

This PR completes auto pair deletions. Currently, pairs are only deleted on ranges that are a single grapheme in width, since the normal change mapping process results in an incorrect selection on multi-grapheme ranges.

This is achieved with two new functions:

* `change_by_and_with_selection`
* `delete_by_and_with_selection`

They are helpers which take a transformation function that produces individual changes, one range at a time, and can optionally produce a new range that replaces the input range that it took as an argument. When one is not given, the input range is mapped through the change set as normal. This allows the caller to apply changes to the text and incrementally build a new selection as they go, picking and choosing in which cases new ranges are computed explicitly, and in which they are mapped normally.

Concretely, this solves the problem of needing auto pair deletes to work concurrently with dedenting on backspace; the auto pair hooks were changed to operate on individual ranges and return individual changes, rather than producing a whole complete transaction. Then deleting was enabled to compose changes from all 3 possible scenarios at once, i.e. deleting a single grapheme, dedenting, and auto pair deletions.

[![asciicast](https://asciinema.org/a/HlcFfnoFFIpVOnzvtts2Y9OXX.svg)](https://asciinema.org/a/HlcFfnoFFIpVOnzvtts2Y9OXX)

Additionally, this PR inserts an extra whitespace when the cursor is inside a pair to pad the left and right.

[![asciicast](https://asciinema.org/a/iPRzxTo4bLE3acaD5uFIQZo0N.svg)](https://asciinema.org/a/iPRzxTo4bLE3acaD5uFIQZo0N)
