### PR TITLE
Display the full (rust) compiler error

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -717,6 +717,9 @@ impl Client {
                     ]),
                     ..Default::default()
                 }),
+                /*experimental: Some(
+                    serde_json::from_str("{\"colorDiagnosticOutput\": true}").unwrap(),
+                ),*/
                 ..Default::default()
             },
             trace: None,

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2673,7 +2673,7 @@ fn global_search(cx: &mut Context) {
         },
     )
     .with_preview(|_editor, FileResult { path, line_num, .. }| {
-        Some((path.as_path().into(), Some((*line_num, *line_num))))
+        Some((path.as_path().into(), Some((*line_num, *line_num)), None))
     })
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
@@ -3235,7 +3235,7 @@ fn buffer_picker(cx: &mut Context) {
             let cursor_line = selection.primary().cursor_line(doc.text().slice(..));
             (cursor_line, cursor_line)
         });
-        Some((meta.id.into(), lines))
+        Some((meta.id.into(), lines, None))
     });
     cx.push_layer(Box::new(overlaid(picker)));
 }
@@ -3326,7 +3326,7 @@ fn jumplist_picker(cx: &mut Context) {
     .with_preview(|editor, meta| {
         let doc = &editor.documents.get(&meta.id)?;
         let line = meta.selection.primary().cursor_line(doc.text().slice(..));
-        Some((meta.id.into(), Some((line, line))))
+        Some((meta.id.into(), Some((line, line)), None))
     });
     cx.push_layer(Box::new(overlaid(picker)));
 }
@@ -3409,7 +3409,7 @@ fn changed_file_picker(cx: &mut Context) {
             }
         },
     )
-    .with_preview(|_editor, meta| Some((meta.path().into(), None)));
+    .with_preview(|_editor, meta| Some((meta.path().into(), None, None)));
     let injector = picker.injector();
 
     cx.editor

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -70,7 +70,7 @@ fn thread_picker(
                     frame.line.saturating_sub(1),
                     frame.end_line.unwrap_or(frame.line).saturating_sub(1),
                 ));
-                Some((path.into(), pos))
+                Some((path.into(), pos, None))
             });
             compositor.push(Box::new(picker));
         },
@@ -770,6 +770,7 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
                         frame.line.saturating_sub(1),
                         frame.end_line.unwrap_or(frame.line).saturating_sub(1),
                     )),
+                    None,
                 )
             })
     });

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -180,7 +180,11 @@ pub fn syntax_symbol_picker(cx: &mut Context) {
         },
     )
     .with_preview(|_editor, tag| {
-        Some((tag.doc.path_or_id()?, Some((tag.start_line, tag.end_line))))
+        Some((
+            tag.doc.path_or_id()?,
+            Some((tag.start_line, tag.end_line)),
+            None,
+        ))
     })
     .truncate_start(false);
 
@@ -426,6 +430,7 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
         Some((
             tag.doc.path_or_id()?,
             Some((tag.start_line, tag.end_line)),
+            None
         ))
     })
     .with_history_register(Some(reg))

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -278,7 +278,7 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
             cx.editor.set_error(err);
         }
     })
-    .with_preview(|_editor, path| Some((path.as_path().into(), None)));
+    .with_preview(|_editor, path| Some((path.as_path().into(), None, None)));
     let injector = picker.injector();
     let timeout = std::time::Instant::now() + std::time::Duration::from_millis(30);
 
@@ -349,7 +349,7 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
             }
         },
     )
-    .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None)));
+    .with_preview(|_editor, (path, _is_dir)| Some((path.as_path().into(), None, None)));
 
     Ok(picker)
 }

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1088,10 +1088,16 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                 self.to_end();
             }
             key!(Esc) | ctrl!('c') => return close_fn(self),
