### PR TITLE
Allow access to arbitrary files if CAP_DAC_OVERRIDE is set on Linux

### DIFF
--- a/helix-stdx/Cargo.toml
+++ b/helix-stdx/Cargo.toml
@@ -26,7 +26,7 @@ unicode-segmentation.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "1.1", features = ["fs"] }
+rustix = { version = "1.1", features = ["fs", "thread"] }
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
`CAP_DAC_OVERRIDE` on linux allows bypassing the defined permission bits and owners of files and directories. However, Helix would itself refuse to write to files if the permission bits were prohibitive, even if CAP_DAC_OVERRIDE was set.

Fixes #14999
