### PR TITLE
Support loading configuration from .config/helix in project directory

### DIFF
--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -141,7 +141,14 @@ pub fn log_file() -> PathBuf {
 }
 
 pub fn workspace_config_file() -> PathBuf {
-    find_workspace().0.join(".helix").join("config.toml")
+    let root = find_workspace().0;
+    let dot_config_path = root.join(".config").join("helix").join("config.toml");
+
+    if dot_config_path.exists() {
+        dot_config_path
+    } else {
+        root.join(".helix").join("config.toml")
+    }
 }
 
 pub fn lang_config_file() -> PathBuf {
@@ -254,6 +261,7 @@ pub fn find_workspace_in(dir: impl AsRef<Path>) -> (PathBuf, bool) {
             || ancestor.join(".svn").exists()
             || ancestor.join(".jj").exists()
             || ancestor.join(".helix").exists()
+            || ancestor.join(".config").join("helix").exists()
         {
             return (ancestor.to_owned(), false);
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2569,6 +2569,7 @@ fn global_search(cx: &mut Context) {
                 })
                 .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
                 .add_custom_ignore_filename(".helix/ignore")
+                .add_custom_ignore_filename(".config/helix/ignore")
                 .build_parallel()
                 .run(|| {
                     let mut searcher = searcher.clone();

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -229,7 +229,8 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks))
         .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
-        .add_custom_ignore_filename(".helix/ignore");
+        .add_custom_ignore_filename(".helix/ignore")
+        .add_custom_ignore_filename(".config/helix/ignore");
 
     let mut regex_matcher_builder = RegexMatcherBuilder::new();
     regex_matcher_builder.case_smart(config.search.smart_case);

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -238,6 +238,7 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks))
         .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
         .add_custom_ignore_filename(".helix/ignore")
+        .add_custom_ignore_filename(".config/helix/ignore")
         .types(get_excluded_types())
         .build()
         .filter_map(|entry| {
@@ -372,6 +373,7 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
         .max_depth(Some(1))
         .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
         .add_custom_ignore_filename(".helix/ignore")
+        .add_custom_ignore_filename(".config/helix/ignore")
         .types(get_excluded_types())
         .build()
         .filter_map(|entry| {

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -38,7 +38,8 @@ pub enum Variable {
     LineEnding,
     /// Curreng working directory
     CurrentWorkingDirectory,
-    /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
+    /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`,
+    /// `jj`, `.helix`, or `.config/helix`
     WorkspaceDirectory,
     // The name of current buffers language as set in `languages.toml`
     Language,


### PR DESCRIPTION
In addition to `<project>/.helix`, also try to load configuration from `<project>/.config/helix`.

This is not ready to merge, some pending discussions/choices:

- Is this worth supporting?
- What should the behavior be if both directories have a `config.toml` or a `ignore`?, E.g., `.helix/config.toml` and `.config/helix/config.toml`
- What should the behavior be if `config.toml` is present in one and `ignore` in the other? E.g., `.helix/config.toml` and `.config/helix/ignore`.
- What should `config-open-workspace` do if both (or none) of the files exist?

I like using the `.config` directory with the tools that currently support it to avoid having lots of dotfiles in the repo root, but this is not (yet?) widespread.

Would this be something you would be willing to support? I'm not particularly experienced with rust but I'd be interested in giving an implementation a shot pending answers to the above questions.