### PR TITLE
Make it easier to iterate on language related changes

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,1 @@
+../languages.toml

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
             shellHook = ''
               export RUST_BACKTRACE="1"
               export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"
+              export HELIX_RUNTIME="''${PWD}/runtime/"
             '';
           };
       })


### PR DESCRIPTION
These changes make it easier to test language related changes, for contributors who hack on Helix in Helix.

1. A symlink is created from `languages.toml` -> `.helix/languages.toml` This makes changes to `languages.toml` visible when you use `hx` within the repository.
2. Export `$HELIX_RUNTIME` to point to `runtime/` in the Nix devshell. This makes changes to queries under `runtime/queries/*/*.scm` take effect when you invoke Helix as you normally do with `hx`