-            ctrl!(Enter) => {
-                if let (Some(selection), Some(file_fn)) = (&self.selection(), &self.file_fn) {
-                    if let Some((_, _, Some(notes))) = (file_fn.as_ref())(ctx.editor, selection) {
-                        /*let _ = ctx.editor.new_file(Action::Replace);
+            ctrl!(Enter) | shift!(Enter) => {
+                if let (Some(option), Some(file_fn)) = (&self.selection(), &self.file_fn) {
+                    if let Some((_, _, Some(notes))) = (file_fn.as_ref())(ctx.editor, option) {
+                        (self.callback_fn)(ctx, option, Action::Replace);
+                        let action = match key_event {
+                            ctrl!(Enter) => Action::Replace,
+                            shift!(Enter) => Action::HorizontalSplit,
+                            _ => unreachable!(),
+                        };
+                        /*let _ = ctx.editor.new_file(action);
                         let (view, document) = current!(ctx.editor);
 
                         let transaction = Transaction::insert(
@@ -1103,7 +1109,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                         document.readonly = true;
                         document.reset_modified();*/
                         let _ = ctx.editor.new_file_from_document(
-                            Action::Replace,
+                            action,
                             Document::from(
                                 Rope::from_str(&notes),
                                 Some((UTF_8, false)),

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -41,8 +41,8 @@ use std::{
 
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::{
-    char_idx_at_visual_offset, fuzzy::MATCHER, movement::Direction,
-    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position,
+    char_idx_at_visual_offset, encoding::UTF_8, fuzzy::MATCHER, movement::Direction,
+    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position, Rope,
 };
 use helix_view::{
     editor::Action,
@@ -81,7 +81,7 @@ impl From<DocumentId> for PathOrId<'_> {
 type FileCallback<T> = Box<dyn for<'a> Fn(&'a Editor, &'a T) -> Option<FileLocation<'a>>>;
 
 /// File path and range of lines (used to align and highlight lines)
-pub type FileLocation<'a> = (PathOrId<'a>, Option<(usize, usize)>);
+pub type FileLocation<'a> = (PathOrId<'a>, Option<(usize, usize)>, Option<String>);
 
 pub enum CachedPreview {
     Document(Box<Document>),
@@ -587,7 +587,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         editor: &'editor Editor,
     ) -> Option<(Preview<'picker, 'editor>, Option<(usize, usize)>)> {
         let current = self.selection()?;
-        let (path_or_id, range) = (self.file_fn.as_ref()?)(editor, current)?;
+        let (path_or_id, range, _) = (self.file_fn.as_ref()?)(editor, current)?;
 
         match path_or_id {
             PathOrId::Path(path) => {
@@ -1088,6 +1088,33 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                 self.to_end();
             }
             key!(Esc) | ctrl!('c') => return close_fn(self),
+            ctrl!(Enter) => {
+                if let (Some(selection), Some(file_fn)) = (&self.selection(), &self.file_fn) {
+                    if let Some((_, _, Some(notes))) = (file_fn.as_ref())(ctx.editor, selection) {
+                        /*let _ = ctx.editor.new_file(Action::Replace);
+                        let (view, document) = current!(ctx.editor);
+
+                        let transaction = Transaction::insert(
+                            document.text(),
+                            &Selection::point(document.text().len_chars() - 1),
+                            notes.into(),
+                        );
+                        document.apply(&transaction, view.id);
+                        document.readonly = true;
+                        document.reset_modified();*/
+                        let _ = ctx.editor.new_file_from_document(
+                            Action::Replace,
+                            Document::from(
+                                Rope::from_str(&notes),
+                                Some((UTF_8, false)),
+                                ctx.editor.config.clone(),
+                                ctx.editor.syn_loader.clone(),
+                            ),
+                        );
+                        return close_fn(self);
+                    }
+                }
+            }
             alt!(Enter) => {
                 if let Some(option) = self.selection() {
                     (self.callback_fn)(ctx, option, self.default_action);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1862,7 +1862,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
This pull requests adds the CTRL+ENTER and SHIFT+ENTER key bindings in preview that opens a scratch buffer showing the full compiler error.

This is an alternative to #13571  

## Motivation

When displaying the errors from the LSP, at least in the case of Rust, it is sometimes useful to see the full compiler error. This pull request modifies the Diagnostics Picker's by adding the CTRL+ENTER and SHIFT+ENTER key binding that opens a scratch buffer to display the actual compiler error (if available).

| Key Binding | Description |
|-|-|
| `CTRL`+`ENTER` | Jumps to the error location and opens the full compiler error in a new scratch buffer |
| `SHIFT`+`ENTER` | Jumps to the error location and opens the full compiler error in a new horizontal split scratch buffer |

For now, the error is displayed without coloring. Using color requires more work.

I tested this PR only in the context of Rust, but I assume other LSPs might do the same.

### New Buffer
<img width="1230" height="769" alt="Screenshot 2025-12-28 at 14 10 04" src="https://github.com/user-attachments/assets/d9201224-b84d-4e5b-819f-df863963f653" />

### New Horizontal Buffer
<img width="1227" height="772" alt="Screenshot 2025-12-28 at 14 10 19" src="https://github.com/user-attachments/assets/553fe244-3c3e-4582-95d9-c595ba3a7c0e" />

## Still needs

- [ ] This pull request still needs a documentation update before merge.

## Additional Notes

### Editor API 

I had to. modify the `Editor` API and make the `Editor::new_file_from_document` function public to open a scratch buffer with text. Without this, I can open a new empty scratch buffer and apply a transaction, but it will show up in the undo history and will not allow the user to close is without using `buffer-close!` or `q!` which are the second command when typing. 

The code doing this is now commented, it seems that `document.reset_modified();` has no effect.

### Picker API

This pull request adds the ability to attach notes to pickers. It uses this to attach the full compiler error as a note. The picker does not really care about the note contents, it just display the notes when CTRL+ENTER or SHIFT+ENTER are pressed.

Another solution would have been to either:
- add a new callback function for *notes*
- add another parameter to the callback function to inform the caller that the user has pressed CTRL+ENTER or SHIFT+ENTER
- add another variants to `Action` like `Notes` and `HorizontalNotes`