### PR TITLE
Add `nu` formatter `nufmt`

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2492,6 +2492,8 @@ shebangs = ["nu"]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "nu-lsp" ]
+formatter = { command = "nufmt", args = ["--stdin"] } # https://github.com/nushell/nufmt
+auto-format = false
 
 [[grammar]]
 name = "nu"


### PR DESCRIPTION
Set `auto-format = false` since `nufmt` does not have a stable release yet, so a user might encounter some edge cases that generate undesired output.