### PR TITLE
recognize `Android.bp` files, as... something?

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -799,7 +799,7 @@ source = { git = "https://github.com/jzelinskie/tree-sitter-spicedb", rev = "a4e
 name = "go"
 scope = "source.go"
 injection-regex = "go"
-file-types = ["go"]
+file-types = ["go", { glob = "Android.bp" }]
 roots = ["go.work", "go.mod"]
 auto-format = true
 comment-token = "//"


### PR DESCRIPTION
https://source.android.com/docs/setup/reference/androidbp

Those files [are widespread](https://github.com/search?q=path%3AAndroid.bp&type=code), especially in [this repo](https://github.com/aosp-mirror/platform_frameworks_base)

IDK if the syntax is 100% Go ~but it seems like so~
