### PR TITLE
Update vim_dark_high_contrast theme: Add jump label highlight

### DIFF
--- a/runtime/themes/vim_dark_high_contrast.toml
+++ b/runtime/themes/vim_dark_high_contrast.toml
@@ -19,6 +19,7 @@
 "ui.virtual.wrap" = { fg = "dark-blue" }
 "ui.virtual.indent-guide" = { fg = "dark-blue" }
 "ui.virtual.ruler" = { bg = "dark-white" }
+"ui.virtual.jump-label" = { fg = "light-yellow", modifiers = ["bold"] }
 "ui.window" = { bg = "dark-white" }
 
 "diagnostic.error" = { bg = "dark-red" }


### PR DESCRIPTION
Before:
<img width="1133" height="505" alt="image" src="https://github.com/user-attachments/assets/95220cd2-a15d-46ac-9002-06a259d04e34" />

After:
<img width="1158" height="619" alt="image" src="https://github.com/user-attachments/assets/3f00ca36-256a-4f32-903a-9f8aca30211a" />
