### PR TITLE
New feature: Add command for the recent picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "nucleo",
  "once_cell",
  "open",
+ "path-clean",
  "pulldown-cmark",
  "same-file",
  "serde",
@@ -2133,6 +2134,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathdiff"

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -293,6 +293,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `b`     | Open buffer picker                                                      | `buffer_picker`                            |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
 | `g`     | Open changed file picker                                                | `changed_file_picker`                      |
+| `l`     | Open recent/latest file picker                                          | `recent_picker`                            |
 | `G`     | Debug (experimental)                                                    | N/A                                        |
 | `k`     | Show documentation for item under cursor in a [popup](#popup) (**LSP**) | `hover`                                    |
 | `s`     | Open document symbol picker (**LSP** or **TS**)                         | `lsp_or_syntax_symbol_picker`              |

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -152,6 +152,10 @@ pub fn default_log_file() -> PathBuf {
     cache_dir().join("helix.log")
 }
 
+pub fn default_recents_file() -> PathBuf {
+    cache_dir().join("recents.txt")
+}
+
 /// Merge two TOML documents, merging values from `right` onto `left`
 ///
 /// `merge_depth` sets the nesting depth up to which values are merged instead

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -62,6 +62,7 @@ futures-util = { version = "0.3", features = ["std", "async-await"], default-fea
 arc-swap = { version = "1.7.1" }
 termini = "1"
 indexmap = "2.12"
+path-clean = "1.0.1"
 
 # Logging
 fern = "0.7"

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -401,6 +401,7 @@ impl MappableCommand {
         append_mode, "Append after selection",
         command_mode, "Enter command mode",
         file_picker, "Open file picker",
+        recent_picker, "Open recent file picker",
         file_picker_in_current_buffer_directory, "Open file picker at current buffer's directory",
         file_picker_in_current_directory, "Open file picker at current working directory",
         file_explorer, "Open file explorer in workspace root",
@@ -3066,6 +3067,16 @@ fn file_picker(cx: &mut Context) {
         return;
     }
     let picker = ui::file_picker(cx.editor, root);
+    cx.push_layer(Box::new(overlaid(picker)));
+}
+
+fn recent_picker(cx: &mut Context) {
+    let root = find_workspace().0;
+    if !root.exists() {
+        cx.editor.set_error("Workspace directory does not exist");
+        return;
+    }
+    let picker = ui::recent_picker(cx.editor, root);
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -224,6 +224,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
         "space" => { "Space"
             "f" => file_picker,
+            "l" => recent_picker, // l stands for latest files
             "F" => file_picker_in_current_directory,
             "e" => file_explorer,
             "E" => file_explorer_in_current_buffer_directory,


### PR DESCRIPTION
- Added a new command on spacemode <space>l to open the latest files
- Just copied the functionality for the normal picker
- Added the new command to the keymap markdown

This is tested with a simple cargo run and runs without errors. It hooks into the save function of the editor.

Questions:
- Move hook to another place?
- Add disable options?
- Write tests?
- Does this run on all platforms (only tested on linux with the development flake)