### PR TITLE
fix: stale "nothing selected" and "no selections remaining" errors persisting after successful regex selection

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5214,7 +5214,7 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
                 selection::keep_or_remove_matches(text, doc.selection(view.id), &regex, remove)
             {
                 doc.set_selection(view.id, selection);
-            } else {
+            } else if event == PromptEvent::Validate {
                 cx.editor.set_error("no selections remaining");
             }
         },


### PR DESCRIPTION
Tiny fix for "nothing selected" and "no selections remaining" errors generated during typing being incorrectly persisted to the status line.

If any intermediate state of the regex (while typing) yields no matches, an error is set in the editor status line (but not visible). And successful match does not explicitly clear this error, so it remains there (in the editor status line) even after the user completes a valid regex and confirms the selection. It's probably fine to only add this error after confirm?

An alternative fix would be to explicitly clear this error on a successful match.

<img width="1606" height="724" alt="Screenshot_2026-01-02_01-34-27" src="https://github.com/user-attachments/assets/b8b372be-b38b-448d-9987-4db4d55daf5c" />