### PR TITLE
Add buffer-close-next/previous commands

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -9,6 +9,10 @@
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |
 | `:buffer-close-others!`, `:bco!`, `:bcloseother!` | Force close all buffers but the currently focused one. |
+| `:buffer-close-next`, `:bcn`, `:bclosenext` | Close all buffers after the currently focused one. |
+| `:buffer-close-next!`, `:bcn!`, `:bclosenext!` | Force close all buffers after the currently focused one. |
+| `:buffer-close-previous`, `:bcp`, `:bcloseprevious` | Close all buffers before the currently focused one. |
+| `:buffer-close-previous!`, `:bcp!`, `:bcloseprevious!` | Force close all buffers before the currently focused one. |
 | `:buffer-close-all`, `:bca`, `:bcloseall` | Close all buffers without quitting. |
 | `:buffer-close-all!`, `:bca!`, `:bcloseall!` | Force close all buffers ignoring unsaved changes without quitting. |
 | `:buffer-next`, `:bn`, `:bnext` | Goto next buffer. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -319,6 +319,104 @@ fn force_buffer_close_others(
     buffer_close_by_ids_impl(cx, &document_ids, true)
 }
 
+fn buffer_gather_prev_next_impl(
+    editor: &mut Editor,
+    direction: Direction,
+    skip_visible: bool,
+) -> Vec<DocumentId> {
+    let current_document_id = &doc!(editor).id();
+
+    let visible_document_ids = if skip_visible {
+        editor
+            .tree
+            .views()
+            .map(|view| &view.0.doc)
+            .collect::<HashSet<_>>()
+    } else {
+        HashSet::from([current_document_id])
+    };
+
+    let filter_visible = |doc_id: &DocumentId| !visible_document_ids.contains(doc_id);
+
+    if direction == Direction::Forward {
+        editor
+            .documents()
+            .map(|doc| doc.id())
+            .skip_while(|doc_id| *doc_id != *current_document_id)
+            .filter(filter_visible)
+            .collect()
+    } else {
+        editor
+            .documents()
+            .map(|doc| doc.id())
+            .take_while(|doc_id| *doc_id != *current_document_id)
+            .filter(filter_visible)
+            .collect()
+    }
+}
+
+fn buffer_close_next(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids =
+        buffer_gather_prev_next_impl(cx.editor, Direction::Forward, args.has_flag("skip-visible"));
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
+fn force_buffer_close_next(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids =
+        buffer_gather_prev_next_impl(cx.editor, Direction::Forward, args.has_flag("skip-visible"));
+    buffer_close_by_ids_impl(cx, &document_ids, true)
+}
+
+fn buffer_close_previous(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_prev_next_impl(
+        cx.editor,
+        Direction::Backward,
+        args.has_flag("skip-visible"),
+    );
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
+fn force_buffer_close_previous(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let document_ids = buffer_gather_prev_next_impl(
+        cx.editor,
+        Direction::Backward,
+        args.has_flag("skip-visible"),
+    );
+    buffer_close_by_ids_impl(cx, &document_ids, true)
+}
+
 fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
     editor.documents().map(|doc| doc.id()).collect()
 }
@@ -2856,6 +2954,38 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["bco!", "bcloseother!"],
         doc: "Force close all buffers but the currently focused one.",
         fun: force_buffer_close_others,
+        completer: CommandCompleter::none(),
+        signature: BUFFER_CLOSE_OTHERS_SIGNATURE,
+    },
+    TypableCommand {
+        name: "buffer-close-next",
+        aliases: &["bcn", "bclosenext"],
+        doc: "Close all buffers after the currently focused one.",
+        fun: buffer_close_next,
+        completer: CommandCompleter::none(),
+        signature: BUFFER_CLOSE_OTHERS_SIGNATURE,
+    },
+    TypableCommand {
+        name: "buffer-close-next!",
+        aliases: &["bcn!", "bclosenext!"],
+        doc: "Force close all buffers after the currently focused one.",
+        fun: force_buffer_close_next,
+        completer: CommandCompleter::none(),
+        signature: BUFFER_CLOSE_OTHERS_SIGNATURE,
+    },
+    TypableCommand {
+        name: "buffer-close-previous",
+        aliases: &["bcp", "bcloseprevious"],
+        doc: "Close all buffers before the currently focused one.",
+        fun: buffer_close_previous,
+        completer: CommandCompleter::none(),
+        signature: BUFFER_CLOSE_OTHERS_SIGNATURE,
+    },
+    TypableCommand {
+        name: "buffer-close-previous!",
+        aliases: &["bcp!", "bcloseprevious!"],
+        doc: "Force close all buffers before the currently focused one.",
+        fun: force_buffer_close_previous,
         completer: CommandCompleter::none(),
         signature: BUFFER_CLOSE_OTHERS_SIGNATURE,
     },


### PR DESCRIPTION
These commands close the buffers after/before the current buffer respectively. This is useful when using the bufferline feauture. It mimicks tab-like behavior as seen in other (mostly GUI) apps.

Other names I've considered:
- `buffer-close-all-next/-previous`
- `buffer-close-forward/-backward`
- `buffer-close-other-next/-previous`

Here is an annotated screenshot from Helix:
<img width="759" height="465" alt="helix-buffer-close-next" src="https://github.com/user-attachments/assets/be0b8e09-a21e-47fb-ac19-b89f2efcd72f" />

Here is an example from Safari.app:
<img width="1003" height="420" alt="safari-close-right" src="https://github.com/user-attachments/assets/ad4dea45-60fb-4580-8cf2-ae51fafd7f10" />

