### PR TITLE
Improve Caddyfile language detection

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4838,7 +4838,14 @@ source = { git = "https://github.com/polychromatist/tree-sitter-luau", rev = "ec
 name = "caddyfile"
 scope = "source.caddyfile"
 injection-regex = "caddyfile"
-file-types = [{ glob = "Caddyfile" }]
+file-types = [
+  "Caddyfile",
+  { glob = "Caddyfile" },
+  { glob = "Caddyfile.*" },
+  "caddyfile",
+  { glob = "caddyfile" },
+  { glob = "caddyfile.*" },
+]
 comment-tokens = ["#"]
 indent = { tab-width = 4, unit = "    " }
 formatter = { command = "caddy", args = ["fmt", "-"] }


### PR DESCRIPTION
Based on https://github.com/caddyserver/caddy/issues/5909, there are officially recognized naming patterns besides literal `Caddyfile`.