### PR TITLE
add block-comment-tokens to nix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1107,6 +1107,7 @@ injection-regex = "nix"
 file-types = ["nix"]
 shebangs = []
 comment-token = "#"
+block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "nil", "nixd" ]
 indent = { tab-width = 2, unit = "  " }
 formatter = { command = "nixfmt" }


### PR DESCRIPTION
`toggle_comments`, `toggle_block_comments`, `toggle_line_comments`, `goto_next_comment`, and `goto_prev_comment` all seem to work as expected after a small amount of testing.