### PR TITLE
don't mark lifetimes and labels in locals as variables

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -23,3 +23,6 @@
 
 ; References
 (identifier) @local.reference
+; lifetimes / labels
+(lifetime (identifier) @label)
+(label (identifier) @label)


### PR DESCRIPTION
before:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/f0e6045f-07d1-4781-b1bd-e20afb228c0c" />
(note that labels are black and variables are blue)

after:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/87898c25-36f6-488d-a2d6-ed10e97db462" />
