### PR TITLE
`expand_selection_around`

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -387,8 +387,11 @@ impl Range {
 
     /// Converts this char range into an in order byte range, discarding
     /// direction.
-    pub fn into_byte_range(&self, text: RopeSlice) -> (usize, usize) {
-        (text.char_to_byte(self.from()), text.char_to_byte(self.to()))
+    pub fn into_byte_range(&self, text: RopeSlice) -> (u32, u32) {
+        (
+            text.char_to_byte(self.from()) as u32,
+            text.char_to_byte(self.to()) as u32,
+        )
     }
 }
 

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -703,22 +703,161 @@ impl Selection {
     pub fn contains(&self, other: &Selection) -> bool {
         is_subset::<true>(self.range_bounds(), other.range_bounds())
     }
+
+    /// returns true if self has at least one range that overlaps with at least one range from other
+    pub fn overlaps(&self, other: &Selection) -> bool {
+        let (mut iter_self, mut iter_other) = (self.iter(), other.iter());
+        let (mut ele_self, mut ele_other) = (iter_self.next(), iter_other.next());
+
+        loop {
+            match (ele_self, ele_other) {
+                (Some(ra), Some(rb)) => {
+                    if ra.overlaps(rb) {
+                        return true;
+                    } else if ra.from() > rb.from() {
+                        ele_self = iter_self.next();
+                    } else {
+                        ele_other = iter_other.next();
+                    }
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// Returns the given selection with the overlapping portions of `other`
+    /// cut out. If one range from this selection is equal to one from `other`,
+    /// this range is removed. If this results in an entirely empty selection,
+    /// `None` is returned.
+    pub fn without(self, other: &Selection) -> Option<Self> {
+        if other.contains(&self) {
+            return None;
+        }
+
+        let mut primary_index = self.primary_index;
+        let mut ranges = smallvec!();
+        let (mut iter_self, mut iter_other) = (self.into_iter(), other.iter());
+        let (mut ele_self, mut ele_other) = (iter_self.next(), iter_other.next());
+        let mut cur_index = 0;
+
+        loop {
+            match (ele_self, ele_other) {
+                (Some(ra), Some(rb)) => {
+                    if !ra.overlaps(rb) {
+                        // there's no overlap and it's on the left of rb
+                        if ra.to() <= rb.from() {
+                            ranges.push(ra);
+                            ele_self = iter_self.next();
+                            cur_index += 1;
+
+                        // otherwise it must be on the right, so move rb forward
+                        } else {
+                            ele_other = iter_other.next();
+                        }
+
+                        continue;
+                    }
+
+                    // otherwise there is overlap, so truncate or split
+                    if rb.contains_range(&ra) {
+                        ele_self = iter_self.next();
+                        cur_index += 1;
+                        continue;
+                    }
+
+                    // [ ra  ]
+                    //     [ rb  ]
+                    if ra.from() <= rb.from() && ra.to() <= rb.to() && ra.to() >= rb.from() {
+                        let new = if ra.direction() == Direction::Backward {
+                            Range::new(rb.from(), ra.head)
+                        } else {
+                            Range::new(ra.anchor, rb.from())
+                        };
+
+                        ranges.push(new);
+                        ele_self = iter_self.next();
+                        cur_index += 1;
+
+                    //     [ ra  ]
+                    // [ rb  ]
+                    } else if ra.from() >= rb.from() && ra.to() >= rb.to() && ra.from() <= rb.to() {
+                        let new = if ra.direction() == Direction::Backward {
+                            Range::new(ra.anchor, rb.to() + 1)
+                        } else {
+                            Range::new(rb.to(), ra.head)
+                        };
+
+                        // don't settle on the new range yet because the next
+                        // rb could chop off the other end of ra
+                        ele_self = Some(new);
+                        ele_other = iter_other.next();
+
+                    // [    ra    ]
+                    //    [ rb ]
+                    } else if ra.from() < rb.from() && ra.to() > rb.to() {
+                        // we must split the range into two
+                        let left = if ra.direction() == Direction::Backward {
+                            Range::new(rb.from(), ra.head)
+                        } else {
+                            Range::new(ra.anchor, rb.from())
+                        };
+
+                        let right = if ra.direction() == Direction::Backward {
+                            Range::new(ra.anchor, rb.to())
+                        } else {
+                            Range::new(rb.to(), ra.head)
+                        };
+
+                        // We do NOT push right onto the results right away.
+                        // We must put it back into the iterator and check it
+                        // again in case a further range splits it again.
+                        ranges.push(left);
+                        ele_other = iter_other.next();
+
+                        // offset the primary index whenever we split
+                        if cur_index < primary_index {
+                            primary_index += 1;
+                        }
+
+                        cur_index += 1;
+                        ele_self = Some(right);
+                    }
+                }
+                // the rest just get included as is
+                (Some(range), None) => {
+                    ranges.push(range);
+                    ele_self = iter_self.next();
+                    cur_index += 1;
+                }
+                // exhausted `self`, nothing left to do
+                (None, _) => {
+                    break;
+                }
+            }
+        }
+
+        if ranges.is_empty() {
+            return None;
+        }
+
+        Some(Selection::new(ranges, primary_index))
+    }
 }
 
 impl<'a> IntoIterator for &'a Selection {
     type Item = &'a Range;
     type IntoIter = std::slice::Iter<'a, Range>;
 
-    fn into_iter(self) -> std::slice::Iter<'a, Range> {
+    fn into_iter(self) -> Self::IntoIter {
         self.ranges().iter()
     }
 }
 
 impl IntoIterator for Selection {
     type Item = Range;
-    type IntoIter = smallvec::IntoIter<[Range; 1]>;
+    type IntoIter = smallvec::IntoIter<[Self::Item; 1]>;
 
-    fn into_iter(self) -> smallvec::IntoIter<[Range; 1]> {
+    fn into_iter(self) -> Self::IntoIter {
         self.ranges.into_iter()
     }
 }
@@ -885,6 +1024,7 @@ pub fn split_on_matches(text: RopeSlice, selection: &Selection, regex: &rope::Re
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::test;
     use crate::Rope;
 
     #[test]
@@ -975,7 +1115,7 @@ mod test {
     }
 
     #[test]
-    fn test_overlaps() {
+    fn test_range_overlaps() {
         fn overlaps(a: (usize, usize), b: (usize, usize)) -> bool {
             Range::new(a.0, a.1).overlaps(&Range::new(b.0, b.1))
         }
@@ -1023,6 +1163,160 @@ mod test {
 
         // Two zero-width ranges, overlap.
         assert!(overlaps((1, 1), (1, 1)));
+    }
+
+    #[test]
+    fn test_selection_overlaps() {
+        fn overlaps(a: &[(usize, usize)], b: &[(usize, usize)]) -> bool {
+            let a = Selection::new(
+                a.iter()
+                    .map(|(anchor, head)| Range::new(*anchor, *head))
+                    .collect(),
+                0,
+            );
+            let b = Selection::new(
+                b.iter()
+                    .map(|(anchor, head)| Range::new(*anchor, *head))
+                    .collect(),
+                0,
+            );
+            a.overlaps(&b)
+        }
+
+        // Two non-zero-width ranges, no overlap.
+        assert!(!overlaps(&[(0, 3)], &[(3, 6)]));
+        assert!(!overlaps(&[(0, 3)], &[(6, 3)]));
+        assert!(!overlaps(&[(3, 0)], &[(3, 6)]));
+        assert!(!overlaps(&[(3, 0)], &[(6, 3)]));
+        assert!(!overlaps(&[(3, 6)], &[(0, 3)]));
+        assert!(!overlaps(&[(3, 6)], &[(3, 0)]));
+        assert!(!overlaps(&[(6, 3)], &[(0, 3)]));
+        assert!(!overlaps(&[(6, 3)], &[(3, 0)]));
+
+        // more ranges in one or the other, no overlap
+        assert!(!overlaps(&[(6, 3), (9, 6)], &[(3, 0)]));
+        assert!(!overlaps(&[(6, 3), (6, 9)], &[(3, 0)]));
+        assert!(!overlaps(&[(3, 6), (9, 6)], &[(3, 0)]));
+        assert!(!overlaps(&[(3, 6), (6, 9)], &[(3, 0)]));
+        assert!(!overlaps(&[(6, 3), (9, 6)], &[(0, 3)]));
+        assert!(!overlaps(&[(6, 3), (6, 9)], &[(0, 3)]));
+        assert!(!overlaps(&[(3, 6), (9, 6)], &[(0, 3)]));
+        assert!(!overlaps(&[(3, 6), (6, 9)], &[(0, 3)]));
+
+        assert!(!overlaps(&[(6, 3)], &[(3, 0), (9, 6)]));
+        assert!(!overlaps(&[(6, 3)], &[(3, 0), (6, 9)]));
+        assert!(!overlaps(&[(3, 6)], &[(3, 0), (9, 6)]));
+        assert!(!overlaps(&[(3, 6)], &[(3, 0), (6, 9)]));
+        assert!(!overlaps(&[(6, 3)], &[(0, 3), (9, 6)]));
+        assert!(!overlaps(&[(6, 3)], &[(0, 3), (6, 9)]));
+        assert!(!overlaps(&[(3, 6)], &[(0, 3), (9, 6)]));
+        assert!(!overlaps(&[(3, 6)], &[(0, 3), (6, 9)]));
+
+        // Two non-zero-width ranges, overlap.
+        assert!(overlaps(&[(0, 4)], &[(3, 6)]));
+        assert!(overlaps(&[(0, 4)], &[(6, 3)]));
+        assert!(overlaps(&[(4, 0)], &[(3, 6)]));
+        assert!(overlaps(&[(4, 0)], &[(6, 3)]));
+        assert!(overlaps(&[(3, 6)], &[(0, 4)]));
+        assert!(overlaps(&[(3, 6)], &[(4, 0)]));
+        assert!(overlaps(&[(6, 3)], &[(0, 4)]));
+        assert!(overlaps(&[(6, 3)], &[(4, 0)]));
+
+        // Two non-zero-width ranges, overlap, extra from one or the other
+        assert!(overlaps(&[(0, 4), (7, 10)], &[(3, 6)]));
+        assert!(overlaps(&[(0, 4), (7, 10)], &[(6, 3)]));
+        assert!(overlaps(&[(4, 0), (7, 10)], &[(3, 6)]));
+        assert!(overlaps(&[(4, 0), (7, 10)], &[(6, 3)]));
+        assert!(overlaps(&[(3, 6), (7, 10)], &[(0, 4)]));
+        assert!(overlaps(&[(3, 6), (7, 10)], &[(4, 0)]));
+        assert!(overlaps(&[(6, 3), (7, 10)], &[(0, 4)]));
+        assert!(overlaps(&[(6, 3), (7, 10)], &[(4, 0)]));
+        assert!(overlaps(&[(0, 4), (10, 7)], &[(3, 6)]));
+        assert!(overlaps(&[(0, 4), (10, 7)], &[(6, 3)]));
+        assert!(overlaps(&[(4, 0), (10, 7)], &[(3, 6)]));
+        assert!(overlaps(&[(4, 0), (10, 7)], &[(6, 3)]));
+        assert!(overlaps(&[(3, 6), (10, 7)], &[(0, 4)]));
+        assert!(overlaps(&[(3, 6), (10, 7)], &[(4, 0)]));
+        assert!(overlaps(&[(6, 3), (10, 7)], &[(0, 4)]));
+        assert!(overlaps(&[(6, 3), (10, 7)], &[(4, 0)]));
+
+        assert!(overlaps(&[(0, 4)], &[(3, 6), (7, 10)]));
+        assert!(overlaps(&[(0, 4)], &[(6, 3), (7, 10)]));
+        assert!(overlaps(&[(4, 0)], &[(3, 6), (7, 10)]));
+        assert!(overlaps(&[(4, 0)], &[(6, 3), (7, 10)]));
+        assert!(overlaps(&[(3, 6)], &[(0, 4), (7, 10)]));
+        assert!(overlaps(&[(3, 6)], &[(4, 0), (7, 10)]));
+        assert!(overlaps(&[(6, 3)], &[(0, 4), (7, 10)]));
+        assert!(overlaps(&[(6, 3)], &[(4, 0), (7, 10)]));
+        assert!(overlaps(&[(0, 4)], &[(3, 6), (10, 7)]));
+        assert!(overlaps(&[(0, 4)], &[(6, 3), (10, 7)]));
+        assert!(overlaps(&[(4, 0)], &[(3, 6), (10, 7)]));
+        assert!(overlaps(&[(4, 0)], &[(6, 3), (10, 7)]));
+        assert!(overlaps(&[(3, 6)], &[(0, 4), (10, 7)]));
+        assert!(overlaps(&[(3, 6)], &[(4, 0), (10, 7)]));
+        assert!(overlaps(&[(6, 3)], &[(0, 4), (10, 7)]));
+        assert!(overlaps(&[(6, 3)], &[(4, 0), (10, 7)]));
+
+        // Zero-width and non-zero-width range, no overlap.
+        assert!(!overlaps(&[(0, 3)], &[(3, 3)]));
+        assert!(!overlaps(&[(3, 0)], &[(3, 3)]));
+        assert!(!overlaps(&[(3, 3)], &[(0, 3)]));
+        assert!(!overlaps(&[(3, 3)], &[(3, 0)]));
+
+        assert!(!overlaps(&[(0, 3), (7, 10)], &[(3, 3)]));
+        assert!(!overlaps(&[(3, 0), (7, 10)], &[(3, 3)]));
+        assert!(!overlaps(&[(3, 3), (7, 10)], &[(0, 3)]));
+        assert!(!overlaps(&[(3, 3), (7, 10)], &[(3, 0)]));
+
+        assert!(!overlaps(&[(0, 3)], &[(3, 3), (7, 10)]));
+        assert!(!overlaps(&[(3, 0)], &[(3, 3), (7, 10)]));
+        assert!(!overlaps(&[(3, 3)], &[(0, 3), (7, 10)]));
+        assert!(!overlaps(&[(3, 3)], &[(3, 0), (7, 10)]));
+
+        // Zero-width and non-zero-width range, overlap.
+        assert!(overlaps(&[(1, 4)], &[(1, 1)]));
+        assert!(overlaps(&[(4, 1)], &[(1, 1)]));
+        assert!(overlaps(&[(1, 1)], &[(1, 4)]));
+        assert!(overlaps(&[(1, 1)], &[(4, 1)]));
+
+        assert!(overlaps(&[(1, 4)], &[(3, 3)]));
+        assert!(overlaps(&[(4, 1)], &[(3, 3)]));
+        assert!(overlaps(&[(3, 3)], &[(1, 4)]));
+        assert!(overlaps(&[(3, 3)], &[(4, 1)]));
+
+        assert!(overlaps(&[(1, 4), (7, 10)], &[(1, 1)]));
+        assert!(overlaps(&[(4, 1), (7, 10)], &[(1, 1)]));
+        assert!(overlaps(&[(1, 1), (7, 10)], &[(1, 4)]));
+        assert!(overlaps(&[(1, 1), (7, 10)], &[(4, 1)]));
+
+        assert!(overlaps(&[(1, 4), (7, 10)], &[(3, 3)]));
+        assert!(overlaps(&[(4, 1), (7, 10)], &[(3, 3)]));
+        assert!(overlaps(&[(3, 3), (7, 10)], &[(1, 4)]));
+        assert!(overlaps(&[(3, 3), (7, 10)], &[(4, 1)]));
+
+        assert!(overlaps(&[(1, 4)], &[(1, 1), (7, 10)]));
+        assert!(overlaps(&[(4, 1)], &[(1, 1), (7, 10)]));
+        assert!(overlaps(&[(1, 1)], &[(1, 4), (7, 10)]));
+        assert!(overlaps(&[(1, 1)], &[(4, 1), (7, 10)]));
+
+        assert!(overlaps(&[(1, 4)], &[(3, 3), (7, 10)]));
+        assert!(overlaps(&[(4, 1)], &[(3, 3), (7, 10)]));
+        assert!(overlaps(&[(3, 3)], &[(1, 4), (7, 10)]));
+        assert!(overlaps(&[(3, 3)], &[(4, 1), (7, 10)]));
+
+        // Two zero-width ranges, no overlap.
+        assert!(!overlaps(&[(0, 0)], &[(1, 1)]));
+        assert!(!overlaps(&[(1, 1)], &[(0, 0)]));
+
+        assert!(!overlaps(&[(0, 0), (2, 2)], &[(1, 1)]));
+        assert!(!overlaps(&[(0, 0), (2, 2)], &[(1, 1)]));
+        assert!(!overlaps(&[(1, 1)], &[(0, 0), (2, 2)]));
+        assert!(!overlaps(&[(1, 1)], &[(0, 0), (2, 2)]));
+
+        // Two zero-width ranges, overlap.
+        assert!(overlaps(&[(1, 1)], &[(1, 1)]));
+        assert!(overlaps(&[(1, 1), (2, 2)], &[(1, 1)]));
+        assert!(overlaps(&[(1, 1)], &[(1, 1), (2, 2)]));
     }
 
     #[test]
@@ -1443,8 +1737,14 @@ mod test {
         // multiple matches
         assert!(contains(vec!((1, 1), (2, 2)), vec!((1, 1), (2, 2))));
 
-        // smaller set can't contain bigger
+        // extra items out of range
         assert!(!contains(vec!((1, 1)), vec!((1, 1), (2, 2))));
+
+        // one big range can contain multiple smaller ranges
+        assert!(contains(
+            vec!((1, 10)),
+            vec!((1, 1), (2, 2), (3, 3), (3, 5), (7, 10))
+        ));
 
         assert!(contains(
             vec!((1, 1), (2, 4), (5, 6), (7, 9), (10, 13)),
@@ -1457,5 +1757,144 @@ mod test {
             vec!((1, 4), (7, 10)),
             vec!((1, 2), (3, 4), (7, 9))
         ));
+    }
+
+    #[test]
+    fn test_selection_without() {
+        let without = |one, two, expected: Option<_>| {
+            println!("one: {:?}", one);
+            println!("two: {:?}", two);
+            println!("expected: {:?}", expected);
+
+            let (one_text, one_sel) = test::print(one);
+            let (two_text, two_sel) = test::print(two);
+            assert_eq!(one_text, two_text); // sanity
+            let actual_sel = one_sel.without(&two_sel);
+
+            let expected_sel = expected.map(|exp| {
+                let (expected_text, expected_sel) = test::print(exp);
+                assert_eq!(two_text, expected_text);
+                expected_sel
+            });
+            let actual = actual_sel
+                .as_ref()
+                .map(|sel| test::plain(two_text.to_string(), sel));
+
+            println!("actual: {:?}\n\n", actual);
+
+            assert_eq!(
+                expected_sel,
+                actual_sel,
+                "expected: {:?}, got: {:?}",
+                expected_sel
+                    .as_ref()
+                    .map(|sel| test::plain(two_text.to_string(), sel)),
+                actual,
+            );
+        };
+
+        without(
+            "#[foo bar baz|]#",
+            "foo #[bar|]# baz",
+            Some("#[foo |]#bar#( baz|)#"),
+        );
+
+        without("#[foo bar baz|]#", "#[foo bar baz|]#", None);
+        without("#[foo bar|]# baz", "#[foo bar baz|]#", None);
+        without("foo #[bar|]# baz", "#[foo bar baz|]#", None);
+
+        // direction is preserved
+        without(
+            "#[|foo bar baz]#",
+            "foo #[|bar]# baz",
+            Some("#[|foo ]#bar#(| baz)#"),
+        );
+
+        // preference for direction is given to the left
+        without(
+            "#[|foo bar baz]#",
+            "foo #[bar|]# baz",
+            Some("#[|foo ]#bar#(| baz)#"),
+        );
+
+        // disjoint ranges on the right are ignored
+        without(
+            "#[foo bar|]# baz",
+            "foo bar #[baz|]#",
+            Some("#[foo bar|]# baz"),
+        );
+        without(
+            "#[foo bar|]# baz",
+            "foo bar#[ baz|]#",
+            Some("#[foo bar|]# baz"),
+        );
+        without(
+            "#(foo|)# #[bar|]# baz",
+            "foo#[ b|]#ar ba#(z|)#",
+            Some("#(foo|)# b#[ar|]# baz"),
+        );
+
+        // ranges contained by those one on the right are removed
+        without(
+            "#[foo bar|]# #(b|)#az",
+            "foo bar#[ b|]#a#(z|)#",
+            Some("#[foo bar|]# baz"),
+        );
+        without(
+            "#[foo|]# bar #(baz|)#",
+            "foo bar#[ b|]#a#(z|)#",
+            Some("#[foo|]# bar b#(a|)#z"),
+        );
+        without(
+            "#[foo bar|]# #(b|)#az",
+            "foo bar #[b|]#a#(z|)#",
+            Some("#[foo bar|]# baz"),
+        );
+        without(
+            "#[foo bar|]# #(b|)#a#(z|)#",
+            "foo bar #[b|]#a#(z|)#",
+            Some("#[foo bar|]# baz"),
+        );
+        without(
+            "#[foo bar|]# #(b|)#a#(z|)#",
+            "foo bar #[b|]#a#(z|)#",
+            Some("#[foo bar|]# baz"),
+        );
+
+        // more than one range intersected by a single range on the right
+        without(
+            "#[foo bar|]# #(baz|)#",
+            "foo b#[ar ba|]#z",
+            Some("#[foo b|]#ar ba#(z|)#"),
+        );
+
+        // partial overlap
+        without(
+            "#[foo bar|]# baz",
+            "foo #[bar baz|]#",
+            Some("#[foo |]#bar baz"),
+        );
+        without(
+            "#[foo bar|]# baz",
+            "foo#[ bar baz|]#",
+            Some("#[foo|]# bar baz"),
+        );
+        without(
+            "#[foo bar|]# baz",
+            "foo ba#[r baz|]#",
+            Some("#[foo ba|]#r baz"),
+        );
+        without(
+            "foo ba#[r baz|]#",
+            "#[foo bar|]# baz",
+            Some("foo bar#[ baz|]#"),
+        );
+
+        // primary selection is moved - preference given to the left of a split
+        without(
+            "#(|foo)# #(|bar baz)# #[|quux]#",
+            "f#(o|)#o ba#[r b|]#az q#(uu|)#x",
+            Some("#(|f)#o#(|o)# #(|ba)#r b#(|az)# #[|q]#uu#(|x)#"),
+        );
     }
 }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4220,6 +4220,7 @@ fn goto_prev_diag(cx: &mut Context) {
         view.diagnostics_handler
             .immediately_show_diagnostic(doc, view.id);
     };
+
     cx.editor.apply_motion(motion)
 }
 
@@ -5752,6 +5753,8 @@ fn reverse_selection_contents(cx: &mut Context) {
 
 // tree sitter node selection
 
+const EXPAND_KEY: &str = "expand";
+
 fn expand_selection(cx: &mut Context) {
     let motion = |editor: &mut Editor| {
         let (view, doc) = current!(editor);
@@ -5759,42 +5762,52 @@ fn expand_selection(cx: &mut Context) {
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
 
-            let current_selection = doc.selection(view.id);
+            let current_selection = doc.selection(view.id).clone();
             let selection = object::expand_selection(syntax, text, current_selection.clone());
 
             // check if selection is different from the last one
-            if *current_selection != selection {
-                // save current selection so it can be restored using shrink_selection
-                view.object_selections.push(current_selection.clone());
+            if current_selection != selection {
+                let prev_selections = doc
+                    .view_data_mut(view.id)
+                    .object_selections
+                    .entry(EXPAND_KEY)
+                    .or_default();
 
-                doc.set_selection(view.id, selection);
+                // save current selection so it can be restored using shrink_selection
+                prev_selections.push(current_selection);
+                doc.set_selection_clear(view.id, selection, false);
             }
         }
     };
+
     cx.editor.apply_motion(motion);
 }
 
 fn shrink_selection(cx: &mut Context) {
     let motion = |editor: &mut Editor| {
         let (view, doc) = current!(editor);
-        let current_selection = doc.selection(view.id);
+        let current_selection = doc.selection(view.id).clone();
+        let prev_expansions = doc
+            .view_data_mut(view.id)
+            .object_selections
+            .entry(EXPAND_KEY)
+            .or_default();
+
         // try to restore previous selection
-        if let Some(prev_selection) = view.object_selections.pop() {
-            if current_selection.contains(&prev_selection) {
-                doc.set_selection(view.id, prev_selection);
-                return;
-            } else {
-                // clear existing selection as they can't be shrunk to anyway
-                view.object_selections.clear();
-            }
+        if let Some(prev_selection) = prev_expansions.pop() {
+            // allow shrinking the selection only if current selection contains the previous object selection
+            doc.set_selection_clear(view.id, prev_selection, false);
+            return;
         }
+
         // if not previous selection, shrink to first child
         if let Some(syntax) = doc.syntax() {
             let text = doc.text().slice(..);
-            let selection = object::shrink_selection(syntax, text, current_selection.clone());
-            doc.set_selection(view.id, selection);
+            let selection = object::shrink_selection(syntax, text, current_selection);
+            doc.set_selection_clear(view.id, selection, false);
         }
     };
+
     cx.editor.apply_motion(motion);
 }
 
@@ -5912,8 +5925,6 @@ fn match_brackets(cx: &mut Context) {
 
     doc.set_selection(view.id, selection);
 }
-
-//
 
 fn jump_forward(cx: &mut Context) {
     cx.editor.jump_forward(cx.editor.tree.focus, cx.count());

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -531,6 +531,7 @@ impl MappableCommand {
         select_prev_sibling, "Select previous sibling the in syntax tree",
         select_all_siblings, "Select all siblings of the current node",
         select_all_children, "Select all children of the current node",
+        expand_selection_around, "Expand selection to parent syntax node, but exclude the selection you started with",
         jump_forward, "Jump forward on jumplist",
         jump_backward, "Jump backward on jumplist",
         save_selection, "Save current selection to jumplist",
@@ -5754,6 +5755,8 @@ fn reverse_selection_contents(cx: &mut Context) {
 // tree sitter node selection
 
 const EXPAND_KEY: &str = "expand";
+const EXPAND_AROUND_BASE_KEY: &str = "expand_around_base";
+const PARENTS_KEY: &str = "parents";
 
 fn expand_selection(cx: &mut Context) {
     let motion = |editor: &mut Editor| {
@@ -5797,6 +5800,33 @@ fn shrink_selection(cx: &mut Context) {
         if let Some(prev_selection) = prev_expansions.pop() {
             // allow shrinking the selection only if current selection contains the previous object selection
             doc.set_selection_clear(view.id, prev_selection, false);
+
+            // Do a corresponding pop of the parents from `expand_selection_around`
+            doc.view_data_mut(view.id)
+                .object_selections
+                .entry(PARENTS_KEY)
+                .and_modify(|parents| {
+                    parents.pop();
+                });
+
+            // need to do this again because borrowing
+            let prev_expansions = doc
+                .view_data_mut(view.id)
+                .object_selections
+                .entry(EXPAND_KEY)
+                .or_default();
+
+            // if we've emptied out the previous expansions, then clear out the
+            // base history as well so it doesn't get used again erroneously
+            if prev_expansions.is_empty() {
+                doc.view_data_mut(view.id)
+                    .object_selections
+                    .entry(EXPAND_AROUND_BASE_KEY)
+                    .and_modify(|base| {
+                        base.clear();
+                    });
+            }
+
             return;
         }
 
@@ -5805,6 +5835,81 @@ fn shrink_selection(cx: &mut Context) {
             let text = doc.text().slice(..);
             let selection = object::shrink_selection(syntax, text, current_selection);
             doc.set_selection_clear(view.id, selection, false);
+        }
+    };
+
+    cx.editor.apply_motion(motion);
+}
+
+fn expand_selection_around(cx: &mut Context) {
+    let motion = |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+
+        if doc.syntax().is_some() {
+            // [NOTE] we do this pop and push dance because if we don't take
+            //        ownership of the objects, then we require multiple
+            //        mutable references to the view's object selections
+            let mut parents_selection = doc
+                .view_data_mut(view.id)
+                .object_selections
+                .entry(PARENTS_KEY)
+                .or_default()
+                .pop();
+
+            let mut base_selection = doc
+                .view_data_mut(view.id)
+                .object_selections
+                .entry(EXPAND_AROUND_BASE_KEY)
+                .or_default()
+                .pop();
+
+            let current_selection = doc.selection(view.id).clone();
+
+            if parents_selection.is_none() || base_selection.is_none() {
+                parents_selection = Some(current_selection.clone());
+                base_selection = Some(current_selection.clone());
+            }
+
+            let text = doc.text().slice(..);
+            let syntax = doc.syntax().unwrap();
+
+            let outside_selection =
+                object::expand_selection(syntax, text, parents_selection.clone().unwrap());
+
+            let target_selection = match outside_selection
+                .clone()
+                .without(&base_selection.clone().unwrap())
+            {
+                Some(sel) => sel,
+                None => outside_selection.clone(),
+            };
+
+            // check if selection is different from the last one
+            if target_selection != current_selection {
+                // save current selection so it can be restored using shrink_selection
+                doc.view_data_mut(view.id)
+                    .object_selections
+                    .entry(EXPAND_KEY)
+                    .or_default()
+                    .push(current_selection);
+
+                doc.set_selection_clear(view.id, target_selection, false);
+            }
+
+            let parents = doc
+                .view_data_mut(view.id)
+                .object_selections
+                .entry(PARENTS_KEY)
+                .or_default();
+
+            parents.push(parents_selection.unwrap());
+            parents.push(outside_selection);
+
+            doc.view_data_mut(view.id)
+                .object_selections
+                .entry(EXPAND_AROUND_BASE_KEY)
+                .or_default()
+                .push(base_selection.unwrap());
         }
     };
 
@@ -5825,6 +5930,7 @@ where
             doc.set_selection(view.id, selection);
         }
     };
+
     cx.editor.apply_motion(motion);
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -87,6 +87,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         ";" => collapse_selection,
         "A-;" => flip_selections,
         "A-o" | "A-up" => expand_selection,
+        "A-O" => expand_selection_around,
         "A-i" | "A-down" => shrink_selection,
         "A-I" | "A-S-down" => select_all_children,
         "A-p" | "A-left" => select_prev_sibling,

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -1039,15 +1039,32 @@ async fn expand_shrink_selection() -> anyhow::Result<()> {
         // shrink with no expansion history defaults to first child
         (
             indoc! {r##"
+                #[(
+                    Some(thing),
+                    Some(other_thing),
+                )|]#
+            "##},
+            "<A-i>",
+            indoc! {r##"
                 (
                     #[Some(thing)|]#,
                     Some(other_thing),
                 )
             "##},
-            "<A-i>",
+        ),
+        // any movement cancels selection history and falls back to first child
+        (
             indoc! {r##"
                 (
-                    #[Some|]#(thing),
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+
+            "##},
+            "<A-o><A-o><A-o>jkvkkk<A-i>",
+            indoc! {r##"
+                (
+                    #[|Some(thing)]#,
                     Some(other_thing),
                 )
             "##},

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -948,3 +948,115 @@ async fn match_bracket() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expand_shrink_selection() -> anyhow::Result<()> {
+    let tests = vec![
+        // single range
+        (
+            indoc! {r##"
+                Some(#[thing|]#)
+            "##},
+            "<A-o><A-o>",
+            indoc! {r##"
+                #[Some(thing)|]#
+            "##},
+        ),
+        // multi range
+        (
+            indoc! {r##"
+                Some(#[thing|]#)
+                Some(#(other_thing|)#)
+            "##},
+            "<A-o>",
+            indoc! {r##"
+                Some#[(thing)|]#
+                Some#((other_thing)|)#
+            "##},
+        ),
+        // multi range collision merges
+        (
+            indoc! {r##"
+                (
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+            "##},
+            "<A-o><A-o><A-o>",
+            indoc! {r##"
+                #[(
+                    Some(thing),
+                    Some(other_thing),
+                )|]#
+            "##},
+        ),
+        // multi range collision merges, then shrinks back to original
+        (
+            indoc! {r##"
+                (
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+            "##},
+            "<A-o><A-o><A-o><A-i>",
+            indoc! {r##"
+                (
+                    #[Some(thing)|]#,
+                    #(Some(other_thing)|)#,
+                )
+            "##},
+        ),
+        (
+            indoc! {r##"
+                (
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+            "##},
+            "<A-o><A-o><A-o><A-i><A-i>",
+            indoc! {r##"
+                (
+                    Some#[(thing)|]#,
+                    Some#((other_thing)|)#,
+                )
+            "##},
+        ),
+        (
+            indoc! {r##"
+                (
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+            "##},
+            "<A-o><A-o><A-o><A-i><A-i><A-i>",
+            indoc! {r##"
+                (
+                    Some(#[thing|]#),
+                    Some(#(other_thing|)#),
+                )
+            "##},
+        ),
+        // shrink with no expansion history defaults to first child
+        (
+            indoc! {r##"
+                (
+                    #[Some(thing)|]#,
+                    Some(other_thing),
+                )
+            "##},
+            "<A-i>",
+            indoc! {r##"
+                (
+                    #[Some|]#(thing),
+                    Some(other_thing),
+                )
+            "##},
+        ),
+    ];
+
+    for test in tests {
+        test_with_config(AppBuilder::new().with_file("foo.rs", None), test).await?;
+    }
+
+    Ok(())
+}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1392,15 +1392,27 @@ impl Document {
         Ok(())
     }
 
-    /// Select text within the [`Document`].
-    pub fn set_selection(&mut self, view_id: ViewId, selection: Selection) {
+    /// Select text within the [`Document`], optionally clearing the previous selection state.
+    pub fn set_selection_clear(&mut self, view_id: ViewId, selection: Selection, clear_prev: bool) {
         // TODO: use a transaction?
         self.selections
             .insert(view_id, selection.ensure_invariants(self.text().slice(..)));
+
         helix_event::dispatch(SelectionDidChange {
             doc: self,
             view: view_id,
-        })
+        });
+
+        if clear_prev {
+            self.view_data
+                .entry(view_id)
+                .and_modify(|view_data| view_data.object_selections.clear());
+        }
+    }
+
+    /// Select text within the [`Document`].
+    pub fn set_selection(&mut self, view_id: ViewId, selection: Selection) {
+        self.set_selection_clear(view_id, selection, true);
     }
 
     /// Find the origin selection of the text in a document, i.e. where
@@ -1618,6 +1630,12 @@ impl Document {
             }
             highlights.ranges = updated;
         }
+
+        // clear out all associated view object selections, as they are no
+        // longer valid
+        self.view_data
+            .values_mut()
+            .for_each(|view_data| view_data.object_selections.clear());
 
         helix_event::dispatch(DocumentDidChange {
             doc: self,
@@ -2084,13 +2102,13 @@ impl Document {
         &self.selections
     }
 
-    fn view_data(&self, view_id: ViewId) -> &ViewData {
+    pub fn view_data(&self, view_id: ViewId) -> &ViewData {
         self.view_data
             .get(&view_id)
             .expect("This should only be called after ensure_view_init")
     }
 
-    fn view_data_mut(&mut self, view_id: ViewId) -> &mut ViewData {
+    pub fn view_data_mut(&mut self, view_id: ViewId) -> &mut ViewData {
         self.view_data.entry(view_id).or_default()
     }
 
@@ -2493,9 +2511,13 @@ impl Document {
     }
 }
 
+/// Stores data needed for views that are tied to this specific Document.
 #[derive(Debug, Default)]
 pub struct ViewData {
     view_position: ViewPosition,
+
+    /// used to store previous selections of tree-sitter objects
+    pub object_selections: HashMap<&'static str, Vec<Selection>>,
 }
 
 #[derive(Clone, Debug)]
@@ -2546,6 +2568,7 @@ mod test {
             Arc::new(ArcSwap::from_pointee(syntax::Loader::default())),
         );
         let view = ViewId::default();
+        doc.ensure_view_init(view);
         doc.set_selection(view, Selection::single(0, 0));
 
         let transaction =
@@ -2584,7 +2607,9 @@ mod test {
             Arc::new(ArcSwap::new(Arc::new(Config::default()))),
             Arc::new(ArcSwap::from_pointee(syntax::Loader::default())),
         );
+
         let view = ViewId::default();
+        doc.ensure_view_init(view);
         doc.set_selection(view, Selection::single(5, 5));
 
         // insert

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -155,8 +155,6 @@ pub struct View {
     // uses two docs because we want to be able to swap between the
     // two last modified docs which we need to manually keep track of
     pub last_modified_docs: [Option<DocumentId>; 2],
-    /// used to store previous selections of tree-sitter objects
-    pub object_selections: Vec<Selection>,
     /// all gutter-related configuration settings, used primarily for gutter rendering
     pub gutters: GutterConfig,
     /// A mapping between documents and the last history revision the view was updated at.
@@ -193,7 +191,6 @@ impl View {
             jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
             docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
-            object_selections: Vec::new(),
             gutters,
             doc_revisions: HashMap::new(),
             diagnostics_handler: DiagnosticsHandler::new(),


### PR DESCRIPTION
>[!NOTE]
>This replaces #7269, which I closed accidentally by deleting the branch.

This adds a new feature: `expand_selection_around`. With this command, one starts with an initial arbitrary selection, and then the `expand_selection_around` acts just like `expand_selection`, except that it splits the new expanded selection around the initial selection. All the while, it remembers what the initial selection was so that you can continue to expand any number of times around this initial selection. Additionally, shrinking works exactly the same way, except that once you get back down to the first expansion, the last shrink in the stack will revert back to your initial selection.

[![asciicast](https://asciinema.org/a/vkBJ0hEauyR5iZWOqsgO9Pseg.svg)](https://asciinema.org/a/vkBJ0hEauyR5iZWOqsgO9Pseg)

## Implementation

The existing `expand_selection` and `shrink_selection` commands are implemented by keeping a list of `Selection`s, which they push and pop off of like a stack.

In order to implement this feature, these "object selections" are generalized into a register of namespaced lists of `Selection`s. Currently these are keyed by hardcoded static strings; this felt cleaner than having special struct fields. Theoretically, other commands that could make use of tracking lists of `Selection`s could use this register in the future too, without specialized members.

Anyway, this particular feature is implemented by keeping 3 distinct `Selection` histories:

* `expand`: this serves the role of the existing object selections: it remembers your final selections at each step of the way, so that you can shrink back down to your previous selections
* `expand_around_base`: this remembers your initial "base" selection before running the `expand_selection_around` command
* `parents`: this tracks the entire span of the parent nodes as you are traversing up the syntax tree

The feature is accomplished by essentially pretending internally that we only have one selection: the entire span of a parent node. Each time we `expand_selection_around` again, this parent node is used to keep traveling up the tree. But before we actually set the final resulting selection, we take the `expand_around_base` selection and split the parent span into two around the base.

For this, it was necessary to add `Selection:: without`, which computes the set difference of two `Selection`s.

Incidentally, along the way, I discovered the same bug reported in #6092, so this includes the same fix as, and could possibly supersede, #6093.

Additionally, I also noticed all the bugs that @pascalkuthe mentioned in https://github.com/helix-editor/helix/pull/6088#pullrequestreview-1314531159 and #6087, i.e. the current object selections don't track all the context that they should: they can end up getting used on the wrong document, view, and could end up getting totally out of sync with any text edits that happen between an expansion and a shrink.

As @pascalkuthe mentioned, fixing this in the general case would be somewhat complex, as it would need to track any text edits and possibly associate views with selection histories, as mentioned in https://github.com/helix-editor/helix/pull/6088#discussion_r1117986531. How this would ultimately end up interacting with the changes in this PR are unclear.

But in any case, I addressed these issues in a simple, but very aggressive way: the object selections are now cleared *any time* a view's selection is set, *except* during these expand and shrink commands. This required a breaking change in `Document::set_selection`: it has to take a mutable reference to the entire `View` now in order to clear the object selections. This is a simple way to ensure that the object selections don't get out of sync with view switches or document edits, since it's likely that every command that could cause a problematic divergence in the object selections also itself sets a selection, plus many that wouldn't. This includes normal mode movements of any kind, for example.

Consequences of this include:

* One can no longer do an expand, then move around, and then a shrink, and have it still go back to what you had before the expand. One could argue that this is a bug anyway.
* One can no longer do an expand, switch buffers, then switch back to the first buffer, then shrink back to the selection one had before the first expand. One could argue that this is a regression, as in #6088. Personally, my opinion is that this is an ok trade-off, since the object selection history was originally intended to allow for consecutive invocations of expansions and shrinks, which is preserved, though others might disagree.
* It makes the diffs quite noisy. For this reason, I very intentionally laid out the commits neatly so that this can easily be reviewed commit-by-commit.

Also, this PR changes the behavior of `shrink_selection` when there was no previous expansion. Currently, the first child is selected. However, this is often not very useful at all, since the first child often something like an open brace or parentheses. Instead, the behavior is changed to select the first child *that is strictly contained within the span of the current node* (credit and thanks to @pascalkuthe again for this idea!). The command is much more useful this way.

@matoous may be interested in this PR as it builds upon their original implementation of the expand and shrink commands.

Based on top of #6156 since it makes use of some of the integration testing improvements
Fixes #6092
Supersedes #6093
Fixes #6087
