### PR TITLE
select_character action

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -66,6 +66,7 @@
 | `page_cursor_half_down` | Move page and cursor half down | normal: `` <C-d> ``, `` Z<C-d> ``, `` z<C-d> ``, `` Z<space> ``, `` z<space> ``, select: `` <C-d> ``, `` Z<C-d> ``, `` z<C-d> ``, `` Z<space> ``, `` z<space> `` |
 | `select_all` | Select whole document | normal: `` % ``, select: `` % `` |
 | `select_regex` | Select all regex matches inside selections | normal: `` s ``, select: `` s `` |
+| `select_character` | Select all matches of character you next press |  |
 | `split_selection` | Split selections on regex matches | normal: `` S ``, select: `` S `` |
 | `split_selection_on_newline` | Split selection on newlines | normal: `` <A-s> ``, select: `` <A-s> `` |
 | `merge_selections` | Merge selections | normal: `` <A-minus> ``, select: `` <A-minus> `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -369,6 +369,7 @@ impl MappableCommand {
         page_cursor_half_down, "Move page and cursor half down",
         select_all, "Select whole document",
         select_regex, "Select all regex matches inside selections",
+        select_character, "Select all matches of character you next press",
         split_selection, "Split selections on regex matches",
         split_selection_on_newline, "Split selection on newlines",
         merge_selections, "Merge selections",
@@ -2210,6 +2211,38 @@ fn select_regex(cx: &mut Context) {
             }
         },
     );
+}
+
+fn select_character(cx: &mut Context) {
+    cx.on_next_key(move |cx, event| {
+        let ch = match event {
+            KeyEvent {
+                code: KeyCode::Char(ch),
+                ..
+            } => ch,
+            KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            } => '\n',
+            KeyEvent {
+                code: KeyCode::Tab, ..
+            } => '\t',
+            _ => return,
+        };
+        let (view, doc) = current!(cx.editor);
+        let text = doc.text().slice(..);
+        let mut buf = [0u8; 4];
+        if let Some(selection) = selection::select_on_matches(
+            text,
+            doc.selection(view.id),
+            &helix_stdx::rope::Regex::new(&helix_core::regex::escape(ch.encode_utf8(&mut buf))) // this silly `encode_utf8` dance avoids a needless String allocation. not sure if it's worth the ugliness.
+                .expect("regex from a single character should never be invalid"),
+        ) {
+            doc.set_selection(view.id, selection);
+        } else {
+            cx.editor.set_error("nothing selected");
+        }
+    });
 }
 
 fn split_selection(cx: &mut Context) {


### PR DESCRIPTION
I notice myself needing to select instances of just a single character very frequently, only to encounter needing to escape some of them, and then *also* needing to press <kbd>Enter</kbd> afterwards. I find it kind of annoying so I made this action.

Now I can press `<the_hotkey>|` to place selections on all the pipes in the following example:
```fish
alphabet | string split '' | sk
```
Rather than `s\|<ret>`.

To reiterate: the character that you type is understood *literally*: if you type `.`, all periods will be selected, rather than every individual character in your selections.

Aside from characters, these keys are understood: <kbd>Tab</kbd>, <kbd>Enter</kbd>.
