### PR TITLE
Fix: adds ownership verification to the workspace detection logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "helix-stdx",
  "log",
  "once_cell",
+ "rustix 1.1.3",
  "serde",
  "tempfile",
  "threadpool",

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml.workspace = true
 etcetera = "0.10"
 once_cell = "1.21"
+rustix = { version = "1.1", features = ["fs", "process"] }
 log = "0.4"
 
 # TODO: these two should be on !wasm32 only


### PR DESCRIPTION
On a system where a Git repository or any of the directories checked here https://github.com/helix-editor/helix/blob/10f07d7eb089430930e6d3547a98b440b927d025/helix-loader/src/lib.rs#L253-L256 is owned by another user and located at the filesystem root `/`, some language servers may fail to start.

As example reference, SystemVerilog's slang-server: https://github.com/hudson-trading/slang-server/blob/a56437d747dd00461641ae2b53f3914f3310242e/src/SlangServer.cpp#L126-L153