### PR TITLE
PTX support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -224,6 +224,7 @@
 | properties | ✓ | ✓ |  |  |  |  |
 | protobuf | ✓ | ✓ | ✓ | ✓ |  | `buf`, `pb`, `protols` |
 | prql | ✓ |  |  |  |  |  |
+| ptx | ✓ |  | ✓ |  |  |  |
 | pug | ✓ |  |  |  |  |  |
 | purescript | ✓ | ✓ |  |  |  | `purescript-language-server` |
 | python | ✓ | ✓ | ✓ | ✓ | ✓ | `ty`, `ruff`, `jedi-language-server`, `pylsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -5323,3 +5323,17 @@ comment-token = "#"
 [[grammar]]
 name = "gnuplot"
 source = { git = "https://codeberg.org/maribu/tree-sitter-gnuplot", rev = "21a3a3929facb964b3592daeb69119294ff84cf2" }
+
+[[language]]
+name = "ptx"
+scope = "source.ptx"
+injection-regex = "ptx"
+file-types = ["ptx"]
+language-servers = []
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "ptx"
+source = { git = "https://codeberg.org/jer-gremlin/tree-sitter-ptx", rev = "3dfa6758d4c15832d051f933101992b9e01d6611" }

--- a/runtime/queries/ptx/folds.scm
+++ b/runtime/queries/ptx/folds.scm
@@ -1,0 +1,5 @@
+; Folding for PTX
+[
+  (func_body)
+  (entry_declaration)
+] @fold

--- a/runtime/queries/ptx/highlights.scm
+++ b/runtime/queries/ptx/highlights.scm
@@ -1,0 +1,47 @@
+; highlights.scm - Syntax highlighting for PTX
+
+; Comments
+(comment) @comment
+
+; Directives
+(version_directive) @keyword
+(target_directive) @keyword
+(address_size_directive) @keyword
+(file_directive) @keyword
+(section_directive) @keyword
+(visibility_directive) @keyword
+(pragma_directive) @keyword
+
+; Keywords
+[
+  ".global"
+  ".const"
+  ".param"
+  ".local"
+  ".shared"
+  ".tex"
+  ".func"
+  ".entry"
+] @keyword
+
+; Types
+(data_type) @type
+
+; Instructions
+(opcode) @function
+
+; Identifiers
+(identifier) @variable
+
+; Registers
+(register) @variable
+
+; Numbers
+(number) @constant.numeric.integer
+(float_literal) @constant.numeric.float
+
+; Strings
+(string) @string
+
+; Labels
+(label) @label

--- a/runtime/queries/ptx/indents.scm
+++ b/runtime/queries/ptx/indents.scm
@@ -1,0 +1,9 @@
+; Indentation for PTX
+[
+  (func_body)
+  (entry_declaration)
+] @indent
+; Do not indent on closing brace
+[
+  "}"
+] @outdent


### PR DESCRIPTION
Adds support for tree-sitter-ptx.

Just syntax highlighting and tree-sitter objects, no auto-fmt, no lsp etc.