### PR TITLE
Add option to make popups follow cursor horizontally

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -59,6 +59,7 @@
 | `trim-final-newlines` | Whether to automatically remove line-endings after the final one on write | `false` |
 | `trim-trailing-whitespace` | Whether to automatically remove whitespace preceding line endings on write | `false` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `"none"` |
+| `popup-follow-cursor` | Whether the popup should follow the cursor horizontally. | `false` |
 | `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `"hybrid"` |
 | `jump-label-alphabet` | The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. | `"abcdefghijklmnopqrstuvwxyz"` |
 | `end-of-line-diagnostics` | Minimum severity of diagnostics to render at the end of the line. Set to `disable` to disable entirely. Refer to the setting about `inline-diagnostics` for more details | `"hint"` |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2482,6 +2482,7 @@ fn run_shell_command(
         return Ok(());
     }
 
+    let follow_cursor = cx.editor.config().popup_follow_cursor;
     let shell = cx.editor.config().shell.clone();
     let args = args.join(" ");
 
@@ -2494,9 +2495,12 @@ fn run_shell_command(
                         format!("```sh\n{}\n```", output.trim_end()),
                         editor.syn_loader.clone(),
                     );
-                    let popup = Popup::new("shell", contents).position(Some(
-                        helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
-                    ));
+                    let mut popup = Popup::new("shell", contents);
+                    if !follow_cursor {
+                        popup = popup.position(Some(
+                            helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
+                        ));
+                    }
                     compositor.replace_or_push("shell", popup);
                 }
                 editor.set_status("Command run");

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -125,10 +125,14 @@ impl<T: Component> Popup<T> {
 
     fn render_info(&mut self, viewport: Rect, editor: &Editor) -> RenderInfo {
         let mut position = editor.cursor().0.unwrap_or_default();
-        if let Some(old_position) = self
-            .position
-            .filter(|old_position| old_position.row == position.row)
-        {
+        let follow_cursor = editor.config().popup_follow_cursor;
+        if let Some(old_position) = self.position.filter(|old_position| {
+            if follow_cursor {
+                *old_position == position
+            } else {
+                old_position.row == position.row
+            }
+        }) {
             position = old_position;
         } else {
             self.position = Some(position);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -406,6 +406,9 @@ pub struct Config {
     pub smart_tab: Option<SmartTabConfig>,
     /// Draw border around popups.
     pub popup_border: PopupBorderConfig,
+    /// Whether the popup should follow the cursor horizontally.
+    /// Defaults to `false`.
+    pub popup_follow_cursor: bool,
     /// Which indent heuristic to use when a new line is inserted
     #[serde(default)]
     pub indent_heuristic: IndentationHeuristic,
@@ -1137,6 +1140,7 @@ impl Default for Config {
             trim_trailing_whitespace: false,
             smart_tab: Some(SmartTabConfig::default()),
             popup_border: PopupBorderConfig::None,
+            popup_follow_cursor: false,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
             inline_diagnostics: InlineDiagnosticsConfig::default(),


### PR DESCRIPTION
Adds a `popup-follow-cursor` editor option which by default is false.

It makes popups follow the cursor horizontally too instead of just
vertically, as a result this might not play nicely with
`preview-completion-insert`
