### PR TITLE
fix tree-sitter grammar example in rainbow bracket guide

### DIFF
--- a/book/src/guides/rainbow_bracket_queries.md
+++ b/book/src/guides/rainbow_bracket_queries.md
@@ -36,7 +36,7 @@ taken into consideration.
 > ```js
 > {
 >   // ...
->   arguments: seq("(", repeat($.argument), ")"),
+>   arguments: $ => seq("(", repeat($.argument), ")"),
 >   // ...
 > }
 > ```


### PR DESCRIPTION
very minor nitpick but it bothered me when reading the rainbow bracket guide: tree-sitter grammar nodes are arrow functions with the rule in the body, and not just the rule directly. due to not being an arrow function, in the current code the `$` is a free identifier, since that comes from the parameter of the arrow function.