### PR TITLE
Apply theme border style to picker

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -699,12 +699,13 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let background = cx.editor.theme.get("ui.background");
         surface.clear_with(area, background);
 
-        const BLOCK: Block<'_> = Block::bordered();
+        let border_style = cx.editor.theme.get("ui.window");
+        let block = Block::bordered().border_style(border_style);
 
         // calculate the inner area inside the box
-        let inner = BLOCK.inner(area);
+        let inner = block.inner(area);
 
-        BLOCK.render(area, surface);
+        block.render(area, surface);
 
         // -- Render the input bar:
 
@@ -888,14 +889,15 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let directory = cx.editor.theme.get("ui.text.directory");
         surface.clear_with(area, background);
 
-        const BLOCK: Block<'_> = Block::bordered();
+        let border_style = cx.editor.theme.get("ui.window");
+        let block = Block::bordered().border_style(border_style);
 
         // calculate the inner area inside the box
-        let inner = BLOCK.inner(area);
+        let inner = block.inner(area);
         // 1 column gap on either side
         let margin = Margin::horizontal(1);
         let inner = inner.inner(margin);
-        BLOCK.render(area, surface);
+        block.render(area, surface);
 
         if let Some((preview, range)) = self.get_preview(cx.editor) {
             let doc = match preview.document() {


### PR DESCRIPTION
The picker borders were rendered with the terminal's default foreground color, which made them invisible on some terminal themes.

This applies the `ui.window` theme scope to picker borders, making them consistent with other window borders in the editor.

<img width="1908" height="1026" alt="スクリーンショット 2025-12-31 0 40 36" src="https://github.com/user-attachments/assets/a18375f2-ac4e-44a3-9c5b-e7b235da77ac" />

<details>
<summary>Theme used for testing</summary>

```toml
inherits = "default"

"ui.window" = { fg = "red" }
```

</details>