### PR TITLE
Advertise relative pattern support client capability for file watchers

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -596,7 +596,7 @@ impl Client {
                     }),
                     did_change_watched_files: Some(lsp::DidChangeWatchedFilesClientCapabilities {
                         dynamic_registration: Some(true),
-                        relative_pattern_support: Some(false),
+                        relative_pattern_support: Some(true),
                     }),
                     file_operations: Some(lsp::WorkspaceFileOperationsClientCapabilities {
                         will_rename: Some(true),


### PR DESCRIPTION
It appears relative patterns for watched files are already implemented and work (my Rust/Helix knowledge is limited, so I may be missing something).

This change sets the `relativePatternSupport` to `true` when advertising client capabilities related to .

```json
  "didChangeWatchedFiles": {
    "dynamicRegistration": true,
    "relativePatternSupport": true
  }
```

RubyLSP requires both fields to be `true` before it will register file watchers, so this would unlock functionality in RubyLSP. I have tested RubyLSP+[ruby-lsp-brakeman](https://github.com/presidentbeef/ruby-lsp-brakeman) with this change and it works without modification to those projects..